### PR TITLE
Support reference image preview in image generation logs and chat

### DIFF
--- a/prd-admin/src/pages/LlmLogsPage.tsx
+++ b/prd-admin/src/pages/LlmLogsPage.tsx
@@ -5,6 +5,7 @@ import { PlatformLabel } from '@/components/design/PlatformLabel';
 import { SearchableSelect, Select } from '@/components/design';
 import { TabBar } from '@/components/design/TabBar';
 import { Dialog } from '@/components/ui/Dialog';
+import { PrdPetalBreathingLoader } from '@/components/ui/PrdPetalBreathingLoader';
 import { SuccessConfettiButton } from '@/components/ui/SuccessConfettiButton';
 import { getAdminDocumentContent, getLlmLogDetail, getLlmLogs, getLlmLogsMeta, listUploadArtifacts } from '@/services';
 import type { LlmRequestLog, LlmRequestLogListItem, UploadArtifact } from '@/types/admin';
@@ -553,7 +554,30 @@ function inferUserPromptCharsFromRequestBody(requestBodyRedacted: string): numbe
   return sum;
 }
 
-function buildCurlFromLog(detail: LlmRequestLog): string {
+/**
+ * 将参考图 URL 注入到请求体 JSON 中（用于 curl 复制和 body 展示）。
+ * 当 body 中 initImageProvided=true 且有 input artifacts 时，补充 image 字段。
+ */
+function injectRefImageIntoRequestBody(bodyText: string, inputArtifacts: UploadArtifact[]): string {
+  if (!inputArtifacts.length) return bodyText;
+  const raw = (bodyText ?? '').trim();
+  if (!raw) return bodyText;
+  try {
+    const obj = JSON.parse(raw) as any;
+    if (obj?.initImageProvided !== true) return bodyText;
+    // 注入参考图 URL
+    if (inputArtifacts.length === 1) {
+      obj.image = inputArtifacts[0].cosUrl;
+    } else {
+      obj.image = inputArtifacts.map((a) => a.cosUrl);
+    }
+    return JSON.stringify(obj);
+  } catch {
+    return bodyText;
+  }
+}
+
+function buildCurlFromLog(detail: LlmRequestLog, inputArtifacts?: UploadArtifact[]): string {
   const apiBase = (detail.apiBase ?? '').trim();
   const path = (detail.path ?? '').trim();
   const url = joinBaseAndPath(apiBase, path) || 'https://api.example.com/v1/chat/completions';
@@ -581,7 +605,8 @@ function buildCurlFromLog(detail: LlmRequestLog): string {
     headers['Content-Type'] = 'application/json';
   }
 
-  const restoredBody = restoreSystemPromptInRequestBody(detail.requestBodyRedacted || '', detail.systemPromptText);
+  let restoredBody = restoreSystemPromptInRequestBody(detail.requestBodyRedacted || '', detail.systemPromptText);
+  restoredBody = injectRefImageIntoRequestBody(restoredBody, inputArtifacts ?? []);
   const bodyPretty = tryPrettyJsonText(restoredBody);
   const headerArgs = Object.entries(headers)
     .filter(([k, v]) => String(k).trim() && v !== undefined && v !== null)
@@ -985,8 +1010,6 @@ export default function LlmLogsPage() {
   }, []);
 
   const totalPages = useMemo(() => Math.max(1, Math.ceil(total / pageSize)), [total, pageSize]);
-  const prettyRequestBody = useMemo(() => (detail ? tryPrettyJsonText(detail.requestBodyRedacted || '') : ''), [detail]);
-  const curlText = useMemo(() => (detail ? buildCurlFromLog(detail) : ''), [detail]);
   const answerText = useMemo(() => (detail?.answerText ?? '').trim(), [detail]);
   const answerHasUnicodeEscapes = useMemo(() => /\\u[0-9a-fA-F]{4}/.test(answerText), [answerText]);
   const answerDisplayText = useMemo(
@@ -1007,6 +1030,12 @@ export default function LlmLogsPage() {
   }, [detail?.requestType]);
   const hasImageArtifacts = artifactInputs.length > 0 || artifactOutputs.length > 0;
   const isImageLikeLog = isImageGenRequest || hasImageArtifacts || typeof detail?.imageSuccessCount === 'number';
+  const prettyRequestBody = useMemo(() => {
+    if (!detail) return '';
+    const restored = injectRefImageIntoRequestBody(detail.requestBodyRedacted || '', artifactInputs);
+    return tryPrettyJsonText(restored);
+  }, [detail, artifactInputs]);
+  const curlText = useMemo(() => (detail ? buildCurlFromLog(detail, artifactInputs) : ''), [detail, artifactInputs]);
   useEffect(() => {
     // 内容不再包含 \uXXXX 时，自动关闭“可见字符”避免误解
     if (!answerHasUnicodeEscapes && answerVisibleChars) setAnswerVisibleChars(false);
@@ -2001,6 +2030,81 @@ export default function LlmLogsPage() {
                                     </div>
                                   </div>
                                 ))}
+                              </div>
+                            </>
+                          ) : artifactInputs.length >= 1 && artifactOutputs.length === 0 ? (
+                            <>
+                              <div className="text-[12px]" style={{ color: 'var(--text-secondary)' }}>
+                                {(detail?.questionText ?? '').trim() || '（无提示词）'}
+                              </div>
+                              <div className="mt-3 grid gap-2" style={{ gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 1fr)' }}>
+                                {/* 参考图 */}
+                                <div className="rounded-[14px] overflow-hidden" style={{ border: '1px solid rgba(255,255,255,0.10)', background: 'rgba(0,0,0,0.18)' }}>
+                                  <div className="px-3 py-2 flex items-center justify-between gap-2" style={{ borderBottom: '1px solid rgba(255,255,255,0.08)' }}>
+                                    <div className="text-[12px] font-semibold" style={{ color: 'var(--text-primary)' }}>
+                                      参考图
+                                    </div>
+                                    <Button
+                                      variant="secondary"
+                                      size="sm"
+                                      onClick={async () => {
+                                        try {
+                                          await navigator.clipboard.writeText(artifactInputs[0].cosUrl || '');
+                                          setCopiedHint('已复制');
+                                          setTimeout(() => setCopiedHint(''), 1200);
+                                        } catch {
+                                          setCopiedHint('复制失败（浏览器权限）');
+                                          setTimeout(() => setCopiedHint(''), 2000);
+                                        }
+                                      }}
+                                    >
+                                      <Copy size={14} />
+                                      复制URL
+                                    </Button>
+                                  </div>
+                                  <img src={artifactInputs[0].cosUrl} alt="input" style={{ width: '100%', height: 320, objectFit: 'contain', display: 'block' }} />
+                                  <div className="px-3 py-2 text-[11px]" style={{ color: 'var(--text-muted)' }}>
+                                    <div className="truncate" title={artifactInputs[0].cosUrl}>
+                                      {artifactInputs[0].cosUrl}
+                                    </div>
+                                    <div className="mt-1 flex items-center justify-between gap-2">
+                                      <span>
+                                        {artifactInputs[0].width}×{artifactInputs[0].height}
+                                      </span>
+                                      <span>
+                                        {fmtBytes(artifactInputs[0].sizeBytes)} · {String(artifactInputs[0].mime || '').toLowerCase()}
+                                      </span>
+                                    </div>
+                                    <div className="mt-1 truncate" title={artifactInputs[0].sha256}>
+                                      sha256: {artifactInputs[0].sha256}
+                                    </div>
+                                  </div>
+                                </div>
+                                {/* 结果图 - 加载中/失败 */}
+                                <div className="rounded-[14px] overflow-hidden relative" style={{ border: '1px solid rgba(255,255,255,0.10)', background: 'rgba(0,0,0,0.18)' }}>
+                                  <div className="px-3 py-2 flex items-center justify-between gap-2" style={{ borderBottom: '1px solid rgba(255,255,255,0.08)' }}>
+                                    <div className="text-[12px] font-semibold" style={{ color: 'var(--text-primary)' }}>
+                                      结果图
+                                    </div>
+                                  </div>
+                                  <div className="flex items-center justify-center" style={{ height: 320 }}>
+                                    {detail?.status === 'running' ? (
+                                      <div className="flex flex-col items-center gap-3">
+                                        <PrdPetalBreathingLoader size={72} />
+                                        <div className="text-[12px]" style={{ color: 'var(--text-muted)' }}>生成中…</div>
+                                      </div>
+                                    ) : detail?.status === 'failed' || detail?.status === 'cancelled' ? (
+                                      <div className="flex flex-col items-center gap-3">
+                                        <PrdPetalBreathingLoader size={72} paused grayscale />
+                                        <div className="text-[12px]" style={{ color: 'rgba(239,68,68,0.85)' }}>
+                                          {detail?.status === 'cancelled' ? '已取消' : '生成失败'}
+                                        </div>
+                                      </div>
+                                    ) : (
+                                      <div className="text-[12px]" style={{ color: 'var(--text-muted)' }}>等待结果</div>
+                                    )}
+                                  </div>
+                                </div>
                               </div>
                             </>
                           ) : (

--- a/prd-api/src/PrdAgent.Api/Controllers/OpenPlatform/OpenPlatformChatController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/OpenPlatform/OpenPlatformChatController.cs
@@ -27,6 +27,7 @@ public class OpenPlatformChatController : ControllerBase
     private readonly IGroupService _groupService;
     private readonly IOpenPlatformService _openPlatformService;
     private readonly ILLMClient _llmClient;
+    private readonly ILLMRequestContextAccessor _llmRequestContext;
     private readonly IIdGenerator _idGenerator;
     private readonly ILogger<OpenPlatformChatController> _logger;
 
@@ -36,6 +37,7 @@ public class OpenPlatformChatController : ControllerBase
         IGroupService groupService,
         IOpenPlatformService openPlatformService,
         ILLMClient llmClient,
+        ILLMRequestContextAccessor llmRequestContext,
         IIdGenerator idGenerator,
         ILogger<OpenPlatformChatController> logger)
     {
@@ -44,6 +46,7 @@ public class OpenPlatformChatController : ControllerBase
         _groupService = groupService;
         _openPlatformService = openPlatformService;
         _llmClient = llmClient;
+        _llmRequestContext = llmRequestContext;
         _idGenerator = idGenerator;
         _logger = logger;
     }
@@ -764,6 +767,19 @@ public class OpenPlatformChatController : ControllerBase
             // 使用简单的系统提示
             var systemPrompt = "You are a helpful AI assistant.";
 
+            // 设置 LLM 请求上下文（确保日志中显示正确的请求类型和来源）
+            using var _scope = _llmRequestContext.BeginScope(new LlmRequestContext(
+                RequestId: requestId,
+                GroupId: boundGroupId,
+                SessionId: null,
+                UserId: boundUserId,
+                ViewRole: null,
+                DocumentChars: null,
+                DocumentHash: null,
+                SystemPromptRedacted: null,
+                RequestType: "reasoning",
+                RequestPurpose: "open-platform-agent.proxy::chat"));
+
             var isFirstChunk = true;
 
             // 调用主模型
@@ -927,6 +943,19 @@ public class OpenPlatformChatController : ControllerBase
 
             // 使用简单的系统提示
             var systemPrompt = "You are a helpful AI assistant.";
+
+            // 设置 LLM 请求上下文（确保日志中显示正确的请求类型和来源）
+            using var _scope = _llmRequestContext.BeginScope(new LlmRequestContext(
+                RequestId: requestId,
+                GroupId: boundGroupId,
+                SessionId: null,
+                UserId: boundUserId,
+                ViewRole: null,
+                DocumentChars: null,
+                DocumentHash: null,
+                SystemPromptRedacted: null,
+                RequestType: "reasoning",
+                RequestPurpose: "open-platform-agent.proxy::chat"));
 
             // 调用主模型
             await foreach (var chunk in _llmClient.StreamGenerateAsync(


### PR DESCRIPTION
## Summary
This PR enhances image generation logging and chat UI to properly display reference images (init images) in both the LLM logs page and the advanced visual agent chat interface. It includes backend changes to save reference images early and frontend changes to render them in the UI with proper fallback handling for legacy logs.

## Key Changes

### Backend (prd-api)
- **OpenAIImageClient.cs**: Moved reference image saving to occur before the LLM request is logged, ensuring the image URL is captured in the request body JSON for curl reproduction and debugging. This allows the image to be displayed in logs even if the generation request fails.
- **OpenPlatformChatController.cs**: Added `ILLMRequestContextAccessor` to properly set LLM request context (request type and purpose) for proxy mode chat operations, ensuring correct logging metadata.

### Frontend - LLM Logs Page (LlmLogsPage.tsx)
- **New function `injectRefImageIntoRequestBody()`**: Injects reference image URLs from artifacts into the request body JSON when `initImageProvided=true` but the image field is missing. This provides backward compatibility with older logs that don't have the image URL embedded.
- **Updated `buildCurlFromLog()`**: Now accepts `inputArtifacts` parameter and uses the new injection function to ensure curl commands include the reference image URL.
- **Enhanced image preview section**: 
  - Shows image preview when either artifacts exist OR `initImageProvided=true` in the request body
  - Added two new UI states for image generation with reference images:
    - When artifacts exist: displays reference image and result image (with loading/error states)
    - When only body has init image: displays reference image from body URL or degraded state for legacy logs
  - Includes copy-to-clipboard functionality for image URLs
  - Shows image metadata (dimensions, file size, MIME type, SHA256)

### Frontend - Advanced Visual Agent Chat (AdvancedVisualAgentTab.tsx)
- **New rich message encoding system**: 
  - `buildGenErrorContent()` / `parseGenError()`: Encodes generation errors with metadata (message, reference image, prompt)
  - `buildGenDoneContent()` / `parseGenDone()`: Encodes successful generations with result image and metadata
- **Updated error handling**: Replaced simple text error messages with rich structured messages that preserve context (reference image, user prompt)
- **Enhanced message rendering**:
  - New error message UI with red styling, reference image thumbnail, and error details
  - New success message UI showing generated image with reference image and prompt context
  - Backward compatibility for legacy text-based error messages ("生成失败：..." format)
  - All messages now include timestamp on hover

## Implementation Details
- Reference images are now saved to COS immediately when the generation request is received, before attempting the actual generation
- The image URL is embedded in the logged request body JSON, enabling proper curl reproduction
- Frontend gracefully handles both new format (with image URL in body) and legacy logs (without image URL)
- Rich message encoding uses JSON prefixes (`[GEN_ERROR]` / `[GEN_DONE]`) to distinguish from plain text messages
- All image preview interactions support click-to-enlarge and copy-to-clipboard workflows