### PR TITLE
Darken starfield background for improved content readability

### DIFF
--- a/prd-admin/src/pages/home/components/StarfieldBackground.tsx
+++ b/prd-admin/src/pages/home/components/StarfieldBackground.tsx
@@ -149,21 +149,24 @@ export function StarfieldBackground({ className, themeColor }: StarfieldBackgrou
           m += layer(uv * mix(10.0, 0.5, depth) + fi * 20.0) * fade;
         }
 
+        // Reduce accumulated brightness for better content readability
+        m *= 0.55;
+
         // Use theme color if provided, otherwise use electric cyan-blue
         vec3 defaultColor = vec3(0.0, 0.70, 0.95);
         vec3 themeBase = length(uThemeColor) > 0.1 ? uThemeColor : defaultColor;
 
         // Create color variations
-        vec3 themeBright = themeBase * 1.3;
-        vec3 themeDark = themeBase * 0.7;
+        vec3 themeBright = themeBase * 1.2;
+        vec3 themeDark = themeBase * 0.6;
 
         float colorMix = sin(iTime * 0.3) * 0.5 + 0.5;
         vec3 baseColor = mix(themeDark, themeBright, colorMix);
 
-        vec3 col = (m - gradient.y * 0.5) * baseColor;
+        vec3 col = (m - gradient.y * 0.4) * baseColor;
 
-        // Tone mapping
-        col = col / (col + 0.8);
+        // Tone mapping (higher constant = darker overall)
+        col = col / (col + 1.2);
 
         gl_FragColor = vec4(col, 1.0);
       }


### PR DESCRIPTION
## Summary
Adjusted the starfield background shader to reduce overall brightness and improve contrast with foreground content, making text and UI elements more readable.

## Key Changes
- Reduced accumulated brightness multiplier from 1.0 to 0.55 to dim the overall starfield effect
- Lowered theme color brightness variation from 1.3 to 1.2 for less intense highlights
- Reduced theme color darkness variation from 0.7 to 0.6 for deeper shadows
- Decreased gradient influence on final color from 0.5 to 0.4
- Increased tone mapping constant from 0.8 to 1.2 to further darken the output

## Implementation Details
These changes work together to create a more subdued background that doesn't compete with foreground content. The cumulative effect of reducing brightness at multiple stages (accumulation, color variation, and tone mapping) ensures the starfield remains visually interesting while providing better contrast for readability.

https://claude.ai/code/session_01HDVEYZg4tH1ctN2vd6Yaeh