### PR TITLE
Clear planItem when editing marker draft text

### DIFF
--- a/prd-admin/src/pages/literary-agent/ArticleIllustrationEditorPage.tsx
+++ b/prd-admin/src/pages/literary-agent/ArticleIllustrationEditorPage.tsx
@@ -2931,7 +2931,7 @@ export default function ArticleIllustrationEditorPage({ workspaceId }: { workspa
                     value={it.draftText}
                     onChange={(e) => {
                       const v = e.target.value;
-                      setMarkerRunItems((prev) => prev.map((x) => (x.markerIndex === it.markerIndex ? { ...x, draftText: v } : x)));
+                      setMarkerRunItems((prev) => prev.map((x) => (x.markerIndex === it.markerIndex ? { ...x, draftText: v, planItem: null } : x)));
                     }}
                     className="mt-1.5 w-full rounded-[10px] px-2.5 py-1.5 text-[12px] outline-none resize-none prd-field"
                     style={{ minHeight: 56 }}


### PR DESCRIPTION
## Summary
Updated the marker draft text input handler to reset the associated `planItem` to `null` when the text is modified. This ensures that any previously selected plan item is cleared when the user edits the draft text.

## Key Changes
- Modified the `setMarkerRunItems` state update in the draft text `onChange` handler to include `planItem: null` alongside the updated `draftText` value
- This prevents stale plan item references when users modify marker text content

## Implementation Details
The change affects the ArticleIllustrationEditorPage component's marker editing functionality. When a user edits the draft text of a marker, the associated plan item is now automatically cleared, ensuring data consistency and preventing potential issues with outdated plan item references.

https://claude.ai/code/session_013TkaLRL8LzuW5ckcdjqLWf