### PR TITLE
Refactor SettingsPage: Split general settings into separate tabs

### DIFF
--- a/prd-admin/src/pages/SettingsPage.tsx
+++ b/prd-admin/src/pages/SettingsPage.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useBreakpoint } from '@/hooks/useBreakpoint';
 import { useSearchParams } from 'react-router-dom';
 import { GlassCard } from '@/components/design/GlassCard';
 import { TabBar } from '@/components/design/TabBar';
@@ -7,7 +6,7 @@ import type { TabBarItem } from '@/components/design/TabBar';
 import { Button } from '@/components/design/Button';
 import { useNavOrderStore } from '@/stores/navOrderStore';
 import { useAuthStore } from '@/stores/authStore';
-import { GripVertical, Settings, RefreshCw, RotateCcw, Image, UserCog, Database } from 'lucide-react';
+import { GripVertical, Palette, RefreshCw, RotateCcw, Image, UserCog, Database, ListOrdered } from 'lucide-react';
 import * as LucideIcons from 'lucide-react';
 import { ThemeSkinEditor } from '@/pages/settings/ThemeSkinEditor';
 import AssetsManagePage from '@/pages/AssetsManagePage';
@@ -30,10 +29,19 @@ function getIcon(name: string, size = 16) {
   return <LucideIcons.Circle size={size} />;
 }
 
