### PR TITLE
Add admin notification system and permission-catalog alerts

### DIFF
--- a/prd-admin/src/pages/ai-chat/AdvancedImageMasterTab.tsx
+++ b/prd-admin/src/pages/ai-chat/AdvancedImageMasterTab.tsx
@@ -11,6 +11,7 @@ import {
   deleteImageMasterWorkspaceAsset,
   createWorkspaceImageGenRun,
   getImageMasterWorkspaceDetail,
+  getImageGenSizeCaps,
   getModels,
   planImageGen,
   refreshImageMasterWorkspaceCover,
@@ -755,14 +756,15 @@ export default function AdvancedImageMasterTab(props: { workspaceId: string; ini
       setAllowedSizes([]);
       return;
     }
-    fetch('/api/v1/admin/image-gen/size-caps?includeFallback=true', {
-      headers: { Authorization: `Bearer ${localStorage.getItem('token') || ''}` },
-    })
-      .then((r) => r.json())
-      .then((data) => {
-        const caps = (data?.data ?? []).find((x: any) => x.modelId === modelId);
+    getImageGenSizeCaps({ includeFallback: true })
+      .then((res) => {
+        if (!res.success) {
+          setAllowedSizes([]);
+          return;
+        }
+        const caps = (res.data?.items ?? []).find((x) => x.modelId === modelId);
         const sizes = Array.isArray(caps?.allowedSizes) ? caps.allowedSizes : [];
-        setAllowedSizes(sizes.map((s: string) => String(s).trim().toLowerCase()));
+        setAllowedSizes(sizes.map((s) => String(s).trim().toLowerCase()));
       })
       .catch(() => setAllowedSizes([]));
   }, [effectiveModel?.id]);

--- a/prd-admin/src/services/contracts/imageGen.ts
+++ b/prd-admin/src/services/contracts/imageGen.ts
@@ -72,6 +72,7 @@ export type ImageGenSizeCapsItem = {
   modelId?: string | null;
   platformId?: string | null;
   modelName?: string | null;
+  allowedSizes?: string[];
   allowedCount: number;
   updatedAt: string;
 };
@@ -179,4 +180,3 @@ export type StreamImageGenRunWithRetryContract = (args: {
   /** 最大重连次数；默认 10（含首次连接） */
   maxAttempts?: number;
 }) => Promise<ApiResponse<true>>;
-

--- a/prd-admin/src/services/contracts/notifications.ts
+++ b/prd-admin/src/services/contracts/notifications.ts
@@ -1,0 +1,26 @@
+import type { ApiResponse } from '@/types/api';
+
+export type AdminNotificationItem = {
+  id: string;
+  key?: string | null;
+  title: string;
+  message?: string | null;
+  level: 'info' | 'warning' | 'error' | 'success' | (string & {});
+  status: 'open' | 'handled' | (string & {});
+  actionLabel?: string | null;
+  actionUrl?: string | null;
+  actionKind?: string | null;
+  source?: string | null;
+  createdAt: string;
+  updatedAt: string;
+  handledAt?: string | null;
+  expiresAt?: string | null;
+};
+
+export type GetAdminNotificationsResponse = {
+  items: AdminNotificationItem[];
+};
+
+export type GetAdminNotificationsContract = (args?: { includeHandled?: boolean }) => Promise<ApiResponse<GetAdminNotificationsResponse>>;
+export type HandleAdminNotificationContract = (id: string) => Promise<ApiResponse<{ handled: boolean }>>;
+export type HandleAllAdminNotificationsContract = () => Promise<ApiResponse<{ handled: boolean }>>;

--- a/prd-admin/src/services/index.ts
+++ b/prd-admin/src/services/index.ts
@@ -13,6 +13,11 @@ import type {
   UpdateUserAuthzContract,
 } from '@/services/contracts/authz';
 import type {
+  GetAdminNotificationsContract,
+  HandleAdminNotificationContract,
+  HandleAllAdminNotificationsContract,
+} from '@/services/contracts/notifications';
+import type {
   GetUsersContract,
   GenerateInviteCodesContract,
   CreateAdminUserContract,
@@ -285,6 +290,11 @@ import { ModelGroupsService } from '@/services/real/modelGroups';
 import { AppCallersService } from '@/services/real/appCallers';
 import { SchedulerConfigService } from '@/services/real/schedulerConfig';
 import { getUserPreferencesReal, updateNavOrderReal } from '@/services/real/userPreferences';
+import {
+  getAdminNotificationsReal,
+  handleAdminNotificationReal,
+  handleAllAdminNotificationsReal,
+} from '@/services/real/notifications';
 
 function withAuth<TArgs extends unknown[], TResult>(
   fn: (...args: TArgs) => Promise<ApiResponse<TResult>>
@@ -307,6 +317,9 @@ export const deleteSystemRole: DeleteSystemRoleContract = withAuth(deleteSystemR
 export const resetBuiltInSystemRoles: ResetBuiltInSystemRolesContract = withAuth(resetBuiltInSystemRolesReal);
 export const getUserAuthz: GetUserAuthzContract = withAuth(getUserAuthzReal);
 export const updateUserAuthz: UpdateUserAuthzContract = withAuth(updateUserAuthzReal);
+export const getAdminNotifications: GetAdminNotificationsContract = withAuth(getAdminNotificationsReal);
+export const handleAdminNotification: HandleAdminNotificationContract = withAuth(handleAdminNotificationReal);
+export const handleAllAdminNotifications: HandleAllAdminNotificationsContract = withAuth(handleAllAdminNotificationsReal);
 
 export const getUsers: GetUsersContract = withAuth(getUsersReal);
 export const createUser: CreateAdminUserContract = withAuth(createUserReal);

--- a/prd-admin/src/services/real/notifications.ts
+++ b/prd-admin/src/services/real/notifications.ts
@@ -1,0 +1,22 @@
+import { apiRequest } from '@/services/real/apiClient';
+import type {
+  GetAdminNotificationsContract,
+  HandleAdminNotificationContract,
+  HandleAllAdminNotificationsContract,
+  GetAdminNotificationsResponse,
+} from '@/services/contracts/notifications';
+
+export const getAdminNotificationsReal: GetAdminNotificationsContract = async (args) => {
+  const includeHandled = Boolean(args?.includeHandled);
+  const qs = includeHandled ? '?includeHandled=true' : '';
+  return await apiRequest<GetAdminNotificationsResponse>(`/api/v1/admin/notifications${qs}`, { method: 'GET' });
+};
+
+export const handleAdminNotificationReal: HandleAdminNotificationContract = async (id) => {
+  const nid = encodeURIComponent(String(id || '').trim());
+  return await apiRequest<{ handled: boolean }>(`/api/v1/admin/notifications/${nid}/handle`, { method: 'POST', body: {} });
+};
+
+export const handleAllAdminNotificationsReal: HandleAllAdminNotificationsContract = async () => {
+  return await apiRequest<{ handled: boolean }>(`/api/v1/admin/notifications/handle-all`, { method: 'POST', body: {} });
+};

--- a/prd-api/src/PrdAgent.Api/Controllers/Admin/AdminImageGenController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Admin/AdminImageGenController.cs
@@ -190,6 +190,7 @@ public class AdminImageGenController : ControllerBase
                 x.ModelId,
                 x.PlatformId,
                 x.ModelName,
+                allowedSizes = x.AllowedSizes,
                 allowedCount = x.AllowedSizes.Count,
                 x.UpdatedAt
             })
@@ -1244,4 +1245,3 @@ public class ImageGenRunPlanItemInput
     public int Count { get; set; } = 1;
     public string? Size { get; set; }
 }
-

--- a/prd-api/src/PrdAgent.Api/Controllers/Admin/AdminNotificationsController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Admin/AdminNotificationsController.cs
@@ -1,0 +1,99 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using MongoDB.Driver;
+using PrdAgent.Api.Models;
+using PrdAgent.Core.Models;
+using PrdAgent.Infrastructure.Database;
+
+namespace PrdAgent.Api.Controllers.Admin;
+
+[ApiController]
+[Route("api/v1/admin/notifications")]
+[Authorize]
+public sealed class AdminNotificationsController : ControllerBase
+{
+    private readonly MongoDbContext _db;
+
+    public AdminNotificationsController(MongoDbContext db)
+    {
+        _db = db;
+    }
+
+    [HttpGet]
+    [ProducesResponseType(typeof(ApiResponse<object>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> List([FromQuery] bool includeHandled = false, CancellationToken ct = default)
+    {
+        var now = DateTime.UtcNow;
+        var filter = Builders<AdminNotification>.Filter.Empty;
+        filter &= Builders<AdminNotification>.Filter.Or(
+            Builders<AdminNotification>.Filter.Eq(x => x.ExpiresAt, null),
+            Builders<AdminNotification>.Filter.Gt(x => x.ExpiresAt, now));
+
+        if (!includeHandled)
+        {
+            filter &= Builders<AdminNotification>.Filter.Eq(x => x.Status, "open");
+        }
+
+        var items = await _db.AdminNotifications
+            .Find(filter)
+            .SortByDescending(x => x.CreatedAt)
+            .Limit(200)
+            .ToListAsync(ct);
+
+        return Ok(ApiResponse<object>.Ok(new
+        {
+            items = items.Select(x => new
+            {
+                x.Id,
+                x.Key,
+                x.Title,
+                x.Message,
+                x.Level,
+                x.Status,
+                x.ActionLabel,
+                x.ActionUrl,
+                x.ActionKind,
+                x.Source,
+                x.CreatedAt,
+                x.UpdatedAt,
+                x.HandledAt,
+                x.ExpiresAt
+            })
+        }));
+    }
+
+    [HttpPost("{id}/handle")]
+    [ProducesResponseType(typeof(ApiResponse<object>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> Handle([FromRoute] string id, CancellationToken ct = default)
+    {
+        var nid = (id ?? string.Empty).Trim();
+        if (string.IsNullOrWhiteSpace(nid))
+        {
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "id 不能为空"));
+        }
+
+        var now = DateTime.UtcNow;
+        var update = Builders<AdminNotification>.Update
+            .Set(x => x.Status, "handled")
+            .Set(x => x.HandledAt, now)
+            .Set(x => x.UpdatedAt, now);
+
+        await _db.AdminNotifications.UpdateOneAsync(x => x.Id == nid, update, cancellationToken: ct);
+        return Ok(ApiResponse<object>.Ok(new { handled = true }));
+    }
+
+    [HttpPost("handle-all")]
+    [ProducesResponseType(typeof(ApiResponse<object>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> HandleAll(CancellationToken ct = default)
+    {
+        var now = DateTime.UtcNow;
+        var filter = Builders<AdminNotification>.Filter.Eq(x => x.Status, "open");
+        var update = Builders<AdminNotification>.Update
+            .Set(x => x.Status, "handled")
+            .Set(x => x.HandledAt, now)
+            .Set(x => x.UpdatedAt, now);
+
+        await _db.AdminNotifications.UpdateManyAsync(filter, update, cancellationToken: ct);
+        return Ok(ApiResponse<object>.Ok(new { handled = true }));
+    }
+}

--- a/prd-api/src/PrdAgent.Api/Middleware/AdminPermissionMiddleware.cs
+++ b/prd-api/src/PrdAgent.Api/Middleware/AdminPermissionMiddleware.cs
@@ -36,6 +36,11 @@ public sealed class AdminPermissionMiddleware
             return AdminPermissionCatalog.AdminAccess;
         }
 
+        if (path.StartsWith("/api/v1/admin/notifications", StringComparison.OrdinalIgnoreCase))
+        {
+            return AdminPermissionCatalog.AdminAccess;
+        }
+
         // 权限管理本身（最敏感）
         if (path.StartsWith("/api/v1/admin/authz", StringComparison.OrdinalIgnoreCase) ||
             path.StartsWith("/api/v1/admin/system-roles", StringComparison.OrdinalIgnoreCase) ||
@@ -183,4 +188,3 @@ public sealed class AdminPermissionMiddleware
         await _next(context);
     }
 }
-

--- a/prd-api/src/PrdAgent.Core/Models/AdminNotification.cs
+++ b/prd-api/src/PrdAgent.Core/Models/AdminNotification.cs
@@ -1,0 +1,27 @@
+namespace PrdAgent.Core.Models;
+
+public class AdminNotification
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString("N");
+
+    /// <summary>
+    /// 用于幂等去重的业务键（如 "permission-catalog-updated"）。
+    /// </summary>
+    public string? Key { get; set; }
+
+    public string Title { get; set; } = string.Empty;
+    public string? Message { get; set; }
+    public string Level { get; set; } = "info";
+    public string Status { get; set; } = "open";
+
+    public string? ActionLabel { get; set; }
+    public string? ActionUrl { get; set; }
+    public string? ActionKind { get; set; }
+
+    public string Source { get; set; } = "system";
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime? HandledAt { get; set; }
+    public DateTime? ExpiresAt { get; set; }
+}

--- a/prd-api/src/PrdAgent.Core/Models/AppSettings.cs
+++ b/prd-api/src/PrdAgent.Core/Models/AppSettings.cs
@@ -51,7 +51,16 @@ public class AppSettings
     /// </summary>
     public string? DesktopLoginBackgroundKey { get; set; }
 
+    /// <summary>
+    /// 权限目录 Hash，用于检测新增权限并提示管理员更新角色。
+    /// </summary>
+    public string? PermissionCatalogHash { get; set; }
+
+    /// <summary>
+    /// 权限目录更新时间（记录目录 Hash 最近一次更新）。
+    /// </summary>
+    public DateTime? PermissionCatalogUpdatedAt { get; set; }
+
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 }
-
 

--- a/prd-api/src/PrdAgent.Infrastructure/Database/BsonClassMapRegistration.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Database/BsonClassMapRegistration.cs
@@ -53,6 +53,7 @@ public static class BsonClassMapRegistration
             RegisterImageGenRunEvent();
             RegisterAdminPromptOverride();
             RegisterAdminIdempotencyRecord();
+            RegisterAdminNotification();
             RegisterSystemPromptSettings();
             RegisterDesktopAssetSkin();
             RegisterDesktopAssetKey();
@@ -357,6 +358,20 @@ public static class BsonClassMapRegistration
             cm.MapIdMember(s => s.Id)
                 .SetSerializer(new StringOrObjectIdSerializer())
                 .SetIdGenerator(GuidStringIdGenerator.Instance);
+        });
+    }
+
+    private static void RegisterAdminNotification()
+    {
+        if (BsonClassMap.IsClassMapRegistered(typeof(AdminNotification))) return;
+
+        BsonClassMap.RegisterClassMap<AdminNotification>(cm =>
+        {
+            cm.AutoMap();
+            cm.MapIdMember(x => x.Id)
+                .SetSerializer(new StringOrObjectIdSerializer())
+                .SetIdGenerator(GuidStringIdGenerator.Instance);
+            cm.SetIgnoreExtraElements(true);
         });
     }
 

--- a/prd-api/src/PrdAgent.Infrastructure/Database/MongoDbContext.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Database/MongoDbContext.cs
@@ -44,6 +44,7 @@ public class MongoDbContext
     public IMongoCollection<LLMPlatform> LLMPlatforms => _database.GetCollection<LLMPlatform>("llmplatforms");
     public IMongoCollection<LLMModel> LLMModels => _database.GetCollection<LLMModel>("llmmodels");
     public IMongoCollection<AppSettings> AppSettings => _database.GetCollection<AppSettings>("appsettings");
+    public IMongoCollection<AdminNotification> AdminNotifications => _database.GetCollection<AdminNotification>("admin_notifications");
     /// <summary>
     /// Prompts 配置（集合名保持 promptstages 以兼容历史数据；语义已迁移为“提示词”）
     /// </summary>


### PR DESCRIPTION
### Motivation
- Provide a built-in system notification feature so the backend can push admin-facing notices (站内信) that appear as a bottom-right toast and in the avatar dropdown list. 
- Alert administrators when the permission catalog changes so they are reminded to re-import/reset built-in roles after deploys or code changes. 
- Replace fragile ad-hoc fetch for image-gen size caps with the authenticated client call and include `allowedSizes` in the API projection for correct frontend behavior.

### Description
- Backend: add `AdminNotification` model and `admin_notifications` collection, register BSON mapping, and expose `GET /api/v1/admin/notifications`, `POST /api/v1/admin/notifications/{id}/handle` and `POST /api/v1/admin/notifications/handle-all` endpoints in `AdminNotificationsController` to list and mark notifications handled. 
- Backend: track permission catalog hash in `AppSettings` and on admin login (`/api/v1/admin/authz/me`) compute the catalog hash and insert a system notification when it differs to prompt admins to review permissions; allow notification endpoints in `AdminPermissionMiddleware`. 
- Backend: include `allowedSizes` in `GetSizeCaps` projection in `AdminImageGenController` so callers receive the full whitelist. 
- Frontend: add notification client contracts and real implementations (`notifications.ts`), register them in the service index, and add UI in `AppShell.tsx` implementing a toast-style bottom-right notification, avatar-dropdown entry that opens a notification dialog with listing, `一键处理` (handle-all) and per-notification `去处理` / mark-as-handled behavior. 
- Frontend: switch `AdvancedImageMasterTab.tsx` from a raw `fetch` using `localStorage` to calling the authenticated `getImageGenSizeCaps` service and use `allowedSizes` from the response. 

### Testing
- No automated unit or integration tests were executed as part of this change. 
- A Playwright screenshot attempt was run but failed with `ERR_EMPTY_RESPONSE` because the local frontend server at `http://localhost:5173` was not running. 
- The code changes were added and committed locally; runtime verification (build/start) was not performed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696847f1f50c832ea1933d8bfc60e3f3)