### PR TITLE
Add permission fingerprint mechanism for cache invalidation

### DIFF
--- a/prd-admin/src/app/App.tsx
+++ b/prd-admin/src/app/App.tsx
@@ -121,6 +121,7 @@ export default function App() {
   const setPermissionsLoaded = useAuthStore((s) => s.setPermissionsLoaded);
   const setIsRoot = useAuthStore((s) => s.setIsRoot);
   const setCdnBaseUrl = useAuthStore((s) => s.setCdnBaseUrl);
+  const setPermFingerprint = useAuthStore((s) => s.setPermFingerprint);
   const setMenuCatalog = useAuthStore((s) => s.setMenuCatalog);
   const menuCatalogLoaded = useAuthStore((s) => s.menuCatalogLoaded);
   const logout = useAuthStore((s) => s.logout);
@@ -143,9 +144,10 @@ export default function App() {
       setPermissions(res.data.effectivePermissions || []);
       setIsRoot(res.data.isRoot ?? false);
       if (res.data.cdnBaseUrl) setCdnBaseUrl(res.data.cdnBaseUrl);
+      if (res.data.permissionFingerprint) setPermFingerprint(res.data.permissionFingerprint);
       setPermissionsLoaded(true);
     })();
-  }, [isAuthenticated, permissionsLoaded, setPermissions, setPermissionsLoaded, setIsRoot, setCdnBaseUrl, logout]);
+  }, [isAuthenticated, permissionsLoaded, setPermissions, setPermissionsLoaded, setIsRoot, setCdnBaseUrl, setPermFingerprint, logout]);
 
   // 加载菜单目录
   useEffect(() => {

--- a/prd-admin/src/services/contracts/authz.ts
+++ b/prd-admin/src/services/contracts/authz.ts
@@ -10,6 +10,8 @@ export type AdminAuthzMe = {
   effectivePermissions: string[];
   /** CDN 基础地址，用于拼接静态资源 URL */
   cdnBaseUrl?: string | null;
+  /** 权限指纹（基于权限目录+角色定义的哈希），用于检测部署/角色变更后的前端缓存失效 */
+  permissionFingerprint?: string | null;
 };
 
 export type AdminPermissionDef = { key: string; name: string; description?: string | null };

--- a/prd-admin/src/services/real/apiClient.ts
+++ b/prd-admin/src/services/real/apiClient.ts
@@ -121,6 +121,33 @@ function getApiErrorLike(x: unknown): { code?: string; message?: string } | null
   return code || message ? { code, message } : null;
 }
 
+/**
+ * 检测后端响应中的权限指纹是否与前端缓存一致。
+ * 若不一致（说明后端发布了新版本或角色发生变更），则清除权限/菜单缓存标记，
+ * 触发 App.tsx 中的 useEffect 自动重新拉取。
+ */
+function checkPermissionFingerprint(res: Response): void {
+  const serverFp = res.headers.get('X-Perm-Fingerprint');
+  if (!serverFp) return; // 旧版后端或非 API 响应，跳过
+
+  const store = useAuthStore.getState();
+  if (!store.isAuthenticated) return;
+
+  const cachedFp = store.permFingerprint;
+  // 首次缓存为空时仅记录，不触发刷新（避免首次登录时多余请求）
+  if (!cachedFp) {
+    store.setPermFingerprint(serverFp);
+    return;
+  }
+
+  if (cachedFp !== serverFp) {
+    // 指纹变更：清除缓存标记，下一轮 React render 会自动重新拉取
+    store.setPermFingerprint(serverFp);
+    store.setPermissionsLoaded(false);
+    store.setMenuCatalogLoaded(false);
+  }
+}
+
 async function tryRefreshAdminToken(): Promise<boolean> {
   const authStore = useAuthStore.getState();
   const token = authStore.token;
@@ -217,6 +244,10 @@ async function apiRequestInner<T>(
     }
     return fail('NETWORK_ERROR', e instanceof Error ? e.message : '网络错误') as unknown as ApiResponse<T>;
   }
+
+  // 检测权限指纹变更：后端每个响应都带 X-Perm-Fingerprint 头，
+  // 若与前端缓存不一致则说明发生了新部署或角色变更，需刷新权限缓存
+  checkPermissionFingerprint(res);
 
   if (res.status === 204) {
     const data = (options?.emptyResponseData ?? (true as unknown)) as T;

--- a/prd-admin/src/stores/authStore.ts
+++ b/prd-admin/src/stores/authStore.ts
@@ -30,6 +30,8 @@ type AuthState = {
   menuCatalogLoaded: boolean;
   /** CDN 基础地址（从后端 /api/authz/me 获取） */
   cdnBaseUrl: string;
+  /** 权限指纹（后端基于权限目录+角色定义计算的哈希，用于检测部署/角色变更后的缓存失效） */
+  permFingerprint: string;
   login: (user: AuthUser, token: string) => void;
   setTokens: (token: string, refreshToken: string, sessionKey: string) => void;
   setPermissions: (permissions: string[]) => void;
@@ -38,6 +40,7 @@ type AuthState = {
   setMenuCatalog: (items: AdminMenuItem[]) => void;
   setMenuCatalogLoaded: (loaded: boolean) => void;
   setCdnBaseUrl: (url: string) => void;
+  setPermFingerprint: (fp: string) => void;
   patchUser: (patch: Partial<AuthUser>) => void;
   logout: () => void;
 };
@@ -56,6 +59,7 @@ export const useAuthStore = create<AuthState>()(
       menuCatalog: [],
       menuCatalogLoaded: false,
       cdnBaseUrl: '',
+      permFingerprint: '',
       login: (user, token) => set({ isAuthenticated: true, user, token }),
       setTokens: (token, refreshToken, sessionKey) => set({ token, refreshToken, sessionKey }),
       setPermissions: (permissions) => set({ permissions: Array.isArray(permissions) ? permissions : [] }),
@@ -64,6 +68,7 @@ export const useAuthStore = create<AuthState>()(
       setMenuCatalog: (items) => set({ menuCatalog: Array.isArray(items) ? items : [], menuCatalogLoaded: true }),
       setMenuCatalogLoaded: (loaded) => set({ menuCatalogLoaded: !!loaded }),
       setCdnBaseUrl: (url) => set({ cdnBaseUrl: (url ?? '').trim().replace(/\/+$/, '') }),
+      setPermFingerprint: (fp) => set({ permFingerprint: fp || '' }),
       patchUser: (patch) =>
         set((s) => (s.user ? { user: { ...s.user, ...patch } } : ({} as Partial<AuthState>))),
       logout: () => {
@@ -83,6 +88,7 @@ export const useAuthStore = create<AuthState>()(
           menuCatalog: [],
           menuCatalogLoaded: false,
           cdnBaseUrl: '',
+          permFingerprint: '',
         });
       },
     }),

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/AuthzController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/AuthzController.cs
@@ -19,17 +19,20 @@ public sealed class AuthzController : ControllerBase
 {
     private readonly IAdminPermissionService _permissionService;
     private readonly IAdminControllerScanner _scanner;
+    private readonly ISystemRoleCacheService _roleCache;
     private readonly MongoDbContext _db;
     private readonly IConfiguration _cfg;
 
     public AuthzController(
         IAdminPermissionService permissionService,
         IAdminControllerScanner scanner,
+        ISystemRoleCacheService roleCache,
         MongoDbContext db,
         IConfiguration cfg)
     {
         _permissionService = permissionService;
         _scanner = scanner;
+        _roleCache = roleCache;
         _db = db;
         _cfg = cfg;
     }
@@ -52,6 +55,8 @@ public sealed class AuthzController : ControllerBase
         var uid = GetUserId();
         var isRoot = IsRoot();
 
+        var fingerprint = _roleCache.GetFingerprint();
+
         if (isRoot)
         {
             return Ok(ApiResponse<AdminAuthzMeResponse>.Ok(new AdminAuthzMeResponse
@@ -63,7 +68,8 @@ public sealed class AuthzController : ControllerBase
                 IsRoot = true,
                 SystemRoleKey = "root",
                 EffectivePermissions = AdminPermissionCatalog.All.Select(x => x.Key).ToList(),
-                CdnBaseUrl = GetCdnBaseUrl()
+                CdnBaseUrl = GetCdnBaseUrl(),
+                PermissionFingerprint = fingerprint
             }));
         }
 
@@ -90,7 +96,8 @@ public sealed class AuthzController : ControllerBase
             IsRoot = false,
             SystemRoleKey = roleKey,
             EffectivePermissions = perms.ToList(),
-            CdnBaseUrl = GetCdnBaseUrl()
+            CdnBaseUrl = GetCdnBaseUrl(),
+            PermissionFingerprint = fingerprint
         }));
     }
 