-function GeneralSettings() {
+/** 皮肤设置页签内容 */
+function SkinSettings() {
+  return (
+    <div className="h-full min-h-0 overflow-y-auto">
+      <ThemeSkinEditor />
+    </div>
+  );
+}
+
+/** 导航顺序页签内容 */
+function NavOrderSettings() {
   const { navOrder, loaded, saving, loadFromServer, setNavOrder, reset } = useNavOrderStore();
   const menuCatalog = useAuthStore((s) => s.menuCatalog);
-  const { isMobile } = useBreakpoint();
 
   const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
@@ -111,7 +119,7 @@ function GeneralSettings() {
 
   return (
     <div className="h-full min-h-0 flex flex-col gap-5 overflow-x-hidden overflow-y-auto">
-      {/* 通用设置操作按钮 */}
+      {/* 操作按钮 */}
       <div className="flex items-center gap-2 shrink-0">
         <Button variant="secondary" size="sm" onClick={() => void loadFromServer()} disabled={saving}>
           <RefreshCw size={14} className={saving ? 'animate-spin' : ''} />
@@ -123,127 +131,119 @@ function GeneralSettings() {
         </Button>
       </div>
 
-      {/* 左右分栏布局：左侧 1/4 导航顺序，右侧 3/4 皮肤编辑 */}
-      <div className={`flex-1 min-h-0 grid gap-5 ${isMobile ? 'grid-cols-1' : 'grid-cols-4'}`}>
-        {/* 左侧：导航顺序设置 */}
-        <div className={`${isMobile ? '' : 'col-span-1'} min-h-0 flex flex-col`}>
-          <GlassCard glow accentHue={210} className="h-full flex flex-col overflow-hidden">
-            <div className="flex items-center justify-between gap-3 mb-4 shrink-0">
-              <div>
-                <h2 className="text-[14px] font-bold" style={{ color: 'var(--text-primary)' }}>
-                  导航顺序
-                </h2>
-                <p className="text-[11px] mt-0.5" style={{ color: 'var(--text-muted)' }}>
-                  拖拽调整左侧导航菜单的显示顺序
-                </p>
-              </div>
-              {saving && (
-                <div className="flex items-center gap-1.5 text-xs" style={{ color: 'var(--text-muted)' }}>
-                  <RefreshCw size={12} className="animate-spin" />
-                  保存中...
-                </div>
-              )}
+      {/* 导航顺序设置 */}
+      <div className="flex-1 min-h-0 flex flex-col max-w-lg">
+        <GlassCard glow accentHue={210} className="h-full flex flex-col overflow-hidden">
+          <div className="flex items-center justify-between gap-3 mb-4 shrink-0">
+            <div>
+              <h2 className="text-[14px] font-bold" style={{ color: 'var(--text-primary)' }}>
+                导航顺序
+              </h2>
+              <p className="text-[11px] mt-0.5" style={{ color: 'var(--text-muted)' }}>
+                拖拽调整左侧导航菜单的显示顺序
+              </p>
             </div>
-
-            {/* 列表容器：隐藏滚动条 + 底部阴影渐隐 */}
-            <div className="relative flex-1 min-h-0">
-              <div
-                className="h-full overflow-y-auto pr-1"
-                style={{
-                  scrollbarWidth: 'none',
-                  msOverflowStyle: 'none',
-                }}
-              >
-                <style>{`
-                  .nav-order-list::-webkit-scrollbar { display: none; }
-                `}</style>
-                <div className="nav-order-list space-y-1.5 pb-6">
-                  {sortedItems.map((item, index) => {
-                    const isDragging = draggingIndex === index;
-                    const isDropTarget = dragOverIndex === index && draggingIndex !== index;
-
-                    return (
-                      <div
-                        key={item.key}
-                        draggable
-                        onDragStart={(e) => handleDragStart(e, index)}
-                        onDragOver={(e) => handleDragOver(e, index)}
-                        onDrop={(e) => handleDrop(e, index)}
-                        onDragEnd={handleDragEnd}
-                        className="flex items-center gap-3 px-3 py-2.5 rounded-[10px] cursor-grab active:cursor-grabbing"
-                        style={{
-                          background: isDragging
-                            ? 'rgba(214,178,106,0.15)'
-                            : isDropTarget
-                              ? 'rgba(214,178,106,0.08)'
-                              : 'var(--nested-block-bg)',
-                          border: isDragging
-                            ? '2px solid rgba(214,178,106,0.5)'
-                            : isDropTarget
-                              ? '2px dashed rgba(214,178,106,0.5)'
-                              : '1px solid var(--nested-block-border)',
-                          opacity: isDragging ? 0.6 : 1,
-                        }}
-                      >
-                        <div
-                          className="shrink-0 w-6 h-6 flex items-center justify-center rounded-md"
-                          style={{ color: 'var(--text-muted)' }}
-                        >
-                          <GripVertical size={14} />
-                        </div>
-                        <div
-                          className="shrink-0 w-8 h-8 rounded-[8px] flex items-center justify-center"
-                          style={{
-                            background: 'var(--bg-card-hover)',
-                            border: '1px solid var(--border-subtle)',
-                            color: 'var(--text-secondary)',
-                          }}
-                        >
-                          {getIcon(item.icon, 16)}
-                        </div>
-                        <div className="flex-1 min-w-0">
-                          <div className="text-[13px] font-medium truncate" style={{ color: 'var(--text-primary)' }}>
-                            {item.label}
-                          </div>
-                        </div>
-                        <div
-                          className="shrink-0 text-[10px] font-mono px-2 py-0.5 rounded"
-                          style={{
-                            background: 'var(--bg-input)',
-                            color: 'var(--text-muted)',
-                          }}
-                        >
-                          {index + 1}
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
-              {/* 底部阴影渐隐遮罩 */}
-              <div
-                className="absolute bottom-0 left-0 right-0 h-12 pointer-events-none"
-                style={{
-                  background: 'linear-gradient(to top, var(--card-bg, rgba(30,30,35,0.95)) 0%, transparent 100%)',
-                }}
-              />
-            </div>
-
-            {sortedItems.length === 0 && (
-              <div
-                className="text-center py-8 text-sm"
-                style={{ color: 'var(--text-muted)' }}
-              >
-                {loaded ? '暂无可显示的导航项' : '加载中...'}
+            {saving && (
+              <div className="flex items-center gap-1.5 text-xs" style={{ color: 'var(--text-muted)' }}>
+                <RefreshCw size={12} className="animate-spin" />
+                保存中...
               </div>
             )}
-          </GlassCard>
-        </div>
+          </div>
 
-        {/* 右侧：皮肤编辑 */}
-        <div className={`${isMobile ? '' : 'col-span-3'} min-h-0 overflow-y-auto`}>
-          <ThemeSkinEditor />
-        </div>
+          {/* 列表容器：隐藏滚动条 + 底部阴影渐隐 */}
+          <div className="relative flex-1 min-h-0">
+            <div
+              className="h-full overflow-y-auto pr-1"
+              style={{
+                scrollbarWidth: 'none',
+                msOverflowStyle: 'none',
+              }}
+            >
+              <style>{`
+                .nav-order-list::-webkit-scrollbar { display: none; }
+              `}</style>
+              <div className="nav-order-list space-y-1.5 pb-6">
+                {sortedItems.map((item, index) => {
+                  const isDragging = draggingIndex === index;
+                  const isDropTarget = dragOverIndex === index && draggingIndex !== index;
+
+                  return (
+                    <div
+                      key={item.key}
+                      draggable
+                      onDragStart={(e) => handleDragStart(e, index)}
+                      onDragOver={(e) => handleDragOver(e, index)}
+                      onDrop={(e) => handleDrop(e, index)}
+                      onDragEnd={handleDragEnd}
+                      className="flex items-center gap-3 px-3 py-2.5 rounded-[10px] cursor-grab active:cursor-grabbing"
+                      style={{
+                        background: isDragging
+                          ? 'rgba(214,178,106,0.15)'
+                          : isDropTarget
+                            ? 'rgba(214,178,106,0.08)'
+                            : 'var(--nested-block-bg)',
+                        border: isDragging
+                          ? '2px solid rgba(214,178,106,0.5)'
+                          : isDropTarget
+                            ? '2px dashed rgba(214,178,106,0.5)'
+                            : '1px solid var(--nested-block-border)',
+                        opacity: isDragging ? 0.6 : 1,
+                      }}
+                    >
+                      <div
+                        className="shrink-0 w-6 h-6 flex items-center justify-center rounded-md"
+                        style={{ color: 'var(--text-muted)' }}
+                      >
+                        <GripVertical size={14} />
+                      </div>
+                      <div
+                        className="shrink-0 w-8 h-8 rounded-[8px] flex items-center justify-center"
+                        style={{
+                          background: 'var(--bg-card-hover)',
+                          border: '1px solid var(--border-subtle)',
+                          color: 'var(--text-secondary)',
+                        }}
+                      >
+                        {getIcon(item.icon, 16)}
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <div className="text-[13px] font-medium truncate" style={{ color: 'var(--text-primary)' }}>
+                          {item.label}
+                        </div>
+                      </div>
+                      <div
+                        className="shrink-0 text-[10px] font-mono px-2 py-0.5 rounded"
+                        style={{
+                          background: 'var(--bg-input)',
+                          color: 'var(--text-muted)',
+                        }}
+                      >
+                        {index + 1}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+            {/* 底部阴影渐隐遮罩 */}
+            <div
+              className="absolute bottom-0 left-0 right-0 h-12 pointer-events-none"
+              style={{
+                background: 'linear-gradient(to top, var(--card-bg, rgba(30,30,35,0.95)) 0%, transparent 100%)',
+              }}
+            />
+          </div>
+
+          {sortedItems.length === 0 && (
+            <div
+              className="text-center py-8 text-sm"
+              style={{ color: 'var(--text-muted)' }}
+            >
+              {loaded ? '暂无可显示的导航项' : '加载中...'}
+            </div>
+          )}
+        </GlassCard>
       </div>
     </div>
   );
@@ -257,7 +257,8 @@ export default function SettingsPage() {
   // 根据权限构建可见 tab 列表
   const tabs = useMemo(() => {
     const list: TabBarItem[] = [
-      { key: 'general', label: '通用设置', icon: <Settings size={14} /> },
+      { key: 'skin', label: '皮肤设置', icon: <Palette size={14} /> },
+      { key: 'nav-order', label: '导航顺序', icon: <ListOrdered size={14} /> },
     ];
     const hasPerm = (p: string) => isRoot || perms.includes(p) || perms.includes('super');
     if (hasPerm('assets.read')) list.push({ key: 'assets', label: '资源管理', icon: <Image size={14} /> });
@@ -266,7 +267,7 @@ export default function SettingsPage() {
     return list;
   }, [perms, isRoot]);
 
-  const tabFromUrl = searchParams.get('tab') || 'general';
+  const tabFromUrl = searchParams.get('tab') || 'skin';
   const [activeTab, setActiveTab] = useState(tabFromUrl);
 
   // 同步 URL 参数
@@ -291,7 +292,8 @@ export default function SettingsPage() {
       />
 
       <div className="flex-1 min-h-0">
-        {activeTab === 'general' && <GeneralSettings />}
+        {activeTab === 'skin' && <SkinSettings />}
+        {activeTab === 'nav-order' && <NavOrderSettings />}
         {activeTab === 'assets' && <AssetsManagePage />}
         {activeTab === 'authz' && <AuthzPage />}
         {activeTab === 'data' && <DataManagePage />}


### PR DESCRIPTION
## Summary
Refactored the SettingsPage to split the combined "General Settings" tab into two separate, focused tabs: "Skin Settings" and "Navigation Order". This improves UX by organizing settings into logical groups and simplifies the component structure.

## Key Changes
- **Split GeneralSettings component**: Extracted `SkinSettings` and `NavOrderSettings` as separate functional components
- **Removed responsive grid layout**: Eliminated the mobile-responsive two-column layout (1/4 + 3/4 split) in favor of dedicated tabs, removing the `useBreakpoint` hook dependency
- **Updated tab configuration**: Changed from single "通用设置" (General Settings) tab to two tabs:
  - "皮肤设置" (Skin Settings) with Palette icon
  - "导航顺序" (Navigation Order) with ListOrdered icon
- **Updated icon imports**: Replaced `Settings` icon with `Palette` and added `ListOrdered` from lucide-react
- **Simplified NavOrderSettings**: Removed `isMobile` state and responsive grid logic, keeping only the drag-and-drop navigation order UI
- **Updated default tab**: Changed default active tab from 'general' to 'skin'

## Implementation Details
- Each settings section now has its own dedicated tab and component, making the codebase more maintainable
- The `SkinSettings` component wraps `ThemeSkinEditor` with proper overflow handling
- The `NavOrderSettings` component retains all drag-and-drop functionality with improved code organization
- Tab routing remains consistent with URL parameter synchronization

https://claude.ai/code/session_01Kw52uad52fUHrgEGMWpPLm