### PR TITLE
Fix duplicated rich composer text

### DIFF
--- a/prd-admin/src/components/RichComposer/index.tsx
+++ b/prd-admin/src/components/RichComposer/index.tsx
@@ -14,6 +14,7 @@ import {
   $getRoot,
   $getSelection,
   $isRangeSelection,
+  $isTextNode,
   COMMAND_PRIORITY_HIGH,
   KEY_ENTER_COMMAND,
 } from 'lexical';
@@ -89,17 +90,17 @@ function EditorInner({
         const imageRefs: Array<{ canvasKey: string; refId: number }> = [];
         editor.getEditorState().read(() => {
           const root = $getRoot();
-          // 遍历所有节点
+          text = root.getTextContent();
+          // 遍历所有节点（只收集 image refs，避免重复拼接文本）
           const traverse = (node: any) => {
             if ($isImageChipNode(node)) {
-              text += `@img${node.getRefId()}`;
               imageRefs.push({
                 canvasKey: node.getCanvasKey(),
                 refId: node.getRefId(),
               });
-            } else if (node.getTextContent) {
-              text += node.getTextContent();
+              return;
             }
+            if ($isTextNode(node)) return;
             if (node.getChildren) {
               for (const child of node.getChildren()) {
                 traverse(child);


### PR DESCRIPTION
### Motivation
- The RichComposer `getStructuredContent` previously concatenated node text while traversing the tree which could duplicate text (root text + child text) and cause repeated user prompts being sent.

### Description
- Use `root.getTextContent()` for the message text and only traverse nodes to collect image chips, avoiding appending text during traversal, and add import of `$isTextNode` to skip text nodes when scanning for image refs.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967dc60c0a8832e914347f3b044b5e7)