### PR TITLE
Refactor marker generation to anchor-based insertion with AI thinking display

### DIFF
--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/LlmGateway.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/LlmGateway.cs
@@ -364,8 +364,10 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
             // 记录思考过程（如果有）
             if (thinkingBuilder.Length > 0)
             {
+                var thinkingAction = request.IncludeThinking ? "已传递给调用方" : "已过滤";
                 _logger.LogDebug(
-                    "[LlmGateway] 模型思考过程已过滤（{ThinkingChars} 字符）。AppCallerCode: {AppCallerCode}, Model: {Model}",
+                    "[LlmGateway] 模型思考过程{ThinkingAction}（{ThinkingChars} 字符）。AppCallerCode: {AppCallerCode}, Model: {Model}",
+                    thinkingAction,
                     thinkingBuilder.Length,
                     request.AppCallerCode,
                     resolution?.ActualModel);


### PR DESCRIPTION
## Summary
This PR refactors the article illustration marker generation workflow to use anchor-based insertion mode instead of streaming full article content. It adds AI thinking process visualization, implements entrance animations for new marker cards, and introduces image display size controls in the preview.

## Key Changes

### Marker Generation & Insertion
- **Anchor-based insertion mode**: Replaced full-text streaming with anchor-based marker insertion (`insertionMode: 'anchor'`), where LLM identifies insertion points in the article and markers are inserted incrementally
- **Anchor matching logic**: Implemented `findAnchorInsertPos()` function with 4-level fuzzy matching (exact, case-insensitive, whitespace-normalized, punctuation-normalized) to locate marker insertion positions
- **Direct marker parsing**: Markers are now directly marked as 'parsed' status with default 1:1 size, eliminating the need for separate intent parsing via `planImageGen()`

### AI Output Visualization
- **Thinking process display**: Added real-time display of LLM thinking content in a dedicated panel during generation (`thinkingContent` state)
- **Raw output feedback**: Implemented `rawMarkerOutput` state to show LLM's raw output for visual feedback in anchor mode
- **Streaming phase UI**: Created full-screen AI output view during marker generation showing both thinking and output sections with markdown rendering

### Visual Enhancements
- **Entrance animations**: Added `marker-card-glow-entrance` animation with conic-gradient border sweep effect for newly inserted marker cards
- **Marker highlighting**: Implemented `prd-md-marker-new` class with glowing animation for markers inserted during streaming
- **Image display controls**: Added sticky image size picker (30%, 50%, 75%, 100%) in article preview using CSS custom property `--img-display-size`
- **Improved marker localization**: Enhanced `locateMarkerInPreview()` with multiple fallback strategies using `data-marker-idx` attributes, class selectors, and alt text matching

### API & Service Updates
- **New API calls**: Added `optimizeLiteraryPrompt()` and `getAdapterInfoByModelName()` service imports
- **Service renaming**: Renamed imported functions to use "VisualAgent" terminology (`getLiteraryAgentWorkspaceDetailReal` → `getVisualAgentWorkspaceDetail`, etc.)
- **Model size options**: Fetch image generation model size options from adapter info and populate `sizesByResolutionForPicker` state

### UI/UX Improvements
- **Optional prompt selection**: Made prompt template selection optional (no longer required to generate markers)
- **Prompt optimization**: Added `handleOptimizePrompt()` function to extract style descriptions from prompts via AI
- **Progress feedback**: Added streaming progress indicator showing identified marker count
- **Collapsible thinking panel**: Thinking content displayed as collapsible `<details>` element in final preview
- **Image wrapping**: Changed image rendering to use raw `<img>` tags with `data-marker-idx` attributes instead of markdown syntax for better URL handling

### State Management
- **New state variables**: `thinkingContent`, `optimizingPromptId`, `sizesByResolutionForPicker`, `glowingMarkers`, `imageDisplaySize`, `rawMarkerOutput`
- **Ref tracking**: Added `thinkingPanelRef` for auto-scroll and `knownMarkerIndicesRef` to track new marker indices for animation triggering
- **Streaming detection**: Improved `isStreamingRef` usage to control UI phase transitions and auto-scroll behavior

### Code Cleanup
- Removed `flushSync` import (no longer needed with anchor-based approach)
- Removed unused `currentLineBuffer` line-by-line parsing logic
- Simplified marker extraction by eliminating intermediate intent parsing step

## Implementation Details
- Anchor insertion preserves original article text and inserts markers at contextually appropriate positions
- Thinking panel auto-scrolls to bottom during streaming for real-time feedback
- Entrance animations use CSS `@keyframes` with opacity and transform transitions
- Image size control uses CSS custom properties for dynamic max-width adjustment
- Marker localization uses progressive fallback strategy for robustness across different rendering states

https://claude.ai/code/session_014Ff1iFfzc7VYV9BKfcjiPF

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it rewires the marker-generation streaming protocol/UI (new `anchor` insertion mode, new chunk types, and removal of `planImageGen` parsing), which can break generation/preview synchronization if backend chunk semantics differ. Mostly front-end UX changes plus a small backend logging tweak.
> 
> **Overview**
> **Marker generation is refactored to an anchor-based workflow.** The editor now calls `generateArticleMarkers` with `insertionMode: 'anchor'`, incrementally inserts `[插图]` markers into the article via new fuzzy anchor matching helpers, and treats incoming `marker` events as immediately `parsed` (removing the `planImageGen` intent-parsing step).
> 
> **Streaming UX is overhauled.** During generation the left pane switches to an AI output view showing live `thinking` and raw output, adds progress/entrance animations for newly discovered marker cards, and updates marker locating/highlighting by using `data-marker-idx` attributes (also switching rendered images to raw `<img>` tags).
> 
> **Configuration/controls are expanded.** Prompt templates are repositioned as optional *style* presets with an `optimizeLiteraryPrompt` action, image sizes per marker are selectable via `ImageSizePicker` populated from `getAdapterInfoByModelName`, and the article preview gains a quick control for image display size.
> 
> **Backend logging is adjusted.** `LlmGateway` debug logs now indicate whether thinking content was forwarded or filtered based on `IncludeThinking`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 889158197ba3b4d39b903c082342e7b9e67b7f07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->