### PR TITLE
Context compression logging

### DIFF
--- a/prd-api/src/PrdAgent.Core/Interfaces/ICacheManager.cs
+++ b/prd-api/src/PrdAgent.Core/Interfaces/ICacheManager.cs
@@ -42,6 +42,8 @@ public static class CacheKeys
     public const string Document = "document:";
     public const string ChatHistory = "chat:history:";
     public const string GroupChatHistory = "chat:history:group:";
+    // 群组上下文压缩状态（用于将较长历史压缩为摘要，避免 prompt 过长；不包含 PRD）
+    public const string GroupContextCompression = "chat:compress:group:";
     // 群组上下文重置点（用于 LLM 上下文拼接的截断，不影响消息历史）
     public const string GroupContextReset = "chat:reset:group:";
     public const string UserSession = "user:session:";
@@ -54,6 +56,7 @@ public static class CacheKeys
     public static string ForDocument(string documentId) => $"{Document}{documentId}";
     public static string ForChatHistory(string sessionId) => $"{ChatHistory}{sessionId}";
     public static string ForGroupChatHistory(string groupId) => $"{GroupChatHistory}{groupId}";
+    public static string ForGroupContextCompression(string groupId) => $"{GroupContextCompression}{groupId}";
     public static string ForGroupContextReset(string groupId) => $"{GroupContextReset}{groupId}";
 
     public static string ForAuthRefresh(string userId, string clientType, string sessionKey)

--- a/prd-api/src/PrdAgent.Core/Interfaces/ILLMRequestContextAccessor.cs
+++ b/prd-api/src/PrdAgent.Core/Interfaces/ILLMRequestContextAccessor.cs
@@ -1,5 +1,14 @@
 namespace PrdAgent.Core.Interfaces;
 
