### PR TITLE
Support custom watermark fonts; add border/background and color controls to watermark UI and renderer

### DIFF
--- a/prd-admin/src/services/contracts/watermark.ts
+++ b/prd-admin/src/services/contracts/watermark.ts
@@ -12,9 +12,13 @@ export type WatermarkSpec = {
   offsetY: number;
   iconEnabled: boolean;
   iconImageRef?: string | null;
+  borderEnabled?: boolean;
+  backgroundEnabled?: boolean;
   baseCanvasWidth: number;
   modelKey?: string | null;
   color?: string | null;
+  textColor?: string | null;
+  backgroundColor?: string | null;
 };
 
 export type WatermarkSettings = {
@@ -44,3 +48,5 @@ export type GetWatermarkContract = () => Promise<ApiResponse<WatermarkSettings>>
 export type PutWatermarkContract = (input: { spec: WatermarkSpec }) => Promise<ApiResponse<WatermarkSettings>>;
 export type GetWatermarkFontsContract = () => Promise<ApiResponse<WatermarkFontInfo[]>>;
 export type GetModelSizesContract = (input: { modelKey: string }) => Promise<ApiResponse<{ modelKey: string; sizes: ModelSizeInfo[] }>>;
+export type UploadWatermarkFontContract = (input: { file: File; displayName?: string }) => Promise<ApiResponse<WatermarkFontInfo>>;
+export type DeleteWatermarkFontContract = (input: { fontKey: string }) => Promise<ApiResponse<{ deleted: boolean }>>;

--- a/prd-admin/src/services/index.ts
+++ b/prd-admin/src/services/index.ts
@@ -149,6 +149,8 @@ import type {
   GetModelSizesContract,
   GetWatermarkContract,
   GetWatermarkFontsContract,
+  UploadWatermarkFontContract,
+  DeleteWatermarkFontContract,
   PutWatermarkContract,
 } from '@/services/contracts/watermark';
 import { useAuthStore } from '@/stores/authStore';
@@ -187,7 +189,14 @@ import { activateLLMConfigReal, createLLMConfigReal, deleteLLMConfigReal, getLLM
 import { getLlmLogDetailReal, getLlmLogsMetaReal, getLlmLogsReal, getLlmModelStatsReal } from '@/services/real/llmLogs';
 import { getAdminDocumentContentReal } from '@/services/real/adminDocuments';
 import { listUploadArtifactsReal } from '@/services/real/uploadArtifacts';
-import { getModelSizesReal, getWatermarkFontsReal, getWatermarkReal, putWatermarkReal } from '@/services/real/watermark';
+import {
+  deleteWatermarkFontReal,
+  getModelSizesReal,
+  getWatermarkFontsReal,
+  getWatermarkReal,
+  putWatermarkReal,
+  uploadWatermarkFontReal,
+} from '@/services/real/watermark';
 import { adminImpersonateReal } from '@/services/real/lab';
 import {
   createModelLabExperimentReal,
@@ -552,4 +561,6 @@ export const updateNavOrder: UpdateNavOrderContract = withAuth(updateNavOrderRea
 export const getWatermark: GetWatermarkContract = withAuth(getWatermarkReal);
 export const putWatermark: PutWatermarkContract = withAuth(putWatermarkReal);
 export const getWatermarkFonts: GetWatermarkFontsContract = withAuth(getWatermarkFontsReal);
+export const uploadWatermarkFont: UploadWatermarkFontContract = withAuth(uploadWatermarkFontReal);
+export const deleteWatermarkFont: DeleteWatermarkFontContract = withAuth(deleteWatermarkFontReal);
 export const getModelSizes: GetModelSizesContract = withAuth(getModelSizesReal);

--- a/prd-admin/src/services/real/watermark.ts
+++ b/prd-admin/src/services/real/watermark.ts
@@ -1,10 +1,15 @@
 import { apiRequest } from '@/services/real/apiClient';
+import { useAuthStore } from '@/stores/authStore';
 import type {
   GetModelSizesContract,
   GetWatermarkContract,
   GetWatermarkFontsContract,
+  UploadWatermarkFontContract,
+  DeleteWatermarkFontContract,
   PutWatermarkContract,
+  WatermarkFontInfo,
 } from '@/services/contracts/watermark';
+import type { ApiResponse } from '@/types/api';
 
 export const getWatermarkReal: GetWatermarkContract = async () => {
   return await apiRequest('/api/user/watermark', { method: 'GET' });
@@ -16,6 +21,34 @@ export const putWatermarkReal: PutWatermarkContract = async (input) => {
 
 export const getWatermarkFontsReal: GetWatermarkFontsContract = async () => {
   return await apiRequest('/api/watermark/fonts', { method: 'GET' });
+};
+
+export const uploadWatermarkFontReal: UploadWatermarkFontContract = async (input) => {
+  const token = useAuthStore.getState().token;
+  const headers: Record<string, string> = { Accept: 'application/json' };
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  const fd = new FormData();
+  fd.append('file', input.file);
+  if (input.displayName) fd.append('displayName', input.displayName);
+
+  const rawBase = ((import.meta.env.VITE_API_BASE_URL as string | undefined) ?? '').trim().replace(/\/+$/, '');
+  const url = rawBase ? `${rawBase}/api/watermark/fonts` : '/api/watermark/fonts';
+  const res = await fetch(url, { method: 'POST', headers, body: fd });
+  const text = await res.text();
+  try {
+    return JSON.parse(text) as ApiResponse<WatermarkFontInfo>;
+  } catch {
+    return {
+      success: false,
+      data: null as never,
+      error: { code: 'INVALID_FORMAT', message: `响应解析失败（HTTP ${res.status}）` },
+    };
+  }
+};
+
+export const deleteWatermarkFontReal: DeleteWatermarkFontContract = async (input) => {
+  return await apiRequest(`/api/watermark/fonts/${encodeURIComponent(input.fontKey)}`, { method: 'DELETE' });
 };
 
 export const getModelSizesReal: GetModelSizesContract = async (input) => {

--- a/prd-api/src/PrdAgent.Api/Controllers/WatermarkController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/WatermarkController.cs
@@ -8,6 +8,8 @@ using PrdAgent.Core.Models;
 using PrdAgent.Core.Services;
 using PrdAgent.Infrastructure.Database;
 using PrdAgent.Infrastructure.Services;
+using PrdAgent.Infrastructure.Services.AssetStorage;
+using SixLabors.Fonts;
 
 namespace PrdAgent.Api.Controllers;
 
@@ -17,12 +19,18 @@ public class WatermarkController : ControllerBase
 {
     private readonly MongoDbContext _db;
     private readonly WatermarkFontRegistry _fontRegistry;
+    private readonly IAssetStorage _assetStorage;
     private readonly ILogger<WatermarkController> _logger;
 
-    public WatermarkController(MongoDbContext db, WatermarkFontRegistry fontRegistry, ILogger<WatermarkController> logger)
+    public WatermarkController(
+        MongoDbContext db,
+        WatermarkFontRegistry fontRegistry,
+        IAssetStorage assetStorage,
+        ILogger<WatermarkController> logger)
     {
         _db = db;
         _fontRegistry = fontRegistry;
+        _assetStorage = assetStorage;
         _logger = logger;
     }
 
@@ -74,7 +82,8 @@ public class WatermarkController : ControllerBase
         }
 
         var spec = request.Spec;
-        var (ok, message) = WatermarkSpecValidator.Validate(spec, _fontRegistry.FontKeys);
+        var allowedFontKeys = await GetAllowedFontKeysAsync(userId, ct);
+        var (ok, message) = WatermarkSpecValidator.Validate(spec, allowedFontKeys);
         if (!ok)
         {
             return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, message ?? "水印配置无效"));
@@ -107,10 +116,28 @@ public class WatermarkController : ControllerBase
 
     [HttpGet("/api/watermark/fonts")]
     [HttpGet("/api/v1/watermark/fonts")]
-    public IActionResult GetFonts()
+    public async Task<IActionResult> GetFonts(CancellationToken ct)
     {
-        var fonts = _fontRegistry.BuildFontInfos(fontKey => $"/api/watermark/fonts/{Uri.EscapeDataString(fontKey)}/file");
-        return Ok(ApiResponse<IReadOnlyList<WatermarkFontInfo>>.Ok(fonts));
+        var userId = GetUserId(User);
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            return Unauthorized(ApiResponse<object>.Fail(ErrorCodes.UNAUTHORIZED, "未授权"));
+        }
+
+        var defaultFonts = _fontRegistry.BuildDefaultFontInfos(fontKey => $"/api/watermark/fonts/{Uri.EscapeDataString(fontKey)}/file");
+        var assets = await _db.WatermarkFontAssets
+            .Find(x => x.OwnerUserId == userId)
+            .SortByDescending(x => x.UpdatedAt)
+            .ToListAsync(ct);
+        var customFonts = assets.Select(x => new WatermarkFontInfo
+        {
+            FontKey = x.FontKey,
+            DisplayName = x.DisplayName,
+            FontFamily = x.FontFamily,
+            FontFileUrl = x.Url
+        }).ToList();
+
+        return Ok(ApiResponse<IReadOnlyList<WatermarkFontInfo>>.Ok(defaultFonts.Concat(customFonts).ToList()));
     }
 
     [AllowAnonymous]
@@ -127,9 +154,200 @@ public class WatermarkController : ControllerBase
         return PhysicalFile(path, mime);
     }
 
+    [HttpPost("/api/watermark/fonts")]
+    [HttpPost("/api/v1/watermark/fonts")]
+    [RequestSizeLimit(MaxUploadBytes)]
+    public async Task<IActionResult> UploadFont([FromForm] IFormFile file, [FromForm] string? displayName, CancellationToken ct)
+    {
+        var userId = GetUserId(User);
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            return Unauthorized(ApiResponse<object>.Fail(ErrorCodes.UNAUTHORIZED, "未授权"));
+        }
+
+        if (file == null || file.Length <= 0)
+        {
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.CONTENT_EMPTY, "file 不能为空"));
+        }
+
+        if (file.Length > MaxUploadBytes)
+        {
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.DOCUMENT_TOO_LARGE, "文件过大"));
+        }
+
+        byte[] bytes;
+        await using (var ms = new MemoryStream())
+        {
+            await file.CopyToAsync(ms, ct);
+            bytes = ms.ToArray();
+        }
+
+        if (bytes.Length == 0)
+        {
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.CONTENT_EMPTY, "file 内容为空"));
+        }
+
+        var ext = ExtractExtension(file.FileName);
+        if (!IsAllowedFontExt(ext))
+        {
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "仅支持 ttf/otf/woff/woff2 字体"));
+        }
+
+        var mime = GuessFontMime(file.ContentType, ext);
+        string familyName;
+        try
+        {
+            var collection = new FontCollection();
+            var family = collection.Add(new MemoryStream(bytes));
+            familyName = family.Name;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Invalid font upload.");
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "字体解析失败"));
+        }
+
+        var stored = await _assetStorage.SaveAsync(bytes, mime, ct, domain: AppDomainPaths.DomainWatermark, type: AppDomainPaths.TypeFont);
+        var fontKey = BuildCustomFontKey(userId, stored.Sha256);
+        var publicUrl = _assetStorage is LocalAssetStorage
+            ? $"/api/watermark/fonts/{Uri.EscapeDataString(fontKey)}/file"
+            : stored.Url;
+        var display = NormalizeDisplayName(displayName, file.FileName, fontKey);
+        var relativeFileName = _fontRegistry.SaveCustomFontFile(fontKey, ext, bytes);
+        _fontRegistry.AddCustomFontDefinition(new WatermarkFontDefinition(fontKey, display, relativeFileName, familyName));
+
+        var now = DateTime.UtcNow;
+        var update = Builders<WatermarkFontAsset>.Update
+            .Set(x => x.OwnerUserId, userId)
+            .Set(x => x.FontKey, fontKey)
+            .Set(x => x.DisplayName, display)
+            .Set(x => x.FontFamily, familyName)
+            .Set(x => x.Sha256, stored.Sha256)
+            .Set(x => x.Mime, stored.Mime)
+            .Set(x => x.SizeBytes, stored.SizeBytes)
+            .Set(x => x.Url, publicUrl)
+            .Set(x => x.FileName, relativeFileName)
+            .Set(x => x.UpdatedAt, now)
+            .SetOnInsert(x => x.CreatedAt, now);
+
+        var options = new FindOneAndUpdateOptions<WatermarkFontAsset>
+        {
+            IsUpsert = true,
+            ReturnDocument = ReturnDocument.After
+        };
+
+        var saved = await _db.WatermarkFontAssets.FindOneAndUpdateAsync(
+            Builders<WatermarkFontAsset>.Filter.Where(x => x.OwnerUserId == userId && x.FontKey == fontKey),
+            update,
+            options,
+            ct);
+
+        return Ok(ApiResponse<WatermarkFontInfo>.Ok(new WatermarkFontInfo
+        {
+            FontKey = saved.FontKey,
+            DisplayName = saved.DisplayName,
+            FontFamily = saved.FontFamily,
+            FontFileUrl = saved.Url
+        }));
+    }
+
+    [HttpDelete("/api/watermark/fonts/{fontKey}")]
+    [HttpDelete("/api/v1/watermark/fonts/{fontKey}")]
+    public async Task<IActionResult> DeleteFont([FromRoute] string fontKey, CancellationToken ct)
+    {
+        var userId = GetUserId(User);
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            return Unauthorized(ApiResponse<object>.Fail(ErrorCodes.UNAUTHORIZED, "未授权"));
+        }
+
+        var doc = await _db.WatermarkFontAssets
+            .Find(x => x.OwnerUserId == userId && x.FontKey == fontKey)
+            .FirstOrDefaultAsync(ct);
+        if (doc == null)
+        {
+            return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "字体不存在"));
+        }
+
+        await _db.WatermarkFontAssets.DeleteOneAsync(x => x.Id == doc.Id, ct);
+        _fontRegistry.RemoveCustomFontDefinition(fontKey);
+        _fontRegistry.DeleteCustomFontFile(doc.FileName);
+
+        try
+        {
+            await _assetStorage.DeleteByShaAsync(doc.Sha256, ct, domain: AppDomainPaths.DomainWatermark, type: AppDomainPaths.TypeFont);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Delete watermark font asset failed: {FontKey}", fontKey);
+        }
+
+        return Ok(ApiResponse<object>.Ok(new { deleted = true }));
+    }
+
+    private async Task<IReadOnlyCollection<string>> GetAllowedFontKeysAsync(string userId, CancellationToken ct)
+    {
+        var customKeys = await _db.WatermarkFontAssets
+            .Find(x => x.OwnerUserId == userId)
+            .Project(x => x.FontKey)
+            .ToListAsync(ct);
+        return _fontRegistry.DefaultFontKeys.Concat(customKeys).ToList();
+    }
+
+    private const long MaxUploadBytes = 20 * 1024 * 1024;
+
+    private static string ExtractExtension(string fileName)
+    {
+        var ext = Path.GetExtension(fileName ?? string.Empty);
+        return string.IsNullOrWhiteSpace(ext) ? string.Empty : ext.Trim().TrimStart('.').ToLowerInvariant();
+    }
+
+    private static bool IsAllowedFontExt(string ext)
+    {
+        if (string.IsNullOrWhiteSpace(ext)) return false;
+        return ext is "ttf" or "otf" or "woff" or "woff2";
+    }
+
+    private static string GuessFontMime(string? contentType, string ext)
+    {
+        var mime = (contentType ?? string.Empty).Trim().ToLowerInvariant();
+        if (mime is "font/ttf" or "font/otf" or "font/woff" or "font/woff2") return mime;
+        return ext switch
+        {
+            "otf" => "font/otf",
+            "woff" => "font/woff",
+            "woff2" => "font/woff2",
+            _ => "font/ttf"
+        };
+    }
+
+    private static string NormalizeDisplayName(string? displayName, string? fileName, string fallbackKey)
+    {
+        var name = (displayName ?? string.Empty).Trim();
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            name = Path.GetFileNameWithoutExtension(fileName ?? string.Empty).Trim();
+        }
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            name = fallbackKey;
+        }
+        return name.Length > 64 ? name[..64] : name;
+    }
+
+    private static string BuildCustomFontKey(string userId, string sha256)
+    {
+        var userHash = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(userId)))
+            .ToLowerInvariant()
+            .Substring(0, 6);
+        var sha = (sha256 ?? string.Empty).Trim().ToLowerInvariant();
+        if (sha.Length > 10) sha = sha[..10];
+        return $"custom-{userHash}-{sha}";
+    }
+
     private WatermarkSpec BuildDefaultSpec()
     {
-        var fontKey = _fontRegistry.FontKeys.FirstOrDefault() ?? _fontRegistry.DefaultFontKey;
+        var fontKey = _fontRegistry.DefaultFontKeys.FirstOrDefault() ?? _fontRegistry.DefaultFontKey;
         return new WatermarkSpec
         {
             Enabled = false,
@@ -143,9 +361,13 @@ public class WatermarkController : ControllerBase
             OffsetY = 24,
             IconEnabled = false,
             IconImageRef = null,
+            BorderEnabled = false,
+            BackgroundEnabled = false,
             BaseCanvasWidth = 320,
             ModelKey = "default",
-            Color = "#FFFFFF"
+            Color = "#FFFFFF",
+            TextColor = "#FFFFFF",
+            BackgroundColor = "#000000"
         };
     }
 

