### PR TITLE
Add style prompt feature for unified image generation styling

### DIFF
--- a/prd-admin/src/pages/ai-chat/AdvancedVisualAgentTab.tsx
+++ b/prd-admin/src/pages/ai-chat/AdvancedVisualAgentTab.tsx
@@ -35,6 +35,7 @@ import {
   refreshVisualAgentWorkspaceCover,
   saveVisualAgentWorkspaceCanvas,
   updateVisualAgentPreferences,
+  updateVisualAgentWorkspace,
   uploadVisualAgentWorkspaceAsset,
 } from '@/services';
 import type { ModelGroupForApp } from '@/types/modelGroup';
@@ -87,6 +88,7 @@ import {
   Maximize2,
   MessageSquare,
   MousePointer2,
+  Palette,
   Plus,
   Send,
   Settings,
@@ -936,6 +938,12 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
   const watermarkPanelRef = useRef<WatermarkSettingsPanelHandle | null>(null);
   const configDialogRef = useRef<ConfigDialogHandle | null>(null);
   const enabledImageModels = useMemo(() => allImageGenModels.filter((m) => m.enabled), [allImageGenModels]);
+
+  // 风格统一
+  const [stylePrompt, setStylePrompt] = useState('');
+  const [stylePopoverOpen, setStylePopoverOpen] = useState(false);
+  const [stylePromptDraft, setStylePromptDraft] = useState('');
+  const stylePromptActive = stylePrompt.trim().length > 0;
 
   // ── 快捷操作 (Quick Actions) ──
   const [diyQuickActions, setDiyQuickActions] = useState<QuickActionConfig[]>([]);
@@ -2174,6 +2182,11 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
       if (cancelled) return;
       setWorkspace(detail.data.workspace);
       setHasMoreMessages(!!detail.data.hasMoreMessages);
+      // 从 workspace 恢复风格统一提示词
+      if (detail.data.workspace.stylePrompt) {
+        setStylePrompt(detail.data.workspace.stylePrompt);
+        setStylePromptDraft(detail.data.workspace.stylePrompt);
+      }
 
       // 服务器下发视口（缩放/相机）：首次进入也要回放，否则会永远停在 DEFAULT_ZOOM=0.5
       const vp = detail.data.viewport;
@@ -7751,6 +7764,142 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
                                               </DropdownMenu.Content>
                     </DropdownMenu.Portal>
                   </DropdownMenu.Root>
+
+                  {/* 风格统一按钮 */}
+                  <Popover.Root open={stylePopoverOpen} onOpenChange={setStylePopoverOpen}>
+                    <Popover.Trigger asChild>
+                      <button
+                        type="button"
+                        className="h-7 w-7 rounded-full inline-flex items-center justify-center"
+                        style={{
+                          border: stylePromptActive ? '1px solid rgba(168, 85, 247, 0.45)' : '1px solid rgba(255,255,255,0.10)',
+                          background: stylePromptActive ? 'rgba(168, 85, 247, 0.14)' : 'rgba(255,255,255,0.04)',
+                          color: stylePromptActive ? 'rgba(192, 132, 252, 0.95)' : 'var(--text-secondary)',
+                        }}
+                        aria-label="风格统一"
+                        title={stylePromptActive ? `风格统一: ${stylePrompt}` : '风格统一（为所有生图自动添加统一风格描述）'}
+                        onClick={() => {
+                          setStylePromptDraft(stylePrompt);
+                          setStylePopoverOpen(true);
+                        }}
+                      >
+                        <Palette size={14} />
+                      </button>
+                    </Popover.Trigger>
+                    <Popover.Portal>
+                      <Popover.Content
+                        side="top"
+                        align="end"
+                        sideOffset={8}
+                        className="z-50 rounded-[14px] p-3"
+                        style={{
+                          ...glassPopoverCompact,
+                          width: 300,
+                          background: 'rgba(32, 32, 36, 0.96)',
+                          border: '1px solid rgba(255, 255, 255, 0.18)',
+                          boxShadow: '0 18px 60px rgba(0,0,0,0.6), 0 0 0 1px rgba(255, 255, 255, 0.08) inset',
+                        }}
+                        onOpenAutoFocus={(e) => e.preventDefault()}
+                      >
+                        <div className="text-[12px] font-semibold mb-2" style={{ color: 'rgba(255,255,255,0.75)' }}>
+                          风格统一
+                        </div>
+                        <div className="text-[10px] mb-2" style={{ color: 'rgba(255,255,255,0.40)' }}>
+                          设置后，本工作区所有生图请求将自动附加风格描述
+                        </div>
+
+                        {/* 快捷预设 */}
+                        <div className="flex flex-wrap gap-1 mb-2">
+                          {[
+                            { label: '水彩', value: '水彩画风格，柔和的色彩渐变，纸质纹理' },
+                            { label: '赛博朋克', value: '赛博朋克风格，霓虹灯光，暗色调，未来科技感' },
+                            { label: '扁平插画', value: '现代扁平插画风格，简洁几何形状，明快配色' },
+                            { label: '油画', value: '古典油画风格，浓郁笔触，丰富层次感' },
+                            { label: '极简', value: '极简主义风格，大量留白，克制的色彩' },
+                            { label: '日式动漫', value: '日式动漫风格，精致线条，鲜艳色彩' },
+                          ].map((preset) => (
+                            <button
+                              key={preset.label}
+                              type="button"
+                              className="h-5 px-2 rounded-full text-[10px] font-medium transition-colors hover:bg-white/10"
+                              style={{
+                                border: stylePromptDraft === preset.value ? '1px solid rgba(168, 85, 247, 0.5)' : '1px solid rgba(255,255,255,0.12)',
+                                background: stylePromptDraft === preset.value ? 'rgba(168, 85, 247, 0.15)' : 'rgba(255,255,255,0.04)',
+                                color: stylePromptDraft === preset.value ? 'rgba(192, 132, 252, 0.95)' : 'rgba(255,255,255,0.60)',
+                              }}
+                              onClick={() => setStylePromptDraft(preset.value)}
+                            >
+                              {preset.label}
+                            </button>
+                          ))}
+                        </div>
+
+                        <textarea
+                          className="w-full rounded-[8px] px-2.5 py-2 text-[12px] resize-none outline-none"
+                          style={{
+                            background: 'rgba(0,0,0,0.24)',
+                            border: '1px solid rgba(255,255,255,0.12)',
+                            color: 'var(--text-primary)',
+                            minHeight: 60,
+                            maxHeight: 120,
+                          }}
+                          placeholder="如：水彩风格、暖色调、柔和光影..."
+                          value={stylePromptDraft}
+                          onChange={(e) => setStylePromptDraft(e.target.value)}
+                          maxLength={500}
+                        />
+
+                        <div className="mt-2 flex items-center justify-between">
+                          <span className="text-[10px]" style={{ color: 'rgba(255,255,255,0.30)' }}>
+                            {stylePromptDraft.trim().length}/500
+                          </span>
+                          <div className="flex gap-1.5">
+                            {stylePromptActive ? (
+                              <button
+                                type="button"
+                                className="h-6 px-2.5 rounded-full text-[11px] font-medium transition-colors hover:bg-white/10"
+                                style={{
+                                  border: '1px solid rgba(239, 68, 68, 0.35)',
+                                  background: 'rgba(239, 68, 68, 0.10)',
+                                  color: 'rgba(248, 113, 113, 0.95)',
+                                }}
+                                onClick={() => {
+                                  setStylePrompt('');
+                                  setStylePromptDraft('');
+                                  setStylePopoverOpen(false);
+                                  if (workspaceId) {
+                                    void updateVisualAgentWorkspace({ id: workspaceId, stylePrompt: '' });
+                                  }
+                                }}
+                              >
+                                清除
+                              </button>
+                            ) : null}
+                            <button
+                              type="button"
+                              className="h-6 px-3 rounded-full text-[11px] font-semibold transition-colors"
+                              style={{
+                                background: stylePromptDraft.trim() ? 'rgba(168, 85, 247, 0.85)' : 'rgba(255,255,255,0.08)',
+                                border: stylePromptDraft.trim() ? '1px solid rgba(168, 85, 247, 0.65)' : '1px solid rgba(255,255,255,0.12)',
+                                color: stylePromptDraft.trim() ? 'rgba(255, 255, 255, 0.95)' : 'rgba(255,255,255,0.35)',
+                              }}
+                              disabled={!stylePromptDraft.trim()}
+                              onClick={() => {
+                                const val = stylePromptDraft.trim();
+                                setStylePrompt(val);
+                                setStylePopoverOpen(false);
+                                if (workspaceId) {
+                                  void updateVisualAgentWorkspace({ id: workspaceId, stylePrompt: val });
+                                }
+                              }}
+                            >
+                              应用
+                            </button>
+                          </div>
+                        </div>
+                      </Popover.Content>
+                    </Popover.Portal>
+                  </Popover.Root>
 
                   {/* 设置按钮 */}
                   <button

--- a/prd-admin/src/services/contracts/visualAgent.ts
+++ b/prd-admin/src/services/contracts/visualAgent.ts
@@ -84,6 +84,8 @@ export type VisualAgentWorkspace = {
   articleWorkflow?: ArticleIllustrationWorkflow | null;
   /** 文件夹名称（用于分组显示） */
   folderName?: string | null;
+  /** 风格统一提示词（设置后生图时自动拼接） */
+  stylePrompt?: string | null;
 };
 
 export type VisualAgentViewport = {
@@ -114,6 +116,7 @@ export type UpdateVisualAgentWorkspaceContract = (input: {
   scenarioType?: string;
   folderName?: string | null;
   selectedPromptId?: string | null;
+  stylePrompt?: string | null;
   idempotencyKey?: string;
 }) => Promise<ApiResponse<{ workspace: VisualAgentWorkspace }>>;
 export type DeleteVisualAgentWorkspaceContract = (input: { id: string; idempotencyKey?: string }) => Promise<ApiResponse<{ deleted: boolean }>>;

--- a/prd-admin/src/services/real/visualAgent.ts
+++ b/prd-admin/src/services/real/visualAgent.ts
@@ -141,6 +141,7 @@ export const updateVisualAgentWorkspaceReal: UpdateVisualAgentWorkspaceContract 
       scenarioType: input.scenarioType,
       folderName: input.folderName,
       selectedPromptId: input.selectedPromptId,
+      stylePrompt: input.stylePrompt,
     },
   });
 };

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ImageMasterController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ImageMasterController.cs
@@ -355,6 +355,12 @@ public class ImageMasterController : ControllerBase
             var pid = request.SelectedPromptId.Trim();
             update = update.Set(x => x.SelectedPromptId, string.IsNullOrEmpty(pid) ? null : pid);
         }
