### PR TITLE
Include auth token in share view requests when user is logged in

### DIFF
--- a/prd-admin/src/services/real/webPages.ts
+++ b/prd-admin/src/services/real/webPages.ts
@@ -231,9 +231,13 @@ export interface ShareViewData {
 export async function viewShare(token: string, password?: string): Promise<ApiResponse<ShareViewData>> {
   const q = password ? `?password=${encodeURIComponent(password)}` : '';
   // 使用 raw fetch 避免 apiRequest 的 401 自动 refresh/redirect 逻辑，此端点是公开的
+  // 但仍需携带 auth token（如果已登录），以便后端识别观看者身份
   const url = joinUrl(getApiBaseUrl(), `${api.webPages.viewShare(encodeURIComponent(token))}${q}`);
+  const headers: Record<string, string> = { Accept: 'application/json' };
+  const authToken = useAuthStore.getState().token;
+  if (authToken) headers.Authorization = `Bearer ${authToken}`;
   try {
-    const res = await fetch(url, { headers: { Accept: 'application/json' } });
+    const res = await fetch(url, { headers });
     const json = await res.json();
     return json as ApiResponse<ShareViewData>;
   } catch {


### PR DESCRIPTION
## Summary
Modified the `viewShare` function to include the authentication token in the request headers when a user is logged in. This allows the backend to identify the viewer's identity while maintaining the public nature of the endpoint.

## Key Changes
- Updated the `viewShare` function to conditionally include the `Authorization` header with the bearer token from the auth store
- Refactored headers construction to build them dynamically based on whether an auth token is available
- Added clarifying comment explaining that while the endpoint is public, authenticated requests should carry the auth token for backend viewer identification

## Implementation Details
- The auth token is retrieved from `useAuthStore.getState().token` only when needed
- The `Authorization` header is only added if a token exists, maintaining backward compatibility for unauthenticated requests
- The change preserves the existing behavior of using raw `fetch` to avoid the automatic 401 refresh/redirect logic of `apiRequest`

https://claude.ai/code/session_01WGR8nsjsGtZeqWs8is2giG