### PR TITLE
Fix empty message bubbles and improve markdown styling in AI chat

### DIFF
--- a/prd-admin/src/pages/AiChatPage.tsx
+++ b/prd-admin/src/pages/AiChatPage.tsx
@@ -76,10 +76,14 @@ function StreamingDot() {
  * LLM 经常用 ```markdown / ```md 包裹"本来就想渲染的 Markdown"，
  * 这会导致 ReactMarkdown 将其当作代码块显示（<pre><code>），而非解析内部的 markdown 语法。
  * 这里仅解包 markdown/md 语言标记，其它代码块保持不动。
+ * 同时去除文本开头的空白行（换行符），避免渲染出额外空白。
  */
 function unwrapMarkdownFences(text: string): string {
   if (!text) return text;
-  return text.replace(/```(?:markdown|md)\s*\n([\s\S]*?)\n```/g, '$1');
+  let result = text.replace(/```(?:markdown|md)\s*\n([\s\S]*?)\n```/g, '$1');
+  // 去除开头的空白行（连续的换行符、空格、制表符组成的行）
+  result = result.replace(/^[\s\n\r]+/, '');
+  return result;
 }
 
 const AssistantMarkdown = memo(function AssistantMarkdown({ content }: { content: string }) {

--- a/prd-admin/src/pages/AiChatPage.tsx
+++ b/prd-admin/src/pages/AiChatPage.tsx
@@ -1319,6 +1319,8 @@ export default function AiChatPage() {
                           .prd-md h2 { font-size: 16px; }
                           .prd-md h3 { font-size: 14px; }
                           .prd-md p { margin: 10px 0; }
+                          .prd-md > *:first-child { margin-top: 0; }
+                          .prd-md > *:last-child { margin-bottom: 0; }
                           .prd-md ul, .prd-md ol { margin: 10px 0; padding-left: 20px; }
                           .prd-md li { margin: 5px 0; }
                           .prd-md strong { font-weight: 600; color: var(--text-primary); }
@@ -1340,9 +1342,12 @@ export default function AiChatPage() {
                           @keyframes prd-md-block-in { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: translateY(0); } }
                         `}</style>
                         {/* 简化渲染：直接渲染 content，借鉴文学创作的流畅体验 */}
-                        <AssistantMarkdown content={unwrapMarkdownFences(m.content || '')} />
+                        {/* 当内容为空时不渲染 markdown，避免显示空气泡 */}
+                        {(m.content || '').trim() ? (
+                          <AssistantMarkdown content={unwrapMarkdownFences(m.content || '')} />
+                        ) : null}
                         {isThisStreaming ? (
-                          <div className="mt-2 text-[12px]" style={{ color: 'var(--text-muted)' }}>
+                          <div className={`text-[12px] ${(m.content || '').trim() ? 'mt-2' : ''}`} style={{ color: 'var(--text-muted)' }}>
                             输出中
                             <StreamingDot />
                           </div>


### PR DESCRIPTION
## Summary
Improved the AI chat message rendering by preventing empty message bubbles from displaying and refining markdown styling for better visual consistency.

## Key Changes
- **Empty content handling**: Added a check to prevent rendering empty markdown content, avoiding unnecessary empty message bubbles in the chat interface
- **Markdown spacing**: Added CSS rules to remove top margin from first child and bottom margin from last child elements within `.prd-md` containers for cleaner spacing
- **Conditional spacing**: Made the top margin on the "输出中" (streaming) indicator conditional - only applies when there's actual content above it, preventing awkward spacing when content is empty

## Implementation Details
- The empty content check uses `.trim()` to handle whitespace-only messages
- CSS improvements use `:first-child` and `:last-child` selectors to eliminate unwanted margins at container boundaries
- The streaming indicator now dynamically applies `mt-2` class only when needed, improving visual hierarchy during the streaming state

https://claude.ai/code/session_01HBdnFM4WmkpUXvE1pg6Jsh