+        if (request?.StylePrompt != null)
+        {
+            var sp = request.StylePrompt.Trim();
+            if (sp.Length > 500) sp = sp[..500];
+            update = update.Set(x => x.StylePrompt, string.IsNullOrEmpty(sp) ? null : sp);
+        }
 
         // 文章配图场景：若更新了 articleContent，触发"提交型修改"逻辑（version++、清后续、清旧配图）
         var articleContentChanged = !string.IsNullOrWhiteSpace(request?.ArticleContent) 
@@ -1333,6 +1339,14 @@ public class ImageMasterController : ControllerBase
 
             var prompt = (request?.Prompt ?? string.Empty).Trim();
             if (string.IsNullOrWhiteSpace(prompt)) return BadRequest(ApiResponse<object>.Fail(ErrorCodes.CONTENT_EMPTY, "prompt 不能为空"));
+
+            // 风格统一：若 workspace 设置了 StylePrompt，自动拼接到用户 prompt 后面
+            var stylePrompt = (ws.StylePrompt ?? string.Empty).Trim();
+            if (!string.IsNullOrWhiteSpace(stylePrompt))
+            {
+                prompt = $"{prompt}\n\n风格要求：{stylePrompt}";
+                _logger.LogInformation("[CreateWorkspaceImageGenRun] StylePrompt applied: {StylePrompt}", stylePrompt);
+            }
 
             var targetKey = (request?.TargetKey ?? string.Empty).Trim();
             if (string.IsNullOrWhiteSpace(targetKey)) return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "targetKey 不能为空"));
