### PR TITLE
Add LLM request context propagation to gateway clients

### DIFF
--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/GatewayLLMClient.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/GatewayLLMClient.cs
@@ -12,6 +12,7 @@ namespace PrdAgent.Infrastructure.LlmGateway;
 public class GatewayLLMClient : ILLMClient
 {
     private readonly ILlmGateway _gateway;
+    private readonly ILLMRequestContextAccessor? _contextAccessor;
     private readonly string _appCallerCode;
     private readonly string _modelType;
     private readonly string? _platformId;
@@ -33,7 +34,8 @@ public class GatewayLLMClient : ILLMClient
         bool enablePromptCache = true,
         int maxTokens = 4096,
         double temperature = 0.2,
-        bool includeThinking = false)
+        bool includeThinking = false,
+        ILLMRequestContextAccessor? contextAccessor = null)
     {
         _gateway = gateway;
         _appCallerCode = appCallerCode;
@@ -44,6 +46,7 @@ public class GatewayLLMClient : ILLMClient
         _maxTokens = maxTokens;
         _temperature = temperature;
         _includeThinking = includeThinking;
+        _contextAccessor = contextAccessor;
     }
 
     /// <summary>AppCallerCode（用于测试断言）</summary>
@@ -85,6 +88,8 @@ public class GatewayLLMClient : ILLMClient
     {
         var requestBody = BuildRequestBody(systemPrompt, messages);
 
+        var scopeCtx = _contextAccessor?.Current;
+
         var request = new GatewayRequest
         {
             AppCallerCode = _appCallerCode,
@@ -95,6 +100,13 @@ public class GatewayLLMClient : ILLMClient
             TimeoutSeconds = 120,
             Context = new GatewayRequestContext
             {
+                RequestId = scopeCtx?.RequestId,
+                SessionId = scopeCtx?.SessionId,
+                GroupId = scopeCtx?.GroupId,
+                UserId = scopeCtx?.UserId,
+                ViewRole = scopeCtx?.ViewRole,
+                DocumentChars = scopeCtx?.DocumentChars,
+                DocumentHash = scopeCtx?.DocumentHash,
                 QuestionText = messages.LastOrDefault(m => m.Role == "user")?.Content,
                 SystemPromptChars = systemPrompt?.Length,
                 SystemPromptText = systemPrompt

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/LlmGateway.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/LlmGateway.cs
@@ -21,6 +21,7 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly ILogger<LlmGateway> _logger;
     private readonly ILlmRequestLogWriter? _logWriter;
+    private readonly ILLMRequestContextAccessor? _contextAccessor;
     private readonly Dictionary<string, IGatewayAdapter> _adapters = new(StringComparer.OrdinalIgnoreCase);
     private readonly ExchangeTransformerRegistry _transformerRegistry = new();
     private const string InvalidAppCallerErrorCode = "APP_CALLER_INVALID";
@@ -29,12 +30,14 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
         IModelResolver modelResolver,
         IHttpClientFactory httpClientFactory,
         ILogger<LlmGateway> logger,
-        ILlmRequestLogWriter? logWriter = null)
+        ILlmRequestLogWriter? logWriter = null,
+        ILLMRequestContextAccessor? contextAccessor = null)
     {
         _modelResolver = modelResolver;
         _httpClientFactory = httpClientFactory;
         _logger = logger;
         _logWriter = logWriter;
+        _contextAccessor = contextAccessor;
 
         // 注册适配器
         RegisterAdapter(new OpenAIGatewayAdapter());
@@ -1208,7 +1211,8 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
             enablePromptCache: true,
             maxTokens: maxTokens,
             temperature: temperature,
-            includeThinking: includeThinking);
+            includeThinking: includeThinking,
+            contextAccessor: _contextAccessor);
     }
 
     private static bool TryValidateAppCaller(string appCallerCode, string modelType, out string error)


### PR DESCRIPTION
## Summary
This PR adds support for propagating LLM request context information through the gateway client infrastructure. The changes enable passing request metadata (such as RequestId, SessionId, UserId, etc.) from the application context to the LLM gateway requests.

## Key Changes
- Added `ILLMRequestContextAccessor` dependency to both `GatewayLLMClient` and `LlmGateway` classes
- Modified `GatewayLLMClient` constructor to accept an optional `contextAccessor` parameter and store it as a field
- Updated `StreamGenerateAsync` method to retrieve the current context from the accessor and populate the `GatewayRequestContext` with context fields:
  - RequestId
  - SessionId
  - GroupId
  - UserId
  - ViewRole
  - DocumentChars
  - DocumentHash
- Modified `LlmGateway` constructor to accept and store the optional `contextAccessor` parameter
- Updated `CreateClient` method to pass the `_contextAccessor` when instantiating `GatewayLLMClient`

## Implementation Details
- The `contextAccessor` parameter is optional (nullable) in all constructors, maintaining backward compatibility
- Context information is retrieved at request time via `_contextAccessor?.Current`, allowing for dynamic context resolution
- The context fields are populated into the `GatewayRequestContext` before sending the request to the gateway

https://claude.ai/code/session_015mFZJMZTaCrztGQFwokinY