+public record GroupContextCompressionInfo(
+    bool Applied,
+    string? GroupId,
+    long? FromSeq,
+    long? ToSeq,
+    int? OriginalChars,
+    int? CompressedChars,
+    string? CompressedText);
+
 public record LlmRequestContext(
     string RequestId,
     string? GroupId,
@@ -12,7 +21,8 @@ public record LlmRequestContext(
     string? RequestType = null,
     string? RequestPurpose = null,
     string? PlatformId = null,
-    string? PlatformName = null);
+    string? PlatformName = null,
+    GroupContextCompressionInfo? GroupContextCompression = null);
 
 public interface ILLMRequestContextAccessor
 {

--- a/prd-api/src/PrdAgent.Core/Interfaces/ILlmRequestLogWriter.cs
+++ b/prd-api/src/PrdAgent.Core/Interfaces/ILlmRequestLogWriter.cs
@@ -28,7 +28,14 @@ public record LlmLogStart(
     string? RequestType = null,
     string? RequestPurpose = null,
     string? PlatformId = null,
-    string? PlatformName = null);
+    string? PlatformName = null,
+    // 群上下文压缩信息（用于管理后台清晰展示“压缩发生了什么”）
+    bool? GroupContextCompressed = null,
+    long? GroupContextCompressedFromSeq = null,
+    long? GroupContextCompressedToSeq = null,
+    int? GroupContextOriginalChars = null,
+    int? GroupContextCompressedChars = null,
+    string? GroupContextCompressedText = null);
 
 public record LlmLogDone(
     int? StatusCode,

--- a/prd-api/src/PrdAgent.Core/Models/GroupContextCompressionState.cs
+++ b/prd-api/src/PrdAgent.Core/Models/GroupContextCompressionState.cs
@@ -1,0 +1,28 @@
+namespace PrdAgent.Core.Models;
+
+/// <summary>
+/// 群上下文压缩状态（不包含 PRD）
+/// - 用于将“较长的历史消息”压缩为一段摘要，以替代原始历史传递给大模型
+/// - 该状态通常缓存于 Redis（ICacheManager），并可随时间过期；过期后可再次压缩重建
+/// </summary>
+public class GroupContextCompressionState
+{
+    public string GroupId { get; set; } = string.Empty;
+
+    /// <summary>本次摘要覆盖的群消息 seq 范围（闭区间）</summary>
+    public long FromSeq { get; set; }
+    public long ToSeq { get; set; }
+
+    /// <summary>被压缩的原始文本字符数（不含 PRD）</summary>
+    public int OriginalChars { get; set; }
+
+    /// <summary>压缩后摘要字符数</summary>
+    public int CompressedChars { get; set; }
+
+    /// <summary>压缩后的摘要文本（用于直接拼入 LLM 上下文）</summary>
+    public string CompressedText { get; set; } = string.Empty;
+
+    /// <summary>创建时间（UTC）</summary>
+    public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
+}
+

--- a/prd-api/src/PrdAgent.Core/Models/LlmRequestLog.cs
+++ b/prd-api/src/PrdAgent.Core/Models/LlmRequestLog.cs
@@ -63,6 +63,17 @@ public class LlmRequestLog
     /// </summary>
     public int? UserPromptChars { get; set; }
 
+    // 群上下文压缩（不包含 PRD）
+    public bool? GroupContextCompressed { get; set; }
+    public long? GroupContextCompressedFromSeq { get; set; }
+    public long? GroupContextCompressedToSeq { get; set; }
+    public int? GroupContextOriginalChars { get; set; }
+    public int? GroupContextCompressedChars { get; set; }
+    /// <summary>
+    /// 压缩后的摘要文本（用于排障；可能被截断；不包含 PRD）
+    /// </summary>
+    public string? GroupContextCompressedText { get; set; }
+
     /// <summary>
     /// Token 统计来源：
     /// - reported：上游 Provider 返回 usage

--- a/prd-api/src/PrdAgent.Core/Services/GroupContextCompressionPlanner.cs
+++ b/prd-api/src/PrdAgent.Core/Services/GroupContextCompressionPlanner.cs
@@ -1,0 +1,62 @@
+using PrdAgent.Core.Models;
+
+namespace PrdAgent.Core.Services;
+
+/// <summary>
+/// 纯规划器：决定“哪些消息需要被压缩、哪些保留原文”
+/// - 不做任何 I/O，不调用 LLM，便于单测
+/// </summary>
+public static class GroupContextCompressionPlanner
+{
+    public sealed record Plan(
+        bool ShouldCompress,
+        IReadOnlyList<Message> ToCompress,
+        IReadOnlyList<Message> KeepRaw,
+        int TotalCharsBefore);
+
+    public static Plan CreatePlan(
+        IReadOnlyList<Message> orderedMessages,
+        int thresholdChars,
+        int targetKeepMaxChars,
+        int minKeepCount,
+        Func<Message, bool>? exclude = null)
+    {
+        exclude ??= (_ => false);
+        var msgs = orderedMessages.Where(m => m != null && !exclude(m)).ToList();
+
+        var total = msgs.Sum(m => (m.Content ?? string.Empty).Length);
+        if (total <= thresholdChars)
+        {
+            return new Plan(false, Array.Empty<Message>(), msgs, total);
+        }
+
+        // 从后往前保留，直到 keepChars <= targetKeepMaxChars 或达到 minKeepCount
+        var keep = new List<Message>();
+        var keepChars = 0;
+        for (var i = msgs.Count - 1; i >= 0; i--)
+        {
+            var m = msgs[i];
+            keep.Insert(0, m);
+            keepChars += (m.Content ?? string.Empty).Length;
+            if (keep.Count >= minKeepCount && keepChars >= targetKeepMaxChars)
+            {
+                // 已达到“至少保留 minKeepCount”且 keep 已足够大，停止继续扩大 keep
+                break;
+            }
+        }
+
+        // 确保至少保留 minKeepCount
+        if (keep.Count < minKeepCount)
+        {
+            var need = Math.Min(minKeepCount, msgs.Count);
+            keep = msgs.TakeLast(need).ToList();
+        }
+
+        var keepSet = new HashSet<string>(keep.Select(m => m.Id));
+        var toCompress = msgs.Where(m => !keepSet.Contains(m.Id)).ToList();
+
+        // 若没有可压缩内容（全部都在 keep），则仍返回 shouldCompress=true（调用方可选择“强制压缩 keep 的前半段”或退化截断）
+        return new Plan(true, toCompress, keep, total);
+    }
+}
+

--- a/prd-api/src/PrdAgent.Infrastructure/LLM/ClaudeClient.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LLM/ClaudeClient.cs
@@ -203,6 +203,7 @@ public class ClaudeClient : ILLMClient
             };
             if (enablePromptCache) headers["anthropic-beta"] = "prompt-caching-2024-07-31";
 
