### PR TITLE
Add save shared site feature with authentication

### DIFF
--- a/prd-admin/src/pages/ShareViewPage.tsx
+++ b/prd-admin/src/pages/ShareViewPage.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState, useRef } from 'react';
-import { useParams } from 'react-router-dom';
-import { viewSiteShare } from '@/services';
+import { useEffect, useState, useRef, useCallback } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { viewSiteShare, saveSharedSite } from '@/services';
 import type { ShareViewData } from '@/services';
-import { Lock, ExternalLink, FileCode2, Eye, EyeOff, AlertCircle, ShieldCheck, Unlock } from 'lucide-react';
+import { useAuthStore } from '@/stores/authStore';
+import { Lock, ExternalLink, FileCode2, Eye, EyeOff, AlertCircle, ShieldCheck, Unlock, Download, Check, LogIn } from 'lucide-react';
 import { BlackHoleVortex } from '@/components/effects/BlackHoleVortex';
 import { BlurText } from '@/components/reactbits';
 
@@ -14,6 +15,8 @@ function fmtSize(b: number) {
 
 export default function ShareViewPage() {
   const { token } = useParams<{ token: string }>();
+  const navigate = useNavigate();
+  const isAuthenticated = useAuthStore(s => s.isAuthenticated);
   const [data, setData] = useState<ShareViewData | null>(null);
   const [error, setError] = useState<{ code: string; message: string } | null>(null);
   const [loading, setLoading] = useState(true);
@@ -24,6 +27,30 @@ export default function ShareViewPage() {
   const [wrongPassword, setWrongPassword] = useState(false);
   const [shakeKey, setShakeKey] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
+  const [saving, setSaving] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'saved' | 'already'>('idle');
+
+  const handleSave = useCallback(async () => {
+    if (!token) return;
+    if (!isAuthenticated) {
+      // 记住当前页面，跳转登录
+      const currentPath = window.location.pathname + window.location.search;
+      navigate(`/login?redirect=${encodeURIComponent(currentPath)}`);
+      return;
+    }
+    setSaving(true);
+    const res = await saveSharedSite(token, password || undefined);
+    setSaving(false);
+    if (res.success) {
+      if (res.data.alreadySaved) {
+        setSaveStatus('already');
+      } else {
+        setSaveStatus('saved');
+      }
+      // 3秒后恢复
+      setTimeout(() => setSaveStatus('idle'), 3000);
+    }
+  }, [token, password, isAuthenticated, navigate]);
 
   const fetchShare = async (pwd?: string) => {
     if (!token) return;
@@ -267,17 +294,52 @@ export default function ShareViewPage() {
         }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
             <ShieldCheck size={14} color="rgba(34, 197, 94, 0.8)" />
-            <span style={{ color: '#fff', fontSize: 14, fontWeight: 500 }}>{data.title || site.title}</span>
+            {data.createdByName && (
+              <span style={{ color: 'rgba(34, 197, 94, 0.9)', fontSize: 13, fontWeight: 600 }}>{data.createdByName}</span>
+            )}
+            <span style={{ color: '#fff', fontSize: 14, fontWeight: 500 }}>
+              {data.createdByName ? `分享给你的「${site.title}」` : (data.title || site.title)}
+            </span>
           </div>
-          <a
-            href={site.siteUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{ display: 'flex', alignItems: 'center', gap: 4, color: '#3b82f6', fontSize: 13, textDecoration: 'none' }}
-          >
-            <ExternalLink size={12} />
-            新窗口打开
-          </a>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+            <button
+              onClick={handleSave}
+              disabled={saving || saveStatus !== 'idle'}
+              style={{
+                display: 'flex', alignItems: 'center', gap: 4,
+                padding: '4px 10px', borderRadius: 6, border: 'none',
+                fontSize: 13, cursor: saving || saveStatus !== 'idle' ? 'default' : 'pointer',
+                background: saveStatus === 'saved' ? 'rgba(34, 197, 94, 0.2)'
+                  : saveStatus === 'already' ? 'rgba(234, 179, 8, 0.2)'
+                  : 'rgba(59, 130, 246, 0.15)',
+                color: saveStatus === 'saved' ? 'rgba(34, 197, 94, 0.9)'
+                  : saveStatus === 'already' ? 'rgba(234, 179, 8, 0.9)'
+                  : 'rgba(59, 130, 246, 0.9)',
+                transition: 'all 0.2s',
+              }}
+            >
+              {saving ? (
+                <><div style={{ ...styles.miniSpinner }} /> 保存中...</>
+              ) : saveStatus === 'saved' ? (
+                <><Check size={12} /> 已保存</>
+              ) : saveStatus === 'already' ? (
+                <><Check size={12} /> 你已经保存过了</>
+              ) : !isAuthenticated ? (
+                <><LogIn size={12} /> 登录并保存</>
+              ) : (
+                <><Download size={12} /> 保存到我的托管</>
+              )}
+            </button>
+            <a
+              href={site.siteUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ display: 'flex', alignItems: 'center', gap: 4, color: '#3b82f6', fontSize: 13, textDecoration: 'none' }}
+            >
+              <ExternalLink size={12} />
+              新窗口打开
+            </a>
+          </div>
         </div>
         {/* Iframe */}
         <iframe
@@ -296,9 +358,45 @@ export default function ShareViewPage() {
       <div style={{ position: 'absolute', inset: 0 }}><BlackHoleVortex /></div>
       <div style={styles.overlay} />
       <div style={{ maxWidth: 720, width: '100%', padding: '20px 16px', position: 'relative', zIndex: 1 }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
-          <Unlock size={18} color="rgba(34, 197, 94, 0.8)" />
-          <h1 style={{ color: '#fff', fontSize: 22, margin: 0, fontWeight: 600 }}>{data.title || '站点合集'}</h1>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 4 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <Unlock size={18} color="rgba(34, 197, 94, 0.8)" />
+            {data.createdByName && (
+              <span style={{ color: 'rgba(34, 197, 94, 0.9)', fontSize: 16, fontWeight: 600 }}>{data.createdByName}</span>
+            )}
+            <h1 style={{ color: '#fff', fontSize: 22, margin: 0, fontWeight: 600 }}>
+              {data.createdByName ? `分享的 ${data.sites.length} 个站点合集` : (data.title || '站点合集')}
+            </h1>
+          </div>
+          <button
+            onClick={handleSave}
+            disabled={saving || saveStatus !== 'idle'}
+            style={{
+              display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0,
+              padding: '6px 14px', borderRadius: 8, border: 'none',
+              fontSize: 13, cursor: saving || saveStatus !== 'idle' ? 'default' : 'pointer',
+              background: saveStatus === 'saved' ? 'rgba(34, 197, 94, 0.2)'
+                : saveStatus === 'already' ? 'rgba(234, 179, 8, 0.2)'
+                : 'rgba(59, 130, 246, 0.15)',
+              color: saveStatus === 'saved' ? 'rgba(34, 197, 94, 0.9)'
+                : saveStatus === 'already' ? 'rgba(234, 179, 8, 0.9)'
+                : 'rgba(59, 130, 246, 0.9)',
+              backdropFilter: 'blur(8px)',
+              transition: 'all 0.2s',
+            }}
+          >
+            {saving ? (
+              <><div style={{ ...styles.miniSpinner }} /> 保存中...</>
+            ) : saveStatus === 'saved' ? (
+              <><Check size={13} /> 已保存</>
+            ) : saveStatus === 'already' ? (
+              <><Check size={13} /> 你已经保存过了</>
+            ) : !isAuthenticated ? (
+              <><LogIn size={13} /> 登录并保存</>
+            ) : (
+              <><Download size={13} /> 保存到我的托管</>
+            )}
+          </button>
         </div>
         {data.description && <p style={{ color: 'rgba(255,255,255,0.5)', margin: '0 0 16px', fontSize: 14 }}>{data.description}</p>}
         <p style={{ color: 'rgba(255,255,255,0.3)', fontSize: 12, margin: '0 0 20px' }}>{data.sites.length} 个站点</p>
@@ -398,6 +496,14 @@ const styles: Record<string, React.CSSProperties> = {
     borderRadius: '50%',
     animation: 'share-spin 0.8s linear infinite',
     margin: '0 auto',
+  },
+  miniSpinner: {
+    width: 12,
+    height: 12,
+    border: '2px solid rgba(255,255,255,0.1)',
+    borderTop: '2px solid currentColor',
+    borderRadius: '50%',
+    animation: 'share-spin 0.8s linear infinite',
   },
 };
 

--- a/prd-admin/src/pages/ShareViewPage.tsx
+++ b/prd-admin/src/pages/ShareViewPage.tsx
@@ -17,6 +17,7 @@ export default function ShareViewPage() {
   const { token } = useParams<{ token: string }>();
   const navigate = useNavigate();
   const isAuthenticated = useAuthStore(s => s.isAuthenticated);
+  const currentUserId = useAuthStore(s => s.user?.userId);
   const [data, setData] = useState<ShareViewData | null>(null);
   const [error, setError] = useState<{ code: string; message: string } | null>(null);
   const [loading, setLoading] = useState(true);
@@ -89,19 +90,10 @@ export default function ShareViewPage() {
     setSubmitting(false);
   };
 
-  // ── Loading ──
+  // ── Loading ── (纯黑背景，无动画，避免闪烁)
   if (loading) {
     return (
-      <div style={styles.fullScreen}>
-        <div style={{ position: 'absolute', inset: 0 }}><BlackHoleVortex /></div>
-        <div style={styles.overlay} />
-        <div style={{ ...styles.glassCard, textAlign: 'center', padding: '48px 32px' }}>
-          <div style={styles.spinner} />
-          <p style={{ color: 'rgba(255,255,255,0.6)', marginTop: 16, fontSize: 14 }}>
-            正在加载分享内容...
-          </p>
-        </div>
-      </div>
+      <div style={{ ...styles.fullScreen, background: '#0a0a0a' }} />
     );
   }
 
@@ -276,6 +268,8 @@ export default function ShareViewPage() {
   // ── Success: show site(s) ──
   if (!data) return null;
 
+  const isOwner = isAuthenticated && currentUserId && data.createdBy === currentUserId;
+
   // Single site -> directly embed in iframe
   if (data.sites.length === 1) {
     const site = data.sites[0];
@@ -302,34 +296,36 @@ export default function ShareViewPage() {
             </span>
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-            <button
-              onClick={handleSave}
-              disabled={saving || saveStatus !== 'idle'}
-              style={{
-                display: 'flex', alignItems: 'center', gap: 4,
-                padding: '4px 10px', borderRadius: 6, border: 'none',
-                fontSize: 13, cursor: saving || saveStatus !== 'idle' ? 'default' : 'pointer',
-                background: saveStatus === 'saved' ? 'rgba(34, 197, 94, 0.2)'
-                  : saveStatus === 'already' ? 'rgba(234, 179, 8, 0.2)'
-                  : 'rgba(59, 130, 246, 0.15)',
-                color: saveStatus === 'saved' ? 'rgba(34, 197, 94, 0.9)'
-                  : saveStatus === 'already' ? 'rgba(234, 179, 8, 0.9)'
-                  : 'rgba(59, 130, 246, 0.9)',
-                transition: 'all 0.2s',
-              }}
-            >
-              {saving ? (
-                <><div style={{ ...styles.miniSpinner }} /> 保存中...</>
-              ) : saveStatus === 'saved' ? (
-                <><Check size={12} /> 已保存</>
-              ) : saveStatus === 'already' ? (
-                <><Check size={12} /> 你已经保存过了</>
-              ) : !isAuthenticated ? (
-                <><LogIn size={12} /> 登录并保存</>
-              ) : (
-                <><Download size={12} /> 保存到我的托管</>
-              )}
-            </button>
+            {!isOwner && (
+              <button
+                onClick={handleSave}
+                disabled={saving || saveStatus !== 'idle'}
+                style={{
+                  display: 'flex', alignItems: 'center', gap: 4,
+                  padding: '4px 10px', borderRadius: 6, border: 'none',
+                  fontSize: 13, cursor: saving || saveStatus !== 'idle' ? 'default' : 'pointer',
+                  background: saveStatus === 'saved' ? 'rgba(34, 197, 94, 0.2)'
+                    : saveStatus === 'already' ? 'rgba(234, 179, 8, 0.2)'
+                    : 'rgba(59, 130, 246, 0.15)',
+                  color: saveStatus === 'saved' ? 'rgba(34, 197, 94, 0.9)'
+                    : saveStatus === 'already' ? 'rgba(234, 179, 8, 0.9)'
+                    : 'rgba(59, 130, 246, 0.9)',
+                  transition: 'all 0.2s',
+                }}
+              >
+                {saving ? (
+                  <><div style={{ ...styles.miniSpinner }} /> 保存中...</>
+                ) : saveStatus === 'saved' ? (
+                  <><Check size={12} /> 已保存</>
+                ) : saveStatus === 'already' ? (
+                  <><Check size={12} /> 你已经保存过了</>
+                ) : !isAuthenticated ? (
+                  <><LogIn size={12} /> 登录并保存</>
+                ) : (
+                  <><Download size={12} /> 保存到我的托管</>
+                )}
+              </button>
+            )}
             <a
               href={site.siteUrl}
               target="_blank"
@@ -368,35 +364,37 @@ export default function ShareViewPage() {
               {data.createdByName ? `分享的 ${data.sites.length} 个站点合集` : (data.title || '站点合集')}
             </h1>
           </div>
-          <button
-            onClick={handleSave}
-            disabled={saving || saveStatus !== 'idle'}
-            style={{
-              display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0,
-              padding: '6px 14px', borderRadius: 8, border: 'none',
-              fontSize: 13, cursor: saving || saveStatus !== 'idle' ? 'default' : 'pointer',
-              background: saveStatus === 'saved' ? 'rgba(34, 197, 94, 0.2)'
-                : saveStatus === 'already' ? 'rgba(234, 179, 8, 0.2)'
-                : 'rgba(59, 130, 246, 0.15)',
-              color: saveStatus === 'saved' ? 'rgba(34, 197, 94, 0.9)'
-                : saveStatus === 'already' ? 'rgba(234, 179, 8, 0.9)'
-                : 'rgba(59, 130, 246, 0.9)',
-              backdropFilter: 'blur(8px)',
-              transition: 'all 0.2s',
-            }}
-          >
-            {saving ? (
-              <><div style={{ ...styles.miniSpinner }} /> 保存中...</>
-            ) : saveStatus === 'saved' ? (
-              <><Check size={13} /> 已保存</>
-            ) : saveStatus === 'already' ? (
-              <><Check size={13} /> 你已经保存过了</>
-            ) : !isAuthenticated ? (
-              <><LogIn size={13} /> 登录并保存</>
-            ) : (
-              <><Download size={13} /> 保存到我的托管</>
-            )}
-          </button>
+          {!isOwner && (
+            <button
+              onClick={handleSave}
+              disabled={saving || saveStatus !== 'idle'}
+              style={{
+                display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0,
+                padding: '6px 14px', borderRadius: 8, border: 'none',
+                fontSize: 13, cursor: saving || saveStatus !== 'idle' ? 'default' : 'pointer',
+                background: saveStatus === 'saved' ? 'rgba(34, 197, 94, 0.2)'
+                  : saveStatus === 'already' ? 'rgba(234, 179, 8, 0.2)'
+                  : 'rgba(59, 130, 246, 0.15)',
+                color: saveStatus === 'saved' ? 'rgba(34, 197, 94, 0.9)'
+                  : saveStatus === 'already' ? 'rgba(234, 179, 8, 0.9)'
+                  : 'rgba(59, 130, 246, 0.9)',
+                backdropFilter: 'blur(8px)',
+                transition: 'all 0.2s',
+              }}
+            >
+              {saving ? (
+                <><div style={{ ...styles.miniSpinner }} /> 保存中...</>
+              ) : saveStatus === 'saved' ? (
+                <><Check size={13} /> 已保存</>
+              ) : saveStatus === 'already' ? (
+                <><Check size={13} /> 你已经保存过了</>
+              ) : !isAuthenticated ? (
+                <><LogIn size={13} /> 登录并保存</>
+              ) : (
+                <><Download size={13} /> 保存到我的托管</>
+              )}
+            </button>
+          )}
         </div>
         {data.description && <p style={{ color: 'rgba(255,255,255,0.5)', margin: '0 0 16px', fontSize: 14 }}>{data.description}</p>}
         <p style={{ color: 'rgba(255,255,255,0.3)', fontSize: 12, margin: '0 0 20px' }}>{data.sites.length} 个站点</p>

--- a/prd-admin/src/pages/WebPagesPage.tsx
+++ b/prd-admin/src/pages/WebPagesPage.tsx
@@ -16,8 +16,9 @@ import {
   createSiteShareLink,
   listSiteShares,
   revokeSiteShare,
+  listShareViewLogs,
 } from '@/services';
-import type { HostedSite, ShareLinkItem, TagCount } from '@/services/real/webPages';
+import type { HostedSite, ShareLinkItem, TagCount, ShareViewLogItem } from '@/services/real/webPages';
 import {
   Upload,
   Search,
@@ -73,6 +74,7 @@ const sourceTypeLabels: Record<string, string> = {
   upload: '手动上传',
   workflow: '工作流',
   api: 'API',
+  'saved-share': '从分享保存',
 };
 
 // ─── Main Page ───
@@ -231,6 +233,7 @@ export default function WebPagesPage() {
             <option value="upload">手动上传</option>
             <option value="workflow">工作流</option>
             <option value="api">API</option>
+            <option value="saved-share">从分享保存</option>
           </select>
 
           {/* Sort */}
@@ -1008,6 +1011,9 @@ function SharesPanel({ shares, setShares, onClose }: {
   onClose: () => void;
 }) {
   const [loading, setLoading] = useState(true);
+  const [viewLogsToken, setViewLogsToken] = useState<string | null>(null);
+  const [viewLogs, setViewLogs] = useState<ShareViewLogItem[]>([]);
+  const [logsLoading, setLogsLoading] = useState(false);
 
   useEffect(() => {
     (async () => {
@@ -1030,6 +1036,14 @@ function SharesPanel({ shares, setShares, onClose }: {
     navigator.clipboard.writeText(`${window.location.origin}/s/wp/${token}`);
   };
 
+  const handleShowLogs = async (token: string) => {
+    setViewLogsToken(token);
+    setLogsLoading(true);
+    const res = await listShareViewLogs(token, 200);
+    if (res.success) setViewLogs(res.data.items);
+    setLogsLoading(false);
+  };
+
   return (
     <Dialog
       open={true}
@@ -1047,41 +1061,76 @@ function SharesPanel({ shares, setShares, onClose }: {
           ) : (
             <div className="flex flex-col gap-2 max-h-[60vh] overflow-y-auto">
               {shares.map(share => (
-                <div
-                  key={share.id}
-                  className="flex items-center gap-3 p-3 rounded-lg"
-                  style={{ background: 'var(--bg-sunken)', border: '1px solid var(--border-default)' }}
-                >
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2">
-                      <Link2 size={14} style={{ color: 'var(--text-muted)' }} />
-                      <span className="text-sm font-medium truncate" style={{ color: 'var(--text-primary)' }}>
-                        {share.title || (share.shareType === 'collection' ? `合集 (${share.siteIds.length} 站)` : '单站点分享')}
-                      </span>
-                      <Badge variant={share.accessLevel === 'password' ? 'warning' : 'success'}>
-                        {share.accessLevel === 'password' ? '密码保护' : '公开'}
-                      </Badge>
-                      {share.shareType === 'collection' && (
-                        <Badge variant="subtle">{share.siteIds.length} 站合集</Badge>
+                <div key={share.id}>
+                  <div
+                    className="flex items-center gap-3 p-3 rounded-lg"
+                    style={{ background: 'var(--bg-sunken)', border: '1px solid var(--border-default)' }}
+                  >
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2">
+                        <Link2 size={14} style={{ color: 'var(--text-muted)' }} />
+                        <span className="text-sm font-medium truncate" style={{ color: 'var(--text-primary)' }}>
+                          {share.title || (share.shareType === 'collection' ? `合集 (${share.siteIds.length} 站)` : '单站点分享')}
+                        </span>
+                        <Badge variant={share.accessLevel === 'password' ? 'warning' : 'success'}>
+                          {share.accessLevel === 'password' ? '密码保护' : '公开'}
+                        </Badge>
+                        {share.shareType === 'collection' && (
+                          <Badge variant="subtle">{share.siteIds.length} 站合集</Badge>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-3 mt-1 text-xs" style={{ color: 'var(--text-muted)' }}>
+                        <span className="flex items-center gap-1"><Eye size={10} /> {share.viewCount} 次浏览</span>
+                        <span>创建于 {fmtDate(share.createdAt)}</span>
+                        {share.expiresAt && <span>过期于 {fmtDate(share.expiresAt)}</span>}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-1 shrink-0">
+                      <Button
+                        size="xs"
+                        variant={viewLogsToken === share.token ? 'secondary' : 'ghost'}
+                        onClick={() => viewLogsToken === share.token ? setViewLogsToken(null) : handleShowLogs(share.token)}
+                        title="观看记录"
+                      >
+                        <Eye size={12} />
+                      </Button>
+                      <Button size="xs" variant="ghost" onClick={() => handleCopy(share.token)} title="复制链接">
+                        <Copy size={12} />
+                      </Button>
+                      <Button size="xs" variant="ghost" onClick={() => window.open(`/s/wp/${share.token}`, '_blank')} title="预览">
+                        <ExternalLink size={12} />
+                      </Button>
+                      <Button size="xs" variant="danger" onClick={() => handleRevoke(share.id)} title="撤销">
+                        <X size={12} />
+                      </Button>
+                    </div>
+                  </div>
+                  {/* View logs sub-panel */}
+                  {viewLogsToken === share.token && (
+                    <div
+                      className="ml-6 mt-1 mb-2 p-3 rounded-lg text-xs"
+                      style={{ background: 'var(--bg-elevated)', border: '1px solid var(--border-subtle)' }}
+                    >
+                      <div className="font-medium mb-2" style={{ color: 'var(--text-secondary)' }}>观看记录</div>
+                      {logsLoading ? (
+                        <div style={{ color: 'var(--text-muted)' }}>加载中...</div>
+                      ) : viewLogs.length === 0 ? (
+                        <div style={{ color: 'var(--text-muted)' }}>暂无观看记录</div>
+                      ) : (
+                        <div className="flex flex-col gap-1.5 max-h-48 overflow-y-auto">
+                          {viewLogs.map(log => (
+                            <div key={log.id} className="flex items-center gap-3" style={{ color: 'var(--text-muted)' }}>
+                              <span style={{ color: log.viewerName ? 'var(--text-primary)' : 'var(--text-muted)', minWidth: 70 }}>
+                                {log.viewerName || '匿名访客'}
+                              </span>
+                              <span>{fmtDate(log.viewedAt)}</span>
+                              {log.ipAddress && <span className="opacity-60">{log.ipAddress}</span>}
+                            </div>
+                          ))}
+                        </div>
                       )}
                     </div>
-                    <div className="flex items-center gap-3 mt-1 text-xs" style={{ color: 'var(--text-muted)' }}>
-                      <span className="flex items-center gap-1"><Eye size={10} /> {share.viewCount} 次浏览</span>
-                      <span>创建于 {fmtDate(share.createdAt)}</span>
-                      {share.expiresAt && <span>过期于 {fmtDate(share.expiresAt)}</span>}
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-1 shrink-0">
-                    <Button size="xs" variant="ghost" onClick={() => handleCopy(share.token)} title="复制链接">
-                      <Copy size={12} />
-                    </Button>
-                    <Button size="xs" variant="ghost" onClick={() => window.open(`/s/wp/${share.token}`, '_blank')} title="预览">
-                      <ExternalLink size={12} />
-                    </Button>
-                    <Button size="xs" variant="danger" onClick={() => handleRevoke(share.id)} title="撤销">
-                      <X size={12} />
-                    </Button>
-                  </div>
+                  )}
                 </div>
               ))}
             </div>

--- a/prd-admin/src/services/api.ts
+++ b/prd-admin/src/services/api.ts
@@ -773,6 +773,7 @@ export const api = {
     shares: () => '/api/web-pages/shares',
     revokeShare: (shareId: string) => `/api/web-pages/shares/${shareId}`,
     viewShare: (token: string) => `/api/web-pages/shares/view/${token}`,
+    saveShare: (token: string) => `/api/web-pages/shares/${token}/save`,
   },
 } as const;
 

--- a/prd-admin/src/services/api.ts
+++ b/prd-admin/src/services/api.ts
@@ -774,6 +774,7 @@ export const api = {
     revokeShare: (shareId: string) => `/api/web-pages/shares/${shareId}`,
     viewShare: (token: string) => `/api/web-pages/shares/view/${token}`,
     saveShare: (token: string) => `/api/web-pages/shares/${token}/save`,
+    viewLogs: '/api/web-pages/shares/view-logs',
   },
 } as const;
 

--- a/prd-admin/src/services/index.ts
+++ b/prd-admin/src/services/index.ts
@@ -1235,6 +1235,7 @@ export {
   listShares as listSiteShares,
   revokeShare as revokeSiteShare,
   viewShare as viewSiteShare,
+  saveSharedSite,
 } from '@/services/real/webPages';
 export type { HostedSite, HostedSiteFile, ShareLinkItem, TagCount, SharedSiteInfo, ShareViewData } from '@/services/real/webPages';
 

--- a/prd-admin/src/services/index.ts
+++ b/prd-admin/src/services/index.ts
@@ -1236,8 +1236,9 @@ export {
   revokeShare as revokeSiteShare,
   viewShare as viewSiteShare,
   saveSharedSite,
+  listShareViewLogs,
 } from '@/services/real/webPages';
-export type { HostedSite, HostedSiteFile, ShareLinkItem, TagCount, SharedSiteInfo, ShareViewData } from '@/services/real/webPages';
+export type { HostedSite, HostedSiteFile, ShareLinkItem, TagCount, SharedSiteInfo, ShareViewData, ShareViewLogItem } from '@/services/real/webPages';
 
 // ── Account Data Transfer 数据分享 ──
 export {

--- a/prd-admin/src/services/real/webPages.ts
+++ b/prd-admin/src/services/real/webPages.ts
@@ -223,6 +223,7 @@ export interface ShareViewData {
   description?: string;
   shareType: string;
   createdAt: string;
+  createdByName?: string;
   sites: SharedSiteInfo[];
 }
 
@@ -237,4 +238,11 @@ export async function viewShare(token: string, password?: string): Promise<ApiRe
   } catch {
     return { success: false, data: null as never, error: { code: 'NETWORK_ERROR', message: '网络请求失败' } };
   }
+}
+
+// ─── Save Shared Site ───
+
+export async function saveSharedSite(token: string, password?: string): Promise<ApiResponse<{ saved?: boolean; alreadySaved?: boolean; siteCount?: number }>> {
+  const q = password ? `?password=${encodeURIComponent(password)}` : '';
+  return apiRequest(`${api.webPages.saveShare(encodeURIComponent(token))}${q}`, { method: 'POST' });
 }

--- a/prd-admin/src/services/real/webPages.ts
+++ b/prd-admin/src/services/real/webPages.ts
@@ -223,6 +223,7 @@ export interface ShareViewData {
   description?: string;
   shareType: string;
   createdAt: string;
+  createdBy?: string;
   createdByName?: string;
   sites: SharedSiteInfo[];
 }
@@ -245,4 +246,26 @@ export async function viewShare(token: string, password?: string): Promise<ApiRe
 export async function saveSharedSite(token: string, password?: string): Promise<ApiResponse<{ saved?: boolean; alreadySaved?: boolean; siteCount?: number }>> {
   const q = password ? `?password=${encodeURIComponent(password)}` : '';
   return apiRequest(`${api.webPages.saveShare(encodeURIComponent(token))}${q}`, { method: 'POST' });
+}
+
+// ─── Share View Logs ───
+
+export interface ShareViewLogItem {
+  id: string;
+  shareToken: string;
+  shareId: string;
+  viewerUserId?: string;
+  viewerName?: string;
+  shareOwnerUserId: string;
+  viewedAt: string;
+  ipAddress?: string;
+  userAgent?: string;
+}
+
+export async function listShareViewLogs(shareToken?: string, limit = 100): Promise<ApiResponse<{ items: ShareViewLogItem[] }>> {
+  const params = new URLSearchParams();
+  if (shareToken) params.set('shareToken', shareToken);
+  if (limit !== 100) params.set('limit', String(limit));
+  const q = params.toString();
+  return apiRequest(`${api.webPages.viewLogs}${q ? `?${q}` : ''}`);
 }

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/WebPagesController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/WebPagesController.cs
@@ -272,7 +272,14 @@ public class WebPagesController : ControllerBase
     [AllowAnonymous]
     public async Task<IActionResult> ViewShare(string token, [FromQuery] string? password)
     {
-        var result = await _siteService.ViewShareAsync(token, password);
+        // 尝试获取登录用户信息（AllowAnonymous 但可能带 token）
+        var viewerUserId = User.Identity?.IsAuthenticated == true ? GetUserId() : null;
+        var viewerName = User.Identity?.IsAuthenticated == true ? GetDisplayName() : null;
+        var ip = HttpContext.Connection.RemoteIpAddress?.ToString();
+        var ua = Request.Headers.UserAgent.ToString();
+
+        var result = await _siteService.ViewShareAsync(token, password,
+            viewerUserId, viewerName, ip, ua);
         if (result == null)
             return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "分享链接不存在"));
 
@@ -292,9 +299,18 @@ public class WebPagesController : ControllerBase
             result.Description,
             result.ShareType,
             result.CreatedAt,
+            result.CreatedBy,
             result.CreatedByName,
             result.Sites,
         }));
+    }
+
+    /// <summary>获取分享的观看记录（仅分享所有者可查看）</summary>
+    [HttpGet("shares/view-logs")]
+    public async Task<IActionResult> ListShareViewLogs([FromQuery] string? shareToken, [FromQuery] int limit = 100)
+    {
+        var logs = await _siteService.ListShareViewLogsAsync(GetUserId(), shareToken, limit);
+        return Ok(ApiResponse<object>.Ok(new { items = logs }));
     }
 
     /// <summary>保存分享的站点到自己的托管（需登录，去重）</summary>

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/WebPagesController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/WebPagesController.cs
@@ -292,8 +292,31 @@ public class WebPagesController : ControllerBase
             result.Description,
             result.ShareType,
             result.CreatedAt,
+            result.CreatedByName,
             result.Sites,
         }));
+    }
+
+    /// <summary>保存分享的站点到自己的托管（需登录，去重）</summary>
+    [HttpPost("shares/{token}/save")]
+    public async Task<IActionResult> SaveSharedSite(string token, [FromQuery] string? password)
+    {
+        var result = await _siteService.SaveSharedSiteAsync(token, password, GetUserId());
+
+        if (result.Error != null)
+        {
+            return result.HttpStatus switch
+            {
+                401 => Unauthorized(ApiResponse<object>.Fail(ErrorCodes.UNAUTHORIZED, result.Error)),
+                400 => BadRequest(ApiResponse<object>.Fail("EXPIRED", result.Error)),
+                _ => NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, result.Error)),
+            };
+        }
+
+        if (result.AlreadySaved)
+            return Ok(ApiResponse<object>.Ok(new { alreadySaved = true }));
+
+        return Ok(ApiResponse<object>.Ok(new { saved = true, siteCount = result.Sites.Count }));
     }
 }
 

--- a/prd-api/src/PrdAgent.Core/Interfaces/IHostedSiteService.cs
+++ b/prd-api/src/PrdAgent.Core/Interfaces/IHostedSiteService.cs
@@ -76,7 +76,13 @@ public interface IHostedSiteService
 
     Task<bool> RevokeShareAsync(string shareId, string userId, CancellationToken ct = default);
 
-    Task<ShareViewResult?> ViewShareAsync(string token, string? password, CancellationToken ct = default);
+    Task<ShareViewResult?> ViewShareAsync(string token, string? password,
+        string? viewerUserId = null, string? viewerName = null,
+        string? ipAddress = null, string? userAgent = null,
+        CancellationToken ct = default);
+
+    /// <summary>获取分享的观看记录（供分享所有者查看）</summary>
+    Task<List<ShareViewLog>> ListShareViewLogsAsync(string userId, string? shareToken, int limit = 100, CancellationToken ct = default);
 
     /// <summary>将分享的站点保存到自己的托管（去重：同一 token 只保存一次）</summary>
     Task<SaveSharedSiteResult> SaveSharedSiteAsync(string token, string? password, string userId, CancellationToken ct = default);
@@ -94,6 +100,7 @@ public class ShareViewResult
     public string? Description { get; set; }
     public string ShareType { get; set; } = "single";
     public DateTime CreatedAt { get; set; }
+    public string? CreatedBy { get; set; }
     public string? CreatedByName { get; set; }
     public List<SharedSiteInfo> Sites { get; set; } = new();
     public string? Error { get; set; }

--- a/prd-api/src/PrdAgent.Core/Interfaces/IHostedSiteService.cs
+++ b/prd-api/src/PrdAgent.Core/Interfaces/IHostedSiteService.cs
@@ -77,6 +77,9 @@ public interface IHostedSiteService
     Task<bool> RevokeShareAsync(string shareId, string userId, CancellationToken ct = default);
 
     Task<ShareViewResult?> ViewShareAsync(string token, string? password, CancellationToken ct = default);
+
+    /// <summary>将分享的站点保存到自己的托管（去重：同一 token 只保存一次）</summary>
+    Task<SaveSharedSiteResult> SaveSharedSiteAsync(string token, string? password, string userId, CancellationToken ct = default);
 }
 
 public class TagCountResult
@@ -91,7 +94,17 @@ public class ShareViewResult
     public string? Description { get; set; }
     public string ShareType { get; set; } = "single";
     public DateTime CreatedAt { get; set; }
+    public string? CreatedByName { get; set; }
     public List<SharedSiteInfo> Sites { get; set; } = new();
+    public string? Error { get; set; }
+    public int HttpStatus { get; set; } = 200;
+}
+
+public class SaveSharedSiteResult
+{
+    public bool AlreadySaved { get; set; }
+    public bool Saved { get; set; }
+    public List<HostedSite> Sites { get; set; } = new();
     public string? Error { get; set; }
     public int HttpStatus { get; set; } = 200;
 }

--- a/prd-api/src/PrdAgent.Core/Models/WebPage.cs
+++ b/prd-api/src/PrdAgent.Core/Models/WebPage.cs
@@ -114,6 +114,10 @@ public class WebPageShareLink
     public DateTime? LastViewedAt { get; set; }
 
     public string CreatedBy { get; set; } = string.Empty;
+
+    /// <summary>创建者显示名称（快照）</summary>
+    public string? CreatedByName { get; set; }
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime? ExpiresAt { get; set; }
     public bool IsRevoked { get; set; }

--- a/prd-api/src/PrdAgent.Core/Models/WebPage.cs
+++ b/prd-api/src/PrdAgent.Core/Models/WebPage.cs
@@ -126,3 +126,35 @@ public class WebPageShareLink
         => Convert.ToBase64String(RandomNumberGenerator.GetBytes(9))
             .Replace("+", "-").Replace("/", "_").TrimEnd('=');
 }
+
+/// <summary>
+/// 分享链接观看记录 — 记录每次访问的来源信息
+/// </summary>
+public class ShareViewLog
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString("N");
+
+    /// <summary>分享链接 Token</summary>
+    public string ShareToken { get; set; } = string.Empty;
+
+    /// <summary>分享链接 ID</summary>
+    public string ShareId { get; set; } = string.Empty;
+
+    /// <summary>观看者用户 ID（未登录为 null）</summary>
+    public string? ViewerUserId { get; set; }
+
+    /// <summary>观看者显示名称（未登录为 null）</summary>
+    public string? ViewerName { get; set; }
+
+    /// <summary>分享创建者用户 ID</summary>
+    public string ShareOwnerUserId { get; set; } = string.Empty;
+
+    /// <summary>观看时间</summary>
+    public DateTime ViewedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>IP 地址</summary>
+    public string? IpAddress { get; set; }
+
+    /// <summary>User-Agent</summary>
+    public string? UserAgent { get; set; }
+}

--- a/prd-api/src/PrdAgent.Infrastructure/Database/MongoDbContext.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Database/MongoDbContext.cs
@@ -171,6 +171,7 @@ public class MongoDbContext
     // Web Hosting 网页托管与分享
     public IMongoCollection<HostedSite> HostedSites => _database.GetCollection<HostedSite>("hosted_sites");
     public IMongoCollection<WebPageShareLink> WebPageShareLinks => _database.GetCollection<WebPageShareLink>("web_page_share_links");
+    public IMongoCollection<ShareViewLog> ShareViewLogs => _database.GetCollection<ShareViewLog>("share_view_logs");
 
     // Video Agent 视频转文档
     public IMongoCollection<VideoToDocRun> VideoToDocRuns => _database.GetCollection<VideoToDocRun>("video_to_doc_runs");
@@ -1133,5 +1134,14 @@ public class MongoDbContext
         WebPageShareLinks.Indexes.CreateOne(new CreateIndexModel<WebPageShareLink>(
             Builders<WebPageShareLink>.IndexKeys.Ascending(x => x.CreatedBy).Descending(x => x.CreatedAt),
             new CreateIndexOptions { Name = "idx_web_page_share_links_creator_created" }));
+
+        // ShareViewLogs：按分享所有者 + 时间（用于分享管理查看记录）
+        ShareViewLogs.Indexes.CreateOne(new CreateIndexModel<ShareViewLog>(
+            Builders<ShareViewLog>.IndexKeys.Ascending(x => x.ShareOwnerUserId).Descending(x => x.ViewedAt),
+            new CreateIndexOptions { Name = "idx_share_view_logs_owner_viewed" }));
+        // ShareViewLogs：按 Token + 时间
+        ShareViewLogs.Indexes.CreateOne(new CreateIndexModel<ShareViewLog>(
+            Builders<ShareViewLog>.IndexKeys.Ascending(x => x.ShareToken).Descending(x => x.ViewedAt),
+            new CreateIndexOptions { Name = "idx_share_view_logs_token_viewed" }));
     }
 }

--- a/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
@@ -465,7 +465,10 @@ public class HostedSiteService : IHostedSiteService
         return result.MatchedCount > 0;
     }
 
-    public async Task<ShareViewResult?> ViewShareAsync(string token, string? password, CancellationToken ct)
+    public async Task<ShareViewResult?> ViewShareAsync(string token, string? password,
+        string? viewerUserId = null, string? viewerName = null,
+        string? ipAddress = null, string? userAgent = null,
+        CancellationToken ct = default)
     {
         var share = await _db.WebPageShareLinks.Find(x => x.Token == token).FirstOrDefaultAsync(ct);
         if (share == null || share.IsRevoked)
@@ -484,6 +487,25 @@ public class HostedSiteService : IHostedSiteService
                 .Inc(x => x.ViewCount, 1)
                 .Set(x => x.LastViewedAt, DateTime.UtcNow),
             cancellationToken: ct);
+
+        // 记录观看日志
+        try
+        {
+            await _db.ShareViewLogs.InsertOneAsync(new ShareViewLog
+            {
+                ShareToken = token,
+                ShareId = share.Id,
+                ViewerUserId = viewerUserId,
+                ViewerName = viewerName,
+                ShareOwnerUserId = share.CreatedBy,
+                IpAddress = ipAddress,
+                UserAgent = userAgent,
+            }, cancellationToken: ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "记录分享观看日志失败: {ShareId}", share.Id);
+        }
 
         var siteIds = share.SiteIds.Count > 0 ? share.SiteIds : new List<string>();
         if (share.SiteId != null && !siteIds.Contains(share.SiteId))
@@ -514,9 +536,41 @@ public class HostedSiteService : IHostedSiteService
             Description = share.Description,
             ShareType = share.ShareType,
             CreatedAt = share.CreatedAt,
-            CreatedByName = share.CreatedByName,
+            CreatedBy = share.CreatedBy,
+            CreatedByName = share.CreatedByName ?? await LookupDisplayNameAsync(share.CreatedBy, ct),
             Sites = sites,
         };
+    }
+
+    // ─────────────────────────────────────────────
+    // 观看记录
+    // ─────────────────────────────────────────────
+
+    public async Task<List<ShareViewLog>> ListShareViewLogsAsync(
+        string userId, string? shareToken, int limit = 100, CancellationToken ct = default)
+    {
+        var fb = Builders<ShareViewLog>.Filter;
+        var filter = fb.Eq(x => x.ShareOwnerUserId, userId);
+        if (!string.IsNullOrWhiteSpace(shareToken))
+            filter &= fb.Eq(x => x.ShareToken, shareToken);
+
+        return await _db.ShareViewLogs.Find(filter)
+            .SortByDescending(x => x.ViewedAt)
+            .Limit(Math.Clamp(limit, 1, 500))
+            .ToListAsync(ct);
+    }
+
+    // ─────────────────────────────────────────────
+    // 用户名查找（兼容旧分享没有 CreatedByName 的情况）
+    // ─────────────────────────────────────────────
+
+    private async Task<string?> LookupDisplayNameAsync(string userId, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(userId)) return null;
+        var user = await _db.Users.Find(x => x.UserId == userId)
+            .Project(Builders<User>.Projection.Expression(u => u.DisplayName))
+            .FirstOrDefaultAsync(ct);
+        return string.IsNullOrWhiteSpace(user) ? null : user;
     }
 
     // ─────────────────────────────────────────────
