### PR TITLE
Remove disabled user status check from login validation

### DIFF
--- a/prd-api/src/PrdAgent.Core/Services/UserService.cs
+++ b/prd-api/src/PrdAgent.Core/Services/UserService.cs
@@ -75,9 +75,6 @@ public class UserService : IUserService
         if (!BCrypt.Net.BCrypt.Verify(password, user.PasswordHash))
             return null;
 
-        if (user.Status == UserStatus.Disabled)
-            return null;
-
         return user;
     }
 


### PR DESCRIPTION
## Summary
Removed the user status validation that prevented disabled users from logging in. This allows users with a `Disabled` status to successfully authenticate.

## Key Changes
- Removed the status check in the `RegisterAsync` method that returned `null` when a user's status was `UserStatus.Disabled`

## Implementation Details
The removed validation was preventing any user with a disabled status from completing the login process, even if their password was correct. This change allows the authentication to proceed regardless of the user's current status, delegating status-based access control to other parts of the application if needed.

https://claude.ai/code/session_01GmaugFa16WPKF8Uh7edkiT