### PR TITLE
Add image fallback with gradient backgrounds for agent and tool cards

### DIFF
--- a/prd-admin/src/components/agent-switcher/AgentSwitcher.tsx
+++ b/prd-admin/src/components/agent-switcher/AgentSwitcher.tsx
@@ -77,6 +77,7 @@ function AgentCard({
   convergeOffset?: { x: number; y: number };
 }) {
   const iconUrl = getAgentIconUrl(agent.key);
+  const [iconFailed, setIconFailed] = useState(false);
   const description = AGENT_DESCRIPTIONS[agent.key];
   const direction = ENTRY_DIRECTIONS[index];
 
@@ -125,16 +126,52 @@ function AgentCard({
             : 'translateY(0) scale(1)',
         }}
       >
-        {/* 图片铺满整个卡片 */}
-        <img
-          src={iconUrl}
-          alt={agent.name}
-          className="absolute inset-0 w-full h-full object-cover transition-transform duration-500 ease-out"
-          style={{
-            transform: isSelected ? 'scale(1.06)' : 'scale(1)',
-          }}
-          draggable={false}
-        />
+        {/* 图片铺满整个卡片，加载失败时降级为渐变背景 */}
+        {iconUrl && !iconFailed ? (
+          <img
+            src={iconUrl}
+            alt={agent.name}
+            className="absolute inset-0 w-full h-full object-cover transition-transform duration-500 ease-out"
+            style={{
+              transform: isSelected ? 'scale(1.06)' : 'scale(1)',
+            }}
+            draggable={false}
+            onError={() => setIconFailed(true)}
+          />
+        ) : (
+          <div
+            className="absolute inset-0 transition-transform duration-500 ease-out"
+            style={{
+              transform: isSelected ? 'scale(1.06)' : 'scale(1)',
+              background: `
+                radial-gradient(ellipse at 30% 20%, ${agent.color.text}35 0%, transparent 60%),
+                radial-gradient(ellipse at 70% 80%, ${agent.color.text}20 0%, transparent 50%),
+                linear-gradient(145deg, rgba(20, 22, 35, 0.98) 0%, rgba(12, 14, 22, 0.99) 100%)
+              `,
+            }}
+          >
+            <div className="absolute inset-0 flex items-center justify-center" style={{ paddingBottom: '30%' }}>
+              <div
+                className="absolute rounded-full blur-3xl"
+                style={{
+                  width: 80,
+                  height: 80,
+                  background: `radial-gradient(circle, ${agent.color.text}50 0%, ${agent.color.text}15 60%, transparent 100%)`,
+                }}
+              />
+              <div
+                className="relative text-[42px] font-bold"
+                style={{
+                  color: agent.color.text,
+                  opacity: 0.85,
+                  textShadow: `0 0 30px ${agent.color.text}60`,
+                }}
+              >
+                {agent.name[0]}
+              </div>
+            </div>
+          </div>
+        )}
 
         {/* 底部渐变遮罩 — 保证文字可读 */}
         <div

--- a/prd-admin/src/pages/ai-toolbox/components/ToolCard.tsx
+++ b/prd-admin/src/pages/ai-toolbox/components/ToolCard.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import type { ToolboxItem } from '@/services';
 import { useToolboxStore } from '@/stores/toolboxStore';
 import { useNavigate } from 'react-router-dom';
@@ -119,6 +120,7 @@ export function ToolCard({ item }: ToolCardProps) {
   const isCustomized = !!item.routePath;
   const favorited = isFavorite(item.id);
   const coverUrl = getCoverImageUrl(item.agentKey);
+  const [coverFailed, setCoverFailed] = useState(false);
 
   const handleClick = () => {
     if (isCustomized && item.routePath) {
@@ -143,12 +145,13 @@ export function ToolCard({ item }: ToolCardProps) {
       }}
     >
       {/* Cover visual — CDN 图片 or 渐变 + 大图标 */}
-      {coverUrl ? (
+      {coverUrl && !coverFailed ? (
         <img
           src={coverUrl}
           alt={item.name}
           className="absolute inset-0 w-full h-full object-cover transition-transform duration-500 ease-out group-hover:scale-[1.06]"
           draggable={false}
+          onError={() => setCoverFailed(true)}
         />
       ) : (
         <div


### PR DESCRIPTION
## Summary
Added graceful fallback handling for missing or failed image loads in agent and tool card components. When images fail to load, cards now display an elegant gradient background with the agent/tool's initial letter instead of broken image states.

## Key Changes
- **AgentSwitcher.tsx**: 
  - Added `iconFailed` state to track image load failures
  - Implemented conditional rendering: displays agent icon image on success, falls back to gradient background with agent's first letter on failure
  - Fallback design includes radial gradients using the agent's color scheme, a blurred circular glow effect, and centered initial letter with text shadow
  - Maintains scale animation consistency between image and fallback states

- **ToolCard.tsx**:
  - Added `coverFailed` state to track image load failures
  - Implemented conditional rendering: displays cover image on success, falls back to gradient background on failure
  - Added `onError` handler to both components to trigger fallback UI

## Implementation Details
- Both components use React's `useState` hook to manage image load failure state
- Fallback backgrounds use CSS gradients with the component's color scheme for visual consistency
- Scale animations are preserved on fallback elements to maintain smooth interactions
- Agent card fallback displays the agent's first letter (initial) as a visual identifier
- All fallback styling respects the existing design system and animation patterns

https://claude.ai/code/session_01Aj6djEcwTfZeariADBorg4