### PR TITLE
Add menu items and permissions for new Agent features

### DIFF
--- a/.claude/skills/add-agent-permission/SKILL.md
+++ b/.claude/skills/add-agent-permission/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: add-agent-permission
+description: 新增 Agent 权限。当需要为新功能添加权限时，自动判断分类并同步修改所有相关文件。触发词："加权限"、"新增权限"、"add permission"、"注册 agent"。
+---
+
+# Add Agent Permission - Agent 权限注册技能
+
+为新功能自动注册权限，确保后端定义、前端映射、内置角色、路由守卫全部同步。
+
+## 触发词
+
+- "加权限"
+- "新增权限"
+- "add permission"
+- "注册 agent"
+
+## 执行流程
+
+### Step 1: 读取规则文档
+
+先读取 `doc/rule.agent-permissions.md`，理解权限分类决策树和命名规范。
+
+### Step 2: 判断权限分类
+
+根据决策树判定新功能属于哪个分类：
+
+```
+是否调用 LLM/AI? → YES → 有独立页面? → YES → Agent 权限
+是否调用 LLM/AI? → NO  → 面向管理员? → YES → 基础设施权限
+```
+
+**关键判定依据**：
+- 有 LLM 调用 + 独立页面 → `{key}-agent.use`（Agent 权限）
+- 有管理/跨用户操作 → 追加 `{key}-agent.manage`
+- 纯管理功能 → `{module}.read` / `{module}.write`
+
+### Step 3: 同步修改文件（必须全部完成）
+
+按以下顺序修改，缺一不可：
+
+#### 3.1 后端权限定义
+**文件**: `prd-api/src/PrdAgent.Core/Security/AdminPermissionCatalog.cs`
+
+```csharp
+// 1. 添加常量
+public const string NewAgentUse = "new-agent.use";
+
+// 2. 在 All 列表中注册
+new(NewAgentUse, "新 Agent 名称", "功能描述"),
+```
+
+#### 3.2 后端内置角色
+**文件**: `prd-api/src/PrdAgent.Core/Security/BuiltInSystemRoles.cs`
+
+**规则**：
+- Agent `.use` 权限 → 必须添加到 `agent_tester`、`viewer`、`operator`
+- Agent `.manage` 权限 → 仅添加到 `operator`
+- 基础设施 `.read` → 添加到 `viewer`、`operator`
+- 基础设施 `.write` → 仅添加到 `operator`
+
+#### 3.3 后端 Controller
+**文件**: 对应的 Controller 文件
+
+```csharp
+[AdminController("new-agent", AdminPermissionCatalog.NewAgentUse)]
+```
+
+#### 3.4 前端权限菜单映射
+**文件**: `prd-admin/src/lib/authzMenuMapping.ts`
+
+```typescript
+// menuList 中添加
+{
+  appKey: 'new-agent',
+  label: '新 Agent',
+  icon: 'IconName',
+  permissions: ['new-agent.use'],
+},
+
+// allPermissions 中添加
+{ key: 'new-agent.use', label: '新 Agent', description: '功能描述', category: 'use' },
+```
+
+#### 3.5 前端路由守卫
+**文件**: `prd-admin/src/app/App.tsx`
+
+```tsx
+<Route path="new-agent" element={
+  <RequirePermission perm="new-agent.use"><NewAgentPage /></RequirePermission>
+} />
+```
+
+### Step 4: 更新规则文档
+
+将新权限登记到 `doc/rule.agent-permissions.md` 的对应表格中。
+
+### Step 5: 验证清单
+
+完成后输出验证清单：
+
+- [ ] `AdminPermissionCatalog.cs` — 常量 + All 列表
+- [ ] `BuiltInSystemRoles.cs` — agent_tester / viewer / operator 已添加
+- [ ] Controller — `[AdminController]` 属性正确
+- [ ] `authzMenuMapping.ts` — menuList + allPermissions
+- [ ] `App.tsx` — `RequirePermission` 使用正确权限
+- [ ] `doc/rule.agent-permissions.md` — 已登记
+
+## 禁止事项
+
+- 禁止使用 `access` 作为 Agent 路由的权限检查（太宽松）
+- 禁止前端路由权限与后端 Controller 权限不一致
+- 禁止新增 Agent 而不更新 `agent_tester` 角色
+- 禁止将 AI 应用的权限挂在非 agent 分类下（如 lab、settings）