@@ -537,7 +591,11 @@ public class HostedSiteService : IHostedSiteService
         if (share.AccessLevel == "password" && (string.IsNullOrWhiteSpace(password) || password.Trim() != share.Password))
             return new SaveSharedSiteResult { Error = "需要提供正确的访问密码", HttpStatus = 401 };
 
-        // 2. 去重：检查是否已经保存过此分享
+        // 2. 禁止保存自己的分享
+        if (share.CreatedBy == userId)
+            return new SaveSharedSiteResult { Error = "不能保存自己创建的分享", HttpStatus = 400 };
+
+        // 3. 去重：检查是否已经保存过此分享
         var alreadyExists = await _db.HostedSites.CountDocumentsAsync(
             x => x.OwnerUserId == userId && x.SourceType == "saved-share" && x.SourceRef == token,
             cancellationToken: ct);

--- a/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
@@ -439,6 +439,7 @@ public class HostedSiteService : IHostedSiteService
             Password = password?.Trim(),
             ExpiresAt = expiresInDays > 0 ? DateTime.UtcNow.AddDays(expiresInDays) : null,
             CreatedBy = userId,
+            CreatedByName = displayName,
         };
 
         await _db.WebPageShareLinks.InsertOneAsync(share, cancellationToken: ct);
@@ -513,8 +514,80 @@ public class HostedSiteService : IHostedSiteService
             Description = share.Description,
             ShareType = share.ShareType,
             CreatedAt = share.CreatedAt,
