### PR TITLE
Filter model thinking content from LLM stream responses

### DIFF
--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/GatewayLLMClient.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/GatewayLLMClient.cs
@@ -108,6 +108,12 @@ public class GatewayLLMClient : ILLMClient
                 yield break;
             }
 
+            // 跳过思考过程块（Gateway 已过滤，此处为防御性检查）
+            if (chunk.Type == GatewayChunkType.Thinking)
+            {
+                continue;
+            }
+
             if (chunk.Type == GatewayChunkType.Start)
             {
                 yield return new LLMStreamChunk { Type = "start" };

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/GatewayResponse.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/GatewayResponse.cs
@@ -315,6 +315,7 @@ public class GatewayStreamChunk
     public string? RawData { get; init; }
 
     public static GatewayStreamChunk Text(string content) => new() { Type = GatewayChunkType.Text, Content = content };
+    public static GatewayStreamChunk Thinking(string content) => new() { Type = GatewayChunkType.Thinking, Content = content };
     public static GatewayStreamChunk Start(GatewayModelResolution resolution) => new() { Type = GatewayChunkType.Start, Resolution = resolution };
     public static GatewayStreamChunk Done(string? finishReason, GatewayTokenUsage? usage) => new() { Type = GatewayChunkType.Done, FinishReason = finishReason, TokenUsage = usage };
     public static GatewayStreamChunk Fail(string error) => new() { Type = GatewayChunkType.Error, Error = error };
@@ -334,6 +335,12 @@ public enum GatewayChunkType
     /// 文本内容
     /// </summary>
     Text,
+
+    /// <summary>
+    /// 思考过程（reasoning_content / &lt;think&gt; 标签内容）
+    /// 由适配器产生，Gateway 默认过滤不传给调用方
+    /// </summary>
+    Thinking,
 
     /// <summary>
     /// 工具调用

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/ThinkTagStripper.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/ThinkTagStripper.cs
@@ -1,0 +1,134 @@
+namespace PrdAgent.Infrastructure.LlmGateway;
+
+/// <summary>
+/// 流式思考标签剥离器
+/// 处理模型在 content 字段中嵌入 &lt;think&gt;...&lt;/think&gt; 标签的情况
+///
+/// 工作原理：
+/// - 跟踪是否在 &lt;think&gt; 块内
+/// - &lt;think&gt; 块内的内容被过滤，不输出到最终结果
+/// - &lt;/think&gt; 之后的内容正常输出
+/// - 支持跨 chunk 边界的标签检测
+/// </summary>
+public class ThinkTagStripper
+{
+    private bool _insideThink;
+    private string _pendingBuffer = string.Empty;
+
+    private const string OpenTag = "<think>";
+    private const string CloseTag = "</think>";
+
+    /// <summary>
+    /// 处理一个流式 chunk，返回应该输出的内容（过滤掉 think 标签内的部分）
+    /// 返回 null 表示当前 chunk 全部被过滤
+    /// </summary>
+    public string? Process(string content)
+    {
+        var input = _pendingBuffer + content;
+        _pendingBuffer = string.Empty;
+
+        var result = new System.Text.StringBuilder();
+        var pos = 0;
+
+        while (pos < input.Length)
+        {
+            if (_insideThink)
+            {
+                // 在 think 块内，寻找 </think>
+                var closeIdx = input.IndexOf(CloseTag, pos, StringComparison.OrdinalIgnoreCase);
+                if (closeIdx >= 0)
+                {
+                    // 找到关闭标签，跳过 think 内容
+                    _insideThink = false;
+                    pos = closeIdx + CloseTag.Length;
+                }
+                else
+                {
+                    // 没找到关闭标签，可能标签跨 chunk 了
+                    // 保留末尾可能是部分 </think> 的内容
+                    var partialLen = PendingPartialMatch(input, pos, CloseTag);
+                    if (partialLen > 0)
+                    {
+                        _pendingBuffer = input[^partialLen..];
+                    }
+                    // think 块内的内容全部丢弃
+                    break;
+                }
+            }
+            else
+            {
+                // 在正常内容区，寻找 <think>
+                var openIdx = input.IndexOf(OpenTag, pos, StringComparison.OrdinalIgnoreCase);
+                if (openIdx >= 0)
+                {
+                    // 找到开始标签，输出标签之前的内容
+                    if (openIdx > pos)
+                    {
+                        result.Append(input, pos, openIdx - pos);
+                    }
+                    _insideThink = true;
+                    pos = openIdx + OpenTag.Length;
+                }
+                else
+                {
+                    // 没有 <think> 标签
+                    // 检查末尾是否有部分 <think> 匹配
+                    var partialLen = PendingPartialMatch(input, pos, OpenTag);
+                    if (partialLen > 0)
+                    {
+                        // 输出到部分匹配之前的内容
+                        result.Append(input, pos, input.Length - pos - partialLen);
+                        _pendingBuffer = input[^partialLen..];
+                    }
+                    else
+                    {
+                        result.Append(input, pos, input.Length - pos);
+                    }
+                    break;
+                }
+            }
+        }
+
+        var output = result.ToString();
+        return output.Length > 0 ? output : null;
+    }
+
+    /// <summary>
+    /// 刷新剩余缓冲区（流结束时调用）
+    /// 返回未处理的挂起内容
+    /// </summary>
+    public string? Flush()
+    {
+        if (string.IsNullOrEmpty(_pendingBuffer))
+            return null;
+
+        var remaining = _pendingBuffer;
+        _pendingBuffer = string.Empty;
+
+        // 如果在 think 块内，丢弃剩余内容
+        if (_insideThink)
+            return null;
+
+        return remaining;
+    }
+
+    /// <summary>
+    /// 检查 input 末尾是否有 tag 的部分前缀匹配
+    /// 返回部分匹配的长度，0 表示无匹配
+    /// </summary>
+    private static int PendingPartialMatch(string input, int startPos, string tag)
+    {
+        // 从 tag 的最长前缀（tag.Length - 1 个字符）开始，逐步缩短
+        var maxCheck = Math.Min(tag.Length - 1, input.Length - startPos);
+        for (var len = maxCheck; len > 0; len--)
+        {
+            var suffix = input.AsSpan(input.Length - len);
+            var prefix = tag.AsSpan(0, len);
+            if (suffix.Equals(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return len;
+            }
+        }
+        return 0;
+    }
+}


### PR DESCRIPTION
## Summary
This PR implements filtering of model thinking/reasoning content from LLM stream responses. It handles two sources of thinking content:
1. `reasoning_content` fields (e.g., from DeepSeek reasoning mode)
2. `<think>...</think>` tags embedded in regular content (e.g., from Claude)

Thinking content is now captured separately for logging but excluded from the final response sent to callers.

## Key Changes

- **OpenAIGatewayAdapter.cs**: Modified to extract `reasoning_content` separately as a `Thinking` chunk type instead of mixing it with regular content
- **GatewayResponse.cs**: Added new `GatewayChunkType.Thinking` enum value and factory method `GatewayStreamChunk.Thinking()`
- **GatewayLLMClient.cs**: Added defensive filtering to skip `Thinking` chunks before yielding to callers
- **LlmGateway.cs**: 
  - Integrated `ThinkTagStripper` to filter `<think>` tags from text content
  - Accumulates thinking content for debug logging
  - Logs filtered thinking character count with request context
- **ThinkTagStripper.cs** (new): Stateful stream processor that handles:
  - Cross-chunk boundary tag detection
  - Partial tag matching at chunk boundaries
  - Proper buffering of incomplete tags

## Implementation Details

- Thinking content is filtered at the Gateway layer, preventing it from reaching API callers
- Debug logs record the volume of filtered thinking content for observability
- The `ThinkTagStripper` uses a pending buffer to handle tags split across multiple chunks
- Case-insensitive tag matching for robustness
- Defensive check in `GatewayLLMClient` ensures no thinking chunks leak through

https://claude.ai/code/session_019LtYBtPwyuv4Y5pPhL6niQ