### PR TITLE
Id generator test fix

### DIFF
--- a/prd-api/src/PrdAgent.Infrastructure/Services/IdGenerator.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/IdGenerator.cs
@@ -17,10 +17,16 @@ public class IdGenerator : IIdGenerator
     // 已废弃：所有类别统一从 1 开始，直接 INCR 即可
     // private static readonly Dictionary<string, int> CategoryStartIndex = ...
 
-    public IdGenerator(ConnectionMultiplexer redis, bool useReadableIds)
+    public IdGenerator(IConnectionMultiplexer redis, bool useReadableIds)
     {
         _redis = redis.GetDatabase();
         _useReadableIds = useReadableIds;
+    }
+
+    // 兼容历史调用方（DI 里多数仍注入 ConnectionMultiplexer）
+    public IdGenerator(ConnectionMultiplexer redis, bool useReadableIds)
+        : this((IConnectionMultiplexer)redis, useReadableIds)
+    {
     }
 
     public async Task<string> GenerateIdAsync(string category)


### PR DESCRIPTION
Refactor `IdGeneratorTests` to be a pure unit test by mocking Redis dependencies, resolving CI failures caused by external service requirements.

The original `IdGeneratorTests` directly connected to `localhost:6379` in its constructor, leading to `RedisConnectionException` in CI environments without a running Redis instance. This PR introduces Moq to simulate Redis `INCR` operations with an in-memory, thread-safe counter, making the tests stateless and independent. A new `IdGenerator` constructor accepting `IConnectionMultiplexer` was added to enable this mocking, while maintaining backward compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-269128cd-417d-46fc-ad53-a7a29c971430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-269128cd-417d-46fc-ad53-a7a29c971430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