+            var comp = ctx?.GroupContextCompression;
             logId = await _logWriter.StartAsync(
                 new LlmLogStart(
                     RequestId: requestId,
@@ -230,7 +231,13 @@ public class ClaudeClient : ILLMClient
                     UserPromptChars: userPromptChars,
                     StartedAt: startedAt,
                     PlatformId: _platformId,
-                    PlatformName: _platformName),
+                    PlatformName: _platformName,
+                    GroupContextCompressed: comp?.Applied,
+                    GroupContextCompressedFromSeq: comp?.FromSeq,
+                    GroupContextCompressedToSeq: comp?.ToSeq,
+                    GroupContextOriginalChars: comp?.OriginalChars,
+                    GroupContextCompressedChars: comp?.CompressedChars,
+                    GroupContextCompressedText: comp?.CompressedText),
                 cancellationToken);
         }
 

--- a/prd-api/src/PrdAgent.Infrastructure/LLM/LlmRequestLogWriter.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LLM/LlmRequestLogWriter.cs
@@ -64,6 +64,14 @@ public class LlmRequestLogWriter : ILlmRequestLogWriter
                 DocumentChars = start.DocumentChars,
                 DocumentHash = start.DocumentHash,
                 UserPromptChars = start.UserPromptChars,
+                    GroupContextCompressed = start.GroupContextCompressed,
+                    GroupContextCompressedFromSeq = start.GroupContextCompressedFromSeq,
+                    GroupContextCompressedToSeq = start.GroupContextCompressedToSeq,
+                    GroupContextOriginalChars = start.GroupContextOriginalChars,
+                    GroupContextCompressedChars = start.GroupContextCompressedChars,
+                    GroupContextCompressedText = string.IsNullOrWhiteSpace(start.GroupContextCompressedText)
+                        ? null
+                        : Truncate(start.GroupContextCompressedText, requestBodyMaxChars),
                 StartedAt = start.StartedAt,
                 Status = "running"
             };

--- a/prd-api/src/PrdAgent.Infrastructure/LLM/OpenAIClient.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LLM/OpenAIClient.cs
@@ -164,6 +164,7 @@ public class OpenAIClient : ILLMClient
 
             var reqLogJson = LlmLogRedactor.RedactJson(JsonSerializer.Serialize(reqForLog));
             var (apiBaseForLog, pathForLog) = OpenAICompatUrl.SplitApiBaseAndPath(_chatCompletionsEndpointOrPath, _httpClient.BaseAddress);
+            var comp = ctx?.GroupContextCompression;
             logId = await _logWriter.StartAsync(
                 new LlmLogStart(
                     RequestId: requestId,
@@ -197,7 +198,13 @@ public class OpenAIClient : ILLMClient
                     UserPromptChars: userPromptChars,
                     StartedAt: startedAt,
                     PlatformId: _platformId,
-                    PlatformName: _platformName),
+                    PlatformName: _platformName,
+                    GroupContextCompressed: comp?.Applied,
+                    GroupContextCompressedFromSeq: comp?.FromSeq,
+                    GroupContextCompressedToSeq: comp?.ToSeq,
+                    GroupContextOriginalChars: comp?.OriginalChars,
+                    GroupContextCompressedChars: comp?.CompressedChars,
+                    GroupContextCompressedText: comp?.CompressedText),
                 cancellationToken);
         }
 