--- a/prd-api/src/PrdAgent.Core/Models/ApiResponse.cs
+++ b/prd-api/src/PrdAgent.Core/Models/ApiResponse.cs
@@ -38,6 +38,8 @@ public class ApiError
 /// </summary>
 public static class ErrorCodes
 {
+    public const string NOT_FOUND = "NOT_FOUND";
+
     // 文档相关
     public const string INVALID_FORMAT = "INVALID_FORMAT";
     public const string CONTENT_EMPTY = "CONTENT_EMPTY";
@@ -81,4 +83,3 @@ public static class ErrorCodes
     // 生图相关
     public const string IMAGE_GEN_RUN_NOT_FOUND = "IMAGE_GEN_RUN_NOT_FOUND";
 }
-

--- a/prd-api/src/PrdAgent.Core/Models/WatermarkFontAsset.cs
+++ b/prd-api/src/PrdAgent.Core/Models/WatermarkFontAsset.cs
@@ -1,0 +1,17 @@
+namespace PrdAgent.Core.Models;
+
+public class WatermarkFontAsset
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString("N");
+    public string OwnerUserId { get; set; } = string.Empty;
+    public string FontKey { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
+    public string FontFamily { get; set; } = string.Empty;
+    public string Sha256 { get; set; } = string.Empty;
+    public string Mime { get; set; } = "application/octet-stream";
+    public long SizeBytes { get; set; } = 0;
+    public string Url { get; set; } = string.Empty;
+    public string FileName { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/prd-api/src/PrdAgent.Core/Models/WatermarkSpec.cs
+++ b/prd-api/src/PrdAgent.Core/Models/WatermarkSpec.cs
@@ -24,9 +24,17 @@ public class WatermarkSpec
 
     public string? IconImageRef { get; set; }
 
+    public bool BorderEnabled { get; set; }
+
+    public bool BackgroundEnabled { get; set; }
+
     public int BaseCanvasWidth { get; set; }
 
     public string? ModelKey { get; set; }
 
     public string? Color { get; set; }
+
+    public string? TextColor { get; set; }
+
+    public string? BackgroundColor { get; set; }
 }

--- a/prd-api/src/PrdAgent.Core/Services/WatermarkSpecValidator.cs
+++ b/prd-api/src/PrdAgent.Core/Services/WatermarkSpecValidator.cs
@@ -71,6 +71,14 @@ public static class WatermarkSpecValidator
         {
             return (false, "color 必须为 #RRGGBB 或 #RRGGBBAA");
         }
+        if (!string.IsNullOrWhiteSpace(spec.TextColor) && !HexColorRegex.IsMatch(spec.TextColor))
+        {
+            return (false, "textColor 必须为 #RRGGBB 或 #RRGGBBAA");
+        }
+        if (!string.IsNullOrWhiteSpace(spec.BackgroundColor) && !HexColorRegex.IsMatch(spec.BackgroundColor))
+        {
+            return (false, "backgroundColor 必须为 #RRGGBB 或 #RRGGBBAA");
+        }
 
         return (true, null);
     }

