### PR TITLE
Include image URLs in AI chat image generation runs

### DIFF
--- a/prd-admin/src/pages/ai-chat/AdvancedVisualAgentTab.tsx
+++ b/prd-admin/src/pages/ai-chat/AdvancedVisualAgentTab.tsx
@@ -2435,7 +2435,7 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
             void (async () => {
               for (const el of runningElements) {
                 try {
-                  const res = await getImageGenRun({ runId: el.runId!, includeItems: true });
+                  const res = await getImageGenRun({ runId: el.runId!, includeItems: true, includeImages: true });
                   if (!res.success || !res.data?.run) continue;
                   const run = res.data.run;
                   if (run.status === 'Failed' || run.status === 'Cancelled') {

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ImageGenController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ImageGenController.cs
@@ -1468,7 +1468,7 @@ public class ImageGenController : ControllerBase
                 x.RatioAdjusted,
                 status = x.Status.ToString(),
                 base64 = includeImages ? x.Base64 : null,
-                url = includeImages ? x.Url : null,
+                x.Url,
                 x.RevisedPrompt,
                 x.ErrorCode,
                 x.ErrorMessage,


### PR DESCRIPTION
## Summary
Updated the image generation run retrieval to always include image URLs in the response, and ensured the frontend requests this data when fetching run details.

## Key Changes
- **Frontend (AdvancedVisualAgentTab.tsx)**: Added `includeImages: true` parameter to `getImageGenRun()` call to request image data when polling running image generation tasks
- **Backend (ImageGenController.cs)**: Modified the `GetRun()` endpoint to always return the `Url` field regardless of the `includeImages` query parameter, while keeping `Base64` conditional on the parameter

## Implementation Details
The backend change ensures that image URLs are always available in the API response, which is important for displaying generated images in the UI. The frontend now explicitly requests image data when checking the status of running image generation operations, ensuring that image URLs are properly populated when the run completes.

https://claude.ai/code/session_01Vs9tJeBtQBbEpvd8F3iJHp