### PR TITLE
Add confirmation dialog to defect close action

### DIFF
--- a/prd-admin/src/pages/defect-agent/components/DefectDetailPanel.tsx
+++ b/prd-admin/src/pages/defect-agent/components/DefectDetailPanel.tsx
@@ -253,10 +253,18 @@ export function DefectDetailPanel() {
   };
 
   const handleCloseDefect = async () => {
+    const confirmed = await systemDialog.confirm({
+      title: '完成缺陷',
+      message: '确定要将该缺陷标记为已完成吗？',
+      confirmText: '确定',
+      cancelText: '取消',
+    });
+    if (!confirmed) return;
+
     const res = await closeDefect({ id: defect.id });
     if (res.success && res.data) {
       updateDefectInList(res.data.defect);
-      toast.success('已关闭');
+      toast.success('缺陷已完成');
       loadStats();
     } else {
       toast.error(res.error?.message || '操作失败');


### PR DESCRIPTION
## Summary
Added a confirmation dialog to the defect close action to prevent accidental completion of defects. Users must now explicitly confirm before marking a defect as completed.

## Key Changes
- Added `systemDialog.confirm()` call before closing a defect with appropriate Chinese localization
- Updated success toast message from "已关闭" to "缺陷已完成" for better clarity
- Early return if user cancels the confirmation dialog

## Implementation Details
- The confirmation dialog displays the title "完成缺陷" (Complete Defect) and asks "确定要将该缺陷标记为已完成吗？" (Are you sure you want to mark this defect as completed?)
- Dialog buttons are labeled "确定" (Confirm) and "取消" (Cancel)
- The defect close operation only proceeds if the user confirms the action
- Success message now more accurately reflects the action being performed

https://claude.ai/code/session_01TN2DzdxjSWpP572ndHKGP7