--- a/prd-api/src/PrdAgent.Infrastructure/Database/BsonClassMapRegistration.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Database/BsonClassMapRegistration.cs
@@ -61,6 +61,7 @@ public static class BsonClassMapRegistration
             RegisterOpenPlatformRequestLog();
             RegisterSystemRole();
             RegisterUserPreferences();
+            RegisterWatermarkFontAsset();
             RegisterWatermarkSettings();
 
             _registered = true;
@@ -572,12 +573,37 @@ public static class BsonClassMapRegistration
                 cm.MapMember(x => x.OffsetY).SetElementName("offsetY");
                 cm.MapMember(x => x.IconEnabled).SetElementName("iconEnabled");
                 cm.MapMember(x => x.IconImageRef).SetElementName("iconImageRef");
+                cm.MapMember(x => x.BorderEnabled).SetElementName("borderEnabled");
+                cm.MapMember(x => x.BackgroundEnabled).SetElementName("backgroundEnabled");
                 cm.MapMember(x => x.BaseCanvasWidth).SetElementName("baseCanvasWidth");
                 cm.MapMember(x => x.ModelKey).SetElementName("modelKey");
                 cm.MapMember(x => x.Color).SetElementName("color");
+                cm.MapMember(x => x.TextColor).SetElementName("textColor");
+                cm.MapMember(x => x.BackgroundColor).SetElementName("backgroundColor");
                 cm.SetIgnoreExtraElements(true);
             });
         }
