### PR TITLE
Persist selected prompt template across page refreshes

### DIFF
--- a/prd-admin/src/services/contracts/visualAgent.ts
+++ b/prd-admin/src/services/contracts/visualAgent.ts
@@ -113,6 +113,7 @@ export type UpdateVisualAgentWorkspaceContract = (input: {
   articleContent?: string;
   scenarioType?: string;
   folderName?: string | null;
+  selectedPromptId?: string | null;
   idempotencyKey?: string;
 }) => Promise<ApiResponse<{ workspace: VisualAgentWorkspace }>>;
 export type DeleteVisualAgentWorkspaceContract = (input: { id: string; idempotencyKey?: string }) => Promise<ApiResponse<{ deleted: boolean }>>;

--- a/prd-admin/src/services/real/literaryAgentConfig.ts
+++ b/prd-admin/src/services/real/literaryAgentConfig.ts
@@ -431,6 +431,7 @@ export async function updateLiteraryAgentWorkspaceReal(input: {
   folderName?: string | null;
   memberUserIds?: string[];
   coverAssetId?: string;
+  selectedPromptId?: string | null;
   idempotencyKey?: string;
 }) {
   const headers: Record<string, string> = {};
@@ -448,6 +449,7 @@ export async function updateLiteraryAgentWorkspaceReal(input: {
         folderName: input.folderName,
         memberUserIds: input.memberUserIds,
         coverAssetId: input.coverAssetId,
+        selectedPromptId: input.selectedPromptId,
       },
     }
   );

--- a/prd-admin/src/services/real/visualAgent.ts
+++ b/prd-admin/src/services/real/visualAgent.ts
@@ -140,6 +140,7 @@ export const updateVisualAgentWorkspaceReal: UpdateVisualAgentWorkspaceContract 
       articleContent: input.articleContent,
       scenarioType: input.scenarioType,
       folderName: input.folderName,
+      selectedPromptId: input.selectedPromptId,
     },
   });
 };

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ImageMasterController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ImageMasterController.cs
@@ -350,6 +350,11 @@ public class ImageMasterController : ControllerBase
         if (request?.CoverAssetId != null) update = update.Set(x => x.CoverAssetId, string.IsNullOrWhiteSpace(coverAssetId) ? null : coverAssetId);
         if (!string.IsNullOrWhiteSpace(request?.ScenarioType)) update = update.Set(x => x.ScenarioType, request.ScenarioType);
         if (request?.FolderName != null) update = update.Set(x => x.FolderName, string.IsNullOrWhiteSpace(request.FolderName) ? null : request.FolderName.Trim());
+        if (request?.SelectedPromptId != null)
+        {
+            var pid = request.SelectedPromptId.Trim();
+            update = update.Set(x => x.SelectedPromptId, string.IsNullOrEmpty(pid) ? null : pid);
+        }
 
         // 文章配图场景：若更新了 articleContent，触发"提交型修改"逻辑（version++、清后续、清旧配图）
         var articleContentChanged = !string.IsNullOrWhiteSpace(request?.ArticleContent) 
@@ -2857,6 +2862,8 @@ public class UpdateWorkspaceRequest
     public string? ArticleContent { get; set; }
     public string? ScenarioType { get; set; }
     public string? FolderName { get; set; }
+    /// <summary>文章配图场景：用户选择的系统提示词 ID（传 "" 空字符串表示清除选择）</summary>
+    public string? SelectedPromptId { get; set; }
 }
 
 public class GenerateWorkspaceTitleRequest

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/LiteraryAgentWorkspaceController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/LiteraryAgentWorkspaceController.cs
@@ -200,6 +200,11 @@ public class LiteraryAgentWorkspaceController : ControllerBase
         if (request?.FolderName != null) update = update.Set(x => x.FolderName, request.FolderName.Trim());
         if (request?.MemberUserIds != null) update = update.Set(x => x.MemberUserIds, request.MemberUserIds.Select(x => x.Trim()).Where(x => x != adminId).Distinct().ToList());
         if (request?.CoverAssetId != null) update = update.Set(x => x.CoverAssetId, request.CoverAssetId.Trim());
+        if (request?.SelectedPromptId != null)
+        {
+            var pid = request.SelectedPromptId.Trim();
+            update = update.Set(x => x.SelectedPromptId, string.IsNullOrEmpty(pid) ? null : pid);
+        }
 
         await _db.ImageMasterWorkspaces.UpdateOneAsync(x => x.Id == ws.Id, update, cancellationToken: ct);
         var updated = await _db.ImageMasterWorkspaces.Find(x => x.Id == ws.Id).FirstOrDefaultAsync(ct);

--- a/prd-api/src/PrdAgent.Core/Models/ImageMasterWorkspace.cs
+++ b/prd-api/src/PrdAgent.Core/Models/ImageMasterWorkspace.cs
@@ -65,6 +65,9 @@ public class ImageMasterWorkspace
     /// <summary>场景类型：image-gen(原图片生成) | article-illustration(文章配图) | other(其他)</summary>
     public string ScenarioType { get; set; } = "image-gen";
 
+    /// <summary>文章配图场景专用：用户选择的系统提示词 ID（持久化，刷新后可恢复）</summary>
+    public string? SelectedPromptId { get; set; }
+
     /// <summary>文章配图场景专用：原始文章内容(Markdown)</summary>
     public string? ArticleContent { get; set; }
 


### PR DESCRIPTION
## Summary
Add persistence for the selected prompt template in the Article Illustration Editor. When users select a prompt template, the selection is now saved to the workspace and automatically restored on page refresh.

## Key Changes

**Frontend (ArticleIllustrationEditorPage.tsx)**
- Refactored `setSelectedPrompt` to wrap the state setter with automatic backend persistence via `updateVisualAgentWorkspace()`
- Added `pendingSelectedPromptIdRef` to track the `selectedPromptId` from workspace during initial load
- Modified `loadLiteraryPrompts()` callback to restore the selected prompt after loading, using the persisted ID from workspace
- Prevents automatic selection of the first prompt; only restores user's previous selection

**Backend - Data Model (ImageMasterWorkspace.cs)**
- Added `SelectedPromptId` field to persist the user's selected prompt template ID

**Backend - API Controllers**
- **ImageMasterController.cs**: Added handling for `SelectedPromptId` in `UpdateWorkspace()` endpoint
- **LiteraryAgentWorkspaceController.cs**: Added handling for `SelectedPromptId` in `UpdateWorkspace()` endpoint
- Both controllers trim and normalize the ID (empty string clears the selection)

**Service Layer**
- Updated `UpdateVisualAgentWorkspaceContract` type to include `selectedPromptId` parameter
- Updated `updateVisualAgentWorkspaceReal()` implementation to pass `selectedPromptId` to API
- Updated `updateLiteraryAgentWorkspaceReal()` implementation to pass `selectedPromptId` to API

## Implementation Details
- Selection persistence is asynchronous and non-blocking to the UI
- Empty string (`""`) is used to explicitly clear the selection
- Restoration only occurs on initial load via `pendingSelectedPromptIdRef` to avoid overwriting user interactions
- Errors during persistence are logged but don't interrupt the user experience

https://claude.ai/code/session_0129bFvhSD52YeEBGfpWteeN