--- a/prd-api/src/PrdAgent.Api/Middleware/PermissionFingerprintMiddleware.cs
+++ b/prd-api/src/PrdAgent.Api/Middleware/PermissionFingerprintMiddleware.cs
@@ -1,0 +1,33 @@
+using PrdAgent.Core.Interfaces;
+
+namespace PrdAgent.Api.Middleware;
+
+/// <summary>
+/// 在每个 API 响应中注入 X-Perm-Fingerprint 头。
+/// 前端据此判断权限目录或角色定义是否已变更（如新部署、角色 CRUD），
+/// 若指纹不一致则自动刷新权限缓存，避免频繁发版导致"权限不足"的问题。
+/// </summary>
+public sealed class PermissionFingerprintMiddleware
+{
+    private readonly RequestDelegate _next;
+
+    public PermissionFingerprintMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task Invoke(HttpContext context, ISystemRoleCacheService roleCache)
+    {
+        context.Response.OnStarting(() =>
+        {
+            var fp = roleCache.GetFingerprint();
+            if (!string.IsNullOrEmpty(fp))
+            {
+                context.Response.Headers["X-Perm-Fingerprint"] = fp;
+            }
+            return Task.CompletedTask;
+        });
+
+        await _next(context);
+    }
+}

--- a/prd-api/src/PrdAgent.Api/Models/Responses/AdminAuthzResponses.cs
+++ b/prd-api/src/PrdAgent.Api/Models/Responses/AdminAuthzResponses.cs
@@ -18,6 +18,12 @@ public sealed class AdminAuthzMeResponse
     /// CDN 基础地址，前端用于拼接静态资源 URL（如头像、图标等）
     /// </summary>
     public string? CdnBaseUrl { get; set; }
