### PR TITLE
Model token limit customization

### DIFF
--- a/prd-admin/src/pages/ModelManagePage.tsx
+++ b/prd-admin/src/pages/ModelManagePage.tsx
@@ -61,6 +61,7 @@ type ModelForm = {
   group: string;
   enabled: boolean;
   enablePromptCache: boolean;
+  maxTokens: string;
 };
 
 const defaultPlatformForm: PlatformForm = {
@@ -82,6 +83,7 @@ const defaultModelForm: ModelForm = {
   group: '',
   enabled: true,
   enablePromptCache: true,
+  maxTokens: '',
 };
 
 
@@ -810,11 +812,17 @@ export default function ModelManagePage() {
       group: m.group || '',
       enabled: m.enabled,
       enablePromptCache: typeof (m as any).enablePromptCache === 'boolean' ? (m as any).enablePromptCache : true,
+      maxTokens: (m as any).maxTokens == null ? '' : String((m as any).maxTokens),
     });
     setModelDialogOpen(true);
   };
 
   const submitModel = async () => {
+    const maxTokensRaw = String(modelForm.maxTokens ?? '').trim();
+    const maxTokensNum = maxTokensRaw ? Number(maxTokensRaw) : NaN;
+    const maxTokens =
+      Number.isFinite(maxTokensNum) && maxTokensNum > 0 ? Math.floor(maxTokensNum) : null;
+
     if (editingModel) {
       const res = await updateModel(editingModel.id, {
         name: modelForm.name,
@@ -823,6 +831,7 @@ export default function ModelManagePage() {
         group: modelForm.group || undefined,
         enabled: modelForm.enabled,
         enablePromptCache: modelForm.enablePromptCache,
+        maxTokens,
       });
       if (!res.success) return;
     } else {
@@ -833,6 +842,7 @@ export default function ModelManagePage() {
         group: modelForm.group || undefined,
         enabled: modelForm.enabled,
         enablePromptCache: modelForm.enablePromptCache,
+        maxTokens,
       });
       if (!res.success) return;
     }
@@ -2074,6 +2084,28 @@ export default function ModelManagePage() {
               />
               Prompt Cache（模型级）
             </label>
+
+            <div className="grid gap-2">
+              <div className="text-sm" style={{ color: 'var(--text-secondary)' }}>
+                Max Tokens（可选）
+                <span className="ml-2 text-xs" style={{ color: 'var(--text-muted)' }}>
+                  留空使用默认 4096；将透传到请求的 max_tokens
+                </span>
+              </div>
+              <input
+                value={modelForm.maxTokens}
+                onChange={(e) => setModelForm((s) => ({ ...s, maxTokens: e.target.value }))}
+                className="h-10 w-full rounded-[14px] px-4 text-sm outline-none"
+                style={inputStyle}
+                type="number"
+                min={1}
+                step={1}
+                inputMode="numeric"
+                name="model-max-tokens"
+                autoComplete="off"
+                placeholder="4096"
+              />
+            </div>
 
             <div className="flex justify-end gap-2 pt-2">
               <Button variant="secondary" size="sm" onClick={() => setModelDialogOpen(false)}>

--- a/prd-admin/src/services/contracts/models.ts
+++ b/prd-admin/src/services/contracts/models.ts
@@ -10,6 +10,8 @@ export type CreateModelInput = {
   enabled: boolean;
   group?: string;
   enablePromptCache?: boolean;
+  /** 透传到大模型请求的 max_tokens；不传/传 null 表示使用后端默认 */
+  maxTokens?: number | null;
 };
 
 export type UpdateModelInput = Partial<CreateModelInput> & {

--- a/prd-admin/src/services/mock/impl/models.ts
+++ b/prd-admin/src/services/mock/impl/models.ts
@@ -27,6 +27,7 @@ export async function createModelMock(input: CreateModelInput): Promise<ApiRespo
     isImageGen: false,
     group: input.group,
     enablePromptCache: typeof input.enablePromptCache === 'boolean' ? input.enablePromptCache : true,
+    maxTokens: typeof input.maxTokens === 'number' ? input.maxTokens : null,
   };
 
   db.models.unshift(m);
@@ -48,6 +49,7 @@ export async function updateModelMock(id: string, input: UpdateModelInput): Prom
   m.group = input.group ?? m.group;
   if (typeof input.enabled === 'boolean') m.enabled = input.enabled;
   if (typeof (input as any).enablePromptCache === 'boolean') (m as any).enablePromptCache = (input as any).enablePromptCache;
+  if ('maxTokens' in (input as any)) (m as any).maxTokens = (input as any).maxTokens ?? null;
 
   if (typeof input.isMain === 'boolean') {
     if (input.isMain) {

--- a/prd-admin/src/services/real/models.ts
+++ b/prd-admin/src/services/real/models.ts
@@ -34,6 +34,7 @@ export const createModelReal: CreateModelContract = async (input: CreateModelInp
       group: input.group ?? null,
       enabled: input.enabled,
       enablePromptCache: typeof input.enablePromptCache === 'boolean' ? input.enablePromptCache : true,
+      maxTokens: typeof input.maxTokens === 'number' ? input.maxTokens : null,
     },
   });
 
@@ -52,6 +53,7 @@ export const updateModelReal: UpdateModelContract = async (id: string, input: Up
 
   const m = current.data as any;
 
+  const hasMaxTokens = 'maxTokens' in (input as any);
   const body: Record<string, unknown> = {
     name: input.name ?? m.name,
     modelName: input.modelName ?? m.modelName,
@@ -61,6 +63,7 @@ export const updateModelReal: UpdateModelContract = async (id: string, input: Up
     timeout: m.timeout ?? 360000,
     maxRetries: m.maxRetries ?? 3,
     maxConcurrency: m.maxConcurrency ?? 5,
+    maxTokens: hasMaxTokens ? ((input as any).maxTokens ?? null) : (m.maxTokens ?? null),
     enabled: typeof input.enabled === 'boolean' ? input.enabled : m.enabled,
     enablePromptCache:
       typeof (input as any).enablePromptCache === 'boolean'

--- a/prd-admin/src/types/admin.ts
+++ b/prd-admin/src/types/admin.ts
@@ -50,6 +50,8 @@ export type Model = {
   isImageGen?: boolean;
   group?: string;
   enablePromptCache: boolean;
+  /** 透传到大模型请求的 max_tokens；null/undefined 表示使用后端默认（当前 4096） */
+  maxTokens?: number | null;
   /** 优先级：越小越靠前（用于拖拽排序） */
   priority?: number;
   // 后端模型统计（真实数据；用于模型管理页显示“请求次数/平均耗时”等）

--- a/prd-api/src/PrdAgent.Api/Controllers/Admin/AdminModelsController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Admin/AdminModelsController.cs
@@ -116,6 +116,7 @@ public class AdminModelsController : ControllerBase
             .Project(m => m.Priority)
             .FirstOrDefaultAsync();
 
+        var reqMaxTokens = request.MaxTokens.HasValue && request.MaxTokens.Value > 0 ? request.MaxTokens : null;
         var model = new LLMModel
         {
             Id = await _idGenerator.GenerateIdAsync("model"),
@@ -128,6 +129,7 @@ public class AdminModelsController : ControllerBase
             Timeout = request.Timeout,
             MaxRetries = request.MaxRetries,
             MaxConcurrency = request.MaxConcurrency,
+            MaxTokens = reqMaxTokens,
             Enabled = request.Enabled,
             Priority = request.Priority ?? maxPriority + 1,
             Remark = request.Remark,
@@ -160,6 +162,7 @@ public class AdminModelsController : ControllerBase
             return BadRequest(ApiResponse<object>.Fail("DUPLICATE_MODEL", "模型名称已存在"));
         }
 
+        var reqMaxTokens = request.MaxTokens.HasValue && request.MaxTokens.Value > 0 ? request.MaxTokens : null;
         var update = Builders<LLMModel>.Update
             .Set(m => m.Name, request.Name)
             .Set(m => m.ModelName, request.ModelName)
@@ -169,6 +172,7 @@ public class AdminModelsController : ControllerBase
             .Set(m => m.Timeout, request.Timeout)
             .Set(m => m.MaxRetries, request.MaxRetries)
             .Set(m => m.MaxConcurrency, request.MaxConcurrency)
+            .Set(m => m.MaxTokens, reqMaxTokens)
             .Set(m => m.Enabled, request.Enabled)
             .Set(m => m.EnablePromptCache, request.EnablePromptCache)
             .Set(m => m.Remark, request.Remark)
@@ -671,6 +675,7 @@ public class AdminModelsController : ControllerBase
         m.Timeout,
         m.MaxRetries,
         m.MaxConcurrency,
+        maxTokens = m.MaxTokens,
         m.Enabled,
         m.Priority,
         m.IsMain,
@@ -754,6 +759,7 @@ public class CreateModelRequest
     public int Timeout { get; set; } = 360000;
     public int MaxRetries { get; set; } = 3;
     public int MaxConcurrency { get; set; } = 5;
+    public int? MaxTokens { get; set; }
     public bool Enabled { get; set; } = true;
     public bool EnablePromptCache { get; set; } = true;
     public int? Priority { get; set; }
@@ -771,6 +777,7 @@ public class UpdateModelRequest
     public int Timeout { get; set; } = 360000;
     public int MaxRetries { get; set; } = 3;
     public int MaxConcurrency { get; set; } = 5;
+    public int? MaxTokens { get; set; }
     public bool Enabled { get; set; } = true;
     public bool EnablePromptCache { get; set; } = true;
     public int? Priority { get; set; }

--- a/prd-api/src/PrdAgent.Core/Models/LLMModel.cs
+++ b/prd-api/src/PrdAgent.Core/Models/LLMModel.cs
@@ -58,6 +58,12 @@ public class LLMModel
     
     /// <summary>模型级最大并发数</summary>
     public int MaxConcurrency { get; set; } = 5;
+
+    /// <summary>
+    /// 最大输出 Token 数（透传到大模型请求的 max_tokens/MaxTokens）
+    /// - null 表示使用服务端默认值（当前为 4096）
+    /// </summary>
+    public int? MaxTokens { get; set; }
     
     /// <summary>是否启用</summary>
     public bool Enabled { get; set; } = true;

--- a/prd-api/src/PrdAgent.Infrastructure/Services/ModelDomainService.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/ModelDomainService.cs
@@ -13,6 +13,7 @@ namespace PrdAgent.Infrastructure.Services;
 
 public class ModelDomainService : IModelDomainService
 {
+    private const int DefaultMaxTokens = 4096;
     private readonly MongoDbContext _db;
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IConfiguration _config;
@@ -66,9 +67,10 @@ public class ModelDomainService : IModelDomainService
         httpClient.BaseAddress = new Uri(apiUrlTrim.TrimEnd('#').TrimEnd('/') + "/");
 
         var enablePromptCache = mainEnablePromptCache && (model.EnablePromptCache ?? true);
+        var maxTokens = model.MaxTokens.HasValue && model.MaxTokens.Value > 0 ? model.MaxTokens.Value : DefaultMaxTokens;
         if (platformType == "anthropic" || apiUrl.Contains("anthropic.com"))
         {
-            return new ClaudeClient(httpClient, apiKey, model.ModelName, 4096, 0.2, enablePromptCache, _claudeLogger, _logWriter, _ctxAccessor, platformId, platformName);
+            return new ClaudeClient(httpClient, apiKey, model.ModelName, maxTokens, 0.2, enablePromptCache, _claudeLogger, _logWriter, _ctxAccessor, platformId, platformName);
         }
 
         // 默认 OpenAI 兼容：按 baseURL 规则选择 chat/completions 的最终调用方式
@@ -83,7 +85,7 @@ public class ModelDomainService : IModelDomainService
             httpClient,
             apiKey,
             model.ModelName,
-            1024,
+            maxTokens,
             0.2,
             enablePromptCache,
             _logWriter,


### PR DESCRIPTION
Adds configurable `maxTokens` to models and updates the default for OpenAI-compatible clients.

The previous hardcoded `max_tokens` of 1024 for OpenAI-compatible models was too restrictive, preventing longer responses and customization. This change allows users to define `maxTokens` per model and increases the default to 4096.

---
<a href="https://cursor.com/background-agent?bcId=bc-94688dc7-cf5c-4ac9-b767-ad98aef7b4f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-94688dc7-cf5c-4ac9-b767-ad98aef7b4f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables per-model control of output token limits and applies a higher default when unspecified.
> 
> - Admin UI: adds optional `Max Tokens` field in `ModelManagePage.tsx`; parses to int or `null`; passes through `createModel`/`updateModel`.
> - Types/contracts: extend `Model`, `CreateModelInput`/`UpdateModelInput` with optional `maxTokens`.
> - Mock/real services: store/forward `maxTokens`; include in POST/PUT bodies and responses.
> - API: add `MaxTokens` to `LLMModel`, `CreateModelRequest`/`UpdateModelRequest`; controller persists/updates and returns `maxTokens`.
> - Runtime: `ModelDomainService` reads `model.MaxTokens` (fallback `4096`) and passes to `OpenAIClient` and `ClaudeClient` (was `1024` for OpenAI).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef9267aa3f5b3945121b4a4f7db64fc1022243d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->