### PR TITLE
Enable developer mode permanently in release builds

### DIFF
--- a/prd-desktop/src-tauri/src/commands/config.rs
+++ b/prd-desktop/src-tauri/src/commands/config.rs
@@ -78,25 +78,10 @@ fn save_config_to_file(app: &tauri::AppHandle, config: &AppConfig) -> Result<(),
 }
 
 fn sanitize_config_for_release(cfg: &mut AppConfig) -> bool {
-    // 发布版不允许使用“开发者模式”，也不允许默认/历史遗留的 localhost 配置影响线上使用。
-    // 仅在本地调试（debug_assertions）才允许开发者模式与 localhost。
-    if cfg!(debug_assertions) {
-        return false;
-    }
-
-    let mut changed = false;
-    if cfg.is_developer {
-        cfg.is_developer = false;
-        changed = true;
-    }
-
-    let trimmed = cfg.api_base_url.trim();
-    if trimmed == DEFAULT_API_URL_DEV || is_localhost_url(trimmed) {
-        cfg.api_base_url = api_client::get_default_api_url();
-        changed = true;
-    }
-
-    changed
+    // 开发者模式常开：不再在发布版强制关闭 is_developer 或重置 localhost 地址。
+    // 用户可自行在设置中切换开发者模式与 API 地址。
+    let _ = cfg;
+    false
 }
 
 /// 获取当前配置

--- a/prd-desktop/src/components/Settings/SettingsModal.tsx
+++ b/prd-desktop/src/components/Settings/SettingsModal.tsx
@@ -588,29 +588,27 @@ export default function SettingsModal() {
             </div>
           </div>
 
-          {/* 开发者选项：仅本地调试可见（发布版默认关闭且不提供入口） */}
-          {import.meta.env.DEV && (
-            <div className="space-y-3">
-              <label className="block text-sm font-medium text-text-secondary">
-                开发者选项
-              </label>
+          {/* 开发者选项：常开，不受构建模式限制 */}
+          <div className="space-y-3">
+            <label className="block text-sm font-medium text-text-secondary">
+              开发者选项
+            </label>
 
-              <label className="flex items-center gap-3 cursor-pointer">
-                <div className="relative">
-                  <input
-                    type="checkbox"
-                    checked={isDeveloper}
-                    onChange={(e) => handleDeveloperChange(e.target.checked)}
-                    className="sr-only"
-                  />
-                  <div className={`w-10 h-6 rounded-full transition-colors ${isDeveloper ? 'bg-cyan-500' : 'bg-black/10 dark:bg-white/20'}`}>
-                    <div className={`absolute top-1 left-1 w-4 h-4 bg-white rounded-full transition-transform ${isDeveloper ? 'translate-x-4' : ''}`} />
-                  </div>
+            <label className="flex items-center gap-3 cursor-pointer">
+              <div className="relative">
+                <input
+                  type="checkbox"
+                  checked={isDeveloper}
+                  onChange={(e) => handleDeveloperChange(e.target.checked)}
+                  className="sr-only"
+                />
+                <div className={`w-10 h-6 rounded-full transition-colors ${isDeveloper ? 'bg-cyan-500' : 'bg-black/10 dark:bg-white/20'}`}>
+                  <div className={`absolute top-1 left-1 w-4 h-4 bg-white rounded-full transition-transform ${isDeveloper ? 'translate-x-4' : ''}`} />
                 </div>
-                <span className="text-sm text-text-secondary">我是开发者（默认地址切换到本地）</span>
-              </label>
-            </div>
-          )}
+              </div>
+              <span className="text-sm text-text-secondary">我是开发者（默认地址切换到本地）</span>
+            </label>
+          </div>
 
           {/* API 地址配置 */}
           <div className="space-y-3">


### PR DESCRIPTION
## Summary
This PR removes the build-time restrictions on developer mode, allowing it to be available in both debug and release builds. Users can now toggle developer mode and configure API addresses directly through the settings UI without needing to rebuild the application.

## Key Changes
- **Backend (Rust)**: Simplified `sanitize_config_for_release()` to no longer force-disable developer mode or reset localhost API URLs in release builds. The function now returns early without modifying the config.
- **Frontend (React)**: Removed the `import.meta.env.DEV` conditional guard that hid developer options in production builds. The developer options section is now always visible and accessible to users.

## Implementation Details
- Users can now self-manage their developer mode preference and API endpoint configuration through the Settings modal
- The change maintains backward compatibility - existing configs are preserved and not sanitized on startup
- Developer options UI remains unchanged; only the visibility/availability is modified
- This enables better flexibility for testing and debugging in production environments while maintaining user control

https://claude.ai/code/session_01QFaSz1Nyseik1gQN2qvRbZ