+
+    /// <summary>
+    /// 权限指纹（基于权限目录 + 角色定义计算的哈希）。
+    /// 前端缓存此值，当检测到变化时自动刷新权限缓存。
+    /// </summary>
+    public string? PermissionFingerprint { get; set; }
 }
 
 public sealed class SystemRoleDto

--- a/prd-api/src/PrdAgent.Api/Program.cs
+++ b/prd-api/src/PrdAgent.Api/Program.cs
@@ -518,21 +518,23 @@ builder.Services.AddCors(options =>
             policy
                 .SetIsOriginAllowed(origin =>
                 {
-                    if (string.IsNullOrWhiteSpace(origin) || origin == "null") return false;
+                    if (string.IsNullOrWhiteSpace(origin) || origin == “null”) return false;
                     if (!Uri.TryCreate(origin, UriKind.Absolute, out var uri)) return false;
                     // 兼容 IPv4/IPv6 回环：localhost、127.0.0.1、[::1]
-                    // 说明：Mac/Windows 上某些情况下前端会以 http://[::1]:port 作为 Origin，若未放行会导致预检 OPTIONS 403“看似随机”波动
-                    return uri.Host is "localhost" or "127.0.0.1" or "::1";
+                    // 说明：Mac/Windows 上某些情况下前端会以 http://[::1]:port 作为 Origin，若未放行会导致预检 OPTIONS 403”看似随机”波动
+                    return uri.Host is “localhost” or “127.0.0.1” or “::1”;
                 })
                 .AllowAnyHeader()
-                .AllowAnyMethod();
+                .AllowAnyMethod()
+                .WithExposedHeaders(“X-Perm-Fingerprint”);
             return;
         }
 
         // 生产环境：严格按配置允许来源
         policy.WithOrigins(allowedOrigins)
             .AllowAnyHeader()
-            .AllowAnyMethod();
+            .AllowAnyMethod()
+            .WithExposedHeaders(“X-Perm-Fingerprint”);
     });
 });
 
@@ -951,6 +953,8 @@ app.UseMiddleware<PrdAgent.Api.Middleware.UserLastActiveMiddleware>();
 app.UseAuthorization();
 // 管理后台权限（菜单/页面/接口统一绑定 permission key）
 app.UseMiddleware<PrdAgent.Api.Middleware.AdminPermissionMiddleware>();
+// 权限指纹：每个响应注入 X-Perm-Fingerprint，前端据此判断是否需要刷新权限缓存
+app.UseMiddleware<PrdAgent.Api.Middleware.PermissionFingerprintMiddleware>();
 app.MapControllers();
 
 // 健康检查端点

--- a/prd-api/src/PrdAgent.Core/Interfaces/ISystemRoleCacheService.cs
+++ b/prd-api/src/PrdAgent.Core/Interfaces/ISystemRoleCacheService.cs
@@ -27,4 +27,11 @@ public interface ISystemRoleCacheService
     /// 初始化缓存（启动时调用）
     /// </summary>
     Task InitializeAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// 获取权限指纹（基于权限目录 + 内置角色 + 自定义角色变更时间计算的哈希）。
+    /// 每次部署新版本（权限目录变更）或角色 CRUD 操作后指纹会变化，
+    /// 前端据此判断是否需要刷新权限缓存。
+    /// </summary>
+    string GetFingerprint();
 }

--- a/prd-api/src/PrdAgent.Infrastructure/Services/SystemRoleCacheService.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/SystemRoleCacheService.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 using PrdAgent.Core.Interfaces;
@@ -30,6 +32,9 @@ public sealed class SystemRoleCacheService : ISystemRoleCacheService
 
     // 快速查找表
     private Dictionary<string, SystemRole> _roleByKey = new(StringComparer.OrdinalIgnoreCase);
