### PR TITLE
Add delete platform option to context menu

### DIFF
--- a/prd-admin/src/pages/ModelManagePage.tsx
+++ b/prd-admin/src/pages/ModelManagePage.tsx
@@ -919,7 +919,7 @@ export default function ModelManagePage() {
     // 右键时顺便选中，符合用户预期（菜单操作作用于当前行）
     setSelectedPlatformId(p.id);
     const menuW = 220;
-    const menuH = 96;
+    const menuH = 140;
     const x = Math.min(e.clientX, Math.max(8, window.innerWidth - menuW - 8));
     const y = Math.min(e.clientY, Math.max(8, window.innerHeight - menuH - 8));
     setPlatformCtxMenu({ open: true, x, y, platform: p });
@@ -1371,7 +1371,21 @@ export default function ModelManagePage() {
                 }}
               >
                 <Pencil size={16} />
-                重命名
+                编辑
+              </button>
+              <button
+                type="button"
+                className="w-full flex items-center gap-2 rounded-[12px] px-3 py-2 text-sm hover:bg-white/5"
+                style={{ color: 'rgba(239,68,68,0.9)' }}
+                onClick={() => {
+                  const p = platformCtxMenu.platform;
+                  closePlatformCtxMenu();
+                  if (!p) return;
+                  onDeletePlatform(p);
+                }}
+              >
+                <Trash2 size={16} />
+                删除
               </button>
               <div className="h-px my-1" style={{ background: 'rgba(255,255,255,0.08)' }} />
               <button


### PR DESCRIPTION
## Summary
Added a delete platform option to the platform context menu in the Model Manage page, allowing users to remove platforms directly from the right-click menu.

## Changes
- Increased context menu height from 96px to 140px to accommodate the new delete button
- Changed "重命名" (Rename) label to "编辑" (Edit) for consistency
- Added a new delete button with:
  - Red styling (`rgba(239,68,68,0.9)`) to indicate destructive action
  - Trash2 icon for visual clarity
  - Click handler that calls `onDeletePlatform()` with the selected platform
  - Proper menu closure before executing the delete action

## Implementation Details
- The delete button follows the existing button styling pattern in the context menu
- Includes null check for the platform object before proceeding with deletion
- Menu is closed before the delete operation to prevent UI state issues

https://claude.ai/code/session_01GEzPfH9LUqEhHTGBPgsNkL