### PR TITLE
Adjust chat panel positioning and sizing on desktop

### DIFF
--- a/prd-admin/src/pages/ai-chat/AdvancedVisualAgentTab.tsx
+++ b/prd-admin/src/pages/ai-chat/AdvancedVisualAgentTab.tsx
@@ -7133,10 +7133,10 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
 
           {/* 右侧：浮动对话面板（液态大玻璃效果）— 移动端全屏覆盖 / 桌面端浮动 */}
           <div
-            className={`${isMobile ? 'absolute inset-0' : 'absolute right-3 top-1/2 -translate-y-1/2'} z-30 flex flex-col`}
+            className={`${isMobile ? 'absolute inset-0' : 'absolute right-3 top-3'} z-30 flex flex-col`}
             style={{
-              width: isMobile ? '100%' : 350,
-              height: isMobile ? '100%' : '75%',
+              width: isMobile ? '100%' : 420,
+              height: isMobile ? '100%' : 'calc(100% - 24px)',
               display: isMobile && !mobileShowChat ? 'none' : undefined,
               // 移动端：底部留出工具栏空间
               paddingBottom: isMobile ? 60 : undefined,


### PR DESCRIPTION
## Summary
Updated the floating chat panel layout on desktop to improve positioning and accommodate larger content width.

## Key Changes
- Changed desktop panel vertical alignment from centered (`top-1/2 -translate-y-1/2`) to top-aligned (`top-3`)
- Increased desktop panel width from 350px to 420px for better content display
- Updated desktop panel height from fixed 75% to dynamic `calc(100% - 24px)` to account for top spacing

## Implementation Details
These changes ensure the chat panel:
- Aligns with the top of the viewport on desktop (with 12px padding)
- Provides more horizontal space for chat content and interactions
- Scales responsively with the available viewport height while maintaining proper spacing
- Maintains full-screen behavior on mobile devices unchanged

https://claude.ai/code/session_01AYFWsqSgHeychD75ntydG7