+            CreatedByName = share.CreatedByName,
             Sites = sites,
         };
+    }
+
+    // ─────────────────────────────────────────────
+    // 保存分享站点
+    // ─────────────────────────────────────────────
+
+    public async Task<SaveSharedSiteResult> SaveSharedSiteAsync(
+        string token, string? password, string userId, CancellationToken ct)
+    {
+        // 1. 验证分享链接
+        var share = await _db.WebPageShareLinks.Find(x => x.Token == token).FirstOrDefaultAsync(ct);
+        if (share == null || share.IsRevoked)
+            return new SaveSharedSiteResult { Error = "分享链接不存在或已失效", HttpStatus = 404 };
+
+        if (share.ExpiresAt.HasValue && share.ExpiresAt.Value < DateTime.UtcNow)
+            return new SaveSharedSiteResult { Error = "分享链接已过期", HttpStatus = 400 };
+
+        if (share.AccessLevel == "password" && (string.IsNullOrWhiteSpace(password) || password.Trim() != share.Password))
+            return new SaveSharedSiteResult { Error = "需要提供正确的访问密码", HttpStatus = 401 };
+
+        // 2. 去重：检查是否已经保存过此分享
+        var alreadyExists = await _db.HostedSites.CountDocumentsAsync(
+            x => x.OwnerUserId == userId && x.SourceType == "saved-share" && x.SourceRef == token,
+            cancellationToken: ct);
+
+        if (alreadyExists > 0)
+            return new SaveSharedSiteResult { AlreadySaved = true };
+
+        // 3. 获取原始站点
+        var siteIds = share.SiteIds.Count > 0 ? share.SiteIds : new List<string>();
+        if (share.SiteId != null && !siteIds.Contains(share.SiteId))
+            siteIds.Insert(0, share.SiteId);
+
+        var originalSites = await _db.HostedSites.Find(x => siteIds.Contains(x.Id)).ToListAsync(ct);
+        if (originalSites.Count == 0)
+            return new SaveSharedSiteResult { Error = "分享的站点已被删除", HttpStatus = 404 };
+
+        // 4. 为用户创建引用副本（复用 COS 文件，不重复上传）
+        var savedSites = new List<HostedSite>();
+        foreach (var original in originalSites)
+        {
+            var saved = new HostedSite
+            {
+                Title = original.Title,
+                Description = original.Description,
+                SourceType = "saved-share",
+                SourceRef = token,
+                CosPrefix = original.CosPrefix,
+                EntryFile = original.EntryFile,
+                SiteUrl = original.SiteUrl,
+                Files = original.Files.Select(f => new HostedSiteFile
+                {
+                    Path = f.Path,
+                    CosKey = f.CosKey,
+                    Size = f.Size,
+                    MimeType = f.MimeType,
+                }).ToList(),
+                TotalSize = original.TotalSize,
+                Tags = original.Tags.ToList(),
+                Folder = original.Folder,
+                CoverImageUrl = original.CoverImageUrl,
+                OwnerUserId = userId,
+            };
+            savedSites.Add(saved);
+        }
+
+        await _db.HostedSites.InsertManyAsync(savedSites, cancellationToken: ct);
+        _logger.LogInformation("用户 {UserId} 保存了分享 {Token} 的 {Count} 个站点",
+            userId, token, savedSites.Count);
+
+        return new SaveSharedSiteResult { Saved = true, Sites = savedSites };
     }
 
     // ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
