### PR TITLE
Refactor model pool list to hierarchical grouped layout

### DIFF
--- a/prd-admin/src/pages/ModelPoolManagePage.tsx
+++ b/prd-admin/src/pages/ModelPoolManagePage.tsx
@@ -36,8 +36,8 @@ import {
   Check,
   ChevronRight,
   ChevronDown,
-  Unfold,
-  Fold,
+  UnfoldVertical,
+  FoldVertical,
 } from 'lucide-react';
 import { useEffect, useMemo, useState, useCallback } from 'react';
 import { systemDialog } from '@/lib/systemDialog';
@@ -398,7 +398,7 @@ export function ModelPoolManagePage() {
                   setExpandedPoolIds(new Set(pools.filter(p => (p.models?.length || 0) > 0).map(p => p.id)));
                 }}
               >
-                <Unfold size={14} />
+                <UnfoldVertical size={14} />
               </Button>
             </Tooltip>
             <Tooltip content="全部折叠">
@@ -410,7 +410,7 @@ export function ModelPoolManagePage() {
                   setExpandedPoolIds(new Set());
                 }}
               >
-                <Fold size={14} />
+                <FoldVertical size={14} />
               </Button>
             </Tooltip>
             <Button variant="primary" size="sm" onClick={handleAddPool}>

--- a/prd-admin/src/pages/ModelPoolManagePage.tsx
+++ b/prd-admin/src/pages/ModelPoolManagePage.tsx
@@ -411,7 +411,7 @@ export function ModelPoolManagePage() {
                 <span className="w-5 shrink-0" />
                 <span className="min-w-[120px] flex-[2]">名称</span>
                 <span className="min-w-[100px] flex-1">代码</span>
-                <span className="w-[70px] shrink-0 text-center">策略</span>
+                <span className="w-[80px] shrink-0 text-center">策略</span>
                 <span className="w-[50px] shrink-0 text-center">优先级</span>
                 <span className="min-w-[100px] flex-1">健康状态</span>
                 <span className="w-[120px] shrink-0" />
@@ -447,16 +447,16 @@ export function ModelPoolManagePage() {
                         : <ChevronDown size={14} style={{ color: 'var(--text-muted)' }} />
                       }
                       <GroupIcon size={16} style={{ color: 'var(--text-secondary)' }} />
-                      <span className="text-[13px] font-semibold" style={{ color: 'var(--text-primary)' }}>
+                      <span className="text-[13px] font-semibold shrink-0" style={{ color: 'var(--text-primary)' }}>
                         {group.label}
                       </span>
-                      <span className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
+                      <span className="text-[11px] shrink-0 whitespace-nowrap" style={{ color: 'var(--text-muted)' }}>
                         {totalPools} 个池 · {totalModels} 个模型
                       </span>
                       <div className="flex-1" />
                       {/* 分组健康摘要 */}
                       {totalModels > 0 && (
-                        <div className="flex items-center gap-2 text-[11px]">
+                        <div className="flex items-center gap-2 text-[11px] shrink-0 whitespace-nowrap">
                           {totalHealthy === totalModels ? (
                             <span className="flex items-center gap-1" style={{ color: 'rgba(34,197,94,0.95)' }}>
                               <span className="w-1.5 h-1.5 rounded-full" style={{ background: 'rgba(34,197,94,0.95)' }} />
@@ -519,8 +519,8 @@ export function ModelPoolManagePage() {
                             </span>
 
                             {/* 名称 */}
-                            <div className="min-w-[120px] flex-[2] flex items-center gap-2 min-w-0">
-                              <span className="text-[13px] font-semibold truncate" style={{ color: 'var(--text-primary)' }}>
+                            <div className="min-w-[120px] flex-[2] flex items-center gap-2">
+                              <span className="text-[13px] font-semibold truncate min-w-0" style={{ color: 'var(--text-primary)' }}>
                                 {pool.name}
                               </span>
                               {pool.isDefaultForType && (
@@ -543,9 +543,9 @@ export function ModelPoolManagePage() {
                             </span>
 
                             {/* 策略 */}
-                            <span className="w-[70px] shrink-0 text-center">
+                            <span className="w-[80px] shrink-0 text-center">
                               <span
-                                className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium"
+                                className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium whitespace-nowrap"
                                 style={{ background: `${strategyOpt.color}12`, color: strategyOpt.color }}
                               >
                                 <StrategyIcon size={10} />
@@ -562,7 +562,7 @@ export function ModelPoolManagePage() {
                             </span>
 
                             {/* 健康状态 */}
-                            <div className="min-w-[100px] flex-1 flex items-center gap-1.5">
+                            <div className="min-w-[100px] flex-1 flex items-center gap-1.5 whitespace-nowrap">
                               {modelCount === 0 ? (
                                 <span className="text-[11px]" style={{ color: 'var(--text-muted)' }}>无模型</span>
                               ) : healthyCnt === modelCount ? (


### PR DESCRIPTION
## Summary
Transformed the model pool management page from a grid card layout to a hierarchical list view with collapsible type groups and expandable pool rows. This provides better organization, improved information density, and enhanced usability for managing large numbers of model pools.

## Key Changes

- **New hierarchical structure**: Pools are now grouped by model type (chat, embedding, etc.) with collapsible sections showing aggregate statistics
- **Expandable pool rows**: Individual pools can be expanded to reveal their model list, replacing the previous card-based layout
- **Bulk expand/collapse**: Added toolbar buttons to expand/collapse all type groups and pool rows simultaneously
- **Enhanced information display**: 
  - Type group headers show pool count, model count, backup pool status, strategy distribution, and health summary
  - Pool rows display code, strategy, and health status in aligned columns for easy scanning
  - Inline health status indicators with color-coded dots (green/yellow/red)
- **Improved visual hierarchy**: Added list header row for column alignment, hover states for interactivity, and consistent spacing
- **Better state management**: Separate state tracking for expanded pools (`expandedPoolIds`) and collapsed type groups (`collapsedTypes`)
- **Optimized grouping logic**: Pools are sorted within each type group with backup pools pinned to top, others sorted alphabetically

## Implementation Details

- Introduced `groupedByType` memoized selector that organizes filtered pools by model type with proper sorting
- Added new icons from lucide-react: `ChevronDown`, `UnfoldVertical`, `FoldVertical`
- Replaced grid layout with flex column structure for better list presentation
- Maintained all existing functionality (edit, delete, copy, predict) with improved accessibility via hover-revealed buttons
- Updated label from "默认" (default) to "备用" (backup) for clarity

https://claude.ai/code/session_01CPrwecej9deDxYtiRcWhD3