### PR TITLE
refactor: unify panel/card background colors to use CSS variables

### DIFF
--- a/prd-admin/src/pages/AiChatPage.tsx
+++ b/prd-admin/src/pages/AiChatPage.tsx
@@ -1009,7 +1009,7 @@ export default function AiChatPage() {
                   key={s.sessionId}
                   className="flex items-center gap-2 px-2 py-1 rounded-[10px] group"
                   style={{
-                    background: isActive ? 'rgba(255,255,255,0.06)' : 'transparent',
+                    background: isActive ? 'var(--bg-input-hover)' : 'transparent',
                   }}
                 >
                   <button
@@ -1083,7 +1083,7 @@ export default function AiChatPage() {
         <button
           type="button"
           className="px-3 h-[28px] rounded-[9px] text-[12px] font-semibold hover:bg-white/5 transition-colors truncate flex items-center gap-1.5"
-          style={{ border: '1px solid rgba(255,255,255,0.12)', color: 'var(--text-primary)', maxWidth: '280px', background: 'rgba(255,255,255,0.04)' }}
+          style={{ border: '1px solid var(--border-default)', color: 'var(--text-primary)', maxWidth: '280px', background: 'var(--bg-input)' }}
           onClick={() => {
             if (sessions.length === 0) {
               setCreateOpen(true);
@@ -1135,9 +1135,9 @@ export default function AiChatPage() {
         type="button"
         className="text-[11px] h-[28px] px-2.5 rounded-[9px] transition-colors"
         style={{ 
-          border: '1px solid rgba(255,255,255,0.12)', 
+          border: '1px solid var(--border-default)',
           color: isTestMode ? 'var(--accent-gold)' : 'var(--text-secondary)',
-          background: isTestMode ? 'rgba(214, 178, 106, 0.08)' : 'rgba(255,255,255,0.04)',
+          background: isTestMode ? 'rgba(214, 178, 106, 0.08)' : 'var(--bg-input)',
           cursor: isTestMode ? 'default' : 'pointer',
         }}
         onClick={() => !isTestMode && setDebugMode((v) => !v)}
@@ -1198,7 +1198,7 @@ export default function AiChatPage() {
                   className="w-full max-w-[520px] rounded-[20px] p-6 flex flex-col items-center gap-4 transition-colors"
                   style={{
                     border: `2px dashed ${prdDragOver ? 'var(--accent-gold)' : 'var(--border-subtle)'}`,
-                    background: prdDragOver ? 'rgba(214,178,106,0.08)' : 'rgba(255,255,255,0.02)',
+                    background: prdDragOver ? 'rgba(214,178,106,0.08)' : 'var(--list-item-bg)',
                   }}
                   onDragOver={(e) => { e.preventDefault(); setPrdDragOver(true); }}
                   onDragLeave={() => setPrdDragOver(false)}
@@ -1239,7 +1239,7 @@ export default function AiChatPage() {
                   <div
                     className="max-w-[85%] rounded-[14px] px-3.5 py-2.5 relative group"
                     style={{
-                      background: isUser ? 'rgba(214, 178, 106, 0.12)' : 'rgba(255,255,255,0.03)',
+                      background: isUser ? 'rgba(214, 178, 106, 0.12)' : 'var(--nested-block-bg)',
                       border: isUser ? '1px solid rgba(214, 178, 106, 0.30)' : '1px solid var(--border-subtle)',
                       color: 'var(--text-primary)',
                       wordBreak: 'break-word',
@@ -1253,7 +1253,7 @@ export default function AiChatPage() {
                           style={{
                             border: '1px solid var(--border-subtle)',
                             color: 'var(--text-secondary)',
-                            background: 'rgba(255,255,255,0.02)',
+                            background: 'var(--list-item-bg)',
                           }}
                           title="本轮回答角色"
                         >
@@ -1291,7 +1291,7 @@ export default function AiChatPage() {
                           <button
                             type="button"
                             className="text-[11px] rounded-full px-2 py-1 hover:bg-white/5"
-                            style={{ border: '1px solid var(--border-subtle)', color: 'var(--text-secondary)', background: 'rgba(255,255,255,0.02)' }}
+                            style={{ border: '1px solid var(--border-subtle)', color: 'var(--text-secondary)', background: 'var(--list-item-bg)' }}
                             onClick={() => {
                               setComposer(m.content || '');
                               setResendTargetMessageId(m.id);
@@ -1324,12 +1324,12 @@ export default function AiChatPage() {
                           .prd-md li { margin: 5px 0; }
                           .prd-md strong { font-weight: 600; color: var(--text-primary); }
                           .prd-md em { font-style: italic; color: var(--text-secondary); }
-                          .prd-md code { font-family: ui-monospace, monospace; font-size: 12px; background: rgba(255,255,255,0.08); border: 1px solid rgba(255,255,255,0.12); padding: 2px 6px; border-radius: 6px; }
-                          .prd-md pre { background: rgba(0,0,0,0.3); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; padding: 12px; overflow: auto; margin: 12px 0; }
+                          .prd-md code { font-family: ui-monospace, monospace; font-size: 12px; background: var(--border-subtle); border: 1px solid var(--border-default); padding: 2px 6px; border-radius: 6px; }
+                          .prd-md pre { background: var(--nested-block-bg); border: 1px solid var(--border-default); border-radius: 12px; padding: 12px; overflow: auto; margin: 12px 0; }
                           .prd-md pre code { background: transparent; border: 0; padding: 0; }
                           .prd-md blockquote { margin: 12px 0; padding: 8px 12px; border-left: 3px solid rgba(214, 178, 106, 0.40); background: rgba(214, 178, 106, 0.06); color: var(--text-primary); border-radius: 10px; }
                           .prd-md a { color: rgba(147, 197, 253, 0.95); text-decoration: underline; }
-                          .prd-md hr { border: 0; border-top: 1px solid rgba(255,255,255,0.12); margin: 16px 0; }
+                          .prd-md hr { border: 0; border-top: 1px solid var(--border-default); margin: 16px 0; }
 
                           /* 流式输出“高级感”：高帧率灰度尾巴（未提交部分） */
                           .prd-md-stream-live { margin-top: 8px; white-space: pre-wrap; word-break: break-word; font-size: 12px; line-height: 1.6; color: var(--text-muted); opacity: 0.92; filter: saturate(0.55); }
@@ -1374,7 +1374,7 @@ export default function AiChatPage() {
                           <button
                             type="button"
                             className="text-[11px] rounded-full px-2 py-1 hover:bg-white/5"
-                            style={{ border: '1px solid var(--border-subtle)', color: 'var(--text-secondary)', background: 'rgba(255,255,255,0.02)' }}
+                            style={{ border: '1px solid var(--border-subtle)', color: 'var(--text-secondary)', background: 'var(--list-item-bg)' }}
                             onClick={() => openCitationDrawer(m.citations || [], 0)}
                             title="右侧展开引用内容"
                           >
@@ -1387,7 +1387,7 @@ export default function AiChatPage() {
                               key={`${c.headingId || c.headingTitle || 'c'}-${idx}`}
                               type="button"
                               className="inline-flex items-center rounded-full px-2 py-1 text-[11px] hover:bg-white/5"
-                              style={{ border: '1px solid var(--border-subtle)', color: 'var(--text-secondary)', background: 'rgba(255,255,255,0.02)' }}
+                              style={{ border: '1px solid var(--border-subtle)', color: 'var(--text-secondary)', background: 'var(--list-item-bg)' }}
                               title={c.excerpt || c.headingTitle || c.headingId || ''}
                               onClick={() => openCitationDrawer(m.citations || [], idx)}
                             >
@@ -1621,7 +1621,7 @@ export default function AiChatPage() {
             <pre
               className="w-full rounded-[14px] p-3 text-[12px] overflow-auto"
               style={{
-                background: 'rgba(255,255,255,0.03)',
+                background: 'var(--nested-block-bg)',
                 border: '1px solid var(--border-subtle)',
                 color: 'var(--text-primary)',
                 whiteSpace: 'pre-wrap',
@@ -1639,7 +1639,7 @@ export default function AiChatPage() {
             <pre
               className="w-full rounded-[14px] p-3 text-[12px] overflow-auto"
               style={{
-                background: 'rgba(255,255,255,0.03)',
+                background: 'var(--nested-block-bg)',
                 border: '1px solid var(--border-subtle)',
                 color: 'var(--text-primary)',
                 whiteSpace: 'pre-wrap',
@@ -1681,7 +1681,7 @@ export default function AiChatPage() {
                 onChange={(e) => setPrdTitle(e.target.value)}
                 className="flex-1 h-10 rounded-[10px] px-3 text-sm outline-none"
                 style={{
-                  background: 'rgba(255,255,255,0.03)',
+                  background: 'var(--nested-block-bg)',
                   border: '1px solid var(--border-subtle)',
                   color: 'var(--text-primary)',
                 }}
@@ -1711,7 +1711,7 @@ export default function AiChatPage() {
               onChange={(e) => setPrdText(e.target.value)}
               className="w-full flex-1 min-h-[420px] rounded-[16px] px-4 py-3 text-sm outline-none resize-y"
               style={{
-                background: 'rgba(255,255,255,0.03)',
+                background: 'var(--nested-block-bg)',
                 border: '1px solid var(--border-subtle)',
                 color: 'var(--text-primary)',
                 fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
@@ -1783,7 +1783,7 @@ export default function AiChatPage() {
                     className="w-full text-left rounded-[14px] px-3 py-2"
                     style={{
                       border: '1px solid var(--border-subtle)',
-                      background: active ? 'rgba(255,255,255,0.06)' : 'rgba(255,255,255,0.02)',
+                      background: active ? 'var(--bg-input-hover)' : 'var(--list-item-bg)',
                       color: 'var(--text-primary)',
                     }}
                     onClick={() => setCitationDrawerActiveIndex(idx)}

--- a/prd-admin/src/pages/AssetsManagePage.tsx
+++ b/prd-admin/src/pages/AssetsManagePage.tsx
@@ -933,7 +933,7 @@ function AssetRowBlock(props: {
                   ? 'linear-gradient(135deg, rgba(239,68,68,0.08) 0%, rgba(239,68,68,0.02) 100%)'
                   : isFallback
                     ? 'linear-gradient(135deg, rgba(234,179,8,0.06) 0%, rgba(234,179,8,0.02) 100%)'
-                    : 'linear-gradient(135deg, rgba(255,255,255,0.03) 0%, rgba(255,255,255,0.01) 100%)',
+                    : 'linear-gradient(135deg, var(--nested-block-bg) 0%, var(--list-item-bg) 100%)',
               }}
               title={isUploading ? '上传中...' : (url ? `点击替换\n${url}` : '点击上传')}
               onClick={() => !isUploading && onUpload(skin, row.key)}

--- a/prd-admin/src/pages/AssetsManagePage.tsx
+++ b/prd-admin/src/pages/AssetsManagePage.tsx
@@ -135,8 +135,8 @@ function InputField({
           mono && 'font-mono'
         )}
         style={{
-          background: 'rgba(255,255,255,0.04)',
-          border: '1px solid rgba(255,255,255,0.08)',
+          background: 'var(--bg-input)',
+          border: '1px solid var(--border-subtle)',
           color: 'var(--text-primary)',
         }}
       />
@@ -546,7 +546,7 @@ export default function AssetsManagePage() {
             <SectionTitle icon={<User size={16} />} title="无头像兜底" badge="required" />
           </div>
           <p className="text-[12px] mb-5" style={{ color: 'var(--text-muted)' }}>
-            固定路径 <code className="font-mono text-[11px] px-1.5 py-0.5 rounded-[6px]" style={{ background: 'rgba(255,255,255,0.04)' }}>/icon/backups/head/nohead.png</code>
+            固定路径 <code className="font-mono text-[11px] px-1.5 py-0.5 rounded-[6px]" style={{ background: 'var(--bg-input)' }}>/icon/backups/head/nohead.png</code>
           </p>
 
           <div className={cn('flex gap-5', isMobile ? 'flex-col items-stretch' : 'items-start')}>
@@ -562,7 +562,7 @@ export default function AssetsManagePage() {
                 height: isMobile ? '100px' : '120px',
                 background: isNoHeadBroken
                   ? 'linear-gradient(135deg, rgba(239,68,68,0.08) 0%, rgba(239,68,68,0.03) 100%)'
-                  : 'rgba(255,255,255,0.02)',
+                  : 'var(--list-item-bg)',
               }}
             >
                 {noHeadPreviewUrl ? (
@@ -590,7 +590,7 @@ export default function AssetsManagePage() {
               <div className="text-[11px] font-semibold uppercase tracking-wider mb-1.5" style={{ color: 'var(--text-muted)' }}>当前地址</div>
               <div
                 className="font-mono text-[12px] break-all p-2.5 rounded-[10px]"
-                style={{ background: 'rgba(255,255,255,0.02)', border: '1px solid rgba(255,255,255,0.05)', color: 'var(--text-secondary)' }}
+                style={{ background: 'var(--list-item-bg)', border: '1px solid var(--bg-card-hover)', color: 'var(--text-secondary)' }}
               >
                 {noHeadPreviewUrl || '-'}
               </div>
@@ -682,14 +682,14 @@ export default function AssetsManagePage() {
           <GlassCard glow className="overflow-hidden">
             <SectionTitle icon={<Plus size={16} />} title="快速创建" />
             <p className="mt-1.5 mb-4 text-[11px]" style={{ color: 'var(--text-muted)' }}>
-              资源根目录：<code className="font-mono text-[10px] px-1.5 py-0.5 rounded-[6px]" style={{ background: 'rgba(255,255,255,0.04)' }}>{desktopRoot || '-'}</code>
+              资源根目录：<code className="font-mono text-[10px] px-1.5 py-0.5 rounded-[6px]" style={{ background: 'var(--bg-input)' }}>{desktopRoot || '-'}</code>
             </p>
 
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
               {/* 新建皮肤 */}
               <div
                 className="p-3.5 rounded-[12px]"
-                style={{ background: 'rgba(255,255,255,0.015)', border: '1px solid rgba(255,255,255,0.05)' }}
+                style={{ background: 'var(--list-item-bg)', border: '1px solid var(--bg-card-hover)' }}
               >
                 <div className="flex items-center gap-2 mb-2.5">
                   <Palette size={13} style={{ color: 'var(--accent-gold)' }} />
@@ -718,7 +718,7 @@ export default function AssetsManagePage() {
                 {/* 新建 Key */}
               <div
                 className="p-3.5 rounded-[12px]"
-                style={{ background: 'rgba(255,255,255,0.015)', border: '1px solid rgba(255,255,255,0.05)' }}
+                style={{ background: 'var(--list-item-bg)', border: '1px solid var(--bg-card-hover)' }}
               >
                 <div className="flex items-center gap-2 mb-2.5">
                   <FolderOpen size={13} style={{ color: 'var(--accent-gold)' }} />
@@ -774,8 +774,8 @@ export default function AssetsManagePage() {
             <div
               className="rounded-[12px] overflow-hidden"
               style={{
-                background: 'rgba(255,255,255,0.015)',
-                border: '1px solid rgba(255,255,255,0.05)',
+                background: 'var(--list-item-bg)',
+                border: '1px solid var(--bg-card-hover)',
               }}
             >
               <div className="overflow-x-auto">
@@ -785,8 +785,8 @@ export default function AssetsManagePage() {
                   className="grid"
                   style={{
                     gridTemplateColumns: `minmax(160px, 1fr) repeat(${columns.length}, minmax(90px, 1fr))`,
-                    borderBottom: '1px solid rgba(255,255,255,0.05)',
-                    background: 'rgba(255,255,255,0.01)',
+                    borderBottom: '1px solid var(--bg-card-hover)',
+                    background: 'var(--list-item-bg)',
                   }}
                 >
                   <div
@@ -861,7 +861,7 @@ function AssetRowBlock(props: {
       className="grid"
       style={{
         gridTemplateColumns: `minmax(180px, 1fr) repeat(${columns.length}, minmax(100px, 1fr))`,
-        borderBottom: '1px solid rgba(255,255,255,0.04)',
+        borderBottom: '1px solid var(--bg-input)',
       }}
     >
       {/* 行标题 */}

--- a/prd-admin/src/pages/AuthzPage.tsx
+++ b/prd-admin/src/pages/AuthzPage.tsx
@@ -222,8 +222,8 @@ export default function AuthzPage() {
       onClick={() => setUserDropdownOpen(true)}
       className="h-7 flex items-center gap-1.5 px-2.5 rounded-lg text-xs font-medium transition-colors"
       style={{
-        background: activeUser ? 'rgba(214, 178, 106, 0.15)' : 'rgba(255, 255, 255, 0.06)',
-        border: activeUser ? '1px solid rgba(214, 178, 106, 0.3)' : '1px solid rgba(255, 255, 255, 0.1)',
+        background: activeUser ? 'rgba(214, 178, 106, 0.15)' : 'var(--bg-input-hover)',
+        border: activeUser ? '1px solid rgba(214, 178, 106, 0.3)' : '1px solid var(--border-default)',
         color: activeUser ? 'rgba(214, 178, 106, 0.95)' : 'var(--text-secondary)',
       }}
     >
@@ -257,8 +257,8 @@ export default function AuthzPage() {
         onClick={() => setCreateOpen(true)}
         className="h-7 flex items-center gap-1.5 px-2.5 rounded-lg text-xs font-medium transition-colors hover:bg-white/10"
         style={{
-          background: 'rgba(255, 255, 255, 0.06)',
-          border: '1px solid rgba(255, 255, 255, 0.1)',
+          background: 'var(--bg-input-hover)',
+          border: '1px solid var(--border-default)',
           color: 'var(--text-secondary)',
         }}
       >
@@ -278,8 +278,8 @@ export default function AuthzPage() {
         }}
         className="h-7 flex items-center gap-1.5 px-2.5 rounded-lg text-xs font-medium transition-colors hover:bg-white/10"
         style={{
-          background: activeUser ? 'rgba(214, 178, 106, 0.12)' : 'rgba(255, 255, 255, 0.06)',
-          border: activeUser ? '1px solid rgba(214, 178, 106, 0.25)' : '1px solid rgba(255, 255, 255, 0.1)',
+          background: activeUser ? 'rgba(214, 178, 106, 0.12)' : 'var(--bg-input-hover)',
+          border: activeUser ? '1px solid rgba(214, 178, 106, 0.25)' : '1px solid var(--border-default)',
           color: activeUser ? 'rgba(214, 178, 106, 0.95)' : 'var(--text-secondary)',
         }}
       >
@@ -294,8 +294,8 @@ export default function AuthzPage() {
         disabled={resetSubmitting}
         className="h-7 w-7 flex items-center justify-center rounded-lg transition-colors hover:bg-white/10 disabled:opacity-50"
         style={{
-          background: 'rgba(255, 255, 255, 0.06)',
-          border: '1px solid rgba(255, 255, 255, 0.1)',
+          background: 'var(--bg-input-hover)',
+          border: '1px solid var(--border-default)',
           color: 'var(--text-secondary)',
         }}
       >
@@ -356,8 +356,8 @@ export default function AuthzPage() {
                 onChange={(e) => setCreateKey(e.target.value)}
                 className="mt-2 h-10 w-full rounded-[14px] px-4 text-sm outline-none"
                 style={{
-                  background: 'rgba(255,255,255,0.04)',
-                  border: '1px solid rgba(255,255,255,0.12)',
+                  background: 'var(--bg-input)',
+                  border: '1px solid var(--border-default)',
                   color: 'var(--text-primary)',
                 }}
                 placeholder="例如：ops 或 content_viewer"
@@ -372,8 +372,8 @@ export default function AuthzPage() {
                 onChange={(e) => setCreateName(e.target.value)}
                 className="mt-2 h-10 w-full rounded-[14px] px-4 text-sm outline-none"
                 style={{
-                  background: 'rgba(255,255,255,0.04)',
-                  border: '1px solid rgba(255,255,255,0.12)',
+                  background: 'var(--bg-input)',
+                  border: '1px solid var(--border-default)',
                   color: 'var(--text-primary)',
                 }}
                 placeholder="例如：内容只读"
@@ -407,14 +407,14 @@ export default function AuthzPage() {
             style={{
               ...glassPopoverCompact,
               background: 'rgba(24, 24, 28, 0.95)',
-              border: '1px solid rgba(255, 255, 255, 0.1)',
+              border: '1px solid var(--border-default)',
               boxShadow: '0 25px 50px -12px rgba(0, 0, 0, 0.5)',
             }}
           >
             {/* Header */}
             <div
               className="flex items-center justify-between px-5 py-4"
-              style={{ borderBottom: '1px solid rgba(255, 255, 255, 0.06)' }}
+              style={{ borderBottom: '1px solid var(--nested-block-border)' }}
             >
               <div>
                 <div className="text-base font-semibold" style={{ color: 'var(--text-primary)' }}>
@@ -456,7 +456,7 @@ export default function AuthzPage() {
                         }}
                         className="w-full px-4 py-3 text-left rounded-xl transition-all duration-200"
                         style={{
-                          background: isSelected ? 'rgba(214, 178, 106, 0.15)' : 'rgba(255, 255, 255, 0.02)',
+                          background: isSelected ? 'rgba(214, 178, 106, 0.15)' : 'var(--list-item-bg)',
                           border: isSelected ? '1px solid rgba(214, 178, 106, 0.3)' : '1px solid transparent',
                         }}
                       >
@@ -475,7 +475,7 @@ export default function AuthzPage() {
                           <span
                             className="text-[11px] px-2 py-0.5 rounded-md"
                             style={{
-                              background: userRole?.isBuiltIn ? 'rgba(214, 178, 106, 0.1)' : 'rgba(255, 255, 255, 0.05)',
+                              background: userRole?.isBuiltIn ? 'rgba(214, 178, 106, 0.1)' : 'var(--bg-card-hover)',
                               color: userRole?.isBuiltIn ? 'rgba(214, 178, 106, 0.8)' : 'var(--text-muted)',
                             }}
                           >
@@ -493,7 +493,7 @@ export default function AuthzPage() {
             <div
               className="px-5 py-3 text-xs flex items-center justify-between"
               style={{
-                borderTop: '1px solid rgba(255, 255, 255, 0.06)',
+                borderTop: '1px solid var(--nested-block-border)',
                 color: 'var(--text-muted)',
               }}
             >
@@ -532,14 +532,14 @@ export default function AuthzPage() {
             style={{
               ...glassPopoverCompact,
               background: 'rgba(24, 24, 28, 0.95)',
-              border: '1px solid rgba(255, 255, 255, 0.1)',
+              border: '1px solid var(--border-default)',
               boxShadow: '0 25px 50px -12px rgba(0, 0, 0, 0.5)',
             }}
           >
             {/* Header */}
             <div
               className="flex items-center justify-between px-5 py-4"
-              style={{ borderBottom: '1px solid rgba(255, 255, 255, 0.06)' }}
+              style={{ borderBottom: '1px solid var(--nested-block-border)' }}
             >
               <div>
                 <div className="text-base font-semibold" style={{ color: 'var(--text-primary)' }}>
@@ -600,8 +600,8 @@ export default function AuthzPage() {
                       disabled={assignRoleSubmitting}
                       className="w-full px-4 py-3 text-left rounded-xl transition-all duration-200 disabled:opacity-50"
                       style={{
-                        background: isCurrentRole ? 'rgba(214, 178, 106, 0.15)' : 'rgba(255, 255, 255, 0.02)',
-                        border: isCurrentRole ? '1px solid rgba(214, 178, 106, 0.3)' : '1px solid rgba(255, 255, 255, 0.06)',
+                        background: isCurrentRole ? 'rgba(214, 178, 106, 0.15)' : 'var(--list-item-bg)',
+                        border: isCurrentRole ? '1px solid rgba(214, 178, 106, 0.3)' : '1px solid var(--nested-block-border)',
                       }}
                     >
                       <div className="flex items-center justify-between">
@@ -609,7 +609,7 @@ export default function AuthzPage() {
                           <div
                             className="w-9 h-9 rounded-[10px] flex items-center justify-center"
                             style={{
-                              background: role.isBuiltIn ? 'rgba(214, 178, 106, 0.12)' : 'rgba(255, 255, 255, 0.05)',
+                              background: role.isBuiltIn ? 'rgba(214, 178, 106, 0.12)' : 'var(--bg-card-hover)',
                             }}
                           >
                             {role.isBuiltIn ? (
@@ -652,7 +652,7 @@ export default function AuthzPage() {
             <div
               className="px-5 py-3 text-[11px]"
               style={{
-                borderTop: '1px solid rgba(255, 255, 255, 0.06)',
+                borderTop: '1px solid var(--nested-block-border)',
                 color: 'var(--text-muted)',
               }}
             >

--- a/prd-admin/src/pages/AutomationRulesPage.tsx
+++ b/prd-admin/src/pages/AutomationRulesPage.tsx
@@ -62,7 +62,7 @@ const inputCls =
   + ' hover:border-white/20 focus:ring-2 focus:ring-white/10';
 const inputStyle: React.CSSProperties = {
   background: 'var(--bg-input)',
-  border: '1px solid rgba(255,255,255,0.12)',
+  border: '1px solid var(--border-default)',
   color: 'var(--text-primary)',
 };
 
@@ -152,12 +152,12 @@ function UserMultiSelect({ allUsers, selectedIds, onChange }: {
       </button>
       {open && (
         <div className="absolute z-[120] mt-2 w-full rounded-[14px] overflow-hidden" style={selectContentStyle}>
-          <div className="p-2 border-b" style={{ borderColor: 'rgba(255,255,255,0.12)' }}>
+          <div className="p-2 border-b" style={{ borderColor: 'var(--border-default)' }}>
             <div className="relative">
               <Search size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2" style={{ color: 'var(--text-muted)' }} />
               <input ref={searchRef} type="text" value={search} onChange={(e) => setSearch(e.target.value)}
                 placeholder="搜索用户..." className="w-full pl-8 pr-3 h-8 rounded-[8px] text-sm outline-none"
-                style={{ background: 'var(--bg-input)', border: '1px solid rgba(255,255,255,0.12)', color: 'var(--text-primary)' }}
+                style={{ background: 'var(--bg-input)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
               />
             </div>
           </div>
@@ -168,7 +168,7 @@ function UserMultiSelect({ allUsers, selectedIds, onChange }: {
               <span className="flex-1">全局通知（所有管理员）</span>
               {selectedIds.length === 0 && <Check size={12} className="text-green-400 flex-shrink-0" />}
             </button>
-            <div className="mx-2 my-1" style={{ borderTop: '1px solid rgba(255,255,255,0.06)' }} />
+            <div className="mx-2 my-1" style={{ borderTop: '1px solid var(--nested-block-border)' }} />
             {filtered.map((user) => (
               <button key={user.userId} type="button" onClick={() => toggle(user.userId)}
                 className={selectItemClass + ' w-full text-left flex items-center gap-2'}>
@@ -430,9 +430,9 @@ export default function AutomationRulesPage() {
         <div className="grid h-full" style={{ gridTemplateColumns: isMobile ? '1fr' : '280px minmax(0, 1fr)', gridTemplateRows: isMobile ? 'auto minmax(0, 1fr)' : undefined }}>
 
           {/* ── 左侧：规则列表 ── */}
-          <div className="min-h-0 flex flex-col" style={{ borderRight: isMobile ? 'none' : '1px solid rgba(255,255,255,0.06)', borderBottom: isMobile ? '1px solid rgba(255,255,255,0.06)' : 'none', maxHeight: isMobile ? '40vh' : undefined, height: isMobile ? 'auto' : '100%' }}>
+          <div className="min-h-0 flex flex-col" style={{ borderRight: isMobile ? 'none' : '1px solid var(--nested-block-border)', borderBottom: isMobile ? '1px solid var(--nested-block-border)' : 'none', maxHeight: isMobile ? '40vh' : undefined, height: isMobile ? 'auto' : '100%' }}>
             {/* 列表头 */}
-            <div className="flex items-center justify-between px-4 py-3" style={{ borderBottom: '1px solid rgba(255,255,255,0.06)' }}>
+            <div className="flex items-center justify-between px-4 py-3" style={{ borderBottom: '1px solid var(--nested-block-border)' }}>
               <span className="text-xs font-medium" style={{ color: 'var(--text-muted)' }}>
                 自动化规则 ({rules.length})
               </span>
@@ -508,7 +508,7 @@ export default function AutomationRulesPage() {
                       <div className="flex items-center gap-1.5 mt-1 ml-[21px]">
                         {rule.actions.map((a, i) => (
                           <span key={i} className="inline-flex items-center gap-0.5 text-[10px] px-1.5 py-0.5 rounded-full"
-                            style={{ background: 'rgba(255,255,255,0.06)' }}>
+                            style={{ background: 'var(--bg-input-hover)' }}>
                             {actionTypeIcons[a.type]}
                             {actionTypeLabels[a.type]}
                           </span>
@@ -534,7 +534,7 @@ export default function AutomationRulesPage() {
             ) : (
               <>
                 {/* 编辑器头部 */}
-                <div className="flex items-center gap-3 px-5 py-3" style={{ borderBottom: '1px solid rgba(255,255,255,0.06)' }}>
+                <div className="flex items-center gap-3 px-5 py-3" style={{ borderBottom: '1px solid var(--nested-block-border)' }}>
                   <span className="flex-shrink-0" style={{ color: edit.triggerType === 'incoming_webhook' ? 'rgba(34,197,94,0.7)' : 'rgba(59,130,246,0.7)' }}>
                     {triggerTypeIcon[edit.triggerType]}
                   </span>
@@ -625,7 +625,7 @@ export default function AutomationRulesPage() {
                     <div className="space-y-2">
                       {edit.actions.map((action, idx) => (
                         <div key={idx} className="p-3 rounded-[12px] space-y-2"
-                          style={{ background: 'rgba(255,255,255,0.02)', border: '1px solid rgba(255,255,255,0.08)' }}>
+                          style={{ background: 'var(--list-item-bg)', border: '1px solid var(--border-subtle)' }}>
                           <div className="flex items-center justify-between">
                             <span className="text-xs font-medium flex items-center gap-1.5">
                               {actionTypeIcons[action.type]}
@@ -670,7 +670,7 @@ export default function AutomationRulesPage() {
                 </div>
 
                 {/* 底部操作栏 */}
-                <div className="flex flex-wrap items-center gap-2 px-5 py-3" style={{ borderTop: '1px solid rgba(255,255,255,0.06)' }}>
+                <div className="flex flex-wrap items-center gap-2 px-5 py-3" style={{ borderTop: '1px solid var(--nested-block-border)' }}>
                   <Button size="sm" onClick={handleSave} disabled={saving}>
                     {saving ? <Loader2 size={14} className="animate-spin" /> : <Save size={14} />}
                     {edit.id ? '保存' : '创建'}

--- a/prd-admin/src/pages/DataManagePage.tsx
+++ b/prd-admin/src/pages/DataManagePage.tsx
@@ -264,7 +264,7 @@ function CollectionValidationDialog({ open, onOpenChange, collectionName, onRefr
             <div className="text-lg font-bold mt-1" style={{ color: 'rgba(59,130,246,0.95)' }}>{data?.entityFields.length ?? 0}</div>
           </div>
         </div>
-        <div className="flex-1 overflow-auto rounded-[12px]" style={{ background: 'rgba(0,0,0,0.2)', border: '1px solid rgba(255,255,255,0.06)' }}>
+        <div className="flex-1 overflow-auto rounded-[12px]" style={{ background: 'var(--nested-block-bg)', border: '1px solid var(--nested-block-border)' }}>
           {loading ? (
             <div className="flex items-center justify-center h-full" style={{ color: 'var(--text-muted)' }}><RefreshCw size={20} className="animate-spin mr-2" />扫描中...</div>
           ) : !data?.hasEntity ? (
@@ -284,13 +284,13 @@ function CollectionValidationDialog({ open, onOpenChange, collectionName, onRefr
                   <div className="space-y-1 mb-2">
                     {item.issues.map((issue, i) => (<div key={i} className="text-xs flex items-center gap-2" style={{ color: 'rgba(239,68,68,0.9)' }}><AlertTriangle size={12} />{issue}</div>))}
                   </div>
-                  <pre className="p-2 rounded-[6px] text-xs overflow-x-auto max-h-[150px]" style={{ background: 'rgba(0,0,0,0.2)', color: 'var(--text-secondary)' }}>{JSON.stringify(item.document, null, 2)}</pre>
+                  <pre className="p-2 rounded-[6px] text-xs overflow-x-auto max-h-[150px]" style={{ background: 'var(--nested-block-bg)', color: 'var(--text-secondary)' }}>{JSON.stringify(item.document, null, 2)}</pre>
                 </div>
               ))}
             </div>
           )}
         </div>
-        <div className="flex items-center justify-end gap-2 pt-2" style={{ borderTop: '1px solid rgba(255,255,255,0.06)' }}>
+        <div className="flex items-center justify-end gap-2 pt-2" style={{ borderTop: '1px solid var(--nested-block-border)' }}>
           <Button variant="secondary" size="sm" onClick={loadData} disabled={loading}><RefreshCw size={14} className={loading ? 'animate-spin' : ''} />重新扫描</Button>
         </div>
       </div>
@@ -307,13 +307,13 @@ function MappingRow({ mapping, onView, onValidate, onDelete, deleting }: { mappi
     if (!mapping.existsInDatabase) return 'rgba(239,68,68,0.15)';
     if (!mapping.hasEntity) return 'rgba(239,68,68,0.1)';
     if (mapping.appOwners.length === 0) return 'rgba(168,85,247,0.1)';
-    return 'rgba(255,255,255,0.02)';
+    return 'var(--list-item-bg)';
   };
   const protectedCollections = ['users', 'llmplatforms', 'llmmodels', 'system_roles'];
   const isProtected = protectedCollections.includes(mapping.collectionName.toLowerCase());
 
   return (
-    <div className="grid gap-3 items-center px-3 py-2.5 rounded-[10px] transition-colors hover:bg-white/3" style={{ gridTemplateColumns: '2fr 4fr 6fr', background: getStatusColor(), border: '1px solid rgba(255,255,255,0.05)' }}>
+    <div className="grid gap-3 items-center px-3 py-2.5 rounded-[10px] transition-colors hover:bg-white/3" style={{ gridTemplateColumns: '2fr 4fr 6fr', background: getStatusColor(), border: '1px solid var(--bg-card-hover)' }}>
       <div className="min-w-0"><Badge variant={mapping.appOwners.length > 0 ? 'subtle' : 'danger'} size="sm">{appDisplay}</Badge></div>
       <div className="min-w-0">
         <div className="text-sm font-medium truncate" style={{ color: mapping.hasEntity ? 'var(--text-primary)' : 'rgba(239,68,68,0.8)' }}>{entityDisplay}</div>
@@ -436,7 +436,7 @@ export default function DataManagePage() {
   };
 
   const UserRow = ({ u }: { u: AdminUserPreviewItem }) => (
-    <div className="grid gap-2 rounded-[10px] px-3 py-2.5 transition-colors hover:bg-white/3" style={{ gridTemplateColumns: '1.2fr 1fr 0.6fr 0.6fr 1fr', background: 'rgba(255,255,255,0.02)', border: '1px solid rgba(255,255,255,0.05)' }}>
+    <div className="grid gap-2 rounded-[10px] px-3 py-2.5 transition-colors hover:bg-white/3" style={{ gridTemplateColumns: '1.2fr 1fr 0.6fr 0.6fr 1fr', background: 'var(--list-item-bg)', border: '1px solid var(--bg-card-hover)' }}>
       <div className="min-w-0"><div className="text-sm font-medium truncate" style={{ color: 'var(--text-primary)' }}>{u.username || '-'}</div><div className="text-xs truncate" style={{ color: 'var(--text-muted)' }}>{u.displayName || '-'}</div></div>
       <div className="min-w-0 text-xs font-mono self-center truncate" style={{ color: 'var(--text-secondary)' }}>{u.userId?.slice(0, 8) || '-'}...</div>
       <div className="text-xs self-center" style={{ color: 'var(--text-secondary)' }}>{u.role}</div>
@@ -497,7 +497,7 @@ export default function DataManagePage() {
         </div>
         <div className="overflow-x-auto">
         <div className="min-w-[600px]">
-        <div className="grid gap-3 items-center px-3 py-2 rounded-[8px] text-[10px] font-semibold uppercase tracking-wider mb-2" style={{ gridTemplateColumns: '2fr 4fr 6fr', color: 'var(--text-muted)', background: 'rgba(255,255,255,0.03)' }}>
+        <div className="grid gap-3 items-center px-3 py-2 rounded-[8px] text-[10px] font-semibold uppercase tracking-wider mb-2" style={{ gridTemplateColumns: '2fr 4fr 6fr', color: 'var(--text-muted)', background: 'var(--nested-block-bg)' }}>
           <div>应用</div><div>实体类</div><div>集合名 / 操作</div>
         </div>
         <div className="space-y-1.5 max-h-[400px] overflow-y-auto">
@@ -531,7 +531,7 @@ export default function DataManagePage() {
       <Dialog open={usersPurgeOpen} onOpenChange={(open) => { setUsersPurgeOpen(open); if (!open) { setUsersPurgeStep(1); setUsersConfirmText(''); setUsersPreview(null); } }} title={usersPurgeStep === 1 ? '预览：清理用户数据' : '二次确认：删除用户数据'} description={usersPurgeStep === 1 ? '将删除非管理员用户账号（ADMIN 保留）。' : '该操作不可恢复。'} maxWidth={900} content={
         <div className="min-h-0 flex flex-col gap-4">
           {usersPurgeStep === 1 ? (<>
-            <div className="rounded-[12px] p-4" style={{ background: 'linear-gradient(135deg, rgba(255,255,255,0.04) 0%, rgba(0,0,0,0.08) 100%)', border: '1px solid rgba(255,255,255,0.08)' }}>
+            <div className="rounded-[12px] p-4" style={{ background: 'linear-gradient(135deg, var(--bg-input) 0%, rgba(0,0,0,0.08) 100%)', border: '1px solid var(--border-subtle)' }}>
               {usersPreviewLoading ? (<div className="flex items-center gap-2 text-sm" style={{ color: 'var(--text-muted)' }}><RefreshCw size={14} className="animate-spin" />加载预览中...</div>) : usersPreview ? (
                 <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
                   <div><div className="text-xs" style={{ color: 'var(--text-muted)' }}>总用户</div><div className="text-xl font-bold mt-1" style={{ color: 'var(--text-primary)' }}>{fmtNum(usersPreview.totalUsers)}</div></div>
@@ -544,16 +544,16 @@ export default function DataManagePage() {
             {usersPreview?.notes?.length ? <div className="text-xs space-y-1" style={{ color: 'var(--text-muted)' }}>{usersPreview.notes.map((t, idx) => <div key={idx}>- {t}</div>)}</div> : null}
             <div className="space-y-2">
               <div className="flex items-center gap-2"><Users size={14} style={{ color: 'rgba(239,68,68,0.75)' }} /><span className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>将删除的用户（示例）</span></div>
-              <div className="rounded-[12px] p-3 max-h-[200px] overflow-y-auto overflow-x-auto" style={{ background: 'rgba(0,0,0,0.15)', border: '1px solid rgba(255,255,255,0.06)' }}>
+              <div className="rounded-[12px] p-3 max-h-[200px] overflow-y-auto overflow-x-auto" style={{ background: 'var(--nested-block-bg)', border: '1px solid var(--nested-block-border)' }}>
                 <div className="min-w-[500px] space-y-2">
-                <div className="grid gap-2 px-3 py-2 rounded-[8px] text-[10px] font-semibold uppercase tracking-wider" style={{ gridTemplateColumns: '1.2fr 1fr 0.6fr 0.6fr 1fr', color: 'var(--text-muted)', background: 'rgba(255,255,255,0.03)' }}><div>账号</div><div>UserId</div><div>Role</div><div>Status</div><div>CreatedAt</div></div>
+                <div className="grid gap-2 px-3 py-2 rounded-[8px] text-[10px] font-semibold uppercase tracking-wider" style={{ gridTemplateColumns: '1.2fr 1fr 0.6fr 0.6fr 1fr', color: 'var(--text-muted)', background: 'var(--nested-block-bg)' }}><div>账号</div><div>UserId</div><div>Role</div><div>Status</div><div>CreatedAt</div></div>
                 {usersPreviewLoading ? <div className="text-sm py-4 text-center" style={{ color: 'var(--text-muted)' }}>加载中...</div> : usersPreview?.sampleWillDeleteUsers?.length ? usersPreview.sampleWillDeleteUsers.map((u) => <UserRow key={u.userId} u={u} />) : <div className="text-sm py-4 text-center" style={{ color: 'var(--text-muted)' }}>无（可能只有管理员账号）</div>}
                 </div>
               </div>
             </div>
             <div className="space-y-2">
               <div className="flex items-center gap-2"><Users size={14} style={{ color: 'rgba(34,197,94,0.75)' }} /><span className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>将保留的管理员（示例）</span></div>
-              <div className="rounded-[12px] p-3 max-h-[150px] overflow-y-auto overflow-x-auto" style={{ background: 'rgba(0,0,0,0.15)', border: '1px solid rgba(255,255,255,0.06)' }}>
+              <div className="rounded-[12px] p-3 max-h-[150px] overflow-y-auto overflow-x-auto" style={{ background: 'var(--nested-block-bg)', border: '1px solid var(--nested-block-border)' }}>
                 <div className="min-w-[500px] space-y-2">
                 {usersPreview?.sampleWillKeepAdmins?.length ? usersPreview.sampleWillKeepAdmins.map((u) => <UserRow key={u.userId} u={u} />) : <div className="text-sm py-4 text-center" style={{ color: 'var(--text-muted)' }}>无管理员账号（异常）</div>}
                 </div>
@@ -563,7 +563,7 @@ export default function DataManagePage() {
             <div className="rounded-[12px] px-4 py-3 text-sm flex items-center gap-3" style={{ background: 'linear-gradient(135deg, rgba(239,68,68,0.15) 0%, rgba(239,68,68,0.08) 100%)', border: '1px solid rgba(239,68,68,0.30)', color: 'rgba(239,68,68,0.95)' }}><AlertTriangle size={18} />将删除非管理员用户账号，该操作不可恢复。</div>
             <div className="space-y-3"><div className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>请输入 <code className="px-1.5 py-0.5 rounded bg-white/5 font-mono">DELETE</code> 以确认</div><input value={usersConfirmText} onChange={(e) => setUsersConfirmText(e.target.value)} placeholder="DELETE" className="w-full h-[44px] rounded-[12px] px-4 text-sm outline-none transition-all prd-field" autoFocus /></div>
           </>)}
-          <div className="pt-3 flex items-center justify-end gap-2" style={{ borderTop: '1px solid rgba(255,255,255,0.06)' }}>
+          <div className="pt-3 flex items-center justify-end gap-2" style={{ borderTop: '1px solid var(--nested-block-border)' }}>
             <Button variant="secondary" size="sm" onClick={() => { if (usersPurgeStep === 1) setUsersPurgeOpen(false); else { setUsersPurgeStep(1); setUsersConfirmText(''); } }}>{usersPurgeStep === 1 ? '取消' : '返回预览'}</Button>
             {usersPurgeStep === 1 ? <Button variant="primary" size="sm" disabled={usersPreviewLoading} onClick={() => setUsersPurgeStep(2)}>下一步</Button> : <Button variant="danger" size="sm" disabled={usersConfirmText !== 'DELETE' || loading} onClick={doPurgeUsers}>确认删除</Button>}
           </div>

--- a/prd-admin/src/pages/DataManagePage.tsx
+++ b/prd-admin/src/pages/DataManagePage.tsx
@@ -80,7 +80,7 @@ function StatCard({
   loading?: boolean;
 }) {
   const accentColors = {
-    default: { bg: 'rgba(255,255,255,0.04)', border: 'rgba(255,255,255,0.06)', icon: 'rgba(255,255,255,0.5)', text: 'var(--text-primary)' },
+    default: { bg: 'var(--bg-input)', border: 'var(--nested-block-border)', icon: 'rgba(255,255,255,0.5)', text: 'var(--text-primary)' },
     gold: { bg: 'rgba(214,178,106,0.06)', border: 'rgba(214,178,106,0.12)', icon: 'var(--accent-gold)', text: 'var(--accent-gold)' },
     blue: { bg: 'rgba(59,130,246,0.06)', border: 'rgba(59,130,246,0.12)', icon: 'rgba(59,130,246,0.9)', text: 'rgba(59,130,246,0.95)' },
     green: { bg: 'rgba(34,197,94,0.06)', border: 'rgba(34,197,94,0.12)', icon: 'rgba(34,197,94,0.9)', text: 'rgba(34,197,94,0.95)' },
@@ -91,13 +91,13 @@ function StatCard({
   return (
     <div className="relative overflow-hidden rounded-[12px] p-3.5 transition-all duration-200" style={{ background: colors.bg, border: `1px solid ${colors.border}` }}>
       <div className="relative flex items-start gap-3">
-        <div className="shrink-0 w-9 h-9 rounded-[10px] flex items-center justify-center" style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.05)' }}>
+        <div className="shrink-0 w-9 h-9 rounded-[10px] flex items-center justify-center" style={{ background: 'var(--bg-input)', border: '1px solid var(--bg-card-hover)' }}>
           <span style={{ color: colors.icon }}>{icon}</span>
         </div>
         <div className="min-w-0 flex-1">
           <div className="text-[11px] font-semibold uppercase tracking-wider truncate" style={{ color: 'var(--text-muted)' }}>{label}</div>
           <div className="mt-1 text-xl font-bold tabular-nums tracking-tight" style={{ color: colors.text, letterSpacing: '-0.02em' }}>
-            {loading ? <span className="inline-block w-14 h-6 rounded-[8px] animate-pulse" style={{ background: 'rgba(255,255,255,0.05)' }} /> : value}
+            {loading ? <span className="inline-block w-14 h-6 rounded-[8px] animate-pulse" style={{ background: 'var(--bg-card-hover)' }} /> : value}
           </div>
           {subValue && <div className="mt-0.5 text-[10px]" style={{ color: 'var(--text-muted)' }}>{subValue}</div>}
         </div>
@@ -168,16 +168,16 @@ function CollectionDataViewerDialog({ open, onOpenChange, collectionName }: { op
           </div>
           <Button variant="secondary" size="xs" onClick={loadData} disabled={loading}><RefreshCw size={13} className={loading ? 'animate-spin' : ''} />刷新</Button>
         </div>
-        <div className="flex-1 overflow-auto rounded-[12px]" style={{ background: 'rgba(0,0,0,0.2)', border: '1px solid rgba(255,255,255,0.06)' }}>
+        <div className="flex-1 overflow-auto rounded-[12px]" style={{ background: 'var(--nested-block-bg)', border: '1px solid var(--nested-block-border)' }}>
           {loading ? (
             <div className="flex items-center justify-center h-full" style={{ color: 'var(--text-muted)' }}><RefreshCw size={20} className="animate-spin mr-2" />加载中...</div>
           ) : viewMode === 'table' ? (
             <div className="overflow-auto">
               <table className="w-full text-sm">
                 <thead>
-                  <tr style={{ background: 'rgba(255,255,255,0.03)' }}>
+                  <tr style={{ background: 'var(--nested-block-bg)' }}>
                     {data?.fields.map((field) => (
-                      <th key={field} className="px-3 py-2 text-left font-semibold whitespace-nowrap" style={{ color: 'var(--text-secondary)', borderBottom: '1px solid rgba(255,255,255,0.06)' }}>{field}</th>
+                      <th key={field} className="px-3 py-2 text-left font-semibold whitespace-nowrap" style={{ color: 'var(--text-secondary)', borderBottom: '1px solid var(--nested-block-border)' }}>{field}</th>
                     ))}
                   </tr>
                 </thead>
@@ -185,7 +185,7 @@ function CollectionDataViewerDialog({ open, onOpenChange, collectionName }: { op
                   {data?.data.map((row, idx) => (
                     <tr key={idx} className="hover:bg-white/3 transition-colors">
                       {data.fields.map((field) => (
-                        <td key={field} className="px-3 py-2 whitespace-nowrap max-w-[300px] truncate" style={{ color: 'var(--text-primary)', borderBottom: '1px solid rgba(255,255,255,0.04)' }}>
+                        <td key={field} className="px-3 py-2 whitespace-nowrap max-w-[300px] truncate" style={{ color: 'var(--text-primary)', borderBottom: '1px solid var(--bg-input)' }}>
                           {typeof (row as Record<string, unknown>)[field] === 'object' ? JSON.stringify((row as Record<string, unknown>)[field]) : String((row as Record<string, unknown>)[field] ?? '-')}
                         </td>
                       ))}
@@ -197,12 +197,12 @@ function CollectionDataViewerDialog({ open, onOpenChange, collectionName }: { op
           ) : (
             <div className="p-4 space-y-3 overflow-auto">
               {data?.data.map((row, idx) => (
-                <pre key={idx} className="p-3 rounded-[8px] text-xs overflow-x-auto" style={{ background: 'rgba(255,255,255,0.03)', color: 'var(--text-primary)' }}>{JSON.stringify(row, null, 2)}</pre>
+                <pre key={idx} className="p-3 rounded-[8px] text-xs overflow-x-auto" style={{ background: 'var(--nested-block-bg)', color: 'var(--text-primary)' }}>{JSON.stringify(row, null, 2)}</pre>
               ))}
             </div>
           )}
         </div>
-        <div className="flex items-center justify-between pt-2" style={{ borderTop: '1px solid rgba(255,255,255,0.06)' }}>
+        <div className="flex items-center justify-between pt-2" style={{ borderTop: '1px solid var(--nested-block-border)' }}>
           <div className="text-xs" style={{ color: 'var(--text-muted)' }}>第 {page} / {data?.totalPages ?? 1} 页</div>
           <div className="flex items-center gap-2">
             <Button variant="secondary" size="xs" disabled={page <= 1} onClick={() => setPage((p) => p - 1)}><ChevronLeft size={14} />上一页</Button>
@@ -247,7 +247,7 @@ function CollectionValidationDialog({ open, onOpenChange, collectionName, onRefr
     <Dialog open={open} onOpenChange={onOpenChange} title={`字段匹配验证：${collectionName}`} description={data?.hasEntity ? `实体类：${data.entityName}` : '无对应实体类'} maxWidth={1200} content={
       <div className="flex flex-col gap-4 min-h-[400px] max-h-[70vh]">
         <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-          <div className="rounded-[10px] p-3" style={{ background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.06)' }}>
+          <div className="rounded-[10px] p-3" style={{ background: 'var(--nested-block-bg)', border: '1px solid var(--nested-block-border)' }}>
             <div className="text-xs" style={{ color: 'var(--text-muted)' }}>扫描文档</div>
             <div className="text-lg font-bold mt-1" style={{ color: 'var(--text-primary)' }}>{fmtNum(data?.scannedDocuments ?? 0)}</div>
           </div>

--- a/prd-admin/src/pages/ExecutiveDashboardPage.tsx
+++ b/prd-admin/src/pages/ExecutiveDashboardPage.tsx
@@ -161,7 +161,7 @@ function StatRow({ label, value, sub, icon: Icon }: { label: string; value: stri
 function ProgressBar({ value, max, color }: { value: number; max: number; color: string }) {
   const pct = max > 0 ? Math.min(100, (value / max) * 100) : 0;
   return (
-    <div className="h-1.5 rounded-full w-full" style={{ background: 'rgba(255,255,255,0.06)' }}>
+    <div className="h-1.5 rounded-full w-full" style={{ background: 'var(--bg-input-hover)' }}>
       <div className="h-full rounded-full transition-all" style={{ width: `${pct}%`, background: color }} />
     </div>
   );
@@ -171,7 +171,7 @@ function LoadingSkeleton({ rows = 3 }: { rows?: number }) {
   return (
     <div className="space-y-3 animate-pulse">
       {Array.from({ length: rows }, (_, i) => (
-        <div key={i} className="h-4 rounded" style={{ background: 'rgba(255,255,255,0.06)', width: `${70 + Math.random() * 30}%` }} />
+        <div key={i} className="h-4 rounded" style={{ background: 'var(--bg-input-hover)', width: `${70 + Math.random() * 30}%` }} />
       ))}
     </div>
   );
@@ -388,7 +388,7 @@ function TeamInsightsTab({ leaderboard, loading }: { leaderboard: ExecutiveLeade
         <div className="overflow-x-auto">
           <table className="w-full text-[12px]">
             <thead>
-              <tr style={{ borderBottom: '1px solid rgba(255,255,255,0.08)' }}>
+              <tr style={{ borderBottom: '1px solid var(--border-subtle)' }}>
                 <th className="text-left py-2.5 pr-2 font-medium w-8" style={{ color: 'var(--text-muted)' }}>#</th>
                 <th className="text-left py-2.5 pr-4 font-medium" style={{ color: 'var(--text-muted)' }}>成员</th>
                 <th
@@ -450,7 +450,7 @@ function TeamInsightsTab({ leaderboard, loading }: { leaderboard: ExecutiveLeade
                     </td>
                     <td className="py-2.5 px-2 text-right">
                       <div className="flex items-center justify-end gap-2">
-                        <div className="w-16 h-2 rounded-full overflow-hidden" style={{ background: 'rgba(255,255,255,0.06)' }}>
+                        <div className="w-16 h-2 rounded-full overflow-hidden" style={{ background: 'var(--bg-input-hover)' }}>
                           <div className="h-full rounded-full" style={{ width: `${(user.totalScore / maxScore) * 100}%`, background: 'linear-gradient(90deg, rgba(214,178,106,0.6), rgba(214,178,106,0.9))' }} />
                         </div>
                         <span className="tabular-nums font-bold text-[12px] w-10 text-right" style={{ color: isTop3 ? 'rgba(214,178,106,0.95)' : 'var(--text-primary)' }}>
@@ -467,7 +467,7 @@ function TeamInsightsTab({ leaderboard, loading }: { leaderboard: ExecutiveLeade
                       return (
                         <td key={dim.key} className="py-2.5 px-2 text-right">
                           <div className="flex items-center justify-end gap-1.5">
-                            <div className="w-10 h-1.5 rounded-full overflow-hidden" style={{ background: 'rgba(255,255,255,0.06)' }}>
+                            <div className="w-10 h-1.5 rounded-full overflow-hidden" style={{ background: 'var(--bg-input-hover)' }}>
                               <div className="h-full rounded-full" style={{ width: `${pct}%`, background: meta?.barColor ?? 'rgba(148,163,184,0.5)' }} />
                             </div>
                             <span className="tabular-nums text-[11px] w-8 text-right" style={{ color: raw > 0 ? 'var(--text-secondary)' : 'var(--text-muted)' }}>
@@ -526,7 +526,7 @@ function TeamInsightsTab({ leaderboard, loading }: { leaderboard: ExecutiveLeade
                         <div className="text-[11px] font-medium truncate" style={{ color: 'var(--text-primary)' }}>{u.displayName}</div>
                         <div className="text-[8px]" style={{ color: roleColor }}>{u.role}</div>
                       </div>
-                      <div className="flex-1 h-3 rounded-full overflow-hidden" style={{ background: 'rgba(255,255,255,0.04)' }}>
+                      <div className="flex-1 h-3 rounded-full overflow-hidden" style={{ background: 'var(--bg-input)' }}>
                         <div className="h-full rounded-full transition-all" style={{ width: `${pct}%`, background: meta.barColor }} />
                       </div>
                       <span className="text-[11px] font-bold tabular-nums w-10 text-right flex-shrink-0" style={{ color: meta.color }}>
@@ -589,7 +589,7 @@ function AgentUsageTab({ agents, team, loading }: { agents: ExecutiveAgentStat[]
         <div className="overflow-x-auto">
           <table className="w-full text-[12px]">
             <thead>
-              <tr style={{ borderBottom: '1px solid rgba(255,255,255,0.08)' }}>
+              <tr style={{ borderBottom: '1px solid var(--border-subtle)' }}>
                 <th className="text-left py-2 pr-4 font-medium" style={{ color: 'var(--text-muted)' }}>Agent</th>
                 <th className="text-right py-2 px-3 font-medium" style={{ color: 'var(--text-muted)' }}>调用次数</th>
                 <th className="text-right py-2 px-3 font-medium" style={{ color: 'var(--text-muted)' }}>用户数</th>
@@ -645,7 +645,7 @@ function CostCenterTab({ models, loading }: { models: ExecutiveModelStat[]; load
         <div className="overflow-x-auto">
           <table className="w-full text-[12px]">
             <thead>
-              <tr style={{ borderBottom: '1px solid rgba(255,255,255,0.08)' }}>
+              <tr style={{ borderBottom: '1px solid var(--border-subtle)' }}>
                 <th className="text-left py-2 font-medium" style={{ color: 'var(--text-muted)' }}>模型</th>
                 <th className="text-right py-2 font-medium" style={{ color: 'var(--text-muted)' }}>调用</th>
                 <th className="text-right py-2 font-medium" style={{ color: 'var(--text-muted)' }}>输入 Token</th>
@@ -715,7 +715,7 @@ function IntegrationsTab() {
               {idx < roadmap.length - 1 && (
                 <div className="hidden md:block absolute top-5 -right-2 w-4 h-0.5" style={{ background: 'rgba(255,255,255,0.1)' }} />
               )}
-              <div className="p-4 rounded-xl" style={{ background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.06)' }}>
+              <div className="p-4 rounded-xl" style={{ background: 'var(--nested-block-bg)', border: '1px solid var(--nested-block-border)' }}>
                 <div className="flex items-center gap-2 mb-3">
                   <div className="w-6 h-6 rounded-full flex items-center justify-center text-[10px] font-bold"
                     style={{ background: 'rgba(214,178,106,0.15)', color: 'rgba(214,178,106,0.9)' }}>
@@ -813,7 +813,7 @@ export default function ExecutiveDashboardPage() {
               value={days}
               onChange={e => setDays(Number(e.target.value))}
               className="text-xs px-2 py-1 rounded-md border-0 outline-none cursor-pointer"
-              style={{ background: 'rgba(255,255,255,0.06)', color: 'var(--text-secondary)' }}
+              style={{ background: 'var(--bg-input-hover)', color: 'var(--text-secondary)' }}
             >
               {DAYS_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
             </select>

--- a/prd-admin/src/pages/GroupsPage.tsx
+++ b/prd-admin/src/pages/GroupsPage.tsx
@@ -411,7 +411,7 @@ export default function GroupsPage() {
                 setPage(1);
               }}
               className="h-8 w-full rounded-lg pl-8 pr-3 text-xs outline-none"
-              style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.1)', color: 'var(--text-primary)' }}
+              style={{ background: 'var(--bg-input)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
               placeholder="搜索群组名/群组ID/群主"
             />
           </div>
@@ -473,22 +473,22 @@ export default function GroupsPage() {
                     </div>
 
                     {/* 统计数据网格 - 4列 */}
-                    <div className="grid grid-cols-2 sm:grid-cols-4 gap-1 my-3 py-2 rounded-lg" style={{ background: 'rgba(255,255,255,0.03)' }}>
+                    <div className="grid grid-cols-2 sm:grid-cols-4 gap-1 my-3 py-2 rounded-lg" style={{ background: 'var(--nested-block-bg)' }}>
                       <div className="text-center">
                         <div className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>{g.memberCount}</div>
                         <div className="text-[9px]" style={{ color: 'var(--text-muted)' }}>成员</div>
                       </div>
-                      <div className="text-center" style={{ borderLeft: '1px solid rgba(255,255,255,0.06)' }}>
+                      <div className="text-center" style={{ borderLeft: '1px solid var(--nested-block-border)' }}>
                         <div className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>{g.messageCount ?? 0}</div>
                         <div className="text-[9px]" style={{ color: 'var(--text-muted)' }}>消息</div>
                       </div>
-                      <div className="text-center" style={{ borderLeft: '1px solid rgba(255,255,255,0.06)' }}>
+                      <div className="text-center" style={{ borderLeft: '1px solid var(--nested-block-border)' }}>
                         <div className="text-sm font-semibold" style={{ color: hasWarning ? 'rgba(245,158,11,0.95)' : 'var(--text-primary)' }}>
                           {g.pendingGapCount ?? 0}
                         </div>
                         <div className="text-[9px]" style={{ color: 'var(--text-muted)' }}>缺失</div>
                       </div>
-                      <div className="text-center" style={{ borderLeft: '1px solid rgba(255,255,255,0.06)' }}>
+                      <div className="text-center" style={{ borderLeft: '1px solid var(--nested-block-border)' }}>
                         <div className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>{formatTokens(g.prdTokenEstimate)}</div>
                         <div className="text-[9px]" style={{ color: 'var(--text-muted)' }}>Tokens</div>
                       </div>
@@ -516,7 +516,7 @@ export default function GroupsPage() {
                     </div>
 
                     {/* Footer：快捷操作 + 复制 */}
-                    <div className="flex items-center justify-between pt-2" style={{ borderTop: '1px solid rgba(255,255,255,0.06)' }}>
+                    <div className="flex items-center justify-between pt-2" style={{ borderTop: '1px solid var(--nested-block-border)' }}>
                       <div className="flex items-center gap-1">
                         <button
                           className="px-1.5 py-0.5 rounded text-[9px] font-medium transition-colors hover:brightness-110"
@@ -713,7 +713,7 @@ export default function GroupsPage() {
                 {tab === 'members' ? (
                   <div className="overflow-x-auto">
                   <table className="w-full text-sm">
-                    <thead style={{ background: 'rgba(255,255,255,0.03)' }}>
+                    <thead style={{ background: 'var(--nested-block-bg)' }}>
                       <tr>
                         <th className="text-left px-4 py-3" style={{ color: 'var(--text-secondary)' }}>成员</th>
                         <th className="text-left px-4 py-3" style={{ color: 'var(--text-secondary)' }}>角色</th>
@@ -802,7 +802,7 @@ export default function GroupsPage() {
                     </div>
                     <div className="overflow-x-auto">
                     <table className="w-full text-sm">
-                    <thead style={{ background: 'rgba(255,255,255,0.03)' }}>
+                    <thead style={{ background: 'var(--nested-block-bg)' }}>
                       <tr>
                         <th className="text-left px-4 py-3" style={{ color: 'var(--text-secondary)' }}>问题</th>
                         <th className="text-left px-4 py-3" style={{ color: 'var(--text-secondary)' }}>类型</th>
@@ -904,15 +904,15 @@ export default function GroupsPage() {
                       .prd-md p { margin: 8px 0; }
                       .prd-md ul,.prd-md ol { margin: 8px 0; padding-left: 18px; }
                       .prd-md li { margin: 4px 0; }
-                      .prd-md hr { border: 0; border-top: 1px solid rgba(255,255,255,0.10); margin: 12px 0; }
-                      .prd-md blockquote { margin: 10px 0; padding: 6px 10px; border-left: 3px solid rgba(255,255,255,0.16); background: rgba(255,255,255,0.04); color: var(--text-secondary); border-radius: 10px; }
+                      .prd-md hr { border: 0; border-top: 1px solid var(--border-default); margin: 12px 0; }
+                      .prd-md blockquote { margin: 10px 0; padding: 6px 10px; border-left: 3px solid rgba(255,255,255,0.16); background: var(--bg-input); color: var(--text-secondary); border-radius: 10px; }
                       .prd-md a { color: rgba(147, 197, 253, 0.95); text-decoration: underline; }
-                      .prd-md code { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; font-size: 12px; background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.10); padding: 0 6px; border-radius: 8px; }
-                      .prd-md pre { background: rgba(0,0,0,0.28); border: 1px solid rgba(255,255,255,0.10); border-radius: 14px; padding: 12px; overflow: auto; }
+                      .prd-md code { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; font-size: 12px; background: var(--bg-input-hover); border: 1px solid var(--border-default); padding: 0 6px; border-radius: 8px; }
+                      .prd-md pre { background: var(--nested-block-bg); border: 1px solid var(--border-default); border-radius: 14px; padding: 12px; overflow: auto; }
                       .prd-md pre code { background: transparent; border: 0; padding: 0; }
                       .prd-md table { width: 100%; border-collapse: collapse; margin: 10px 0; }
-                      .prd-md th,.prd-md td { border: 1px solid rgba(255,255,255,0.10); padding: 6px 8px; }
-                      .prd-md th { color: var(--text-primary); background: rgba(255,255,255,0.03); }
+                      .prd-md th,.prd-md td { border: 1px solid var(--border-default); padding: 6px 8px; }
+                      .prd-md th { color: var(--text-primary); background: var(--nested-block-bg); }
                     `}</style>
                     <div className="flex flex-wrap items-center justify-between gap-3">
                       <div className="text-xs" style={{ color: 'var(--text-muted)' }}>

--- a/prd-admin/src/pages/LlmLogsPage.tsx
+++ b/prd-admin/src/pages/LlmLogsPage.tsx
@@ -2251,8 +2251,8 @@ export function LlmLogsPanel({ embedded, defaultAppKey, customApis }: {
                             {effInputs.length > 0 ? (
                               <div className="space-y-2">
                               {effInputs.map((img, idx) => (
-                                <div key={`in-${idx}`} className="rounded-[12px] overflow-hidden" style={{ border: '1px solid rgba(255,255,255,0.10)', background: 'rgba(0,0,0,0.18)' }}>
-                                  <div className="px-3 py-1.5 flex items-center justify-between gap-2" style={{ borderBottom: '1px solid rgba(255,255,255,0.08)' }}>
+                                <div key={`in-${idx}`} className="rounded-[12px] overflow-hidden" style={{ border: '1px solid var(--border-default)', background: 'rgba(0,0,0,0.18)' }}>
+                                  <div className="px-3 py-1.5 flex items-center justify-between gap-2" style={{ borderBottom: '1px solid var(--border-subtle)' }}>
                                     <div className="text-[11px] font-semibold truncate" style={{ color: 'var(--text-primary)' }}>
                                       {img.label}{effInputs.length > 1 ? ` #${idx + 1}` : ''}
                                     </div>
@@ -2269,7 +2269,7 @@ export function LlmLogsPanel({ embedded, defaultAppKey, customApis }: {
                               ))}
                               </div>
                             ) : (
-                              <div className="rounded-[12px] flex items-center justify-center" style={{ border: '1px solid rgba(255,255,255,0.10)', background: 'rgba(0,0,0,0.18)', height: 120 }}>
+                              <div className="rounded-[12px] flex items-center justify-center" style={{ border: '1px solid var(--border-default)', background: 'rgba(0,0,0,0.18)', height: 120 }}>
                                 <div className="text-[11px]" style={{ color: 'var(--text-muted)' }}>（无输入）</div>
                               </div>
                             )}
@@ -2280,8 +2280,8 @@ export function LlmLogsPanel({ embedded, defaultAppKey, customApis }: {
                             {effOutputs.length > 0 ? (
                               <div className="space-y-2">
                               {effOutputs.map((img, idx) => (
-                                <div key={`out-${idx}`} className="rounded-[12px] overflow-hidden" style={{ border: '1px solid rgba(255,255,255,0.10)', background: 'rgba(0,0,0,0.18)' }}>
-                                  <div className="px-3 py-1.5 flex items-center justify-between gap-2" style={{ borderBottom: '1px solid rgba(255,255,255,0.08)' }}>
+                                <div key={`out-${idx}`} className="rounded-[12px] overflow-hidden" style={{ border: '1px solid var(--border-default)', background: 'rgba(0,0,0,0.18)' }}>
+                                  <div className="px-3 py-1.5 flex items-center justify-between gap-2" style={{ borderBottom: '1px solid var(--border-subtle)' }}>
                                     <div className="text-[11px] font-semibold truncate" style={{ color: 'var(--text-primary)' }}>
                                       {img.label}{effOutputs.length > 1 ? ` #${idx + 1}` : ''}
                                     </div>
@@ -2298,7 +2298,7 @@ export function LlmLogsPanel({ embedded, defaultAppKey, customApis }: {
                               ))}
                               </div>
                             ) : (
-                              <div className="rounded-[12px] flex items-center justify-center" style={{ border: '1px solid rgba(255,255,255,0.10)', background: 'rgba(0,0,0,0.18)', flex: 1, minHeight: 120 }}>
+                              <div className="rounded-[12px] flex items-center justify-center" style={{ border: '1px solid var(--border-default)', background: 'rgba(0,0,0,0.18)', flex: 1, minHeight: 120 }}>
                                 {detail?.status === 'running' ? (
                                   <div className="flex flex-col items-center gap-2">
                                     <Loader2 size={24} className="animate-spin" style={{ color: 'var(--text-muted)' }} />

--- a/prd-admin/src/pages/LlmLogsPage.tsx
+++ b/prd-admin/src/pages/LlmLogsPage.tsx
@@ -164,7 +164,7 @@ function requestTypeChipStyle(tone: RequestTypeTone): React.CSSProperties {
   if (tone === 'blue') return { background: 'rgba(59, 130, 246, 0.12)', border: '1px solid rgba(59, 130, 246, 0.28)', color: 'rgba(59, 130, 246, 0.95)' };
   if (tone === 'purple') return { background: 'rgba(168, 85, 247, 0.12)', border: '1px solid rgba(168, 85, 247, 0.28)', color: 'rgba(168, 85, 247, 0.95)' };
   if (tone === 'gold') return { background: 'rgba(214, 178, 106, 0.18)', border: '1px solid rgba(214, 178, 106, 0.35)', color: 'var(--accent-gold-2)' };
-  return { background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.14)', color: 'var(--text-muted)' };
+  return { background: 'var(--bg-input-hover)', border: '1px solid var(--border-default)', color: 'var(--text-muted)' };
 }
 
 function extractImageSizeAdjustmentHint(it: LlmRequestLogListItem): { from?: string; to?: string; ratioAdjusted?: boolean } | null {
@@ -1255,7 +1255,7 @@ export function LlmLogsPanel({ embedded, defaultAppKey, customApis }: {
 
   const inputStyle: React.CSSProperties = {
     background: 'var(--bg-input)',
-    border: '1px solid rgba(255,255,255,0.12)',
+    border: '1px solid var(--border-default)',
     color: 'var(--text-primary)',
   };
 
@@ -1442,7 +1442,7 @@ export function LlmLogsPanel({ embedded, defaultAppKey, customApis }: {
                   }}
                   className="px-4 py-3 cursor-pointer hover:bg-white/2"
                   style={{
-                    background: active ? 'rgba(255,255,255,0.03)' : 'transparent',
+                    background: active ? 'var(--nested-block-bg)' : 'transparent',
                   }}
                 >
                   <div className="flex items-start justify-between gap-2 sm:gap-4">
@@ -1458,7 +1458,7 @@ export function LlmLogsPanel({ embedded, defaultAppKey, customApis }: {
                         {it.requestPurpose && (
                           <span
                             className="inline-flex items-center gap-1 text-[10px] font-mono px-1.5 py-0.5 rounded shrink-0 cursor-help"
-                            style={{ background: 'rgba(255,255,255,0.06)', color: 'var(--text-muted)' }}
+                            style={{ background: 'var(--bg-input-hover)', color: 'var(--text-muted)' }}
                             title={it.requestPurpose}
                           >
                             <AppCallerKeyIcon size={10} className="opacity-60" />
@@ -1663,14 +1663,14 @@ export function LlmLogsPanel({ embedded, defaultAppKey, customApis }: {
                                   {sizes.length ? (
                                     <div
                                       className="mt-2 rounded-[10px] p-2"
-                                      style={{ border: '1px solid rgba(255,255,255,0.10)', background: 'rgba(255,255,255,0.02)', maxHeight: 220, overflow: 'auto' }}
+                                      style={{ border: '1px solid var(--border-default)', background: 'var(--list-item-bg)', maxHeight: 220, overflow: 'auto' }}
                                     >
                                       <div className="flex flex-wrap gap-1.5">
                                         {sizes.map((s, idx) => (
                                           <span
                                             key={`${s}-${idx}`}
                                             className="inline-flex items-center rounded-[10px] px-2 py-1 text-[11px] font-semibold"
-                                            style={{ border: '1px solid rgba(255,255,255,0.10)', color: 'var(--text-secondary)', background: 'rgba(0,0,0,0.18)' }}
+                                            style={{ border: '1px solid var(--border-default)', color: 'var(--text-secondary)', background: 'rgba(0,0,0,0.18)' }}
                                             title={s}
                                           >
                                             {s}
@@ -1845,7 +1845,7 @@ export function LlmLogsPanel({ embedded, defaultAppKey, customApis }: {
                         className="rounded-[12px] px-2.5 py-1.5 min-w-0"
                         style={{
                           border: '1px solid var(--border-subtle)',
-                          background: 'rgba(255,255,255,0.02)',
+                          background: 'var(--list-item-bg)',
                           minWidth: 0,
                           ...(ss?.container ?? {}),
                         }}
@@ -1978,7 +1978,7 @@ export function LlmLogsPanel({ embedded, defaultAppKey, customApis }: {
                 <div className="flex items-center justify-between gap-2">
                   <div className="text-sm font-semibold shrink-0" style={{ color: 'var(--text-primary)' }}>Response</div>
                   <div className="flex items-center gap-1.5 flex-wrap justify-end">
-                    <div className="flex items-center rounded-[8px] p-0.5" style={{ border: '1px solid var(--border-subtle)', background: 'rgba(255,255,255,0.02)' }}>
+                    <div className="flex items-center rounded-[8px] p-0.5" style={{ border: '1px solid var(--border-subtle)', background: 'var(--list-item-bg)' }}>
                       <button
                         type="button"
                         onClick={() => setAnswerView('preview')}
@@ -2131,7 +2131,7 @@ export function LlmLogsPanel({ embedded, defaultAppKey, customApis }: {
                         <div
                           key={it.k}
                           className="rounded-[12px] px-3 py-2 min-w-0 overflow-hidden"
-                          style={{ border: '1px solid var(--border-subtle)', background: 'rgba(255,255,255,0.02)', minWidth: 0 }}
+                          style={{ border: '1px solid var(--border-subtle)', background: 'var(--list-item-bg)', minWidth: 0 }}
                         >
                           <div className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
                             {it.k}
@@ -2238,7 +2238,7 @@ export function LlmLogsPanel({ embedded, defaultAppKey, customApis }: {
 
                       return (
                     <div className="mb-3">
-                      <div className="rounded-[14px] p-3" style={{ border: '1px solid var(--border-subtle)', background: 'rgba(255,255,255,0.02)' }}>
+                      <div className="rounded-[14px] p-3" style={{ border: '1px solid var(--border-subtle)', background: 'var(--list-item-bg)' }}>
                         {/* Prompt */}
                         <div className="text-[12px] mb-3" style={{ color: 'var(--text-secondary)' }}>
                           {(detail?.questionText ?? '').trim() || '（无提示词）'}

--- a/prd-admin/src/pages/LoginPage.tsx
+++ b/prd-admin/src/pages/LoginPage.tsx
@@ -226,7 +226,7 @@ export default function LoginPage() {
                     value={username}
                     onChange={(e) => setUsername(e.target.value)}
                     className="h-11 w-full rounded-[14px] px-4 text-sm outline-none"
-                    style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.12)', color: 'var(--text-primary)' }}
+                    style={{ background: 'var(--bg-input)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
                     placeholder="admin"
                     autoComplete="username"
                   />
@@ -238,7 +238,7 @@ export default function LoginPage() {
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
                     className="h-11 w-full rounded-[14px] px-4 text-sm outline-none"
-                    style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.12)', color: 'var(--text-primary)' }}
+                    style={{ background: 'var(--bg-input)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
                     placeholder="admin"
                     type="password"
                     autoComplete="current-password"
@@ -291,7 +291,7 @@ export default function LoginPage() {
                     value={newPassword}
                     onChange={(e) => setNewPassword(e.target.value)}
                     className="h-11 w-full rounded-[14px] px-4 text-sm outline-none"
-                    style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.12)', color: 'var(--text-primary)' }}
+                    style={{ background: 'var(--bg-input)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
                     placeholder="请输入新密码"
                     type="password"
                     autoComplete="new-password"
@@ -304,7 +304,7 @@ export default function LoginPage() {
                     value={confirmPassword}
                     onChange={(e) => setConfirmPassword(e.target.value)}
                     className="h-11 w-full rounded-[14px] px-4 text-sm outline-none"
-                    style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.12)', color: 'var(--text-primary)' }}
+                    style={{ background: 'var(--bg-input)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
                     placeholder="请再次输入新密码"
                     type="password"
                     autoComplete="new-password"

--- a/prd-admin/src/pages/ModelAppGroupPage.tsx
+++ b/prd-admin/src/pages/ModelAppGroupPage.tsx
@@ -905,8 +905,8 @@ export function ModelAppGroupPage({ onActionsReady }: { onActionsReady?: (action
                   onChange={(e) => setModelTypeFilter(e.target.value)}
                   className="h-9 rounded-[11px] text-[13px]"
                   style={{
-                    background: 'rgba(255,255,255,0.04)',
-                    border: '1px solid rgba(255,255,255,0.08)',
+                    background: 'var(--bg-input)',
+                    border: '1px solid var(--border-subtle)',
                   }}
                 >
                   {MODEL_TYPE_FILTERS.map((type) => (
@@ -925,8 +925,8 @@ export function ModelAppGroupPage({ onActionsReady }: { onActionsReady?: (action
                   onChange={(e) => setSearchTerm(e.target.value)}
                   className="w-full h-9 pl-9 pr-3 rounded-[11px] outline-none text-[13px]"
                   style={{
-                    background: 'rgba(255,255,255,0.04)',
-                    border: '1px solid rgba(255,255,255,0.08)',
+                    background: 'var(--bg-input)',
+                    border: '1px solid var(--border-subtle)',
                     color: 'var(--text-primary)',
                   }}
                 />
@@ -963,15 +963,15 @@ export function ModelAppGroupPage({ onActionsReady }: { onActionsReady?: (action
                         }
                       }}
                       className="px-3 py-3 cursor-pointer hover:bg-white/[0.02] transition-colors"
-                      style={isSelected ? { background: 'rgba(255,255,255,0.06)' } : undefined}
+                      style={isSelected ? { background: 'var(--bg-input-hover)' } : undefined}
                     >
                       <div className="flex items-center gap-3">
                         {/* 应用图标 */}
                         <div
                           className="shrink-0 w-9 h-9 rounded-lg flex items-center justify-center"
                           style={{
-                            background: isSelected ? 'rgba(59, 130, 246, 0.15)' : 'rgba(255,255,255,0.06)',
-                            border: isSelected ? '1px solid rgba(59, 130, 246, 0.3)' : '1px solid rgba(255,255,255,0.08)',
+                            background: isSelected ? 'rgba(59, 130, 246, 0.15)' : 'var(--bg-input-hover)',
+                            border: isSelected ? '1px solid rgba(59, 130, 246, 0.3)' : '1px solid var(--border-subtle)',
                           }}
                         >
                           <Layers size={18} style={{ color: isSelected ? 'rgba(59, 130, 246, 0.9)' : 'var(--text-muted)' }} />
@@ -1258,12 +1258,12 @@ export function ModelAppGroupPage({ onActionsReady }: { onActionsReady?: (action
                                               {/* 实际使用的模型 */}
                                               <div
                                                 className="group flex items-center gap-2 py-1.5 px-2 rounded-lg transition-colors"
-                                                style={{ background: isFallback ? 'rgba(34, 197, 94, 0.05)' : 'rgba(255, 255, 255, 0.02)' }}
+                                                style={{ background: isFallback ? 'rgba(34, 197, 94, 0.05)' : 'var(--list-item-bg)' }}
                                                 onMouseEnter={(e) => {
-                                                  e.currentTarget.style.background = isFallback ? 'rgba(34, 197, 94, 0.1)' : 'rgba(255, 255, 255, 0.06)';
+                                                  e.currentTarget.style.background = isFallback ? 'rgba(34, 197, 94, 0.1)' : 'var(--bg-input-hover)';
                                                 }}
                                                 onMouseLeave={(e) => {
-                                                  e.currentTarget.style.background = isFallback ? 'rgba(34, 197, 94, 0.05)' : 'rgba(255, 255, 255, 0.02)';
+                                                  e.currentTarget.style.background = isFallback ? 'rgba(34, 197, 94, 0.05)' : 'var(--list-item-bg)';
                                                 }}
                                                 title={isFallback ? `降级回退：${resolvedModel.fallbackReason || ''}` : resolvedModel.source === 'legacy' ? '使用传统配置的单模型' : resolvedModel.modelGroupName ? `使用默认模型池：${resolvedModel.modelGroupName}` : '使用默认模型池'}
                                               >
@@ -1274,7 +1274,7 @@ export function ModelAppGroupPage({ onActionsReady }: { onActionsReady?: (action
                                               {/* 平台 */}
                                               <span
                                                 className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] shrink-0"
-                                                style={{ background: 'rgba(255,255,255,0.05)', color: 'var(--text-muted)' }}
+                                                style={{ background: 'var(--bg-card-hover)', color: 'var(--text-muted)' }}
                                               >
                                                 <Server size={10} />
                                                 {resolvedModel.platformName}
@@ -1683,7 +1683,7 @@ export function ModelAppGroupPage({ onActionsReady }: { onActionsReady?: (action
                               className="h-9 w-24 px-2 rounded-[10px] outline-none text-[12px]"
                               style={{
                                 background: 'var(--bg-input)',
-                                border: '1px solid rgba(255,255,255,0.12)',
+                                border: '1px solid var(--border-default)',
                                 color: 'var(--text-primary)',
                               }}
                               title="优先级（越小越靠前）"
@@ -1773,7 +1773,7 @@ export function ModelAppGroupPage({ onActionsReady }: { onActionsReady?: (action
                   className="w-full h-10 px-3 rounded-[12px] outline-none text-[13px]"
                   style={{
                     background: 'var(--bg-input)',
-                    border: '1px solid rgba(255,255,255,0.12)',
+                    border: '1px solid var(--border-default)',
                     color: 'var(--text-primary)',
                   }}
                 />
@@ -1785,7 +1785,7 @@ export function ModelAppGroupPage({ onActionsReady }: { onActionsReady?: (action
                 </label>
                 <div
                   className="rounded-[12px] p-2 max-h-[200px] overflow-auto"
-                  style={{ border: '1px solid rgba(255,255,255,0.12)', background: 'var(--bg-input)' }}
+                  style={{ border: '1px solid var(--border-default)', background: 'var(--bg-input)' }}
                 >
                   {modelGroups.filter(g => g.modelType === requirementForm.modelType).map((group) => (
                     <label
@@ -1864,7 +1864,7 @@ export function ModelAppGroupPage({ onActionsReady }: { onActionsReady?: (action
                   className="w-full h-10 px-3 rounded-[12px] outline-none text-[13px]"
                   style={{
                     background: 'var(--bg-input)',
-                    border: '1px solid rgba(255,255,255,0.12)',
+                    border: '1px solid var(--border-default)',
                     color: 'var(--text-primary)',
                   }}
                 />
@@ -1883,7 +1883,7 @@ export function ModelAppGroupPage({ onActionsReady }: { onActionsReady?: (action
                   className="w-full h-10 px-3 rounded-[12px] outline-none text-[13px]"
                   style={{
                     background: 'var(--bg-input)',
-                    border: '1px solid rgba(255,255,255,0.12)',
+                    border: '1px solid var(--border-default)',
                     color: 'var(--text-primary)',
                     opacity: editingGroup ? 0.6 : 1,
                   }}
@@ -1920,7 +1920,7 @@ export function ModelAppGroupPage({ onActionsReady }: { onActionsReady?: (action
                   className="w-full px-3 py-2 rounded-[12px] outline-none text-[13px] resize-none"
                   style={{
                     background: 'var(--bg-input)',
-                    border: '1px solid rgba(255,255,255,0.12)',
+                    border: '1px solid var(--border-default)',
                     color: 'var(--text-primary)',
                   }}
                 />
@@ -1978,7 +1978,7 @@ export function ModelAppGroupPage({ onActionsReady }: { onActionsReady?: (action
                     className="w-full h-10 px-3 rounded-[12px] outline-none text-[13px]"
                     style={{
                       background: 'var(--bg-input)',
-                      border: '1px solid rgba(255,255,255,0.12)',
+                      border: '1px solid var(--border-default)',
                       color: 'var(--text-primary)',
                     }}
                   />
@@ -1998,7 +1998,7 @@ export function ModelAppGroupPage({ onActionsReady }: { onActionsReady?: (action
                     className="w-full h-10 px-3 rounded-[12px] outline-none text-[13px]"
                     style={{
                       background: 'var(--bg-input)',
-                      border: '1px solid rgba(255,255,255,0.12)',
+                      border: '1px solid var(--border-default)',
                       color: 'var(--text-primary)',
                     }}
                   />
@@ -2018,7 +2018,7 @@ export function ModelAppGroupPage({ onActionsReady }: { onActionsReady?: (action
                     className="w-full h-10 px-3 rounded-[12px] outline-none text-[13px]"
                     style={{
                       background: 'var(--bg-input)',
-                      border: '1px solid rgba(255,255,255,0.12)',
+                      border: '1px solid var(--border-default)',
                       color: 'var(--text-primary)',
                     }}
                   />
@@ -2038,7 +2038,7 @@ export function ModelAppGroupPage({ onActionsReady }: { onActionsReady?: (action
                     className="w-full h-10 px-3 rounded-[12px] outline-none text-[13px]"
                     style={{
                       background: 'var(--bg-input)',
-                      border: '1px solid rgba(255,255,255,0.12)',
+                      border: '1px solid var(--border-default)',
                       color: 'var(--text-primary)',
                     }}
                   />
@@ -2058,7 +2058,7 @@ export function ModelAppGroupPage({ onActionsReady }: { onActionsReady?: (action
                     className="w-full h-10 px-3 rounded-[12px] outline-none text-[13px]"
                     style={{
                       background: 'var(--bg-input)',
-                      border: '1px solid rgba(255,255,255,0.12)',
+                      border: '1px solid var(--border-default)',
                       color: 'var(--text-primary)',
                     }}
                   />
@@ -2076,7 +2076,7 @@ export function ModelAppGroupPage({ onActionsReady }: { onActionsReady?: (action
                     className="w-full h-10 px-3 rounded-[12px] outline-none text-[13px]"
                     style={{
                       background: 'var(--bg-input)',
-                      border: '1px solid rgba(255,255,255,0.12)',
+                      border: '1px solid var(--border-default)',
                       color: 'var(--text-primary)',
                     }}
                   />
@@ -2094,7 +2094,7 @@ export function ModelAppGroupPage({ onActionsReady }: { onActionsReady?: (action
                   className="w-full h-10 px-3 rounded-[12px] outline-none text-[13px]"
                   style={{
                     background: 'var(--bg-input)',
-                    border: '1px solid rgba(255,255,255,0.12)',
+                    border: '1px solid var(--border-default)',
                     color: 'var(--text-primary)',
                   }}
                 />
@@ -2169,7 +2169,7 @@ export function ModelAppGroupPage({ onActionsReady }: { onActionsReady?: (action
 
                 <div
                   className="rounded-[12px] p-3 min-h-[200px] max-h-[400px] overflow-auto"
-                  style={{ border: '1px solid rgba(255,255,255,0.08)', background: 'rgba(255,255,255,0.02)' }}
+                  style={{ border: '1px solid var(--border-subtle)', background: 'var(--list-item-bg)' }}
                 >
                   {filteredGroups.length === 0 ? (
                     <div className="py-12 text-center text-[12px]" style={{ color: 'var(--text-muted)' }}>
@@ -2217,7 +2217,7 @@ export function ModelAppGroupPage({ onActionsReady }: { onActionsReady?: (action
                                   ? 'rgba(59, 130, 246, 0.12)'
                                   : isMatching
                                     ? 'rgba(34, 197, 94, 0.06)'
-                                    : 'rgba(255,255,255,0.04)',
+                                    : 'var(--bg-input)',
                                 border: isSelected
                                   ? '1px solid rgba(59, 130, 246, 0.4)'
                                   : isMatching

--- a/prd-admin/src/pages/ModelManagePage.tsx
+++ b/prd-admin/src/pages/ModelManagePage.tsx
@@ -998,7 +998,7 @@ export default function ModelManagePage() {
               ? 'rgba(168,85,247,0.18)'
               : t.includes('deepseek')
                 ? 'rgba(239,68,68,0.16)'
-                : 'rgba(255,255,255,0.08)';
+                : 'var(--border-subtle)';
     const fg =
       t.includes('openai')
         ? 'rgba(16,185,129,0.95)'
@@ -1150,7 +1150,7 @@ export default function ModelManagePage() {
 
   const inputStyle: React.CSSProperties = {
     background: 'var(--bg-input)',
-    border: '1px solid rgba(255,255,255,0.12)',
+    border: '1px solid var(--border-default)',
     color: 'var(--text-primary)',
   };
 
@@ -1176,7 +1176,7 @@ export default function ModelManagePage() {
               onClick={() => setPlatformSidebarCollapsed((prev) => !prev)}
               className="inline-flex items-center justify-center h-8 w-8 rounded-[8px] transition-colors hover:bg-white/6 shrink-0 ml-auto"
               style={{
-                border: '1px solid rgba(255,255,255,0.12)',
+                border: '1px solid var(--border-default)',
                 color: 'var(--text-secondary)',
               }}
               title={platformSidebarCollapsed ? '展开平台列表' : '折叠平台列表'}
@@ -1225,13 +1225,13 @@ export default function ModelManagePage() {
               }}
               className="w-full flex items-center gap-3 rounded-[14px] px-3 py-2.5 text-left transition-colors hover:bg-white/2 cursor-pointer select-none"
               style={{
-                background: selectedPlatformId === '__all__' ? 'rgba(255,255,255,0.04)' : 'transparent',
+                background: selectedPlatformId === '__all__' ? 'var(--bg-input)' : 'transparent',
                 border: selectedPlatformId === '__all__' ? '1px solid var(--border-default)' : '1px solid transparent',
               }}
             >
               <div
                 className="h-9 w-9 rounded-full flex items-center justify-center text-[12px] font-extrabold"
-                style={{ background: 'rgba(255,255,255,0.08)', color: 'rgba(247,247,251,0.78)', border: '1px solid var(--border-subtle)' }}
+                style={{ background: 'var(--border-subtle)', color: 'rgba(247,247,251,0.78)', border: '1px solid var(--border-subtle)' }}
               >
                 <LayoutGrid size={16} />
               </div>
@@ -1261,7 +1261,7 @@ export default function ModelManagePage() {
                     }}
                     className="w-full flex items-center gap-3 rounded-[14px] px-3 py-2.5 text-left transition-colors hover:bg-white/2 cursor-pointer select-none"
                     style={{
-                      background: isSelected ? 'rgba(255,255,255,0.04)' : 'transparent',
+                      background: isSelected ? 'var(--bg-input)' : 'transparent',
                       border: isSelected ? '1px solid var(--border-default)' : '1px solid transparent',
                     }}
                   >
@@ -1292,7 +1292,7 @@ export default function ModelManagePage() {
                       style={
                         p.enabled
                           ? { background: 'rgba(34,197,94,0.12)', border: '1px solid rgba(34,197,94,0.28)', color: 'rgba(34,197,94,0.95)' }
-                          : { background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.12)', color: 'var(--text-secondary)' }
+                          : { background: 'var(--bg-input)', border: '1px solid var(--border-default)', color: 'var(--text-secondary)' }
                       }
                       disabled={loading || platformTogglingId === p.id}
                       aria-label={p.enabled ? '点击禁用平台' : '点击启用平台'}
@@ -1390,7 +1390,7 @@ export default function ModelManagePage() {
                 <Trash2 size={16} />
                 删除
               </button>
-              <div className="h-px my-1" style={{ background: 'rgba(255,255,255,0.08)' }} />
+              <div className="h-px my-1" style={{ background: 'var(--border-subtle)' }} />
               <button
                 type="button"
                 className="w-full flex items-center gap-2 rounded-[12px] px-3 py-2 text-sm hover:bg-white/5"
@@ -1513,8 +1513,8 @@ export default function ModelManagePage() {
                     }}
                     className="relative h-7 w-12 rounded-full transition-colors"
                     style={{
-                      background: selectedPlatform.enabled ? 'rgba(34,197,94,0.22)' : 'rgba(255,255,255,0.10)',
-                      border: selectedPlatform.enabled ? '1px solid rgba(34,197,94,0.35)' : '1px solid rgba(255,255,255,0.14)',
+                      background: selectedPlatform.enabled ? 'rgba(34,197,94,0.22)' : 'var(--border-default)',
+                      border: selectedPlatform.enabled ? '1px solid rgba(34,197,94,0.35)' : '1px solid var(--border-default)',
                     }}
                     aria-label={selectedPlatform.enabled ? '已启用，点击关闭' : '已禁用，点击启用'}
                   >
@@ -1545,7 +1545,7 @@ export default function ModelManagePage() {
                           className="flex h-[30px] box-border items-center overflow-hidden rounded-[14px]"
                           style={{
                             background: 'var(--bg-input)',
-                            border: '1px solid rgba(255,255,255,0.12)',
+                            border: '1px solid var(--border-default)',
                           }}
                         >
                           <input
@@ -1576,7 +1576,7 @@ export default function ModelManagePage() {
                             {showApiKey ? <EyeOff size={18} /> : <Eye size={18} />}
                           </button>
 
-                          <div className="h-6 w-px" style={{ background: 'rgba(255,255,255,0.12)' }} />
+                          <div className="h-6 w-px" style={{ background: 'var(--border-default)' }} />
 
                           <button
                             type="button"
@@ -1767,8 +1767,8 @@ export default function ModelManagePage() {
                                             text={`请求 ${formatCompactZh(s.requestCount)}`}
                                             title={`${titlePrefix} · 请求次数${sFromLogs ? '' : '（模型计数）'}`}
                                             style={{
-                                              background: 'rgba(255,255,255,0.05)',
-                                              border: '1px solid rgba(255,255,255,0.12)',
+                                              background: 'var(--bg-card-hover)',
+                                              border: '1px solid var(--border-default)',
                                               color: white,
                                             }}
                                           />
@@ -1815,7 +1815,7 @@ export default function ModelManagePage() {
                                       type="button"
                                       className="inline-flex items-center justify-center h-[32px] w-[32px] rounded-[10px] transition-colors disabled:opacity-60 disabled:cursor-not-allowed hover:bg-white/6"
                                       style={{
-                                        border: '1px solid rgba(255,255,255,0.10)',
+                                        border: '1px solid var(--border-default)',
                                         color: 'var(--text-secondary)',
                                       }}
                                       title="一键添加到模型池"
@@ -1835,7 +1835,7 @@ export default function ModelManagePage() {
                                           ? testResult.ok
                                             ? { background: 'rgba(34,197,94,0.18)', border: '1px solid rgba(34,197,94,0.35)', color: 'rgba(34,197,94,0.95)' }
                                             : { background: 'rgba(239,68,68,0.14)', border: '1px solid rgba(239,68,68,0.28)', color: 'rgba(239,68,68,0.95)' }
-                                          : { border: '1px solid rgba(255,255,255,0.10)', color: 'var(--text-secondary)' }
+                                          : { border: '1px solid var(--border-default)', color: 'var(--text-secondary)' }
                                       }
                                       title={testResult?.modelId === m.id && !testResult.ok ? testResult.msg : `测试：${m.name}`}
                                     >
@@ -1849,7 +1849,7 @@ export default function ModelManagePage() {
                                     </button>
 
                                     {/* 操作按钮组（主/意图/识图/生图）- 用圆角矩形框框选 */}
-                                    <div className="inline-flex items-center gap-1 rounded-[10px] px-1.5 py-1" style={{ border: '1px solid rgba(255,255,255,0.12)', background: 'rgba(255,255,255,0.03)' }}>
+                                    <div className="inline-flex items-center gap-1 rounded-[10px] px-1.5 py-1" style={{ border: '1px solid var(--border-default)', background: 'var(--nested-block-bg)' }}>
                                     <Button
                                       variant="ghost"
                                       size="sm"
@@ -1932,7 +1932,7 @@ export default function ModelManagePage() {
                                           onClick={(e) => e.stopPropagation()}
                                           className="inline-flex items-center justify-center h-[32px] w-[32px] rounded-[10px] transition-colors hover:bg-white/6"
                                           style={{
-                                            border: '1px solid rgba(255,255,255,0.10)',
+                                            border: '1px solid var(--border-default)',
                                             color: 'var(--text-secondary)',
                                           }}
                                           aria-label="更多操作"
@@ -1967,7 +1967,7 @@ export default function ModelManagePage() {
                                             <DatabaseZap size={14} />
                                             {m.enablePromptCache ? 'Prompt Cache: 开' : 'Prompt Cache: 关'}
                                           </DropdownMenu.Item>
-                                          <DropdownMenu.Separator className="h-px my-1" style={{ background: 'rgba(255,255,255,0.08)' }} />
+                                          <DropdownMenu.Separator className="h-px my-1" style={{ background: 'var(--border-subtle)' }} />
                                           <DropdownMenu.Item
                                             className="flex items-center gap-2 rounded-[8px] px-3 py-2 text-sm outline-none cursor-pointer hover:bg-white/5"
                                             style={{ color: 'var(--text-primary)' }}
@@ -1980,7 +1980,7 @@ export default function ModelManagePage() {
                                             <Pencil size={14} />
                                             编辑
                                           </DropdownMenu.Item>
-                                          <DropdownMenu.Separator className="h-px my-1" style={{ background: 'rgba(255,255,255,0.08)' }} />
+                                          <DropdownMenu.Separator className="h-px my-1" style={{ background: 'var(--border-subtle)' }} />
                                           <ConfirmTip
                                             title={`确认删除模型"${m.name}"？`}
                                             description="该操作不可撤销"
@@ -2446,7 +2446,7 @@ export default function ModelManagePage() {
               </label>
 
               {/* 预览将添加的模型 */}
-              <div className="rounded-[12px] p-3" style={{ background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.08)' }}>
+              <div className="rounded-[12px] p-3" style={{ background: 'var(--nested-block-bg)', border: '1px solid var(--border-subtle)' }}>
                 <div className="text-[11px] font-semibold mb-2" style={{ color: 'var(--text-muted)' }}>
                   将添加的模型
                 </div>

--- a/prd-admin/src/pages/ModelPoolManagePage.tsx
+++ b/prd-admin/src/pages/ModelPoolManagePage.tsx
@@ -591,7 +591,7 @@ export function ModelPoolManagePage() {
                                         ? <ChevronDown size={13} style={{ color: 'var(--text-muted)' }} />
                                         : <ChevronRight size={13} style={{ color: 'var(--text-muted)' }} />
                                     ) : (
-                                      <span className="w-3 h-px" style={{ background: 'rgba(255,255,255,0.1)' }} />
+                                      <span className="w-3 h-px" style={{ background: 'var(--border-default)' }} />
                                     )}
                                   </span>
                                   <span className="text-[13px] font-semibold truncate min-w-0 flex-1" style={{ color: 'var(--text-primary)' }}>
@@ -700,7 +700,7 @@ export function ModelPoolManagePage() {
                                       ? <ChevronDown size={13} style={{ color: 'var(--text-muted)' }} />
                                       : <ChevronRight size={13} style={{ color: 'var(--text-muted)' }} />
                                   ) : (
-                                    <span className="w-3 h-px" style={{ background: 'rgba(255,255,255,0.1)' }} />
+                                    <span className="w-3 h-px" style={{ background: 'var(--border-default)' }} />
                                   )}
                                 </span>
 
@@ -1374,7 +1374,7 @@ function InlineDispatchPreview({
                     )}
                   </div>
                   {platformNameById.get(m.platformId) && (
-                    <span className="text-[9px] px-1 py-0.5 rounded shrink-0" style={{ background: 'rgba(255,255,255,0.06)', color: 'var(--text-muted)' }}>
+                    <span className="text-[9px] px-1 py-0.5 rounded shrink-0" style={{ background: 'var(--bg-input-hover)', color: 'var(--text-muted)' }}>
                       {platformNameById.get(m.platformId)}
                     </span>
                   )}

--- a/prd-admin/src/pages/ModelPoolManagePage.tsx
+++ b/prd-admin/src/pages/ModelPoolManagePage.tsx
@@ -385,8 +385,8 @@ export function ModelPoolManagePage() {
                 onChange={(e) => setSearchTerm(e.target.value)}
                 className="w-full h-9 pl-9 pr-3 rounded-[11px] outline-none text-[13px]"
                 style={{
-                  background: 'rgba(255,255,255,0.04)',
-                  border: '1px solid rgba(255,255,255,0.08)',
+                  background: 'var(--bg-input)',
+                  border: '1px solid var(--border-subtle)',
                   color: 'var(--text-primary)',
                 }}
               />
@@ -442,7 +442,7 @@ export function ModelPoolManagePage() {
               {!isMobile && (
                 <div
                   className="flex items-center gap-3 pl-12 pr-4 py-2 text-[11px] font-semibold select-none"
-                  style={{ color: 'var(--text-muted)', borderBottom: '1px solid rgba(255,255,255,0.06)' }}
+                  style={{ color: 'var(--text-muted)', borderBottom: '1px solid var(--nested-block-border)' }}
                 >
                   <span className="w-5 shrink-0" />
                   <span className="min-w-[120px] flex-[2]">名称</span>
@@ -473,9 +473,9 @@ export function ModelPoolManagePage() {
                     {/* ── 第一级：类型分组头 ── */}
                     <div
                       className={`flex items-center gap-3 px-4 py-2 cursor-pointer select-none ${isMobile ? 'flex-wrap gap-y-1' : ''}`}
-                      style={{ background: 'rgba(255,255,255,0.02)', borderBottom: '1px solid rgba(255,255,255,0.06)' }}
-                      onMouseEnter={e => { e.currentTarget.style.background = 'rgba(255,255,255,0.04)'; }}
-                      onMouseLeave={e => { e.currentTarget.style.background = 'rgba(255,255,255,0.02)'; }}
+                      style={{ background: 'var(--list-item-bg)', borderBottom: '1px solid var(--nested-block-border)' }}
+                      onMouseEnter={e => { e.currentTarget.style.background = 'var(--bg-input)'; }}
+                      onMouseLeave={e => { e.currentTarget.style.background = 'var(--list-item-bg)'; }}
                       onClick={() => setCollapsedTypes(prev => {
                         const next = new Set(prev);
                         if (next.has(group.type)) next.delete(group.type);
@@ -571,8 +571,8 @@ export function ModelPoolManagePage() {
                         <div key={pool.id}>
                           <div
                             className={`group transition-colors cursor-pointer ${isMobile ? 'flex flex-col gap-2 px-3 py-2.5' : 'flex items-center gap-3 pl-12 pr-4 py-2.5'}`}
-                            style={{ borderBottom: '1px solid rgba(255,255,255,0.04)' }}
-                            onMouseEnter={e => { e.currentTarget.style.background = 'rgba(255,255,255,0.03)'; }}
+                            style={{ borderBottom: '1px solid var(--nested-block-border)' }}
+                            onMouseEnter={e => { e.currentTarget.style.background = 'var(--nested-block-bg)'; }}
                             onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
                             onClick={() => setExpandedPoolIds(prev => {
                               const next = new Set(prev);
@@ -815,7 +815,7 @@ export function ModelPoolManagePage() {
                           {isExpanded && pool.models && pool.models.length > 0 && (
                             <div
                               className={`py-2 pr-4 ${isMobile ? 'pl-3' : 'pl-12'}`}
-                              style={{ background: 'rgba(255,255,255,0.015)', borderBottom: '1px solid rgba(255,255,255,0.06)' }}
+                              style={{ background: 'var(--list-item-bg)', borderBottom: '1px solid var(--nested-block-border)' }}
                             >
                               <div className={`${isMobile ? 'ml-2' : 'ml-5'} space-y-1`}>
                                 {pool.models.map((model, idx) => {
@@ -906,7 +906,7 @@ export function ModelPoolManagePage() {
                     onChange={(e) => setPoolForm({ ...poolForm, name: e.target.value })}
                     placeholder="例如：主对话模型池"
                     className="w-full h-9 px-3 rounded-[10px] outline-none text-[13px]"
-                    style={{ background: 'var(--bg-input)', border: '1px solid rgba(255,255,255,0.12)', color: 'var(--text-primary)' }}
+                    style={{ background: 'var(--bg-input)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
                   />
                 </div>
                 <div>
@@ -920,7 +920,7 @@ export function ModelPoolManagePage() {
                     placeholder="例如：main-chat-pool"
                     disabled={!!editingPool}
                     className="w-full h-9 px-3 rounded-[10px] outline-none text-[13px]"
-                    style={{ background: 'var(--bg-input)', border: '1px solid rgba(255,255,255,0.12)', color: 'var(--text-primary)', opacity: editingPool ? 0.6 : 1 }}
+                    style={{ background: 'var(--bg-input)', border: '1px solid var(--border-default)', color: 'var(--text-primary)', opacity: editingPool ? 0.6 : 1 }}
                   />
                 </div>
                 <div>
@@ -952,7 +952,7 @@ export function ModelPoolManagePage() {
                     min={1}
                     max={100}
                     className="w-full h-9 px-3 rounded-[10px] outline-none text-[13px] text-center"
-                    style={{ background: 'var(--bg-input)', border: '1px solid rgba(255,255,255,0.12)', color: 'var(--text-primary)' }}
+                    style={{ background: 'var(--bg-input)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
                     title="数字越小优先级越高"
                   />
                 </div>
@@ -999,7 +999,7 @@ export function ModelPoolManagePage() {
                   placeholder="模型池用途说明..."
                   rows={2}
                   className="w-full px-3 py-2 rounded-[10px] outline-none text-[13px] resize-none"
-                  style={{ background: 'var(--bg-input)', border: '1px solid rgba(255,255,255,0.12)', color: 'var(--text-primary)' }}
+                  style={{ background: 'var(--bg-input)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
                 />
               </div>
 
@@ -1017,7 +1017,7 @@ export function ModelPoolManagePage() {
 
                 <div
                   className="rounded-[12px] overflow-hidden"
-                  style={{ border: '1px solid rgba(255,255,255,0.08)', background: 'rgba(255,255,255,0.02)' }}
+                  style={{ border: '1px solid var(--border-subtle)', background: 'var(--list-item-bg)' }}
                 >
                   {poolForm.models.length === 0 ? (
                     <div className="py-10 text-center text-[12px]" style={{ color: 'var(--text-muted)' }}>
@@ -1053,7 +1053,7 @@ export function ModelPoolManagePage() {
                                     }));
                                   }}
                                   className="h-7 w-14 px-1 rounded-md outline-none text-[11px] text-center"
-                                  style={{ background: 'var(--bg-input)', border: '1px solid rgba(255,255,255,0.10)', color: 'var(--text-primary)' }}
+                                  style={{ background: 'var(--bg-input)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
                                   title="优先级（越小越优先）"
                                 />
                                 <button
@@ -1070,7 +1070,7 @@ export function ModelPoolManagePage() {
                       </div>
 
                       {/* 虚线分隔 */}
-                      <div className="mx-3" style={{ borderTop: '1px dashed rgba(255,255,255,0.10)' }} />
+                      <div className="mx-3" style={{ borderTop: '1px dashed var(--border-default)' }} />
 
                       {/* 调度预测可视化（本地计算） */}
                       <InlineDispatchPreview
@@ -1212,28 +1212,28 @@ function InlineDispatchPreview({
               return (
                 <div key={keyOfModel(m)} className="flex items-center gap-2">
                   <div className="flex flex-col items-center w-4 shrink-0 self-stretch">
-                    <div className="w-px flex-1 transition-all duration-400" style={{ background: isActive ? `${color}40` : 'rgba(255,255,255,0.06)' }} />
+                    <div className="w-px flex-1 transition-all duration-400" style={{ background: isActive ? `${color}40` : 'var(--nested-block-border)' }} />
                     <div
                       className="w-2 h-2 rounded-full border-[1.5px] shrink-0 transition-all duration-400"
                       style={{
-                        borderColor: isActive ? color : 'rgba(255,255,255,0.15)',
+                        borderColor: isActive ? color : 'var(--border-default)',
                         background: isTarget && isActive ? color : 'transparent',
                         boxShadow: isTarget && isActive ? `0 0 8px ${color}50` : 'none',
                       }}
                     />
-                    <div className="w-px flex-1" style={{ background: i < sorted.length - 1 ? 'rgba(255,255,255,0.06)' : 'transparent' }} />
+                    <div className="w-px flex-1" style={{ background: i < sorted.length - 1 ? 'var(--nested-block-border)' : 'transparent' }} />
                   </div>
                   <div
                     className="flex-1 flex items-center gap-2 px-2 py-1.5 rounded-lg transition-all duration-400"
                     style={{
                       opacity: isActive ? 1 : 0.15,
                       transform: isActive ? 'translateX(0)' : 'translateX(-6px)',
-                      background: isTarget ? `${color}10` : 'rgba(255,255,255,0.03)',
-                      border: `1px solid ${isTarget ? `${color}25` : 'rgba(255,255,255,0.05)'}`,
+                      background: isTarget ? `${color}10` : 'var(--nested-block-bg)',
+                      border: `1px solid ${isTarget ? `${color}25` : 'var(--nested-block-border)'}`,
                     }}
                   >
                     {platformNameById.get(m.platformId) && (
-                      <span className="text-[9px] px-1 py-0.5 rounded shrink-0" style={{ background: 'rgba(255,255,255,0.06)', color: 'var(--text-muted)' }}>
+                      <span className="text-[9px] px-1 py-0.5 rounded shrink-0" style={{ background: 'var(--bg-input-hover)', color: 'var(--text-muted)' }}>
                         {platformNameById.get(m.platformId)}
                       </span>
                     )}
@@ -1241,7 +1241,7 @@ function InlineDispatchPreview({
                     <span
                       className="text-[10px] px-1.5 py-0.5 rounded-md shrink-0"
                       style={{
-                        background: isTarget ? `${color}18` : 'rgba(255,255,255,0.05)',
+                        background: isTarget ? `${color}18` : 'var(--bg-card-hover)',
                         color: isTarget ? color : 'var(--text-muted)',
                       }}
                     >
@@ -1308,12 +1308,12 @@ function InlineDispatchPreview({
                   style={{
                     opacity: isActive ? 1 : 0.15,
                     transform: isActive ? 'translateY(0) scale(1)' : 'translateY(-4px) scale(0.96)',
-                    background: isWinner ? `${color}12` : 'rgba(255,255,255,0.03)',
-                    border: `1px solid ${isWinner ? `${color}35` : 'rgba(255,255,255,0.06)'}`,
+                    background: isWinner ? `${color}12` : 'var(--nested-block-bg)',
+                    border: `1px solid ${isWinner ? `${color}35` : 'var(--nested-block-border)'}`,
                   }}
                 >
                   {platformNameById.get(m.platformId) && (
-                    <span className="text-[9px] px-1 py-0.5 rounded" style={{ background: 'rgba(255,255,255,0.06)', color: 'var(--text-muted)' }}>
+                    <span className="text-[9px] px-1 py-0.5 rounded" style={{ background: 'var(--bg-input-hover)', color: 'var(--text-muted)' }}>
                       {platformNameById.get(m.platformId)}
                     </span>
                   )}
@@ -1356,15 +1356,15 @@ function InlineDispatchPreview({
                   className="flex items-center gap-2 px-2 py-1.5 rounded-lg transition-all duration-300"
                   style={{
                     opacity: isActive ? 1 : 0.15,
-                    background: isCurrent ? `${color}10` : 'rgba(255,255,255,0.03)',
-                    border: `1px solid ${isCurrent ? `${color}30` : 'rgba(255,255,255,0.05)'}`,
+                    background: isCurrent ? `${color}10` : 'var(--nested-block-bg)',
+                    border: `1px solid ${isCurrent ? `${color}30` : 'var(--nested-block-border)'}`,
                   }}
                 >
                   <div
                     className="w-5 h-5 rounded-md flex items-center justify-center shrink-0 transition-all duration-300"
                     style={{
-                      background: isCurrent ? `${color}20` : 'rgba(255,255,255,0.04)',
-                      border: `1px solid ${isCurrent ? `${color}40` : 'rgba(255,255,255,0.08)'}`,
+                      background: isCurrent ? `${color}20` : 'var(--bg-input)',
+                      border: `1px solid ${isCurrent ? `${color}40` : 'var(--border-subtle)'}`,
                     }}
                   >
                     {isCurrent ? (

--- a/prd-admin/src/pages/OpenPlatformPage.tsx
+++ b/prd-admin/src/pages/OpenPlatformPage.tsx
@@ -1233,7 +1233,7 @@ function LogsDialog({
           </div>
 
           {total > pageSize && (
-            <div className="flex justify-between items-center pt-4 border-t" style={{ borderColor: 'rgba(255,255,255,0.06)' }}>
+            <div className="flex justify-between items-center pt-4 border-t" style={{ borderColor: 'var(--nested-block-border)' }}>
               <div className="text-sm" style={{ color: 'var(--text-muted)' }}>
                 共 {total} 条，第 {page} / {Math.ceil(total / pageSize)} 页
               </div>
@@ -1406,12 +1406,12 @@ function CurlCommandDialog({ open, onClose, curlCommand }: { open: boolean; onCl
                 复制命令
               </Button>
             </div>
-            <pre className="p-4 rounded-lg text-xs overflow-x-auto" style={{ background: 'rgba(0,0,0,0.3)', border: '1px solid rgba(255,255,255,0.08)' }}>
+            <pre className="p-4 rounded-lg text-xs overflow-x-auto" style={{ background: 'var(--nested-block-bg)', border: '1px solid var(--border-subtle)' }}>
               <code style={{ color: 'var(--text-secondary)' }}>{curlCommand}</code>
             </pre>
           </div>
 
-          <div className="flex justify-end pt-4 border-t" style={{ borderColor: 'rgba(255,255,255,0.06)' }}>
+          <div className="flex justify-end pt-4 border-t" style={{ borderColor: 'var(--nested-block-border)' }}>
             <Button onClick={onClose}>关闭</Button>
           </div>
         </div>

--- a/prd-admin/src/pages/OpenPlatformPage.tsx
+++ b/prd-admin/src/pages/OpenPlatformPage.tsx
@@ -263,7 +263,7 @@ export default function OpenPlatformPage() {
       />
 
       <GlassCard glow className="mt-6">
-        <div className="p-4 border-b" style={{ borderColor: 'rgba(255,255,255,0.06)' }}>
+        <div className="p-4 border-b" style={{ borderColor: 'var(--nested-block-border)' }}>
           <input
             type="text"
             placeholder="搜索应用名称或描述..."
@@ -271,8 +271,8 @@ export default function OpenPlatformPage() {
             onChange={(e) => setSearch(e.target.value)}
             className="w-full px-3 py-2 rounded-md outline-none transition-colors"
             style={{
-              background: 'rgba(255,255,255,0.03)',
-              border: '1px solid rgba(255,255,255,0.08)',
+              background: 'var(--nested-block-bg)',
+              border: '1px solid var(--border-subtle)',
               color: 'var(--text-primary)',
             }}
           />
@@ -280,7 +280,7 @@ export default function OpenPlatformPage() {
 
         <div className="overflow-x-auto">
           <table className="w-full min-w-[700px]">
-            <thead style={{ background: 'rgba(255,255,255,0.02)' }}>
+            <thead style={{ background: 'var(--list-item-bg)' }}>
               <tr>
                 <th className="px-4 py-3 text-left text-sm font-medium">应用名称</th>
                 <th className="px-4 py-3 text-left text-sm font-medium">绑定信息</th>
@@ -292,20 +292,20 @@ export default function OpenPlatformPage() {
             </thead>
             <tbody>
               {apps.map((app) => (
-                <tr key={app.id} className="transition-colors" style={{ borderTop: '1px solid rgba(255,255,255,0.04)' }} onMouseEnter={(e) => e.currentTarget.style.background = 'rgba(255,255,255,0.02)'} onMouseLeave={(e) => e.currentTarget.style.background = 'transparent'}>
+                <tr key={app.id} className="transition-colors" style={{ borderTop: '1px solid var(--bg-input)' }} onMouseEnter={(e) => e.currentTarget.style.background = 'var(--list-item-bg)'} onMouseLeave={(e) => e.currentTarget.style.background = 'transparent'}>
                   <td className="px-4 py-3">
                     <div className="font-medium">{app.appName}</div>
                     {app.description && <div className="text-sm text-muted-foreground">{app.description}</div>}
                   </td>
                   <td className="px-4 py-3">
                     <div className="flex flex-col gap-2">
-                      <div className="flex items-center gap-2 px-2 py-1 rounded-lg text-sm" style={{ background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.10)' }}>
+                      <div className="flex items-center gap-2 px-2 py-1 rounded-lg text-sm" style={{ background: 'var(--bg-card-hover)', border: '1px solid var(--border-default)' }}>
                         <div className="w-5 h-5 rounded-full flex items-center justify-center text-xs font-semibold" style={{ background: 'var(--gold-gradient)', color: '#1a1206' }}>
                           {app.boundUserName.charAt(0).toUpperCase()}
                         </div>
                         <span className="font-medium">{app.boundUserName}</span>
                       </div>
-                      <div className="flex items-center gap-2 px-2 py-1 rounded-lg text-sm" style={{ background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.10)' }}>
+                      <div className="flex items-center gap-2 px-2 py-1 rounded-lg text-sm" style={{ background: 'var(--bg-card-hover)', border: '1px solid var(--border-default)' }}>
                         <div className="w-5 h-5 rounded flex items-center justify-center text-xs" style={{ background: 'rgba(59,130,246,0.15)', color: 'rgba(96,165,250,0.95)' }}>
                           #
                         </div>
@@ -384,7 +384,7 @@ export default function OpenPlatformPage() {
                               <RefreshCw size={14} />
                               <span>重新生成密钥</span>
                             </DropdownMenu.Item>
-                            <DropdownMenu.Separator className="my-1 h-px" style={{ background: 'rgba(255,255,255,0.10)' }} />
+                            <DropdownMenu.Separator className="my-1 h-px" style={{ background: 'var(--border-default)' }} />
                             <DropdownMenu.Item
                               className="flex items-center gap-2 px-3 py-2 text-sm rounded-[10px] cursor-pointer outline-none transition-colors"
                               style={{ color: 'rgba(239,68,68,0.95)' }}
@@ -411,7 +411,7 @@ export default function OpenPlatformPage() {
         </div>
 
         {total > pageSize && (
-          <div className="p-4 border-t flex justify-between items-center" style={{ borderColor: 'rgba(255,255,255,0.06)' }}>
+          <div className="p-4 border-t flex justify-between items-center" style={{ borderColor: 'var(--nested-block-border)' }}>
             <div className="text-sm text-muted-foreground">
               共 {total} 条，第 {page} / {Math.ceil(total / pageSize)} 页
             </div>
@@ -1098,7 +1098,7 @@ function LogsDialog({
 
           {/* 筛选面板 */}
           {showFilters && (
-            <div className="p-4 rounded-lg" style={{ background: 'rgba(255,255,255,0.02)', border: '1px solid rgba(255,255,255,0.06)' }}>
+            <div className="p-4 rounded-lg" style={{ background: 'var(--list-item-bg)', border: '1px solid var(--nested-block-border)' }}>
               <div className="flex items-center gap-2 mb-3">
                 <Filter size={14} style={{ color: 'var(--accent-gold)' }} />
                 <span className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>筛选条件</span>
@@ -1158,7 +1158,7 @@ function LogsDialog({
           )}
           <div className="overflow-x-auto max-h-[600px] overflow-y-auto">
             <table className="w-full text-sm">
-              <thead className="sticky top-0" style={{ background: 'rgba(255,255,255,0.02)' }}>
+              <thead className="sticky top-0" style={{ background: 'var(--list-item-bg)' }}>
                 <tr>
                   <th className="px-3 py-2 text-left text-xs font-medium" style={{ color: 'var(--text-muted)' }}>时间</th>
                   <th className="px-3 py-2 text-left text-xs font-medium" style={{ color: 'var(--text-muted)' }}>应用</th>
@@ -1174,8 +1174,8 @@ function LogsDialog({
                   <tr 
                     key={log.id} 
                     className="transition-colors cursor-pointer"
-                    style={{ borderTop: '1px solid rgba(255,255,255,0.04)' }}
-                    onMouseEnter={(e) => e.currentTarget.style.background = 'rgba(255,255,255,0.02)'}
+                    style={{ borderTop: '1px solid var(--bg-input)' }}
+                    onMouseEnter={(e) => e.currentTarget.style.background = 'var(--list-item-bg)'}
                     onMouseLeave={(e) => e.currentTarget.style.background = 'transparent'}
                     onClick={() => handleViewDetail(log)}
                   >
@@ -1188,7 +1188,7 @@ function LogsDialog({
                       <div className="font-medium" style={{ color: 'var(--text-primary)' }}>{log.appName}</div>
                     </td>
                     <td className="px-3 py-2.5">
-                      <code className="text-xs px-1.5 py-0.5 rounded" style={{ background: 'rgba(0,0,0,0.2)', color: 'var(--text-secondary)' }}>
+                      <code className="text-xs px-1.5 py-0.5 rounded" style={{ background: 'var(--nested-block-bg)', color: 'var(--text-secondary)' }}>
                         {log.path}
                       </code>
                     </td>
@@ -1268,7 +1268,7 @@ function LogsDialog({
               <div className="grid grid-cols-2 gap-4">
                 <div>
                   <div className="text-xs font-medium mb-1" style={{ color: 'var(--text-muted)' }}>请求 ID</div>
-                  <code className="text-xs px-2 py-1 rounded block" style={{ background: 'rgba(0,0,0,0.2)', color: 'var(--text-secondary)' }}>
+                  <code className="text-xs px-2 py-1 rounded block" style={{ background: 'var(--nested-block-bg)', color: 'var(--text-secondary)' }}>
                     {selectedLog.requestId}
                   </code>
                 </div>
@@ -1298,7 +1298,7 @@ function LogsDialog({
 
               <div>
                 <div className="text-xs font-medium mb-1" style={{ color: 'var(--text-muted)' }}>请求路径</div>
-                <code className="text-xs px-2 py-1 rounded block" style={{ background: 'rgba(0,0,0,0.2)', color: 'var(--text-secondary)' }}>
+                <code className="text-xs px-2 py-1 rounded block" style={{ background: 'var(--nested-block-bg)', color: 'var(--text-secondary)' }}>
                   {selectedLog.method} {selectedLog.path}
                 </code>
               </div>
@@ -1319,7 +1319,7 @@ function LogsDialog({
               {selectedLog.groupId && (
                 <div>
                   <div className="text-xs font-medium mb-1" style={{ color: 'var(--text-muted)' }}>群组 ID</div>
-                  <code className="text-xs px-2 py-1 rounded block" style={{ background: 'rgba(0,0,0,0.2)', color: 'var(--text-secondary)' }}>
+                  <code className="text-xs px-2 py-1 rounded block" style={{ background: 'var(--nested-block-bg)', color: 'var(--text-secondary)' }}>
                     {selectedLog.groupId}
                   </code>
                 </div>
@@ -1328,7 +1328,7 @@ function LogsDialog({
               {selectedLog.sessionId && (
                 <div>
                   <div className="text-xs font-medium mb-1" style={{ color: 'var(--text-muted)' }}>会话 ID</div>
-                  <code className="text-xs px-2 py-1 rounded block" style={{ background: 'rgba(0,0,0,0.2)', color: 'var(--text-secondary)' }}>
+                  <code className="text-xs px-2 py-1 rounded block" style={{ background: 'var(--nested-block-bg)', color: 'var(--text-secondary)' }}>
                     {selectedLog.sessionId}
                   </code>
                 </div>

--- a/prd-admin/src/pages/PromptStagesPage.tsx
+++ b/prd-admin/src/pages/PromptStagesPage.tsx
@@ -38,9 +38,9 @@ function SegmentedTabs<T extends string>(props: {
   return (
     <div
       className="inline-flex items-center max-w-full p-1 rounded-[14px] overflow-x-auto"
-      style={{ 
-        background: 'rgba(0,0,0,0.20)', 
-        border: '1px solid rgba(255,255,255,0.08)',
+      style={{
+        background: 'var(--nested-block-bg)',
+        border: '1px solid var(--border-subtle)',
         boxShadow: '0 2px 8px -2px rgba(0, 0, 0, 0.3) inset',
       }}
       aria-label={ariaLabel}
@@ -860,14 +860,14 @@ export default function PromptStagesPage() {
       />
 
       {uiErr && (
-        <div className="rounded-[14px] px-4 py-3 text-sm" style={{ border: '1px solid rgba(255,255,255,0.10)', background: 'rgba(0,0,0,0.20)', color: 'rgba(255,120,120,0.95)' }}>
+        <div className="rounded-[14px] px-4 py-3 text-sm" style={{ border: '1px solid var(--border-default)', background: 'var(--nested-block-bg)', color: 'rgba(255,120,120,0.95)' }}>
           {uiErr}
         </div>
       )}
       {uiMsg && (
         <div
           className="rounded-[14px] px-4 py-3 text-sm relative overflow-hidden"
-          style={{ border: '1px solid rgba(255,255,255,0.10)', background: 'rgba(0,0,0,0.20)', color: 'rgba(34,197,94,0.95)' }}
+          style={{ border: '1px solid var(--border-default)', background: 'var(--nested-block-bg)', color: 'rgba(34,197,94,0.95)' }}
         >
           {uiMsg}
           {uiMsg === '已保存' && saveAnimKey ? (
@@ -948,8 +948,8 @@ export default function PromptStagesPage() {
                       : 'var(--bg-input)',
                     border: active
                       ? '1px solid rgba(214, 178, 106, 0.40)'
-                      : '1px solid rgba(255, 255, 255, 0.08)',
-                    boxShadow: active 
+                      : '1px solid var(--border-subtle)',
+                    boxShadow: active
                       ? '0 4px 16px -4px rgba(214, 178, 106, 0.2), 0 0 0 1px rgba(255, 255, 255, 0.03) inset'
                       : '0 2px 8px -2px rgba(0, 0, 0, 0.2)',
                   }}
@@ -1013,8 +1013,8 @@ export default function PromptStagesPage() {
                             height: 28,
                             borderRadius: 10,
                             color: active ? '#1a1206' : 'var(--text-secondary)',
-                            background: active ? 'var(--gold-gradient)' : 'rgba(255,255,255,0.06)',
-                            border: active ? '1px solid rgba(0,0,0,0.08)' : '1px solid rgba(255,255,255,0.10)',
+                            background: active ? 'var(--gold-gradient)' : 'var(--bg-input-hover)',
+                            border: active ? '1px solid rgba(0,0,0,0.08)' : '1px solid var(--border-default)',
                             boxShadow: active ? 'var(--shadow-gold)' : 'none',
                             cursor: 'grab',
                           }}
@@ -1030,7 +1030,7 @@ export default function PromptStagesPage() {
                       <button
                         type="button"
                         className="h-[28px] px-2.5 rounded-[10px] text-[12px] font-semibold transition-colors inline-flex items-center gap-1.5 shrink-0"
-                        style={{ background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.12)', color: 'var(--text-primary)' }}
+                        style={{ background: 'var(--bg-input-hover)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
                         onClick={(e) => {
                           e.stopPropagation();
                           goTest({ role: roleEnum, promptKey: s.promptKey });
@@ -1208,7 +1208,7 @@ export default function PromptStagesPage() {
                   className="h-full w-full rounded-[14px] px-3 py-3 pr-12 text-sm outline-none resize-none"
                   style={{
                     border: '1px solid var(--border-subtle)',
-                    background: 'linear-gradient(180deg, rgba(255,255,255,0.035) 0%, rgba(255,255,255,0.03) 100%)',
+                    background: 'var(--nested-block-bg)',
                     color: 'var(--text-primary)',
                     lineHeight: 1.6,
                     fontFamily:
@@ -1227,8 +1227,8 @@ export default function PromptStagesPage() {
                   }}
                   className="absolute bottom-2 right-2 h-9 w-9 inline-flex items-center justify-center rounded-[12px] transition-colors"
                   style={{
-                    background: optBusy ? 'rgba(239,68,68,0.12)' : 'rgba(255,255,255,0.06)',
-                    border: optBusy ? '1px solid rgba(239,68,68,0.28)' : '1px solid rgba(255,255,255,0.12)',
+                    background: optBusy ? 'rgba(239,68,68,0.12)' : 'var(--bg-input-hover)',
+                    border: optBusy ? '1px solid rgba(239,68,68,0.28)' : '1px solid var(--border-default)',
                     color: optBusy ? 'rgba(239,68,68,0.95)' : 'var(--text-secondary)',
                   }}
                   title={optBusy ? '停止优化' : '魔法棒：优化提示词（大模型）'}
@@ -1287,7 +1287,7 @@ export default function PromptStagesPage() {
                         : 'var(--bg-input)',
                       border: active
                         ? '1px solid rgba(214, 178, 106, 0.40)'
-                        : '1px solid rgba(255, 255, 255, 0.08)',
+                        : '1px solid var(--border-subtle)',
                       boxShadow: active
                         ? '0 4px 16px -4px rgba(214, 178, 106, 0.2), 0 0 0 1px rgba(255, 255, 255, 0.03) inset'
                         : '0 2px 8px -2px rgba(0, 0, 0, 0.2)',
@@ -1311,7 +1311,7 @@ export default function PromptStagesPage() {
                       <button
                         type="button"
                         className="h-[28px] px-2.5 rounded-[10px] text-[12px] font-semibold transition-colors inline-flex items-center gap-1.5 shrink-0"
-                        style={{ background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.12)', color: 'var(--text-primary)' }}
+                        style={{ background: 'var(--bg-input-hover)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
                         onClick={(e) => {
                           e.stopPropagation();
                           goTest({ role: r, promptKey: null });
@@ -1382,7 +1382,7 @@ export default function PromptStagesPage() {
                       disabled={sysLoading || sysSaving || !sysSettings}
                       className="flex-1 min-h-0 w-full rounded-[14px] px-3 py-2.5 text-[13px] outline-none resize-none transition-all duration-200 focus:ring-2 focus:ring-offset-0"
                       style={{
-                        border: '1px solid rgba(255, 255, 255, 0.08)',
+                        border: '1px solid var(--border-subtle)',
                         background: 'linear-gradient(135deg, var(--bg-input) 0%, rgba(20, 20, 22, 0.98) 100%)',
                         color: 'var(--text-primary)',
                         lineHeight: 1.6,
@@ -1393,7 +1393,7 @@ export default function PromptStagesPage() {
                         e.currentTarget.style.boxShadow = '0 2px 8px -2px rgba(0, 0, 0, 0.2) inset, 0 0 0 1px rgba(214, 178, 106, 0.2) inset, 0 0 0 2px rgba(214, 178, 106, 0.1)';
                       }}
                       onBlur={(e) => {
-                        e.currentTarget.style.borderColor = 'rgba(255, 255, 255, 0.08)';
+                        e.currentTarget.style.borderColor = 'var(--border-subtle)';
                         e.currentTarget.style.boxShadow = '0 2px 8px -2px rgba(0, 0, 0, 0.2) inset, 0 0 0 1px rgba(255, 255, 255, 0.02) inset';
                       }}
                     />
@@ -1410,7 +1410,7 @@ export default function PromptStagesPage() {
                   className="h-full w-full rounded-[14px] px-3 py-3 text-sm outline-none resize-none"
                   style={{
                     border: '1px solid var(--border-subtle)',
-                    background: 'linear-gradient(180deg, rgba(255,255,255,0.035) 0%, rgba(255,255,255,0.03) 100%)',
+                    background: 'var(--nested-block-bg)',
                     color: 'var(--text-primary)',
                     lineHeight: 1.6,
                     fontFamily:
@@ -1431,7 +1431,7 @@ export default function PromptStagesPage() {
       {showLiterary && (
         <div className="flex-1 min-h-0 flex flex-col gap-4">
           {literaryError && (
-            <div className="rounded-[14px] px-4 py-3 text-sm" style={{ border: '1px solid rgba(255,255,255,0.10)', background: 'rgba(0,0,0,0.20)', color: 'rgba(255,120,120,0.95)' }}>
+            <div className="rounded-[14px] px-4 py-3 text-sm" style={{ border: '1px solid var(--border-default)', background: 'var(--nested-block-bg)', color: 'rgba(255,120,120,0.95)' }}>
               {literaryError}
             </div>
           )}
@@ -1582,8 +1582,8 @@ export default function PromptStagesPage() {
               <div
                 className="rounded-[14px] px-4 py-3 text-sm"
                 style={{
-                  border: '1px solid rgba(255,255,255,0.10)',
-                  background: 'rgba(0,0,0,0.20)',
+                  border: '1px solid var(--border-default)',
+                  background: 'var(--nested-block-bg)',
                   color: 'rgba(255,120,120,0.95)',
                 }}
               >
@@ -1638,7 +1638,7 @@ export default function PromptStagesPage() {
                   className="mt-3 flex-1 min-h-[360px] w-full rounded-[14px] px-3 py-3 text-sm outline-none resize-none"
                   style={{
                     border: '1px solid var(--border-subtle)',
-                    background: 'rgba(255,255,255,0.03)',
+                    background: 'var(--nested-block-bg)',
                     color: 'var(--text-primary)',
                     lineHeight: 1.6,
                     fontFamily:
@@ -1660,7 +1660,7 @@ export default function PromptStagesPage() {
                   className="mt-3 flex-1 min-h-[360px] w-full rounded-[14px] px-3 py-3 text-sm outline-none resize-none"
                   style={{
                     border: '1px solid var(--border-subtle)',
-                    background: 'linear-gradient(180deg, rgba(255,255,255,0.035) 0%, rgba(255,255,255,0.03) 100%)',
+                    background: 'var(--nested-block-bg)',
                     color: 'var(--text-primary)',
                     lineHeight: 1.6,
                     fontFamily:

--- a/prd-admin/src/pages/SettingsPage.tsx
+++ b/prd-admin/src/pages/SettingsPage.tsx
@@ -176,12 +176,12 @@ function GeneralSettings() {
                             ? 'rgba(214,178,106,0.15)'
                             : isDropTarget
                               ? 'rgba(214,178,106,0.08)'
-                              : 'rgba(255,255,255,0.03)',
+                              : 'var(--nested-block-bg)',
                           border: isDragging
                             ? '2px solid rgba(214,178,106,0.5)'
                             : isDropTarget
                               ? '2px dashed rgba(214,178,106,0.5)'
-                              : '1px solid rgba(255,255,255,0.06)',
+                              : '1px solid var(--nested-block-border)',
                           opacity: isDragging ? 0.6 : 1,
                         }}
                       >
@@ -194,8 +194,8 @@ function GeneralSettings() {
                         <div
                           className="shrink-0 w-8 h-8 rounded-[8px] flex items-center justify-center"
                           style={{
-                            background: 'rgba(255,255,255,0.05)',
-                            border: '1px solid rgba(255,255,255,0.08)',
+                            background: 'var(--bg-card-hover)',
+                            border: '1px solid var(--border-subtle)',
                             color: 'var(--text-secondary)',
                           }}
                         >
@@ -209,7 +209,7 @@ function GeneralSettings() {
                         <div
                           className="shrink-0 text-[10px] font-mono px-2 py-0.5 rounded"
                           style={{
-                            background: 'rgba(255,255,255,0.04)',
+                            background: 'var(--bg-input)',
                             color: 'var(--text-muted)',
                           }}
                         >

--- a/prd-admin/src/pages/SkillsPage.tsx
+++ b/prd-admin/src/pages/SkillsPage.tsx
@@ -483,8 +483,8 @@ export default function SkillsPage() {
           width: 100%;
           padding: 6px 10px;
           border-radius: 8px;
-          border: 1px solid rgba(255,255,255,0.1);
-          background: rgba(255,255,255,0.05);
+          border: 1px solid var(--border-default);
+          background: var(--bg-card-hover);
           color: rgba(255,255,255,0.9);
           font-size: 13px;
           outline: none;
@@ -501,7 +501,7 @@ export default function SkillsPage() {
           cursor: pointer;
         }
         select.field-input option {
-          background: #1a1a2e;
+          background: var(--bg-elevated);
           color: #fff;
         }
         textarea.field-input {

--- a/prd-admin/src/pages/StatsPage.tsx
+++ b/prd-admin/src/pages/StatsPage.tsx
@@ -170,7 +170,7 @@ export default function StatsPage() {
           </div>
           <div
             className="mt-3 rounded-[14px] overflow-hidden"
-            style={{ background: 'rgba(255,255,255,0.02)', border: '1px solid var(--border-subtle)' }}
+            style={{ background: 'var(--list-item-bg)', border: '1px solid var(--border-subtle)' }}
           >
             {loading ? (
               <div className="h-[280px] flex items-center justify-center" style={{ color: 'var(--text-muted)' }}>
@@ -194,7 +194,7 @@ export default function StatsPage() {
           </div>
           <div
             className="mt-3 rounded-[14px] overflow-hidden"
-            style={{ background: 'rgba(255,255,255,0.02)', border: '1px solid var(--border-subtle)' }}
+            style={{ background: 'var(--list-item-bg)', border: '1px solid var(--border-subtle)' }}
           >
             {loading ? (
               <div className="h-[280px] flex items-center justify-center" style={{ color: 'var(--text-muted)' }}>
@@ -219,7 +219,7 @@ export default function StatsPage() {
         </div>
         <div className="mt-3 overflow-hidden rounded-[14px]" style={{ border: '1px solid var(--border-subtle)' }}>
           <table className="w-full text-sm">
-            <thead style={{ background: 'rgba(255,255,255,0.03)' }}>
+            <thead style={{ background: 'var(--nested-block-bg)' }}>
               <tr>
                 <th className="text-left px-4 py-3" style={{ color: 'var(--text-secondary)' }}>群组</th>
                 <th className="text-right px-4 py-3" style={{ color: 'var(--text-secondary)' }}>成员</th>

--- a/prd-admin/src/pages/UsersPage.tsx
+++ b/prd-admin/src/pages/UsersPage.tsx
@@ -1723,7 +1723,7 @@ export default function UsersPage() {
                             min={1}
                             max={10000}
                             className="mt-1 h-10 w-full rounded-[10px] px-3 text-sm outline-none"
-                            style={{ background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.12)', color: 'var(--text-primary)' }}
+                            style={{ background: 'var(--bg-input-hover)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
                           />
                         </div>
                       </div>

--- a/prd-admin/src/pages/UsersPage.tsx
+++ b/prd-admin/src/pages/UsersPage.tsx
@@ -667,7 +667,7 @@ export default function UsersPage() {
                     setPage(1);
                   }}
                   className="h-[36px] w-full rounded-[10px] pl-9 pr-4 text-[13px] outline-none transition-all duration-200 focus:ring-2 focus:ring-[var(--accent-gold)]/20"
-                  style={{ background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.08)', color: 'var(--text-primary)' }}
+                  style={{ background: 'var(--nested-block-bg)', border: '1px solid var(--border-subtle)', color: 'var(--text-primary)' }}
                   placeholder="搜索用户名或昵称"
                 />
               </div>
@@ -718,8 +718,8 @@ export default function UsersPage() {
         <div
           className="mt-4 flex-1 min-h-0 overflow-auto rounded-[14px] p-4"
           style={{
-            background: 'rgba(255,255,255,0.015)',
-            border: '1px solid rgba(255,255,255,0.05)',
+            background: 'var(--list-item-bg)',
+            border: '1px solid var(--bg-card-hover)',
           }}
         >
           {loading ? (
@@ -747,16 +747,16 @@ export default function UsersPage() {
                     key={u.userId}
                     className="group relative rounded-[10px] p-2.5 transition-all duration-150"
                     style={{
-                      background: isBot ? 'rgba(34,197,94,0.03)' : 'rgba(255,255,255,0.02)',
-                      border: isBot ? '1px solid rgba(34,197,94,0.15)' : '1px solid rgba(255,255,255,0.06)',
+                      background: isBot ? 'rgba(34,197,94,0.03)' : 'var(--list-item-bg)',
+                      border: isBot ? '1px solid rgba(34,197,94,0.15)' : '1px solid var(--nested-block-border)',
                     }}
                     onMouseEnter={(e) => {
-                      e.currentTarget.style.background = isBot ? 'rgba(34,197,94,0.06)' : 'rgba(255,255,255,0.04)';
-                      e.currentTarget.style.borderColor = isBot ? 'rgba(34,197,94,0.25)' : 'rgba(255,255,255,0.1)';
+                      e.currentTarget.style.background = isBot ? 'rgba(34,197,94,0.06)' : 'var(--bg-input)';
+                      e.currentTarget.style.borderColor = isBot ? 'rgba(34,197,94,0.25)' : 'var(--border-default)';
                     }}
                     onMouseLeave={(e) => {
-                      e.currentTarget.style.background = isBot ? 'rgba(34,197,94,0.03)' : 'rgba(255,255,255,0.02)';
-                      e.currentTarget.style.borderColor = isBot ? 'rgba(34,197,94,0.15)' : 'rgba(255,255,255,0.06)';
+                      e.currentTarget.style.background = isBot ? 'rgba(34,197,94,0.03)' : 'var(--list-item-bg)';
+                      e.currentTarget.style.borderColor = isBot ? 'rgba(34,197,94,0.15)' : 'var(--nested-block-border)';
                     }}
                   >
                     {/* 操作按钮：悬浮显示 */}
@@ -766,7 +766,7 @@ export default function UsersPage() {
                           <button
                             type="button"
                             className="inline-flex items-center justify-center h-6 w-6 rounded-[6px] transition-colors hover:bg-white/10"
-                            style={{ background: 'rgba(0,0,0,0.3)', color: 'var(--text-secondary)' }}
+                            style={{ background: 'var(--nested-block-bg)', color: 'var(--text-secondary)' }}
                             aria-label="更多操作"
                           >
                             <MoreVertical size={14} />
@@ -796,7 +796,7 @@ export default function UsersPage() {
                               {statusUpdatingUserId === u.userId ? '处理中...' : u.status === 'Active' ? '停用账户' : '启用账户'}
                             </DropdownMenu.Item>
 
-                            <DropdownMenu.Separator className="h-px my-1" style={{ background: 'rgba(255,255,255,0.06)' }} />
+                            <DropdownMenu.Separator className="h-px my-1" style={{ background: 'var(--nested-block-border)' }} />
 
                             {/* 角色切换子菜单 */}
                             <DropdownMenu.Sub>
@@ -837,7 +837,7 @@ export default function UsersPage() {
                               </DropdownMenu.Portal>
                             </DropdownMenu.Sub>
 
-                            <DropdownMenu.Separator className="h-px my-1" style={{ background: 'rgba(255,255,255,0.06)' }} />
+                            <DropdownMenu.Separator className="h-px my-1" style={{ background: 'var(--nested-block-border)' }} />
 
                             {isLockedUser(u) && (
                               <DropdownMenu.Item
@@ -920,7 +920,7 @@ export default function UsersPage() {
                               限流配置
                             </DropdownMenu.Item>
 
-                            <DropdownMenu.Separator className="h-px my-1" style={{ background: 'rgba(255,255,255,0.06)' }} />
+                            <DropdownMenu.Separator className="h-px my-1" style={{ background: 'var(--nested-block-border)' }} />
 
                             <DropdownMenu.Item
                               className="flex items-center gap-2 rounded-[6px] px-2.5 py-1.5 text-[12px] outline-none cursor-pointer hover:bg-white/5"
@@ -935,7 +935,7 @@ export default function UsersPage() {
                               {switchingUserId === u.userId ? '切换中...' : '切换登录'}
                             </DropdownMenu.Item>
 
-                            <DropdownMenu.Separator className="h-px my-1" style={{ background: 'rgba(255,255,255,0.06)' }} />
+                            <DropdownMenu.Separator className="h-px my-1" style={{ background: 'var(--nested-block-border)' }} />
 
                             <DropdownMenu.Item
                               className="flex items-center gap-2 rounded-[6px] px-2.5 py-1.5 text-[12px] outline-none cursor-pointer hover:bg-white/5"
@@ -1139,7 +1139,7 @@ export default function UsersPage() {
               <div className="shrink-0">
                 <div
                   className="h-16 w-16 rounded-[12px] overflow-hidden flex items-center justify-center relative group cursor-pointer"
-                  style={{ background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.12)' }}
+                  style={{ background: 'var(--bg-input-hover)', border: '1px solid var(--border-default)' }}
                   title="创建成功后可设置头像"
                   onClick={() => toast.info('提示', '请先完成用户创建，创建成功后将自动弹出头像设置')}
                 >
@@ -1174,7 +1174,7 @@ export default function UsersPage() {
                       }
                     }}
                     className="mt-1.5 h-9 w-full rounded-[10px] px-3 text-sm outline-none"
-                    style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.12)', color: 'var(--text-primary)' }}
+                    style={{ background: 'var(--bg-input)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
                     placeholder="4-32位"
                     autoComplete="off"
                   />
@@ -1189,7 +1189,7 @@ export default function UsersPage() {
                       setCreateError(null);
                     }}
                     className="mt-1.5 h-9 w-full rounded-[10px] px-3 text-sm outline-none"
-                    style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.12)', color: 'var(--text-primary)' }}
+                    style={{ background: 'var(--bg-input)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
                     placeholder="自动同步"
                     autoComplete="off"
                   />
@@ -1208,7 +1208,7 @@ export default function UsersPage() {
                 }}
                 type="password"
                 className="mt-1.5 h-9 w-full rounded-[10px] px-3 text-sm outline-none"
-                style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.12)', color: 'var(--text-primary)' }}
+                style={{ background: 'var(--bg-input)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
                 placeholder="设置登录密码"
                 autoComplete="new-password"
               />
@@ -1221,7 +1221,7 @@ export default function UsersPage() {
                 <div className="text-sm font-semibold mb-2" style={{ color: 'var(--text-secondary)' }}>角色</div>
                 <div
                   className="rounded-[10px] p-2 space-y-1 flex-1"
-                  style={{ background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.08)' }}
+                  style={{ background: 'var(--nested-block-bg)', border: '1px solid var(--border-subtle)' }}
                 >
                   {([
                     { key: 'PM', label: 'PM', desc: '产品经理' },
@@ -1253,7 +1253,7 @@ export default function UsersPage() {
                 <div className="text-sm font-semibold mb-2" style={{ color: 'var(--text-secondary)' }}>权限</div>
                 <div
                   className="rounded-[10px] p-2 space-y-1 flex-1"
-                  style={{ background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.08)' }}
+                  style={{ background: 'var(--nested-block-bg)', border: '1px solid var(--border-subtle)' }}
                 >
                   {(createSystemRoles.length > 0 ? createSystemRoles : [
                     { key: 'admin', name: '管理员' },
@@ -1359,7 +1359,7 @@ export default function UsersPage() {
                   setNameError(null);
                 }}
                 className="mt-2 h-10 w-full rounded-[14px] px-4 text-sm outline-none"
-                style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.12)', color: 'var(--text-primary)' }}
+                style={{ background: 'var(--bg-input)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
                 placeholder="请输入姓名（1-50 字符）"
                 autoComplete="off"
               />
@@ -1411,7 +1411,7 @@ export default function UsersPage() {
                 }}
                 type="password"
                 className="mt-2 h-10 w-full rounded-[14px] px-4 text-sm outline-none"
-                style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.12)', color: 'var(--text-primary)' }}
+                style={{ background: 'var(--bg-input)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
                 placeholder="设置登录密码"
                 autoComplete="new-password"
               />
@@ -1549,7 +1549,7 @@ export default function UsersPage() {
               <div className="min-w-0">
                 <div className="text-sm font-semibold" style={{ color: 'var(--text-secondary)' }}>额外允许（勾选 permission）</div>
                 <div className="mt-2 rounded-[14px] p-2 overflow-auto min-h-[160px] max-h-[220px]"
-                     style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.12)' }}>
+                     style={{ background: 'var(--bg-input)', border: '1px solid var(--border-default)' }}>
                   {authzCatalog.map((p) => {
                     const k = String(p.key || '').trim();
                     const checked = authzAllowSet.has(k);
@@ -1580,7 +1580,7 @@ export default function UsersPage() {
               <div className="min-w-0">
                 <div className="text-sm font-semibold" style={{ color: 'var(--text-secondary)' }}>禁止（勾选 permission）</div>
                 <div className="mt-2 rounded-[14px] p-2 overflow-auto min-h-[160px] max-h-[220px]"
-                     style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.12)' }}>
+                     style={{ background: 'var(--bg-input)', border: '1px solid var(--border-default)' }}>
                   {authzCatalog.map((p) => {
                     const k = String(p.key || '').trim();
                     const checked = authzDenySet.has(k);
@@ -1649,7 +1649,7 @@ export default function UsersPage() {
                 {/* 豁免开关 */}
                 <div
                   className="rounded-[14px] p-4"
-                  style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.12)' }}
+                  style={{ background: 'var(--bg-input)', border: '1px solid var(--border-default)' }}
                 >
                   <label className="flex items-center gap-3 cursor-pointer">
                     <input
@@ -1674,7 +1674,7 @@ export default function UsersPage() {
                 {!rateLimitIsExempt && (
                   <div
                     className="rounded-[14px] p-4"
-                    style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.12)' }}
+                    style={{ background: 'var(--bg-input)', border: '1px solid var(--border-default)' }}
                   >
                     <label className="flex items-center gap-3 cursor-pointer">
                       <input
@@ -1708,7 +1708,7 @@ export default function UsersPage() {
                             min={1}
                             max={100000}
                             className="mt-1 h-10 w-full rounded-[10px] px-3 text-sm outline-none"
-                            style={{ background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.12)', color: 'var(--text-primary)' }}
+                            style={{ background: 'var(--bg-input-hover)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
                           />
                         </div>
                         <div>

--- a/prd-admin/src/pages/authz/MenuPermissionDialog.tsx
+++ b/prd-admin/src/pages/authz/MenuPermissionDialog.tsx
@@ -58,7 +58,7 @@ export function MenuPermissionDialog({ open, onOpenChange, menuAppKey }: MenuPer
         {/* Header */}
         <div
           className="flex items-center justify-between px-5 py-4"
-          style={{ borderBottom: '1px solid rgba(255, 255, 255, 0.06)' }}
+          style={{ borderBottom: '1px solid var(--nested-block-border)' }}
         >
           <div>
             <div className="text-base font-semibold" style={{ color: 'var(--text-primary)' }}>
@@ -93,7 +93,7 @@ export function MenuPermissionDialog({ open, onOpenChange, menuAppKey }: MenuPer
                   <div
                     key={perm.key}
                     className="p-3 rounded-xl"
-                    style={{ background: 'rgba(255, 255, 255, 0.03)' }}
+                    style={{ background: 'var(--nested-block-bg)' }}
                   >
                     <div className="flex items-start justify-between gap-3">
                       <div className="flex-1 min-w-0">
@@ -135,7 +135,7 @@ export function MenuPermissionDialog({ open, onOpenChange, menuAppKey }: MenuPer
         <div
           className="px-5 py-3 text-xs"
           style={{
-            borderTop: '1px solid rgba(255, 255, 255, 0.06)',
+            borderTop: '1px solid var(--nested-block-border)',
             color: 'var(--text-muted)',
           }}
         >

--- a/prd-admin/src/pages/authz/PermissionMatrix.tsx
+++ b/prd-admin/src/pages/authz/PermissionMatrix.tsx
@@ -162,7 +162,7 @@ export function PermissionMatrix({
                 className="text-[11px] font-medium px-2 py-1 rounded-md"
                 style={{
                   color: 'var(--text-muted)',
-                  background: 'rgba(255, 255, 255, 0.03)',
+                  background: 'var(--nested-block-bg)',
                 }}
               >
                 菜单 / 角色
@@ -179,7 +179,7 @@ export function PermissionMatrix({
                     highlightRoleKey === role.key
                       ? 'rgba(214, 178, 106, 0.12)'
                       : role.isBuiltIn
-                        ? 'rgba(255, 255, 255, 0.02)'
+                        ? 'var(--list-item-bg)'
                         : 'transparent',
                   color: highlightRoleKey === role.key ? 'rgba(214, 178, 106, 0.95)' : 'var(--text-primary)',
                   minWidth: 88,
@@ -190,7 +190,7 @@ export function PermissionMatrix({
                   <div
                     className="flex items-center gap-1.5 px-2.5 py-1 rounded-lg"
                     style={{
-                      background: role.isBuiltIn ? 'rgba(214, 178, 106, 0.08)' : 'rgba(255, 255, 255, 0.04)',
+                      background: role.isBuiltIn ? 'rgba(214, 178, 106, 0.08)' : 'var(--bg-input)',
                     }}
                   >
                     {role.isBuiltIn && <ShieldCheck size={11} style={{ color: 'rgba(214, 178, 106, 0.7)' }} />}
@@ -200,7 +200,7 @@ export function PermissionMatrix({
                     className="text-[10px] px-1.5 py-0.5 rounded-md"
                     style={{
                       color: 'var(--text-muted)',
-                      background: 'rgba(255, 255, 255, 0.03)',
+                      background: 'var(--nested-block-bg)',
                     }}
                   >
                     {role.permissions?.length || 0} 项
@@ -223,7 +223,7 @@ export function PermissionMatrix({
                 onMouseEnter={() => setHoveredRow(menu.appKey)}
                 onMouseLeave={() => setHoveredRow(null)}
                 style={{
-                  background: hoveredRow === menu.appKey ? 'rgba(255, 255, 255, 0.04)' : 'transparent',
+                  background: hoveredRow === menu.appKey ? 'var(--bg-input)' : 'transparent',
                 }}
               >
                 {/* 菜单行头 - 可点击查看权限详情 */}
@@ -247,10 +247,10 @@ export function PermissionMatrix({
                     <div
                       className="w-8 h-8 rounded-[10px] flex items-center justify-center transition-all duration-250 ease-out shrink-0"
                       style={{
-                        background: hoveredRow === menu.appKey ? 'rgba(214, 178, 106, 0.18)' : 'rgba(255, 255, 255, 0.05)',
+                        background: hoveredRow === menu.appKey ? 'rgba(214, 178, 106, 0.18)' : 'var(--bg-card-hover)',
                         transform: hoveredRow === menu.appKey ? 'scale(1.08)' : 'scale(1)',
                         boxShadow: hoveredRow === menu.appKey ? '0 4px 16px rgba(214, 178, 106, 0.25)' : '0 2px 8px rgba(0, 0, 0, 0.1)',
-                        border: hoveredRow === menu.appKey ? '1px solid rgba(214, 178, 106, 0.25)' : '1px solid rgba(255, 255, 255, 0.06)',
+                        border: hoveredRow === menu.appKey ? '1px solid rgba(214, 178, 106, 0.25)' : '1px solid var(--nested-block-border)',
                       }}
                     >
                       <Icon
@@ -289,7 +289,7 @@ export function PermissionMatrix({
                         background: isHighlighted
                           ? 'rgba(214, 178, 106, 0.08)'
                           : isRowHovered
-                            ? 'rgba(255, 255, 255, 0.03)'
+                            ? 'var(--nested-block-bg)'
                             : 'transparent',
                         borderBottom: '1px solid rgba(255, 255, 255, 0.04)',
                       }}
@@ -349,7 +349,7 @@ export function PermissionMatrix({
         <span className="flex items-center gap-2">
           <span
             className="w-5 h-5 rounded-md flex items-center justify-center"
-            style={{ background: 'rgba(255, 255, 255, 0.03)' }}
+            style={{ background: 'var(--nested-block-bg)' }}
           >
             <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
               <circle cx="8" cy="8" r="5" stroke="rgba(255, 255, 255, 0.25)" strokeWidth="1.5" />

--- a/prd-admin/src/pages/authz/PermissionPopover.tsx
+++ b/prd-admin/src/pages/authz/PermissionPopover.tsx
@@ -99,7 +99,7 @@ export function PermissionPopover({
         {/* Header */}
         <div
           className="flex items-center justify-between px-4 py-3"
-          style={{ borderBottom: '1px solid rgba(255, 255, 255, 0.06)' }}
+          style={{ borderBottom: '1px solid var(--nested-block-border)' }}
         >
           <div>
             <div className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
@@ -167,7 +167,7 @@ export function PermissionPopover({
         {/* Footer */}
         <div
           className="flex items-center justify-between px-4 py-3"
-          style={{ borderTop: '1px solid rgba(255, 255, 255, 0.06)' }}
+          style={{ borderTop: '1px solid var(--nested-block-border)' }}
         >
           <div className="flex items-center gap-2">
             {!isBuiltIn && permDefs.length > 0 && (

--- a/prd-admin/src/pages/channels/ChannelTasksPage.tsx
+++ b/prd-admin/src/pages/channels/ChannelTasksPage.tsx
@@ -202,7 +202,7 @@ export default function ChannelTasksPage() {
 
       {/* 任务列表 */}
       <GlassCard glow className="flex-1 flex flex-col">
-        <div className="p-4 border-b flex items-center gap-4" style={{ borderColor: 'rgba(255,255,255,0.06)' }}>
+        <div className="p-4 border-b flex items-center gap-4" style={{ borderColor: 'var(--nested-block-border)' }}>
           <div className="flex items-center gap-2 flex-1">
             <Search size={16} className="text-muted-foreground" />
             <input
@@ -212,8 +212,8 @@ export default function ChannelTasksPage() {
               onChange={(e) => setSearch(e.target.value)}
               className="flex-1 px-3 py-2 rounded-md outline-none transition-colors"
               style={{
-                background: 'rgba(255,255,255,0.03)',
-                border: '1px solid rgba(255,255,255,0.08)',
+                background: 'var(--nested-block-bg)',
+                border: '1px solid var(--border-subtle)',
                 color: 'var(--text-primary)',
               }}
             />
@@ -245,7 +245,7 @@ export default function ChannelTasksPage() {
 
         <div className="flex-1 overflow-auto">
           <table className="w-full">
-            <thead style={{ background: 'rgba(255,255,255,0.02)' }}>
+            <thead style={{ background: 'var(--list-item-bg)' }}>
               <tr>
                 <th className="px-4 py-3 text-left text-sm font-medium">任务 ID</th>
                 <th className="px-4 py-3 text-left text-sm font-medium">通道</th>
@@ -262,13 +262,13 @@ export default function ChannelTasksPage() {
                 <tr
                   key={task.id}
                   className="transition-colors cursor-pointer"
-                  style={{ borderTop: '1px solid rgba(255,255,255,0.04)' }}
-                  onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,0.02)')}
+                  style={{ borderTop: '1px solid var(--bg-input)' }}
+                  onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--list-item-bg)')}
                   onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
                   onClick={() => handleViewDetail(task)}
                 >
                   <td className="px-4 py-3">
-                    <code className="text-xs px-1.5 py-0.5 rounded" style={{ background: 'rgba(0,0,0,0.2)' }}>
+                    <code className="text-xs px-1.5 py-0.5 rounded" style={{ background: 'var(--nested-block-bg)' }}>
                       {task.id}
                     </code>
                   </td>
@@ -349,7 +349,7 @@ export default function ChannelTasksPage() {
         {total > pageSize && (
           <div
             className="p-4 border-t flex justify-between items-center"
-            style={{ borderColor: 'rgba(255,255,255,0.06)' }}
+            style={{ borderColor: 'var(--nested-block-border)' }}
           >
             <div className="text-sm text-muted-foreground">
               共 {total} 条，第 {page} / {Math.ceil(total / pageSize)} 页

--- a/prd-admin/src/pages/channels/ChannelsPage.tsx
+++ b/prd-admin/src/pages/channels/ChannelsPage.tsx
@@ -186,7 +186,7 @@ export default function ChannelsPage() {
                 style={{
                   background: stat.isEnabled
                     ? 'linear-gradient(135deg, rgba(34,197,94,0.2), rgba(34,197,94,0.1))'
-                    : 'rgba(255,255,255,0.05)',
+                    : 'var(--bg-card-hover)',
                   color: stat.isEnabled ? 'rgb(34,197,94)' : 'var(--text-muted)',
                 }}
               >
@@ -204,7 +204,7 @@ export default function ChannelsPage() {
                 </div>
               </div>
             </div>
-            <div className="mt-3 pt-3 border-t flex justify-between text-xs" style={{ borderColor: 'rgba(255,255,255,0.06)' }}>
+            <div className="mt-3 pt-3 border-t flex justify-between text-xs" style={{ borderColor: 'var(--nested-block-border)' }}>
               <span className="text-muted-foreground">
                 成功: <span className="text-green-400">{stat.todaySuccessCount}</span>
               </span>
@@ -224,7 +224,7 @@ export default function ChannelsPage() {
 
       {/* 白名单列表 */}
       <GlassCard glow className="flex-1 flex flex-col">
-        <div className="p-4 border-b flex items-center gap-4" style={{ borderColor: 'rgba(255,255,255,0.06)' }}>
+        <div className="p-4 border-b flex items-center gap-4" style={{ borderColor: 'var(--nested-block-border)' }}>
           <div className="flex items-center gap-2 flex-1">
             <Search size={16} className="text-muted-foreground" />
             <input
@@ -234,8 +234,8 @@ export default function ChannelsPage() {
               onChange={(e) => setSearch(e.target.value)}
               className="flex-1 px-3 py-2 rounded-md outline-none transition-colors"
               style={{
-                background: 'rgba(255,255,255,0.03)',
-                border: '1px solid rgba(255,255,255,0.08)',
+                background: 'var(--nested-block-bg)',
+                border: '1px solid var(--border-subtle)',
                 color: 'var(--text-primary)',
               }}
             />
@@ -261,7 +261,7 @@ export default function ChannelsPage() {
 
         <div className="flex-1 overflow-auto">
           <table className="w-full">
-            <thead style={{ background: 'rgba(255,255,255,0.02)' }}>
+            <thead style={{ background: 'var(--list-item-bg)' }}>
               <tr>
                 <th className="px-4 py-3 text-left text-sm font-medium">规则模式</th>
                 <th className="px-4 py-3 text-left text-sm font-medium">通道</th>
@@ -277,8 +277,8 @@ export default function ChannelsPage() {
                 <tr
                   key={wl.id}
                   className="transition-colors"
-                  style={{ borderTop: '1px solid rgba(255,255,255,0.04)' }}
-                  onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,0.02)')}
+                  style={{ borderTop: '1px solid var(--bg-input)' }}
+                  onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--list-item-bg)')}
                   onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
                 >
                   <td className="px-4 py-3">
@@ -363,7 +363,7 @@ export default function ChannelsPage() {
                             </DropdownMenu.Item>
                             <DropdownMenu.Separator
                               className="my-1 h-px"
-                              style={{ background: 'rgba(255,255,255,0.10)' }}
+                              style={{ background: 'var(--border-default)' }}
                             />
                             <DropdownMenu.Item
                               className="flex items-center gap-2 px-3 py-2 text-sm rounded-[10px] cursor-pointer outline-none transition-colors"
@@ -395,7 +395,7 @@ export default function ChannelsPage() {
         {total > pageSize && (
           <div
             className="p-4 border-t flex justify-between items-center"
-            style={{ borderColor: 'rgba(255,255,255,0.06)' }}
+            style={{ borderColor: 'var(--nested-block-border)' }}
           >
             <div className="text-sm text-muted-foreground">
               共 {total} 条，第 {page} / {Math.ceil(total / pageSize)} 页

--- a/prd-admin/src/pages/channels/IdentityMappingsPage.tsx
+++ b/prd-admin/src/pages/channels/IdentityMappingsPage.tsx
@@ -148,7 +148,7 @@ export default function IdentityMappingsPage() {
       />
 
       <GlassCard glow className="flex-1 flex flex-col">
-        <div className="p-4 border-b flex items-center gap-4" style={{ borderColor: 'rgba(255,255,255,0.06)' }}>
+        <div className="p-4 border-b flex items-center gap-4" style={{ borderColor: 'var(--nested-block-border)' }}>
           <div className="flex items-center gap-2 flex-1">
             <Search size={16} className="text-muted-foreground" />
             <input
@@ -158,8 +158,8 @@ export default function IdentityMappingsPage() {
               onChange={(e) => setSearch(e.target.value)}
               className="flex-1 px-3 py-2 rounded-md outline-none transition-colors"
               style={{
-                background: 'rgba(255,255,255,0.03)',
-                border: '1px solid rgba(255,255,255,0.08)',
+                background: 'var(--nested-block-bg)',
+                border: '1px solid var(--border-subtle)',
                 color: 'var(--text-primary)',
               }}
             />
@@ -185,7 +185,7 @@ export default function IdentityMappingsPage() {
 
         <div className="flex-1 overflow-auto">
           <table className="w-full">
-            <thead style={{ background: 'rgba(255,255,255,0.02)' }}>
+            <thead style={{ background: 'var(--list-item-bg)' }}>
               <tr>
                 <th className="px-4 py-3 text-left text-sm font-medium">通道标识</th>
                 <th className="px-4 py-3 text-left text-sm font-medium">通道类型</th>
@@ -200,8 +200,8 @@ export default function IdentityMappingsPage() {
                 <tr
                   key={mapping.id}
                   className="transition-colors"
-                  style={{ borderTop: '1px solid rgba(255,255,255,0.04)' }}
-                  onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,0.02)')}
+                  style={{ borderTop: '1px solid var(--bg-input)' }}
+                  onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--list-item-bg)')}
                   onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
                 >
                   <td className="px-4 py-3">
@@ -264,7 +264,7 @@ export default function IdentityMappingsPage() {
                             </DropdownMenu.Item>
                             <DropdownMenu.Separator
                               className="my-1 h-px"
-                              style={{ background: 'rgba(255,255,255,0.10)' }}
+                              style={{ background: 'var(--border-default)' }}
                             />
                             <DropdownMenu.Item
                               className="flex items-center gap-2 px-3 py-2 text-sm rounded-[10px] cursor-pointer outline-none transition-colors"
@@ -296,7 +296,7 @@ export default function IdentityMappingsPage() {
         {total > pageSize && (
           <div
             className="p-4 border-t flex justify-between items-center"
-            style={{ borderColor: 'rgba(255,255,255,0.06)' }}
+            style={{ borderColor: 'var(--nested-block-border)' }}
           >
             <div className="text-sm text-muted-foreground">
               共 {total} 条，第 {page} / {Math.ceil(total / pageSize)} 页

--- a/prd-admin/src/pages/channels/components/TaskDetailDrawer.tsx
+++ b/prd-admin/src/pages/channels/components/TaskDetailDrawer.tsx
@@ -78,7 +78,7 @@ export function TaskDetailDrawer({
         style={{
           ...glassDrawer,
           background: 'linear-gradient(180deg, rgba(20,20,25,0.98) 0%, rgba(15,15,20,0.98) 100%)',
-          borderLeft: '1px solid rgba(255,255,255,0.1)',
+          borderLeft: '1px solid var(--border-default)',
         }}
         onClick={(e) => e.stopPropagation()}
       >
@@ -265,7 +265,7 @@ export function TaskDetailDrawer({
                     src={task.result.imageUrl}
                     alt="结果图片"
                     className="mt-2 rounded-lg max-w-full"
-                    style={{ border: '1px solid rgba(255,255,255,0.1)' }}
+                    style={{ border: '1px solid var(--border-default)' }}
                   />
                 )}
               </Section>

--- a/prd-admin/src/pages/channels/components/TaskDetailDrawer.tsx
+++ b/prd-admin/src/pages/channels/components/TaskDetailDrawer.tsx
@@ -86,8 +86,8 @@ export function TaskDetailDrawer({
         <div
           className="sticky top-0 z-10 p-4 border-b"
           style={{
-            background: 'rgba(255,255,255,0.02)',
-            borderColor: 'rgba(255,255,255,0.08)',
+            background: 'var(--list-item-bg)',
+            borderColor: 'var(--border-subtle)',
           }}
         >
           <div className="flex items-center justify-between">
@@ -176,8 +176,8 @@ export function TaskDetailDrawer({
             <div
               className="p-3 rounded-lg text-sm whitespace-pre-wrap"
               style={{
-                background: 'rgba(255,255,255,0.03)',
-                border: '1px solid rgba(255,255,255,0.08)',
+                background: 'var(--nested-block-bg)',
+                border: '1px solid var(--border-subtle)',
                 maxHeight: '200px',
                 overflow: 'auto',
               }}
@@ -194,8 +194,8 @@ export function TaskDetailDrawer({
                 <div
                   className="p-3 rounded-lg text-xs font-mono"
                   style={{
-                    background: 'rgba(0,0,0,0.3)',
-                    border: '1px solid rgba(255,255,255,0.08)',
+                    background: 'var(--nested-block-bg)',
+                    border: '1px solid var(--border-subtle)',
                   }}
                 >
                   <pre className="overflow-auto">{JSON.stringify(task.parsedParameters, null, 2)}</pre>
@@ -215,8 +215,8 @@ export function TaskDetailDrawer({
                       key={att.id}
                       className="flex items-center justify-between p-3 rounded-lg"
                       style={{
-                        background: 'rgba(255,255,255,0.03)',
-                        border: '1px solid rgba(255,255,255,0.08)',
+                        background: 'var(--nested-block-bg)',
+                        border: '1px solid var(--border-subtle)',
                       }}
                     >
                       <div>
@@ -344,8 +344,8 @@ export function TaskDetailDrawer({
                       key={idx}
                       className="p-3 rounded-lg"
                       style={{
-                        background: 'rgba(255,255,255,0.03)',
-                        border: '1px solid rgba(255,255,255,0.08)',
+                        background: 'var(--nested-block-bg)',
+                        border: '1px solid var(--border-subtle)',
                       }}
                     >
                       <div className="flex items-center justify-between">
@@ -353,7 +353,7 @@ export function TaskDetailDrawer({
                         <span className="text-xs text-muted-foreground">{fmtDate(resp.sentAt)}</span>
                       </div>
                       {resp.messageId && (
-                        <div className="text-xs text-muted-foreground mt-2 font-mono px-2 py-1 rounded" style={{ background: 'rgba(0,0,0,0.2)' }}>
+                        <div className="text-xs text-muted-foreground mt-2 font-mono px-2 py-1 rounded" style={{ background: 'var(--nested-block-bg)' }}>
                           {resp.messageId}
                         </div>
                       )}
@@ -375,8 +375,8 @@ export function TaskDetailDrawer({
                 <div
                   className="p-3 rounded-lg text-xs font-mono"
                   style={{
-                    background: 'rgba(0,0,0,0.3)',
-                    border: '1px solid rgba(255,255,255,0.08)',
+                    background: 'var(--nested-block-bg)',
+                    border: '1px solid var(--border-subtle)',
                   }}
                 >
                   <pre className="overflow-auto">{JSON.stringify(task.metadata, null, 2)}</pre>

--- a/prd-admin/src/pages/channels/components/WhitelistEditDialog.tsx
+++ b/prd-admin/src/pages/channels/components/WhitelistEditDialog.tsx
@@ -197,7 +197,7 @@ export function WhitelistEditDialog({
                   <Tooltip.Portal>
                     <Tooltip.Content
                       className="px-3 py-2 text-xs rounded-lg max-w-xs"
-                      style={{ background: 'rgba(0,0,0,0.9)', border: '1px solid rgba(255,255,255,0.1)' }}
+                      style={{ background: 'rgba(0,0,0,0.9)', border: '1px solid var(--border-default)' }}
                       sideOffset={5}
                     >
                       支持通配符 *，例如 *@company.com 匹配该域名下所有邮箱
@@ -305,7 +305,7 @@ export function WhitelistEditDialog({
                     <Tooltip.Portal>
                       <Tooltip.Content
                         className="px-3 py-2 text-xs rounded-lg"
-                        style={{ background: 'rgba(0,0,0,0.9)', border: '1px solid rgba(255,255,255,0.1)' }}
+                        style={{ background: 'rgba(0,0,0,0.9)', border: '1px solid var(--border-default)' }}
                         sideOffset={5}
                       >
                         数值越大优先级越高

--- a/prd-admin/src/pages/channels/components/WhitelistEditDialog.tsx
+++ b/prd-admin/src/pages/channels/components/WhitelistEditDialog.tsx
@@ -172,8 +172,8 @@ export function WhitelistEditDialog({
                     onClick={() => setChannelType(key)}
                     className="flex-1 px-3 py-2 rounded-lg text-sm transition-colors flex items-center justify-center gap-2"
                     style={{
-                      background: channelType === key ? 'rgba(59,130,246,0.15)' : 'rgba(255,255,255,0.03)',
-                      border: channelType === key ? '1px solid rgba(59,130,246,0.4)' : '1px solid rgba(255,255,255,0.08)',
+                      background: channelType === key ? 'rgba(59,130,246,0.15)' : 'var(--nested-block-bg)',
+                      border: channelType === key ? '1px solid rgba(59,130,246,0.4)' : '1px solid var(--border-subtle)',
                       color: channelType === key ? 'rgb(96,165,250)' : 'var(--text-secondary)',
                     }}
                   >
@@ -269,8 +269,8 @@ export function WhitelistEditDialog({
                   onClick={() => handleAgentToggle(agent.key)}
                   className="px-3 py-1.5 text-sm rounded-lg transition-colors flex items-center gap-1.5"
                   style={{
-                    background: allowedAgents.includes(agent.key) ? 'rgba(34,197,94,0.15)' : 'rgba(255,255,255,0.03)',
-                    border: allowedAgents.includes(agent.key) ? '1px solid rgba(34,197,94,0.4)' : '1px solid rgba(255,255,255,0.08)',
+                    background: allowedAgents.includes(agent.key) ? 'rgba(34,197,94,0.15)' : 'var(--nested-block-bg)',
+                    border: allowedAgents.includes(agent.key) ? '1px solid rgba(34,197,94,0.4)' : '1px solid var(--border-subtle)',
                     color: allowedAgents.includes(agent.key) ? 'rgb(34,197,94)' : 'var(--text-secondary)',
                   }}
                 >

--- a/prd-admin/src/pages/defect-agent/components/DefectCard.tsx
+++ b/prd-admin/src/pages/defect-agent/components/DefectCard.tsx
@@ -527,8 +527,8 @@ export function DefectCard({ defect }: DefectCardProps) {
                         key={att.id}
                         className="w-10 h-10 rounded overflow-hidden flex-shrink-0 cursor-pointer hover:ring-2 hover:ring-white/30 transition-all"
                         style={{
-                          background: 'rgba(0,0,0,0.3)',
-                          border: '1px solid rgba(255,255,255,0.1)',
+                          background: 'var(--nested-block-bg)',
+                          border: '1px solid var(--border-default)',
                         }}
                         onClick={(e) => att.url && handleImageClick(e, att.url)}
                         title="点击查看大图"
@@ -550,7 +550,7 @@ export function DefectCard({ defect }: DefectCardProps) {
                       <div
                         className="w-10 h-10 rounded flex-shrink-0 flex items-center justify-center text-[10px]"
                         style={{
-                          background: 'rgba(255,255,255,0.06)',
+                          background: 'var(--bg-input-hover)',
                           color: 'var(--text-muted)',
                         }}
                       >
@@ -567,9 +567,9 @@ export function DefectCard({ defect }: DefectCardProps) {
                       rel="noopener noreferrer"
                       className="inline-flex items-center gap-1.5 px-2 py-1 rounded-full text-[10px] hover:ring-2 hover:ring-white/30 transition-all"
                       style={{
-                        background: 'rgba(255,255,255,0.06)',
+                        background: 'var(--bg-input-hover)',
                         color: 'var(--text-muted)',
-                        border: '1px solid rgba(255,255,255,0.1)',
+                        border: '1px solid var(--border-default)',
                       }}
                       title={`打开附件 ${otherAttachments[0].fileName}`}
                       onClick={(e) => e.stopPropagation()}
@@ -582,9 +582,9 @@ export function DefectCard({ defect }: DefectCardProps) {
                       type="button"
                       className="inline-flex items-center gap-1.5 px-2 py-1 rounded-full text-[10px] hover:ring-2 hover:ring-white/30 transition-all"
                       style={{
-                        background: 'rgba(255,255,255,0.06)',
+                        background: 'var(--bg-input-hover)',
                         color: 'var(--text-muted)',
-                        border: '1px solid rgba(255,255,255,0.1)',
+                        border: '1px solid var(--border-default)',
                       }}
                       title={`查看附件 ${otherAttachments.length} 个`}
                       onClick={(e) => {
@@ -603,7 +603,7 @@ export function DefectCard({ defect }: DefectCardProps) {
             {/* 底部：严重性 + 状态 + 人员 + 时间 + 操作 */}
             <div
               className="px-3 py-2 flex items-center border-t text-[11px]"
-              style={{ borderColor: 'rgba(255,255,255,0.06)', color: 'var(--text-muted)' }}
+              style={{ borderColor: 'var(--nested-block-border)', color: 'var(--text-muted)' }}
             >
               {/* 严重性标签 - 左下角 */}
               <div
@@ -618,11 +618,11 @@ export function DefectCard({ defect }: DefectCardProps) {
               <div
                 className="inline-flex items-center gap-1.5 px-1.5 py-0.5 rounded mr-2 flex-shrink-0 text-[10px]"
                 style={{
-                  background: 'rgba(255,255,255,0.06)',
+                  background: 'var(--bg-input-hover)',
                   color: 'var(--text-muted)',
                   border: isReporterMe
                     ? '1px solid rgba(255, 255, 255, 0.5)'
-                    : '1px solid rgba(255,255,255,0.08)',
+                    : '1px solid var(--border-subtle)',
                 }}
                 title={reporterDisplayName}
               >
@@ -644,11 +644,11 @@ export function DefectCard({ defect }: DefectCardProps) {
               <div
                 className="inline-flex items-center gap-1.5 px-1.5 py-0.5 rounded flex-shrink-0 text-[10px]"
                 style={{
-                  background: 'rgba(255,255,255,0.06)',
+                  background: 'var(--bg-input-hover)',
                   color: 'var(--text-muted)',
                   border: isAssigneeMe
                     ? '1px solid rgba(255, 255, 255, 0.5)'
-                    : '1px solid rgba(255,255,255,0.08)',
+                    : '1px solid var(--border-subtle)',
                 }}
                 title={assigneeDisplayName}
               >

--- a/prd-admin/src/pages/defect-agent/components/DefectDetailPanel.tsx
+++ b/prd-admin/src/pages/defect-agent/components/DefectDetailPanel.tsx
@@ -415,13 +415,13 @@ export function DefectDetailPanel() {
           {/* Header - 固定高度 52px */}
           <div
             className="flex items-center justify-between px-5 h-[52px] flex-shrink-0"
-            style={{ borderBottom: '1px solid rgba(255, 255, 255, 0.06)' }}
+            style={{ borderBottom: '1px solid var(--nested-block-border)' }}
           >
             {/* 左侧：Bug icon + 缺陷编号 */}
             <div
               className="flex items-center gap-1.5 px-2 py-1 rounded flex-shrink-0"
               style={{
-                background: 'rgba(255,255,255,0.06)',
+                background: 'var(--bg-input-hover)',
               }}
             >
               <Bug size={14} style={{ color: 'var(--accent-primary)' }} />
@@ -474,8 +474,8 @@ export function DefectDetailPanel() {
                       key={att.id}
                       className="flex-shrink-0 w-[100px] h-[70px] rounded-lg overflow-hidden cursor-pointer hover:ring-2 hover:ring-white/30 transition-all"
                       style={{
-                        background: 'rgba(0,0,0,0.3)',
-                        border: '1px solid rgba(255,255,255,0.1)',
+                        background: 'var(--nested-block-bg)',
+                        border: '1px solid var(--border-default)',
                       }}
                       onClick={() => att.url && setLightboxImage(att.url)}
                       title="点击查看大图"
@@ -516,9 +516,9 @@ export function DefectDetailPanel() {
                       rel="noopener noreferrer"
                       className="flex items-center gap-2 px-3 py-2 rounded-lg text-[12px] hover:bg-white/10 hover:ring-2 hover:ring-white/30 transition-all"
                       style={{
-                        background: 'rgba(255,255,255,0.05)',
+                        background: 'var(--bg-card-hover)',
                         color: 'var(--text-secondary)',
-                        border: '1px solid rgba(255,255,255,0.08)',
+                        border: '1px solid var(--border-subtle)',
                       }}
                     >
                       <FileText size={12} />
@@ -588,7 +588,7 @@ export function DefectDetailPanel() {
                 style={{
                   background: 'rgba(255,255,255,0)',
                   color: 'var(--text-secondary)',
-                  border: '1px solid rgba(255,255,255,0.06)',
+                  border: '1px solid var(--nested-block-border)',
                   minHeight: hasScreenshots
                     ? (isShortContent ? '220px' : '360px')
                     : (isShortContent ? '240px' : '440px'),
@@ -609,8 +609,8 @@ export function DefectDetailPanel() {
                         style={{
                           width: '100px',
                           height: '70px',
-                          background: 'rgba(0,0,0,0.3)',
-                          border: '1px solid rgba(255,255,255,0.1)',
+                          background: 'var(--nested-block-bg)',
+                          border: '1px solid var(--border-default)',
                         }}
                         onClick={() => setLightboxImage(seg.content)}
                         title={seg.name || '点击查看大图'}
@@ -693,7 +693,7 @@ export function DefectDetailPanel() {
           {/* Actions - 最小高度 60px，与右侧对齐 */}
           <div
             className={`px-5 min-h-[60px] flex ${isMobile ? 'flex-col gap-2 py-3' : 'items-center justify-between'} flex-shrink-0`}
-            style={{ borderTop: '1px solid rgba(255, 255, 255, 0.06)' }}
+            style={{ borderTop: '1px solid var(--nested-block-border)' }}
           >
             {/* Left: 严重程度 + 人员信息 + 删除按钮 */}
             <div className={`flex items-center gap-3 ${isMobile ? 'flex-wrap' : ''}`}>
@@ -718,11 +718,11 @@ export function DefectDetailPanel() {
               <div
                 className="inline-flex items-center gap-1.5 px-2 py-1 rounded flex-shrink-0 text-[11px]"
                 style={{
-                  background: 'rgba(255,255,255,0.06)',
+                  background: 'var(--bg-input-hover)',
                   color: 'var(--text-muted)',
                   border: userId && defect.reporterId === userId
                     ? '1px solid rgba(255, 255, 255, 0.5)'
-                    : '1px solid rgba(255,255,255,0.08)',
+                    : '1px solid var(--border-subtle)',
                 }}
                 title={defect.reporterName || '未知'}
               >
@@ -742,11 +742,11 @@ export function DefectDetailPanel() {
               <div
                 className="inline-flex items-center gap-1.5 px-2 py-1 rounded flex-shrink-0 text-[11px]"
                 style={{
-                  background: 'rgba(255,255,255,0.06)',
+                  background: 'var(--bg-input-hover)',
                   color: 'var(--text-muted)',
                   border: userId && defect.assigneeId === userId
                     ? '1px solid rgba(255, 255, 255, 0.5)'
-                    : '1px solid rgba(255,255,255,0.08)',
+                    : '1px solid var(--border-subtle)',
                 }}
                 title={defect.assigneeName || '未指派'}
               >
@@ -845,21 +845,21 @@ export function DefectDetailPanel() {
           <div
             className={`${isMobile ? 'w-full' : 'w-[45%]'} flex flex-col`}
             style={{
-              borderLeft: isMobile ? 'none' : '1px solid rgba(255, 255, 255, 0.06)',
-              borderTop: isMobile ? '1px solid rgba(255, 255, 255, 0.06)' : 'none',
+              borderLeft: isMobile ? 'none' : '1px solid var(--nested-block-border)',
+              borderTop: isMobile ? '1px solid var(--nested-block-border)' : 'none',
             }}
           >
             {/* Chat Header - 与左侧 Header 高度对齐 (52px) */}
             <div
               className="px-4 h-[52px] flex items-center gap-2 flex-shrink-0"
-              style={{ borderBottom: '1px solid rgba(255, 255, 255, 0.06)' }}
+              style={{ borderBottom: '1px solid var(--nested-block-border)' }}
             >
               <MessageCircle size={14} style={{ color: 'var(--text-muted)' }} />
               <span className="text-[13px] font-medium" style={{ color: 'var(--text-primary)' }}>
                 评论
               </span>
               {messages.length > 0 && (
-                <span className="text-[11px] px-1.5 py-0.5 rounded" style={{ background: 'rgba(255,255,255,0.08)', color: 'var(--text-muted)' }}>
+                <span className="text-[11px] px-1.5 py-0.5 rounded" style={{ background: 'var(--border-subtle)', color: 'var(--text-muted)' }}>
                   {messages.filter(m => m.role === 'user').length}
                 </span>
               )}
@@ -909,7 +909,7 @@ export function DefectDetailPanel() {
                           className="w-5 h-5 rounded-full flex-shrink-0 overflow-hidden flex items-center justify-center"
                           style={{
                             background: isAssistant ? 'rgba(100,180,255,0.2)' : 'rgba(255,180,70,0.15)',
-                            border: '1px solid rgba(255,255,255,0.1)',
+                            border: '1px solid var(--border-default)',
                           }}
                         >
                           {avatarSrc ? (
@@ -932,7 +932,7 @@ export function DefectDetailPanel() {
                           className="group relative max-w-[90%] rounded-[10px] px-3 py-2 text-[12px] leading-relaxed"
                           style={{
                             background: isUser ? 'rgb(50, 45, 35)' : 'rgb(35, 35, 40)',
-                            border: '1px solid rgba(255,255,255,0.08)',
+                            border: '1px solid var(--border-subtle)',
                             color: 'var(--text-primary)',
                           }}
                         >
@@ -947,8 +947,8 @@ export function DefectDetailPanel() {
                                 className="block w-full mt-2 rounded-lg overflow-hidden hover:ring-2 hover:ring-white/30 transition-all"
                                 style={{
                                   maxWidth: '180px',
-                                  background: 'rgba(0,0,0,0.3)',
-                                  border: '1px solid rgba(255,255,255,0.1)',
+                                  background: 'var(--nested-block-bg)',
+                                  border: '1px solid var(--border-default)',
                                 }}
                                 onClick={() => setLightboxImage(seg.content)}
                                 title={seg.name || '点击查看大图'}
@@ -974,8 +974,8 @@ export function DefectDetailPanel() {
                                 type="button"
                                 className="flex items-center gap-2 rounded-lg px-2 py-1 text-[11px] hover:ring-2 hover:ring-white/30 transition-all"
                                 style={{
-                                  background: 'rgba(255,255,255,0.06)',
-                                  border: '1px solid rgba(255,255,255,0.08)',
+                                  background: 'var(--bg-input-hover)',
+                                  border: '1px solid var(--border-subtle)',
                                   color: 'var(--text-secondary)',
                                 }}
                                 onClick={() => att.url && setLightboxImage(att.url)}
@@ -995,8 +995,8 @@ export function DefectDetailPanel() {
                                 rel="noopener noreferrer"
                                 className="flex items-center gap-2 rounded-lg px-2 py-1 text-[11px] hover:ring-2 hover:ring-white/30 transition-all"
                                 style={{
-                                  background: 'rgba(255,255,255,0.06)',
-                                  border: '1px solid rgba(255,255,255,0.08)',
+                                  background: 'var(--bg-input-hover)',
+                                  border: '1px solid var(--border-subtle)',
                                   color: 'var(--text-secondary)',
                                 }}
                               >
@@ -1024,7 +1024,7 @@ export function DefectDetailPanel() {
             {/* Chat Input - 与左侧 Footer 高度对齐 (min 60px) */}
             <div
               className="px-4 min-h-[60px] flex items-center flex-shrink-0"
-              style={{ borderTop: '1px solid rgba(255, 255, 255, 0.06)' }}
+              style={{ borderTop: '1px solid var(--nested-block-border)' }}
             >
               <div className="w-full space-y-2">
                 {pendingAttachments.length > 0 && (
@@ -1034,8 +1034,8 @@ export function DefectDetailPanel() {
                         key={att.id}
                         className="group relative flex items-center gap-2 rounded-lg px-2 py-1 text-[11px]"
                         style={{
-                          background: 'rgba(255,255,255,0.06)',
-                          border: '1px solid rgba(255,255,255,0.08)',
+                          background: 'var(--bg-input-hover)',
+                          border: '1px solid var(--border-subtle)',
                           color: 'var(--text-secondary)',
                         }}
                       >
@@ -1064,10 +1064,10 @@ export function DefectDetailPanel() {
                 <div
                   className="flex items-center gap-2 rounded-lg px-3 py-2 transition-all duration-200"
                   style={{
-                    background: 'rgba(255,255,255,0.04)',
-                    border: commentFocused 
-                      ? '1px solid rgba(214, 178, 106, 0.55)' 
-                      : '1px solid rgba(255,255,255,0.08)',
+                    background: 'var(--bg-input)',
+                    border: commentFocused
+                      ? '1px solid rgba(214, 178, 106, 0.55)'
+                      : '1px solid var(--border-subtle)',
                     boxShadow: commentFocused 
                       ? '0 0 0 2px rgba(214, 178, 106, 0.15)' 
                       : 'none',

--- a/prd-admin/src/pages/defect-agent/components/DefectSubmitPanel.tsx
+++ b/prd-admin/src/pages/defect-agent/components/DefectSubmitPanel.tsx
@@ -230,7 +230,7 @@ export function DefectSubmitPanel() {
         {/* Header */}
         <div
           className="flex items-center justify-between px-5 py-4 border-b"
-          style={{ borderColor: 'rgba(255,255,255,0.08)' }}
+          style={{ borderColor: 'var(--border-subtle)' }}
         >
           <div className="flex items-center gap-3">
             <div
@@ -270,8 +270,8 @@ export function DefectSubmitPanel() {
                 onChange={(e) => setAssigneeUserId(e.target.value)}
                 className="flex-1 px-3 py-2 rounded-lg text-[13px] outline-none transition-colors"
                 style={{
-                  background: 'rgba(255,255,255,0.06)',
-                  border: '1px solid rgba(255,255,255,0.1)',
+                  background: 'var(--bg-input-hover)',
+                  border: '1px solid var(--border-default)',
                   color: 'var(--text-primary)',
                 }}
               >
@@ -297,8 +297,8 @@ export function DefectSubmitPanel() {
                 onChange={(e) => setSelectedTemplateId(e.target.value)}
                 className="flex-1 px-3 py-2 rounded-lg text-[13px] outline-none transition-colors"
                 style={{
-                  background: 'rgba(255,255,255,0.06)',
-                  border: '1px solid rgba(255,255,255,0.1)',
+                  background: 'var(--bg-input-hover)',
+                  border: '1px solid var(--border-default)',
                   color: 'var(--text-primary)',
                 }}
               >
@@ -342,9 +342,9 @@ export function DefectSubmitPanel() {
             className="flex-1 min-h-[280px] flex flex-col rounded-xl overflow-hidden transition-all duration-200"
             style={{
               background: 'rgba(0,0,0,0.14)',
-              border: focused 
-                ? '1px solid rgba(214, 178, 106, 0.55)' 
-                : '1px solid rgba(255,255,255,0.08)',
+              border: focused
+                ? '1px solid rgba(214, 178, 106, 0.55)'
+                : '1px solid var(--border-subtle)',
               boxShadow: focused 
                 ? '0 0 0 2px rgba(214, 178, 106, 0.15)' 
                 : 'none',
@@ -370,7 +370,7 @@ export function DefectSubmitPanel() {
             {attachments.length > 0 && (
               <div
                 className="px-4 py-3 border-t flex flex-wrap gap-2"
-                style={{ borderColor: 'rgba(255,255,255,0.08)' }}
+                style={{ borderColor: 'var(--border-subtle)' }}
               >
                 {attachments.map((file, index) => (
                   <div
@@ -381,8 +381,8 @@ export function DefectSubmitPanel() {
                       <div
                         className="w-16 h-16 rounded-lg overflow-hidden"
                         style={{
-                          background: 'rgba(255,255,255,0.06)',
-                          border: '1px solid rgba(255,255,255,0.1)',
+                          background: 'var(--bg-input-hover)',
+                          border: '1px solid var(--border-default)',
                         }}
                       >
                         <img
@@ -395,7 +395,7 @@ export function DefectSubmitPanel() {
                       <div
                         className="flex items-center gap-1.5 px-2 py-1 rounded-lg text-[11px]"
                         style={{
-                          background: 'rgba(255,255,255,0.06)',
+                          background: 'var(--bg-input-hover)',
                           color: 'var(--text-secondary)',
                         }}
                       >
@@ -420,7 +420,7 @@ export function DefectSubmitPanel() {
             {/* Input Actions */}
             <div
               className="px-4 py-3 border-t flex items-center gap-2"
-              style={{ borderColor: 'rgba(255,255,255,0.08)' }}
+              style={{ borderColor: 'var(--border-subtle)' }}
             >
               <input
                 ref={fileInputRef}
@@ -451,8 +451,8 @@ export function DefectSubmitPanel() {
                         onClick={() => setSeverity(opt.value)}
                         className="px-2 py-1 rounded-md text-[11px] transition-colors"
                         style={{
-                          background: active ? 'rgba(214, 178, 106, 0.2)' : 'rgba(255,255,255,0.06)',
-                          border: active ? '1px solid rgba(214, 178, 106, 0.4)' : '1px solid rgba(255,255,255,0.08)',
+                          background: active ? 'rgba(214, 178, 106, 0.2)' : 'var(--bg-input-hover)',
+                          border: active ? '1px solid rgba(214, 178, 106, 0.4)' : '1px solid var(--border-subtle)',
                           color: active ? 'var(--text-primary)' : 'var(--text-muted)',
                         }}
                       >

--- a/prd-admin/src/pages/lab-llm/LlmLabTab.tsx
+++ b/prd-admin/src/pages/lab-llm/LlmLabTab.tsx
@@ -2509,7 +2509,7 @@ export default function LlmLabTab() {
             <button
               type="button"
               className="inline-flex items-center justify-center gap-2 font-semibold transition-colors disabled:opacity-60 disabled:cursor-not-allowed h-[30px] px-3 rounded-[10px] text-[12px] text-(--text-primary) hover:bg-white/8 hover:border-white/20 shrink-0"
-              style={{ background: 'rgba(255, 255, 255, 0.06)', border: '1px solid rgba(255, 255, 255, 0.12)' }}
+              style={{ background: 'var(--bg-input-hover)', border: '1px solid var(--border-default)' }}
               onClick={openCreateExperiment}
               disabled={experimentsLoading}
             >
@@ -2525,7 +2525,7 @@ export default function LlmLabTab() {
             <button
               type="button"
               className="h-10 w-full rounded-[14px] px-3 text-sm inline-flex items-center justify-between gap-2"
-              style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.12)', color: 'var(--text-primary)' }}
+              style={{ background: 'var(--bg-input)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
               onClick={openLoadExperiment}
               disabled={experimentsLoading}
               title="点击加载实验"
@@ -2547,7 +2547,7 @@ export default function LlmLabTab() {
                 max={50}
                 onChange={(e) => setParams((p) => ({ ...p, maxConcurrency: Math.max(1, Math.min(50, Number(e.target.value || 1))) }))}
                 className="mt-1 h-9 w-full rounded-[12px] px-2 text-sm outline-none"
-                style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.12)', color: 'var(--text-primary)' }}
+                style={{ background: 'var(--bg-input)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
               />
             </label>
             <label className="text-xs" style={{ color: 'var(--text-muted)' }}>
@@ -2558,7 +2558,7 @@ export default function LlmLabTab() {
                 min={1}
                 onChange={(e) => setParams((p) => ({ ...p, repeatN: Math.max(1, Number(e.target.value || 1)) }))}
                 className="mt-1 h-9 w-full rounded-[12px] px-2 text-sm outline-none"
-                style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.12)', color: 'var(--text-primary)' }}
+                style={{ background: 'var(--bg-input)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
               />
             </label>
           </div>
@@ -2617,7 +2617,7 @@ export default function LlmLabTab() {
                       <button
                         type="button"
                         className="inline-flex items-center justify-center gap-2 font-semibold transition-colors disabled:opacity-60 disabled:cursor-not-allowed h-[30px] px-3 rounded-[10px] text-[12px] text-(--text-primary) hover:bg-white/8 hover:border-white/20 shrink-0"
-                        style={{ background: 'rgba(255, 255, 255, 0.06)', border: '1px solid rgba(255, 255, 255, 0.12)' }}
+                        style={{ background: 'var(--bg-input-hover)', border: '1px solid var(--border-default)' }}
                         title="将该集合模型加入当前实验"
                       >
                         <Tag size={14} />
@@ -2675,7 +2675,7 @@ export default function LlmLabTab() {
                         <div
                           key={pid}
                           className="rounded-[14px] p-3"
-                          style={{ border: '1px solid var(--border-subtle)', background: 'rgba(255,255,255,0.02)' }}
+                          style={{ border: '1px solid var(--border-subtle)', background: 'var(--list-item-bg)' }}
                         >
                           <div className="flex items-center justify-between gap-2">
                             <div className="flex items-center gap-2 min-w-0">
@@ -2702,8 +2702,8 @@ export default function LlmLabTab() {
                                     isDisabled ? 'hover:brightness-[1.03]' : 'hover:-translate-y-px hover:brightness-[1.06]'
                                   )}
                                   style={{
-                                    border: isDisabled ? '1px solid rgba(255,255,255,0.06)' : '1px solid rgba(255,255,255,0.10)',
-                                    background: isDisabled ? 'rgba(255,255,255,0.01)' : 'rgba(255,255,255,0.02)',
+                                    border: isDisabled ? '1px solid var(--nested-block-border)' : '1px solid var(--border-default)',
+                                    background: isDisabled ? 'rgba(255,255,255,0.01)' : 'var(--list-item-bg)',
                                     color: isDisabled ? 'var(--text-muted)' : 'var(--text-primary)',
                                     opacity: isDisabled ? 0.78 : 1,
                                   }}
@@ -2730,7 +2730,7 @@ export default function LlmLabTab() {
                                   <button
                                     type="button"
                                     className="shrink-0 inline-flex items-center justify-center h-7 w-7 rounded-[10px] transition-colors hover:bg-white/6"
-                                    style={{ border: '1px solid rgba(255,255,255,0.10)', color: 'var(--text-muted)' }}
+                                    style={{ border: '1px solid var(--border-default)', color: 'var(--text-muted)' }}
                                     title="从实验中移除该模型"
                                     onClick={(e) => {
                                       e.stopPropagation();
@@ -2815,7 +2815,7 @@ export default function LlmLabTab() {
                           max={20}
                           onChange={(e) => setSingleN(Math.max(1, Math.min(20, Number(e.target.value || 1))))}
                           className="ml-2 h-[28px] w-[64px] rounded-[10px] px-2 text-[12px] outline-none"
-                          style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.12)', color: 'var(--text-primary)' }}
+                          style={{ background: 'var(--bg-input)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
                         />
                       </label>
                     ) : null}
@@ -2829,8 +2829,8 @@ export default function LlmLabTab() {
                             type="button"
                             className="shrink-0 h-[28px] rounded-[10px] px-2 transition-colors inline-flex items-center gap-2 hover:bg-white/6"
                             style={{
-                              background: 'rgba(255,255,255,0.03)',
-                              border: '1px solid rgba(255,255,255,0.10)',
+                              background: 'var(--nested-block-bg)',
+                              border: '1px solid var(--border-default)',
                               color: 'var(--text-primary)',
                             }}
                             aria-label="选择图片比例"
@@ -2841,8 +2841,8 @@ export default function LlmLabTab() {
                               style={{
                                 width: 16,
                                 height: 16,
-                                border: '1px solid rgba(255,255,255,0.12)',
-                                background: 'rgba(255,255,255,0.02)',
+                                border: '1px solid var(--border-default)',
+                                background: 'var(--list-item-bg)',
                               }}
                             >
                               <span
@@ -2851,7 +2851,7 @@ export default function LlmLabTab() {
                                   height: Math.max(6, Math.round(currentAspectOpt.iconH * 0.55)),
                                   borderRadius: 4,
                                   border: '2px solid rgba(255,255,255,0.22)',
-                                  background: 'rgba(255,255,255,0.02)',
+                                  background: 'var(--list-item-bg)',
                                 }}
                               />
                             </span>
@@ -2888,8 +2888,8 @@ export default function LlmLabTab() {
                                       style={{
                                         width: 22,
                                         height: 22,
-                                        border: '1px solid rgba(255,255,255,0.12)',
-                                        background: 'rgba(255,255,255,0.02)',
+                                        border: '1px solid var(--border-default)',
+                                        background: 'var(--list-item-bg)',
                                       }}
                                     >
                                       <span
@@ -2898,7 +2898,7 @@ export default function LlmLabTab() {
                                           height: Math.max(6, Math.round(opt.iconH * scale)),
                                           borderRadius: 5,
                                           border: '2px solid rgba(255,255,255,0.22)',
-                                          background: 'rgba(255,255,255,0.02)',
+                                          background: 'var(--list-item-bg)',
                                         }}
                                       />
                                     </span>
@@ -3084,8 +3084,8 @@ export default function LlmLabTab() {
                       onChange={(e) => setImageGenPlanSystemPromptText(e.target.value)}
                       className="h-36 w-full rounded-[14px] px-3 py-2 text-[12px] outline-none resize-none disabled:opacity-60"
                       style={{
-                        background: 'rgba(255,255,255,0.04)',
-                        border: '1px solid rgba(255,255,255,0.12)',
+                        background: 'var(--bg-input)',
+                        border: '1px solid var(--border-default)',
                         color: 'var(--text-primary)',
                       }}
                       placeholder="系统提示词"
@@ -3098,7 +3098,7 @@ export default function LlmLabTab() {
                         style={{
                           ...glassBadge,
                           background: 'rgba(0,0,0,0.35)',
-                          border: '1px solid rgba(255,255,255,0.10)',
+                          border: '1px solid var(--border-default)',
                         }}
                       >
                         <Button
@@ -3135,8 +3135,8 @@ export default function LlmLabTab() {
                       }}
                       className="h-36 w-full rounded-[14px] px-3 py-2 text-sm outline-none resize-none"
                       style={{
-                        background: 'rgba(255,255,255,0.04)',
-                        border: '1px solid rgba(255,255,255,0.12)',
+                        background: 'var(--bg-input)',
+                        border: '1px solid var(--border-default)',
                         color: 'var(--text-primary)',
                       }}
                       placeholder={mainMode === 'infer' ? '输入或粘贴内容' : imageSubMode === 'single' ? '输入图片描述' : imageSubMode === 'batch' ? '输入需求描述' : '输入图片描述（将生成 10 比例 × 3 档 = 30 张）'}
@@ -3162,8 +3162,8 @@ export default function LlmLabTab() {
                   }}
                   className="mt-2 h-36 w-full rounded-[14px] px-3 py-2 text-sm outline-none resize-none"
                   style={{
-                    background: 'rgba(255,255,255,0.04)',
-                    border: '1px solid rgba(255,255,255,0.12)',
+                    background: 'var(--bg-input)',
+                    border: '1px solid var(--border-default)',
                     color: 'var(--text-primary)',
                   }}
                   placeholder={mainMode === 'infer' ? '输入或粘贴内容' : imageSubMode === 'single' ? '输入图片描述' : '输入需求描述'}
@@ -3299,7 +3299,7 @@ export default function LlmLabTab() {
               <div className="h-full min-h-[220px] flex flex-col items-center justify-center text-center px-6">
                 <div
                   className="h-12 w-12 rounded-full flex items-center justify-center"
-                  style={{ background: 'rgba(255,255,255,0.06)', border: '1px solid var(--border-subtle)' }}
+                  style={{ background: 'var(--bg-input-hover)', border: '1px solid var(--border-subtle)' }}
                 >
                   <TimerOff size={22} style={{ color: 'var(--text-muted)' }} />
                 </div>
@@ -3316,8 +3316,8 @@ export default function LlmLabTab() {
                   <div
                     className="rounded-[12px] px-3 py-2 text-xs"
                     style={{
-                      background: 'rgba(255,255,255,0.03)',
-                      border: '1px solid rgba(255,255,255,0.10)',
+                      background: 'var(--nested-block-bg)',
+                      border: '1px solid var(--border-default)',
                       color: 'var(--text-muted)',
                     }}
                   >
@@ -3328,7 +3328,7 @@ export default function LlmLabTab() {
                   <div
                     key={it.itemId}
                     className="rounded-[14px] p-3"
-                    style={{ border: '1px solid var(--border-subtle)', background: 'rgba(255,255,255,0.02)' }}
+                    style={{ border: '1px solid var(--border-subtle)', background: 'var(--list-item-bg)' }}
                   >
                     {mode === 'imageGenPlan'
                       ? (() => {
@@ -3381,8 +3381,8 @@ export default function LlmLabTab() {
                         }
                         if (st === 'bad') return chipStyle(false);
                         return {
-                          background: 'rgba(255,255,255,0.04)',
-                          border: '1px solid rgba(255,255,255,0.12)',
+                          background: 'var(--bg-input)',
+                          border: '1px solid var(--border-default)',
                           color: 'var(--text-secondary)',
                         };
                       };
@@ -3413,8 +3413,8 @@ export default function LlmLabTab() {
                             <span
                               className="inline-flex items-center rounded-full px-2.5 py-1 text-[11px] font-semibold tracking-wide"
                               style={{
-                                background: 'rgba(255,255,255,0.04)',
-                                border: '1px solid rgba(255,255,255,0.12)',
+                                background: 'var(--bg-input)',
+                                border: '1px solid var(--border-default)',
                                 color: 'var(--text-secondary)',
                               }}
                               title={`原始输出超过上限 ${MAX_RUN_RAW_CHARS} 字符，已截断；校验基于截断文本`}
@@ -3441,8 +3441,8 @@ export default function LlmLabTab() {
                             <span
                               className="inline-flex items-center rounded-full px-2 py-[2px] text-[11px] font-semibold shrink-0"
                               style={{
-                                background: 'rgba(255,255,255,0.04)',
-                                border: '1px solid rgba(255,255,255,0.12)',
+                                background: 'var(--bg-input)',
+                                border: '1px solid var(--border-default)',
                                 color: 'var(--text-secondary)',
                               }}
                               title="重复请求序号"
@@ -3491,8 +3491,8 @@ export default function LlmLabTab() {
                                 key={c.key}
                                 className="inline-flex items-center rounded-full px-2.5 py-1 text-[11px] font-semibold tracking-wide"
                                 style={{
-                                  background: 'rgba(255,255,255,0.04)',
-                                  border: '1px solid rgba(255,255,255,0.12)',
+                                  background: 'var(--bg-input)',
+                                  border: '1px solid var(--border-default)',
                                   color: 'var(--text-secondary)',
                                 }}
                               >
@@ -3573,7 +3573,7 @@ export default function LlmLabTab() {
                           <button
                             type="button"
                             className="inline-flex items-center gap-1 rounded-[10px] px-2 py-1 text-[11px] font-semibold transition-colors hover:bg-white/6"
-                            style={{ border: '1px solid rgba(255,255,255,0.10)', color: 'var(--text-secondary)' }}
+                            style={{ border: '1px solid var(--border-default)', color: 'var(--text-secondary)' }}
                             onClick={() => {
                               const text = it.rawText || it.preview || (it.status === 'running' ? '（等待输出）' : '（无输出）');
                               void copyToClipboard(text);
@@ -3587,7 +3587,7 @@ export default function LlmLabTab() {
                           <button
                             type="button"
                             className="inline-flex items-center gap-1 rounded-[10px] px-2 py-1 text-[11px] font-semibold transition-colors hover:bg-white/6"
-                            style={{ border: '1px solid rgba(255,255,255,0.10)', color: 'var(--text-secondary)' }}
+                            style={{ border: '1px solid var(--border-default)', color: 'var(--text-secondary)' }}
                             onClick={() => {
                               const text = it.rawText || it.preview || (it.status === 'running' ? '（等待输出）' : '（无输出）');
                               setPreviewDialog({ open: true, title: it.displayName || '输出预览', text });
@@ -3602,7 +3602,7 @@ export default function LlmLabTab() {
                       </div>
                       <div
                         className="mt-1 rounded-[12px] px-2.5 py-2 min-w-0"
-                        style={{ border: '1px solid rgba(255,255,255,0.10)', background: 'rgba(255,255,255,0.02)' }}
+                        style={{ border: '1px solid var(--border-default)', background: 'var(--list-item-bg)' }}
                       >
                         <InlineMarquee
                           text={it.preview || (it.status === 'running' ? '（等待输出）' : '（无输出）')}
@@ -3718,8 +3718,8 @@ export default function LlmLabTab() {
                               canSelect ? 'cursor-zoom-in' : 'cursor-default',
                             ].join(' ')}
                             style={{
-                              border: selected ? '2px solid rgba(250,204,21,0.95)' : '1px solid rgba(255,255,255,0.10)',
-                              background: 'rgba(255,255,255,0.02)',
+                              border: selected ? '2px solid rgba(250,204,21,0.95)' : '1px solid var(--border-default)',
+                              background: 'var(--list-item-bg)',
                               height: '100%',
                             }}
                             onClick={() => {
@@ -3777,8 +3777,8 @@ export default function LlmLabTab() {
                                 type="button"
                                 className="absolute right-2 top-2 h-8 w-8 rounded-[10px] inline-flex items-center justify-center transition-colors hover:bg-white/6"
                                 style={{
-                                  border: selected ? '2px solid rgba(250,204,21,0.95)' : '1px solid rgba(255,255,255,0.10)',
-                                  background: selected ? 'rgba(250,204,21,0.12)' : 'rgba(0,0,0,0.20)',
+                                  border: selected ? '2px solid rgba(250,204,21,0.95)' : '1px solid var(--border-default)',
+                                  background: selected ? 'rgba(250,204,21,0.12)' : 'var(--nested-block-bg)',
                                   color: selected ? 'rgba(250,204,21,0.95)' : 'var(--text-secondary)',
                                 }}
                                 onClick={(e) => {
@@ -3796,7 +3796,7 @@ export default function LlmLabTab() {
                             {canSelect ? (
                               <div
                                 className="absolute left-2 bottom-2 h-8 w-8 rounded-[10px] inline-flex items-center justify-center"
-                                style={{ border: '1px solid rgba(255,255,255,0.10)', background: 'rgba(0,0,0,0.20)', color: 'var(--text-secondary)' }}
+                                style={{ border: '1px solid var(--border-default)', background: 'var(--nested-block-bg)', color: 'var(--text-secondary)' }}
                                 title="点击放大预览"
                                 aria-label="点击放大预览"
                               >
@@ -3914,7 +3914,7 @@ export default function LlmLabTab() {
                                 <div
                                   key={g.model.modelId}
                                   className="rounded-[14px] p-3 flex flex-col min-h-0"
-                                  style={{ border: '1px solid var(--border-subtle)', background: 'rgba(255,255,255,0.02)' }}
+                                  style={{ border: '1px solid var(--border-subtle)', background: 'var(--list-item-bg)' }}
                                 >
                                   <div className="flex items-center justify-between gap-2">
                                     <div className="text-xs font-semibold truncate" style={{ color: 'var(--text-primary)' }} title={g.model.displayName}>
@@ -4016,7 +4016,7 @@ export default function LlmLabTab() {
                   <div className="h-full min-h-[220px] flex flex-col items-center justify-center text-center px-6">
                     <div
                       className="h-12 w-12 rounded-full flex items-center justify-center"
-                      style={{ background: 'rgba(255,255,255,0.06)', border: '1px solid var(--border-subtle)' }}
+                      style={{ background: 'var(--bg-input-hover)', border: '1px solid var(--border-subtle)' }}
                     >
                       <Layers size={22} style={{ color: 'var(--text-muted)' }} />
                     </div>
@@ -4079,7 +4079,7 @@ export default function LlmLabTab() {
                           <div
                             key={it.key}
                             className="rounded-[14px] p-3 flex flex-col gap-2"
-                            style={{ border: '1px solid var(--border-subtle)', background: 'rgba(255,255,255,0.02)' }}
+                            style={{ border: '1px solid var(--border-subtle)', background: 'var(--list-item-bg)' }}
                           >
                             <div className="flex items-start justify-between gap-2">
                               <div className="text-xs font-semibold min-w-0" style={{ color: 'var(--text-primary)' }}>
@@ -4119,8 +4119,8 @@ export default function LlmLabTab() {
                             <div
                               className="rounded-[12px] overflow-hidden relative"
                               style={{
-                                border: '1px solid rgba(255,255,255,0.10)',
-                                background: 'rgba(255,255,255,0.02)',
+                                border: '1px solid var(--border-default)',
+                                background: 'var(--list-item-bg)',
                                 height: imageThumbHeight,
                               }}
                               onClick={() => {
@@ -4152,7 +4152,7 @@ export default function LlmLabTab() {
                               {it.status === 'done' && src ? (
                                 <div
                                   className="absolute left-2 bottom-2 h-8 w-8 rounded-[10px] inline-flex items-center justify-center pointer-events-none"
-                                  style={{ border: '1px solid rgba(255,255,255,0.10)', background: 'rgba(0,0,0,0.20)', color: 'var(--text-secondary)' }}
+                                  style={{ border: '1px solid var(--border-default)', background: 'var(--nested-block-bg)', color: 'var(--text-secondary)' }}
                                   title="点击放大预览"
                                   aria-label="点击放大预览"
                                 >
@@ -4222,7 +4222,7 @@ export default function LlmLabTab() {
                             <div
                               key={g.key}
                               className="rounded-[14px] p-3 flex flex-col min-h-0"
-                              style={{ border: '1px solid var(--border-subtle)', background: 'rgba(255,255,255,0.02)' }}
+                              style={{ border: '1px solid var(--border-subtle)', background: 'var(--list-item-bg)' }}
                             >
                               <div className="flex items-center justify-between gap-2">
                                 <div className="text-xs font-semibold truncate" style={{ color: 'var(--text-primary)' }} title={g.model.displayName}>
@@ -4236,8 +4236,8 @@ export default function LlmLabTab() {
                                 <div
                                   className="mt-2 rounded-[12px] flex items-center justify-center text-xs"
                                   style={{
-                                    border: '1px solid rgba(255,255,255,0.10)',
-                                    background: 'rgba(255,255,255,0.02)',
+                                    border: '1px solid var(--border-default)',
+                                    background: 'var(--list-item-bg)',
                                     height: imageThumbHeight,
                                     color: 'var(--text-muted)',
                                   }}
@@ -4282,7 +4282,7 @@ export default function LlmLabTab() {
                 : '解析模型：意图模型'}
             </div>
 
-            <div className="mt-3 flex-1 min-h-0 overflow-auto rounded-[14px] p-3" style={{ border: '1px solid rgba(255,255,255,0.10)' }}>
+            <div className="mt-3 flex-1 min-h-0 overflow-auto rounded-[14px] p-3" style={{ border: '1px solid var(--border-default)' }}>
               {planResult?.items?.length ? (
                 <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
                   {planResult.items.map((it, idx) => (
@@ -4291,7 +4291,7 @@ export default function LlmLabTab() {
                       className="rounded-[14px] p-3 flex flex-col min-h-0"
                       style={{
                         border: '1px solid var(--border-subtle)',
-                        background: 'rgba(255, 255, 255, 0.02)',
+                        background: 'var(--list-item-bg)',
                         minHeight: 306,
                       }}
                     >
@@ -4316,8 +4316,8 @@ export default function LlmLabTab() {
                               <span
                                 className="inline-flex items-center rounded-[10px] px-2 py-1 text-[11px] font-semibold"
                                 style={{
-                                  border: '1px solid rgba(255,255,255,0.10)',
-                                  background: 'rgba(0,0,0,0.20)',
+                                  border: '1px solid var(--border-default)',
+                                  background: 'var(--nested-block-bg)',
                                   color: 'var(--text-secondary)',
                                 }}
                                 title="解析到的尺寸（单条覆盖）或回退全局尺寸"
@@ -4327,8 +4327,8 @@ export default function LlmLabTab() {
                               <span
                                 className="inline-flex items-center rounded-[10px] px-2 py-1 text-[11px] font-semibold"
                                 style={{
-                                  border: '1px solid rgba(255,255,255,0.10)',
-                                  background: 'rgba(0,0,0,0.20)',
+                                  border: '1px solid var(--border-default)',
+                                  background: 'var(--nested-block-bg)',
                                   color: 'var(--text-secondary)',
                                 }}
                                 title="从提示词/尺寸推导出的比例"
@@ -4344,8 +4344,8 @@ export default function LlmLabTab() {
                       <div
                         className="mt-2 rounded-[12px] flex flex-col items-center justify-center gap-2 px-3 text-center"
                         style={{
-                          border: '1px solid rgba(255,255,255,0.10)',
-                          background: 'rgba(255,255,255,0.02)',
+                          border: '1px solid var(--border-default)',
+                          background: 'var(--list-item-bg)',
                           height: 208,
                           color: 'var(--text-muted)',
                         }}
@@ -4367,7 +4367,7 @@ export default function LlmLabTab() {
 
                       <div className="mt-2 flex items-center justify-between gap-2">
                         <div className="inline-flex items-center rounded-[10px] px-2 py-1 text-[11px] font-semibold"
-                             style={{ border: '1px solid rgba(255,255,255,0.10)', background: 'rgba(0,0,0,0.20)', color: 'var(--text-secondary)' }}>
+                             style={{ border: '1px solid var(--border-default)', background: 'var(--nested-block-bg)', color: 'var(--text-secondary)' }}>
                           条目 #{idx + 1}
                         </div>
                         <Button
@@ -4487,7 +4487,7 @@ export default function LlmLabTab() {
                 previewJsonCheckPhase === 'failed' ? 'llm-json-scanBox--failed' : '',
                 previewJsonCheckPhase === 'passed' ? 'llm-json-scanBox--passed' : '',
               ].join(' ')}
-              style={{ border: '1px solid var(--border-subtle)', background: 'rgba(0,0,0,0.22)' }}
+              style={{ border: '1px solid var(--border-subtle)', background: 'var(--nested-block-bg)' }}
             >
               <pre className="text-xs whitespace-pre-wrap wrap-break-word" style={{ color: 'var(--text-primary)' }}>
                 {previewDialog.text || '（无输出）'}
@@ -4537,7 +4537,7 @@ export default function LlmLabTab() {
               </Button>
             </div>
 
-            <div className="flex-1 min-h-0 overflow-auto rounded-[14px] p-3" style={{ border: '1px solid rgba(255,255,255,0.10)' }}>
+            <div className="flex-1 min-h-0 overflow-auto rounded-[14px] p-3" style={{ border: '1px solid var(--border-default)' }}>
               {imagePreviewDialog.src ? (
                 <div className="w-full h-full flex items-center justify-center">
                   <img
@@ -4585,7 +4585,7 @@ export default function LlmLabTab() {
               value={createExperimentName}
               onChange={(e) => setCreateExperimentName(e.target.value)}
               className="h-10 w-full rounded-[14px] px-3 text-sm outline-none"
-              style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.12)', color: 'var(--text-primary)' }}
+              style={{ background: 'var(--bg-input)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
               placeholder="例如：默认实验"
               autoFocus
             />
@@ -4593,7 +4593,7 @@ export default function LlmLabTab() {
               <button
                 type="button"
                 className="inline-flex items-center justify-center gap-2 font-semibold transition-colors disabled:opacity-60 disabled:cursor-not-allowed h-10 px-4 rounded-[12px] text-[13px] text-(--text-primary) hover:bg-white/8 hover:border-white/20"
-                style={{ background: 'rgba(255, 255, 255, 0.02)', border: '1px solid rgba(255, 255, 255, 0.12)' }}
+                style={{ background: 'var(--list-item-bg)', border: '1px solid var(--border-default)' }}
                 onClick={() => setCreateExperimentOpen(false)}
               >
                 取消
@@ -4601,7 +4601,7 @@ export default function LlmLabTab() {
               <button
                 type="button"
                 className="inline-flex items-center justify-center gap-2 font-semibold transition-colors disabled:opacity-60 disabled:cursor-not-allowed h-10 px-4 rounded-[12px] text-[13px] text-(--text-primary) hover:bg-white/8 hover:border-white/20"
-                style={{ background: 'rgba(255, 255, 255, 0.06)', border: '1px solid rgba(255, 255, 255, 0.12)' }}
+                style={{ background: 'var(--bg-input-hover)', border: '1px solid var(--border-default)' }}
                 onClick={confirmCreateExperiment}
                 disabled={!createExperimentName.trim()}
               >
@@ -4626,7 +4626,7 @@ export default function LlmLabTab() {
               <button
                 type="button"
                 className="inline-flex items-center justify-center gap-2 font-semibold transition-colors disabled:opacity-60 disabled:cursor-not-allowed h-[30px] px-3 rounded-[10px] text-[12px] text-(--text-primary) hover:bg-white/8 hover:border-white/20 shrink-0"
-                style={{ background: 'rgba(255, 255, 255, 0.06)', border: '1px solid rgba(255, 255, 255, 0.12)' }}
+                style={{ background: 'var(--bg-input-hover)', border: '1px solid var(--border-default)' }}
                 onClick={load}
                 disabled={experimentsLoading}
               >
@@ -4639,7 +4639,7 @@ export default function LlmLabTab() {
                 暂无实验
               </div>
             ) : (
-              <div className="max-h-[420px] overflow-auto pr-1 rounded-[14px]" style={{ border: '1px solid rgba(255,255,255,0.10)' }}>
+              <div className="max-h-[420px] overflow-auto pr-1 rounded-[14px]" style={{ border: '1px solid var(--border-default)' }}>
                 <div className="p-2 grid gap-1">
                   {experiments.map((e) => (
                     <div
@@ -4665,7 +4665,7 @@ export default function LlmLabTab() {
                       <button
                         type="button"
                         className="inline-flex items-center justify-center gap-2 font-semibold transition-colors disabled:opacity-60 disabled:cursor-not-allowed h-[30px] px-3 rounded-[10px] text-[12px] text-(--text-primary) hover:bg-white/8 hover:border-white/20 shrink-0"
-                        style={{ background: 'rgba(255, 255, 255, 0.02)', border: '1px solid rgba(255, 255, 255, 0.12)' }}
+                        style={{ background: 'var(--list-item-bg)', border: '1px solid var(--border-default)' }}
                         onClick={async (evt) => {
                           evt.stopPropagation();
                           const ok = await systemDialog.confirm({
@@ -4693,7 +4693,7 @@ export default function LlmLabTab() {
               <button
                 type="button"
                 className="inline-flex items-center justify-center gap-2 font-semibold transition-colors disabled:opacity-60 disabled:cursor-not-allowed h-10 px-4 rounded-[12px] text-[13px] text-(--text-primary) hover:bg-white/8 hover:border-white/20"
-                style={{ background: 'rgba(255, 255, 255, 0.02)', border: '1px solid rgba(255, 255, 255, 0.12)' }}
+                style={{ background: 'var(--list-item-bg)', border: '1px solid var(--border-default)' }}
                 onClick={() => setLoadExperimentOpen(false)}
               >
                 取消
@@ -4701,7 +4701,7 @@ export default function LlmLabTab() {
               <button
                 type="button"
                 className="inline-flex items-center justify-center gap-2 font-semibold transition-colors disabled:opacity-60 disabled:cursor-not-allowed h-10 px-4 rounded-[12px] text-[13px] text-(--text-primary) hover:bg-white/8 hover:border-white/20"
-                style={{ background: 'rgba(255, 255, 255, 0.06)', border: '1px solid rgba(255, 255, 255, 0.12)' }}
+                style={{ background: 'var(--bg-input-hover)', border: '1px solid var(--border-default)' }}
                 onClick={confirmLoadExperiment}
                 disabled={!loadExperimentId}
               >

--- a/prd-admin/src/pages/literary-agent/ArticleIllustrationEditorPage.tsx
+++ b/prd-admin/src/pages/literary-agent/ArticleIllustrationEditorPage.tsx
@@ -95,15 +95,15 @@ const PRD_MD_STYLE = `
   .prd-md p { margin: 10px 0; }
   .prd-md ul,.prd-md ol { margin: 10px 0; padding-left: 18px; }
   .prd-md li { margin: 6px 0; }
-  .prd-md hr { border: 0; border-top: 1px solid rgba(255,255,255,0.10); margin: 14px 0; }
+  .prd-md hr { border: 0; border-top: 1px solid var(--border-default); margin: 14px 0; }
   .prd-md blockquote { margin: 12px 0; padding: 8px 12px; border-left: 3px solid rgba(231,206,151,0.35); background: rgba(231,206,151,0.06); color: rgba(231,206,151,0.92); border-radius: 10px; }
   .prd-md a { color: rgba(147, 197, 253, 0.95); text-decoration: underline; }
-  .prd-md code { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; font-size: 12px; background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.10); padding: 0 6px; border-radius: 8px; }
-  .prd-md pre { background: rgba(0,0,0,0.28); border: 1px solid rgba(255,255,255,0.10); border-radius: 14px; padding: 12px; overflow: auto; }
+  .prd-md code { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; font-size: 12px; background: var(--bg-input-hover); border: 1px solid var(--border-default); padding: 0 6px; border-radius: 8px; }
+  .prd-md pre { background: var(--nested-block-bg); border: 1px solid var(--border-default); border-radius: 14px; padding: 12px; overflow: auto; }
   .prd-md pre code { background: transparent; border: 0; padding: 0; }
   .prd-md table { width: 100%; border-collapse: collapse; margin: 12px 0; }
-  .prd-md th,.prd-md td { border: 1px solid rgba(255,255,255,0.10); padding: 7px 9px; vertical-align: top; }
-  .prd-md th { color: var(--text-primary); background: rgba(255,255,255,0.03); }
+  .prd-md th,.prd-md td { border: 1px solid var(--border-default); padding: 7px 9px; vertical-align: top; }
+  .prd-md th { color: var(--text-primary); background: var(--nested-block-bg); }
   .prd-md .prd-md-marker {
     background: rgba(245, 158, 11, 0.22);
     border: 1px solid rgba(245, 158, 11, 0.32);
@@ -2428,8 +2428,8 @@ export default function ArticleIllustrationEditorPage({ workspaceId }: { workspa
               <div
                 className={configPillBaseClass}
                 style={{
-                  background: selectedPrompt ? 'rgba(147, 197, 253, 0.08)' : 'rgba(255,255,255,0.03)',
-                  border: selectedPrompt ? '1px solid rgba(147, 197, 253, 0.15)' : '1px solid rgba(255,255,255,0.08)'
+                  background: selectedPrompt ? 'rgba(147, 197, 253, 0.08)' : 'var(--nested-block-bg)',
+                  border: selectedPrompt ? '1px solid rgba(147, 197, 253, 0.15)' : '1px solid var(--border-subtle)'
                 }}
                 onClick={() => {
                   if (selectedPrompt) handleEditPrompt(selectedPrompt);
@@ -2446,8 +2446,8 @@ export default function ArticleIllustrationEditorPage({ workspaceId }: { workspa
               <div
                 className={configPillBaseClass}
                 style={{ 
-                  background: referenceImageConfigs.find(c => c.isActive) ? 'rgba(192, 132, 252, 0.08)' : 'rgba(255,255,255,0.03)', 
-                  border: referenceImageConfigs.find(c => c.isActive) ? '1px solid rgba(192, 132, 252, 0.15)' : '1px solid rgba(255,255,255,0.08)' 
+                  background: referenceImageConfigs.find(c => c.isActive) ? 'rgba(192, 132, 252, 0.08)' : 'var(--nested-block-bg)',
+                  border: referenceImageConfigs.find(c => c.isActive) ? '1px solid rgba(192, 132, 252, 0.15)' : '1px solid var(--border-subtle)' 
                 }}
                 onClick={() => {
                   const activeRefConfig = referenceImageConfigs.find(c => c.isActive);
@@ -2469,8 +2469,8 @@ export default function ArticleIllustrationEditorPage({ workspaceId }: { workspa
               <div
                 className={configPillBaseClass}
                 style={{ 
-                  background: watermarkStatus.enabled ? 'rgba(251, 191, 36, 0.08)' : 'rgba(255,255,255,0.03)', 
-                  border: watermarkStatus.enabled ? '1px solid rgba(251, 191, 36, 0.15)' : '1px solid rgba(255,255,255,0.08)' 
+                  background: watermarkStatus.enabled ? 'rgba(251, 191, 36, 0.08)' : 'var(--nested-block-bg)',
+                  border: watermarkStatus.enabled ? '1px solid rgba(251, 191, 36, 0.15)' : '1px solid var(--border-subtle)' 
                 }}
                 onClick={() => {
                   setPendingWatermarkEdit(true);
@@ -2505,7 +2505,7 @@ export default function ArticleIllustrationEditorPage({ workspaceId }: { workspa
             <div className="flex items-center justify-between mb-2">
               <div className="flex items-center gap-2">
                 <span className="text-xs font-semibold" style={{ color: 'var(--text-primary)' }}>配图标记</span>
-                <span className="text-[10px] px-1.5 py-0.5 rounded" style={{ background: 'rgba(255,255,255,0.08)', color: 'var(--text-muted)' }}>
+                <span className="text-[10px] px-1.5 py-0.5 rounded" style={{ background: 'var(--border-subtle)', color: 'var(--text-muted)' }}>
                   {markerRunItems.filter(x => x.status === 'done').length}/{markerRunItems.length}
                 </span>
               </div>
@@ -2720,7 +2720,7 @@ export default function ArticleIllustrationEditorPage({ workspaceId }: { workspa
                                 ? 'rgba(239, 68, 68, 0.12)'
                                 : it.status === 'running' || it.status === 'parsing'
                                   ? 'rgba(250, 204, 21, 0.12)'
-                                  : 'rgba(255,255,255,0.06)',
+                                  : 'var(--bg-input-hover)',
                           border:
                             it.status === 'done'
                               ? '1px solid rgba(34, 197, 94, 0.28)'
@@ -2728,7 +2728,7 @@ export default function ArticleIllustrationEditorPage({ workspaceId }: { workspa
                                 ? '1px solid rgba(239, 68, 68, 0.28)'
                                 : it.status === 'running' || it.status === 'parsing'
                                   ? '1px solid rgba(250, 204, 21, 0.24)'
-                                  : '1px solid rgba(255,255,255,0.10)',
+                                  : '1px solid var(--border-default)',
                           color:
                             it.status === 'done'
                               ? 'rgba(34, 197, 94, 0.95)'
@@ -2756,7 +2756,7 @@ export default function ArticleIllustrationEditorPage({ workspaceId }: { workspa
                     style={{
                       height: 120,
                       background: 'rgba(0,0,0,0.18)',
-                      border: '1px solid rgba(255,255,255,0.10)',
+                      border: '1px solid var(--border-default)',
                       cursor: canShow ? 'pointer' : 'default',
                     }}
                     onClick={() => {

--- a/prd-admin/src/pages/literary-agent/ArticleIllustrationEditorPage.tsx
+++ b/prd-admin/src/pages/literary-agent/ArticleIllustrationEditorPage.tsx
@@ -2875,7 +2875,7 @@ export default function ArticleIllustrationEditorPage({ workspaceId }: { workspa
                               style={{
                                 width: previewW,
                                 height: previewH,
-                                background: 'rgba(255,255,255,0.03)',
+                                background: 'var(--nested-block-bg)',
                                 border: '1.5px dashed rgba(99, 102, 241, 0.3)',
                                 transition: 'width 0.2s, height 0.2s',
                               }}
@@ -3026,8 +3026,8 @@ export default function ArticleIllustrationEditorPage({ workspaceId }: { workspa
                         .create-prompt-md p { margin: 6px 0; }
                         .create-prompt-md ul,.create-prompt-md ol { margin: 6px 0; padding-left: 18px; }
                         .create-prompt-md li { margin: 3px 0; }
-                        .create-prompt-md code { font-family: ui-monospace, monospace; font-size: 12px; background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.10); padding: 0 4px; border-radius: 4px; }
-                        .create-prompt-md pre { background: rgba(0,0,0,0.28); border: 1px solid rgba(255,255,255,0.10); border-radius: 8px; padding: 10px; overflow: auto; margin: 6px 0; }
+                        .create-prompt-md code { font-family: ui-monospace, monospace; font-size: 12px; background: var(--bg-input-hover); border: 1px solid var(--border-default); padding: 0 4px; border-radius: 4px; }
+                        .create-prompt-md pre { background: var(--nested-block-bg); border: 1px solid var(--border-default); border-radius: 8px; padding: 10px; overflow: auto; margin: 6px 0; }
                         .create-prompt-md pre code { background: transparent; border: 0; padding: 0; }
                       `}</style>
                       <div className="create-prompt-md">
@@ -3143,8 +3143,8 @@ export default function ArticleIllustrationEditorPage({ workspaceId }: { workspa
                         .edit-prompt-md p { margin: 6px 0; }
                         .edit-prompt-md ul,.edit-prompt-md ol { margin: 6px 0; padding-left: 18px; }
                         .edit-prompt-md li { margin: 3px 0; }
-                        .edit-prompt-md code { font-family: ui-monospace, monospace; font-size: 12px; background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.10); padding: 0 4px; border-radius: 4px; }
-                        .edit-prompt-md pre { background: rgba(0,0,0,0.28); border: 1px solid rgba(255,255,255,0.10); border-radius: 8px; padding: 10px; overflow: auto; margin: 6px 0; }
+                        .edit-prompt-md code { font-family: ui-monospace, monospace; font-size: 12px; background: var(--bg-input-hover); border: 1px solid var(--border-default); padding: 0 4px; border-radius: 4px; }
+                        .edit-prompt-md pre { background: var(--nested-block-bg); border: 1px solid var(--border-default); border-radius: 8px; padding: 10px; overflow: auto; margin: 6px 0; }
                         .edit-prompt-md pre code { background: transparent; border: 0; padding: 0; }
                       `}</style>
                       <div className="edit-prompt-md">
@@ -3293,7 +3293,7 @@ export default function ArticleIllustrationEditorPage({ workspaceId }: { workspa
                               className="overflow-auto border rounded-[6px]"
                               style={{
                                 borderColor: 'var(--border-subtle)',
-                                background: 'rgba(255,255,255,0.02)',
+                                background: 'var(--list-item-bg)',
                                 height: '100px',
                               }}
                             >
@@ -3306,8 +3306,8 @@ export default function ArticleIllustrationEditorPage({ workspaceId }: { workspa
                                 .modal-prompt-md p { margin: 2px 0; white-space: pre-wrap; }
                                 .modal-prompt-md ul,.modal-prompt-md ol { margin: 2px 0; padding-left: 14px; }
                                 .modal-prompt-md li { margin: 1px 0; }
-                                .modal-prompt-md code { font-family: ui-monospace, monospace; font-size: 10px; background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.10); padding: 0 3px; border-radius: 3px; }
-                                .modal-prompt-md pre { background: rgba(0,0,0,0.28); border: 1px solid rgba(255,255,255,0.10); border-radius: 4px; padding: 4px 6px; overflow: auto; margin: 2px 0; }
+                                .modal-prompt-md code { font-family: ui-monospace, monospace; font-size: 10px; background: var(--bg-input-hover); border: 1px solid var(--border-default); padding: 0 3px; border-radius: 3px; }
+                                .modal-prompt-md pre { background: var(--nested-block-bg); border: 1px solid var(--border-default); border-radius: 4px; padding: 4px 6px; overflow: auto; margin: 2px 0; }
                                 .modal-prompt-md pre code { background: transparent; border: 0; padding: 0; }
                               `}</style>
                               <div className="modal-prompt-md">
@@ -3492,7 +3492,7 @@ export default function ArticleIllustrationEditorPage({ workspaceId }: { workspa
                                 className="overflow-auto border rounded-[6px] p-2"
                                 style={{
                                   borderColor: 'var(--border-subtle)',
-                                  background: 'rgba(255,255,255,0.02)',
+                                  background: 'var(--list-item-bg)',
                                 }}
                               >
                                 <div className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
@@ -3503,8 +3503,8 @@ export default function ArticleIllustrationEditorPage({ workspaceId }: { workspa
                               <div
                                 className="flex items-center justify-center overflow-hidden rounded-[6px]"
                                 style={{
-                                  background: 'rgba(255,255,255,0.02)',
-                                  border: '1px solid rgba(255,255,255,0.08)',
+                                  background: 'var(--list-item-bg)',
+                                  border: '1px solid var(--border-subtle)',
                                   cursor: config.imageUrl ? 'zoom-in' : 'default',
                                 }}
                                 onClick={() => config.imageUrl && setEnlargedRefImageUrl(config.imageUrl)}
@@ -3893,7 +3893,7 @@ export default function ArticleIllustrationEditorPage({ workspaceId }: { workspa
                   <div
                     className="flex-1 rounded-lg overflow-hidden relative group cursor-pointer"
                     style={{
-                      background: editingRefConfig.imageUrl ? 'transparent' : 'rgba(255,255,255,0.02)',
+                      background: editingRefConfig.imageUrl ? 'transparent' : 'var(--list-item-bg)',
                       border: editingRefConfig.imageUrl ? 'none' : '1px dashed var(--border-subtle)',
                       minHeight: '200px',
                     }}

--- a/prd-admin/src/pages/literary-agent/ConfigManagementDialog.tsx
+++ b/prd-admin/src/pages/literary-agent/ConfigManagementDialog.tsx
@@ -457,7 +457,7 @@ export const ConfigManagementDialog = forwardRef<ConfigManagementDialogHandle, C
                       <div className="px-2 pb-1 flex-1 min-h-0 overflow-hidden">
                         <div
                           className="h-full overflow-auto border rounded-[6px]"
-                          style={{ borderColor: 'var(--border-subtle)', background: 'rgba(255,255,255,0.02)', minHeight: '80px', maxHeight: '120px' }}
+                          style={{ borderColor: 'var(--border-subtle)', background: 'var(--list-item-bg)', minHeight: '80px', maxHeight: '120px' }}
                         >
                           <style>{`
                             .modal-prompt-md { font-size: 11px; line-height: 1.5; color: var(--text-secondary); padding: 8px; }
@@ -543,7 +543,7 @@ export const ConfigManagementDialog = forwardRef<ConfigManagementDialogHandle, C
               <div className="px-2 pb-1">
                 <div
                   className="overflow-hidden border rounded-[6px] p-2"
-                  style={{ borderColor: 'var(--border-subtle)', background: 'rgba(255,255,255,0.02)', maxHeight: '80px' }}
+                  style={{ borderColor: 'var(--border-subtle)', background: 'var(--list-item-bg)', maxHeight: '80px' }}
                 >
                   <div className="text-[11px] line-clamp-3" style={{ color: 'var(--text-muted)' }}>
                     {prompt.content || '（内容为空）'}
@@ -631,7 +631,7 @@ export const ConfigManagementDialog = forwardRef<ConfigManagementDialogHandle, C
                         <div className="grid gap-2" style={{ gridTemplateColumns: 'minmax(0, 1fr) 80px' }}>
                           <div
                             className="overflow-auto border rounded-[6px] p-2"
-                            style={{ borderColor: 'var(--border-subtle)', background: 'rgba(255,255,255,0.02)', minHeight: '60px', maxHeight: '80px' }}
+                            style={{ borderColor: 'var(--border-subtle)', background: 'var(--list-item-bg)', minHeight: '60px', maxHeight: '80px' }}
                           >
                             <div className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
                               {config.prompt || '（无提示词）'}
@@ -642,8 +642,8 @@ export const ConfigManagementDialog = forwardRef<ConfigManagementDialogHandle, C
                             style={{
                               background: config.imageUrl
                                 ? 'repeating-conic-gradient(#3a3a3a 0% 25%, #2a2a2a 0% 50%) 50% / 12px 12px'
-                                : 'rgba(255,255,255,0.02)',
-                              border: config.imageUrl ? 'none' : '1px solid rgba(255,255,255,0.08)',
+                                : 'var(--list-item-bg)',
+                              border: config.imageUrl ? 'none' : '1px solid var(--border-subtle)',
                               minHeight: '60px',
                               maxHeight: '80px',
                             }}
@@ -727,7 +727,7 @@ export const ConfigManagementDialog = forwardRef<ConfigManagementDialogHandle, C
                   style={{
                     background: config.imageUrl
                       ? 'repeating-conic-gradient(#3a3a3a 0% 25%, #2a2a2a 0% 50%) 50% / 12px 12px'
-                      : 'rgba(255,255,255,0.02)',
+                      : 'var(--list-item-bg)',
                     height: '80px',
                   }}
                 >

--- a/prd-admin/src/pages/literary-agent/LiteraryAgentWorkspaceListPage.tsx
+++ b/prd-admin/src/pages/literary-agent/LiteraryAgentWorkspaceListPage.tsx
@@ -68,7 +68,7 @@ function ArticlePreview({ markdown }: { markdown: string }) {
           .literary-preview-md ul,.literary-preview-md ol { margin: 2px 0; padding-left: 12px; }
           .literary-preview-md li { margin: 1px 0; }
           .literary-preview-md blockquote { margin: 2px 0; padding: 2px 6px; border-left: 2px solid rgba(231,206,151,0.35); background: rgba(231,206,151,0.06); border-radius: 4px; }
-          .literary-preview-md code { font-size: 9px; background: rgba(255,255,255,0.06); padding: 0 3px; border-radius: 3px; }
+          .literary-preview-md code { font-size: 9px; background: var(--bg-input-hover); padding: 0 3px; border-radius: 3px; }
         `}</style>
         <div className="literary-preview-md">
           <ReactMarkdown
@@ -425,7 +425,7 @@ export default function LiteraryAgentWorkspaceListPage() {
         <div className="px-2 pb-2 flex-1 min-h-0 overflow-hidden">
           <div
             className="h-full overflow-hidden border rounded-[5px] text-[12px] md:text-[10px] flex flex-col"
-            style={{ borderColor: 'var(--border-subtle)', background: 'rgba(255,255,255,0.02)' }}
+            style={{ borderColor: 'var(--border-subtle)', background: 'var(--list-item-bg)' }}
           >
             <div className="p-1.5 flex-1 overflow-hidden">
               <ArticlePreview markdown={getArticlePreviewText(ws)} />

--- a/prd-admin/src/pages/open-platform/AppsPanel.tsx
+++ b/prd-admin/src/pages/open-platform/AppsPanel.tsx
@@ -296,7 +296,7 @@ export default function AppsPanel({ onActionsReady }: AppsPanelProps) {
     <div className="h-full overflow-hidden p-1">
       <GlassCard glow className="h-full flex flex-col">
         {/* ============ 顶部统计栏 ============ */}
-        <div className="p-4 border-b border-white/10 flex-shrink-0" style={{ background: 'rgba(255,255,255,0.02)' }}>
+        <div className="p-4 border-b border-white/10 flex-shrink-0" style={{ background: 'var(--list-item-bg)' }}>
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center gap-3">
               <Key size={18} className="text-muted-foreground" />
@@ -309,7 +309,7 @@ export default function AppsPanel({ onActionsReady }: AppsPanelProps) {
 
           {/* 统计卡片 - 横向排列 */}
           <div className="grid grid-cols-4 gap-3">
-            <div className="p-3 rounded-lg flex items-center gap-3" style={{ background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.06)' }}>
+            <div className="p-3 rounded-lg flex items-center gap-3" style={{ background: 'var(--nested-block-bg)', border: '1px solid var(--nested-block-border)' }}>
               <div className="w-9 h-9 rounded-lg flex items-center justify-center" style={{ background: 'rgba(59,130,246,0.1)' }}>
                 <Layers size={16} className="text-blue-400" />
               </div>
@@ -319,7 +319,7 @@ export default function AppsPanel({ onActionsReady }: AppsPanelProps) {
               </div>
             </div>
 
-            <div className="p-3 rounded-lg flex items-center gap-3" style={{ background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.06)' }}>
+            <div className="p-3 rounded-lg flex items-center gap-3" style={{ background: 'var(--nested-block-bg)', border: '1px solid var(--nested-block-border)' }}>
               <div className="w-9 h-9 rounded-lg flex items-center justify-center" style={{ background: 'rgba(34,197,94,0.1)' }}>
                 <Activity size={16} className="text-green-400" />
               </div>
@@ -329,7 +329,7 @@ export default function AppsPanel({ onActionsReady }: AppsPanelProps) {
               </div>
             </div>
 
-            <div className="p-3 rounded-lg flex items-center gap-3" style={{ background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.06)' }}>
+            <div className="p-3 rounded-lg flex items-center gap-3" style={{ background: 'var(--nested-block-bg)', border: '1px solid var(--nested-block-border)' }}>
               <div className="w-9 h-9 rounded-lg flex items-center justify-center" style={{ background: 'rgba(251,191,36,0.1)' }}>
                 <Zap size={16} className="text-amber-400" />
               </div>
@@ -339,7 +339,7 @@ export default function AppsPanel({ onActionsReady }: AppsPanelProps) {
               </div>
             </div>
 
-            <div className="p-3 rounded-lg flex items-center gap-3" style={{ background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.06)' }}>
+            <div className="p-3 rounded-lg flex items-center gap-3" style={{ background: 'var(--nested-block-bg)', border: '1px solid var(--nested-block-border)' }}>
               <div className="w-9 h-9 rounded-lg flex items-center justify-center" style={{ background: 'rgba(168,85,247,0.1)' }}>
                 <TrendingUp size={16} className="text-purple-400" />
               </div>
@@ -383,7 +383,7 @@ export default function AppsPanel({ onActionsReady }: AppsPanelProps) {
                     value={search}
                     onChange={(e) => setSearch(e.target.value)}
                     className="h-8 pl-8 pr-3 text-sm rounded-lg outline-none"
-                    style={{ background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.1)', width: '160px' }}
+                    style={{ background: 'var(--bg-card-hover)', border: '1px solid var(--border-default)', width: '160px' }}
                   />
                 </div>
                 <Button variant="secondary" size="sm" onClick={() => setCreateDialogOpen(true)} className="whitespace-nowrap">
@@ -405,7 +405,7 @@ export default function AppsPanel({ onActionsReady }: AppsPanelProps) {
                     <div
                       key={app.id}
                       className={`flex items-center gap-3 p-3 rounded-lg transition-colors hover:bg-white/[0.03] ${selectedIds.has(app.id) ? 'bg-blue-500/10' : ''}`}
-                      style={{ border: selectedIds.has(app.id) ? '1px solid rgba(59,130,246,0.3)' : '1px solid rgba(255,255,255,0.06)' }}
+                      style={{ border: selectedIds.has(app.id) ? '1px solid rgba(59,130,246,0.3)' : '1px solid var(--nested-block-border)' }}
                     >
                       {/* 选择框 */}
                       <button
@@ -438,7 +438,7 @@ export default function AppsPanel({ onActionsReady }: AppsPanelProps) {
 
                       {/* 密钥信息 */}
                       <div className="flex-shrink-0 text-right">
-                        <code className="text-xs px-2 py-0.5 rounded" style={{ background: 'rgba(255,255,255,0.05)' }}>
+                        <code className="text-xs px-2 py-0.5 rounded" style={{ background: 'var(--bg-card-hover)' }}>
                           {app.apiKeyMasked}
                         </code>
                         <div className="text-[10px] text-muted-foreground mt-0.5">
@@ -529,7 +529,7 @@ export default function AppsPanel({ onActionsReady }: AppsPanelProps) {
               {endpointStats.map((ep, idx) => {
                 const Icon = ep.icon;
                 return (
-                  <div key={idx} className="p-3 rounded-lg" style={{ background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.06)' }}>
+                  <div key={idx} className="p-3 rounded-lg" style={{ background: 'var(--nested-block-bg)', border: '1px solid var(--nested-block-border)' }}>
                     <div className="flex items-center gap-2 mb-2">
                       <div className="w-7 h-7 rounded flex items-center justify-center" style={{ background: colorMap[ep.color] }}>
                         <Icon size={14} className={textColorMap[ep.color]} />
@@ -540,15 +540,15 @@ export default function AppsPanel({ onActionsReady }: AppsPanelProps) {
                       </div>
                     </div>
                     <div className="grid grid-cols-3 gap-2 text-center">
-                      <div className="p-1.5 rounded" style={{ background: 'rgba(255,255,255,0.03)' }}>
+                      <div className="p-1.5 rounded" style={{ background: 'var(--nested-block-bg)' }}>
                         <div className="text-sm font-semibold">{ep.today.toLocaleString()}</div>
                         <div className="text-[10px] text-muted-foreground">今日请求</div>
                       </div>
-                      <div className="p-1.5 rounded" style={{ background: 'rgba(255,255,255,0.03)' }}>
+                      <div className="p-1.5 rounded" style={{ background: 'var(--nested-block-bg)' }}>
                         <div className="text-sm font-semibold text-green-400">{ep.success}%</div>
                         <div className="text-[10px] text-muted-foreground">成功率</div>
                       </div>
-                      <div className="p-1.5 rounded" style={{ background: 'rgba(255,255,255,0.03)' }}>
+                      <div className="p-1.5 rounded" style={{ background: 'var(--nested-block-bg)' }}>
                         <div className="text-sm font-semibold">{ep.latency}s</div>
                         <div className="text-[10px] text-muted-foreground">平均延迟</div>
                       </div>
@@ -564,7 +564,7 @@ export default function AppsPanel({ onActionsReady }: AppsPanelProps) {
               <button
                 onClick={showCurlCommand}
                 className="w-full p-2.5 rounded-lg text-left text-sm hover:bg-white/5 transition-colors flex items-center gap-2"
-                style={{ border: '1px solid rgba(255,255,255,0.06)' }}
+                style={{ border: '1px solid var(--nested-block-border)' }}
               >
                 <Code size={14} className="text-muted-foreground" />
                 <span>查看 curl 调用示例</span>
@@ -572,7 +572,7 @@ export default function AppsPanel({ onActionsReady }: AppsPanelProps) {
               <a
                 href="#"
                 className="w-full p-2.5 rounded-lg text-left text-sm hover:bg-white/5 transition-colors flex items-center gap-2 block"
-                style={{ border: '1px solid rgba(255,255,255,0.06)' }}
+                style={{ border: '1px solid var(--nested-block-border)' }}
               >
                 <ExternalLink size={14} className="text-muted-foreground" />
                 <span>查看 API 文档</span>
@@ -750,7 +750,7 @@ function CreateAppDialog({ open, onClose, onCreate }: { open: boolean; onClose: 
                   <Tooltip.Portal>
                     <Tooltip.Content
                       className="px-3 py-2 text-xs rounded-lg max-w-xs"
-                      style={{ background: 'rgba(0,0,0,0.9)', border: '1px solid rgba(255,255,255,0.1)' }}
+                      style={{ background: 'rgba(0,0,0,0.9)', border: '1px solid var(--border-default)' }}
                       sideOffset={5}
                     >
                       忽略 API 请求中的 system message
@@ -897,7 +897,7 @@ function ApiKeyDialog({ open, onClose, apiKey }: { open: boolean; onClose: () =>
           <div className="flex gap-2">
             <code
               className="flex-1 px-3 py-2 rounded-lg text-sm break-all font-mono"
-              style={{ background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.1)' }}
+              style={{ background: 'var(--bg-card-hover)', border: '1px solid var(--border-default)' }}
             >
               {apiKey}
             </code>
@@ -951,7 +951,7 @@ function CurlCommandDialog({ open, onClose, curlCommand }: { open: boolean; onCl
 
           <pre
             className="p-4 rounded-lg text-xs overflow-x-auto font-mono"
-            style={{ background: 'rgba(0,0,0,0.3)', border: '1px solid rgba(255,255,255,0.08)' }}
+            style={{ background: 'var(--nested-block-bg)', border: '1px solid var(--border-subtle)' }}
           >
             <code>{curlCommand}</code>
           </pre>

--- a/prd-admin/src/pages/open-platform/BindingPanel.tsx
+++ b/prd-admin/src/pages/open-platform/BindingPanel.tsx
@@ -106,7 +106,7 @@ export default function BindingPanel({ onActionsReady }: BindingPanelProps) {
     <div className="h-full overflow-auto p-1">
       <GlassCard glow className="min-h-full">
         {/* 顶部提示栏 */}
-        <div className="p-4 border-b border-white/10" style={{ background: 'rgba(255,255,255,0.02)' }}>
+        <div className="p-4 border-b border-white/10" style={{ background: 'var(--list-item-bg)' }}>
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
               <Users size={18} className="text-muted-foreground" />
@@ -147,7 +147,7 @@ export default function BindingPanel({ onActionsReady }: BindingPanelProps) {
                   <div
                     key={mapping.id}
                     className="flex items-center justify-between p-4 rounded-lg transition-colors hover:bg-white/[0.03]"
-                    style={{ border: '1px solid rgba(255,255,255,0.06)' }}
+                    style={{ border: '1px solid var(--nested-block-border)' }}
                   >
                     <div className="flex items-center gap-4">
                       <div

--- a/prd-admin/src/pages/open-platform/ChannelsPanel.tsx
+++ b/prd-admin/src/pages/open-platform/ChannelsPanel.tsx
@@ -122,7 +122,7 @@ export default function ChannelsPanel({ onActionsReady }: ChannelsPanelProps) {
     <div className="h-full overflow-auto p-1">
       <GlassCard glow className="min-h-full">
         {/* 顶部提示栏 */}
-        <div className="p-4 border-b border-white/10" style={{ background: 'rgba(255,255,255,0.02)' }}>
+        <div className="p-4 border-b border-white/10" style={{ background: 'var(--list-item-bg)' }}>
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
               <Webhook size={18} className="text-muted-foreground" />
@@ -141,8 +141,8 @@ export default function ChannelsPanel({ onActionsReady }: ChannelsPanelProps) {
               <div
                 className="p-4 rounded-lg"
                 style={{
-                  background: webhookStats.isEnabled ? 'rgba(34,197,94,0.06)' : 'rgba(255,255,255,0.02)',
-                  border: webhookStats.isEnabled ? '1px solid rgba(34,197,94,0.2)' : '1px solid rgba(255,255,255,0.06)',
+                  background: webhookStats.isEnabled ? 'rgba(34,197,94,0.06)' : 'var(--list-item-bg)',
+                  border: webhookStats.isEnabled ? '1px solid rgba(34,197,94,0.2)' : '1px solid var(--nested-block-border)',
                 }}
               >
                 <div className="flex items-center justify-between">
@@ -150,7 +150,7 @@ export default function ChannelsPanel({ onActionsReady }: ChannelsPanelProps) {
                     <div
                       className="w-12 h-12 rounded-lg flex items-center justify-center"
                       style={{
-                        background: webhookStats.isEnabled ? 'rgba(34,197,94,0.15)' : 'rgba(255,255,255,0.05)',
+                        background: webhookStats.isEnabled ? 'rgba(34,197,94,0.15)' : 'var(--bg-card-hover)',
                         color: webhookStats.isEnabled ? 'rgb(34,197,94)' : 'var(--text-muted)',
                       }}
                     >
@@ -190,7 +190,7 @@ export default function ChannelsPanel({ onActionsReady }: ChannelsPanelProps) {
                     value={search}
                     onChange={(e) => setSearch(e.target.value)}
                     className="h-8 pl-8 pr-3 text-sm rounded-lg outline-none"
-                    style={{ background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.1)', width: '160px' }}
+                    style={{ background: 'var(--bg-card-hover)', border: '1px solid var(--border-default)', width: '160px' }}
                   />
                 </div>
                 <Button variant="secondary" size="sm" onClick={() => setCreateDialogOpen(true)} className="whitespace-nowrap flex-shrink-0">
@@ -211,12 +211,12 @@ export default function ChannelsPanel({ onActionsReady }: ChannelsPanelProps) {
                   <div
                     key={wl.id}
                     className="flex items-center justify-between p-4 rounded-lg transition-colors hover:bg-white/[0.03]"
-                    style={{ border: '1px solid rgba(255,255,255,0.06)' }}
+                    style={{ border: '1px solid var(--nested-block-border)' }}
                   >
                     <div className="flex items-center gap-4 flex-1 min-w-0">
                       <div
                         className="w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0"
-                        style={{ background: 'rgba(255,255,255,0.05)' }}
+                        style={{ background: 'var(--bg-card-hover)' }}
                       >
                         <Webhook size={16} />
                       </div>

--- a/prd-admin/src/pages/open-platform/EmailChannelPanel.tsx
+++ b/prd-admin/src/pages/open-platform/EmailChannelPanel.tsx
@@ -369,7 +369,7 @@ export default function EmailChannelPanel({ onActionsReady }: EmailChannelPanelP
               ) : (
                 <div className="space-y-2">
                   {workflows.map((wf) => (
-                    <div key={wf.id} className="flex items-center justify-between p-3 rounded-lg" style={{ border: '1px solid rgba(255,255,255,0.06)' }}>
+                    <div key={wf.id} className="flex items-center justify-between p-3 rounded-lg" style={{ border: '1px solid var(--nested-block-border)' }}>
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2">
                           <span className="font-medium text-sm">{wf.displayName}</span>
@@ -483,7 +483,7 @@ export default function EmailChannelPanel({ onActionsReady }: EmailChannelPanelP
               ) : (
                 <div className="space-y-2">
                   {mappings.map((m) => (
-                    <div key={m.id} className="flex items-center justify-between p-3 rounded-lg" style={{ border: '1px solid rgba(255,255,255,0.06)' }}>
+                    <div key={m.id} className="flex items-center justify-between p-3 rounded-lg" style={{ border: '1px solid var(--nested-block-border)' }}>
                       <div className="flex items-center gap-3">
                         <div className="w-8 h-8 rounded-lg flex items-center justify-center" style={{ background: 'rgba(59,130,246,0.1)' }}>
                           <Mail size={14} className="text-blue-400" />

--- a/prd-admin/src/pages/open-platform/LogsPanel.tsx
+++ b/prd-admin/src/pages/open-platform/LogsPanel.tsx
@@ -87,7 +87,7 @@ export default function LogsPanel({ onActionsReady }: LogsPanelProps) {
     <div className="h-full overflow-auto p-1">
       <GlassCard glow className="min-h-full">
         {/* 顶部提示栏 */}
-        <div className="p-4 border-b border-white/10" style={{ background: 'rgba(255,255,255,0.02)' }}>
+        <div className="p-4 border-b border-white/10" style={{ background: 'var(--list-item-bg)' }}>
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
               <FileText size={18} className="text-muted-foreground" />
@@ -111,7 +111,7 @@ export default function LogsPanel({ onActionsReady }: LogsPanelProps) {
                     type="text"
                     placeholder="搜索..."
                     className="h-8 pl-8 pr-3 text-sm rounded-lg outline-none"
-                    style={{ background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.1)', width: '140px' }}
+                    style={{ background: 'var(--bg-card-hover)', border: '1px solid var(--border-default)', width: '140px' }}
                     disabled
                   />
                 </div>
@@ -178,7 +178,7 @@ export default function LogsPanel({ onActionsReady }: LogsPanelProps) {
                         </div>
 
                         {/* 请求 ID */}
-                        <code className="text-xs text-muted-foreground px-2 py-1 rounded flex-shrink-0" style={{ background: 'rgba(0,0,0,0.2)' }}>
+                        <code className="text-xs text-muted-foreground px-2 py-1 rounded flex-shrink-0" style={{ background: 'var(--nested-block-bg)' }}>
                           {log.requestId.slice(-12)}
                         </code>
                       </div>
@@ -315,14 +315,14 @@ export default function LogsPanel({ onActionsReady }: LogsPanelProps) {
                 <div className="grid grid-cols-2 gap-4">
                   <div
                     className="p-3 rounded-lg"
-                    style={{ background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.08)' }}
+                    style={{ background: 'var(--nested-block-bg)', border: '1px solid var(--border-subtle)' }}
                   >
                     <div className="text-xs text-muted-foreground mb-1">开始时间</div>
                     <div className="text-sm font-medium">{fmtDate(selectedLog.startedAt)}</div>
                   </div>
                   <div
                     className="p-3 rounded-lg"
-                    style={{ background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.08)' }}
+                    style={{ background: 'var(--nested-block-bg)', border: '1px solid var(--border-subtle)' }}
                   >
                     <div className="text-xs text-muted-foreground mb-1">结束时间</div>
                     <div className="text-sm font-medium">{fmtDate(selectedLog.endedAt)}</div>

--- a/prd-admin/src/pages/open-platform/TasksPanel.tsx
+++ b/prd-admin/src/pages/open-platform/TasksPanel.tsx
@@ -131,7 +131,7 @@ export default function TasksPanel({ onActionsReady }: TasksPanelProps) {
     <div className="h-full overflow-auto p-1">
       <GlassCard glow className="min-h-full">
         {/* 顶部提示栏 */}
-        <div className="p-4 border-b border-white/10" style={{ background: 'rgba(255,255,255,0.02)' }}>
+        <div className="p-4 border-b border-white/10" style={{ background: 'var(--list-item-bg)' }}>
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
               <ListTodo size={18} className="text-muted-foreground" />
@@ -153,7 +153,7 @@ export default function TasksPanel({ onActionsReady }: TasksPanelProps) {
               <div className="grid grid-cols-5 gap-3">
                 <div
                   className="p-3 rounded-lg text-center"
-                  style={{ background: 'rgba(255,255,255,0.02)', border: '1px solid rgba(255,255,255,0.06)' }}
+                  style={{ background: 'var(--list-item-bg)', border: '1px solid var(--nested-block-border)' }}
                 >
                   <div className="text-2xl font-bold">{stats.todayTotal}</div>
                   <div className="text-xs text-muted-foreground mt-1">今日任务</div>
@@ -205,7 +205,7 @@ export default function TasksPanel({ onActionsReady }: TasksPanelProps) {
                     value={search}
                     onChange={(e) => setSearch(e.target.value)}
                     className="h-8 pl-8 pr-3 text-sm rounded-lg outline-none"
-                    style={{ background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.1)', width: '160px' }}
+                    style={{ background: 'var(--bg-card-hover)', border: '1px solid var(--border-default)', width: '160px' }}
                   />
                 </div>
                 <Select value={channelTypeFilter} onChange={(e) => setChannelTypeFilter(e.target.value)} uiSize="sm">
@@ -236,7 +236,7 @@ export default function TasksPanel({ onActionsReady }: TasksPanelProps) {
                     className="p-4 rounded-lg transition-colors hover:bg-white/[0.03] cursor-pointer"
                     style={{
                       background: statusBgColors[task.status] || 'transparent',
-                      border: `1px solid ${statusBorderColors[task.status] || 'rgba(255,255,255,0.06)'}`,
+                      border: `1px solid ${statusBorderColors[task.status] || 'var(--nested-block-border)'}`,
                     }}
                     onClick={() => openDetail(task)}
                   >
@@ -245,7 +245,7 @@ export default function TasksPanel({ onActionsReady }: TasksPanelProps) {
                         {/* 通道图标 */}
                         <div
                           className="w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0"
-                          style={{ background: 'rgba(255,255,255,0.05)' }}
+                          style={{ background: 'var(--bg-card-hover)' }}
                         >
                           {channelIcons[task.channelType] || <Webhook size={16} />}
                         </div>
@@ -274,7 +274,7 @@ export default function TasksPanel({ onActionsReady }: TasksPanelProps) {
                         </div>
 
                         {/* 任务 ID */}
-                        <code className="text-xs text-muted-foreground px-2 py-1 rounded flex-shrink-0" style={{ background: 'rgba(0,0,0,0.2)' }}>
+                        <code className="text-xs text-muted-foreground px-2 py-1 rounded flex-shrink-0" style={{ background: 'var(--nested-block-bg)' }}>
                           {task.id.slice(-12)}
                         </code>
                       </div>

--- a/prd-admin/src/pages/open-platform/WebhookConfigDialog.tsx
+++ b/prd-admin/src/pages/open-platform/WebhookConfigDialog.tsx
@@ -250,7 +250,7 @@ export function WebhookConfigDialog({ open, onClose, app }: WebhookConfigDialogP
             {/* 请求结构说明 */}
             <div
               className="p-3 rounded-lg text-xs space-y-2"
-              style={{ background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.06)' }}
+              style={{ background: 'var(--nested-block-bg)', border: '1px solid var(--nested-block-border)' }}
             >
               <p className="font-medium text-muted-foreground">Webhook请求结构</p>
               <pre className="text-[11px] text-muted-foreground whitespace-pre-wrap font-mono leading-relaxed">
@@ -322,7 +322,7 @@ export function WebhookConfigDialog({ open, onClose, app }: WebhookConfigDialogP
                     <span>已使用 {(config.tokensUsed ?? 0).toLocaleString()} / {tokenQuotaLimit.toLocaleString()} tokens</span>
                     <span>{usedPercent.toFixed(1)}%</span>
                   </div>
-                  <div className="h-2 rounded-full overflow-hidden" style={{ background: 'rgba(255,255,255,0.06)' }}>
+                  <div className="h-2 rounded-full overflow-hidden" style={{ background: 'var(--bg-input-hover)' }}>
                     <div
                       className="h-full rounded-full transition-all"
                       style={{
@@ -365,8 +365,8 @@ export function WebhookConfigDialog({ open, onClose, app }: WebhookConfigDialogP
                       onClick={() => setNotifyTarget(opt.value)}
                       className="px-3 py-1.5 rounded-lg text-xs border transition-colors"
                       style={{
-                        background: notifyTarget === opt.value ? 'rgba(59,130,246,0.15)' : 'rgba(255,255,255,0.03)',
-                        borderColor: notifyTarget === opt.value ? 'rgba(59,130,246,0.4)' : 'rgba(255,255,255,0.08)',
+                        background: notifyTarget === opt.value ? 'rgba(59,130,246,0.15)' : 'var(--nested-block-bg)',
+                        borderColor: notifyTarget === opt.value ? 'rgba(59,130,246,0.4)' : 'var(--border-subtle)',
                         color: notifyTarget === opt.value ? 'rgb(147,197,253)' : undefined,
                       }}
                     >
@@ -426,7 +426,7 @@ export function WebhookConfigDialog({ open, onClose, app }: WebhookConfigDialogP
                       <div
                         key={log.id}
                         className="flex items-center justify-between px-2.5 py-1.5 rounded-lg text-xs"
-                        style={{ background: 'rgba(255,255,255,0.02)' }}
+                        style={{ background: 'var(--list-item-bg)' }}
                       >
                         <div className="flex items-center gap-2">
                           {log.success ? (

--- a/prd-admin/src/pages/open-platform/WorkflowsPanel.tsx
+++ b/prd-admin/src/pages/open-platform/WorkflowsPanel.tsx
@@ -156,7 +156,7 @@ export default function WorkflowsPanel({ onActionsReady }: WorkflowsPanelProps) 
     <div className="h-full overflow-auto p-1">
       <GlassCard glow className="min-h-full">
         {/* 顶部提示栏 */}
-        <div className="p-4 border-b border-white/10" style={{ background: 'rgba(255,255,255,0.02)' }}>
+        <div className="p-4 border-b border-white/10" style={{ background: 'var(--list-item-bg)' }}>
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
               <FileText size={18} className="text-muted-foreground" />
@@ -196,7 +196,7 @@ export default function WorkflowsPanel({ onActionsReady }: WorkflowsPanelProps) 
                     <Tooltip.Portal>
                       <Tooltip.Content
                         className="px-3 py-2 text-sm rounded-lg max-w-xs"
-                        style={{ background: 'rgba(0,0,0,0.9)', border: '1px solid rgba(255,255,255,0.1)' }}
+                        style={{ background: 'rgba(0,0,0,0.9)', border: '1px solid var(--border-default)' }}
                         sideOffset={5}
                       >
                         配置不同的邮箱前缀，发送到对应地址的邮件会触发相应的处理流程
@@ -223,7 +223,7 @@ export default function WorkflowsPanel({ onActionsReady }: WorkflowsPanelProps) 
                   <div
                     key={wf.id}
                     className="flex items-center justify-between p-4 rounded-lg transition-colors hover:bg-white/[0.03]"
-                    style={{ border: '1px solid rgba(255,255,255,0.06)' }}
+                    style={{ border: '1px solid var(--nested-block-border)' }}
                   >
                     <div className="flex items-center gap-4 flex-1 min-w-0">
                       <div className="flex-1 min-w-0">

--- a/prd-admin/src/pages/system-logs/SystemLogsTab.tsx
+++ b/prd-admin/src/pages/system-logs/SystemLogsTab.tsx
@@ -279,7 +279,7 @@ export default function SystemLogsTab() {
 
   const inputStyle: React.CSSProperties = {
     background: 'var(--bg-input)',
-    border: '1px solid rgba(255,255,255,0.12)',
+    border: '1px solid var(--border-default)',
     color: 'var(--text-primary)',
   };
 
@@ -480,7 +480,7 @@ export default function SystemLogsTab() {
                     fadingOutIds.has(it.id) ? 'animate-fade-out' : ''
                   }`}
                   style={{
-                    background: 'rgba(255,255,255,0.05)',
+                    background: 'var(--bg-card-hover)',
                     border: '1px solid rgba(59, 130, 246, 0.2)',
                     animation: fadingOutIds.has(it.id) ? 'fadeOut 0.5s ease-out forwards' : undefined,
                   }}
@@ -686,7 +686,7 @@ export default function SystemLogsTab() {
                   </div>
                   <div
                     style={{
-                      background: 'rgba(0,0,0,0.2)',
+                      background: 'var(--nested-block-bg)',
                       border: '1px solid var(--border-subtle)',
                       borderRadius: 12,
                       padding: 12,
@@ -712,7 +712,7 @@ export default function SystemLogsTab() {
                           <div
                             key={llm.id}
                             className="flex items-center gap-3 text-xs p-2 rounded-lg"
-                            style={{ background: 'rgba(255,255,255,0.05)' }}
+                            style={{ background: 'var(--bg-card-hover)' }}
                           >
                             <Badge
                               variant={llm.status === 'succeeded' ? 'success' : llm.status === 'failed' ? 'subtle' : 'new'}

--- a/prd-admin/src/pages/visual-agent/VisualAgentWorkspaceListPage.tsx
+++ b/prd-admin/src/pages/visual-agent/VisualAgentWorkspaceListPage.tsx
@@ -343,7 +343,7 @@ function CoverMosaic(props: { title: string; assets: VisualAgentWorkspace['cover
         className="h-full w-full"
         style={{
           ...p.style,
-          background: 'rgba(255,255,255,0.03)',
+          background: 'var(--nested-block-bg)',
         }}
       />
     );
@@ -439,7 +439,7 @@ function ToolbarButton(props: {
           style={{
             background: 'rgba(30, 30, 35, 0.95)',
             color: '#fff',
-            border: '1px solid rgba(255,255,255,0.1)',
+            border: '1px solid var(--border-default)',
             boxShadow: '0 4px 12px rgba(0,0,0,0.3)',
           }}
         >
@@ -688,7 +688,7 @@ function QuickInputBox(props: {
                   borderRadius: 4,
                   overflow: 'hidden',
                   border: '1px solid rgba(255,255,255,0.22)',
-                  background: 'rgba(255,255,255,0.02)',
+                  background: 'var(--list-item-bg)',
                   color: 'rgba(255,255,255,0.82)',
                 }}
                 title={`参考图：${selectedImage.file.name}`}
@@ -725,7 +725,7 @@ function QuickInputBox(props: {
                     borderRadius: 3,
                     overflow: 'hidden',
                     border: '1px solid rgba(255,255,255,0.22)',
-                    background: 'rgba(255,255,255,0.06)',
+                    background: 'var(--bg-input-hover)',
                     display: 'inline-flex',
                     flex: '0 0 auto',
                   }}
@@ -795,7 +795,7 @@ function QuickInputBox(props: {
                           borderRadius: 4,
                           overflow: 'hidden',
                           border: '1px solid rgba(255,255,255,0.22)',
-                          background: 'rgba(255,255,255,0.02)',
+                          background: 'var(--list-item-bg)',
                           color: 'rgba(255,255,255,0.82)',
                         }}
                         title="选择档位"
@@ -872,7 +872,7 @@ function QuickInputBox(props: {
                           borderRadius: 4,
                           overflow: 'hidden',
                           border: '1px solid rgba(255,255,255,0.22)',
-                          background: 'rgba(255,255,255,0.02)',
+                          background: 'var(--list-item-bg)',
                           color: 'rgba(255,255,255,0.82)',
                         }}
                         title="选择比例"
@@ -1024,9 +1024,9 @@ function QuickInputBox(props: {
               onClick={openDefectDialog}
               className="h-9 w-9 rounded-xl flex items-center justify-center transition-all duration-200 hover:bg-white/10"
               style={{
-                background: 'rgba(255,255,255,0.06)',
+                background: 'var(--bg-input-hover)',
                 color: 'rgba(255,255,255,0.5)',
-                border: '1px solid rgba(255,255,255,0.08)',
+                border: '1px solid var(--border-subtle)',
               }}
               title="提交缺陷 (Cmd/Ctrl+B)"
             >
@@ -1040,7 +1040,7 @@ function QuickInputBox(props: {
               style={{
                 background: canSubmit
                   ? 'linear-gradient(135deg, rgba(218,175,75,0.95) 0%, rgba(195,155,65,0.95) 100%)'
-                  : 'rgba(255,255,255,0.08)',
+                  : 'var(--border-subtle)',
                 color: canSubmit ? 'rgba(15,12,5,0.95)' : 'rgba(255,255,255,0.35)',
                 cursor: canSubmit ? 'pointer' : 'not-allowed',
                 boxShadow: canSubmit ? '0 4px 20px rgba(195,155,65,0.3)' : 'none',
@@ -1146,8 +1146,8 @@ function ProjectCard(props: {
         data-ws-card="1"
         data-ws-id={ws.id}
         style={{
-          background: hasCover ? 'transparent' : 'rgba(255,255,255,0.04)',
-          border: hasCover ? 'none' : '1px solid rgba(255,255,255,0.1)',
+          background: hasCover ? 'transparent' : 'var(--bg-input)',
+          border: hasCover ? 'none' : '1px solid var(--border-default)',
           boxShadow: '0 4px 20px rgba(0,0,0,0.2)',
         }}
       >
@@ -1224,14 +1224,14 @@ function NewProjectCard(props: { onClick: () => void }) {
         className="h-[160px] rounded-xl flex flex-col items-center justify-center gap-2.5 transition-all duration-300 group-hover:scale-[1.02] group-hover:border-white/25"
         style={{
           border: '1.5px dashed rgba(255,255,255,0.2)',
-          background: 'rgba(255,255,255,0.02)',
+          background: 'var(--list-item-bg)',
         }}
       >
         <div
           className="w-12 h-12 rounded-full flex items-center justify-center transition-all duration-300 group-hover:scale-110"
           style={{
-            background: 'rgba(255,255,255,0.06)',
-            border: '1px solid rgba(255,255,255,0.1)',
+            background: 'var(--bg-input-hover)',
+            border: '1px solid var(--border-default)',
           }}
         >
           <Plus size={22} style={{ color: 'rgba(255,255,255,0.6)' }} />
@@ -1272,7 +1272,7 @@ function ProjectCarousel(props: {
       <div className="max-w-[1340px] mx-auto px-5 mb-4">
         <div
           className="flex items-center justify-between py-3"
-          style={{ borderTop: '1px solid rgba(255,255,255,0.06)' }}
+          style={{ borderTop: '1px solid var(--nested-block-border)' }}
         >
           <h2
             className="text-[14px] font-medium tracking-wide"


### PR DESCRIPTION
Replace hardcoded rgba(255,255,255,0.0x) background and border values
across 11 page files with theme-aware CSS variables (--nested-block-bg,
--list-item-bg, --bg-input, --border-default, etc.) to ensure consistent
panel colors throughout the admin UI.

https://claude.ai/code/session_016YZF7tyWVdi1rk9HKLKXdg