### PR TITLE
Add vision mode for image recognition and analysis

### DIFF
--- a/prd-admin/package-lock.json
+++ b/prd-admin/package-lock.json
@@ -29,6 +29,7 @@
         "jszip": "^3.10.1",
         "lexical": "^0.39.0",
         "lucide-react": "^0.468.0",
+        "motion": "^12.34.3",
         "react": "^18.3.1",
         "react-colorful": "^5.6.1",
         "react-dom": "^18.3.1",
@@ -4845,6 +4846,33 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/framer-motion": {
+      "version": "12.34.3",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.34.3.tgz",
+      "integrity": "sha512-v81ecyZKYO/DfpTwHivqkxSUBzvceOpoI+wLfgCgoUIKxlFKEXdg0oR9imxwXumT4SFy8vRk9xzJ5l3/Du/55Q==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.34.3",
+        "motion-utils": "^12.29.2",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -6662,6 +6690,47 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/motion": {
+      "version": "12.34.3",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.34.3.tgz",
+      "integrity": "sha512-xZIkBGO7v/Uvm+EyaqYd+9IpXu0sZqLywVlGdCFrrMiaO9JI4Kx51mO9KlHSWwll+gZUVY5OJsWgYI5FywJ/tw==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.34.3",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.34.3",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.34.3.tgz",
+      "integrity": "sha512-sYgFe+pR9aIM7o4fhs2aXtOI+oqlUd33N9Yoxcgo1Fv7M20sRkHtCmzE/VRNIcq7uNJ+qio+Xubt1FXH3pQ+eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.29.2"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.29.2",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.29.2.tgz",
+      "integrity": "sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/prd-admin/src/pages/LabPage.tsx
+++ b/prd-admin/src/pages/LabPage.tsx
@@ -10,7 +10,7 @@ type LabTab = 'workshop' | 'llm' | 'desktop' | 'showcase';
 
 export default function LabPage() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const tab = (searchParams.get('tab') ?? 'workshop') as LabTab;
