### PR TITLE
Add QR code generation for hosted sites

### DIFF
--- a/prd-admin/package.json
+++ b/prd-admin/package.json
@@ -34,6 +34,7 @@
     "lexical": "^0.39.0",
     "lucide-react": "^0.468.0",
     "motion": "^12.34.3",
+    "qrcode.react": "^4.2.0",
     "react": "^18.3.1",
     "react-colorful": "^5.6.1",
     "react-dom": "^18.3.1",

--- a/prd-admin/pnpm-lock.yaml
+++ b/prd-admin/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       motion:
         specifier: ^12.34.3
         version: 12.34.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      qrcode.react:
+        specifier: ^4.2.0
+        version: 4.2.0(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -2574,6 +2577,11 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  qrcode.react@4.2.0:
+    resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   react-colorful@5.6.1:
     resolution: {integrity: sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==}
@@ -5805,6 +5813,10 @@ snapshots:
   property-information@7.1.0: {}
 
   punycode@2.3.1: {}
+
+  qrcode.react@4.2.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   react-colorful@5.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:

--- a/prd-admin/src/pages/WebPagesPage.tsx
+++ b/prd-admin/src/pages/WebPagesPage.tsx
@@ -41,7 +41,9 @@ import {
   FileArchive,
   HardDrive,
   UploadCloud,
+  QrCode,
 } from 'lucide-react';
+import { QRCodeSVG } from 'qrcode.react';
 
 // ─── Utility ───
 
@@ -100,6 +102,7 @@ export default function WebPagesPage() {
   const [shareTargetId, setShareTargetId] = useState<string | null>(null);
   const [showSharesPanel, setShowSharesPanel] = useState(false);
   const [shares, setShares] = useState<ShareLinkItem[]>([]);
+  const [qrSite, setQrSite] = useState<HostedSite | null>(null);
 
   // ─── Load ───
 
@@ -350,6 +353,7 @@ export default function WebPagesPage() {
               onEdit={() => { setEditItem(site); setShowUploadDialog(true); }}
               onDelete={() => handleDelete(site.id)}
               onShare={() => handleShare(site.id)}
+              onQrCode={() => setQrSite(site)}
             />
           ))}
         </div>
@@ -364,6 +368,7 @@ export default function WebPagesPage() {
               onEdit={() => { setEditItem(site); setShowUploadDialog(true); }}
               onDelete={() => handleDelete(site.id)}
               onShare={() => handleShare(site.id)}
+              onQrCode={() => setQrSite(site)}
             />
           ))}
         </div>
@@ -396,6 +401,26 @@ export default function WebPagesPage() {
           onClose={() => setShowSharesPanel(false)}
         />
       )}
+
+      {/* QR Code Dialog */}
+      <Dialog
+        open={!!qrSite}
+        onOpenChange={(open) => { if (!open) setQrSite(null); }}
+        title="扫码访问"
+        description={qrSite?.title}
+        content={
+          qrSite ? (
+            <div className="flex flex-col items-center gap-4 py-4">
+              <div className="p-4 rounded-2xl" style={{ background: '#fff' }}>
+                <QRCodeSVG value={qrSite.siteUrl} size={280} level="H" />
+              </div>
+              <p className="text-xs text-center break-all px-4" style={{ color: 'var(--text-muted)', maxWidth: 320 }}>
+                {qrSite.siteUrl}
+              </p>
+            </div>
+          ) : null
+        }
+      />
     </div>
   );
 }
@@ -452,13 +477,14 @@ function SitePreview({ url, className, style }: { url: string; className?: strin
   );
 }
 