+    }
+
+    private static void RegisterWatermarkFontAsset()
+    {
+        if (BsonClassMap.IsClassMapRegistered(typeof(WatermarkFontAsset))) return;
+        BsonClassMap.RegisterClassMap<WatermarkFontAsset>(cm =>
+        {
+            cm.AutoMap();
+            cm.SetIgnoreExtraElements(true);
+            cm.MapMember(x => x.OwnerUserId).SetElementName("ownerUserId");
+            cm.MapMember(x => x.FontKey).SetElementName("fontKey");
+            cm.MapMember(x => x.DisplayName).SetElementName("displayName");
+            cm.MapMember(x => x.FontFamily).SetElementName("fontFamily");
+            cm.MapMember(x => x.Sha256).SetElementName("sha256");
+            cm.MapMember(x => x.Mime).SetElementName("mime");
+            cm.MapMember(x => x.SizeBytes).SetElementName("sizeBytes");
+            cm.MapMember(x => x.Url).SetElementName("url");
+            cm.MapMember(x => x.FileName).SetElementName("fileName");
+            cm.MapMember(x => x.CreatedAt).SetElementName("createdAt");
+            cm.MapMember(x => x.UpdatedAt).SetElementName("updatedAt");
+        });
     }
 
     private static void RegisterParsedPrd()

