### PR TITLE
Improve image size adaptation to prioritize same-tier resolution matching

### DIFF
--- a/prd-admin/src/lib/__tests__/sizeAdaptation.test.ts
+++ b/prd-admin/src/lib/__tests__/sizeAdaptation.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { ASPECT_OPTIONS, type AspectOptionId } from '../imageAspectOptions';
+import { ASPECT_OPTIONS, type AspectOptionId, detectTierFromSize } from '../imageAspectOptions';
 
 // 复制核心逻辑（纯函数，不依赖 React）
 function detectTierFromRefImage(w: number, h: number): '1k' | '2k' | '4k' {
@@ -217,6 +217,28 @@ describe('尺寸适配测试', () => {
         console.error('以下随机尺寸映射到了白名单之外:', failures);
       }
       expect(failures.length).toBe(0);
+    });
+  });
+
+  describe('detectTierFromSize 回退测试', () => {
+    it('ASPECT_OPTIONS 内的尺寸应精确匹配', () => {
+      expect(detectTierFromSize('1024x1024')).toBe('1k');
+      expect(detectTierFromSize('2048x2048')).toBe('2k');
+      expect(detectTierFromSize('4096x4096')).toBe('4k');
+    });
+
+    it('不在 ASPECT_OPTIONS 中的白名单尺寸应按像素面积回退', () => {
+      // Gemini 白名单中的尺寸，不在 ASPECT_OPTIONS 的 size1k/size2k/size4k 中
+      expect(detectTierFromSize('1344x768')).toBe('1k');   // 1,032,192 < 2,500,000
+      expect(detectTierFromSize('832x1248')).toBe('1k');   // 1,038,336 < 2,500,000
+      expect(detectTierFromSize('1184x864')).toBe('1k');   // 1,022,976 < 2,500,000
+      expect(detectTierFromSize('896x1152')).toBe('1k');   // 1,032,192 < 2,500,000
+    });
+
+    it('无效输入仍返回 null', () => {
+      expect(detectTierFromSize('')).toBeNull();
+      expect(detectTierFromSize('abc')).toBeNull();
+      expect(detectTierFromSize('0x0')).toBeNull();
     });
   });
 

--- a/prd-admin/src/lib/imageAspectOptions.ts
+++ b/prd-admin/src/lib/imageAspectOptions.ts
@@ -90,6 +90,14 @@ export function detectTierFromSize(size: string): '1k' | '2k' | '4k' | null {
     if (opt.size2k.toLowerCase() === s) return '2k';
     if (opt.size4k.toLowerCase() === s) return '4k';
   }
+  // 回退：对不在 ASPECT_OPTIONS 中的白名单尺寸（如 Gemini 的 1344x768），按像素面积推断档位
+  const [w, h] = s.split(/[x×]/).map(Number);
+  if (w && h && w > 0 && h > 0) {
+    const pixels = w * h;
+    if (pixels >= 8_000_000) return '4k';
+    if (pixels >= 2_500_000) return '2k';
+    return '1k';
+  }
   return null;
 }
 

--- a/prd-api/src/PrdAgent.Infrastructure/LLM/ImageGenModelAdapterRegistry.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LLM/ImageGenModelAdapterRegistry.cs
@@ -74,18 +74,43 @@ public static class ImageGenModelAdapterRegistry
 
     /// <summary>
     /// 白名单模式：选择最接近的尺寸
+    /// 优先在同一分辨率档位内匹配，避免跨档位降级（如用户选 2K 却匹配到 1K）
     /// </summary>
     private static SizeAdaptationResult NormalizeSizeWhitelist(ImageGenModelAdapterConfig config, int reqW, int reqH, List<string> allSizes, List<string> allRatios)
     {
-        var result = new SizeAdaptationResult();
+        var reqTier = DetectResolution(reqW, reqH);
+
+        // 第一轮：仅在同档位内匹配
+        var sameTierSizes = allSizes.Where(s => TryParseSize(s, out var sw, out var sh) && DetectResolution(sw, sh) == reqTier).ToList();
+        if (sameTierSizes.Count > 0)
+        {
+            var result = ScoreBestSize(sameTierSizes, reqW, reqH, allRatios);
+            if (result != null) return result;
+        }
+
+        // 第二轮：同档位无匹配，回退到全量尺寸
+        var fallback = ScoreBestSize(allSizes, reqW, reqH, allRatios);
+        return fallback ?? new SizeAdaptationResult
+        {
+            Size = "1024x1024", Width = 1024, Height = 1024,
+            AspectRatio = DetectAspectRatio(1024, 1024, allRatios),
+            Resolution = "1k", SizeAdjusted = true,
+        };
+    }
+
+    /// <summary>
+    /// 从候选尺寸列表中评分选出最佳匹配
+    /// </summary>
+    private static SizeAdaptationResult? ScoreBestSize(List<string> candidates, int reqW, int reqH, List<string> allRatios)
+    {
         var reqRatio = (double)reqW / reqH;
         var reqArea = (long)reqW * reqH;
 
         string? bestSize = null;
         double bestScore = double.MaxValue;
-        int bestW = 1024, bestH = 1024;
+        int bestW = 0, bestH = 0;
 
-        foreach (var sizeStr in allSizes)
+        foreach (var sizeStr in candidates)
         {
             if (!TryParseSize(sizeStr, out var w, out var h)) continue;
 
@@ -106,15 +131,18 @@ public static class ImageGenModelAdapterRegistry
             }
         }
 
