### PR TITLE
Unify message & agent metrics across PRD, defect, and visual agents

### DIFF
--- a/prd-admin/src/components/design/KpiCard.tsx
+++ b/prd-admin/src/components/design/KpiCard.tsx
@@ -1,3 +1,5 @@
+import { Info } from 'lucide-react';
+import { Tooltip } from '@/components/ui/Tooltip';
 import { GlassCard } from '@/components/design/GlassCard';
 
 type Accent = 'default' | 'green' | 'gold' | 'blue' | 'purple';
@@ -18,6 +20,7 @@ export function KpiCard({
   accent = 'default',
   trend,
   trendLabel,
+  info,
 }: {
   title: string;
   value: number | string;
@@ -26,6 +29,7 @@ export function KpiCard({
   accent?: Accent;
   trend?: 'up' | 'down' | 'neutral';
   trendLabel?: string;
+  info?: string;
 }) {
   const display = typeof value === 'number' ? value.toLocaleString() : value;
   const colors = accentColors[accent];
@@ -38,8 +42,13 @@ export function KpiCard({
       accentHue={colors.hue}
     >
       <div className="flex items-start justify-between gap-2">
-        <div className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: 'var(--text-muted)' }}>
+        <div className="flex items-center gap-1 text-[11px] font-semibold uppercase tracking-wider" style={{ color: 'var(--text-muted)' }}>
           {title}
+          {info && (
+            <Tooltip content={info} side="top">
+              <Info size={11} style={{ color: 'var(--text-muted)', opacity: 0.5, flexShrink: 0 }} />
+            </Tooltip>
+          )}
         </div>
         {/* 装饰性光点 */}
         <div

--- a/prd-admin/src/pages/ExecutiveDashboardPage.tsx
+++ b/prd-admin/src/pages/ExecutiveDashboardPage.tsx
@@ -590,12 +590,13 @@ function AgentUsageTab({ agents, team, loading }: { agents: ExecutiveAgentStat[]
                 <div className="flex justify-between text-[11px]">
                   <span className="flex items-center gap-1" style={{ color: 'var(--text-muted)' }}>
                     使用人数
-                    <InfoTip tip="在所选时间范围内，通过 LLM Gateway 调用过该 Agent 的独立用户数" />
+                    <InfoTip tip="在所选时间范围内使用过该 Agent 的独立用户数（综合 API 调用与 LLM 调用）" />
                   </span>
                   <span style={{ color }}>{agent.users}/{totalUsers} 人</span>
                 </div>
                 <ProgressBar value={agent.users} max={totalUsers} color={color} />
-                <StatRow label="调用次数" value={agent.calls} info="该 Agent 在所选时间范围内触发的 LLM 请求总次数（基于 llm_request_logs）" />
+                <StatRow label="业务操作" value={agent.apiCalls ?? 0} info="该 Agent 在所选时间范围内的写操作次数（POST/PUT/DELETE），反映实际业务使用量" />
+                <StatRow label="LLM 调用" value={agent.llmCalls ?? 0} info="该 Agent 触发的大模型请求次数（基于 llm_request_logs）" />
                 <StatRow label="Token 消耗" value={formatTokens(agent.tokens)} info="该 Agent 所有 LLM 请求的输入 + 输出 Token 总和" />
                 <StatRow label="平均响应" value={`${(agent.avgDurationMs / 1000).toFixed(1)}s`} info="该 Agent 所有已完成 LLM 请求的平均耗时（不含未完成请求）" />
               </div>
@@ -612,16 +613,19 @@ function AgentUsageTab({ agents, team, loading }: { agents: ExecutiveAgentStat[]
               <tr style={{ borderBottom: '1px solid var(--border-subtle)' }}>
                 <th className="text-left py-2 pr-4 font-medium" style={{ color: 'var(--text-muted)' }}>Agent</th>
                 <th className="text-right py-2 px-3 font-medium" style={{ color: 'var(--text-muted)' }}>
-                  <span className="inline-flex items-center gap-1 justify-end">调用次数 <InfoTip tip="LLM 请求总次数" /></span>
+                  <span className="inline-flex items-center gap-1 justify-end">总调用 <InfoTip tip="业务操作 + LLM 调用合计" /></span>
+                </th>
+                <th className="text-right py-2 px-3 font-medium" style={{ color: 'var(--text-muted)' }}>
+                  <span className="inline-flex items-center gap-1 justify-end">业务操作 <InfoTip tip="POST/PUT/DELETE 请求数" /></span>
+                </th>
+                <th className="text-right py-2 px-3 font-medium" style={{ color: 'var(--text-muted)' }}>
+                  <span className="inline-flex items-center gap-1 justify-end">LLM <InfoTip tip="大模型调用次数" /></span>
                 </th>
                 <th className="text-right py-2 px-3 font-medium" style={{ color: 'var(--text-muted)' }}>
                   <span className="inline-flex items-center gap-1 justify-end">用户数 <InfoTip tip="去重后的独立用户数" /></span>
                 </th>
                 <th className="text-right py-2 px-3 font-medium" style={{ color: 'var(--text-muted)' }}>
                   <span className="inline-flex items-center gap-1 justify-end">Token <InfoTip tip="输入 + 输出 Token 总和" /></span>
-                </th>
-                <th className="text-right py-2 px-3 font-medium" style={{ color: 'var(--text-muted)' }}>
-                  <span className="inline-flex items-center gap-1 justify-end">平均响应 <InfoTip tip="已完成请求的平均耗时" /></span>
                 </th>
               </tr>
             </thead>
@@ -631,10 +635,11 @@ function AgentUsageTab({ agents, team, loading }: { agents: ExecutiveAgentStat[]
                   <td className="py-2 pr-4">
                     <span className="text-sm font-medium" style={{ color: AGENT_COLORS[a.appKey] ?? 'var(--text-primary)' }}>{a.name}</span>
                   </td>
-                  <td className="py-2 px-3 text-right tabular-nums" style={{ color: 'var(--text-primary)' }}>{a.calls.toLocaleString()}</td>
+                  <td className="py-2 px-3 text-right tabular-nums font-semibold" style={{ color: 'var(--text-primary)' }}>{a.calls.toLocaleString()}</td>
+                  <td className="py-2 px-3 text-right tabular-nums" style={{ color: 'var(--text-secondary)' }}>{(a.apiCalls ?? 0).toLocaleString()}</td>
+                  <td className="py-2 px-3 text-right tabular-nums" style={{ color: 'var(--text-secondary)' }}>{(a.llmCalls ?? 0).toLocaleString()}</td>
                   <td className="py-2 px-3 text-right tabular-nums" style={{ color: 'var(--text-primary)' }}>{a.users}</td>
                   <td className="py-2 px-3 text-right tabular-nums" style={{ color: 'var(--text-primary)' }}>{formatTokens(a.tokens)}</td>
-                  <td className="py-2 px-3 text-right tabular-nums" style={{ color: 'var(--text-primary)' }}>{(a.avgDurationMs / 1000).toFixed(1)}s</td>
                 </tr>
               ))}
             </tbody>

--- a/prd-admin/src/services/contracts/executive.ts
+++ b/prd-admin/src/services/contracts/executive.ts
@@ -44,6 +44,8 @@ export type ExecutiveAgentStat = {
   users: number;
   tokens: number;
   avgDurationMs: number;
+  llmCalls: number;
+  apiCalls: number;
 };
 
 export type ExecutiveModelStat = {


### PR DESCRIPTION
## Summary
Enhanced the Executive Dashboard to provide unified metrics across all agent types (PRD, Defect, Visual, Literary, AI Toolbox, Open Platform) by consolidating data from multiple sources and adding comprehensive tooltips for metric definitions.

## Key Changes

**Backend (ExecutiveController.cs):**
- **Message Aggregation**: Modified `GetOverview()` and `GetTrends()` to combine messages from three sources:
  - PRD conversations (Messages collection)
  - Defect messages (DefectMessages collection)
  - Visual creation messages (ImageMasterMessages collection)
  
- **Agent Metrics Unification**: Refactored `GetAgents()` and `GetLeaderboard()` to merge data from two sources:
  - LLM request logs (llm_request_logs) for model calls and token usage
  - API request logs (api_request_logs) for write operations (POST/PUT/DELETE), excluding read-only GET requests
  - Added agent route prefix mapping to identify agents from API paths
  - Separated `llmCalls` and `apiCalls` metrics for transparency
  
- **Duration Calculation Fix**: Updated `GetModels()` to only average duration for completed requests (where `DurationMs` has a value), preventing null values from skewing averages

**Frontend (ExecutiveDashboardPage.tsx & KpiCard.tsx):**
- Added `Info` icon tooltips to all KPI cards and stat rows with detailed metric definitions
- Updated Agent Usage table to display separate columns for:
  - Total calls (API + LLM combined)
  - Business operations (API calls)
  - LLM calls
  - Unique users
  - Token consumption
- Enhanced table headers with contextual tooltips explaining each metric
- Added `info` prop to `KpiCard` and `StatRow` components for consistent tooltip support

**Contract Updates (executive.ts):**
- Extended `ExecutiveAgentStat` type with `llmCalls` and `apiCalls` fields for granular visibility

## Implementation Details
- Agent identification uses route prefix matching (case-insensitive) for API logs
- Message aggregation uses union of all three collections' timestamps/dates
- User deduplication across LLM and API metrics uses `Math.Max()` to avoid double-counting
- All tooltips follow consistent styling with muted color and reduced opacity

https://claude.ai/code/session_01VPLztcmYgJD6AHTftCRhiE