### PR TITLE
Fix image size fallback and model health reset API endpoint

### DIFF
--- a/prd-admin/src/pages/literary-agent/ArticleIllustrationEditorPage.tsx
+++ b/prd-admin/src/pages/literary-agent/ArticleIllustrationEditorPage.tsx
@@ -493,7 +493,7 @@ export default function ArticleIllustrationEditorPage({ workspaceId }: { workspa
       setImageGenModel({
         id: `pool-${pool.id}-${topPoolModel.modelId}`,
         name: pool.name || topPoolModel.modelId,
-        modelName: topPoolModel.modelId,
+        modelName: pool.code || topPoolModel.modelId,
         platformId: topPoolModel.platformId,
         enabled: true,
         isImageGen: true,

--- a/prd-admin/src/pages/literary-agent/ArticleIllustrationEditorPage.tsx
+++ b/prd-admin/src/pages/literary-agent/ArticleIllustrationEditorPage.tsx
@@ -50,7 +50,7 @@ import {
 } from '@/services/real/literaryAgentConfig';
 import type { LiteraryAgentModelPool, LiteraryAgentAllModelsResponse } from '@/services/contracts/literaryAgentConfig';
 import { ImageSizePicker } from '@/components/ui/ImageSizePicker';
-import type { SizesByResolution } from '@/lib/imageAspectOptions';
+import { ASPECT_OPTIONS, type SizesByResolution } from '@/lib/imageAspectOptions';
 import { Wand2, Download, Sparkles, FileText, Plus, Trash2, Edit2, Upload, Copy, DownloadCloud, MapPin, Image as ImageIcon, CheckCircle2, Pencil, Settings, Globe, User, TrendingUp, Clock, Search, GitFork, Share2, Loader2, ArrowLeft } from 'lucide-react';
 import type { ReferenceImageConfig } from '@/services/contracts/literaryAgentConfig';
 import React, { useState, useCallback, useEffect, useRef } from 'react';
@@ -506,11 +506,18 @@ export default function ArticleIllustrationEditorPage({ workspaceId }: { workspa
     }
   }, [referenceImageConfigs, text2ImgPool, img2ImgPool]);
 
+  // 从 ASPECT_OPTIONS 构建默认尺寸选项（当适配器未返回尺寸时作为 fallback）
+  const defaultSizesByResolution: SizesByResolution = React.useMemo(() => ({
+    '1k': ASPECT_OPTIONS.map(opt => ({ size: opt.size1k, aspectRatio: opt.id })),
+    '2k': ASPECT_OPTIONS.map(opt => ({ size: opt.size2k, aspectRatio: opt.id })),
+    '4k': ASPECT_OPTIONS.map(opt => ({ size: opt.size4k, aspectRatio: opt.id })),
+  }), []);
+
   // 从后端获取生图模型的尺寸选项（按分辨率分组，与视觉创作一致）
   useEffect(() => {
     const modelName = imageGenModel?.modelName;
     if (!modelName) {
-      setSizesByResolutionForPicker({ '1k': [], '2k': [], '4k': [] });
+      setSizesByResolutionForPicker(defaultSizesByResolution);
       return;
     }
     let cancelled = false;
@@ -520,20 +527,23 @@ export default function ArticleIllustrationEditorPage({ workspaceId }: { workspa
         if (cancelled) return;
         if (res.success && res.data?.matched && res.data.sizesByResolution) {
           const data = res.data.sizesByResolution;
-          setSizesByResolutionForPicker({
+          const resolved: SizesByResolution = {
             '1k': Array.isArray(data['1k']) ? data['1k'] : [],
             '2k': Array.isArray(data['2k']) ? data['2k'] : [],
             '4k': Array.isArray(data['4k']) ? data['4k'] : [],
-          });
+          };
+          // 适配器返回了有效尺寸则使用，否则 fallback 到默认
+          const hasAny = resolved['1k'].length > 0 || resolved['2k'].length > 0 || resolved['4k'].length > 0;
+          setSizesByResolutionForPicker(hasAny ? resolved : defaultSizesByResolution);
         } else {
-          setSizesByResolutionForPicker({ '1k': [], '2k': [], '4k': [] });
+          setSizesByResolutionForPicker(defaultSizesByResolution);
         }
       } catch {
-        if (!cancelled) setSizesByResolutionForPicker({ '1k': [], '2k': [], '4k': [] });
+        if (!cancelled) setSizesByResolutionForPicker(defaultSizesByResolution);
       }
     })();
     return () => { cancelled = true; };
-  }, [imageGenModel?.modelName]);
+  }, [imageGenModel?.modelName, defaultSizesByResolution]);
 
   useEffect(() => {
     let cancelled = false;

--- a/prd-admin/src/services/api.ts
+++ b/prd-admin/src/services/api.ts
@@ -94,7 +94,7 @@ export const api = {
       forApp: () => '/api/mds/model-groups/for-app',
       predict: (id: string) => `/api/mds/model-groups/${id}/predict`,
       resetModelHealth: (groupId: string, modelId: string) =>
-        `/api/mds/model-groups/${groupId}/models/${encodeURIComponent(modelId)}/reset-health`,
+        `/api/mds/model-groups/${groupId}/reset-model-health?modelId=${encodeURIComponent(modelId)}`,
       resetAllHealth: (groupId: string) =>
         `/api/mds/model-groups/${groupId}/reset-all-health`,
     },

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ModelGroupsController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ModelGroupsController.cs
@@ -472,8 +472,8 @@ public class ModelGroupsController : ControllerBase
     /// </summary>
     /// <param name="id">模型池 ID</param>
     /// <param name="modelId">模型 ID（ModelGroupItem.ModelId）</param>
-    [HttpPost("{id}/models/{modelId}/reset-health")]
-    public async Task<IActionResult> ResetModelHealth(string id, string modelId)
+    [HttpPost("{id}/reset-model-health")]
+    public async Task<IActionResult> ResetModelHealth(string id, [FromQuery] string modelId)
     {
         var group = await _db.ModelGroups.Find(g => g.Id == id).FirstOrDefaultAsync();
 


### PR DESCRIPTION
## Summary
This PR addresses two issues: (1) improves the image size picker fallback behavior when the backend adapter doesn't return size options, and (2) refactors the model health reset API endpoint to use query parameters instead of route parameters.

## Key Changes

### Frontend - Article Illustration Editor (ArticleIllustrationEditorPage.tsx)
- **Import ASPECT_OPTIONS**: Added import of `ASPECT_OPTIONS` from `imageAspectOptions` to build default size options
- **Fix modelName assignment**: Changed from using `topPoolModel.modelId` to `pool.code || topPoolModel.modelId` for more accurate model identification
- **Implement size fallback logic**: 
  - Created `defaultSizesByResolution` memoized value that builds default size options from `ASPECT_OPTIONS` for all resolutions (1k, 2k, 4k)
  - Modified the effect that fetches model sizes to use `defaultSizesByResolution` as fallback when:
    - No model is selected
    - Backend adapter returns no data
    - Backend adapter returns empty size arrays
  - Added validation to check if adapter returned any valid sizes before using them

### Backend - Model Groups Controller (ModelGroupsController.cs)
- **Refactor endpoint route**: Changed from `POST {id}/models/{modelId}/reset-health` to `POST {id}/reset-model-health`
- **Move modelId to query parameter**: Changed `modelId` from route parameter to `[FromQuery]` parameter for cleaner API design

### API Client (api.ts)
- **Update endpoint URL**: Updated `resetModelHealth` function to match new backend endpoint structure with query parameter

## Implementation Details
- The `defaultSizesByResolution` is memoized with an empty dependency array since `ASPECT_OPTIONS` is a constant
- The size fallback includes a check (`hasAny`) to ensure at least one resolution has valid sizes before using the adapter response
- The API endpoint change improves REST conventions by using query parameters for filtering/options rather than route parameters

https://claude.ai/code/session_01APPUZJ31RWMNZDdHsp2ror