@@ -2864,6 +2878,8 @@ public class UpdateWorkspaceRequest
     public string? FolderName { get; set; }
     /// <summary>文章配图场景：用户选择的系统提示词 ID（传 "" 空字符串表示清除选择）</summary>
     public string? SelectedPromptId { get; set; }
+    /// <summary>风格统一提示词（传 "" 空字符串表示清除）</summary>
+    public string? StylePrompt { get; set; }
 }
 
 public class GenerateWorkspaceTitleRequest

--- a/prd-api/src/PrdAgent.Core/Models/ImageMasterWorkspace.cs
+++ b/prd-api/src/PrdAgent.Core/Models/ImageMasterWorkspace.cs
@@ -87,6 +87,9 @@ public class ImageMasterWorkspace
 
     /// <summary>文件夹名称（用于分组显示，相同名称的 workspace 归为一组）</summary>
     public string? FolderName { get; set; }
+
+    /// <summary>风格统一提示词：若设置，生图时自动拼接到用户 prompt 后面，确保 workspace 内风格一致</summary>
+    public string? StylePrompt { get; set; }
 }
 
 


### PR DESCRIPTION
## Summary
This PR introduces a "style prompt" feature that allows users to set a unified style description for all image generation requests within a workspace. When enabled, the style prompt is automatically appended to every image generation request, ensuring consistent visual styling across all generated images.

