### PR TITLE
Update background color variable to use --bg-elevated

### DIFF
--- a/prd-admin/src/pages/ai-toolbox/AiToolboxPage.tsx
+++ b/prd-admin/src/pages/ai-toolbox/AiToolboxPage.tsx
@@ -23,7 +23,7 @@ const CATEGORY_OPTIONS: { key: ToolboxCategory; label: string; icon: React.React
 
 // 页面容器样式 - 不透明背景
 const pageContainerStyle: React.CSSProperties = {
-  background: 'var(--bg-primary, #0f1419)',
+  background: 'var(--bg-elevated)',
   borderRadius: '16px',
   border: '1px solid rgba(255, 255, 255, 0.06)',
 };

--- a/prd-admin/src/pages/ai-toolbox/components/BasicCapabilities.tsx
+++ b/prd-admin/src/pages/ai-toolbox/components/BasicCapabilities.tsx
@@ -128,7 +128,7 @@ const CAPABILITIES: Capability[] = [
 
 // 页面容器样式 - 不透明背景
 const pageContainerStyle: React.CSSProperties = {
-  background: 'var(--bg-primary, #0f1419)',
+  background: 'var(--bg-elevated)',
   borderRadius: '16px',
   border: '1px solid rgba(255, 255, 255, 0.06)',
 };

--- a/prd-admin/src/pages/ai-toolbox/components/ToolEditor.tsx
+++ b/prd-admin/src/pages/ai-toolbox/components/ToolEditor.tsx
@@ -96,7 +96,7 @@ const CONFIG_TABS = [
 
 // 页面容器样式 - 不透明背景
 const pageContainerStyle: React.CSSProperties = {
-  background: 'var(--bg-primary, #0f1419)',
+  background: 'var(--bg-elevated)',
   borderRadius: '16px',
   border: '1px solid rgba(255, 255, 255, 0.06)',
 };


### PR DESCRIPTION
## Summary
Updated the background color styling across AI Toolbox components to use the `--bg-elevated` CSS variable instead of the hardcoded fallback value `#0f1419`.

## Key Changes
- **AiToolboxPage.tsx**: Changed `pageContainerStyle` background from `'var(--bg-primary, #0f1419)'` to `'var(--bg-elevated)'`
- **BasicCapabilities.tsx**: Changed `pageContainerStyle` background from `'var(--bg-primary, #0f1419)'` to `'var(--bg-elevated)'`
- **ToolEditor.tsx**: Changed `pageContainerStyle` background from `'var(--bg-primary, #0f1419)'` to `'var(--bg-elevated)'`

## Implementation Details
This change improves consistency with the design system by using the appropriate semantic CSS variable (`--bg-elevated`) for elevated surface backgrounds. This removes the reliance on the `--bg-primary` variable with a hardcoded fallback, allowing for better theme management and ensuring these components respect the design token hierarchy.

https://claude.ai/code/session_01T8sQiNAaQWPeNyXBV4c94T