### PR TITLE
Enable dotnet watch for backend server development

### DIFF
--- a/quick.ps1
+++ b/quick.ps1
@@ -223,7 +223,7 @@ function Ensure-PnpmInstalled {
 # Start backend server
 function Start-Backend {
     Write-Info "Starting backend server..."
-    dotnet run --project "$ScriptDir\prd-api\src\PrdAgent.Api\PrdAgent.Api.csproj"
+    dotnet watch run --project "$ScriptDir\prd-api\src\PrdAgent.Api\PrdAgent.Api.csproj"
 }
 
 # Start admin panel
@@ -318,7 +318,7 @@ function Start-All {
             $OutputEncoding = $utf8NoBom
         } catch {}
 
-        dotnet run --project $projectPath 2>&1 | ForEach-Object { "[api] $_" }
+        dotnet watch run --project $projectPath 2>&1 | ForEach-Object { "[api] $_" }
     } -ArgumentList "$ScriptDir\prd-api\src\PrdAgent.Api\PrdAgent.Api.csproj"
 
     # Start admin in background


### PR DESCRIPTION
## Summary
Updated the backend server startup commands to use `dotnet watch run` instead of `dotnet run`, enabling automatic recompilation and restart on file changes during development.

## Key Changes
- Modified `Start-Backend` function to use `dotnet watch run` for the PrdAgent.Api project
- Updated `Start-All` function to use `dotnet watch run` when starting the API in background mode

## Implementation Details
This change improves the development experience by leveraging dotnet's watch functionality, which automatically detects code changes and restarts the application without manual intervention. Both the standalone backend startup and the all-in-one startup command now benefit from this hot-reload capability.

https://claude.ai/code/session_01QNucptPSz666pR5Y6ZabwG