--- a/doc/rule.agent-permissions.md
+++ b/doc/rule.agent-permissions.md
@@ -1,0 +1,160 @@
+# Agent 权限分类规则
+
+> **版本**：v1.0 | **创建日期**：2026-03-04 | **最后更新**：2026-03-04
+
+## 概述
+
+本文档定义了权限分类的判定规则。当新增功能时，必须参照本规则确定权限归类，避免权限混乱。
+
+---
+
+## 一、权限分类体系
+
+### 1.1 Agent 权限（`{app-key}.use`）
+
+**判定标准**（满足任一即归类为 Agent）：
+- 调用 LLM / AI 模型完成核心功能（不只是辅助）
+- 具有独立的用户交互界面（独立页面或工作区）
+- 消耗 Token / GPU 等计算资源
+- 具有 Run/Worker 异步执行模式
+
+**命名规则**：`{功能}-agent.use`
+
+**已注册 Agent 权限**：
+
+| Agent | 权限 Key | 说明 |
+|-------|---------|------|
+| PRD Agent | `prd-agent.use` | PRD 智能解读与问答 |
+| 视觉创作 Agent | `visual-agent.use` | 高级视觉创作工作区 |
+| 文学创作 Agent | `literary-agent.use` | 文章配图智能生成 |
+| 缺陷管理 Agent | `defect-agent.use` | 提交和查看缺陷 |
+| 视频 Agent | `video-agent.use` | 文章转视频教程生成 |
+| 竞技场 Agent | `arena-agent.use` | 模型盲评对战 |
+| AI 百宝箱 | `ai-toolbox.use` | 多 Agent 协同工具箱 |
+| 周报 Agent | `report-agent.use` | 周报创建与管理 |
+| 工作流引擎 | `workflow-agent.use` | 自动化工作流 |
+| 数据迁移 Agent | `data-migration-agent.use` | 数据映射与迁移 |
+
+### 1.2 Agent 管理权限（`{app-key}.manage`）
+
+**判定标准**：在 Agent 基础使用之上，需要管理权限的场景：
+- 管理模板、配置
+- 管理团队、成员
+- 查看所有用户的数据（跨用户）
+- 删除/修改他人的资源
+
+**命名规则**：`{功能}-agent.manage` 或 `{功能}-agent.{子域}.manage`
+
+**已注册管理权限**：
+
+| 权限 Key | 说明 |
+|---------|------|
+| `defect-agent.manage` | 缺陷模板、指派处理人 |
+| `ai-toolbox.manage` | 百宝箱工作流配置 |
+| `workflow-agent.manage` | 管理所有工作流 |
+| `data-migration-agent.write` | 删除集合、修复数据 |
+| `report-agent.template.manage` | 周报模板管理 |
+| `report-agent.team.manage` | 周报团队管理 |
+| `report-agent.view.all` | 查看所有团队周报 |
+| `report-agent.datasource.manage` | 数据源配置 |
+
+### 1.3 基础设施权限（`{module}.read` / `{module}.write`）
+
+**判定标准**：
+- 不涉及 AI/LLM 调用
+- 属于系统管理、配置、运维类功能
+- 面向管理员而非普通用户
+
+**已注册基础设施权限**：
+
+| 模块 | 读 | 写 |
+|------|-----|-----|
+| 用户管理 | `users.read` | `users.write` |
+| 群组管理 | `groups.read` | `groups.write` |
+| 模型管理 | `mds.read` | `mds.write` |
+| 日志 | `logs.read` | — |
+| 数据管理 | `data.read` | `data.write` |
+| 资产管理 | `assets.read` | `assets.write` |
+| 设置 | `settings.read` | `settings.write` |
+| 提示词 | `prompts.read` | `prompts.write` |
+| 技能 | `skills.read` | `skills.write` |
+| 实验室 | `lab.read` | `lab.write` |
+| 教程邮件 | `tutorial-email.read` | `tutorial-email.write` |
+| 总裁面板 | `executive.read` | — |
+
+### 1.4 平台权限（`{module}.manage`）
+
+| 权限 Key | 说明 |
+|---------|------|
+| `open-platform.manage` | 开放平台 App 管理 |
+| `authz.manage` | 权限角色管理 |
+| `automations.manage` | 自动化规则管理 |
+
+---
+
+## 二、内置角色权限分配原则
+
+### 2.1 角色定位
+
+| 角色 | 定位 | Agent 权限 | 管理权限 | 基础设施权限 |
+|------|------|-----------|---------|------------|
+| **admin** | 全权管理员 | 全部 | 全部 | 全部 |
+| **operator** | 运营/运维 | 全部 `.use` | 部分 `.manage` | 大部分读写 |
+| **viewer** | 只读体验 | 全部 `.use`（不含工作流） | 无 | 仅读 |
+| **agent_tester** | Agent 体验者 | **全部 `.use`** | 无 | 仅 `settings.read` |
+| **none** | 无权限 | 无 | 无 | 无 |
+
+### 2.2 关键规则
+
+1. **agent_tester 必须包含所有 `*.use` 权限** — 这是大部分用户的角色，新增 Agent 后必须同步添加
+2. **viewer 包含大部分 `*.use` 权限** — 只读用户也应能体验 Agent（消耗 Token 但不能管理）
+3. **operator 包含所有 `*.use` + 部分 `*.manage`** — 运维需要管理能力
+4. **新增 Agent 时的必做清单**：
+   - `AdminPermissionCatalog.cs` 添加权限常量 + `All` 列表
+   - `BuiltInSystemRoles.cs` 添加到 agent_tester / viewer / operator
+   - `authzMenuMapping.ts` 添加 menuList + allPermissions
+   - `App.tsx` 路由使用正确的 `RequirePermission`
+
+---
+
+## 三、分类决策树
+
+```
+新增功能 → 是否调用 LLM/AI?
+  ├─ YES → 是否有独立页面?
+  │   ├─ YES → Agent 权限 ({key}-agent.use)
+  │   │   └─ 是否有管理/跨用户操作?
+  │   │       ├─ YES → 追加管理权限 ({key}-agent.manage)
+  │   │       └─ NO  → 仅 .use
+  │   └─ NO  → 嵌入已有 Agent 的权限（如 LLM Gateway 不需要独立权限）
+  └─ NO  → 面向管理员?
+      ├─ YES → 基础设施权限 ({module}.read/.write)
+      └─ NO  → 平台权限 ({module}.manage) 或 access 即可
+```
+
+---
+
+## 四、变更文件清单
+
+新增 Agent 权限时需同步修改的文件：
+
+| # | 文件 | 操作 |
+|---|------|------|
+| 1 | `AdminPermissionCatalog.cs` | 添加 `const string` + `All` 列表条目 |
+| 2 | `BuiltInSystemRoles.cs` | 添加到 admin/operator/viewer/agent_tester |
+| 3 | `ArenaController.cs`（示例） | `[AdminController]` 属性绑定权限 |
+| 4 | `authzMenuMapping.ts` → `menuList` | 添加菜单分组定义 |
+| 5 | `authzMenuMapping.ts` → `allPermissions` | 添加权限条目定义 |
+| 6 | `App.tsx` | `<RequirePermission perm="xxx">` |
+| 7 | `CLAUDE.md` → 功能注册表 | 更新状态 |
+
+---
+
+## 五、反面案例（已修复）
+
+| 问题 | 修复前 | 修复后 |
+|------|--------|--------|
+| 竞技场挂在 lab 权限下 | `[AdminController("lab", LabRead)]` | `[AdminController("arena-agent", ArenaAgentUse)]` |
+| 百宝箱前端路由无门槛 | `RequirePermission perm="access"` | `RequirePermission perm="ai-toolbox.use"` |
+| agent_tester 缺少新 Agent | 无 arena/report/workflow | 补齐全部 `.use` |
+| 前端权限列表严重缺失 | 仅 4 个 Agent 权限 | 全部 21 个权限定义 |

