### PR TITLE
Add list view mode and read status tracking for defects

### DIFF
--- a/prd-admin/src/pages/defect-agent/DefectAgentPage.tsx
+++ b/prd-admin/src/pages/defect-agent/DefectAgentPage.tsx
@@ -5,7 +5,7 @@ import { TabBar } from '@/components/design/TabBar';
 import { useDefectStore } from '@/stores/defectStore';
 import { toast } from '@/lib/toast';
 import { DefectStatus } from '@/services/contracts/defectAgent';
-import { Bug, Plus, FileText, RefreshCw } from 'lucide-react';
+import { Bug, Plus, FileText, RefreshCw, LayoutGrid, List } from 'lucide-react';
 import { DefectList } from './components/DefectList';
 import { DefectSubmitPanel } from './components/DefectSubmitPanel';
 import { DefectDetailPanel } from './components/DefectDetailPanel';
@@ -25,6 +25,8 @@ export default function DefectAgentPage() {
     setShowSubmitPanel,
     showTemplateDialog,
     setShowTemplateDialog,
+    viewMode,
+    setViewMode,
     loadAll,
   } = useDefectStore();
 
@@ -85,6 +87,39 @@ export default function DefectAgentPage() {
         onChange={(key) => setFilter(key as 'submitted' | 'assigned')}
         actions={
           <>
+            {/* 视图切换 */}
+            <div
+              className="flex items-center rounded-lg overflow-hidden"
+              style={{
+                background: 'rgba(255,255,255,0.06)',
+                border: '1px solid rgba(255,255,255,0.1)',
+              }}
+            >
+              <button
+                type="button"
+                className="flex items-center justify-center w-7 h-7 transition-colors"
+                style={{
+                  background: viewMode === 'card' ? 'rgba(255,255,255,0.12)' : 'transparent',
+                  color: viewMode === 'card' ? 'var(--text-primary)' : 'var(--text-muted)',
+                }}
+                onClick={() => setViewMode('card')}
+                title="卡片视图"
+              >
+                <LayoutGrid size={14} />
+              </button>
+              <button
+                type="button"
+                className="flex items-center justify-center w-7 h-7 transition-colors"
+                style={{
+                  background: viewMode === 'list' ? 'rgba(255,255,255,0.12)' : 'transparent',
+                  color: viewMode === 'list' ? 'var(--text-primary)' : 'var(--text-muted)',
+                }}
+                onClick={() => setViewMode('list')}
+                title="列表视图"
+              >
+                <List size={14} />
+              </button>
+            </div>
             <Button
               variant="secondary"
               size="sm"

--- a/prd-admin/src/pages/defect-agent/components/DefectList.tsx
+++ b/prd-admin/src/pages/defect-agent/components/DefectList.tsx
@@ -3,10 +3,11 @@ import { useDefectStore } from '@/stores/defectStore';
 import { useAuthStore } from '@/stores/authStore';
 import { DefectStatus } from '@/services/contracts/defectAgent';
 import { DefectCard } from './DefectCard';
+import { DefectListRow } from './DefectListRow';
 import { Bug, ChevronRight, ChevronDown, Archive } from 'lucide-react';
 
 export function DefectList() {
-  const { defects, loading, filter } = useDefectStore();
+  const { defects, loading, filter, viewMode, readIds } = useDefectStore();
   const userId = useAuthStore((s) => s.user?.userId);
   const [archivedCollapsed, setArchivedCollapsed] = useState(true);
 
@@ -70,6 +71,76 @@ export function DefectList() {
     );
   }
 
+  // 列表视图
+  if (viewMode === 'list') {
+    return (
+      <div className="flex flex-col">
+        {/* 列表头部 */}
+        <div
+          className="flex items-center gap-3 px-3 py-2 text-[10px] font-medium select-none"
+          style={{ color: 'var(--text-muted)', borderBottom: '1px solid var(--border-subtle)' }}
+        >
+          <div className="w-1 flex-shrink-0" />
+          <div className="w-2 flex-shrink-0" />
+          <span className="w-[52px] flex-shrink-0">编号</span>
+          <span className="w-[46px] flex-shrink-0">严重性</span>
+          <span className="flex-1 min-w-0">标题</span>
+          <span className="w-[52px] flex-shrink-0">状态</span>
+          <span className="w-[26px] flex-shrink-0" />
+          <span className="w-[58px] flex-shrink-0">人员</span>
+          <span className="w-[64px] flex-shrink-0 text-right">时间</span>
+          <span className="w-5 flex-shrink-0" />
+        </div>
+
+        {/* 进行中的缺陷 */}
+        {activeDefects.map((defect) => (
+          <DefectListRow key={defect.id} defect={defect} isRead={readIds.has(defect.id)} />
+        ))}
+
+        {/* 进行中为空时的提示 */}
+        {activeDefects.length === 0 && archivedDefects.length > 0 && (
+          <div className="flex items-center justify-center py-8">
+            <div className="text-center">
+              <Bug size={32} style={{ color: 'var(--text-muted)', margin: '0 auto 8px', opacity: 0.4 }} />
+              <div className="text-[12px]" style={{ color: 'var(--text-muted)' }}>暂无进行中的缺陷</div>
+            </div>
+          </div>
+        )}
+
+        {/* 已归档的缺陷（可折叠） */}
+        {archivedDefects.length > 0 && (
+          <>
+            <div
+              className="flex items-center gap-2 px-3 py-2 cursor-pointer select-none transition-colors hover:bg-white/5"
+              style={{ borderBottom: '1px solid var(--border-subtle)' }}
+              onClick={() => setArchivedCollapsed(!archivedCollapsed)}
+            >
+              {archivedCollapsed ? (
+                <ChevronRight size={14} style={{ color: 'var(--text-muted)' }} />
+              ) : (
+                <ChevronDown size={14} style={{ color: 'var(--text-muted)' }} />
+              )}
+              <Archive size={14} style={{ color: 'var(--text-muted)' }} />
+              <span className="text-[12px] font-medium" style={{ color: 'var(--text-secondary)' }}>
+                已归档
+              </span>
+              <span
+                className="text-[10px] px-1.5 py-0.5 rounded"
+                style={{ color: 'var(--text-muted)', background: 'rgba(255,255,255,0.06)' }}
+              >
+                {archivedDefects.length}
+              </span>
+            </div>
+            {!archivedCollapsed && archivedDefects.map((defect) => (
+              <DefectListRow key={defect.id} defect={defect} isRead={readIds.has(defect.id)} />
+            ))}
+          </>
+        )}
+      </div>
+    );
+  }
+
+  // 卡片视图（原有逻辑）
   return (
     <div className="flex flex-col gap-4">
       {/* 进行中的缺陷 */}
@@ -121,7 +192,7 @@ export function DefectList() {
             </span>
             <span
               className="text-[10px] px-1.5 py-0.5 rounded"
-              style={{ 
+              style={{
                 color: 'var(--text-muted)',
                 background: 'rgba(255,255,255,0.06)',
               }}

--- a/prd-admin/src/pages/defect-agent/components/DefectList.tsx
+++ b/prd-admin/src/pages/defect-agent/components/DefectList.tsx
@@ -82,7 +82,6 @@ export function DefectList() {
         >
           <div className="w-1 flex-shrink-0" />
           <div className="w-2 flex-shrink-0" />
-          <span className="w-[52px] flex-shrink-0">编号</span>
           <span className="w-[46px] flex-shrink-0">严重性</span>
           <span className="flex-1 min-w-0">标题</span>
           <span className="w-[52px] flex-shrink-0">状态</span>

--- a/prd-admin/src/pages/defect-agent/components/DefectListRow.tsx
+++ b/prd-admin/src/pages/defect-agent/components/DefectListRow.tsx
@@ -1,0 +1,385 @@
+import { useState } from 'react';
+import { Button } from '@/components/design/Button';
+import { useDefectStore } from '@/stores/defectStore';
+import { useAuthStore } from '@/stores/authStore';
+import { deleteDefect, closeDefect } from '@/services';
+import { toast } from '@/lib/toast';
+import type { DefectReport } from '@/services/contracts/defectAgent';
+import { DefectStatus, DefectSeverity } from '@/services/contracts/defectAgent';
+import {
+  ArrowRight, Clock, Trash2, Check, Bug,
+  AlertTriangle, AlertCircle, Info, MinusCircle,
+  MessageCircle, CheckCircle, Paperclip,
+} from 'lucide-react';
+import { resolveAvatarUrl, resolveNoHeadAvatarUrl } from '@/lib/avatar';
+
+interface DefectListRowProps {
+  defect: DefectReport;
+  isRead: boolean;
+}
+
+const severityConfig: Record<string, { label: string; color: string; bgColor: string; icon: typeof AlertTriangle }> = {
+  [DefectSeverity.Critical]: { label: '致命', color: '#ef4444', bgColor: 'rgba(239,68,68,0.15)', icon: AlertTriangle },
+  [DefectSeverity.Major]: { label: '严重', color: '#f97316', bgColor: 'rgba(249,115,22,0.15)', icon: AlertCircle },
+  [DefectSeverity.Minor]: { label: '一般', color: '#eab308', bgColor: 'rgba(234,179,8,0.15)', icon: Info },
+  [DefectSeverity.Trivial]: { label: '轻微', color: '#22c55e', bgColor: 'rgba(34,197,94,0.15)', icon: MinusCircle },
+};
+
+function formatDate(iso: string | null | undefined) {
+  const s = String(iso ?? '').trim();
+  if (!s) return '';
+  const d = new Date(s);
+  if (Number.isNaN(d.getTime())) return '';
+  const now = new Date();
+  const diffMs = now.getTime() - d.getTime();
+  const diffMin = Math.floor(diffMs / 60000);
+  if (diffMin < 1) return '刚刚';
+  if (diffMin < 60) return `${diffMin}分钟前`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}小时前`;
+  const diffDay = Math.floor(diffHr / 24);
+  if (diffDay < 7) return `${diffDay}天前`;
+  return d.toLocaleDateString();
+}
+
+export function DefectListRow({ defect, isRead }: DefectListRowProps) {
+  const { selectedDefectId, setSelectedDefectId, removeDefectFromList, updateDefectInList, loadStats } = useDefectStore();
+  const userId = useAuthStore((s) => s.user?.userId);
+  const [deleting, setDeleting] = useState(false);
+  const [completing, setCompleting] = useState(false);
+
+  const isSelected = selectedDefectId === defect.id;
+  const title = defect.title || '无标题';
+  const severity = severityConfig[defect.severity] || severityConfig[DefectSeverity.Minor];
+  const SeverityIcon = severity.icon;
+  const reporterDisplayName = defect.reporterName || '未知';
+  const reporterAvatarUrl = resolveAvatarUrl({ avatarFileName: defect.reporterAvatarFileName ?? undefined });
+  const assigneeDisplayName = defect.assigneeName || '未指派';
+  const assigneeAvatarUrl = resolveAvatarUrl({ avatarFileName: defect.assigneeAvatarFileName ?? undefined });
+  const isReporterMe = Boolean(userId && defect.reporterId === userId);
+  const isAssigneeMe = Boolean(userId && defect.assigneeId === userId);
+
+  const isArchived = defect.status === DefectStatus.Resolved || defect.status === DefectStatus.Rejected;
+  const attachmentCount = (defect.attachments || []).length;
+
+  // 未读/已读状态标签逻辑（与 DefectCard 相同）
+  const currentRole =
+    userId && defect.reporterId === userId
+      ? 'reporter'
+      : userId && defect.assigneeId === userId
+      ? 'assignee'
+      : null;
+  const oppositeRole = currentRole === 'reporter' ? 'assignee' : currentRole === 'assignee' ? 'reporter' : null;
+  const myUnread = currentRole === 'reporter'
+    ? defect.reporterUnread
+    : currentRole === 'assignee'
+    ? defect.assigneeUnread
+    : undefined;
+  const peerUnread = oppositeRole === 'reporter'
+    ? defect.reporterUnread
+    : oppositeRole === 'assignee'
+    ? defect.assigneeUnread
+    : undefined;
+
+  const lastCommentByMe = defect.lastCommentBy === currentRole;
+  const lastCommentByPeer = defect.lastCommentBy === oppositeRole;
+
+  let lastActor: 'me' | 'peer' | null = null;
+  let lastAction: 'comment' | 'read' | 'create' | null = null;
+
+  if (lastCommentByMe) {
+    if (peerUnread === false) { lastActor = 'peer'; lastAction = 'read'; }
+    else { lastActor = 'me'; lastAction = 'comment'; }
+  } else if (lastCommentByPeer) {
+    if (myUnread === false) { lastActor = 'me'; lastAction = 'read'; }
+    else { lastActor = 'peer'; lastAction = 'comment'; }
+  } else {
+    if (currentRole === 'reporter') {
+      if (peerUnread === false) { lastActor = 'peer'; lastAction = 'read'; }
+      else { lastActor = 'me'; lastAction = 'create'; }
+    } else if (currentRole === 'assignee') {
+      if (myUnread === false) { lastActor = 'me'; lastAction = 'read'; }
+      else { lastActor = 'peer'; lastAction = 'create'; }
+    }
+  }
+
+  const showMyUnread = !isArchived && myUnread === true;
+
+  const handleDelete = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!confirm('确定要删除此缺陷吗？此操作不可撤销。')) return;
+    setDeleting(true);
+    try {
+      const res = await deleteDefect({ id: defect.id });
+      if (res.success) { removeDefectFromList(defect.id); loadStats(); toast.success('缺陷已删除'); }
+      else { toast.error(res.error?.message || '删除失败'); }
+    } catch (e) { toast.error(String(e)); }
+    finally { setDeleting(false); }
+  };
+
+  const handleComplete = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setCompleting(true);
+    try {
+      const res = await closeDefect({ id: defect.id });
+      if (res.success && res.data?.defect) { updateDefectInList(res.data.defect); toast.success('已完成'); loadStats(); }
+      else { toast.error(res.error?.message || '操作失败'); }
+    } catch (err) { toast.error(String(err)); }
+    finally { setCompleting(false); }
+  };
+
+  // 状态标签的简化版本（适配行内布局）
+  const renderStatusBadge = () => {
+    if (isArchived) {
+      if (defect.status === DefectStatus.Resolved) {
+        return (
+          <span
+            className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium flex-shrink-0"
+            style={{ background: 'rgba(120,220,180,0.15)', color: 'rgba(120,220,180,0.9)' }}
+          >
+            <Check size={10} />
+            已完成
+          </span>
+        );
+      }
+      return (
+        <span
+          className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium flex-shrink-0"
+          style={{ background: 'rgba(255,120,120,0.15)', color: 'rgba(255,120,120,0.9)' }}
+        >
+          驳回
+        </span>
+      );
+    }
+
+    if (showMyUnread && currentRole === 'assignee') {
+      return (
+        <span
+          className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-medium flex-shrink-0"
+          style={{
+            background: 'rgba(255, 100, 100, 0.25)', color: 'rgba(255, 120, 120, 1)',
+            border: '1px solid rgba(255, 100, 100, 0.6)',
+          }}
+        >
+          <Bug size={10} />
+          新缺陷
+        </span>
+      );
+    }
+    if (showMyUnread && currentRole === 'reporter') {
+      return (
+        <span
+          className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-medium flex-shrink-0"
+          style={{
+            background: 'rgba(120, 220, 180, 0.25)', color: 'rgba(120, 220, 180, 1)',
+            border: '1px solid rgba(120, 220, 180, 0.6)',
+          }}
+        >
+          <MessageCircle size={10} />
+          新回复
+        </span>
+      );
+    }
+
+    if (lastActor === 'me' && lastAction === 'comment') {
+      return (
+        <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] flex-shrink-0"
+          style={{ background: 'rgba(120,220,180,0.14)', color: 'rgba(120,220,180,0.9)', border: '1px solid rgba(120,220,180,0.4)' }}>
+          <MessageCircle size={10} />已评
+        </span>
+      );
+    }
+    if (lastActor === 'me' && lastAction === 'read') {
+      return (
+        <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] flex-shrink-0"
+          style={{ background: 'rgba(140,190,255,0.12)', color: 'rgba(140,190,255,0.95)', border: '1px solid rgba(140,190,255,0.45)' }}>
+          <CheckCircle size={10} />已读
+        </span>
+      );
+    }
+    if (lastActor === 'peer' && lastAction === 'comment') {
+      return (
+        <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] flex-shrink-0"
+          style={{ background: 'rgba(120,220,180,0.14)', color: 'rgba(120,220,180,0.9)', border: '1px solid rgba(120,220,180,0.4)' }}>
+          <MessageCircle size={10} />对方已评
+        </span>
+      );
+    }
+    if (lastActor === 'peer' && lastAction === 'read') {
+      return (
+        <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] flex-shrink-0"
+          style={{ background: 'rgba(140,190,255,0.12)', color: 'rgba(140,190,255,0.95)', border: '1px solid rgba(140,190,255,0.45)' }}>
+          <CheckCircle size={10} />对方已读
+        </span>
+      );
+    }
+    if (lastActor === 'me' && lastAction === 'create') {
+      return (
+        <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] flex-shrink-0"
+          style={{ background: 'rgba(255,200,80,0.18)', color: 'rgba(255,200,80,0.95)', border: '1px solid rgba(255,200,80,0.4)' }}>
+          已提交
+        </span>
+      );
+    }
+    if (lastActor === 'peer' && lastAction === 'create') {
+      return (
+        <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] flex-shrink-0"
+          style={{ background: 'rgba(255,200,80,0.18)', color: 'rgba(255,200,80,0.95)', border: '1px solid rgba(255,200,80,0.4)' }}>
+          对方已提交
+        </span>
+      );
+    }
+
+    return null;
+  };
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      className={[
+        'group flex items-center gap-3 px-3 py-2.5 cursor-pointer select-none transition-colors',
+        'hover:bg-white/[0.04]',
+        isSelected ? 'bg-white/[0.06]' : '',
+      ].join(' ')}
+      style={{
+        borderBottom: '1px solid var(--border-subtle)',
+      }}
+      onClick={() => setSelectedDefectId(isSelected ? null : defect.id)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          setSelectedDefectId(isSelected ? null : defect.id);
+        }
+      }}
+    >
+      {/* 严重性色条 */}
+      <div
+        className="w-1 h-6 rounded-full flex-shrink-0"
+        style={{ background: severity.color }}
+      />
+
+      {/* 未读指示点 */}
+      {!isRead && !isArchived && (
+        <div
+          className="w-2 h-2 rounded-full flex-shrink-0"
+          style={{ background: 'rgba(100, 160, 255, 0.9)', boxShadow: '0 0 6px rgba(100, 160, 255, 0.5)' }}
+          title="未查看"
+        />
+      )}
+      {(isRead || isArchived) && <div className="w-2 flex-shrink-0" />}
+
+      {/* 缺陷编号 */}
+      <span
+        className="text-[10px] font-mono flex-shrink-0 w-[52px]"
+        style={{ color: isRead ? 'var(--text-muted)' : 'var(--text-secondary)' }}
+      >
+        {defect.defectNo}
+      </span>
+
+      {/* 严重性 */}
+      <div
+        className="flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium flex-shrink-0"
+        style={{ background: severity.bgColor, color: severity.color }}
+      >
+        <SeverityIcon size={10} />
+        {severity.label}
+      </div>
+
+      {/* 标题 - 已读变灰 */}
+      <span
+        className="text-[13px] font-medium truncate flex-1 min-w-0 transition-colors"
+        style={{
+          color: isRead ? 'var(--text-muted)' : 'var(--text-primary)',
+          opacity: isRead ? 0.7 : 1,
+        }}
+        title={title}
+      >
+        {title}
+      </span>
+
+      {/* 状态标签 */}
+      {renderStatusBadge()}
+
+      {/* 附件数量 */}
+      {attachmentCount > 0 && (
+        <span
+          className="inline-flex items-center gap-1 text-[10px] flex-shrink-0"
+          style={{ color: 'var(--text-muted)' }}
+        >
+          <Paperclip size={10} />
+          {attachmentCount}
+        </span>
+      )}
+
+      {/* 提交者 → 处理者 */}
+      <div className="flex items-center gap-1 flex-shrink-0">
+        <img
+          src={reporterAvatarUrl}
+          alt={reporterDisplayName}
+          className="h-4 w-4 rounded-full object-cover"
+          style={{
+            border: isReporterMe ? '1px solid rgba(255,255,255,0.5)' : '1px solid var(--border-subtle)',
+          }}
+          onError={(e) => { e.currentTarget.onerror = null; e.currentTarget.src = resolveNoHeadAvatarUrl(); }}
+          title={reporterDisplayName}
+        />
+        <ArrowRight size={10} className="opacity-40 flex-shrink-0" />
+        <img
+          src={assigneeAvatarUrl}
+          alt={assigneeDisplayName}
+          className="h-4 w-4 rounded-full object-cover"
+          style={{
+            border: isAssigneeMe ? '1px solid rgba(255,255,255,0.5)' : '1px solid var(--border-subtle)',
+          }}
+          onError={(e) => { e.currentTarget.onerror = null; e.currentTarget.src = resolveNoHeadAvatarUrl(); }}
+          title={assigneeDisplayName}
+        />
+      </div>
+
+      {/* 时间 */}
+      <span
+        className="text-[10px] flex items-center gap-1 flex-shrink-0 w-[64px] justify-end"
+        style={{ color: 'var(--text-muted)' }}
+      >
+        <Clock size={10} />
+        {formatDate(defect.createdAt)}
+      </span>
+
+      {/* 操作按钮 */}
+      <div
+        className={[
+          'flex items-center gap-1 flex-shrink-0',
+          'opacity-0 pointer-events-none transition-opacity duration-100',
+          'group-hover:opacity-100 group-hover:pointer-events-auto',
+        ].join(' ')}
+      >
+        {defect.status === DefectStatus.Resolved ? (
+          <Button
+            size="xs"
+            variant="secondary"
+            className="h-5 w-5 p-0 rounded gap-0 hover:!bg-red-500/20"
+            onClick={handleDelete}
+            disabled={deleting}
+            title="删除缺陷"
+            style={{ color: 'rgba(255,100,100,0.9)' }}
+          >
+            <Trash2 size={10} />
+          </Button>
+        ) : (
+          <Button
+            size="xs"
+            variant="secondary"
+            className="h-5 w-5 p-0 rounded gap-0 hover:bg-white/10"
+            onClick={handleComplete}
+            disabled={completing}
+            title="完成"
+            style={{ color: 'var(--text-primary)' }}
+          >
+            <Check size={10} />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/prd-admin/src/pages/defect-agent/components/DefectListRow.tsx
+++ b/prd-admin/src/pages/defect-agent/components/DefectListRow.tsx
@@ -269,14 +269,6 @@ export function DefectListRow({ defect, isRead }: DefectListRowProps) {
       )}
       {(isRead || isArchived) && <div className="w-2 flex-shrink-0" />}
 
-      {/* 缺陷编号 */}
-      <span
-        className="text-[10px] font-mono flex-shrink-0 w-[52px]"
-        style={{ color: isRead ? 'var(--text-muted)' : 'var(--text-secondary)' }}
-      >
-        {defect.defectNo}
-      </span>
-
       {/* 严重性 */}
       <div
         className="flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium flex-shrink-0"
@@ -286,14 +278,14 @@ export function DefectListRow({ defect, isRead }: DefectListRowProps) {
         {severity.label}
       </div>
 
-      {/* 标题 - 已读变灰 */}
+      {/* 标题 - 已读变灰，tooltip 显示编号 */}
       <span
         className="text-[13px] font-medium truncate flex-1 min-w-0 transition-colors"
         style={{
           color: isRead ? 'var(--text-muted)' : 'var(--text-primary)',
           opacity: isRead ? 0.7 : 1,
         }}
-        title={title}
+        title={`${defect.defectNo} · ${title}`}
       >
         {title}
       </span>

--- a/prd-admin/src/stores/defectStore.ts
+++ b/prd-admin/src/stores/defectStore.ts
@@ -13,6 +13,30 @@ import type {
 } from '@/services/contracts/defectAgent';
 
 type FilterType = 'submitted' | 'assigned' | 'all';
+type ViewMode = 'card' | 'list';
+
+const VIEW_MODE_STORAGE_KEY = 'defect-view-mode';
+const READ_IDS_STORAGE_KEY = 'defect-read-ids';
+
+function loadViewMode(): ViewMode {
+  try {
+    const v = localStorage.getItem(VIEW_MODE_STORAGE_KEY);
+    return v === 'list' ? 'list' : 'card';
+  } catch { return 'card'; }
+}
+
+function loadReadIds(): Set<string> {
+  try {
+    const raw = localStorage.getItem(READ_IDS_STORAGE_KEY);
+    return raw ? new Set(JSON.parse(raw)) : new Set();
+  } catch { return new Set(); }
+}
+
+function saveReadIds(ids: Set<string>) {
+  try {
+    localStorage.setItem(READ_IDS_STORAGE_KEY, JSON.stringify([...ids]));
+  } catch { /* ignore */ }
+}
 
 interface DefectState {
   // Data
@@ -29,6 +53,8 @@ interface DefectState {
   selectedDefectId: string | null;
   showSubmitPanel: boolean;
   showTemplateDialog: boolean;
+  viewMode: ViewMode;
+  readIds: Set<string>;
 
   // Actions
   loadDefects: () => Promise<void>;
@@ -42,6 +68,9 @@ interface DefectState {
   setSelectedDefectId: (id: string | null) => void;
   setShowSubmitPanel: (show: boolean) => void;
   setShowTemplateDialog: (show: boolean) => void;
+  setViewMode: (mode: ViewMode) => void;
+  markAsRead: (id: string) => void;
+  isRead: (id: string) => boolean;
 
   // Update local state
   updateDefectInList: (defect: DefectReport) => void;
@@ -67,6 +96,8 @@ export const useDefectStore = create<DefectState>((set, get) => ({
   selectedDefectId: null,
   showSubmitPanel: false,
   showTemplateDialog: false,
+  viewMode: loadViewMode(),
+  readIds: loadReadIds(),
 
   // Load defects
   loadDefects: async () => {
@@ -146,9 +177,28 @@ export const useDefectStore = create<DefectState>((set, get) => ({
     get().loadDefects();
   },
 
-  setSelectedDefectId: (id) => set({ selectedDefectId: id }),
+  setSelectedDefectId: (id) => {
+    set({ selectedDefectId: id });
+    // 打开详情时自动标记为已读
+    if (id) {
+      get().markAsRead(id);
+    }
+  },
   setShowSubmitPanel: (show) => set({ showSubmitPanel: show }),
   setShowTemplateDialog: (show) => set({ showTemplateDialog: show }),
+  setViewMode: (mode) => {
+    set({ viewMode: mode });
+    try { localStorage.setItem(VIEW_MODE_STORAGE_KEY, mode); } catch { /* ignore */ }
+  },
+  markAsRead: (id) => {
+    const { readIds } = get();
+    if (readIds.has(id)) return;
+    const next = new Set(readIds);
+    next.add(id);
+    set({ readIds: next });
+    saveReadIds(next);
+  },
+  isRead: (id) => get().readIds.has(id),
 
   // Update helpers
   updateDefectInList: (defect) => {
@@ -201,6 +251,8 @@ export const useDefectStore = create<DefectState>((set, get) => ({
       selectedDefectId: null,
       showSubmitPanel: false,
       showTemplateDialog: false,
+      viewMode: loadViewMode(),
+      readIds: loadReadIds(),
     });
   },
 }));


### PR DESCRIPTION
## Summary
Added a new list view mode for the defect agent page alongside the existing card view, with persistent read status tracking for individual defects.

## Key Changes

- **New DefectListRow Component**: Created a compact row-based display for defects with severity indicators, status badges, participant avatars, timestamps, and action buttons. Includes the same read/unread logic as DefectCard but optimized for horizontal layout.

- **View Mode Toggle**: Added card/list view switcher in the DefectAgentPage toolbar. View preference is persisted to localStorage and restored on page reload.

- **Read Status Tracking**: Implemented persistent read/unread state management in defectStore:
  - `readIds` Set tracks which defects have been viewed
  - `markAsRead()` marks a defect as read when its detail panel is opened
  - `isRead()` checks if a defect has been viewed
  - Read status is persisted to localStorage and survives page refreshes

- **DefectList Component Update**: Enhanced to support both view modes with conditional rendering. List view includes collapsible archived section matching the card view layout.

- **Visual Indicators**: 
  - Unread defects show a blue indicator dot in list view
  - Read defects appear with reduced opacity
  - Status badges adapt to list layout (simplified styling)

## Implementation Details

- Read status is automatically set when a user opens a defect's detail panel via `setSelectedDefectId()`
- View mode and read IDs are stored separately in localStorage with fallback error handling
- List view maintains feature parity with card view including severity colors, status tracking, attachment counts, and action buttons
- Responsive design with proper flex layout and hover states for action buttons

https://claude.ai/code/session_01TMrfhD9RbFaUKctCm7xWWm