### PR TITLE
Add key-based watermark operations and UI refinements

### DIFF
--- a/prd-admin/src/pages/WebPagesPage.tsx
+++ b/prd-admin/src/pages/WebPagesPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { GlassCard } from '@/components/design/GlassCard';
 import { Button } from '@/components/design/Button';
 import { Badge } from '@/components/design/Badge';
@@ -33,7 +33,6 @@ import {
   Check,
   X,
   Lock,
-  Globe,
   Clock,
   RefreshCw,
   Link2,
@@ -178,7 +177,7 @@ export default function WebPagesPage() {
         description="上传 HTML 或 ZIP 压缩包，托管并分享你的网页"
         actions={
           <div className="flex items-center gap-2">
-            <Button size="sm" variant="outline" onClick={() => setShowSharesPanel(true)}>
+            <Button size="sm" variant="secondary" onClick={() => setShowSharesPanel(true)}>
               <Link2 size={14} className="mr-1" /> 分享管理
             </Button>
             <Button size="sm" onClick={() => { setEditItem(null); setShowUploadDialog(true); }}>
@@ -309,7 +308,7 @@ export default function WebPagesPage() {
         {selectedIds.size > 0 && (
           <div className="flex items-center gap-2 mt-3 pt-3" style={{ borderTop: '1px solid var(--border-default)' }}>
             <span className="text-sm" style={{ color: 'var(--text-muted)' }}>已选 {selectedIds.size} 项</span>
-            <Button size="xs" variant="outline" onClick={handleBatchShare}><Share2 size={12} className="mr-1" /> 合集分享</Button>
+            <Button size="xs" variant="secondary" onClick={handleBatchShare}><Share2 size={12} className="mr-1" /> 合集分享</Button>
             <Button size="xs" variant="danger" onClick={handleBatchDelete}><Trash2 size={12} className="mr-1" /> 批量删除</Button>
             <Button size="xs" variant="ghost" onClick={() => setSelectedIds(new Set())}>取消选择</Button>
           </div>
@@ -497,7 +496,7 @@ function SiteCard({ site, selected, onSelect, onEdit, onDelete, onShare }: {
         </div>
         {/* Source badge */}
         <div className="absolute top-1.5 right-1.5 z-10">
-          <Badge variant={site.sourceType === 'workflow' ? 'info' : site.sourceType === 'api' ? 'warning' : 'default'}>
+          <Badge variant={site.sourceType === 'workflow' ? 'subtle' : site.sourceType === 'api' ? 'warning' : 'subtle'}>
             {sourceTypeLabels[site.sourceType] ?? site.sourceType}
           </Badge>
         </div>
@@ -588,7 +587,7 @@ function SiteListItem({ site, selected, onSelect, onEdit, onDelete, onShare }: {
           >
             {site.title}
           </span>
-          <Badge variant={site.sourceType === 'workflow' ? 'info' : site.sourceType === 'api' ? 'warning' : 'default'}>
+          <Badge variant={site.sourceType === 'workflow' ? 'subtle' : site.sourceType === 'api' ? 'warning' : 'subtle'}>
             {sourceTypeLabels[site.sourceType] ?? site.sourceType}
           </Badge>
         </div>
@@ -737,7 +736,7 @@ function UploadEditDialog({ item, folders, onClose, onSaved }: {
                   <p className="text-sm" style={{ color: 'var(--text-primary)' }}>{item.entryFile}</p>
                   <p className="text-xs" style={{ color: 'var(--text-muted)' }}>{item.files.length} 个文件, {fmtSize(item.totalSize)}</p>
                 </div>
-                <Button size="xs" variant="outline" onClick={() => fileInputRef.current?.click()}>
+                <Button size="xs" variant="secondary" onClick={() => fileInputRef.current?.click()}>
                   <Upload size={12} className="mr-1" /> 重新上传
                 </Button>
                 <input
@@ -1052,7 +1051,7 @@ function SharesPanel({ shares, setShares, onClose }: {
                         {share.accessLevel === 'password' ? '密码保护' : '公开'}
                       </Badge>
                       {share.shareType === 'collection' && (
-                        <Badge variant="info">{share.siteIds.length} 站合集</Badge>
+                        <Badge variant="subtle">{share.siteIds.length} 站合集</Badge>
                       )}
                     </div>
                     <div className="flex items-center gap-3 mt-1 text-xs" style={{ color: 'var(--text-muted)' }}>

--- a/prd-admin/src/services/contracts/mobile.ts
+++ b/prd-admin/src/services/contracts/mobile.ts
@@ -65,7 +65,7 @@ export interface MobileAssetsResponse {
 }
 
 export type GetMobileAssetsContract = (args?: {
-  category?: 'image' | 'document' | 'attachment';
+  category?: 'image' | 'document' | 'attachment' | 'webpage';
   limit?: number;
   skip?: number;
 }) => Promise<ApiResponse<MobileAssetsResponse>>;

--- a/prd-api/tests/PrdAgent.Api.Tests/Services/LlmSchedulingPolicyTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Services/LlmSchedulingPolicyTests.cs
@@ -134,6 +134,8 @@ public class LlmSchedulingPolicyTests
     {
         public string BuildSystemPrompt(UserRole role, string prdContent) => string.Empty;
         public string BuildPrdContextMessage(string prdContent) => string.Empty;
+        public string BuildMultiPrdContextMessage(List<ParsedPrd> documents) => string.Empty;
+        public string BuildMultiPrdContextMessage(List<ParsedPrd> documents, Func<string, string> getDocumentType, int tokenBudget) => string.Empty;
         public List<GuideOutlineItem> GetGuideOutline(UserRole role) => new();
         public string BuildGapDetectionPrompt(string prdContent, string question) => string.Empty;
     }

--- a/prd-api/tests/PrdAgent.Api.Tests/Services/WatermarkTestHelpers.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Services/WatermarkTestHelpers.cs
@@ -54,6 +54,26 @@ public sealed class NullAssetStorage : IAssetStorage
     {
         return null;
     }
+
+    public Task UploadToKeyAsync(string key, byte[] bytes, string? contentType, CancellationToken ct)
+    {
+        return Task.CompletedTask;
+    }
+
+    public string BuildUrlForKey(string key)
+    {
+        return string.Empty;
+    }
+
+    public Task DeleteByKeyAsync(string key, CancellationToken ct)
+    {
+        return Task.CompletedTask;
+    }
+
+    public string BuildSiteKey(string siteId, string filePath)
+    {
+        return $"test/{siteId}/{filePath}";
+    }
 }
 
 public sealed class EmptyWatermarkFontAssetSource : IWatermarkFontAssetSource


### PR DESCRIPTION
## Summary
This PR adds key-based watermark storage operations to the test helpers, updates the mobile assets API contract to support webpage category, refines UI component variants in the WebPages page, and adds missing method implementations to the fake prompt manager in tests.

## Key Changes

### Backend Changes
- **Watermark Test Helpers**: Added four new methods to `WatermarkTestHelpers` to support key-based watermark operations:
  - `UploadToKeyAsync()` - Upload watermark data using a key
  - `BuildUrlForKey()` - Generate URL for a key-based watermark
  - `DeleteByKeyAsync()` - Delete watermark by key
  - `BuildSiteKey()` - Build a site-specific key from site ID and file path

- **Mobile Assets Contract**: Extended `GetMobileAssetsContract` to support `'webpage'` as a valid category option alongside existing `'image'`, `'document'`, and `'attachment'` categories

- **Test Utilities**: Added missing method implementations to `FakePromptManager`:
  - `BuildMultiPrdContextMessage(List<ParsedPrd>)` - Overload for building context from multiple PRD documents
  - `BuildMultiPrdContextMessage(List<ParsedPrd>, Func<string, string>, int)` - Overload with document type resolver and token budget

### Frontend Changes
- **WebPagesPage Component**:
  - Removed unused `useMemo` import
  - Removed unused `Globe` icon import
  - Updated button variants from `"outline"` to `"secondary"` for share management and batch share buttons
  - Updated Badge variants from `"info"` to `"subtle"` for workflow source type indicators
  - Updated Badge variant from `"info"` to `"subtle"` for collection share count display

## Implementation Details
The watermark key-based operations follow the same async/await pattern as existing SHA-based operations, with `BuildSiteKey()` generating keys in the format `test/{siteId}/{filePath}` for test scenarios. The UI changes standardize button and badge styling across the WebPages interface for better visual consistency.

https://claude.ai/code/session_01G5bV9Svmp8fBsH8j4daNx2