--- a/prd-api/src/PrdAgent.Infrastructure/Services/AssetStorage/AppDomainPaths.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/AssetStorage/AppDomainPaths.cs
@@ -17,6 +17,7 @@ public static class AppDomainPaths
     public const string DomainImageGen = "imagegen";
     public const string DomainUploads = "uploads";
     public const string DomainLlmLogs = "llmlogs";
+    public const string DomainWatermark = "watermark";
 
     // types（全小写）
     public const string TypeImg = "img";
@@ -24,15 +25,16 @@ public static class AppDomainPaths
     public const string TypeLog = "log";
     public const string TypeDoc = "doc";
     public const string TypeMeta = "meta";
+    public const string TypeFont = "font";
 
     private static readonly HashSet<string> DomainAllow = new(StringComparer.Ordinal)
     {
-        DomainImageMaster, DomainImageGen, DomainUploads, DomainLlmLogs,
+        DomainImageMaster, DomainImageGen, DomainUploads, DomainLlmLogs, DomainWatermark,
     };
 
     private static readonly HashSet<string> TypeAllow = new(StringComparer.Ordinal)
     {
-        TypeImg, TypeBin, TypeLog, TypeDoc, TypeMeta,
+        TypeImg, TypeBin, TypeLog, TypeDoc, TypeMeta, TypeFont,
     };
 
     private static readonly Regex SafeSeg = new("^[a-z0-9][a-z0-9_-]*$", RegexOptions.Compiled);
@@ -73,5 +75,4 @@ public static class AppDomainPaths
         return $"{d}/{t}/{sha}.{e}";
     }
 }
-
 

--- a/prd-api/src/PrdAgent.Infrastructure/Services/AssetStorage/LocalAssetStorage.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/AssetStorage/LocalAssetStorage.cs
@@ -65,8 +65,8 @@ public class LocalAssetStorage : IAssetStorage
         // 2) baseDir 兜底（兼容旧数据）
         dirs.Add(_baseDir);
 
-        // 支持常见图片扩展
-        var exts = new[] { "png", "jpg", "jpeg", "webp", "gif" };
+        // 支持常见图片/字体扩展
+        var exts = new[] { "png", "jpg", "jpeg", "webp", "gif", "ttf", "otf", "woff", "woff2" };
         foreach (var dir in dirs.Where(x => !string.IsNullOrWhiteSpace(x)).Distinct(StringComparer.OrdinalIgnoreCase))
         {
             foreach (var ext in exts)
@@ -100,8 +100,8 @@ public class LocalAssetStorage : IAssetStorage
         }
         dirs.Add(_baseDir);
 
