### PR TITLE
Optimize avatar loading and prevent concurrent request storms

### DIFF
--- a/prd-admin/src/assets/model-avatars/index.ts
+++ b/prd-admin/src/assets/model-avatars/index.ts
@@ -1,7 +1,10 @@
-// 支持用户自行下载并放入同一目录：svg / png / jpg（三选一即可）
-const avatarModules = import.meta.glob('./*.{svg,png,jpg,jpeg}', { eager: true, query: '?url', import: 'default' }) as Record<
+import { useEffect, useState } from 'react';
+
+// 懒加载：不再 eager 加载全部 160+ 个头像文件
+// 改为按需加载——仅当组件实际渲染某个头像时才请求对应的文件
+const avatarLoaders = import.meta.glob('./*.{svg,png,jpg,jpeg}', { query: '?url', import: 'default' }) as Record<
   string,
-  string
+  () => Promise<string>
 >;
 
 const extPriority = ['svg', 'png', 'jpg', 'jpeg'] as const;
@@ -14,27 +17,69 @@ const parseFile = (p: string): { key: string; ext: Ext | null } => {
   return { key: m[1].toLowerCase(), ext: m[2].toLowerCase() as Ext };
 };
 
-// 将同名不同格式合并为一个 key，按 extPriority 选“更优”的那个
-const keyToUrl = (() => {
-  const best = new Map<string, { url: string; rank: number }>();
-  for (const [path, url] of Object.entries(avatarModules)) {
-    const { key, ext } = parseFile(path);
-    if (!key || !ext) continue;
-    const rank = extPriority.indexOf(ext);
-    const prev = best.get(key);
-    if (!prev || rank < prev.rank) best.set(key, { url, rank });
-  }
-  return best;
-})();
+// 从 glob keys 同步构建可用头像索引（零 HTTP 请求）
+// 每个 key 记录最佳格式的 loader 路径
+const keyToEntry = new Map<string, { path: string; url: string | null; rank: number }>();
 
-const availableKeys = Array.from(keyToUrl.keys())
+for (const path of Object.keys(avatarLoaders)) {
+  const { key, ext } = parseFile(path);
+  if (!key || !ext) continue;
+  const rank = extPriority.indexOf(ext);
+  const prev = keyToEntry.get(key);
+  if (!prev || rank < prev.rank) {
+    keyToEntry.set(key, { path, url: null, rank });
+  }
+}
+
+const availableKeys = Array.from(keyToEntry.keys())
   .filter(Boolean)
   // 长 key 优先匹配（避免 "gpt" 抢占 "chatgpt"）
   .sort((a, b) => b.length - a.length);
 
-const getByKey = (key: string): string | null => keyToUrl.get((key || '').toLowerCase())?.url || null;
+// 头像加载完成通知（供 React 组件订阅以触发重渲染）
+const listeners = new Set<() => void>();
 
-// 允许通过 JSON 进行“别名/重定向”配置（无需改代码即可新增规则）
+/**
+ * 在组件中调用以订阅头像加载事件，确保懒加载的头像显示后触发重渲染
+ */
+export function useAvatarUpdates() {
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const fn = () => setTick((n) => n + 1);
+    listeners.add(fn);
+    return () => { listeners.delete(fn); };
+  }, []);
+}
+
+// 正在加载中的 key，避免重复触发
+const loadingKeys = new Set<string>();
+
+const getByKey = (key: string): string | null => {
+  const k = (key || '').toLowerCase();
+  const entry = keyToEntry.get(k);
+  if (!entry) return null;
+
+  // 已加载：直接返回
+  if (entry.url) return entry.url;
+
+  // 未加载：触发懒加载
+  if (!loadingKeys.has(k)) {
+    loadingKeys.add(k);
+    const loader = avatarLoaders[entry.path];
+    if (loader) {
+      loader().then((url) => {
+        entry.url = url;
+        loadingKeys.delete(k);
+        // 通知所有订阅组件重新渲染
+        listeners.forEach((fn) => fn());
+      });
+    }
+  }
+
+  return null;
+};
+
+// 允许通过 JSON 进行"别名/重定向"配置（无需改代码即可新增规则）
 // 例如：{ "google": "gemini", "gpt": "chatgpt" }
 import avatarAliases from './avatar-aliases.json';
 const aliases: Record<string, string> = (avatarAliases || {}) as Record<string, string>;
