### PR TITLE
Literary agent button size

### DIFF
--- a/prd-admin/src/pages/literary-agent/LiteraryAgentWorkspaceListPage.tsx
+++ b/prd-admin/src/pages/literary-agent/LiteraryAgentWorkspaceListPage.tsx
@@ -158,15 +158,17 @@ export default function LiteraryAgentWorkspaceListPage() {
 
                 <div
                   className={[
-                    'flex items-center justify-end gap-2 flex-shrink-0',
-                    'opacity-0 translate-y-[-1px] pointer-events-none absolute right-3 top-3',
+                    // 关键：操作按钮区始终 absolute 覆盖显示，避免 hover 时从 absolute 切到 relative 造成布局抖动/撑开页面
+                    'absolute right-3 top-3 z-10',
+                    'flex items-center justify-end gap-2',
+                    'opacity-0 translate-y-[-1px] pointer-events-none',
                     'transition-all duration-150',
-                    'group-hover:opacity-100 group-hover:translate-y-0 group-hover:pointer-events-auto group-hover:relative group-hover:right-auto group-hover:top-auto',
-                    'group-focus-within:opacity-100 group-focus-within:translate-y-0 group-focus-within:pointer-events-auto group-focus-within:relative group-focus-within:right-auto group-focus-within:top-auto',
+                    'group-hover:opacity-100 group-hover:translate-y-0 group-hover:pointer-events-auto',
+                    'group-focus-within:opacity-100 group-focus-within:translate-y-0 group-focus-within:pointer-events-auto',
                   ].join(' ')}
                 >
                   <Button
-                    size="sm"
+                    size="xs"
                     variant="secondary"
                     onClick={(e) => {
                       e.stopPropagation();
@@ -174,10 +176,10 @@ export default function LiteraryAgentWorkspaceListPage() {
                     }}
                     title="编辑"
                   >
-                    <SquarePen size={14} />
+                    <SquarePen size={12} />
                   </Button>
                   <Button
-                    size="sm"
+                    size="xs"
                     variant="secondary"
                     onClick={(e) => {
                       e.stopPropagation();
@@ -185,10 +187,10 @@ export default function LiteraryAgentWorkspaceListPage() {
                     }}
                     title="重命名"
                   >
-                    <Pencil size={14} />
+                    <Pencil size={12} />
                   </Button>
                   <Button
-                    size="sm"
+                    size="xs"
                     variant="danger"
                     onClick={(e) => {
                       e.stopPropagation();
@@ -196,7 +198,7 @@ export default function LiteraryAgentWorkspaceListPage() {
                     }}
                     title="删除"
                   >
-                    <Trash2 size={14} />
+                    <Trash2 size={12} />
                   </Button>
                 </div>
               </div>

--- a/prd-admin/src/pages/literary-agent/LiteraryAgentWorkspaceListPage.tsx
+++ b/prd-admin/src/pages/literary-agent/LiteraryAgentWorkspaceListPage.tsx
@@ -45,6 +45,7 @@ function ArticlePreview({ markdown }: { markdown: string }) {
   const [overflowed, setOverflowed] = useState(false);
 
   const md = useMemo(() => String(markdown || '').trim(), [markdown]);
+  const maxHeightPx = 200; // 摘要预览固定高度：避免整篇文章把卡片撑高
 
   useLayoutEffect(() => {
     const el = rootRef.current;
@@ -69,8 +70,8 @@ function ArticlePreview({ markdown }: { markdown: string }) {
   if (!md) return <div style={{ color: 'var(--text-muted)' }}>（暂无内容）</div>;
 
   return (
-    <div className="relative h-full min-h-0 overflow-hidden">
-      <div ref={rootRef} className="h-full min-h-0 overflow-hidden">
+    <div className="relative overflow-hidden" style={{ maxHeight: maxHeightPx }}>
+      <div ref={rootRef} className="overflow-hidden" style={{ maxHeight: maxHeightPx }}>
         <style>{`
           .literary-preview-md { font-size: 12px; line-height: 1.65; color: var(--text-secondary); white-space: normal; word-break: break-word; }
           .literary-preview-md h1,.literary-preview-md h2,.literary-preview-md h3 { color: var(--text-primary); font-weight: 700; margin: 10px 0 6px; }

--- a/prd-admin/src/pages/literary-agent/LiteraryAgentWorkspaceListPage.tsx
+++ b/prd-admin/src/pages/literary-agent/LiteraryAgentWorkspaceListPage.tsx
@@ -11,6 +11,8 @@ import type { ImageMasterWorkspace } from '@/services/contracts/imageMaster';
 import { Plus, Pencil, Trash2, FileText, SquarePen } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 
 function formatDate(iso: string | null | undefined) {
   const s = String(iso ?? '').trim();
@@ -171,7 +173,7 @@ export default function LiteraryAgentWorkspaceListPage() {
               >
                 <div className="p-3 flex-1">
                   {getArticlePreviewText(ws) ? (
-                    // 预览不渲染 Markdown：用纯文本 + CSS line-clamp，按容器边界裁剪并展示省略号
+                    // 预览渲染 Markdown，但将块级结构扁平化为“单一文本流 + <br/>”，以便 line-clamp 正常工作（按边界裁剪 + 省略号）
                     <div
                       style={{
                         display: '-webkit-box',
@@ -183,7 +185,108 @@ export default function LiteraryAgentWorkspaceListPage() {
                         wordBreak: 'break-word',
                       }}
                     >
-                      {getArticlePreviewText(ws)}
+                      <ReactMarkdown
+                        remarkPlugins={[remarkGfm]}
+                        skipHtml
+                        allowedElements={[
+                          'p',
+                          'strong',
+                          'em',
+                          'code',
+                          'pre',
+                          'blockquote',
+                          'ul',
+                          'ol',
+                          'li',
+                          'a',
+                          'br',
+                          'hr',
+                          'h1',
+                          'h2',
+                          'h3',
+                        ]}
+                        unwrapDisallowed
+                        components={{
+                          // 将块级内容尽量“拍扁”，避免多块布局破坏 clamp
+                          h1: ({ children }) => (
+                            <span style={{ fontWeight: 800, color: 'var(--text-primary)' }}>
+                              {children}
+                              <br />
+                            </span>
+                          ),
+                          h2: ({ children }) => (
+                            <span style={{ fontWeight: 700, color: 'var(--text-primary)' }}>
+                              {children}
+                              <br />
+                            </span>
+                          ),
+                          h3: ({ children }) => (
+                            <span style={{ fontWeight: 700, color: 'var(--text-primary)' }}>
+                              {children}
+                              <br />
+                            </span>
+                          ),
+                          p: ({ children }) => (
+                            <span>
+                              {children}
+                              <br />
+                            </span>
+                          ),
+                          blockquote: ({ children }) => (
+                            <span style={{ color: 'rgba(231,206,151,0.92)' }}>
+                              {children}
+                              <br />
+                            </span>
+                          ),
+                          ul: ({ children }) => (
+                            <span>
+                              {children}
+                              <br />
+                            </span>
+                          ),
+                          ol: ({ children }) => (
+                            <span>
+                              {children}
+                              <br />
+                            </span>
+                          ),
+                          li: ({ children }) => (
+                            <span>
+                              • {children}
+                              <br />
+                            </span>
+                          ),
+                          code: ({ children }) => (
+                            <code
+                              style={{
+                                fontFamily:
+                                  'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+                                fontSize: 11,
+                                background: 'rgba(255,255,255,0.06)',
+                                border: '1px solid rgba(255,255,255,0.10)',
+                                padding: '0 6px',
+                                borderRadius: 8,
+                              }}
+                            >
+                              {children}
+                            </code>
+                          ),
+                          pre: ({ children }) => (
+                            <span>
+                              {children}
+                              <br />
+                            </span>
+                          ),
+                          a: ({ children }) => (
+                            <span style={{ color: 'rgba(147, 197, 253, 0.95)', textDecoration: 'underline' }}>
+                              {children}
+                            </span>
+                          ),
+                          hr: () => <br />,
+                        }}
+                      >
+                        {getArticlePreviewText(ws)}
+                      </ReactMarkdown>
                     </div>
                   ) : (
                     <div style={{ color: 'var(--text-muted)' }}>（暂无内容）</div>


### PR DESCRIPTION
Fixes layout shift on hover for Literary Agent card buttons by ensuring the button container remains absolutely positioned and reducing button sizes.

The previous implementation caused layout shifts because the button container's `position` property changed from `absolute` to `relative` on `group-hover`, forcing a reflow. This PR ensures the container always uses `absolute` positioning, preventing it from affecting the document flow, and also makes the buttons smaller for a more compact hover state.

---
<a href="https://cursor.com/background-agent?bcId=bc-d8595821-3afe-40b5-b5d7-acfd762a49e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d8595821-3afe-40b5-b5d7-acfd762a49e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

