### PR TITLE
Fix watermark layout scaling and image-based sizing

### DIFF
--- a/prd-admin/src/components/watermark/WatermarkSettingsPanel.tsx
+++ b/prd-admin/src/components/watermark/WatermarkSettingsPanel.tsx
@@ -469,12 +469,12 @@ function WatermarkPreview(props: {
   const iconSize = fontSize;
   const gap = fontSize / 4;
 
-  // 水印位置：基于短边计算偏移，保持相对于画布中心的视觉位置一致
+  // 水印位置：基于画布宽高计算，保持比例一致
   // posXRatio/posYRatio 范围 0~1，0.5 表示中心
   const offsetX = spec.posXRatio - 0.5; // 相对于中心的 X 偏移
   const offsetY = spec.posYRatio - 0.5; // 相对于中心的 Y 偏移
-  const centerX = width / 2 + offsetX * shortSide;
-  const centerY = canvasHeight / 2 + offsetY * shortSide;
+  const centerX = width / 2 + offsetX * width;
+  const centerY = canvasHeight / 2 + offsetY * canvasHeight;
 
   // 使用 ref 存储回调和位置，避免依赖变化导致拖拽中断
   const posRef = useRef({ x: spec.posXRatio, y: spec.posYRatio });

--- a/prd-api/src/PrdAgent.Core/Models/WatermarkSpec.cs
+++ b/prd-api/src/PrdAgent.Core/Models/WatermarkSpec.cs
@@ -25,4 +25,6 @@ public class WatermarkSpec
     public string? ModelKey { get; set; }
 
     public string? Color { get; set; }
+
+    public bool ScaleWithImage { get; set; }
 }

--- a/prd-api/src/PrdAgent.Infrastructure/Services/WatermarkLayoutCalculator.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/WatermarkLayoutCalculator.cs
@@ -4,15 +4,20 @@ namespace PrdAgent.Infrastructure.Services;
 
 public static class WatermarkLayoutCalculator
 {
-    public static (double centerX, double centerY) CalculateTextCenter(WatermarkSpec spec, int targetWidth)
+    public static (double centerX, double centerY) CalculateTextCenter(WatermarkSpec spec, int targetWidth, int targetHeight)
     {
         var x = spec.PosXRatio * targetWidth;
-        var y = spec.PosYRatio * targetWidth;
+        var y = spec.PosYRatio * targetHeight;
         return (x, y);
     }
 
     public static double CalculateScaledFontSize(WatermarkSpec spec, int targetWidth)
     {
+        if (!spec.ScaleWithImage)
+        {
+            return Math.Max(1d, spec.FontSizePx);
+        }
+
         var scale = spec.BaseCanvasWidth > 0 ? targetWidth / (double)spec.BaseCanvasWidth : 1d;
         if (!double.IsFinite(scale) || scale <= 0) scale = 1d;
         return Math.Max(1d, spec.FontSizePx * scale);

--- a/prd-api/src/PrdAgent.Infrastructure/Services/WatermarkRenderer.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/WatermarkRenderer.cs
@@ -45,7 +45,7 @@ public class WatermarkRenderer
         var textHeight = textSize.Height;
         var textWidth = textSize.Width;
 
-        var (centerX, centerY) = WatermarkLayoutCalculator.CalculateTextCenter(spec, image.Width);
+        var (centerX, centerY) = WatermarkLayoutCalculator.CalculateTextCenter(spec, image.Width, image.Height);
         var textLeft = (float)(centerX - textWidth / 2);
         var textTop = (float)(centerY - textHeight / 2);
 


### PR DESCRIPTION
### Motivation

- Ensure watermark stays correctly positioned across different canvas aspect ratios and avoid clustering or overflow seen when using a single short-side offset. 
- Make the `scaleWithImage` behavior effective so font sizing follows actual image width only when enabled.

### Description

- Adjusted preview positioning in `WatermarkPreview` to compute center using canvas width/height instead of the short side so `posXRatio`/`posYRatio` map correctly on non-square canvases (`prd-admin/src/components/watermark/WatermarkSettingsPanel.tsx`).
- Added `ScaleWithImage` to the backend `WatermarkSpec` model to persist the frontend `scaleWithImage` flag (`prd-api/src/PrdAgent.Core/Models/WatermarkSpec.cs`).
- Updated `WatermarkLayoutCalculator.CalculateTextCenter` to accept `targetHeight` and compute Y using image height, and changed `CalculateScaledFontSize` to only scale when `ScaleWithImage` is true (`prd-api/src/PrdAgent.Infrastructure/Services/WatermarkLayoutCalculator.cs`).
- Updated `WatermarkRenderer` to pass both `image.Width` and `image.Height` into the layout calculator so server-side rendering matches the new layout rules (`prd-api/src/PrdAgent.Infrastructure/Services/WatermarkRenderer.cs`).

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69689681e1c0832eac96f09aab641f76)