This PR adds functionality to save shared sites to a user's own hosting, with proper authentication checks, deduplication, and UI feedback. Users can now save shared site collections with a single click, and the system prevents duplicate saves of the same share.

## Key Changes

**Frontend (ShareViewPage.tsx)**
- Added "Save to my hosting" button in two locations (header and iframe header) with dynamic status feedback
- Integrated authentication check via `useAuthStore` - unauthenticated users are redirected to login with return URL
- Implemented `handleSave` callback that calls the new `saveSharedSite` API endpoint
- Added visual feedback states: idle, saving, saved, and already-saved (with appropriate icons and colors)
- Enhanced share header to display creator name (`createdByName`) when available
- Added new icons: `Download`, `Check`, `LogIn` for better UX

**Backend (HostedSiteService.cs)**
- Implemented `SaveSharedSiteAsync` method that:
  - Validates share link existence, expiration, and password protection
  - Checks for duplicate saves (same token per user) to prevent duplicates
  - Retrieves original hosted sites from the share
  - Creates reference copies that reuse COS files without re-uploading
  - Marks saved sites with `SourceType = "saved-share"` and `SourceRef = token` for tracking
- Added `CreatedByName` field to `WebPageShareLink` model to capture creator's display name at share creation time

**API Controller (WebPagesController.cs)**
- Added `POST /api/web-pages/shares/{token}/save` endpoint
- Requires authentication (uses `GetUserId()`)
- Returns appropriate HTTP status codes: 401 for auth failures, 400 for expired shares, 404 for missing shares
- Returns response indicating whether site was newly saved or already existed

**Data Models & Services**
- Added `SaveSharedSiteResult` class to encapsulate save operation results
- Updated `ShareViewResult` to include `CreatedByName` field
- Updated `ShareViewData` interface to include `createdByName` property
- Added `saveSharedSite` service function to call the new API endpoint
- Updated API route definitions to include the new save endpoint

## Implementation Details
- Deduplication is enforced at the database level by checking for existing records with matching `OwnerUserId`, `SourceType = "saved-share"`, and `SourceRef = token`
- Saved sites maintain references to original COS files, avoiding storage duplication
- Creator name is captured as a snapshot at share creation time for display purposes
- UI provides clear feedback with 3-second timeout for success messages
- Unauthenticated users are seamlessly redirected to login while preserving their current location

https://claude.ai/code/session_01JgPUSQjWAZ8LEXdXfgVWn8