-        result.Size = bestSize ?? "1024x1024";
-        result.Width = bestW;
-        result.Height = bestH;
-        result.AspectRatio = DetectAspectRatio(bestW, bestH, allRatios);
-        result.Resolution = DetectResolution(bestW, bestH);
-        result.SizeAdjusted = bestW != reqW || bestH != reqH;
-        result.RatioAdjusted = IsRatioSignificantlyDifferent(reqW, reqH, bestW, bestH, 0.05);
+        if (bestSize == null) return null;
 
-        return result;
+        return new SizeAdaptationResult
+        {
+            Size = bestSize,
+            Width = bestW,
+            Height = bestH,
+            AspectRatio = DetectAspectRatio(bestW, bestH, allRatios),
+            Resolution = DetectResolution(bestW, bestH),
+            SizeAdjusted = bestW != reqW || bestH != reqH,
+            RatioAdjusted = IsRatioSignificantlyDifferent(reqW, reqH, bestW, bestH, 0.05),
+        };
     }
 
     /// <summary>

--- a/prd-api/src/PrdAgent.Infrastructure/LLM/OpenAIImageClient.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LLM/OpenAIImageClient.cs
@@ -2228,13 +2228,28 @@ public class OpenAIImageClient
 
         var tr = target.Value.Ratio;
         var ta = target.Value.Area;
+        var targetTier = DetectResolutionTier(ta);
+
+        // 优先在同一分辨率档位内匹配，避免跨档位降级（如 2K → 1K）
+        var sameTier = allowed.Where(a => DetectResolutionTier(a.Area) == targetTier).ToList();
+        var candidates = sameTier.Count > 0 ? sameTier : allowed;
 
         // 先按比例最接近，其次按面积最接近，其次按 |w-w0|+|h-h0|
-        return allowed
+        return candidates
             .OrderBy(a => Math.Abs(a.Ratio - tr))
             .ThenBy(a => Math.Abs(a.Area - ta))
             .ThenBy(a => Math.Abs(a.W - target.Value.W) + Math.Abs(a.H - target.Value.H))
             .First();
+    }
+
+    /// <summary>
+    /// 根据像素总面积判断分辨率档位（与 ImageGenModelAdapterRegistry.DetectResolution 对齐）
+    /// </summary>
+    private static string DetectResolutionTier(long area)
+    {
+        if (area >= 8_000_000) return "4k";
+        if (area >= 2_500_000) return "2k";
+        return "1k";
     }
 
     private static bool IsRatioAdjusted(string? requestedSizeNorm, string? effectiveSizeNorm, double threshold)


### PR DESCRIPTION
## Summary
This PR enhances the image size adaptation logic across the codebase to prevent undesirable cross-tier resolution downgrades (e.g., user requesting 2K but getting matched to 1K). The changes implement a two-tier matching strategy that prioritizes staying within the same resolution tier before falling back to global matching.

## Key Changes

- **ImageGenModelAdapterRegistry.cs**: Refactored `NormalizeSizeWhitelist()` to implement two-round matching:
  - First round: Match only within the same resolution tier as the requested size
  - Second round: Fall back to global matching if no same-tier candidates exist
  - Extracted scoring logic into new `ScoreBestSize()` helper method for reusability

- **OpenAIImageClient.cs**: Added `DetectResolutionTier()` method to align resolution detection with the backend logic, and updated `ChooseClosestAllowedSize()` to prioritize same-tier candidates before considering all allowed sizes

- **imageAspectOptions.ts**: Enhanced `detectTierFromSize()` with fallback logic to infer resolution tier from pixel area for whitelist sizes not in `ASPECT_OPTIONS` (e.g., Gemini's 1344x768), ensuring consistent tier detection across the frontend

- **sizeAdaptation.test.ts**: Added comprehensive test coverage for the new `detectTierFromSize()` fallback behavior, including edge cases and invalid inputs

## Implementation Details

- Resolution tiers are defined by pixel area thresholds: 1K (<2.5M), 2K (2.5M-8M), 4K (≥8M)
- The two-round strategy ensures users get the closest match within their requested tier, improving UX for tier-specific workflows
- Fallback to 1024x1024 only occurs when no candidates are available after both matching rounds

https://claude.ai/code/session_01FCS77AK9n5EWrXXLrvL4Ax