### PR TITLE
Add retry, copy, and download features to Arena battle results

### DIFF
--- a/prd-admin/src/pages/arena/ArenaPage.tsx
+++ b/prd-admin/src/pages/arena/ArenaPage.tsx
@@ -1026,14 +1026,14 @@ export function ArenaPage() {
         for (const id of newlyDone) next.add(id);
         return next;
       });
-      // Clear after animation
+      // Clear after animation completes (matches 3s CSS duration)
       setTimeout(() => {
         setJustCompletedIds((prev) => {
           const next = new Set(prev);
           for (const id of newlyDone) next.delete(id);
           return next;
         });
-      }, 1500);
+      }, 3200);
     }
   }, [panels]);
   function handleCopyPanel(panel: ArenaPanel) {

--- a/prd-admin/src/pages/arena/ArenaPage.tsx
+++ b/prd-admin/src/pages/arena/ArenaPage.tsx
@@ -1575,7 +1575,7 @@ export function ArenaPage() {
                   >
                     <div
                       className={cn(
-                        'flex flex-col h-full rounded-[14px] transition-all duration-500',
+                        'flex flex-col h-full rounded-[14px] overflow-hidden transition-transform duration-500',
                         revealAnimating && 'scale-[0.98]',
                         justCompleted && 'arena-panel-done-pulse'
                       )}

--- a/prd-admin/src/pages/arena/ArenaPage.tsx
+++ b/prd-admin/src/pages/arena/ArenaPage.tsx
@@ -1570,7 +1570,7 @@ export function ArenaPage() {
                 return (
                   <div
                     key={panel.slotId}
-                    className="flex-shrink-0 flex flex-col min-w-0"
+                    className="flex-shrink-0 flex flex-col overflow-hidden"
                     style={{ width: 'calc(33.333% - 8px)', minWidth: '320px' }}
                   >
                     <div
@@ -1662,7 +1662,7 @@ export function ArenaPage() {
                               <ThinkingBlock thinking={panel.thinking} color={labelColor} />
                             )}
                             <div
-                              className="text-[13px] px-3 py-2 rounded-lg"
+                              className="text-[13px] px-3 py-2 rounded-lg break-all"
                               style={{ background: 'rgba(239,68,68,0.08)', color: 'rgba(239,68,68,0.9)', border: '1px solid rgba(239,68,68,0.15)' }}
                             >
                               {panel.errorMessage ?? '响应异常'}

--- a/prd-admin/src/pages/arena/ArenaPage.tsx
+++ b/prd-admin/src/pages/arena/ArenaPage.tsx
@@ -1570,7 +1570,7 @@ export function ArenaPage() {
                 return (
                   <div
                     key={panel.slotId}
-                    className="flex-shrink-0 flex flex-col"
+                    className="flex-shrink-0 flex flex-col min-w-0"
                     style={{ width: 'calc(33.333% - 8px)', minWidth: '320px' }}
                   >
                     <div

--- a/prd-admin/src/styles/globals.css
+++ b/prd-admin/src/styles/globals.css
@@ -1551,15 +1551,15 @@ html[data-perf-mode="performance"] .blur-text span {
   to { transform: rotate(360deg); }
 }
 
-/* Arena panel completion pulse — brief green glow to draw attention */
+/* Arena panel completion pulse — green glow to draw attention */
 @keyframes arena-done-pulse {
-  0% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.4); }
-  50% { box-shadow: 0 0 12px 2px rgba(16, 185, 129, 0.25); }
-  100% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0); }
+  0% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0); border-color: rgba(16, 185, 129, 0); }
+  15% { box-shadow: 0 0 16px 3px rgba(16, 185, 129, 0.35); border-color: rgba(16, 185, 129, 0.5); }
+  100% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0); border-color: rgba(16, 185, 129, 0); }
 }
 .arena-panel-done-pulse {
-  animation: arena-done-pulse 1.5s ease-out;
-  border: 1px solid rgba(16, 185, 129, 0.3);
+  animation: arena-done-pulse 3s ease-out forwards;
+  border: 1px solid rgba(16, 185, 129, 0.5);
 }
 
 /* ── AI-Native UI: Chat Page Styles ───────────────────────────────── */

--- a/prd-admin/src/styles/globals.css
+++ b/prd-admin/src/styles/globals.css
@@ -1551,6 +1551,17 @@ html[data-perf-mode="performance"] .blur-text span {
   to { transform: rotate(360deg); }
 }
 
+/* Arena panel completion pulse — brief green glow to draw attention */
+@keyframes arena-done-pulse {
+  0% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.4); }
+  50% { box-shadow: 0 0 12px 2px rgba(16, 185, 129, 0.25); }
+  100% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0); }
+}
+.arena-panel-done-pulse {
+  animation: arena-done-pulse 1.5s ease-out;
+  border: 1px solid rgba(16, 185, 129, 0.3);
+}
+
 /* ── AI-Native UI: Chat Page Styles ───────────────────────────────── */
 
 /* Typing indicator: 3-dot pulse */


### PR DESCRIPTION
## Summary
Enhanced the Arena page with new user-facing features for managing battle results: the ability to retry battles with the same prompt, copy panel responses to clipboard, and download responses as markdown files.

## Key Changes

- **Retry functionality**: Added `handleRetry()` function that re-runs the same question against the selected models. Includes proper state reset and session storage management.

- **Copy to clipboard**: Implemented `handleCopyPanel()` with visual feedback (Check icon appears for 2 seconds after successful copy).

- **Download as markdown**: Added `handleDownloadPanel()` to export panel responses as markdown files with the model name as the filename.

- **UI improvements**:
  - Added "重试" (Retry) button in the prompt display area (visible only when battle is complete and not streaming)
  - Added Copy and Download buttons to the panel footer, right-aligned next to metrics
  - Imported new icons from lucide-react: `RefreshCw`, `Download`, `Copy`, `Check`

- **Bug fixes**:
  - Fixed race condition in `runDone` event handler by directly setting `allDone=true` instead of checking `panelsRef.current`, which may not be updated yet due to React 18 batching
  - Added safety net `useEffect` hook to detect when all panels are done even if the `runDone` event was missed

## Implementation Details

- Retry uses the same `createArenaRun` and `subscribeToRunStream` flow as the initial send
- Copy feedback uses a 2-second timeout to reset the visual indicator
- Download creates a blob with markdown format and uses the browser's download mechanism
- The retry button only appears when `allDone && !isStreaming` to prevent conflicts
- Copy/Download buttons are always visible for completed panels (not gated by reveal state)

https://claude.ai/code/session_01XyF2Ro9gzAr4xG2f1uSFXs