-        // 支持常见图片扩展（与读取逻辑保持一致）
-        var exts = new[] { "png", "jpg", "jpeg", "webp", "gif" };
+        // 支持常见图片/字体扩展（与读取逻辑保持一致）
+        var exts = new[] { "png", "jpg", "jpeg", "webp", "gif", "ttf", "otf", "woff", "woff2" };
         foreach (var dir in dirs.Where(x => !string.IsNullOrWhiteSpace(x)).Distinct(StringComparer.OrdinalIgnoreCase))
         {
             foreach (var ext in exts)
@@ -136,6 +136,10 @@ public class LocalAssetStorage : IAssetStorage
             "image/jpeg" or "image/jpg" => "jpg",
             "image/webp" => "webp",
             "image/gif" => "gif",
+            "font/ttf" or "application/x-font-ttf" or "application/font-sfnt" => "ttf",
+            "font/otf" or "application/x-font-opentype" => "otf",
+            "font/woff" or "application/font-woff" => "woff",
+            "font/woff2" or "application/font-woff2" => "woff2",
             _ => "png"
         };
     }
@@ -147,9 +151,12 @@ public class LocalAssetStorage : IAssetStorage
             "jpg" or "jpeg" => "image/jpeg",
             "webp" => "image/webp",
             "gif" => "image/gif",
+            "ttf" => "font/ttf",
+            "otf" => "font/otf",
+            "woff" => "font/woff",
+            "woff2" => "font/woff2",
             _ => "image/png"
         };
     }
 }
-
 

--- a/prd-api/src/PrdAgent.Infrastructure/Services/AssetStorage/TencentCosStorage.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/AssetStorage/TencentCosStorage.cs
@@ -393,8 +393,8 @@ public sealed class TencentCosStorage : IAssetStorage, IDisposable
         var d = string.IsNullOrWhiteSpace(domain) ? null : AppDomainPaths.NormDomain(domain);
         var t = string.IsNullOrWhiteSpace(type) ? null : AppDomainPaths.NormType(type);
 
-        // 支持常见图片扩展
-        var exts = new[] { "png", "jpg", "jpeg", "webp", "gif" };
+        // 支持常见图片/字体扩展
+        var exts = new[] { "png", "jpg", "jpeg", "webp", "gif", "ttf", "otf", "woff", "woff2" };
         foreach (var ext in exts)
         {
             // 1) 新规则（domain/type）
@@ -420,8 +420,8 @@ public sealed class TencentCosStorage : IAssetStorage, IDisposable
         var d = string.IsNullOrWhiteSpace(domain) ? null : AppDomainPaths.NormDomain(domain);
         var t = string.IsNullOrWhiteSpace(type) ? null : AppDomainPaths.NormType(type);
 
-        // 由于 ext 可能未知，这里按常见图片扩展逐个尝试删除（不存在视为成功）
-        var exts = new[] { "png", "jpg", "jpeg", "webp", "gif" };
+        // 由于 ext 可能未知，这里按常见图片/字体扩展逐个尝试删除（不存在视为成功）
+        var exts = new[] { "png", "jpg", "jpeg", "webp", "gif", "ttf", "otf", "woff", "woff2" };
         foreach (var ext in exts)
         {
             try
@@ -608,6 +608,10 @@ public sealed class TencentCosStorage : IAssetStorage, IDisposable
             "image/jpeg" or "image/jpg" => "jpg",
             "image/webp" => "webp",
             "image/gif" => "gif",
+            "font/ttf" or "application/x-font-ttf" or "application/font-sfnt" => "ttf",
+            "font/otf" or "application/x-font-opentype" => "otf",
+            "font/woff" or "application/font-woff" => "woff",
+            "font/woff2" or "application/font-woff2" => "woff2",
             _ => "png"
         };
     }
@@ -619,6 +623,10 @@ public sealed class TencentCosStorage : IAssetStorage, IDisposable
             "jpg" or "jpeg" => "image/jpeg",
             "webp" => "image/webp",
             "gif" => "image/gif",
+            "ttf" => "font/ttf",
+            "otf" => "font/otf",
+            "woff" => "font/woff",
+            "woff2" => "font/woff2",
             _ => "image/png"
         };
     }
@@ -902,5 +910,4 @@ public sealed class TencentCosStorage : IAssetStorage, IDisposable
         return null;
     }
 }
-
 

--- a/prd-api/src/PrdAgent.Infrastructure/Services/WatermarkFontRegistry.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/WatermarkFontRegistry.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using MongoDB.Driver;
 using PrdAgent.Core.Models;
 using PrdAgent.Infrastructure.Database;
 using PrdAgent.Infrastructure.Services.AssetStorage;

--- a/prd-api/src/PrdAgent.Infrastructure/Services/WatermarkFontRegistry.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/WatermarkFontRegistry.cs
@@ -2,6 +2,8 @@ using System.Collections.Concurrent;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using PrdAgent.Core.Models;
+using PrdAgent.Infrastructure.Database;
+using PrdAgent.Infrastructure.Services.AssetStorage;
 using SixLabors.Fonts;
 
 namespace PrdAgent.Infrastructure.Services;
