### PR TITLE
Support replay-curl with COS-restored images and truncated text

### DIFF
--- a/prd-admin/src/services/api.ts
+++ b/prd-admin/src/services/api.ts
@@ -165,6 +165,7 @@ export const api = {
     llm: {
       list: () => '/api/logs/llm',
       byId: (id: string) => `/api/logs/llm/${id}`,
+      replayCurl: (id: string) => `/api/logs/llm/${id}/replay-curl`,
       meta: () => '/api/logs/llm/meta',
       modelStats: () => '/api/logs/llm/model-stats',
       batchModelStats: () => '/api/logs/llm/model-stats/batch',

--- a/prd-admin/src/services/contracts/llmLogs.ts
+++ b/prd-admin/src/services/contracts/llmLogs.ts
@@ -98,5 +98,18 @@ export type BatchModelStatsData = {
 
 export type GetBatchModelStatsContract = (params: BatchModelStatsParams) => Promise<ApiResponse<BatchModelStatsData>>;
 
+// replay-curl 响应数据
+export type ReplayCurlData = {
+  curl: string;
+  endpoint?: string;
+  model?: string;
+  imageCount?: number;
+  imageErrors?: string[] | null;
+  requestBodyLength?: number;
+  warning?: string | null;
+};
+
+export type GetReplayCurlContract = (id: string) => Promise<ApiResponse<ReplayCurlData>>;
+
 
 

--- a/prd-admin/src/services/contracts/llmLogs.ts
+++ b/prd-admin/src/services/contracts/llmLogs.ts
@@ -104,7 +104,8 @@ export type ReplayCurlData = {
   endpoint?: string;
   model?: string;
   imageCount?: number;
-  imageErrors?: string[] | null;
+  textCount?: number;
+  restoreErrors?: string[] | null;
   requestBodyLength?: number;
   warning?: string | null;
 };

--- a/prd-admin/src/services/index.ts
+++ b/prd-admin/src/services/index.ts
@@ -36,7 +36,7 @@ import type { GetActiveGroupsContract, GetGapStatsContract, GetMessageTrendContr
 import type { CreatePlatformContract, DeletePlatformContract, GetPlatformsContract, UpdatePlatformContract } from '@/services/contracts/platforms';
 import type { ClearImageGenModelContract, ClearIntentModelContract, ClearVisionModelContract, CreateModelContract, DeleteModelContract, GetModelsContract, SetImageGenModelContract, SetIntentModelContract, SetMainModelContract, SetVisionModelContract, TestModelContract, UpdateModelContract, UpdateModelPrioritiesContract, GetModelAdapterInfoContract, GetModelsAdapterInfoBatchContract, GetAdapterInfoByModelNameContract } from '@/services/contracts/models';
 import type { ActivateLLMConfigContract, CreateLLMConfigContract, DeleteLLMConfigContract, GetLLMConfigsContract, UpdateLLMConfigContract } from '@/services/contracts/llmConfigs';
-import type { GetLlmLogDetailContract, GetLlmLogsContract, GetLlmLogsMetaContract, GetLlmModelStatsContract } from '@/services/contracts/llmLogs';
+import type { GetLlmLogDetailContract, GetLlmLogsContract, GetLlmLogsMetaContract, GetLlmModelStatsContract, GetReplayCurlContract } from '@/services/contracts/llmLogs';
 import type { GetAdminDocumentContentContract } from '@/services/contracts/adminDocuments';
 import type { ListUploadArtifactsContract } from '@/services/contracts/uploadArtifacts';
 import type { AdminImpersonateContract } from '@/services/contracts/lab';
@@ -262,7 +262,7 @@ import { getActiveGroupsReal, getGapStatsReal, getMessageTrendReal, getOverviewS
 import { createPlatformReal, deletePlatformReal, getPlatformsReal, updatePlatformReal } from '@/services/real/platforms';
 import { clearImageGenModelReal, clearIntentModelReal, clearVisionModelReal, createModelReal, deleteModelReal, getModelsReal, setImageGenModelReal, setIntentModelReal, setMainModelReal, setVisionModelReal, testModelReal, updateModelReal, updateModelPrioritiesReal, getModelAdapterInfoReal, getModelsAdapterInfoBatchReal, getAdapterInfoByModelNameReal } from '@/services/real/models';
 import { activateLLMConfigReal, createLLMConfigReal, deleteLLMConfigReal, getLLMConfigsReal, updateLLMConfigReal } from '@/services/real/llmConfigs';
-import { getLlmLogDetailReal, getLlmLogsMetaReal, getLlmLogsReal, getLlmModelStatsReal, getBatchModelStatsReal } from '@/services/real/llmLogs';
+import { getLlmLogDetailReal, getLlmLogsMetaReal, getLlmLogsReal, getLlmModelStatsReal, getBatchModelStatsReal, getReplayCurlReal } from '@/services/real/llmLogs';
 import { getAdminDocumentContentReal } from '@/services/real/adminDocuments';
 import { listUploadArtifactsReal } from '@/services/real/uploadArtifacts';
 import {
@@ -559,6 +559,7 @@ export const getLlmLogDetail: GetLlmLogDetailContract = withAuth(getLlmLogDetail
 export const getLlmLogsMeta: GetLlmLogsMetaContract = withAuth(getLlmLogsMetaReal);
 export const getLlmModelStats: GetLlmModelStatsContract = withAuth(getLlmModelStatsReal);
 export const getBatchModelStats = withAuth(getBatchModelStatsReal);
+export const getReplayCurl: GetReplayCurlContract = withAuth(getReplayCurlReal);
 export const listUploadArtifacts: ListUploadArtifactsContract = withAuth(listUploadArtifactsReal);
 export const getAdminDocumentContent: GetAdminDocumentContentContract = withAuth(getAdminDocumentContentReal);
 

--- a/prd-admin/src/services/index.ts
+++ b/prd-admin/src/services/index.ts
@@ -36,7 +36,7 @@ import type { GetActiveGroupsContract, GetGapStatsContract, GetMessageTrendContr
 import type { CreatePlatformContract, DeletePlatformContract, GetPlatformsContract, UpdatePlatformContract } from '@/services/contracts/platforms';
 import type { ClearImageGenModelContract, ClearIntentModelContract, ClearVisionModelContract, CreateModelContract, DeleteModelContract, GetModelsContract, SetImageGenModelContract, SetIntentModelContract, SetMainModelContract, SetVisionModelContract, TestModelContract, UpdateModelContract, UpdateModelPrioritiesContract, GetModelAdapterInfoContract, GetModelsAdapterInfoBatchContract, GetAdapterInfoByModelNameContract } from '@/services/contracts/models';
 import type { ActivateLLMConfigContract, CreateLLMConfigContract, DeleteLLMConfigContract, GetLLMConfigsContract, UpdateLLMConfigContract } from '@/services/contracts/llmConfigs';
-import type { GetLlmLogDetailContract, GetLlmLogsContract, GetLlmLogsMetaContract, GetLlmModelStatsContract } from '@/services/contracts/llmLogs';
+import type { GetLlmLogDetailContract, GetLlmLogsContract, GetLlmLogsMetaContract, GetLlmModelStatsContract, GetReplayCurlContract } from '@/services/contracts/llmLogs';
 import type { GetAdminDocumentContentContract } from '@/services/contracts/adminDocuments';
 import type { ListUploadArtifactsContract } from '@/services/contracts/uploadArtifacts';
 import type { AdminImpersonateContract } from '@/services/contracts/lab';
@@ -263,7 +263,7 @@ import { getActiveGroupsReal, getGapStatsReal, getMessageTrendReal, getOverviewS
 import { createPlatformReal, deletePlatformReal, getPlatformsReal, updatePlatformReal } from '@/services/real/platforms';
 import { clearImageGenModelReal, clearIntentModelReal, clearVisionModelReal, createModelReal, deleteModelReal, getModelsReal, setImageGenModelReal, setIntentModelReal, setMainModelReal, setVisionModelReal, testModelReal, updateModelReal, updateModelPrioritiesReal, getModelAdapterInfoReal, getModelsAdapterInfoBatchReal, getAdapterInfoByModelNameReal } from '@/services/real/models';
 import { activateLLMConfigReal, createLLMConfigReal, deleteLLMConfigReal, getLLMConfigsReal, updateLLMConfigReal } from '@/services/real/llmConfigs';
-import { getLlmLogDetailReal, getLlmLogsMetaReal, getLlmLogsReal, getLlmModelStatsReal, getBatchModelStatsReal } from '@/services/real/llmLogs';
+import { getLlmLogDetailReal, getLlmLogsMetaReal, getLlmLogsReal, getLlmModelStatsReal, getBatchModelStatsReal, getReplayCurlReal } from '@/services/real/llmLogs';
 import { getAdminDocumentContentReal } from '@/services/real/adminDocuments';
 import { listUploadArtifactsReal } from '@/services/real/uploadArtifacts';
 import {
@@ -561,6 +561,7 @@ export const getLlmLogDetail: GetLlmLogDetailContract = withAuth(getLlmLogDetail
 export const getLlmLogsMeta: GetLlmLogsMetaContract = withAuth(getLlmLogsMetaReal);
 export const getLlmModelStats: GetLlmModelStatsContract = withAuth(getLlmModelStatsReal);
 export const getBatchModelStats = withAuth(getBatchModelStatsReal);
+export const getReplayCurl: GetReplayCurlContract = withAuth(getReplayCurlReal);
 export const listUploadArtifacts: ListUploadArtifactsContract = withAuth(listUploadArtifactsReal);
 export const getAdminDocumentContent: GetAdminDocumentContentContract = withAuth(getAdminDocumentContentReal);
 

--- a/prd-admin/src/services/real/llmLogs.ts
+++ b/prd-admin/src/services/real/llmLogs.ts
@@ -15,6 +15,8 @@ import type {
   LlmLogsMetaData,
   LlmModelStatsData,
   BatchModelStatsData,
+  GetReplayCurlContract,
+  ReplayCurlData,
 } from '@/services/contracts/llmLogs';
 
 function toQuery(params?: GetLlmLogsParams) {
@@ -47,9 +49,13 @@ export const getLlmModelStatsReal: GetLlmModelStatsContract = async (params?: Ge
 };
 
 export const getBatchModelStatsReal: GetBatchModelStatsContract = async (params: BatchModelStatsParams): Promise<ApiResponse<BatchModelStatsData>> => {
-  return await apiRequest<BatchModelStatsData>(api.logs.llm.batchModelStats(), { 
+  return await apiRequest<BatchModelStatsData>(api.logs.llm.batchModelStats(), {
     method: 'POST',
     body: JSON.stringify(params),
   });
+};
+
+export const getReplayCurlReal: GetReplayCurlContract = async (id: string): Promise<ApiResponse<ReplayCurlData>> => {
+  return await apiRequest<ReplayCurlData>(api.logs.llm.replayCurl(encodeURIComponent(id)), { method: 'GET' });
 };
 

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/LlmLogsController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/LlmLogsController.cs
@@ -324,8 +324,12 @@ public class LlmLogsController : ControllerBase
     }
 
     /// <summary>
-    /// 生成可重放的 curl 命令（用于 Vision API 多图请求）
-    /// 通过 SHA256 从 COS 获取图片数据，构建完整请求
+    /// 生成可重放的 curl 命令（通用：恢复截断的文本 + 从 COS 恢复 base64 图片）。
+    /// 支持三种图片引用格式：
+    ///   1. [BASE64_IMAGE:sha256:mime] — 新格式（LogWriter 写入时自动提取）
+    ///   2. image_url.sha256 属性 — 旧格式（visionImageGen 路径）
+    ///   3. image_refs[] + prompt — 旧扁平格式（兼容历史日志）
+    /// 同时恢复被截断的 systemPromptText / questionText。
     /// </summary>
     [HttpGet("{id}/replay-curl")]
     public async Task<IActionResult> ReplayCurl(string id)
@@ -333,192 +337,124 @@ public class LlmLogsController : ControllerBase
         var log = await _db.LlmRequestLogs.Find(x => x.Id == id).FirstOrDefaultAsync();
         if (log == null) return NotFound(ApiResponse<object>.Fail("NOT_FOUND", "日志不存在"));
 
-        // 只支持 vision-multi-image 类型
-        if (log.RequestType != "visionImageGen")
-        {
-            return BadRequest(ApiResponse<object>.Fail("INVALID_TYPE", "仅支持 Vision API 多图请求的 curl 重放"));
-        }
-
         try
         {
-            // 解析存储的请求体
             if (string.IsNullOrWhiteSpace(log.RequestBodyRedacted))
-            {
                 return BadRequest(ApiResponse<object>.Fail("NO_REQUEST_BODY", "请求体为空"));
-            }
 
-            using var doc = JsonDocument.Parse(log.RequestBodyRedacted);
-            var root = doc.RootElement;
-
-            if (!root.TryGetProperty("model", out var modelEl))
-            {
-                return BadRequest(ApiResponse<object>.Fail("INVALID_FORMAT", "请求体缺少 model 字段"));
-            }
-            var model = modelEl.GetString() ?? string.Empty;
-
-            // 新格式：messages[].content[] (贴近真实 Vision API 格式)
-            // 旧格式：image_refs[] + prompt (扁平格式，兼容历史日志)
-            var contentItems = new List<object>();
+            // 先在原始 JSON 字符串上恢复 [BASE64_IMAGE:sha256:mime] 引用
             var imageErrors = new List<string>();
-            string? prompt = null;
+            var imageCount = 0;
+            var bodyJson = log.RequestBodyRedacted!;
 
-            if (root.TryGetProperty("messages", out var messagesEl) && messagesEl.ValueKind == JsonValueKind.Array)
+            // 恢复 [BASE64_IMAGE:sha256:mime] → data:mime;base64,...（从 COS 取回原图）
+            var base64RefPattern = new System.Text.RegularExpressions.Regex(
+                @"\[BASE64_IMAGE:([0-9a-f]{64}):([^\]]+)\]");
+            var refMatches = base64RefPattern.Matches(bodyJson);
+            if (refMatches.Count > 0)
             {
-                // 新格式：从 messages[0].content[] 中提取
-                foreach (var msg in messagesEl.EnumerateArray())
+                var sb = new System.Text.StringBuilder(bodyJson);
+                // 倒序替换避免偏移
+                for (var i = refMatches.Count - 1; i >= 0; i--)
                 {
-                    if (!msg.TryGetProperty("content", out var contentEl) || contentEl.ValueKind != JsonValueKind.Array)
-                        continue;
-
-                    foreach (var item in contentEl.EnumerateArray())
-                    {
-                        if (!item.TryGetProperty("type", out var typeEl)) continue;
-                        var itemType = typeEl.GetString();
-
-                        if (itemType == "text" && item.TryGetProperty("text", out var textEl))
-                        {
-                            prompt = textEl.GetString();
-                            contentItems.Add(new { type = "text", text = prompt });
-                        }
-                        else if (itemType == "image_url" && item.TryGetProperty("image_url", out var imgUrlEl))
-                        {
-                            // 从 image_url.sha256 获取 SHA256，重新加载图片
-                            if (!imgUrlEl.TryGetProperty("sha256", out var sha256El))
-                            {
-                                imageErrors.Add("图片缺少 sha256");
-                                continue;
-                            }
-
-                            var sha256 = sha256El.GetString()?.Trim().ToLowerInvariant();
-                            if (string.IsNullOrWhiteSpace(sha256) || sha256.Length != 64)
-                            {
-                                imageErrors.Add($"无效的 sha256: {sha256}");
-                                continue;
-                            }
-
-                            // 从 COS 加载图片
-                            var found = await _assetStorage.TryReadByShaAsync(
-                                sha256,
-                                HttpContext.RequestAborted,
-                                domain: AppDomainPaths.DomainVisualAgent,
-                                type: AppDomainPaths.TypeImg);
-
-                            if (found == null)
-                            {
-                                imageErrors.Add($"无法从 COS 加载图片: {sha256}");
-                                continue;
-                            }
-
-                            var base64 = Convert.ToBase64String(found.Value.bytes);
-                            var mime = string.IsNullOrWhiteSpace(found.Value.mime) ? "image/png" : found.Value.mime;
-                            var dataUrl = $"data:{mime};base64,{base64}";
-
-                            contentItems.Add(new
-                            {
-                                type = "image_url",
-                                image_url = new { url = dataUrl }
-                            });
-                        }
-                    }
-                }
-            }
-            else if (root.TryGetProperty("image_refs", out var imageRefsEl) && root.TryGetProperty("prompt", out var promptEl))
-            {
-                // 旧格式：兼容历史日志
-                prompt = promptEl.GetString() ?? string.Empty;
-                contentItems.Add(new { type = "text", text = prompt });
-
-                foreach (var imgRef in imageRefsEl.EnumerateArray())
-                {
-                    if (!imgRef.TryGetProperty("sha256", out var sha256El))
-                    {
-                        imageErrors.Add("缺少 sha256");
-                        continue;
-                    }
-
-                    var sha256 = sha256El.GetString()?.Trim().ToLowerInvariant();
-                    if (string.IsNullOrWhiteSpace(sha256) || sha256.Length != 64)
-                    {
-                        imageErrors.Add($"无效的 sha256: {sha256}");
-                        continue;
-                    }
-
-                    var mime = "image/png";
-                    if (imgRef.TryGetProperty("mime", out var mimeEl))
-                    {
-                        mime = mimeEl.GetString() ?? "image/png";
-                    }
+                    var m = refMatches[i];
+                    var sha256 = m.Groups[1].Value;
+                    var mime = m.Groups[2].Value;
 
                     var found = await _assetStorage.TryReadByShaAsync(
-                        sha256,
-                        HttpContext.RequestAborted,
+                        sha256, HttpContext.RequestAborted,
                         domain: AppDomainPaths.DomainVisualAgent,
                         type: AppDomainPaths.TypeImg);
 
                     if (found == null)
                     {
-                        imageErrors.Add($"无法从 COS 加载图片: {sha256}");
+                        imageErrors.Add($"COS 未找到图片: {sha256[..12]}...");
                         continue;
                     }
 
-                    var base64 = Convert.ToBase64String(found.Value.bytes);
-                    var dataUrl = $"data:{mime};base64,{base64}";
-
-                    contentItems.Add(new
-                    {
-                        type = "image_url",
-                        image_url = new { url = dataUrl }
-                    });
+                    imageCount++;
+                    var b64 = Convert.ToBase64String(found.Value.bytes);
+                    var actualMime = string.IsNullOrWhiteSpace(found.Value.mime) ? mime : found.Value.mime;
+                    var dataUrl = $"data:{actualMime};base64,{b64}";
+                    sb.Remove(m.Index, m.Length);
+                    sb.Insert(m.Index, dataUrl);
                 }
-            }
-            else
-            {
-                return BadRequest(ApiResponse<object>.Fail("INVALID_FORMAT", "请求体格式不符合 Vision API 格式"));
+                bodyJson = sb.ToString();
             }
 
-            // 构建完整请求体
-            var fullRequest = new
+            // 恢复被截断的文本字段（systemPrompt / questionText）
+            bodyJson = RestoreTruncatedTextFields(bodyJson, log.SystemPromptText, log.QuestionText);
+
+            // 兼容旧 visionImageGen 格式：image_url.sha256 属性 + image_refs[]
+            using var doc = JsonDocument.Parse(bodyJson);
+            var root = doc.RootElement;
+            var hasOldSha256Refs = false;
+
+            if (root.TryGetProperty("messages", out var msgsEl) && msgsEl.ValueKind == JsonValueKind.Array)
             {
-                model = model,
-                max_tokens = 4096,
-                messages = new[]
+                foreach (var msg in msgsEl.EnumerateArray())
                 {
-                    new
+                    if (!msg.TryGetProperty("content", out var cEl) || cEl.ValueKind != JsonValueKind.Array) continue;
+                    foreach (var item in cEl.EnumerateArray())
                     {
-                        role = "user",
-                        content = contentItems
+                        if (item.TryGetProperty("type", out var t) && t.GetString() == "image_url"
+                            && item.TryGetProperty("image_url", out var iu) && iu.TryGetProperty("sha256", out _))
+                        {
+                            hasOldSha256Refs = true;
+                            break;
+                        }
                     }
+                    if (hasOldSha256Refs) break;
                 }
-            };
+            }
+            var hasOldImageRefs = root.TryGetProperty("image_refs", out _);
 
-            var requestJson = JsonSerializer.Serialize(fullRequest, new JsonSerializerOptions
+            if (hasOldSha256Refs || hasOldImageRefs)
             {
-                WriteIndented = false
-            });
+                // 走旧逻辑：完全重建请求体
+                return await ReplayCurlLegacy(log, root, imageErrors);
+            }
 
-            // 构建 curl 命令（API Key 使用 Postman 环境变量占位符 {{域名}}）
-            var endpoint = $"{log.ApiBase?.TrimEnd('/')}/{log.Path?.TrimStart('/')}";
+            // 通用路径：使用（已恢复图片引用的）bodyJson 构建 curl
+            var endpoint = JoinBaseAndPath(log.ApiBase, log.Path) ?? "https://api.example.com/v1/chat/completions";
             var apiKeyPlaceholder = "YOUR_API_KEY";
             try
             {
                 var host = new Uri(endpoint).Host;
                 if (!string.IsNullOrEmpty(host)) apiKeyPlaceholder = $"{{{{{host}}}}}";
             }
-            catch { /* 解析失败时保持默认占位符 */ }
+            catch { }
 
-            var curlCommand = $"curl -X POST \"{endpoint}\" \\\n" +
-                              $"  -H \"Content-Type: application/json\" \\\n" +
-                              $"  -H \"Authorization: Bearer {apiKeyPlaceholder}\" \\\n" +
-                              $"  -d '{requestJson}'";
+            // 决定认证头
+            var providerLower = (log.Provider ?? "").ToLowerInvariant();
+            var isAnthropicLike = providerLower.Contains("claude") || providerLower.Contains("anthropic");
+            var authHeader = isAnthropicLike
+                ? $"-H 'x-api-key: {apiKeyPlaceholder}'"
+                : $"-H 'Authorization: Bearer {apiKeyPlaceholder}'";
+
+            var method = string.IsNullOrWhiteSpace(log.HttpMethod) ? "POST" : log.HttpMethod.Trim().ToUpperInvariant();
+
+            // 美化 JSON
+            string prettyBody;
+            try
+            {
+                using var prettyDoc = JsonDocument.Parse(bodyJson);
+                prettyBody = JsonSerializer.Serialize(prettyDoc, new JsonSerializerOptions { WriteIndented = true, Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
+            }
+            catch { prettyBody = bodyJson; }
+
+            var curl = $"curl -X {method} '{endpoint}' \\\n" +
+                       $"  -H 'Content-Type: application/json' \\\n" +
+                       $"  {authHeader} \\\n" +
+                       $"  --data-raw '{EscapeSingleQuotesForShell(prettyBody)}'";
 
             return Ok(ApiResponse<object>.Ok(new
             {
-                curl = curlCommand,
-                endpoint = endpoint,
-                model = model,
-                imageCount = contentItems.Count - 1, // 减去 text 项
+                curl,
+                endpoint,
+                imageCount,
                 imageErrors = imageErrors.Count > 0 ? imageErrors : null,
-                requestBodyLength = requestJson.Length,
+                requestBodyLength = prettyBody.Length,
                 warning = imageErrors.Count > 0 ? "部分图片加载失败，curl 可能不完整" : null
             }));
         }
@@ -527,6 +463,172 @@ public class LlmLogsController : ControllerBase
             return BadRequest(ApiResponse<object>.Fail("JSON_PARSE_ERROR", $"解析请求体失败: {ex.Message}"));
         }
     }
+
+    /// <summary>旧 visionImageGen 格式：sha256 属性 / image_refs[]</summary>
+    private async Task<IActionResult> ReplayCurlLegacy(
+        LlmRequestLog log, JsonElement root, List<string> imageErrors)
+    {
+        var model = root.TryGetProperty("model", out var mEl) ? mEl.GetString() ?? "" : "";
+        var contentItems = new List<object>();
+        string? prompt = null;
+
+        if (root.TryGetProperty("messages", out var messagesEl) && messagesEl.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var msg in messagesEl.EnumerateArray())
+            {
+                if (!msg.TryGetProperty("content", out var contentEl) || contentEl.ValueKind != JsonValueKind.Array)
+                    continue;
+                foreach (var item in contentEl.EnumerateArray())
+                {
+                    if (!item.TryGetProperty("type", out var typeEl)) continue;
+                    var itemType = typeEl.GetString();
+                    if (itemType == "text" && item.TryGetProperty("text", out var textEl))
+                    {
+                        prompt = textEl.GetString();
+                        contentItems.Add(new { type = "text", text = prompt });
+                    }
+                    else if (itemType == "image_url" && item.TryGetProperty("image_url", out var imgUrlEl))
+                    {
+                        var sha256 = imgUrlEl.TryGetProperty("sha256", out var s) ? s.GetString()?.Trim().ToLowerInvariant() : null;
+                        if (string.IsNullOrWhiteSpace(sha256) || sha256.Length != 64)
+                        {
+                            imageErrors.Add($"无效的 sha256: {sha256}");
+                            continue;
+                        }
+                        var found = await _assetStorage.TryReadByShaAsync(sha256, HttpContext.RequestAborted,
+                            domain: AppDomainPaths.DomainVisualAgent, type: AppDomainPaths.TypeImg);
+                        if (found == null) { imageErrors.Add($"COS 未找到图片: {sha256[..12]}..."); continue; }
+                        var b64 = Convert.ToBase64String(found.Value.bytes);
+                        var mime = string.IsNullOrWhiteSpace(found.Value.mime) ? "image/png" : found.Value.mime;
+                        contentItems.Add(new { type = "image_url", image_url = new { url = $"data:{mime};base64,{b64}" } });
+                    }
+                }
+            }
+        }
+        else if (root.TryGetProperty("image_refs", out var imageRefsEl) && root.TryGetProperty("prompt", out var promptEl))
+        {
+            prompt = promptEl.GetString() ?? string.Empty;
+            contentItems.Add(new { type = "text", text = prompt });
+            foreach (var imgRef in imageRefsEl.EnumerateArray())
+            {
+                var sha256 = imgRef.TryGetProperty("sha256", out var s) ? s.GetString()?.Trim().ToLowerInvariant() : null;
+                if (string.IsNullOrWhiteSpace(sha256) || sha256.Length != 64) { imageErrors.Add($"无效的 sha256: {sha256}"); continue; }
+                var mime = imgRef.TryGetProperty("mime", out var mimeEl) ? mimeEl.GetString() ?? "image/png" : "image/png";
+                var found = await _assetStorage.TryReadByShaAsync(sha256, HttpContext.RequestAborted,
+                    domain: AppDomainPaths.DomainVisualAgent, type: AppDomainPaths.TypeImg);
+                if (found == null) { imageErrors.Add($"COS 未找到图片: {sha256[..12]}..."); continue; }
+                var b64 = Convert.ToBase64String(found.Value.bytes);
+                contentItems.Add(new { type = "image_url", image_url = new { url = $"data:{mime};base64,{b64}" } });
+            }
+        }
+
+        var fullReq = new { model, max_tokens = 4096, messages = new[] { new { role = "user", content = contentItems } } };
+        var reqJson = JsonSerializer.Serialize(fullReq, new JsonSerializerOptions { WriteIndented = false });
+
+        var endpoint = JoinBaseAndPath(log.ApiBase, log.Path) ?? "https://api.example.com/v1/chat/completions";
+        var apiKeyPlaceholder = "YOUR_API_KEY";
+        try { var host = new Uri(endpoint).Host; if (!string.IsNullOrEmpty(host)) apiKeyPlaceholder = $"{{{{{host}}}}}"; } catch { }
+
+        var curl = $"curl -X POST '{endpoint}' \\\n" +
+                   $"  -H 'Content-Type: application/json' \\\n" +
+                   $"  -H 'Authorization: Bearer {apiKeyPlaceholder}' \\\n" +
+                   $"  --data-raw '{EscapeSingleQuotesForShell(reqJson)}'";
+
+        return Ok(ApiResponse<object>.Ok(new
+        {
+            curl, endpoint, model,
+            imageCount = contentItems.Count - (string.IsNullOrWhiteSpace(prompt) ? 0 : 1),
+            imageErrors = imageErrors.Count > 0 ? imageErrors : null,
+            requestBodyLength = reqJson.Length,
+            warning = imageErrors.Count > 0 ? "部分图片加载失败，curl 可能不完整" : null
+        }));
+    }
+
+    /// <summary>恢复 requestBody 中被截断的文本（系统提示词、用户消息）</summary>
+    private static string RestoreTruncatedTextFields(string bodyJson, string? systemPromptText, string? questionText)
+    {
+        if (string.IsNullOrWhiteSpace(bodyJson)) return bodyJson;
+
+        try
+        {
+            var node = System.Text.Json.Nodes.JsonNode.Parse(bodyJson);
+            if (node is not System.Text.Json.Nodes.JsonObject obj) return bodyJson;
+
+            var messages = obj["messages"] as System.Text.Json.Nodes.JsonArray;
+            if (messages == null) return bodyJson;
+
+            foreach (var msg in messages)
+            {
+                if (msg is not System.Text.Json.Nodes.JsonObject msgObj) continue;
+                var role = msgObj["role"]?.GetValue<string>();
+
+                // 恢复 system 消息的 content
+                if (role == "system" && !string.IsNullOrWhiteSpace(systemPromptText))
+                {
+                    var content = msgObj["content"];
+                    if (content is System.Text.Json.Nodes.JsonValue v && IsTruncatedOrRedacted(v.GetValue<string>()))
+                    {
+                        msgObj["content"] = systemPromptText;
+                    }
+                }
+
+                // 恢复最后一个 user 消息的文本
+                if (role == "user" && !string.IsNullOrWhiteSpace(questionText))
+                {
+                    var content = msgObj["content"];
+                    if (content is System.Text.Json.Nodes.JsonValue uv && IsTruncatedOrRedacted(uv.GetValue<string>()))
+                    {
+                        msgObj["content"] = questionText;
+                    }
+                    else if (content is System.Text.Json.Nodes.JsonArray arr)
+                    {
+                        foreach (var part in arr)
+                        {
+                            if (part is not System.Text.Json.Nodes.JsonObject po) continue;
+                            if (po["type"]?.GetValue<string>() != "text") continue;
+                            var txt = po["text"]?.GetValue<string>();
+                            if (IsTruncatedOrRedacted(txt)) po["text"] = questionText;
+                        }
+                    }
+                }
+            }
+
+            // 恢复顶层 system / system_prompt
+            foreach (var key in new[] { "system", "system_prompt", "systemPrompt" })
+            {
+                if (obj[key] is System.Text.Json.Nodes.JsonValue sv && !string.IsNullOrWhiteSpace(systemPromptText)
+                    && IsTruncatedOrRedacted(sv.GetValue<string>()))
+                {
+                    obj[key] = systemPromptText;
+                }
+            }
+
+            return obj.ToJsonString(new JsonSerializerOptions { Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
+        }
+        catch
+        {
+            return bodyJson;
+        }
+    }
+
+    private static bool IsTruncatedOrRedacted(string? s)
+    {
+        if (string.IsNullOrWhiteSpace(s)) return false;
+        s = s.Trim();
+        if (s.StartsWith('[') && s.EndsWith(']') && (s.Contains("REDACTED") || s.Contains("PROMPT"))) return true;
+        return System.Text.RegularExpressions.Regex.IsMatch(s, @"\.\.\.\[\d+ chars trimmed\]$");
+    }
+
+    private static string JoinBaseAndPath(string? apiBase, string? path)
+    {
+        var b = (apiBase ?? "").TrimEnd('/');
+        var p = (path ?? "").TrimStart('/');
+        if (string.IsNullOrWhiteSpace(b)) return string.IsNullOrWhiteSpace(p) ? "" : p;
+        return string.IsNullOrWhiteSpace(p) ? b : $"{b}/{p}";
+    }
+
+    private static string EscapeSingleQuotesForShell(string s)
+        => s.Replace("'", "'\\''");
 
     /// <summary>
     /// 按模型聚合的近 N 天统计（用于模型管理页展示"请求次数/平均耗时/首字延迟/token"等）

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/LlmLogsController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/LlmLogsController.cs
@@ -496,11 +496,19 @@ public class LlmLogsController : ControllerBase
                 WriteIndented = false
             });
 
-            // 构建 curl 命令
+            // 构建 curl 命令（API Key 使用 Postman 环境变量占位符 {{域名}}）
             var endpoint = $"{log.ApiBase?.TrimEnd('/')}/{log.Path?.TrimStart('/')}";
+            var apiKeyPlaceholder = "YOUR_API_KEY";
+            try
+            {
+                var host = new Uri(endpoint).Host;
+                if (!string.IsNullOrEmpty(host)) apiKeyPlaceholder = $"{{{{{host}}}}}";
+            }
+            catch { /* 解析失败时保持默认占位符 */ }
+
             var curlCommand = $"curl -X POST \"{endpoint}\" \\\n" +
                               $"  -H \"Content-Type: application/json\" \\\n" +
-                              $"  -H \"Authorization: Bearer YOUR_API_KEY\" \\\n" +
+                              $"  -H \"Authorization: Bearer {apiKeyPlaceholder}\" \\\n" +
                               $"  -d '{requestJson}'";
 
             return Ok(ApiResponse<object>.Ok(new

--- a/prd-api/src/PrdAgent.Core/Models/MultiImage/VisionApiModels.cs
+++ b/prd-api/src/PrdAgent.Core/Models/MultiImage/VisionApiModels.cs
@@ -39,10 +39,8 @@ public class VisionMessage
 
 /// <summary>
 /// Vision API 内容项（text 或 image_url）
+/// 注意：仅用于序列化（构建请求体），不做多态反序列化。
 /// </summary>
-[JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
-[JsonDerivedType(typeof(VisionTextContent), "text")]
-[JsonDerivedType(typeof(VisionImageContent), "image_url")]
 public abstract class VisionContentItem
 {
     [JsonPropertyName("type")]

--- a/prd-api/src/PrdAgent.Infrastructure/LLM/LlmRequestLogWriter.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LLM/LlmRequestLogWriter.cs
@@ -33,8 +33,9 @@ public class LlmRequestLogWriter : ILlmRequestLogWriter
             var requestBodyChars = requestBodyRaw.Length;
             var requestBodyMaxChars = LlmLogLimits.GetRequestBodyMaxChars(settings);
 
-            // 先对 JSON 中每个值进行截断（超过 100 字符的值），再整体截断
-            var requestBodyTrimmed = TruncateJsonStringValues(requestBodyRaw, maxValueLength: 100);
+            // 对 JSON 中 base64 data URL 提取 SHA256 摘要（图片由 COS 反查恢复），
+            // 文本内容保留完整（不再按 100 字符截断），整体大小由 requestBodyMaxChars 兜底
+            var requestBodyTrimmed = TruncateJsonStringValues(requestBodyRaw, maxValueLength: requestBodyMaxChars);
             var requestBodyStored = Truncate(requestBodyTrimmed, requestBodyMaxChars);
             var requestBodyTruncated = requestBodyChars > requestBodyStored.Length;
 

--- a/prd-api/src/PrdAgent.Infrastructure/LLM/LlmRequestLogWriter.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LLM/LlmRequestLogWriter.cs
@@ -6,6 +6,7 @@ using MongoDB.Driver;
 using PrdAgent.Core.Interfaces;
 using PrdAgent.Core.Models;
 using PrdAgent.Infrastructure.Database;
+using PrdAgent.Infrastructure.Services.AssetStorage;
 
 namespace PrdAgent.Infrastructure.LLM;
 
@@ -16,12 +17,17 @@ public class LlmRequestLogWriter : ILlmRequestLogWriter
     private readonly MongoDbContext _db;
     private readonly ILogger<LlmRequestLogWriter> _logger;
     private readonly IAppSettingsService _settingsService;
+    private readonly IAssetStorage _assetStorage;
 
-    public LlmRequestLogWriter(MongoDbContext db, ILogger<LlmRequestLogWriter> logger, LlmRequestLogBackground _, IAppSettingsService settingsService)
+    /// <summary>JSON 中字符串值超过此长度时，上传 COS 存储引用</summary>
+    private const int CosTextThreshold = 1024;
+
+    public LlmRequestLogWriter(MongoDbContext db, ILogger<LlmRequestLogWriter> logger, LlmRequestLogBackground _, IAppSettingsService settingsService, IAssetStorage assetStorage)
     {
         _db = db;
         _logger = logger;
         _settingsService = settingsService;
+        _assetStorage = assetStorage;
     }
 
     public async Task<string?> StartAsync(LlmLogStart start, CancellationToken ct = default)
@@ -33,10 +39,12 @@ public class LlmRequestLogWriter : ILlmRequestLogWriter
             var requestBodyChars = requestBodyRaw.Length;
             var requestBodyMaxChars = LlmLogLimits.GetRequestBodyMaxChars(settings);
 
-            // 对 JSON 中 base64 data URL 提取 SHA256 摘要（图片由 COS 反查恢复），
-            // 文本内容保留完整（不再按 100 字符截断），整体大小由 requestBodyMaxChars 兜底
-            var requestBodyTrimmed = TruncateJsonStringValues(requestBodyRaw, maxValueLength: requestBodyMaxChars);
-            var requestBodyStored = Truncate(requestBodyTrimmed, requestBodyMaxChars);
+            // JSON 字符串值处理：
+            //   - base64 data URL → SHA256 摘要引用 [BASE64_IMAGE:sha256:mime]（COS 反查恢复）
+            //   - 文本 > 1024 字符 → 上传 COS 存储引用 [TEXT_COS:sha256:charcount]
+            //   - 整体大小由 requestBodyMaxChars 兜底
+            var requestBodyProcessed = await ProcessJsonStringValuesForCosAsync(requestBodyRaw, ct);
+            var requestBodyStored = Truncate(requestBodyProcessed, requestBodyMaxChars);
             var requestBodyTruncated = requestBodyChars > requestBodyStored.Length;
 
             var log = new LlmRequestLog
@@ -121,44 +129,64 @@ public class LlmRequestLogWriter : ILlmRequestLogWriter
     }
 
     /// <summary>
-    /// 截断 JSON 字符串中超过指定长度的值（两个双引号之间的内容）
-    /// 不做 JSON 反序列化，直接用正则匹配处理
+    /// 异步处理 JSON 字符串值：
+    ///   - base64 data URL → SHA256 摘要引用 [BASE64_IMAGE:sha256:mime]
+    ///   - 文本 > CosTextThreshold → 上传 COS，替换为 [TEXT_COS:sha256:charcount]
+    ///   - 短文本保持不变
+    /// 不做 JSON 反序列化，直接用正则匹配处理。
     /// </summary>
-    /// <param name="json">原始 JSON 字符串</param>
-    /// <param name="maxValueLength">每个值的最大字符数（默认 100）</param>
-    /// <returns>截断后的 JSON 字符串</returns>
-    private static string TruncateJsonStringValues(string json, int maxValueLength = 100)
+    private async Task<string> ProcessJsonStringValuesForCosAsync(string json, CancellationToken ct)
     {
         if (string.IsNullOrEmpty(json)) return json;
-        if (maxValueLength <= 0) return json;
 
-        // 匹配 JSON 字符串值："..."
-        // 需要处理转义字符，如 \" 不应该被当作结束引号
-        // 正则：匹配双引号开始，然后是非双引号或转义序列的字符，最后是双引号结束
+        // 匹配 JSON 字符串值："..."（处理转义字符）
         var pattern = @"""((?:[^""\\]|\\.)*)""";
+        var matches = Regex.Matches(json, pattern);
+        if (matches.Count == 0) return json;
 
-        return Regex.Replace(json, pattern, match =>
+        // 收集需要替换的匹配项（逆序替换避免偏移）
+        var replacements = new List<(int index, int length, string replacement)>();
+
+        foreach (Match match in matches)
         {
-            var fullMatch = match.Value;      // 包含引号的完整匹配
-            var content = match.Groups[1].Value; // 引号内的内容
+            var content = match.Groups[1].Value;
+            if (content.Length <= CosTextThreshold) continue;
 
-            // 如果内容长度超过限制，截断并添加标记
-            if (content.Length > maxValueLength)
+            // base64 data URL → SHA256 摘要引用（不上传 COS，图片已由原始上传流程存入）
+            if (TryExtractBase64DataUrlSha256(content, out var imgSha256, out var mime))
             {
-                // 特殊处理：base64 data URL → 提取 SHA256 摘要保留引用
-                // 格式: [BASE64_IMAGE:<sha256_hex>:<mime>]（约 90 字符，不会再被截断）
-                if (TryExtractBase64DataUrlSha256(content, out var sha256Hex, out var mime))
-                {
-                    return $"\"[BASE64_IMAGE:{sha256Hex}:{mime}]\"";
-                }
-
-                // 截取前 maxValueLength 个字符，注意要处理可能截断转义序列的情况
-                var truncated = SafeTruncateJsonString(content, maxValueLength);
-                return $"\"{truncated}...[{content.Length - maxValueLength} chars trimmed]\"";
+                replacements.Add((match.Index, match.Length, $"\"[BASE64_IMAGE:{imgSha256}:{mime}]\""));
+                continue;
             }
 
-            return fullMatch;
-        });
+            // 长文本 → 上传 COS → [TEXT_COS:sha256:charcount]
+            try
+            {
+                var textBytes = Encoding.UTF8.GetBytes(content);
+                var stored = await _assetStorage.SaveAsync(textBytes, "text/plain", ct,
+                    domain: AppDomainPaths.DomainLogs, type: AppDomainPaths.TypeLog);
+                replacements.Add((match.Index, match.Length, $"\"[TEXT_COS:{stored.Sha256}:{content.Length}]\""));
+            }
+            catch (Exception ex)
+            {
+                // COS 上传失败，降级为截断
+                _logger.LogWarning(ex, "COS text upload failed, falling back to truncation");
+                var truncated = SafeTruncateJsonString(content, CosTextThreshold);
+                replacements.Add((match.Index, match.Length, $"\"{truncated}...[{content.Length - CosTextThreshold} chars trimmed]\""));
+            }
+        }
+
+        if (replacements.Count == 0) return json;
+
+        // 逆序替换（从后向前避免偏移问题）
+        var sb = new StringBuilder(json);
+        foreach (var (index, length, replacement) in replacements.OrderByDescending(r => r.index))
+        {
+            sb.Remove(index, length);
+            sb.Insert(index, replacement);
+        }
+
+        return sb.ToString();
     }
 
     /// <summary>

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/GatewayLLMClient.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/GatewayLLMClient.cs
@@ -90,9 +90,7 @@ public class GatewayLLMClient : ILLMClient
             {
                 QuestionText = messages.LastOrDefault(m => m.Role == "user")?.Content,
                 SystemPromptChars = systemPrompt?.Length,
-                SystemPromptText = systemPrompt?.Length > 500
-                    ? systemPrompt.Substring(0, 500) + "..."
-                    : systemPrompt
+                SystemPromptText = systemPrompt
             }
         };
 


### PR DESCRIPTION
## Summary
Enhance the LLM logs replay-curl feature to automatically restore truncated/redacted content from COS storage, enabling complete curl commands for requests with large images or long text fields.

## Key Changes

### Frontend (LlmLogsPage.tsx)
- **Improved text restoration logic**: Split `restoreSystemPromptInRequestBody` into three focused functions:
  - `isTruncatedText()`: Detect backend-truncated text (`...[N chars trimmed]`)
  - `needsRestore()`: Check if content needs restoration (token placeholders or truncated text)
  - `restoreTruncatedRequestBody()`: Restore both system prompts and user questions from separate fields
  
- **Backend replay-curl detection**: Added `needsBackendReplayCurl()` to detect when request body contains COS references:
  - `[BASE64_IMAGE:sha256:mime]` — new image reference format
  - `[TEXT_COS:sha256:charcount]` — long text COS reference
  - Old truncated base64 data URLs and sha256 attributes
  
- **Smart curl copy flow**: When copying curl, check if backend restoration is needed:
  - Call `getReplayCurl()` API to fetch fully restored curl from COS
  - Fall back to local restoration if backend call fails
  - Display restoration status (image/text counts, warnings)

- **Postman environment variable support**: Extract domain from API URL and use as placeholder (e.g., `{{api.apiyi.com}}`) instead of hardcoded `YOUR_API_KEY`

### Backend (LlmLogsController.cs)
- **Unified replay-curl endpoint**: Generalized from vision-only to support all request types
  - Restore `[TEXT_COS:sha256:charcount]` references by fetching from COS
  - Restore `[BASE64_IMAGE:sha256:mime]` references by fetching images and re-encoding as data URLs
  - Restore truncated systemPromptText and questionText fields
  - Detect and handle legacy formats (image_url.sha256, image_refs[])
  
- **Legacy format support**: Separate `ReplayCurlLegacy()` method for old visionImageGen format with sha256 properties and image_refs arrays

- **Text field restoration**: `RestoreTruncatedTextFields()` helper to restore system/user messages from stored systemPromptText/questionText

### Infrastructure (LlmRequestLogWriter.cs)
- **Proactive COS storage for large text**: Process JSON string values during log write:
  - Detect base64 data URLs → extract SHA256 → store as `[BASE64_IMAGE:sha256:mime]` reference
  - Detect text > 1024 chars → upload to COS → store as `[TEXT_COS:sha256:charcount]` reference
  - Fall back to truncation if COS upload fails
  
- **Threshold-based optimization**: Only upload/reference strings exceeding `CosTextThreshold` (1024 chars)

### API Contracts
- Added `ReplayCurlData` response type with fields: curl, endpoint, model, imageCount, textCount, restoreErrors, requestBodyLength, warning
- Added `GetReplayCurlContract` interface and implementation

## Implementation Details
- **Backward compatibility**: Supports three image reference formats (new, old sha256 property, old image_refs array)
- **Error resilience**: Collects restoration errors and includes them in response; curl is still generated even if some assets fail to restore
- **Shell escaping**: Properly escapes single quotes in curl data for shell execution
- **JSON handling**: Uses both regex (for string value detection) and JsonNode (for structured restoration) to avoid full deserialization overhead

https://claude.ai/code/session_01VzFyp5v8Q42xuqxUBerXqc