## Key Changes

### Frontend (AdvancedVisualAgentTab.tsx)
- Added style prompt state management (`stylePrompt`, `stylePromptDraft`, `stylePopoverOpen`)
- Implemented a new popover UI component with:
  - 6 preset style options (watercolor, cyberpunk, flat illustration, oil painting, minimalism, anime)
  - Custom textarea for entering custom style descriptions (max 500 chars)
  - Apply/Clear buttons to save or remove the style prompt
- Added visual indicator (Palette icon) that highlights when a style prompt is active
- Integrated style prompt recovery from workspace data on component mount
- Imported `updateVisualAgentWorkspace` service and `Palette` icon

### Backend (ImageMasterController.cs)
- Added `StylePrompt` field handling in `UpdateWorkspace` endpoint with 500-character limit
- Implemented automatic style prompt injection in `CreateWorkspaceImageGenRun`:
  - Retrieves the workspace's `StylePrompt` setting
  - Appends it to user's prompt with "风格要求：" prefix when present
  - Logs the style prompt application for debugging

### Data Models
- Extended `ImageMasterWorkspace` model with `StylePrompt` property
- Updated `UpdateWorkspaceRequest` DTO to include `StylePrompt` field
- Updated `VisualAgentWorkspace` contract type with `stylePrompt` property
- Updated `UpdateVisualAgentWorkspaceContract` to accept `stylePrompt` parameter

## Implementation Details
- Style prompts are trimmed and capped at 500 characters to prevent excessive prompt bloating
- The feature gracefully handles empty/null values (treated as "no style prompt")
- UI provides both quick preset selection and free-form text input for flexibility
- Style prompt state persists in the workspace and is restored on page load
- Visual feedback shows when a style prompt is active via border/background color changes

https://claude.ai/code/session_013eneNV3TwNWiQ1suoYh1gj