@@ -56,7 +101,7 @@ const pickByTokens = (raw: string): string | null => {
   const tokens = splitTokens(raw).map(resolveAlias);
   if (tokens.length === 0) return null;
 
-  // 优先取“最后一个 token”（通常是模型家族，如 anthropic-claude -> claude）
+  // 优先取"最后一个 token"（通常是模型家族，如 anthropic-claude -> claude）
   for (let i = tokens.length - 1; i >= 0; i--) {
     const k = tokens[i];
     const u = getByKey(k);
@@ -73,9 +118,9 @@ const pickByTokens = (raw: string): string | null => {
 };
 
 /**
- * 分组->图标（动态）：你只需要把图标文件按“token”命名放进同一目录即可自动生效。
+ * 分组->图标（动态）：你只需要把图标文件按"token"命名放进同一目录即可自动生效。
  * - token 规则：按非字母数字分隔（`openai-gpt` -> `openai`,`gpt`；`anthropic-claude` -> `anthropic`,`claude`）
- * - 优先级：默认优先使用“最后一个 token”（更像模型家族），不再依赖写死的 provider 规则
+ * - 优先级：默认优先使用"最后一个 token"（更像模型家族），不再依赖写死的 provider 规则
  * - 如需特殊映射（如 google->gemini / gpt->chatgpt），写到 `avatar-aliases.json` 即可
  */
 export function getAvatarUrlByGroup(groupName: string): string | null {
@@ -109,7 +154,7 @@ export function getAvatarUrlByPlatformType(platformType: string): string | null 
   const byTokens = pickByTokens(t);
   if (byTokens) return byTokens;
 
-  // 2) 对“google->gemini”做一个通用兜底：如果存在 gemini 图标，则优先使用
+  // 2) 对"google->gemini"做一个通用兜底：如果存在 gemini 图标，则优先使用
   if (t.includes('google')) {
     const gemini = getByKey(resolveAlias('google')) || getByKey('gemini');
     if (gemini) return gemini;
@@ -136,5 +181,3 @@ export function getAvatarUrlByModelName(modelName: string): string | null {
 
   return pickByTokens(raw);
 }
-
-

--- a/prd-admin/src/components/model/PlatformAvailableModelsDialog.tsx
+++ b/prd-admin/src/components/model/PlatformAvailableModelsDialog.tsx
@@ -6,7 +6,7 @@ import { apiRequest } from '@/services/real/apiClient';
 import type { Platform } from '@/types/admin';
 import { resolveCherryGroupKey } from '@/lib/cherryModelGrouping';
 import { inferPresetTagKeys, matchAvailableModelsTab, type PresetTagKey } from '@/lib/modelPresetTags';
-import { getAvatarUrlByGroup, getAvatarUrlByModelName } from '@/assets/model-avatars';
+import { getAvatarUrlByGroup, getAvatarUrlByModelName, useAvatarUpdates } from '@/assets/model-avatars';
 import { ArrowDown, DatabaseZap, ImagePlus, Link2, Minus, Plus, RefreshCw, ScanEye, Search, Sparkles, Star, Wand2, Zap, Settings } from 'lucide-react';
 import { matchAdapterConfig } from '@/lib/imageGenAdapterConfigs';
 import { Tooltip } from '@/components/ui/Tooltip';
@@ -148,6 +148,7 @@ export function PlatformAvailableModelsDialog({
   onBulkAddGroup: (groupName: string, ms: AvailableModel[]) => void | Promise<void>;
   onAfterWriteBack?: () => void | Promise<void>;
 }) {
+  useAvatarUpdates();
   const [availableModels, setAvailableModels] = useState<AvailableModel[]>([]);
   const [availableLoading, setAvailableLoading] = useState(false);
   const [availableError, setAvailableError] = useState<string | null>(null);

--- a/prd-admin/src/pages/arena/ArenaPage.tsx
+++ b/prd-admin/src/pages/arena/ArenaPage.tsx
@@ -6,7 +6,7 @@ import { PlatformLabel } from '@/components/design/PlatformLabel';
 import { toast } from '@/lib/toast';
 import { cn } from '@/lib/cn';
 import { readSseStream } from '@/lib/sse';
-import { getAvatarUrlByModelName, getAvatarUrlByPlatformType } from '@/assets/model-avatars';
+import { getAvatarUrlByModelName, getAvatarUrlByPlatformType, useAvatarUpdates } from '@/assets/model-avatars';
 import {
   getArenaLineup,
   revealArenaSlots,
@@ -267,6 +267,7 @@ function ThinkingBlock({ thinking, color, streaming }: { thinking: string; color
 }
 
 export function ArenaPage() {
+  useAvatarUpdates();
   // --- Lineup state ---
   const [groups, setGroups] = useState<ArenaGroup[]>([]);
   const [selectedGroupKey, setSelectedGroupKey] = useState<string>('');

--- a/prd-admin/src/services/real/apiClient.ts
+++ b/prd-admin/src/services/real/apiClient.ts
@@ -148,7 +148,20 @@ function checkPermissionFingerprint(res: Response): void {
   }
 }
 
+// 去重：多个并发 401 共享同一个 refresh 请求，避免 refresh 风暴
+let inflightRefresh: Promise<boolean> | null = null;
+
 async function tryRefreshAdminToken(): Promise<boolean> {
+  if (inflightRefresh) return inflightRefresh;
+  inflightRefresh = doRefreshAdminToken();
+  try {
+    return await inflightRefresh;
+  } finally {
+    inflightRefresh = null;
+  }
+}
+
+async function doRefreshAdminToken(): Promise<boolean> {
   const authStore = useAuthStore.getState();
   const token = authStore.token;
   const refreshToken = authStore.refreshToken;
@@ -226,7 +239,12 @@ async function apiRequestInner<T>(
   const auth = options?.auth ?? true;
   if (auth) {
     const token = useAuthStore.getState().token;
-    if (token) headers.Authorization = `Bearer ${token}`;
+    if (token) {
+      headers.Authorization = `Bearer ${token}`;
+    } else {
+      // 未登录时直接返回 UNAUTHORIZED，避免发出注定 401 的请求
+      return fail('UNAUTHORIZED', '未登录') as unknown as ApiResponse<T>;
+    }
   }
 
   let body: string | undefined;

--- a/prd-admin/src/services/real/userPreferences.ts
+++ b/prd-admin/src/services/real/userPreferences.ts
@@ -12,7 +12,20 @@ import type {
   VisualAgentPreferences,
 } from '@/services/contracts/userPreferences';
 
+// 去重：navOrderStore + themeStore + VisualAgentTab 可能同时调用，共享一个 in-flight 请求
+let inflightPrefs: Promise<ApiResponse<UserPreferences>> | null = null;
+
 export const getUserPreferencesReal: GetUserPreferencesContract = async (): Promise<ApiResponse<UserPreferences>> => {
+  if (inflightPrefs) return inflightPrefs;
+  inflightPrefs = doGetUserPreferences();
+  try {
+    return await inflightPrefs;
+  } finally {
+    inflightPrefs = null;
+  }
+};
+
+async function doGetUserPreferences(): Promise<ApiResponse<UserPreferences>> {
   const res = await apiRequest<{ navOrder: string[]; themeConfig?: ThemeConfigResponse; visualAgentPreferences?: VisualAgentPreferences }>(
     api.dashboard.userPreferences.get()
   );
@@ -22,7 +35,7 @@ export const getUserPreferencesReal: GetUserPreferencesContract = async (): Prom
     themeConfig: res.data.themeConfig,
     visualAgentPreferences: res.data.visualAgentPreferences,
   });
-};
+}
 
 export const updateNavOrderReal: UpdateNavOrderContract = async (navOrder: string[]): Promise<ApiResponse<void>> => {
   const res = await apiRequest<void>(api.dashboard.userPreferences.navOrder(), {

--- a/prd-admin/src/stores/defectStore.ts
+++ b/prd-admin/src/stores/defectStore.ts
@@ -101,6 +101,7 @@ export const useDefectStore = create<DefectState>((set, get) => ({
 
   // Load defects
   loadDefects: async () => {
+    if (get().loading) return; // 防止并发重复加载
     const { filter, statusFilter } = get();
     set({ loading: true, error: '' });
     try {

--- a/prd-admin/src/stores/navOrderStore.ts
+++ b/prd-admin/src/stores/navOrderStore.ts
@@ -27,6 +27,7 @@ export const useNavOrderStore = create<NavOrderState>()(
       saving: false,
 
       loadFromServer: async () => {
+        if (get().loaded) return; // 已加载过，不再重复请求
         try {
           const res = await getUserPreferences();
           if (res.success && res.data) {

--- a/prd-admin/src/stores/reportAgentStore.ts
+++ b/prd-admin/src/stores/reportAgentStore.ts
@@ -157,6 +157,7 @@ export const useReportAgentStore = create<ReportAgentState>((set, get) => ({
   },
 
   loadAll: async () => {
+    if (get().loading) return; // 防止并发重复加载
     set({ loading: true, error: '' });
     try {
       await Promise.all([

--- a/prd-admin/src/stores/toolboxStore.ts
+++ b/prd-admin/src/stores/toolboxStore.ts
@@ -258,6 +258,7 @@ export const useToolboxStore = create<ToolboxState>((set, get) => ({
 
   // Load all items (builtin + custom)
   loadItems: async () => {
+    if (get().itemsLoading) return; // 防止并发重复加载
     set({ itemsLoading: true });
     try {
       const res = await listToolboxItems();

--- a/prd-admin/src/stores/workflowStore.ts
+++ b/prd-admin/src/stores/workflowStore.ts
@@ -69,6 +69,7 @@ export const useWorkflowStore = create<WorkflowState>((set, get) => ({
   ...initialState,
 
   loadWorkflows: async (tag) => {
+    if (get().loading) return; // 防止并发重复加载
     set({ loading: true, error: '' });
     try {
       const res = await listWorkflows({ tag: tag || get().tagFilter || undefined, pageSize: 100 });


### PR DESCRIPTION
## Summary
This PR implements lazy loading for model avatars and adds request deduplication across multiple services to prevent concurrent request storms and improve performance.

## Key Changes

### Avatar System (model-avatars/index.ts)
- **Lazy Loading**: Changed from eager loading all 160+ avatar files to on-demand loading
  - Renamed `avatarModules` to `avatarLoaders` with lazy glob pattern (removed `eager: true`)
  - Loaders now return `Promise<string>` instead of direct strings
  - Refactored `keyToUrl` to `keyToEntry` to track loading state per avatar
  
- **React Integration**: Added `useAvatarUpdates()` hook for components to subscribe to avatar load events
  - Maintains a listener set that triggers re-renders when avatars finish loading
  - Prevents race conditions with `loadingKeys` set to avoid duplicate requests
  
- **Component Updates**: Integrated `useAvatarUpdates()` hook in:
  - `PlatformAvailableModelsDialog.tsx`
  - `ArenaPage.tsx`

### Request Deduplication
- **apiClient.ts**: Added `inflightRefresh` to deduplicate concurrent token refresh requests
  - Multiple 401 responses now share a single refresh request instead of creating a refresh storm
  - Added early return for unauthenticated requests to avoid unnecessary 401s
  
- **userPreferences.ts**: Added `inflightPrefs` to deduplicate concurrent preference fetches
  - Prevents multiple simultaneous calls from `navOrderStore`, `themeStore`, and `VisualAgentTab`

### Store Concurrency Guards
Added early returns in store load methods to prevent concurrent duplicate loads:
- `defectStore.ts`: `loadDefects()`
- `navOrderStore.ts`: `loadFromServer()`
- `reportAgentStore.ts`: `loadAll()`
- `toolboxStore.ts`: `loadItems()`
- `workflowStore.ts`: `loadWorkflows()`

## Implementation Details
- Avatar loading is transparent: `getByKey()` returns `null` while loading, then triggers re-renders via listeners once complete
- Request deduplication uses promise caching pattern: subsequent calls await the in-flight promise instead of creating new requests
- All changes are backward compatible with existing API contracts

https://claude.ai/code/session_018bBEnzjz4w4133VJie7Bf8