+
+    // 权限指纹（权限目录 + 角色定义的哈希，用于前端缓存失效判断）
+    private string _fingerprint = string.Empty;
 
     public SystemRoleCacheService(MongoDbContext db, ILogger<SystemRoleCacheService> logger)
     {
@@ -93,6 +98,42 @@ public sealed class SystemRoleCacheService : ISystemRoleCacheService
 
         _allRoles = merged.OrderBy(r => r.Key, StringComparer.OrdinalIgnoreCase).ToList();
         _roleByKey = _allRoles.ToDictionary(r => r.Key, r => r, StringComparer.OrdinalIgnoreCase);
+
+        _fingerprint = ComputeFingerprint();
+    }
+
+    /// <summary>
+    /// 基于权限目录 + 所有角色定义计算 SHA256 指纹（取前 12 位 hex）。
+    /// 任何权限目录变更（新部署）或角色权限调整都会改变此值。
+    /// </summary>
+    private string ComputeFingerprint()
+    {
+        var sb = new StringBuilder();
+
+        // 1. 权限目录（每次新增/删除权限 key 都会变）
+        sb.Append("catalog:");
+        foreach (var p in AdminPermissionCatalog.All.OrderBy(x => x.Key, StringComparer.Ordinal))
+        {
+            sb.Append(p.Key).Append(',');
+        }
+
+        // 2. 所有角色的 key + 排序后的权限列表
+        sb.Append("|roles:");
+        foreach (var role in _allRoles)
+        {
+            sb.Append(role.Key).Append('=');
+            if (role.Permissions != null)
+            {
+                foreach (var p in role.Permissions.OrderBy(x => x, StringComparer.Ordinal))
+                {
+                    sb.Append(p).Append(',');
+                }
+            }
+            sb.Append(';');
+        }
+
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(sb.ToString()));
+        return Convert.ToHexString(hash)[..12].ToLowerInvariant();
     }
 
     public IReadOnlyList<SystemRole> GetAllRoles()
@@ -110,6 +151,14 @@ public sealed class SystemRoleCacheService : ISystemRoleCacheService
         lock (_lock)
         {
             return _roleByKey.TryGetValue(key.Trim(), out var role) ? role : null;
+        }
+    }
+
+    public string GetFingerprint()
+    {
+        lock (_lock)
+        {
+            return _fingerprint;
         }
     }
 }


### PR DESCRIPTION
## Summary
Implements a permission fingerprint system that detects when the backend's permission catalog or role definitions change (e.g., after deployment or role CRUD operations), allowing the frontend to automatically invalidate and refresh its permission cache without requiring a full page reload.

## Key Changes

### Backend (.NET)
- **SystemRoleCacheService**: 
  - Added `_fingerprint` field to store a SHA256-based hash of the permission catalog and all role definitions
  - Implemented `ComputeFingerprint()` method that generates a 12-character hex fingerprint based on sorted permission keys and role definitions
  - Added `GetFingerprint()` public method to retrieve the current fingerprint
  - Fingerprint is recalculated whenever the merged role list is rebuilt

- **PermissionFingerprintMiddleware** (new):
  - Injects `X-Perm-Fingerprint` header into every API response
  - Allows frontend to detect permission changes without polling

- **AuthzController**:
  - Injected `ISystemRoleCacheService` dependency
  - Updated `/api/authz/me` endpoint to include `PermissionFingerprint` in the response

- **CORS Configuration** (Program.cs):
  - Exposed `X-Perm-Fingerprint` header in CORS policy for both development and production environments

- **ISystemRoleCacheService Interface**:
  - Added `GetFingerprint()` method contract

### Frontend (React/TypeScript)
- **apiClient.ts**:
  - Added `checkPermissionFingerprint()` function that compares server fingerprint with cached value
  - Automatically clears permission and menu cache flags when fingerprint changes
  - Integrated check into `apiRequestInner()` to run on every API response

- **authStore.ts**:
  - Added `permFingerprint` state field to store the cached fingerprint
  - Added `setPermFingerprint()` action to update the fingerprint

- **App.tsx**:
  - Updated `useEffect` hook to store the fingerprint from `/api/authz/me` response
  - Added dependency on `setPermFingerprint` to trigger re-fetch when permissions are loaded

- **authz.ts** (contracts):
  - Added `permissionFingerprint` field to `AdminAuthzMe` type

## Implementation Details
- Fingerprint is a 12-character lowercase hex string derived from SHA256 hash of concatenated permission catalog and role definitions
- First-time login caches the fingerprint without triggering a refresh (avoids unnecessary requests)
- Subsequent fingerprint mismatches automatically clear the `permissionsLoaded` and `menuCatalogLoaded` flags, triggering React's `useEffect` to re-fetch permissions
- The mechanism works transparently across all API calls via the middleware and client-side interceptor

https://claude.ai/code/session_013AG3DpmgK1qN5a8vLfJ1vQ