@@ -13,36 +15,53 @@ public record WatermarkResolvedFont(Font Font, bool FallbackUsed, string? Fallba
 public class WatermarkFontRegistry
 {
     private readonly string _fontDir;
+    private readonly string _customFontDir;
+    private readonly MongoDbContext _db;
+    private readonly IAssetStorage _assetStorage;
     private readonly ILogger<WatermarkFontRegistry> _logger;
     private readonly FontCollection _fontCollection = new();
     private readonly ConcurrentDictionary<string, FontFamily?> _familyCache = new();
+    private readonly ConcurrentDictionary<string, WatermarkFontDefinition> _customDefinitions = new();
+    private readonly IReadOnlyList<WatermarkFontDefinition> _defaultDefinitions;
 
-    public WatermarkFontRegistry(IHostEnvironment env, ILogger<WatermarkFontRegistry> logger)
+    public WatermarkFontRegistry(
+        IHostEnvironment env,
+        MongoDbContext db,
+        IAssetStorage assetStorage,
+        ILogger<WatermarkFontRegistry> logger)
     {
+        _db = db;
+        _assetStorage = assetStorage;
         _logger = logger;
         _fontDir = Path.Combine(env.ContentRootPath, "Assets", "Fonts");
+        _customFontDir = Path.Combine(_fontDir, "Custom");
+        _defaultDefinitions = new List<WatermarkFontDefinition>
+        {
+            new("dejavu-sans", "DejaVu Sans", "DejaVuSans.ttf")
+        };
+        LoadCustomDefinitionsFromDb();
     }
 
     public string DefaultFontKey => "dejavu-sans";
 
-    public IReadOnlyList<WatermarkFontDefinition> Definitions { get; } = new List<WatermarkFontDefinition>
-    {
-        new("dejavu-sans", "DejaVu Sans", "DejaVuSans.ttf")
-    };
+    public IReadOnlyList<WatermarkFontDefinition> Definitions
+        => _defaultDefinitions.Concat(_customDefinitions.Values).ToList();
+
+    public IReadOnlyList<string> DefaultFontKeys => _defaultDefinitions.Select(x => x.FontKey).ToList();
 
     public IReadOnlyList<string> FontKeys => Definitions.Select(x => x.FontKey).ToList();
 
     public string? TryResolveFontFile(string fontKey)
     {
-        var def = Definitions.FirstOrDefault(x => x.FontKey == fontKey);
+        var def = FindDefinition(fontKey);
         if (def == null) return null;
-        var path = Path.Combine(_fontDir, def.FileName);
+        var path = ResolveFontPath(def);
         return File.Exists(path) ? path : null;
     }
 
     public WatermarkResolvedFont ResolveFont(string fontKey, double fontSizePx)
     {
-        var def = Definitions.FirstOrDefault(x => x.FontKey == fontKey);
+        var def = FindDefinition(fontKey);
         if (def == null)
         {
             _logger.LogWarning("Watermark font key {FontKey} not found. Falling back to {FallbackKey}.", fontKey, DefaultFontKey);
@@ -73,7 +92,7 @@ public class WatermarkFontRegistry
 
     public FontFamily? TryResolveFamily(string fontKey)
     {
-        var def = Definitions.FirstOrDefault(x => x.FontKey == fontKey);
+        var def = FindDefinition(fontKey);
         return def == null ? null : GetOrLoadFamily(def);
     }
 
@@ -81,15 +100,119 @@ public class WatermarkFontRegistry
     {
         return _familyCache.GetOrAdd(def.FontKey, _ =>
         {
-            var path = Path.Combine(_fontDir, def.FileName);
+            var path = ResolveFontPath(def);
             if (!File.Exists(path)) return null;
             return _fontCollection.Add(path);
         });
     }
 
-    public IReadOnlyList<WatermarkFontInfo> BuildFontInfos(Func<string, string> fileUrlResolver)
+    public IReadOnlyList<WatermarkFontInfo> BuildDefaultFontInfos(Func<string, string> fileUrlResolver)
     {
-        return Definitions.Select(def =>
+        return BuildFontInfos(_defaultDefinitions, fileUrlResolver);
+    }
+
+    public void AddCustomFontDefinition(WatermarkFontDefinition definition)
+    {
+        _customDefinitions[definition.FontKey] = definition;
+    }
+
+    public void RemoveCustomFontDefinition(string fontKey)
+    {
+        _customDefinitions.TryRemove(fontKey, out _);
+        _familyCache.TryRemove(fontKey, out _);
+    }
+
+    public string SaveCustomFontFile(string fontKey, string extension, byte[] bytes)
+    {
+        var ext = (extension ?? string.Empty).Trim().TrimStart('.').ToLowerInvariant();
+        if (string.IsNullOrWhiteSpace(ext)) ext = "ttf";
+        Directory.CreateDirectory(_customFontDir);
+        var fileName = $"{fontKey}.{ext}";
+        var filePath = Path.Combine(_customFontDir, fileName);
+        File.WriteAllBytes(filePath, bytes);
+        return NormalizeCustomRelativeFileName(fileName);
+    }
+
+    public void DeleteCustomFontFile(string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName)) return;
+        try
+        {
+            var path = ResolveFontPath(new WatermarkFontDefinition(string.Empty, string.Empty, fileName));
+            if (File.Exists(path)) File.Delete(path);
+        }
+        catch
+        {
+            // ignore
+        }
+    }
+
+    private static string NormalizeCustomRelativeFileName(string fileName)
+    {
+        var rel = Path.Combine("Custom", fileName);
+        return rel.Replace('\\', '/');
+    }
+
+    private void LoadCustomDefinitionsFromDb()
+    {
+        try
+        {
+            var assets = _db.WatermarkFontAssets.Find(_ => true).ToList();
+            foreach (var asset in assets)
+            {
+                if (string.IsNullOrWhiteSpace(asset.FontKey) || string.IsNullOrWhiteSpace(asset.FileName)) continue;
+                EnsureCustomFontFile(asset);
+                _customDefinitions[asset.FontKey] = new WatermarkFontDefinition(
+                    asset.FontKey,
+                    asset.DisplayName,
+                    asset.FileName,
+                    asset.FontFamily);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to load custom watermark fonts.");
+        }
+    }
+
+    private void EnsureCustomFontFile(WatermarkFontAsset asset)
+    {
+        var def = new WatermarkFontDefinition(asset.FontKey, asset.DisplayName, asset.FileName, asset.FontFamily);
+        var path = ResolveFontPath(def);
+        if (File.Exists(path)) return;
+        try
+        {
+            var result = _assetStorage.TryReadByShaAsync(
+                asset.Sha256,
+                CancellationToken.None,
+                domain: AppDomainPaths.DomainWatermark,
+                type: AppDomainPaths.TypeFont).GetAwaiter().GetResult();
+            if (result == null || result.Value.bytes.Length == 0) return;
+            Directory.CreateDirectory(Path.GetDirectoryName(path) ?? _customFontDir);
+            File.WriteAllBytes(path, result.Value.bytes);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to hydrate custom font file {FontKey}.", asset.FontKey);
+        }
+    }
+
+    private WatermarkFontDefinition? FindDefinition(string fontKey)
+    {
+        if (_customDefinitions.TryGetValue(fontKey, out var custom)) return custom;
+        return _defaultDefinitions.FirstOrDefault(x => x.FontKey == fontKey);
+    }
+
+    private string ResolveFontPath(WatermarkFontDefinition def)
+    {
+        if (Path.IsPathRooted(def.FileName)) return def.FileName;
+        var relative = def.FileName.Replace('/', Path.DirectorySeparatorChar);
+        return Path.Combine(_fontDir, relative);
+    }
+
+    private IReadOnlyList<WatermarkFontInfo> BuildFontInfos(IEnumerable<WatermarkFontDefinition> defs, Func<string, string> fileUrlResolver)
+    {
+        return defs.Select(def =>
         {
             var family = GetOrLoadFamily(def);
             var familyName = family?.Name ?? def.FontFamily ?? def.DisplayName;


### PR DESCRIPTION
### Motivation
- Allow admins/users to upload and manage custom watermark fonts and make them available for selection and preview. 
- Enrich watermark styling with optional border, filled background and separate foreground/background color controls. 
- Simplify the icon control in the editor to icon-only controls (no header) while preserving hover tooltips.

### Description
- Backend: add `WatermarkFontAsset` model and Mongo mapping, expose `POST /api/watermark/fonts` (upload) and `DELETE /api/watermark/fonts/{fontKey}` (delete) and extend `GET /api/watermark/fonts` to return defaults + user fonts, and allow user fonts in spec validation (`WatermarkController`, `WatermarkFontAsset`, `GetAllowedFontKeysAsync`).
- Storage & registry: add watermark domain/type to `AppDomainPaths`, support font MIME/ext in `LocalAssetStorage` and `TencentCosStorage`, persist uploaded font bytes via `IAssetStorage`, and extend `WatermarkFontRegistry` to load/save/hydrate custom font files from storage and expose add/remove APIs for custom definitions.
- Watermark spec & rendering: extend `WatermarkSpec` with `BorderEnabled`, `BackgroundEnabled`, `TextColor`, and `BackgroundColor`, validate hex colors in `WatermarkSpecValidator`, and render background/border/text/icon layout with padding and color resolution in `WatermarkRenderer` (including helper `ResolveColorHex`).
- Admin UI & client: update contracts and real-service helpers (`uploadWatermarkFont`, `deleteWatermarkFont`), add a `FontSelect` dropdown with upload/delete flow and two-step delete confirmation, and update `WatermarkSettingsPanel`/editor to remove the “水印图标” title while providing icon-only buttons for border/background toggles and color pickers for foreground/background; preview measurement/layout updated to include decoration padding.

### Testing
- Frontend dev server started with `npm run dev` in `prd-admin` and Vite reported ready (success). 
- A Playwright script ran and produced a screenshot artifact (`artifacts/watermark-settings-updated.png`) to exercise the admin UI surface. 
- No automated unit or integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968b9c079b4832eb4ca9d307c7c7a96)