--- a/prd-api/tests/PrdAgent.Api.Tests/Services/GroupContextCompressionPlannerTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Services/GroupContextCompressionPlannerTests.cs
@@ -1,0 +1,80 @@
+using PrdAgent.Core.Models;
+using PrdAgent.Core.Services;
+using Xunit;
+
+namespace PrdAgent.Api.Tests.Services;
+
+public class GroupContextCompressionPlannerTests
+{
+    [Fact]
+    public void CreatePlan_WhenBelowThreshold_ShouldNotCompress()
+    {
+        var msgs = new List<Message>
+        {
+            new() { Id = "1", Content = "a", GroupSeq = 1 },
+            new() { Id = "2", Content = "bb", GroupSeq = 2 },
+        };
+
+        var plan = GroupContextCompressionPlanner.CreatePlan(
+            msgs,
+            thresholdChars: 10,
+            targetKeepMaxChars: 5,
+            minKeepCount: 1);
+
+        Assert.False(plan.ShouldCompress);
+        Assert.Empty(plan.ToCompress);
+        Assert.Equal(2, plan.KeepRaw.Count);
+        Assert.Equal(3, plan.TotalCharsBefore);
+    }
+
+    [Fact]
+    public void CreatePlan_WhenAboveThreshold_ShouldPlanCompressionAndKeepAtLeastMinCount()
+    {
+        static Message M(string id, int len, long seq)
+            => new() { Id = id, Content = new string('x', len), GroupSeq = seq };
+
+        var msgs = new List<Message>
+        {
+            M("1", 20, 1),
+            M("2", 20, 2),
+            M("3", 20, 3),
+            M("4", 20, 4),
+            M("5", 20, 5),
+        };
+
+        var plan = GroupContextCompressionPlanner.CreatePlan(
+            msgs,
+            thresholdChars: 50,
+            targetKeepMaxChars: 30,
+            minKeepCount: 2);
+
+        Assert.True(plan.ShouldCompress);
+        Assert.True(plan.KeepRaw.Count >= 2);
+        Assert.True(plan.ToCompress.Count >= 1);
+        Assert.Equal(100, plan.TotalCharsBefore);
+    }
+
+    [Fact]
+    public void CreatePlan_ShouldRespectExcludePredicate()
+    {
+        var msgs = new List<Message>
+        {
+            new() { Id = "1", Content = "aaa", GroupSeq = 1 },
+            new() { Id = "2", Content = "[[SYS:CONTEXT_COMPRESSED]] notice", GroupSeq = 2 },
+            new() { Id = "3", Content = "bbb", GroupSeq = 3 },
+        };
+
+        var plan = GroupContextCompressionPlanner.CreatePlan(
+            msgs,
+            thresholdChars: 4,
+            targetKeepMaxChars: 2,
+            minKeepCount: 1,
+            exclude: m => (m.Content ?? "").Contains("[[SYS:CONTEXT_COMPRESSED]]"));
+
+        Assert.True(plan.ShouldCompress);
+        Assert.DoesNotContain(plan.ToCompress, m => (m.Content ?? "").Contains("[[SYS:CONTEXT_COMPRESSED]]"));
+        Assert.DoesNotContain(plan.KeepRaw, m => (m.Content ?? "").Contains("[[SYS:CONTEXT_COMPRESSED]]"));
+        Assert.Equal(6, plan.TotalCharsBefore); // only aaa + bbb
+    }
+}
+


### PR DESCRIPTION
Implement group chat context compression to prevent LLM prompt overflow, improve performance, and reduce costs when history (excluding PRD) exceeds 50,000 characters.

The compression mechanism summarizes older messages while retaining recent ones and the current user's request core. Compression details, including the sequence range and compressed text, are logged in `LlmRequestLog` for traceability. A system message is also posted in the group to inform members about the compression. PRD content is explicitly excluded from the compression process.

---
<a href="https://cursor.com/background-agent?bcId=bc-7508ba96-98ff-4ed9-aa48-423ad6b08c03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7508ba96-98ff-4ed9-aa48-423ad6b08c03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

