### PR TITLE
Remove role-based restrictions for group creation

### DIFF
--- a/prd-api/src/PrdAgent.Api/Controllers/GroupsController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/GroupsController.cs
@@ -100,12 +100,11 @@ public class GroupsController : ControllerBase
             return Unauthorized(ApiResponse<object>.Fail(ErrorCodes.UNAUTHORIZED, "未授权"));
         }
 
-        // 检查用户角色（仅PM可创建）
+        // 验证用户存在
         var user = await _userService.GetByIdAsync(userId);
-        if (user == null || (user.Role != UserRole.PM && user.Role != UserRole.ADMIN))
+        if (user == null)
         {
-            return StatusCode(StatusCodes.Status403Forbidden,
-                ApiResponse<object>.Fail(ErrorCodes.PERMISSION_DENIED, "仅产品经理可创建群组"));
+            return Unauthorized(ApiResponse<object>.Fail(ErrorCodes.UNAUTHORIZED, "用户不存在"));
         }
 
         var prdDocumentId = string.IsNullOrWhiteSpace(request.PrdDocumentId) ? null : request.PrdDocumentId!.Trim();

--- a/prd-api/src/PrdAgent.Core/Services/GroupPermissionService.cs
+++ b/prd-api/src/PrdAgent.Core/Services/GroupPermissionService.cs
@@ -16,7 +16,7 @@ public static class GroupPermissionService
         return permission switch
         {
             // PM 权限
-            GroupPermission.CreateGroup => userRole == UserRole.PM || userRole == UserRole.ADMIN,
+            GroupPermission.CreateGroup => true,
             GroupPermission.DeleteGroup => userRole == UserRole.PM || userRole == UserRole.ADMIN,
             GroupPermission.InviteMembers => userRole == UserRole.PM || userRole == UserRole.ADMIN,
             GroupPermission.RemoveMembers => userRole == UserRole.PM || userRole == UserRole.ADMIN,

--- a/prd-desktop/src/components/Document/DocumentUpload.tsx
+++ b/prd-desktop/src/components/Document/DocumentUpload.tsx
@@ -54,6 +54,7 @@ export default function DocumentUpload() {
             logout();
             return;
           }
+          setError(createResp.error?.message || '创建群组失败');
           // 退化：仅进入上传会话（旧行为）
           const session: Session = {
             sessionId: response.data.sessionId,

--- a/prd-desktop/src/components/Layout/Sidebar.tsx
+++ b/prd-desktop/src/components/Layout/Sidebar.tsx
@@ -306,9 +306,7 @@ export default function Sidebar() {
             logout();
             return;
           }
-          if (!isSystemErrorCode(errorCode)) {
-            setInlineError(resp.error?.message || '创建群组失败');
-          }
+          setInlineError(resp.error?.message || '创建群组失败');
           return;
         }
 
@@ -337,9 +335,7 @@ export default function Sidebar() {
           logout();
           return;
         }
-        if (!isSystemErrorCode(errorCode)) {
-          setInlineError(resp.error?.message || '创建群组失败');
-        }
+        setInlineError(resp.error?.message || '创建群组失败');
         return;
       }
 


### PR DESCRIPTION
## Summary
This PR removes role-based access control restrictions for group creation, allowing all authenticated users to create groups instead of limiting this action to PM and Admin roles only.

## Key Changes
- **GroupsController.cs**: Removed role validation (PM/ADMIN check) during group creation. Now only verifies that the user exists.
- **GroupPermissionService.cs**: Updated `CreateGroup` permission to return `true` for all roles instead of checking for PM or ADMIN role.
- **DocumentUpload.tsx & Sidebar.tsx**: Simplified error handling by removing conditional checks for system error codes. Error messages are now always displayed to users when group creation fails.

## Implementation Details
- The authorization layer still validates that users are authenticated (via token validation)
- User existence is still verified before allowing group creation
- Error messages are now consistently shown to users regardless of error type, improving transparency
- This change democratizes group creation functionality across all user roles while maintaining basic authentication and user validation

https://claude.ai/code/session_01G7FTU6oW2ptywZk4qwTbaD