-function SiteCard({ site, selected, onSelect, onEdit, onDelete, onShare }: {
+function SiteCard({ site, selected, onSelect, onEdit, onDelete, onShare, onQrCode }: {
   site: HostedSite;
   selected: boolean;
   onSelect: () => void;
   onEdit: () => void;
   onDelete: () => void;
   onShare: () => void;
+  onQrCode: () => void;
 }) {
   return (
     <GlassCard
@@ -483,6 +509,9 @@ function SiteCard({ site, selected, onSelect, onEdit, onDelete, onShare }: {
           </button>
           <button onClick={(e) => { e.stopPropagation(); onShare(); }} className="p-1.5 rounded-full bg-white/20 backdrop-blur-sm hover:bg-white/30" title="分享">
             <Share2 size={14} style={{ color: '#fff' }} />
+          </button>
+          <button onClick={(e) => { e.stopPropagation(); onQrCode(); }} className="p-1.5 rounded-full bg-white/20 backdrop-blur-sm hover:bg-white/30" title="二维码">
+            <QrCode size={14} style={{ color: '#fff' }} />
           </button>
           <button onClick={(e) => { e.stopPropagation(); onEdit(); }} className="p-1.5 rounded-full bg-white/20 backdrop-blur-sm hover:bg-white/30" title="编辑">
             <Edit3 size={14} style={{ color: '#fff' }} />
@@ -552,13 +581,14 @@ function SiteCard({ site, selected, onSelect, onEdit, onDelete, onShare }: {
 
 // ─── List View ───
 
-function SiteListItem({ site, selected, onSelect, onEdit, onDelete, onShare }: {
+function SiteListItem({ site, selected, onSelect, onEdit, onDelete, onShare, onQrCode }: {
   site: HostedSite;
   selected: boolean;
   onSelect: () => void;
   onEdit: () => void;
   onDelete: () => void;
   onShare: () => void;
+  onQrCode: () => void;
 }) {
   return (
     <GlassCard
@@ -613,6 +643,9 @@ function SiteListItem({ site, selected, onSelect, onEdit, onDelete, onShare }: {
         </button>
         <button onClick={onShare} className="p-1 rounded hover:bg-[var(--bg-hover)]">
           <Share2 size={14} style={{ color: 'var(--text-muted)' }} />
+        </button>
+        <button onClick={onQrCode} className="p-1 rounded hover:bg-[var(--bg-hover)]" title="二维码">
+          <QrCode size={14} style={{ color: 'var(--text-muted)' }} />
         </button>
         <button onClick={onEdit} className="p-1 rounded hover:bg-[var(--bg-hover)]">
           <Edit3 size={14} style={{ color: 'var(--text-muted)' }} />

--- a/prd-admin/src/pages/WebPagesPage.tsx
+++ b/prd-admin/src/pages/WebPagesPage.tsx
@@ -403,24 +403,9 @@ export default function WebPagesPage() {
       )}
 
       {/* QR Code Dialog */}
-      <Dialog
-        open={!!qrSite}
-        onOpenChange={(open) => { if (!open) setQrSite(null); }}
-        title="扫码访问"
-        description={qrSite?.title}
-        content={
-          qrSite ? (
-            <div className="flex flex-col items-center gap-4 py-4">
-              <div className="p-4 rounded-2xl" style={{ background: '#fff' }}>
-                <QRCodeSVG value={qrSite.siteUrl} size={280} level="H" />
-              </div>
-              <p className="text-xs text-center break-all px-4" style={{ color: 'var(--text-muted)', maxWidth: 320 }}>
-                {qrSite.siteUrl}
-              </p>
-            </div>
-          ) : null
-        }
-      />
+      {qrSite && (
+        <QrCodeDialog site={qrSite} onClose={() => setQrSite(null)} />
+      )}
     </div>
   );
 }
@@ -428,6 +413,64 @@ export default function WebPagesPage() {
 // ─── Card View ───
 
 // ─── Iframe Thumbnail Preview ───
+
+// ─── QR Code Dialog (auto-creates share link) ───
+
+function QrCodeDialog({ site, onClose }: { site: HostedSite; onClose: () => void }) {
+  const [shareUrl, setShareUrl] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setCreating(true);
+      const res = await createSiteShareLink({
+        siteId: site.id,
+        shareType: 'single',
+        expiresInDays: 0,
+      });
+      if (cancelled) return;
+      setCreating(false);
+      if (res.success) {
+        setShareUrl(`${window.location.origin}${res.data.shareUrl}`);
+      } else {
+        setError('创建分享链接失败');
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [site.id]);
+
+  return (
+    <Dialog
+      open={true}
+      onOpenChange={v => { if (!v) onClose(); }}
+      title="扫码访问"
+      description={site.title}
+      content={
+        <div className="flex flex-col items-center gap-4 py-4">
+          {creating ? (
+            <div className="flex items-center gap-2 py-8" style={{ color: 'var(--text-muted)' }}>
+              <RefreshCw size={16} className="animate-spin" />
+              <span className="text-sm">正在生成分享链接…</span>
+            </div>
+          ) : error ? (
+            <p className="text-sm py-8" style={{ color: '#ef4444' }}>{error}</p>
+          ) : shareUrl ? (
+            <>
+              <div className="p-4 rounded-2xl" style={{ background: '#fff' }}>
+                <QRCodeSVG value={shareUrl} size={280} level="H" />
+              </div>
+              <p className="text-xs text-center break-all px-4" style={{ color: 'var(--text-muted)', maxWidth: 320 }}>
+                {shareUrl}
+              </p>
+            </>
+          ) : null}
+        </div>
+      }
+    />
+  );
+}
 
 function SitePreview({ url, className, style }: { url: string; className?: string; style?: React.CSSProperties }) {
   const containerRef = useRef<HTMLDivElement>(null);

--- a/prd-admin/src/pages/WebPagesPage.tsx
+++ b/prd-admin/src/pages/WebPagesPage.tsx
@@ -418,20 +418,38 @@ export default function WebPagesPage() {
 
 function QrCodeDialog({ site, onClose }: { site: HostedSite; onClose: () => void }) {
   const [shareUrl, setShareUrl] = useState<string | null>(null);
-  const [creating, setCreating] = useState(false);
+  const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
 
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      setCreating(true);
+      setLoading(true);
+      // 1. 查找该 site 已有的、可用的无密码分享链接
+      const listRes = await listSiteShares();
+      if (cancelled) return;
+      if (listRes.success) {
+        const existing = listRes.data.items.find(s =>
+          s.siteId === site.id &&
+          s.shareType === 'single' &&
+          !s.isRevoked &&
+          s.accessLevel === 'public' &&
+          (!s.expiresAt || new Date(s.expiresAt) > new Date())
+        );
+        if (existing) {
+          setShareUrl(`${window.location.origin}/s/wp/${existing.token}`);
+          setLoading(false);
+          return;
+        }
+      }
+      // 2. 没有可复用的，才创建新的
       const res = await createSiteShareLink({
         siteId: site.id,
         shareType: 'single',
         expiresInDays: 0,
       });
       if (cancelled) return;
-      setCreating(false);
+      setLoading(false);
       if (res.success) {
         setShareUrl(`${window.location.origin}${res.data.shareUrl}`);
       } else {
@@ -449,7 +467,7 @@ function QrCodeDialog({ site, onClose }: { site: HostedSite; onClose: () => void
       description={site.title}
       content={
         <div className="flex flex-col items-center gap-4 py-4">
-          {creating ? (
+          {loading ? (
             <div className="flex items-center gap-2 py-8" style={{ color: 'var(--text-muted)' }}>
               <RefreshCw size={16} className="animate-spin" />
               <span className="text-sm">正在生成分享链接…</span>


### PR DESCRIPTION
## Summary
Added QR code functionality to the WebPagesPage, allowing users to generate and display QR codes for sharing hosted sites. When a user clicks the QR code button, a share link is automatically created and displayed as a QR code in a dialog.

## Key Changes
- Added `qrcode.react` dependency for QR code generation
- Imported `QrCode` icon from lucide-react and `QRCodeSVG` component from qrcode.react
- Added `qrSite` state to track which site's QR code dialog is open
- Created new `QrCodeDialog` component that:
  - Automatically creates a share link when opened
  - Displays the share URL as a QR code (280x280px)
  - Shows loading state while creating the share link
  - Handles errors gracefully with user-friendly messages
- Added `onQrCode` callback prop to both `SiteCard` and `SiteListItem` components
- Added QR code button to the action buttons in both card and list views
- Integrated QR code dialog rendering in the main component

## Implementation Details
- The QR code dialog uses a cleanup pattern to prevent state updates after unmounting
- Share links are created with `shareType: 'single'` and no expiration (`expiresInDays: 0`)
- The QR code displays the full absolute URL (including origin) for easy scanning
- UI follows existing design patterns with glass-morphism styling and consistent spacing

https://claude.ai/code/session_01KFqVzDvLNFac5NB6ozg42k