### PR TITLE
Skip empty entries when extracting ZIP files

### DIFF
--- a/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
@@ -557,6 +557,9 @@ public class HostedSiteService : IHostedSiteService
                 if (totalSize > MaxExtractedSize)
                     return new ZipExtractResult { Error = $"解压后总大小超过限制 ({MaxExtractedSize / 1024 / 1024}MB)" };
 
+                if (entry.Length == 0)
+                    continue;
+
                 using var entryStream = entry.Open();
                 using var entryMs = new MemoryStream();
                 await entryStream.CopyToAsync(entryMs);


### PR DESCRIPTION
## Summary
Added a check to skip empty entries (0-byte files) during ZIP file extraction in the HostedSiteService to prevent unnecessary processing of empty files.

## Key Changes
- Added validation to skip ZIP entries with zero length before attempting to open and copy their streams
- This prevents wasted resources on empty files and potential edge cases when processing empty entries

## Implementation Details
The check is performed early in the extraction loop, immediately after the total size validation, ensuring empty entries are skipped before any stream operations are performed on them.

https://claude.ai/code/session_011gVSMovJCsMrBXUJPa2ERW