+  const tab = (searchParams.get('tab') ?? 'llm') as LabTab;
 
   const setTab = (next: LabTab) => {
     const sp = new URLSearchParams(searchParams);
@@ -22,8 +22,8 @@ export default function LabPage() {
     <div className="h-full min-h-0 flex flex-col gap-4">
       <TabBar
         items={[
-          { key: 'workshop', label: '试验车间', icon: <FlaskConical size={14} /> },
           { key: 'llm', label: '大模型实验室', icon: <Sparkles size={14} /> },
+          { key: 'workshop', label: '试验车间', icon: <FlaskConical size={14} /> },
           { key: 'desktop', label: '桌面实验室', icon: <Monitor size={14} /> },
           { key: 'showcase', label: '特效展示', icon: <Wand2 size={14} /> },
         ]}

--- a/prd-admin/src/pages/lab-llm/LlmLabTab.tsx
+++ b/prd-admin/src/pages/lab-llm/LlmLabTab.tsx
@@ -3301,76 +3301,88 @@ export default function LlmLabTab() {
 
             {mainMode === 'vision' ? (
               <>
-                {/* 识图模式：图片上传 + 提示词 */}
-                <div className="mt-3 text-xs font-semibold" style={{ color: 'var(--text-primary)' }}>
-                  上传图片
+                {/* 识图模式：左侧上传图片 + 右侧提示词（并排） */}
+                <div className={cn('grid grid-cols-1 lg:grid-cols-2 gap-3', 'mt-3')}>
+                  <div className="text-xs font-semibold" style={{ color: 'var(--text-primary)' }}>
+                    上传图片
+                  </div>
+                  <div className="text-xs font-semibold" style={{ color: 'var(--text-primary)' }}>
+                    识图提示词
+                  </div>
                 </div>
-                <div className="mt-2">
-                  <input
-                    ref={visionFileInputRef}
-                    type="file"
-                    accept="image/*"
-                    multiple
-                    className="hidden"
-                    onChange={(e) => handleVisionImageUpload(e.target.files)}
-                  />
-                  <div className="flex flex-wrap gap-2 items-start">
-                    {visionImages.map((img) => (
-                      <div
-                        key={img.id}
-                        className="relative group rounded-[12px] overflow-hidden"
-                        style={{ width: 80, height: 80, border: '1px solid var(--border-default)', background: 'var(--bg-input)' }}
-                      >
-                        <img src={img.preview} alt={img.name} className="w-full h-full object-cover" />
+                <div className={cn('grid grid-cols-1 lg:grid-cols-2 gap-3', 'mt-2')}>
+                  <div>
+                    <input
+                      ref={visionFileInputRef}
+                      type="file"
+                      accept="image/*"
+                      multiple
+                      className="hidden"
+                      onChange={(e) => handleVisionImageUpload(e.target.files)}
+                    />
+                    <div
+                      className="rounded-[14px] p-2.5 min-h-[140px] flex flex-wrap gap-2 items-start content-start"
+                      style={{
+                        background: 'var(--bg-input)',
+                        border: '1px solid var(--border-default)',
+                      }}
+                    >
+                      {visionImages.map((img) => (
+                        <div
+                          key={img.id}
+                          className="relative group rounded-[10px] overflow-hidden"
+                          style={{ width: 64, height: 64, border: '1px solid var(--border-default)', background: 'var(--bg-input)' }}
+                        >
+                          <img src={img.preview} alt={img.name} className="w-full h-full object-cover" />
+                          <button
+                            type="button"
+                            className="absolute top-0.5 right-0.5 h-4 w-4 rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
+                            style={{ background: 'rgba(0,0,0,0.6)' }}
+                            onClick={() => removeVisionImage(img.id)}
+                            title="移除"
+                          >
+                            <X size={10} style={{ color: '#fff' }} />
+                          </button>
+                        </div>
+                      ))}
+                      {visionImages.length < 10 && (
                         <button
                           type="button"
-                          className="absolute top-1 right-1 h-5 w-5 rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
-                          style={{ background: 'rgba(0,0,0,0.6)' }}
-                          onClick={() => removeVisionImage(img.id)}
-                          title="移除"
+                          className="rounded-[10px] flex flex-col items-center justify-center gap-1 transition-colors hover:bg-white/6"
+                          style={{
+                            width: 64,
+                            height: 64,
+                            border: '2px dashed var(--border-default)',
+                            color: 'var(--text-muted)',
+                          }}
+                          onClick={() => visionFileInputRef.current?.click()}
+                          title="点击上传图片"
                         >
-                          <X size={12} style={{ color: '#fff' }} />
+                          <Upload size={16} />
+                          <span className="text-[10px]">上传</span>
                         </button>
+                      )}
+                    </div>
+                    {visionImages.length > 0 && (
+                      <div className="mt-1 text-[11px]" style={{ color: 'var(--text-muted)' }}>
+                        已上传 {visionImages.length}/10 张
                       </div>
-                    ))}
-                    {visionImages.length < 10 && (
-                      <button
-                        type="button"
-                        className="rounded-[12px] flex flex-col items-center justify-center gap-1 transition-colors hover:bg-white/6"
-                        style={{
-                          width: 80,
-                          height: 80,
-                          border: '2px dashed var(--border-default)',
-                          color: 'var(--text-muted)',
-                        }}
-                        onClick={() => visionFileInputRef.current?.click()}
-                        title="点击上传图片"
-                      >
-                        <Upload size={18} />
-                        <span className="text-[10px]">上传</span>
-                      </button>
                     )}
                   </div>
-                  {visionImages.length > 0 && (
-                    <div className="mt-1 text-[11px]" style={{ color: 'var(--text-muted)' }}>
-                      已上传 {visionImages.length}/10 张
-                    </div>
-                  )}
+                  <div>
+                    <textarea
+                      value={promptText}
+                      onChange={(e) => setPromptText(e.target.value)}
+                      className="h-[140px] w-full rounded-[14px] px-3 py-2 text-sm outline-none resize-none"
+                      style={{
+                        background: 'var(--bg-input)',
+                        border: '1px solid var(--border-default)',
+                        color: 'var(--text-primary)',
+                      }}
+                      placeholder="输入识图提示词（如：请描述这张图片的内容）"
+                    />
+                  </div>
                 </div>
-                <div className="mt-3 text-xs font-semibold" style={{ color: 'var(--text-primary)' }}>
-                  识图提示词
-                </div>
-                <textarea
-                  value={promptText}
-                  onChange={(e) => setPromptText(e.target.value)}
-                  className="mt-2 h-24 w-full rounded-[14px] px-3 py-2 text-sm outline-none resize-none"
-                  style={{
-                    background: 'var(--bg-input)',
-                    border: '1px solid var(--border-default)',
-                    color: 'var(--text-primary)',
-                  }}
-                  placeholder="输入识图提示词（如：请描述这张图片的内容）"
-                />
               </>
             ) : shouldShowImageGenPlanPromptSplit ? (
               <>

--- a/prd-admin/src/services/contracts/modelLab.ts
+++ b/prd-admin/src/services/contracts/modelLab.ts
@@ -81,6 +81,8 @@ export type RunModelLabStreamInput = {
   enablePromptCache?: boolean;
   modelIds?: string[];
   models?: ModelLabSelectedModel[];
+  /** 识图模式：图片 base64 列表（data URI 或纯 base64） */
+  imageBase64List?: string[];
 };
 
 export type RunModelLabStreamEvent = { event?: string; data?: string };


### PR DESCRIPTION
## Summary
This PR adds a new "vision" mode to the Model Lab that enables users to upload images and compare how different LLM models analyze and describe them. This complements the existing "infer" (reasoning) and "image" (generation) modes.

## Key Changes

### Frontend (prd-admin)
- **New Vision Mode UI**: Added "识图" (vision) tab alongside existing "推理" and "生图" modes
  - Image upload interface supporting up to 10 images with preview thumbnails
  - Drag-and-drop style upload button with file input
  - Image removal capability with hover-based delete button
  - Customizable vision prompt textarea with sensible default ("请描述这张图片的内容")

- **Vision Results Display**: Real-time streaming results showing:
  - Model-by-model comparison with TTFT (Time To First Token) and total latency metrics
  - Sortable results by TTFT or total time
  - Output preview with copy and expand functionality
  - Error handling and status indicators (running/done/failed)

- **State Management**: Added vision-specific state variables:
  - `visionImages`: Uploaded image tracking with base64 encoding
  - `visionRunItems`: Results from each model's vision analysis
  - `visionRunning`, `visionRunError`, `visionSortBy`: Control and display state
  - `visionAbortRef`: Abort controller for canceling in-flight requests

- **Cache Persistence**: Vision results are saved to localStorage alongside other lab state for recovery after page refresh

- **Icon Updates**: Added `Eye`, `Upload`, and `X` icons from lucide-react for vision mode UI

### Backend (prd-api)
- **Image Attachment Support**: Modified `RunStreamWithClientAsync` to attach uploaded images to the user message
  - Parses data URI format (`data:image/png;base64,...`) and raw base64
  - Creates `LLMAttachment` objects with proper MIME type detection
  - Supports up to 10 images per request

- **Request Validation**: Added `ImageBase64List` field to `RunStreamRequest` and `EffectiveRunRequest`
  - Filters out empty/whitespace entries
  - Enforces 10-image limit
  - Properly passes images through the request pipeline

### Configuration
- Changed default lab tab from "workshop" to "llm" in LabPage

## Implementation Details
- Vision mode reuses the existing streaming infrastructure (`runModelLabStream`) with image attachments
- Results follow the same `ViewRunItem` structure as inference mode for consistency
- Prompt text is shared across modes but defaults to vision-specific text when switching to vision mode
- Image uploads are converted to base64 client-side before transmission
- Abort controller pattern allows canceling vision runs mid-stream

https://claude.ai/code/session_01LXFJAUMWSLyxgoAgqhYFkg