### PR TITLE
Fix event parsing buffer scope and improve text polish formatting

### DIFF
--- a/prd-admin/src/services/real/aiToolbox.ts
+++ b/prd-admin/src/services/real/aiToolbox.ts
@@ -264,6 +264,8 @@ export function subscribeToolboxRunEvents(
 
       const decoder = new TextDecoder();
       let buffer = '';
+      let currentEvent = '';
+      let currentData = '';
 
       while (true) {
         const { done, value } = await reader.read();
@@ -272,9 +274,6 @@ export function subscribeToolboxRunEvents(
         buffer += decoder.decode(value, { stream: true });
         const lines = buffer.split('\n');
         buffer = lines.pop() || '';
-
-        let currentEvent = '';
-        let currentData = '';
 
         for (const line of lines) {
           if (line.startsWith('event:')) {

--- a/prd-api/src/PrdAgent.Api/Services/Toolbox/Adapters/LiteraryAgentAdapter.cs
+++ b/prd-api/src/PrdAgent.Api/Services/Toolbox/Adapters/LiteraryAgentAdapter.cs
@@ -103,6 +103,7 @@ public class LiteraryAgentAdapter : IAgentAdapter
                     - 保持原意不变
                     - 提升文字的流畅性和表达力
                     - 修正语法和用词问题
+                    - 必须使用换行符分隔不同的段落和章节，保持良好的文本结构和可读性
                     直接输出润色后的内容。
                     """;
                 var textToPolish = previousOutput ?? userMessage;


### PR DESCRIPTION
## Summary
This PR addresses two issues: a variable scope problem in the SSE event parser and improves the text polishing prompt to maintain better document structure.

## Key Changes

- **aiToolbox.ts**: Moved `currentEvent` and `currentData` variable declarations outside the while loop to prevent unnecessary re-initialization on each iteration. This fixes a potential bug where event data could be lost if split across multiple read chunks.

- **LiteraryAgentAdapter.cs**: Enhanced the text polishing prompt to explicitly require line breaks between paragraphs and sections, ensuring the output maintains proper text structure and readability.

## Implementation Details

The buffer scope fix ensures that when processing Server-Sent Events (SSE), if an event and its data are split across multiple `reader.read()` calls, the variables retain their values across iterations rather than being reset. This is critical for correctly parsing multi-line SSE messages.

The prompt improvement adds a specific instruction to use line breaks for separating content sections, which helps maintain document formatting integrity during the text polishing process.

https://claude.ai/code/session_017SjiKUDix7fmaSWLuhRPcc