### PR TITLE
Add watchdog service to fix stuck API request logs

### DIFF
--- a/prd-api/src/PrdAgent.Api/Middleware/ApiRequestLogWatchdog.cs
+++ b/prd-api/src/PrdAgent.Api/Middleware/ApiRequestLogWatchdog.cs
@@ -1,0 +1,79 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Configuration;
+using MongoDB.Driver;
+using PrdAgent.Core.Models;
+using PrdAgent.Infrastructure.Database;
+
+namespace PrdAgent.Api.Middleware;
+
+/// <summary>
+/// API 请求日志 running 状态纠错守门犬。
+/// 当服务器重启/部署时，长生命周期的 SSE 连接（如 messages/stream）会被强制断开，
+/// middleware 的 finally 块来不及执行，导致 api_request_logs 中的 Status 永远停留在 "running"。
+/// 此 Watchdog 定期扫描超时的 "running" 日志，将其标记为 "timeout" 并设置 EndedAt，
+/// 使 TTL 索引能正常清理这些记录。
+/// </summary>
+public sealed class ApiRequestLogWatchdog : BackgroundService
+{
+    private readonly MongoDbContext _db;
+    private readonly ILogger<ApiRequestLogWatchdog> _logger;
+    private readonly TimeSpan _interval;
+    private readonly TimeSpan _timeout;
+
+    public ApiRequestLogWatchdog(MongoDbContext db, ILogger<ApiRequestLogWatchdog> logger, IConfiguration config)
+    {
+        _db = db;
+        _logger = logger;
+
+        // 可配置：API_LOG_WATCHDOG_INTERVAL_SECONDS / API_LOG_WATCHDOG_TIMEOUT_SECONDS
+        // 默认间隔 60 秒，超时 2 小时（SSE 长连接可能合法运行较长时间）
+        var intervalSec = config.GetValue<int?>("API_LOG_WATCHDOG_INTERVAL_SECONDS") ?? 60;
+        var timeoutSec = config.GetValue<int?>("API_LOG_WATCHDOG_TIMEOUT_SECONDS") ?? 7200;
+        _interval = TimeSpan.FromSeconds(Math.Clamp(intervalSec, 10, 600));
+        _timeout = TimeSpan.FromSeconds(Math.Clamp(timeoutSec, 300, 86400));
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(_interval, stoppingToken);
+                await SweepOnce(stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // stop
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "API request log watchdog loop error");
+            }
+        }
+    }
+
+    private async Task SweepOnce(CancellationToken ct)
+    {
+        var now = DateTime.UtcNow;
+        var deadline = now - _timeout;
+
+        var filter =
+            Builders<ApiRequestLog>.Filter.Eq(x => x.Status, "running") &
+            Builders<ApiRequestLog>.Filter.Lt(x => x.StartedAt, deadline) &
+            Builders<ApiRequestLog>.Filter.Eq(x => x.EndedAt, null);
+
+        var update = Builders<ApiRequestLog>.Update
+            .Set(x => x.Status, "timeout")
+            .Set(x => x.EndedAt, now);
+
+        var res = await _db.ApiRequestLogs.UpdateManyAsync(filter, update, cancellationToken: ct);
+        if (res.ModifiedCount > 0)
+        {
+            _logger.LogInformation(
+                "API request log watchdog fixed {Count} stuck running logs (timeout {TimeoutSeconds}s)",
+                res.ModifiedCount, (int)_timeout.TotalSeconds);
+        }
+    }
+}

--- a/prd-api/src/PrdAgent.Api/Program.cs
+++ b/prd-api/src/PrdAgent.Api/Program.cs
@@ -127,6 +127,7 @@ builder.Services.AddSingleton<ILLMRequestContextAccessor, LLMRequestContextAcces
 builder.Services.AddSingleton<LlmRequestLogBackground>();
 builder.Services.AddSingleton<ILlmRequestLogWriter, LlmRequestLogWriter>();
 builder.Services.AddHostedService<LlmRequestLogWatchdog>();
+builder.Services.AddHostedService<PrdAgent.Api.Middleware.ApiRequestLogWatchdog>();
 
 // 应用设置服务（带缓存）
 builder.Services.AddMemoryCache();


### PR DESCRIPTION
## Summary
Introduces a background watchdog service that periodically scans and corrects API request logs stuck in "running" status. This addresses an issue where long-lived SSE connections (like `/messages/stream`) are forcefully disconnected during server restarts/deployments, leaving their logs in an incomplete state and preventing TTL-based cleanup.

## Key Changes
- **New `ApiRequestLogWatchdog` class**: A background service that:
  - Runs on a configurable interval (default: 60 seconds)
  - Scans for logs with "running" status older than a timeout threshold (default: 2 hours)
  - Updates stuck logs by setting status to "timeout" and populating `EndedAt` timestamp
  - Logs the number of fixed records for observability
  
- **Configuration support**: Allows customization via environment variables:
  - `API_LOG_WATCHDOG_INTERVAL_SECONDS`: Scan frequency (clamped 10-600s)
  - `API_LOG_WATCHDOG_TIMEOUT_SECONDS`: Timeout threshold (clamped 300-86400s)

- **Service registration**: Registered as a hosted service in `Program.cs` to run alongside the application

## Implementation Details
- Uses MongoDB bulk update operations for efficiency
- Gracefully handles cancellation and exceptions during background execution
- Timeout default (2 hours) accommodates legitimate long-running SSE connections
- Complements existing `LlmRequestLogWatchdog` with similar pattern for API logs

https://claude.ai/code/session_01Mb4D3j6kuXnmNYKMXnjFHt