### PR TITLE
Add support for .mdc and .txt file formats in document upload

### DIFF
--- a/prd-admin/src/pages/AiChatPage.tsx
+++ b/prd-admin/src/pages/AiChatPage.tsx
@@ -94,7 +94,7 @@ const AssistantMarkdown = memo(function AssistantMarkdown({ content }: { content
 });
 
 const MAX_MESSAGE_CHARS = 16 * 1024;
-const ALLOWED_TEXT_EXTS = ['.md', '.txt', '.log', '.json', '.csv'];
+const ALLOWED_TEXT_EXTS = ['.md', '.mdc', '.txt', '.log', '.json', '.csv'];
 
 function normalizeFileName(name: string) {
   return (name ?? '').trim();
@@ -874,8 +874,9 @@ export default function AiChatPage() {
 
   const onPickPrdFile = async (file: File) => {
     if (!file) return;
-    if (!file.name.toLowerCase().endsWith('.md')) {
-      toast.warning('仅支持 .md 文件');
+    const ext = file.name.toLowerCase();
+    if (!ext.endsWith('.md') && !ext.endsWith('.mdc') && !ext.endsWith('.txt')) {
+      toast.warning('仅支持 .md、.mdc、.txt 文件');
       return;
     }
     const content = await file.text();
@@ -1584,7 +1585,7 @@ export default function AiChatPage() {
       <input
         ref={prdFileRef}
         type="file"
-        accept=".md"
+        accept=".md,.mdc,.txt"
         className="hidden"
         onChange={async (e) => {
           const f = e.currentTarget.files?.[0] ?? null;

--- a/prd-admin/src/pages/literary-agent/ArticleIllustrationEditorPage.tsx
+++ b/prd-admin/src/pages/literary-agent/ArticleIllustrationEditorPage.tsx
@@ -896,8 +896,8 @@ export default function ArticleIllustrationEditorPage({ workspaceId }: { workspa
 
     // 检查文件类型
     const fileName = file.name.toLowerCase();
-    if (!fileName.endsWith('.md') && !fileName.endsWith('.txt')) {
-      toast.warning('仅支持 .md 和 .txt 格式的文件');
+    if (!fileName.endsWith('.md') && !fileName.endsWith('.mdc') && !fileName.endsWith('.txt')) {
+      toast.warning('仅支持 .md、.mdc、.txt 格式的文件');
       return;
     }
 
@@ -2166,7 +2166,7 @@ export default function ArticleIllustrationEditorPage({ workspaceId }: { workspa
                 <input
                   ref={fileInputRef}
                   type="file"
-                  accept=".md,.txt"
+                  accept=".md,.mdc,.txt"
                   onChange={handleFileUpload}
                   className="hidden"
                 />
@@ -2192,7 +2192,7 @@ export default function ArticleIllustrationEditorPage({ workspaceId }: { workspa
                 <input
                   ref={fileInputRef}
                   type="file"
-                  accept=".md,.txt"
+                  accept=".md,.mdc,.txt"
                   onChange={handleFileUpload}
                   className="hidden"
                 />

--- a/prd-api/src/PrdAgent.Core/Services/DocumentValidator.cs
+++ b/prd-api/src/PrdAgent.Core/Services/DocumentValidator.cs
@@ -31,11 +31,11 @@ public static class DocumentValidator
                 $"文档大小超出限制（最大10MB，当前{sizeInBytes / 1024 / 1024:F1}MB）");
         }
 
-        // 格式验证 - 检查是否为Markdown格式
-        if (!IsValidMarkdown(content))
+        // 格式验证 - 检查是否为有效的文本格式（Markdown / MDC / 纯文本）
+        if (!IsValidTextContent(content))
         {
-            return DocumentValidationResult.Fail("INVALID_FORMAT", 
-                "文档格式不正确，请上传Markdown格式的PRD文档");
+            return DocumentValidationResult.Fail("INVALID_FORMAT",
+                "文档格式不正确，请上传 Markdown、MDC 或纯文本格式的文档");
         }
 
         // Token估算
@@ -50,40 +50,41 @@ public static class DocumentValidator
     }
 
     /// <summary>
-    /// 检查是否为有效的Markdown格式
+    /// 检查是否为有效的文本内容（Markdown / MDC / 纯文本）
     /// </summary>
-    private static bool IsValidMarkdown(string content)
+    private static bool IsValidTextContent(string content)
     {
-        // Markdown特征检测
-        var markdownPatterns = new[]
-        {
-            @"^#{1,6}\s+.+",      // 标题
-            @"^\*\s+.+",          // 无序列表
-            @"^\d+\.\s+.+",       // 有序列表
-            @"\*\*.+\*\*",        // 粗体
-            @"`.+`",              // 行内代码
-            @"^\s*```",           // 代码块
-            @"^\s*>\s+.+",        // 引用
-            @"\[.+\]\(.+\)",      // 链接
-            @"^\s*[-*]{3,}\s*$",  // 分隔线
-            @"^\|.+\|"            // 表格
-        };
+        // 去除 MDC/Markdown 的 YAML frontmatter 后再检测
+        var body = StripYamlFrontmatter(content);
 
-        var lines = content.Split('\n');
-        int markdownFeatures = 0;
+        // 纯文本只要有可读字符即可
+        if (body.Trim().Length < 2)
+            return false;
 
-        foreach (var pattern in markdownPatterns)
-        {
-            var regex = new Regex(pattern, RegexOptions.Multiline);
-            if (regex.IsMatch(content))
-            {
-                markdownFeatures++;
-            }
-        }
+        return true;
+    }
 
-        // 至少有2个Markdown特征，或者包含至少一个标题
-        var hasTitle = Regex.IsMatch(content, @"^#{1,6}\s+.+", RegexOptions.Multiline);
-        return hasTitle || markdownFeatures >= 2;
+    /// <summary>
+    /// 去除 YAML frontmatter（--- ... --- 包裹的头部元数据），常见于 .mdc 文件
+    /// </summary>
+    internal static string StripYamlFrontmatter(string content)
+    {
+        if (!content.StartsWith("---"))
+            return content;
+
+        // 查找第二个 --- 标记（frontmatter 的结束）
+        var endIndex = content.IndexOf("\n---", 3, StringComparison.Ordinal);
+        if (endIndex < 0)
+            return content;
+
+        // 跳过结束标记行
+        var afterFrontmatter = endIndex + 4; // "\n---".Length
+        if (afterFrontmatter < content.Length && content[afterFrontmatter] == '\n')
+            afterFrontmatter++;
+        if (afterFrontmatter < content.Length && content[afterFrontmatter] == '\r')
+            afterFrontmatter++;
+
+        return afterFrontmatter >= content.Length ? string.Empty : content[afterFrontmatter..];
     }
 
     /// <summary>

--- a/prd-api/src/PrdAgent.Infrastructure/Markdown/MarkdownParser.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Markdown/MarkdownParser.cs
@@ -3,6 +3,7 @@ using Markdig;
 using Markdig.Syntax;
 using PrdAgent.Core.Interfaces;
 using PrdAgent.Core.Models;
+using PrdAgent.Core.Services;
 
 namespace PrdAgent.Infrastructure.Markdown;
 
@@ -20,9 +21,12 @@ public class MarkdownParser : IMarkdownParser
             .Build();
     }
 
-    /// <summary>解析Markdown文档</summary>
+    /// <summary>解析Markdown文档（自动去除 MDC/YAML frontmatter）</summary>
     public ParsedPrd Parse(string content)
     {
+        // 去除 .mdc 文件的 YAML frontmatter，保留纯 Markdown 正文
+        content = DocumentValidator.StripYamlFrontmatter(content);
+
         var document = Markdig.Markdown.Parse(content, _pipeline);
         // 统一处理 Windows(\r\n) 和 Unix(\n) 换行符
         var lines = content.Replace("\r\n", "\n").Replace("\r", "\n").Split('\n');

--- a/prd-desktop/src/components/Document/DocumentUpload.tsx
+++ b/prd-desktop/src/components/Document/DocumentUpload.tsx
@@ -148,11 +148,12 @@ export default function DocumentUpload() {
     const files = e.dataTransfer.files;
     if (files.length > 0) {
       const file = files[0];
-      if (file.name.endsWith('.md')) {
+      const ext = file.name.toLowerCase();
+      if (ext.endsWith('.md') || ext.endsWith('.mdc') || ext.endsWith('.txt')) {
         const content = await file.text();
         handleUpload(content, file.name);
       } else {
-        setError('仅支持 .md 格式文件');
+        setError('仅支持 .md、.mdc、.txt 格式文件');
       }
     }
   }, []);
@@ -210,7 +211,7 @@ export default function DocumentUpload() {
             
             <h2 className="text-xl font-semibold mb-2">上传PRD文档</h2>
             <p className="text-text-secondary mb-6">
-              拖拽 Markdown 文件到此处，或点击选择文件
+              拖拽文档文件到此处，或点击选择文件（支持 .md / .mdc / .txt）
             </p>
 
             <label className="inline-flex items-center gap-2 px-6 py-3 bg-primary-500 text-white rounded-lg cursor-pointer hover:bg-primary-600 transition-colors">
@@ -220,14 +221,14 @@ export default function DocumentUpload() {
               选择文件
               <input 
                 type="file" 
-                accept=".md" 
+                accept=".md,.mdc,.txt"
                 className="hidden" 
                 onChange={handleFileSelect}
               />
             </label>
 
             <p className="text-xs text-text-secondary mt-4">
-              支持 Ctrl+V 粘贴 Markdown 文本
+              支持 Ctrl+V 粘贴文本内容
             </p>
 
             {error && (

--- a/prd-desktop/src/components/Layout/Sidebar.tsx
+++ b/prd-desktop/src/components/Layout/Sidebar.tsx
@@ -363,8 +363,9 @@ export default function Sidebar() {
     const file = input.files?.[0] ?? null;
     input.value = '';
     if (!file) return;
-    if (!file.name.toLowerCase().endsWith('.md')) {
-      setInlineError('仅支持 .md 格式文件');
+    const ext = file.name.toLowerCase();
+    if (!ext.endsWith('.md') && !ext.endsWith('.mdc') && !ext.endsWith('.txt')) {
+      setInlineError('仅支持 .md、.mdc、.txt 格式文件');
       return;
     }
     try {
@@ -443,8 +444,9 @@ export default function Sidebar() {
     // 允许下次选择同名文件也触发 change
     input.value = '';
     if (!file) return;
-    if (!file.name.toLowerCase().endsWith('.md')) {
-      alert('仅支持 .md 格式文件');
+    const ext = file.name.toLowerCase();
+    if (!ext.endsWith('.md') && !ext.endsWith('.mdc') && !ext.endsWith('.txt')) {
+      alert('仅支持 .md、.mdc、.txt 格式文件');
       return;
     }
     try {
@@ -842,7 +844,7 @@ export default function Sidebar() {
                           <input
                             ref={createPrdInputRef}
                             type="file"
-                            accept=".md"
+                            accept=".md,.mdc,.txt"
                             className="hidden"
                             onChange={handleCreatePrdFileSelect}
                           />
@@ -879,7 +881,7 @@ export default function Sidebar() {
         <input
           ref={fileInputRef}
           type="file"
-          accept=".md"
+          accept=".md,.mdc,.txt"
           className="hidden"
           onChange={handleFileSelectForBind}
         />


### PR DESCRIPTION
## Summary
Extended document format support beyond Markdown (.md) to include MDC (.mdc) and plain text (.txt) files across the application. Updated validation logic, file input filters, and user-facing messages consistently.

## Key Changes

**Backend (PrdAgent.Core)**
- Refactored `IsValidMarkdown()` to `IsValidTextContent()` with simplified validation logic that accepts any text content with minimum 2 characters
- Added `StripYamlFrontmatter()` method to handle MDC files that contain YAML frontmatter (metadata wrapped in `---` delimiters)
- Updated error messages to reflect support for multiple formats: "Markdown、MDC 或纯文本格式"
- Modified `MarkdownParser.Parse()` to automatically strip YAML frontmatter before parsing

**Frontend (prd-desktop)**
- Updated file input `accept` attributes from `.md` to `.md,.mdc,.txt` in:
  - Sidebar component (2 locations: create PRD and bind file inputs)
  - DocumentUpload component
- Updated file extension validation logic to check for all three formats
- Updated user-facing error messages and help text to mention all supported formats

**Frontend (prd-admin)**
- Added `.mdc` to `ALLOWED_TEXT_EXTS` array in AiChatPage
- Updated file input `accept` attributes and validation in:
  - AiChatPage (PRD file picker)
  - ArticleIllustrationEditorPage (2 locations)
- Updated toast messages to reflect support for `.md、.mdc、.txt` formats

## Implementation Details

- The validation now uses a permissive approach: any text content with at least 2 characters is considered valid
- YAML frontmatter stripping handles both Unix (`\n`) and Windows (`\r\n`) line endings
- File extension checks are case-insensitive across all components
- Changes maintain backward compatibility with existing .md files while expanding format support

https://claude.ai/code/session_0144BScv3kwcJ631ePQZfhg9