### PR TITLE
Add terminal tab to log modal for container command execution

### DIFF
--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -733,6 +733,43 @@ export function createBranchRouter(deps: RouterDeps): Router {
     }
   });
 
+  // ── Container exec (run command inside container) ──
+
+  router.post('/branches/:id/container-exec', async (req, res) => {
+    const { id } = req.params;
+    const { profileId, command } = req.body as { profileId?: string; command?: string };
+    if (!command || typeof command !== 'string' || !command.trim()) {
+      res.status(400).json({ error: '请输入命令' });
+      return;
+    }
+
+    const entry = stateService.getBranch(id);
+    if (!entry) {
+      res.status(404).json({ error: `分支 "${id}" 不存在` });
+      return;
+    }
+
+    const svc = profileId ? entry.services[profileId] : Object.values(entry.services)[0];
+    if (!svc) {
+      res.status(404).json({ error: '未找到运行中的服务' });
+      return;
+    }
+
+    try {
+      const result = await shell.exec(
+        `docker exec ${svc.containerName} sh -c ${JSON.stringify(command)}`,
+        { timeout: 30_000 },
+      );
+      res.json({
+        exitCode: result.exitCode,
+        stdout: result.stdout,
+        stderr: result.stderr,
+      });
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
   // ── Git log (historical commits) ──
 
   router.get('/branches/:id/git-log', async (req, res) => {

--- a/cds/web/app.js
+++ b/cds/web/app.js
@@ -731,7 +731,7 @@ function openFullDeployLog(id, event) {
       if (newPre) newPre.scrollTop = prevScrollTop;
     }
   };
-  openLogModal(`部署日志 ${id}`);
+  openLogModal(`部署日志 ${id}`, id);
   renderInline();
   _scrollLogToBottom();
   _startLogPoll(() => { renderInline(); return Promise.resolve(); }, 1000);
@@ -1006,7 +1006,7 @@ async function viewBranchLogs(id) {
         if (newPre) newPre.scrollTop = prevScrollTop;
       }
     };
-    openLogModal(`部署日志 — ${id}`);
+    openLogModal(`部署日志 — ${id}`, id);
     renderInline();
     _scrollLogToBottom();
     _startLogPoll(() => { renderInline(); return Promise.resolve(); }, 1000);
@@ -1046,7 +1046,7 @@ async function viewBranchLogs(id) {
     }
   };
   try {
-    openLogModal(`部署日志 — ${id}`);
+    openLogModal(`部署日志 — ${id}`, id);
     await fetchAndRender();
     _scrollLogToBottom();
     _startLogPoll(fetchAndRender, 3000);
@@ -1075,7 +1075,7 @@ async function viewContainerLogs(id, profileId) {
     }
   };
   try {
-    openLogModal(`日志: ${id}/${profileId || '默认'}`);
+    openLogModal(`日志: ${id}/${profileId || '默认'}`, id, profileId);
     await fetchAndRender();
     _scrollLogToBottom();
     _startLogPoll(fetchAndRender, 3000);
@@ -2624,23 +2624,115 @@ function toggleModalForm(id) {
   if (el) el.classList.toggle('hidden');
 }
 
-// ── Log modal ──
+// ── Log modal (with tabs: logs / terminal) ──
 
 let _logPollTimer = null;
 let _logPollFn = null;
+let _logModalContext = { branchId: null, profileId: null }; // track which branch/service is open
+let _logModalTab = 'logs'; // 'logs' | 'terminal'
+let _terminalHistory = []; // command history per session
+let _terminalHistoryIdx = -1;
 
-function openLogModal(title) {
+function openLogModal(title, branchId, profileId) {
   document.getElementById('logModalTitle').textContent = title;
   document.getElementById('logModal').classList.remove('hidden');
-  // Auto-scroll to bottom after content renders
+  _logModalContext = { branchId: branchId || null, profileId: profileId || null };
+  // Show tabs only when we have branch context (can exec)
+  const tabsEl = document.getElementById('logModalTabs');
+  if (branchId) {
+    tabsEl.classList.remove('hidden');
+  } else {
+    tabsEl.classList.add('hidden');
+  }
+  // Clear terminal state for new session
+  document.getElementById('terminalOutput').innerHTML = '';
+  document.getElementById('terminalInput').value = '';
+  _terminalHistory = [];
+  _terminalHistoryIdx = -1;
+  switchLogTab('logs');
   _scrollLogToBottom();
 }
 
 function closeLogModal() {
   document.getElementById('logModal').classList.add('hidden');
-  // Stop any active log polling
   if (_logPollTimer) { clearInterval(_logPollTimer); _logPollTimer = null; _logPollFn = null; }
+  _logModalContext = { branchId: null, profileId: null };
 }
+
+function switchLogTab(tab) {
+  _logModalTab = tab;
+  const logBody = document.getElementById('logModalBody');
+  const termBody = document.getElementById('terminalBody');
+  const tabs = document.querySelectorAll('#logModalTabs .log-tab');
+  tabs.forEach(t => t.classList.toggle('active', t.dataset.tab === tab));
+  if (tab === 'logs') {
+    logBody.classList.remove('hidden');
+    termBody.classList.add('hidden');
+  } else {
+    logBody.classList.add('hidden');
+    termBody.classList.remove('hidden');
+    const input = document.getElementById('terminalInput');
+    if (input) setTimeout(() => input.focus(), 50);
+  }
+}
+
+async function execTerminalCmd() {
+  const input = document.getElementById('terminalInput');
+  const command = input.value.trim();
+  if (!command) return;
+  const { branchId, profileId } = _logModalContext;
+  if (!branchId) { showToast('无法执行: 未关联分支', 'error'); return; }
+
+  // Push to history
+  _terminalHistory.push(command);
+  _terminalHistoryIdx = _terminalHistory.length;
+
+  // Append command to output
+  const output = document.getElementById('terminalOutput');
+  output.innerHTML += `<div class="term-line term-cmd"><span class="term-prompt">$</span> ${esc(command)}</div>`;
+  input.value = '';
+  input.disabled = true;
+
+  try {
+    const data = await api('POST', `/branches/${encodeURIComponent(branchId)}/container-exec`, { profileId, command });
+    const text = (data.stdout || '') + (data.stderr || '');
+    if (text.trim()) {
+      const exitClass = data.exitCode !== 0 ? ' term-error' : '';
+      output.innerHTML += `<pre class="term-line term-result${exitClass}">${esc(text)}</pre>`;
+    }
+    if (data.exitCode !== 0) {
+      output.innerHTML += `<div class="term-line term-exit">exit code: ${data.exitCode}</div>`;
+    }
+  } catch (e) {
+    output.innerHTML += `<div class="term-line term-error">${esc(e.message)}</div>`;
+  }
+  input.disabled = false;
+  input.focus();
+  output.scrollTop = output.scrollHeight;
+}
+
+// Terminal history navigation (up/down arrows)
+document.addEventListener('keydown', (e) => {
+  if (_logModalTab !== 'terminal') return;
+  const input = document.getElementById('terminalInput');
+  if (!input || document.activeElement !== input) return;
+  if (e.key === 'ArrowUp') {
+    e.preventDefault();
+    if (_terminalHistoryIdx > 0) {
+      _terminalHistoryIdx--;
+      input.value = _terminalHistory[_terminalHistoryIdx] || '';
+    }
+  } else if (e.key === 'ArrowDown') {
+    e.preventDefault();
+    if (_terminalHistoryIdx < _terminalHistory.length - 1) {
+      _terminalHistoryIdx++;
+      input.value = _terminalHistory[_terminalHistoryIdx] || '';
+    } else {
+      _terminalHistoryIdx = _terminalHistory.length;
+      input.value = '';
+    }
+  }
+});
 
 function _startLogPoll(fn, intervalMs) {
   if (_logPollTimer) clearInterval(_logPollTimer);
@@ -2649,14 +2741,13 @@ function _startLogPoll(fn, intervalMs) {
     if (document.getElementById('logModal').classList.contains('hidden')) {
       clearInterval(_logPollTimer); _logPollTimer = null; _logPollFn = null; return;
     }
+    if (_logModalTab !== 'logs') return; // don't poll when on terminal tab
     await _logPollFn();
   }, intervalMs);
 }
 
 function _scrollLogToBottom() {
   requestAnimationFrame(() => {
-    // The actual scrollable element is the <pre> inside logModalBody,
-    // which has max-height + overflow-y: auto via .live-log-output
     const body = document.getElementById('logModalBody');
     if (!body) return;
     const pre = body.querySelector('.live-log-output');

--- a/cds/web/index.html
+++ b/cds/web/index.html
@@ -82,17 +82,38 @@
     <div id="toast" class="toast hidden"></div>
   </div>
 
-  <!-- Log modal -->
+  <!-- Log modal (with tabs: logs / terminal) -->
   <div id="logModal" class="modal hidden">
     <div class="modal-backdrop" onclick="closeLogModal()"></div>
     <div class="modal-dialog">
       <div class="modal-header">
         <h2 id="logModalTitle">日志</h2>
+        <div id="logModalTabs" class="log-modal-tabs hidden">
+          <button class="log-tab active" data-tab="logs" onclick="switchLogTab('logs')">
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M1 2.75C1 1.784 1.784 1 2.75 1h10.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0113.25 12H9.06l-2.573 2.573A1.458 1.458 0 014 13.543V12H2.75A1.75 1.75 0 011 10.25v-7.5zm1.5 0a.25.25 0 01.25-.25h10.5a.25.25 0 01.25.25v7.5a.25.25 0 01-.25.25h-4.5a.75.75 0 00-.75.75v2.19l-2.72-2.72a.75.75 0 00-.53-.22H2.75a.25.25 0 01-.25-.25v-7.5z"/></svg>
+            日志
+          </button>
+          <button class="log-tab" data-tab="terminal" onclick="switchLogTab('terminal')">
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M0 2.75C0 1.784.784 1 1.75 1h12.5c.966 0 1.75.784 1.75 1.75v10.5A1.75 1.75 0 0114.25 15H1.75A1.75 1.75 0 010 13.25V2.75zm1.75-.25a.25.25 0 00-.25.25v10.5c0 .138.112.25.25.25h12.5a.25.25 0 00.25-.25V2.75a.25.25 0 00-.25-.25H1.75zM7.25 8a.75.75 0 01-.22.53l-2.25 2.25a.75.75 0 11-1.06-1.06L5.44 8 3.72 6.28a.75.75 0 011.06-1.06l2.25 2.25c.141.14.22.331.22.53zm1.5 1.5a.75.75 0 000 1.5h3a.75.75 0 000-1.5h-3z"/></svg>
+            终端
+          </button>
+        </div>
         <button class="modal-close" onclick="closeLogModal()">
           <svg width="20" height="20" viewBox="0 0 16 16" fill="currentColor"><path d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"/></svg>
         </button>
       </div>
       <div id="logModalBody" class="modal-body"></div>
+      <div id="terminalBody" class="modal-body hidden">
+        <div id="terminalOutput" class="terminal-output"></div>
+        <div class="terminal-input-row">
+          <span class="terminal-prompt">$</span>
+          <input id="terminalInput" type="text" class="terminal-input" placeholder="输入命令..." autocomplete="off"
+            onkeydown="if(event.key==='Enter')execTerminalCmd()">
+          <button class="terminal-send-btn" onclick="execTerminalCmd()" title="执行">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M.989 2.94a.75.75 0 011.034-.656l12 4.5a.75.75 0 010 1.423l-12 4.5a.75.75 0 01-1.034-.656v-3.18a.75.75 0 01.635-.74L7.025 8l-5.4-.63a.75.75 0 01-.636-.74V2.94z"/></svg>
+          </button>
+        </div>
+      </div>
     </div>
   </div>
 

--- a/cds/web/style.css
+++ b/cds/web/style.css
@@ -1166,6 +1166,68 @@ a.branch-name:hover { color: var(--accent); }
   border-color: var(--border-focus);
 }
 
+/* ════════════════ Log Modal Tabs ════════════════ */
+
+.log-modal-tabs {
+  display: flex; gap: 2px; margin-left: 12px;
+  background: var(--bg-primary); border-radius: 8px; padding: 2px;
+  flex-shrink: 0;
+}
+.log-modal-tabs.hidden { display: none; }
+.log-tab {
+  display: flex; align-items: center; gap: 5px;
+  background: none; border: none; color: var(--text-muted);
+  font-size: 12px; font-weight: 500; padding: 5px 12px;
+  border-radius: 6px; cursor: pointer;
+  transition: all 0.15s ease;
+}
+.log-tab:hover { color: var(--text-secondary); background: var(--bg-hover); }
+.log-tab.active { color: var(--text-primary); background: var(--bg-elevated); }
+.log-tab svg { opacity: 0.7; }
+.log-tab.active svg { opacity: 1; }
+
+/* ════════════════ Terminal ════════════════ */
+
+.terminal-output {
+  font-family: var(--font-mono); font-size: 12px;
+  background: rgba(3, 4, 8, 0.8);
+  border: 1px solid var(--border); border-radius: var(--radius-sm);
+  padding: 12px 14px; min-height: 200px; max-height: 55vh;
+  overflow-y: auto; line-height: 1.6;
+}
+.term-line { margin: 0; padding: 0; white-space: pre-wrap; word-break: break-all; }
+.term-cmd { color: var(--text-primary); padding: 2px 0; }
+.term-prompt { color: var(--accent); margin-right: 6px; user-select: none; }
+.term-result { color: var(--text-secondary); margin: 0; padding: 0; border: none; background: none; font-size: 12px; line-height: 1.6; white-space: pre-wrap; word-break: break-all; }
+.term-error { color: var(--red); }
+.term-exit { color: var(--text-muted); font-size: 11px; padding: 2px 0; }
+
+.terminal-input-row {
+  display: flex; align-items: center; gap: 8px;
+  margin-top: 8px;
+  background: rgba(3, 4, 8, 0.8);
+  border: 1px solid var(--border); border-radius: var(--radius-sm);
+  padding: 8px 12px;
+}
+.terminal-input-row .terminal-prompt {
+  color: var(--accent); font-family: var(--font-mono); font-size: 13px;
+  font-weight: 600; user-select: none; flex-shrink: 0;
+}
+.terminal-input {
+  flex: 1; background: none; border: none; outline: none;
+  color: var(--text-primary); font-family: var(--font-mono); font-size: 13px;
+  caret-color: var(--accent);
+}
+.terminal-input::placeholder { color: var(--text-muted); }
+.terminal-input:disabled { opacity: 0.5; }
+.terminal-send-btn {
+  background: none; border: none; color: var(--text-muted);
+  cursor: pointer; padding: 4px; border-radius: 4px;
+  display: flex; align-items: center; justify-content: center;
+  transition: all 0.15s ease; flex-shrink: 0;
+}
+.terminal-send-btn:hover { color: var(--accent); background: var(--accent-bg); }
+
 /* ════════════════ Live Log ════════════════ */
 
 .live-dot {


### PR DESCRIPTION
## Summary
Enhanced the log modal with a tabbed interface that allows users to view deployment logs and execute commands directly inside running containers via a terminal interface.

## Key Changes

- **Log Modal Enhancement**: Converted the log modal to support multiple tabs (logs and terminal)
  - Added tab switching UI with icons for "日志" (logs) and "终端" (terminal)
  - Tabs only appear when viewing logs for a specific branch (where execution is possible)
  - Maintains separate state for logs and terminal views

- **Terminal Tab Features**:
  - Interactive command input with real-time output display
  - Command history navigation using arrow keys (up/down)
  - Visual distinction for commands, output, errors, and exit codes
  - Styled terminal output with proper formatting and color coding
  - Disabled input state during command execution

- **Backend API**: Added new `/branches/:id/container-exec` endpoint
  - Executes arbitrary shell commands inside running Docker containers
  - Supports optional `profileId` parameter to target specific services
  - Returns stdout, stderr, and exit code
  - 30-second timeout for safety

- **UI/UX Improvements**:
  - Updated `openLogModal()` to accept `branchId` and `profileId` parameters
  - Log polling pauses when terminal tab is active to avoid interference
  - Terminal input auto-focuses when switching to terminal tab
  - Proper cleanup of terminal state when modal closes

- **Styling**: Added comprehensive CSS for terminal UI
  - Dark terminal theme matching development tools aesthetic
  - Responsive layout with proper scrolling for long outputs
  - Visual feedback for interactive elements (hover states, active tabs)

## Implementation Details

- Terminal history is session-scoped and cleared when opening a new log modal
- Command execution is context-aware, using the branch and profile IDs from the modal context
- The terminal gracefully handles errors and displays exit codes for failed commands
- All user input and output is properly escaped to prevent XSS vulnerabilities

https://claude.ai/code/session_01HrK6NQbLU34EDuM734rsAo