### PR TITLE
Remove username-based avatar URL fallback logic

### DIFF
--- a/.cursor/rules/prd-admin.mdc
+++ b/.cursor/rules/prd-admin.mdc
@@ -42,8 +42,8 @@ globs: prd-admin/**
 **【重要】获取用户头像必须使用 `avatarFileName`，禁止使用 `username`！**
 
 原因：
-- `username` 会被 `resolveAvatarUrl` 拼接成 `{username}.png`
-- 用户头像可能是 `.gif`、`.jpg` 等其他格式，使用 `username` 会导致 404
+- `username` 已不再用于拼接头像 URL（未设置头像时统一使用 `nohead.png` 兜底）
+- 用户头像可能是 `.gif`、`.jpg` 等其他格式，必须使用 `avatarFileName` 获取正确文件名
 
 正确做法：
 

--- a/prd-admin/src/lib/avatar.ts
+++ b/prd-admin/src/lib/avatar.ts
@@ -12,7 +12,7 @@ export const DEFAULT_NOHEAD_FILE = 'nohead.png';
  * 用户头像信息接口
  * 
  * 【重要】在模型中存储用户信息时，必须使用 avatarFileName 而非 username 来获取头像！
- * - username 会被拼接成 `{username}.png`，无法正确显示 .gif 等其他格式的头像
+ * - username 已不再用于拼接头像 URL（之前会拼成 `{username}.png` 但文件不存在）
  * - avatarFileName 是用户实际的头像文件名，如 `admin.gif`、`test.png` 等
  * 
  * 示例（后端模型）：

--- a/prd-admin/src/lib/avatar.ts
+++ b/prd-admin/src/lib/avatar.ts
@@ -97,9 +97,7 @@ export function resolveAvatarUrl(args: {
     return joinUrl(base, DEFAULT_BOT_AVATAR_FILES.dev.toLowerCase());
   }
 
-  const username = String(args.username || '').trim().toLowerCase();
-  if (username) return joinUrl(base, `${username}.png`);
-
+  // 人类用户未设置头像：直接使用 nohead.png（避免拼接不存在的 {username}.png）
   return joinUrl(base, DEFAULT_NOHEAD_FILE);
 }
 

--- a/prd-api/src/PrdAgent.Api/Services/AvatarUrlBuilder.cs
+++ b/prd-api/src/PrdAgent.Api/Services/AvatarUrlBuilder.cs
@@ -99,13 +99,7 @@ public static class AvatarUrlBuilder
             return file;
         }
 
-        // 3) 人类用户：默认固定规则为 {login}.png（即使对象不存在也能作为 src 占位；渲染失败由 nohead.png 兜底）
-        if (!string.IsNullOrWhiteSpace(usernameLower))
-        {
-            return $"{usernameLower}.png";
-        }
-
-        // 4) 最终兜底：nohead.png
+        // 3) 人类用户未设置头像：直接使用 nohead.png（避免拼接不存在的 {username}.png 导致图片永远加载失败）
         return DefaultNoHeadFile;
     }
 }


### PR DESCRIPTION
## Summary
Removes the fallback logic that attempted to construct avatar URLs from usernames (e.g., `{username}.png`). This fallback was unreliable as it would reference non-existent files. Now all users without an explicit `avatarFileName` consistently use the `nohead.png` default.

## Changes
- **Backend (AvatarUrlBuilder.cs)**: Removed the conditional logic that constructed avatar filenames from usernames. Now directly returns `nohead.png` for human users without an explicit avatar file.
- **Frontend (avatar.ts)**: Removed the username-to-filename concatenation logic from `resolveAvatarUrl()`. Users without `avatarFileName` now consistently fall back to `nohead.png`.
- **Documentation (.cursor/rules/prd-admin.mdc)**: Updated guidelines to clarify that `username` is no longer used for avatar URL construction and that `avatarFileName` must always be used.

## Implementation Details
- The change simplifies avatar resolution by eliminating a non-functional fallback path
- Prevents broken image links that would occur when trying to load non-existent `{username}.png` files
- Ensures consistent behavior across frontend and backend
- Users with custom avatar formats (`.gif`, `.jpg`, etc.) must explicitly set `avatarFileName` to display correctly

https://claude.ai/code/session_01Fv8n9ztmebuwugfokquLkw