### PR TITLE
Add JSON value kind validation for safe token usage parsing

### DIFF
--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/Adapters/ClaudeGatewayAdapter.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/Adapters/ClaudeGatewayAdapter.cs
@@ -176,7 +176,8 @@ public class ClaudeGatewayAdapter : IGatewayAdapter
                         stopReason = sr.GetString();
                     }
 
-                    if (root.TryGetProperty("usage", out var usageEl))
+                    if (root.TryGetProperty("usage", out var usageEl) &&
+                        usageEl.ValueKind == JsonValueKind.Object)
                     {
                         usage = ParseUsageElement(usageEl);
                     }
@@ -221,7 +222,8 @@ public class ClaudeGatewayAdapter : IGatewayAdapter
         try
         {
             using var doc = JsonDocument.Parse(responseBody);
-            if (doc.RootElement.TryGetProperty("usage", out var usage))
+            if (doc.RootElement.TryGetProperty("usage", out var usage) &&
+                usage.ValueKind == JsonValueKind.Object)
             {
                 return ParseUsageElement(usage);
             }
@@ -240,16 +242,16 @@ public class ClaudeGatewayAdapter : IGatewayAdapter
         int? cacheCreation = null;
         int? cacheRead = null;
 
-        if (usage.TryGetProperty("input_tokens", out var it))
+        if (usage.TryGetProperty("input_tokens", out var it) && it.ValueKind == JsonValueKind.Number)
             inputTokens = it.GetInt32();
 
-        if (usage.TryGetProperty("output_tokens", out var ot))
+        if (usage.TryGetProperty("output_tokens", out var ot) && ot.ValueKind == JsonValueKind.Number)
             outputTokens = ot.GetInt32();
 
-        if (usage.TryGetProperty("cache_creation_input_tokens", out var cc))
+        if (usage.TryGetProperty("cache_creation_input_tokens", out var cc) && cc.ValueKind == JsonValueKind.Number)
             cacheCreation = cc.GetInt32();
 
-        if (usage.TryGetProperty("cache_read_input_tokens", out var cr))
+        if (usage.TryGetProperty("cache_read_input_tokens", out var cr) && cr.ValueKind == JsonValueKind.Number)
             cacheRead = cr.GetInt32();
 
         return new GatewayTokenUsage


### PR DESCRIPTION
## Summary
Add defensive JSON value kind checks before parsing token usage elements in Claude and OpenAI gateway adapters to prevent exceptions when encountering null or unexpected JSON value types.

## Changes
- **ClaudeGatewayAdapter.cs**: Added `ValueKind == JsonValueKind.Object` checks before parsing usage elements in `ConvertToClaudeFormat()` and `ExtractUsageFromResponse()` methods, and before parsing individual token count fields in `ParseUsageElement()`
- **OpenAIGatewayAdapter.cs**: Added similar defensive checks in `ParseStreamChunk()`, `ParseNonStreamResponse()`, and `ParseUsageElement()` methods. Also added validation that `choices` is an array before calling `GetArrayLength()`

## Implementation Details
- When `stream_options.include_usage=true` in OpenAI streaming responses, intermediate chunks may contain `"usage": null` instead of a usage object
- The `TryGetProperty()` method returns true even when the property value is null, so we must explicitly check `ValueKind == JsonValueKind.Object` before attempting to parse
- Similarly, individual token count fields are validated to be `JsonValueKind.Number` before calling `GetInt32()`
- Added clarifying comments explaining the null usage scenario in streaming responses
- These changes prevent potential exceptions and make the parsing logic more robust to API response variations

https://claude.ai/code/session_01CR4Tb5YTCwBpkjVANsKcPJ