--- a/prd-admin/src/app/App.tsx
+++ b/prd-admin/src/app/App.tsx
@@ -251,7 +251,7 @@ export default function App() {
         <Route path="workflow-agent" element={<RequirePermission perm="workflow-agent.use"><WorkflowListPage /></RequirePermission>} />
         <Route path="workflow-agent/:workflowId" element={<RequirePermission perm="workflow-agent.use"><WorkflowEditorPage /></RequirePermission>} />
         <Route path="workflow-agent/:workflowId/canvas" element={<RequirePermission perm="workflow-agent.use"><WorkflowCanvasPage /></RequirePermission>} />
-        <Route path="ai-toolbox" element={<RequirePermission perm="access"><AiToolboxPage /></RequirePermission>} />
+        <Route path="ai-toolbox" element={<RequirePermission perm="ai-toolbox.use"><AiToolboxPage /></RequirePermission>} />
         <Route path="logs" element={<RequirePermission perm="logs.read"><LlmLogsPage /></RequirePermission>} />
         <Route path="open-platform" element={<RequirePermission perm="open-platform.manage"><OpenPlatformTabsPage /></RequirePermission>} />
         <Route path="automations" element={<RequirePermission perm="automations.manage"><AutomationRulesPage /></RequirePermission>} />
@@ -260,7 +260,7 @@ export default function App() {
 
         <Route path="assets" element={<RequirePermission perm="assets.read"><AssetsManagePage /></RequirePermission>} />
         <Route path="skills" element={<RequirePermission perm="skills.read"><SkillsPage /></RequirePermission>} />
-        <Route path="arena" element={<RequirePermission perm="access"><ArenaPage /></RequirePermission>} />
+        <Route path="arena" element={<RequirePermission perm="arena-agent.use"><ArenaPage /></RequirePermission>} />
         <Route path="lab" element={<RequirePermission perm="lab.read"><LabPage /></RequirePermission>} />
         <Route path="settings" element={<RequirePermission perm="access"><SettingsPage /></RequirePermission>} />
         <Route path="executive" element={<RequirePermission perm="access"><ExecutivePage /></RequirePermission>} />

--- a/prd-admin/src/lib/authzMenuMapping.ts
+++ b/prd-admin/src/lib/authzMenuMapping.ts
@@ -105,6 +105,66 @@ export const menuList: MenuDef[] = [
     permissions: ['authz.manage'],
   },
   {
+    appKey: 'defect-agent',
+    label: '缺陷管理 Agent',
+    icon: 'Bug',
+    permissions: ['defect-agent.use', 'defect-agent.manage'],
+  },
+  {
+    appKey: 'arena-agent',
+    label: '竞技场 Agent',
+    icon: 'Swords',
+    permissions: ['arena-agent.use'],
+  },
+  {
+    appKey: 'ai-toolbox',
+    label: 'AI 百宝箱',
+    icon: 'Wrench',
+    permissions: ['ai-toolbox.use', 'ai-toolbox.manage'],
+  },
+  {
+    appKey: 'report-agent',
+    label: '周报 Agent',
+    icon: 'FileBarChart',
+    permissions: [
+      'report-agent.use',
+      'report-agent.template.manage',
+      'report-agent.team.manage',
+      'report-agent.view.all',
+      'report-agent.datasource.manage',
+    ],
+  },
+  {
+    appKey: 'workflow-agent',
+    label: '工作流引擎',
+    icon: 'Workflow',
+    permissions: ['workflow-agent.use', 'workflow-agent.manage'],
+  },
+  {
+    appKey: 'data-migration-agent',
+    label: '数据迁移 Agent',
+    icon: 'DatabaseZap',
+    permissions: ['data-migration-agent.use', 'data-migration-agent.write'],
+  },
+  {
+    appKey: 'skills',
+    label: '技能管理',
+    icon: 'Sparkles',
+    permissions: ['skills.read', 'skills.write'],
+  },
+  {
+    appKey: 'automations',
+    label: '自动化',
+    icon: 'Zap',
+    permissions: ['automations.manage'],
+  },
+  {
+    appKey: 'tutorial-email',
+    label: '教程邮件',
+    icon: 'Mail',
+    permissions: ['tutorial-email.read', 'tutorial-email.write'],
+  },
+  {
     appKey: 'lab',
     label: '实验室',
     icon: 'FlaskConical',
@@ -173,11 +233,36 @@ export const allPermissions: PermissionDef[] = [
   // 权限管理
   { key: 'authz.manage', label: '权限管理', description: '管理系统角色和用户权限', category: 'manage' },
 
-  // Agent 权限（独立）
+  // 技能管理
+  { key: 'skills.read', label: '技能 - 读', description: '查看技能配置', category: 'read' },
+  { key: 'skills.write', label: '技能 - 写', description: '创建/编辑/删除技能', category: 'write' },
+
+  // 自动化
+  { key: 'automations.manage', label: '自动化 - 管理', description: '管理自动化规则', category: 'manage' },
+
+  // Agent 权限
   { key: 'prd-agent.use', label: '米多智能体平台', description: '智能解读与问答', category: 'use' },
   { key: 'visual-agent.use', label: '视觉创作 Agent', description: '高级视觉创作工作区', category: 'use' },
   { key: 'literary-agent.use', label: '文学创作 Agent', description: '文章配图智能生成', category: 'use' },
   { key: 'video-agent.use', label: '视频 Agent', description: '文章转视频教程生成', category: 'use' },
+  { key: 'defect-agent.use', label: '缺陷管理 Agent', description: '提交和查看缺陷', category: 'use' },
+  { key: 'defect-agent.manage', label: '缺陷管理 Agent - 管理', description: '设置模板、指派处理人', category: 'manage' },
+  { key: 'arena-agent.use', label: '竞技场 Agent', description: '模型盲评对战', category: 'use' },
+  { key: 'ai-toolbox.use', label: 'AI 百宝箱', description: '使用 AI 百宝箱功能', category: 'use' },
+  { key: 'ai-toolbox.manage', label: 'AI 百宝箱 - 管理', description: '管理工作流、配置等', category: 'manage' },
+  { key: 'report-agent.use', label: '周报 Agent', description: '基础使用周报功能', category: 'use' },
+  { key: 'report-agent.template.manage', label: '周报 - 模板管理', description: '创建/编辑周报模板', category: 'manage' },
+  { key: 'report-agent.team.manage', label: '周报 - 团队管理', description: '管理周报团队与成员', category: 'manage' },
+  { key: 'report-agent.view.all', label: '周报 - 查看全部', description: '查看所有团队周报', category: 'read' },
+  { key: 'report-agent.datasource.manage', label: '周报 - 数据源管理', description: '配置 Git/SVN 仓库连接', category: 'manage' },
+  { key: 'workflow-agent.use', label: '工作流引擎', description: '创建和执行自动化工作流', category: 'use' },
+  { key: 'workflow-agent.manage', label: '工作流引擎 - 管理', description: '管理所有工作流与执行记录', category: 'manage' },
+  { key: 'data-migration-agent.use', label: '数据迁移 Agent - 读', description: '查看实体与集合映射', category: 'use' },
+  { key: 'data-migration-agent.write', label: '数据迁移 Agent - 写', description: '删除集合、修复数据', category: 'write' },
+
+  // 教程邮件
+  { key: 'tutorial-email.read', label: '教程邮件 - 读', description: '查看教程邮件序列与模板', category: 'read' },
+  { key: 'tutorial-email.write', label: '教程邮件 - 写', description: '编辑序列、模板、触发发送', category: 'write' },
 
   // 总裁面板
   { key: 'executive.read', label: '总裁面板 - 读', description: '查看总裁面板和周报', category: 'read' },

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ArenaController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ArenaController.cs
@@ -16,7 +16,7 @@ namespace PrdAgent.Api.Controllers.Api;
 [ApiController]
 [Route("api/lab/arena")]
 [Authorize]
-[AdminController("lab", AdminPermissionCatalog.LabRead, WritePermission = AdminPermissionCatalog.LabWrite)]
+[AdminController("arena-agent", AdminPermissionCatalog.ArenaAgentUse)]
 public sealed class ArenaController : ControllerBase
 {
     private readonly MongoDbContext _db;

--- a/prd-api/src/PrdAgent.Core/Security/AdminPermissionCatalog.cs
+++ b/prd-api/src/PrdAgent.Core/Security/AdminPermissionCatalog.cs
@@ -80,6 +80,11 @@ public static class AdminPermissionCatalog
     public const string VideoAgentUse = "video-agent.use";
 
     /// <summary>
+    /// 竞技场 Agent 权限：模型盲评对战
+    /// </summary>
+    public const string ArenaAgentUse = "arena-agent.use";
+
+    /// <summary>
     /// AI 百宝箱权限：使用百宝箱功能
     /// </summary>
     public const string AiToolboxUse = "ai-toolbox.use";
@@ -164,6 +169,7 @@ public static class AdminPermissionCatalog
         new(DefectAgentUse, "缺陷管理 Agent", "提交和查看缺陷"),
         new(DefectAgentManage, "缺陷管理 Agent-管理", "设置模板、指派处理人"),
         new(VideoAgentUse, "视频 Agent", "文章转视频教程生成"),
+        new(ArenaAgentUse, "竞技场 Agent", "模型盲评对战"),
         new(AiToolboxUse, "AI 百宝箱", "使用 AI 百宝箱功能"),
         new(AiToolboxManage, "AI 百宝箱-管理", "管理工作流、配置等"),
         new(DataMigrationAgentUse, "数据迁移 Agent-读", "查看实体与集合映射、数据预览"),

--- a/prd-api/src/PrdAgent.Core/Security/BuiltInSystemRoles.cs
+++ b/prd-api/src/PrdAgent.Core/Security/BuiltInSystemRoles.cs
@@ -22,12 +22,18 @@ public static class BuiltInSystemRoles
             Permissions: new List<string>
             {
                 AdminPermissionCatalog.Access,
+                // Agent 权限
                 AdminPermissionCatalog.PrdAgentUse,
                 AdminPermissionCatalog.VisualAgentUse,
                 AdminPermissionCatalog.LiteraryAgentUse,
                 AdminPermissionCatalog.DefectAgentUse,
                 AdminPermissionCatalog.DefectAgentManage,
                 AdminPermissionCatalog.VideoAgentUse,
+                AdminPermissionCatalog.ArenaAgentUse,
+                AdminPermissionCatalog.ReportAgentUse,
+                AdminPermissionCatalog.WorkflowAgentUse,
+                AdminPermissionCatalog.AiToolboxUse,
+                // 管理权限
                 AdminPermissionCatalog.ModelsRead,
                 AdminPermissionCatalog.ModelsWrite,
                 AdminPermissionCatalog.GroupsRead,
@@ -49,11 +55,16 @@ public static class BuiltInSystemRoles
             Permissions: new List<string>
             {
                 AdminPermissionCatalog.Access,
+                // Agent 权限（只读用户也可体验 Agent）
                 AdminPermissionCatalog.PrdAgentUse,
                 AdminPermissionCatalog.VisualAgentUse,
                 AdminPermissionCatalog.LiteraryAgentUse,
                 AdminPermissionCatalog.DefectAgentUse,
                 AdminPermissionCatalog.VideoAgentUse,
+                AdminPermissionCatalog.ArenaAgentUse,
+                AdminPermissionCatalog.ReportAgentUse,
+                AdminPermissionCatalog.AiToolboxUse,
+                // 只读管理权限
                 AdminPermissionCatalog.UsersRead,
                 AdminPermissionCatalog.GroupsRead,
                 AdminPermissionCatalog.ModelsRead,
@@ -70,11 +81,15 @@ public static class BuiltInSystemRoles
             Permissions: new List<string>
             {
                 AdminPermissionCatalog.Access,
+                // 所有 Agent 使用权限
                 AdminPermissionCatalog.PrdAgentUse,
                 AdminPermissionCatalog.VisualAgentUse,
                 AdminPermissionCatalog.LiteraryAgentUse,
                 AdminPermissionCatalog.DefectAgentUse,
                 AdminPermissionCatalog.VideoAgentUse,
+                AdminPermissionCatalog.ArenaAgentUse,
+                AdminPermissionCatalog.ReportAgentUse,
+                AdminPermissionCatalog.WorkflowAgentUse,
                 AdminPermissionCatalog.AiToolboxUse,
                 // PRD Agent 读取提示词需要 settings.read，但不应默认展示"提示词管理"（前端已改为 prompts.write 才可见）
                 AdminPermissionCatalog.SettingsRead,


### PR DESCRIPTION
## Summary
This PR adds support for several new Agent features by introducing menu items, permission definitions, and role assignments. It also refines permission checks for existing features to use more specific permissions instead of generic access controls.

## Key Changes

### Frontend (prd-admin)
- Added 9 new menu items to the navigation:
  - Defect Management Agent (缺陷管理 Agent)
  - Arena Agent (竞技场 Agent)
  - AI Toolbox (AI 百宝箱)
  - Report Agent (周报 Agent)
  - Workflow Engine (工作流引擎)
  - Data Migration Agent (数据迁移 Agent)
  - Skills Management (技能管理)
  - Automations (自动化)
  - Tutorial Email (教程邮件)
- Updated permission checks for AI Toolbox and Arena pages to use specific permissions (`ai-toolbox.use` and `arena-agent.use`) instead of generic `access` permission
- Added 20+ new permission definitions covering the new features with appropriate categories (use, read, write, manage)

### Backend (prd-api)
- Added `ArenaAgentUse` permission constant to `AdminPermissionCatalog`
- Updated built-in system roles to include new Agent permissions:
  - **Admin role**: Added Arena, Report, Workflow, and AI Toolbox Agent permissions
  - **ReadOnly role**: Added Arena, Report, and AI Toolbox Agent permissions (excluding management features)
  - **ContentCreator role**: Added Arena, Report, and Workflow Agent permissions
- Updated `ArenaController` to use specific `arena-agent.use` permission instead of generic `lab` permissions

## Implementation Details
- All new menu items include appropriate icons and permission requirements
- Permission definitions follow consistent naming conventions (e.g., `{feature}.use`, `{feature}.manage`)
- Role assignments ensure appropriate access levels for different user types
- The changes maintain backward compatibility while providing more granular permission control

https://claude.ai/code/session_01R2jUsmYBm9Rae8JtpCCsEo