### PR TITLE
feat: desktop 静默更新 + 动态域名配置 + 默认域名替换

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,29 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "prd-api",
+      "runtimeExecutable": "dotnet",
+      "runtimeArgs": ["watch", "run", "--project", "prd-api/src/PrdAgent.Api"],
+      "port": 5000
+    },
+    {
+      "name": "prd-admin",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--dir", "prd-admin", "dev"],
+      "port": 8000
+    },
+    {
+      "name": "prd-desktop",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--dir", "prd-desktop", "tauri:dev"],
+      "port": 1420
+    },
+    {
+      "name": "prd-video",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--dir", "prd-video", "start"],
+      "port": 3000
+    }
+  ]
+}

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -653,6 +653,28 @@ jobs:
           
           echo "[INFO] Upload complete for $TARGET"
 
+      # 上传客户端动态配置（预设服务器列表等，各 matrix job 用 --clobber 幂等上传）
+      - name: Upload client-config.json
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.ref_name }}"
+          cat > client-config.json << 'CCEOF'
+          {
+            "version": 1,
+            "defaultApiUrl": "https://map.ebcone.net",
+            "presetServers": [
+              { "label": "map.ebcone.net", "url": "https://map.ebcone.net" },
+              { "label": "miduo.org", "url": "https://miduo.org" },
+              { "label": "sassagent.com", "url": "https://sassagent.com" }
+            ]
+          }
+          CCEOF
+          gh release upload "$TAG" client-config.json --clobber
+          echo "[INFO] Uploaded client-config.json to $TAG"
+
       # 生成并上传 updater manifest (latest-{target}.json)
       # 重要：此步骤在上传 .sig 文件后执行，从 GitHub Release 下载已上传的 .sig 文件
       # 以确保 manifest 中的签名与实际可下载的 .sig 文件完全一致

--- a/prd-desktop/src-tauri/src/commands/client_config.rs
+++ b/prd-desktop/src-tauri/src/commands/client_config.rs
@@ -1,0 +1,50 @@
+use serde::{Deserialize, Serialize};
+
+/// 远程客户端配置（从 GitHub Release 产物拉取）
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClientConfig {
+    pub version: u32,
+    pub default_api_url: String,
+    pub preset_servers: Vec<PresetServer>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PresetServer {
+    pub label: String,
+    pub url: String,
+}
+
+const CLIENT_CONFIG_URL: &str =
+    "https://github.com/inernoro/prd_agent/releases/latest/download/client-config.json";
+
+/// 从 GitHub Release 拉取客户端配置（绕过浏览器 CORS）
+#[tauri::command]
+pub async fn fetch_client_config() -> Result<ClientConfig, String> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .map_err(|e| format!("创建 HTTP 客户端失败: {}", e))?;
+
+    let resp = client
+        .get(CLIENT_CONFIG_URL)
+        .header("Accept", "application/json")
+        .send()
+        .await
+        .map_err(|e| format!("请求客户端配置失败: {}", e))?;
+
+    if !resp.status().is_success() {
+        return Err(format!(
+            "获取客户端配置失败: HTTP {}",
+            resp.status().as_u16()
+        ));
+    }
+
+    let config = resp
+        .json::<ClientConfig>()
+        .await
+        .map_err(|e| format!("解析客户端配置失败: {}", e))?;
+
+    Ok(config)
+}

--- a/prd-desktop/src-tauri/src/commands/mod.rs
+++ b/prd-desktop/src-tauri/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod assets;
 pub mod attachment;
 pub mod auth;
 pub mod branding;
+pub mod client_config;
 pub mod config;
 pub mod defect;
 pub mod devtools;

--- a/prd-desktop/src-tauri/src/lib.rs
+++ b/prd-desktop/src-tauri/src/lib.rs
@@ -222,6 +222,7 @@ pub fn run() {
             commands::updater::get_updater_platform_info,
             commands::updater::check_for_update,
             commands::updater::fetch_update_manifests,
+            commands::client_config::fetch_client_config,
             commands::defect::list_defects,
             commands::defect::list_defect_users,
             commands::defect::list_defect_templates,

--- a/prd-desktop/src-tauri/src/services/api_client.rs
+++ b/prd-desktop/src-tauri/src/services/api_client.rs
@@ -7,7 +7,7 @@ use tokio_util::sync::CancellationToken;
 use crate::models::{ApiError, ApiResponse, LoginResponse};
 
 /// 默认 API 地址（非开发者），可通过环境变量 API_BASE_URL 覆盖
-const DEFAULT_API_URL: &str = "https://pa.759800.com";
+const DEFAULT_API_URL: &str = "https://map.ebcone.net";
 
 lazy_static::lazy_static! {
     static ref API_BASE_URL: RwLock<String> = RwLock::new(

--- a/prd-desktop/src/App.tsx
+++ b/prd-desktop/src/App.tsx
@@ -24,6 +24,9 @@ import { useDesktopBrandingStore } from './stores/desktopBrandingStore';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import type { ApiResponse, PromptsClientResponse, UserRole } from './types';
 import { openGroupSessionAndSetStore } from './lib/openGroupSession';
+import { useClientConfigStore } from './stores/clientConfigStore';
+import { useUpdateStore } from './stores/updateStore';
+import UpdateNotification from './components/Feedback/UpdateNotification';
 
 const THEME_STORAGE_KEY = 'prd-desktop-theme';
 
@@ -78,6 +81,35 @@ function App() {
     const skin = isDark ? 'dark' : 'white';
     void refreshBranding('app-start', skin);
     // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // 启动时从 GitHub Release 拉取远程客户端配置（预设服务器列表等）
+  useEffect(() => {
+    if (isTauri()) {
+      void useClientConfigStore.getState().fetchClientConfig();
+    }
+  }, []);
+
+  // 静默更新调度：启动 30s 后首次检查，之后每 2 小时检查一次
+  useEffect(() => {
+    if (!isTauri()) return;
+
+    const INITIAL_DELAY = 30 * 1000;           // 30 秒
+    const PERIODIC_INTERVAL = 2 * 60 * 60 * 1000; // 2 小时
+
+    const check = () => void useUpdateStore.getState().checkAndDownload();
+
+    const initialTimer = window.setTimeout(() => {
+      check();
+      periodicTimer = window.setInterval(check, PERIODIC_INTERVAL);
+    }, INITIAL_DELAY);
+
+    let periodicTimer: ReturnType<typeof setInterval> | undefined;
+
+    return () => {
+      window.clearTimeout(initialTimer);
+      if (periodicTimer) window.clearInterval(periodicTimer);
+    };
   }, []);
 
   // 将窗口标题与服务器下发配置对齐（若未下发则由 store 默认值兜底）
@@ -427,6 +459,9 @@ function App() {
 
       {/* 设置模态框 */}
       <SettingsModal />
+
+      {/* 静默更新右下角通知 */}
+      <UpdateNotification />
 
       {/* 冷启动全局加载遮罩（唯一加载动画） */}
       <StartLoadOverlay open={showColdStartLoading} />

--- a/prd-desktop/src/components/Feedback/UpdateNotification.tsx
+++ b/prd-desktop/src/components/Feedback/UpdateNotification.tsx
@@ -1,0 +1,68 @@
+import { useUpdateStore } from '../../stores/updateStore';
+
+/**
+ * 右下角浮层通知：静默下载完成后提示用户点击安装更新。
+ * 仅在 phase === 'ready' && !isDismissed 时显示。
+ */
+export default function UpdateNotification() {
+  const phase = useUpdateStore((s) => s.phase);
+  const version = useUpdateStore((s) => s.version);
+  const isDismissed = useUpdateStore((s) => s.isDismissed);
+  const installUpdate = useUpdateStore((s) => s.installUpdate);
+  const dismiss = useUpdateStore((s) => s.dismiss);
+
+  if (phase !== 'ready' || isDismissed) return null;
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 animate-slide-in-right">
+      <div className="relative max-w-xs rounded-xl backdrop-blur-xl bg-black/40 dark:bg-white/10 ring-1 ring-white/15 shadow-2xl p-4">
+        {/* 关闭按钮 */}
+        <button
+          onClick={dismiss}
+          className="absolute top-2 right-2 w-6 h-6 flex items-center justify-center rounded-full text-white/50 hover:text-white/90 hover:bg-white/10 transition-colors"
+          title="稍后再说"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-3.5 h-3.5">
+            <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
+          </svg>
+        </button>
+
+        {/* 图标 + 标题 */}
+        <div className="flex items-start gap-3 pr-6">
+          <div className="mt-0.5 flex-shrink-0 w-8 h-8 rounded-lg bg-cyan-500/20 flex items-center justify-center">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4 text-cyan-400">
+              <path fillRule="evenodd" d="M10 17a.75.75 0 01-.75-.75V5.612L5.29 9.77a.75.75 0 01-1.08-1.04l5.25-5.5a.75.75 0 011.08 0l5.25 5.5a.75.75 0 11-1.08 1.04l-3.96-4.158V16.25A.75.75 0 0110 17z" clipRule="evenodd" />
+            </svg>
+          </div>
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-white/90">
+              新版本已就绪
+            </p>
+            <p className="text-xs text-white/50 mt-0.5 truncate">
+              v{version} 已下载完成
+            </p>
+          </div>
+        </div>
+
+        {/* 安装按钮 */}
+        <button
+          onClick={installUpdate}
+          className="mt-3 w-full py-2 px-3 text-xs font-medium rounded-lg bg-cyan-500/80 hover:bg-cyan-500 text-white transition-colors flex items-center justify-center gap-1.5"
+        >
+          安装并重启
+        </button>
+      </div>
+
+      {/* slide-in 动画（内联样式，避免依赖全局 CSS） */}
+      <style>{`
+        @keyframes slideInRight {
+          from { opacity: 0; transform: translateX(24px); }
+          to { opacity: 1; transform: translateX(0); }
+        }
+        .animate-slide-in-right {
+          animation: slideInRight 0.3s ease-out;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/prd-desktop/src/components/Settings/SettingsModal.tsx
+++ b/prd-desktop/src/components/Settings/SettingsModal.tsx
@@ -9,6 +9,8 @@ import { useGroupListStore } from '../../stores/groupListStore';
 import { useMessageStore } from '../../stores/messageStore';
 import { useSessionStore } from '../../stores/sessionStore';
 import { useDesktopBrandingStore } from '../../stores/desktopBrandingStore';
+import { useClientConfigStore } from '../../stores/clientConfigStore';
+import { useUpdateStore } from '../../stores/updateStore';
 import NetworkDiagnosticsModal from '../NetworkDiagnosticsModal';
 
 interface ApiTestResult {
@@ -18,18 +20,18 @@ interface ApiTestResult {
   serverStatus: string | null;
 }
 
-const DEFAULT_API_URL_NON_DEV = 'https://pa.759800.com';
+const DEFAULT_API_URL_NON_DEV = 'https://map.ebcone.net';
 const DEFAULT_API_URL_DEV = 'http://localhost:5000';
 
 /** 预设服务器列表（用户可直接选择，无需手动输入） */
 const PRESET_SERVERS = [
-  { label: 'pa.759800.com', url: 'https://pa.759800.com' },
+  { label: 'map.ebcone.net', url: 'https://map.ebcone.net' },
   { label: 'miduo.org', url: 'https://miduo.org' },
   { label: 'sassagent.com', url: 'https://sassagent.com' },
 ];
 
-function getDefaultApiUrl(isDeveloper: boolean) {
-  return isDeveloper ? DEFAULT_API_URL_DEV : DEFAULT_API_URL_NON_DEV;
+function getDefaultApiUrl(isDeveloper: boolean, effectiveDefault?: string) {
+  return isDeveloper ? DEFAULT_API_URL_DEV : (effectiveDefault ?? DEFAULT_API_URL_NON_DEV);
 }
 
 function byteLen(s: string): number {
@@ -75,6 +77,13 @@ export default function SettingsModal() {
   const clearMessages = useMessageStore((s) => s.clearMessages);
   const refreshBranding = useDesktopBrandingStore((s) => s.refresh);
   const resetBranding = useDesktopBrandingStore((s) => s.resetToLocal);
+  const remotePresetServers = useClientConfigStore((s) => s.presetServers);
+  const remoteDefaultApiUrl = useClientConfigStore((s) => s.defaultApiUrl);
+
+  // 动态配置：远程优先，硬编码兜底
+  const effectivePresets = remotePresetServers ?? PRESET_SERVERS;
+  const effectiveDefaultUrl = remoteDefaultApiUrl ?? DEFAULT_API_URL_NON_DEV;
+
   const [apiUrl, setApiUrl] = useState('');
   const [error, setError] = useState('');
   const [isDeveloper, setIsDeveloper] = useState(false);
@@ -105,13 +114,22 @@ export default function SettingsModal() {
     if (isModalOpen) {
       loadConfig();
       setTestResult(null);
-      setUpdateStatus('idle');
-      setUpdateInfo(null);
       setUpdateError('');
-      pendingUpdateRef.current = null;
       setClearConfirmStep(0);
       setCacheBytes(null);
       setCacheNote('');
+
+      // 若自动更新已发现可用版本，直接填充到手动更新 UI，避免用户重复点击"检查更新"
+      const autoUpdate = useUpdateStore.getState();
+      if (autoUpdate.phase === 'ready' && autoUpdate.version) {
+        setUpdateStatus('available');
+        setUpdateInfo({ version: autoUpdate.version, notes: autoUpdate.notes ?? undefined });
+        pendingUpdateRef.current = autoUpdate._updateObject;
+      } else {
+        setUpdateStatus('idle');
+        setUpdateInfo(null);
+        pendingUpdateRef.current = null;
+      }
 
       if (!isTauri()) {
         setAppVersion('');
@@ -651,7 +669,7 @@ export default function SettingsModal() {
                 <button
                   type="button"
                   onClick={() => {
-                    setApiUrl(getDefaultApiUrl(isDeveloper));
+                    setApiUrl(getDefaultApiUrl(isDeveloper, effectiveDefaultUrl));
                     setTestResult(null);
                   }}
                   className="px-2.5 py-1 text-xs font-medium bg-cyan-500/20 hover:bg-cyan-500/30 text-cyan-100 rounded-lg transition-colors"
@@ -661,7 +679,7 @@ export default function SettingsModal() {
               </div>
               {!isDeveloper && (
                 <select
-                  value={PRESET_SERVERS.some((s) => s.url === apiUrl.trim()) ? apiUrl.trim() : '__custom__'}
+                  value={effectivePresets.some((s) => s.url === apiUrl.trim()) ? apiUrl.trim() : '__custom__'}
                   onChange={(e) => {
                     if (e.target.value !== '__custom__') {
                       setApiUrl(e.target.value);
@@ -670,10 +688,10 @@ export default function SettingsModal() {
                   }}
                   className="w-full px-4 py-3 ui-control transition-colors"
                 >
-                  {PRESET_SERVERS.map((s) => (
+                  {effectivePresets.map((s) => (
                     <option key={s.url} value={s.url}>{s.label}</option>
                   ))}
-                  {!PRESET_SERVERS.some((s) => s.url === apiUrl.trim()) && (
+                  {!effectivePresets.some((s) => s.url === apiUrl.trim()) && (
                     <option value="__custom__">自定义: {apiUrl.trim()}</option>
                   )}
                 </select>
@@ -685,9 +703,9 @@ export default function SettingsModal() {
                   setApiUrl(e.target.value);
                   setTestResult(null);
                 }}
-                placeholder={getDefaultApiUrl(isDeveloper)}
+                placeholder={getDefaultApiUrl(isDeveloper, effectiveDefaultUrl)}
                 className="w-full px-4 py-3 ui-control transition-colors"
-                style={!isDeveloper && PRESET_SERVERS.some((s) => s.url === apiUrl.trim()) ? { display: 'none' } : undefined}
+                style={!isDeveloper && effectivePresets.some((s) => s.url === apiUrl.trim()) ? { display: 'none' } : undefined}
               />
             </div>
           </div>
@@ -898,7 +916,7 @@ export default function SettingsModal() {
       <NetworkDiagnosticsModal
         isOpen={isDiagnosticsOpen}
         onClose={() => setIsDiagnosticsOpen(false)}
-        apiUrl={apiUrl || getDefaultApiUrl(isDeveloper)}
+        apiUrl={apiUrl || getDefaultApiUrl(isDeveloper, effectiveDefaultUrl)}
       />
     </div>
   );

--- a/prd-desktop/src/stores/clientConfigStore.ts
+++ b/prd-desktop/src/stores/clientConfigStore.ts
@@ -1,0 +1,49 @@
+import { create } from 'zustand';
+import { invoke } from '../lib/tauri';
+import { isTauri } from '../lib/tauri';
+
+interface PresetServer {
+  label: string;
+  url: string;
+}
+
+interface ClientConfig {
+  version: number;
+  defaultApiUrl: string;
+  presetServers: PresetServer[];
+}
+
+interface ClientConfigState {
+  /** 远程配置的默认 API 地址 */
+  defaultApiUrl: string | null;
+  /** 远程配置的预设服务器列表 */
+  presetServers: PresetServer[] | null;
+  /** 是否已尝试过拉取（无论成功失败） */
+  isFetched: boolean;
+  /** 从 GitHub Release 拉取客户端配置 */
+  fetchClientConfig: () => Promise<void>;
+}
+
+export const useClientConfigStore = create<ClientConfigState>((set) => ({
+  defaultApiUrl: null,
+  presetServers: null,
+  isFetched: false,
+
+  fetchClientConfig: async () => {
+    if (!isTauri()) {
+      set({ isFetched: true });
+      return;
+    }
+    try {
+      const config = await invoke<ClientConfig>('fetch_client_config');
+      set({
+        defaultApiUrl: config.defaultApiUrl,
+        presetServers: config.presetServers,
+        isFetched: true,
+      });
+    } catch (err) {
+      console.warn('[clientConfig] Failed to fetch remote config:', err);
+      set({ isFetched: true });
+    }
+  },
+}));

--- a/prd-desktop/src/stores/settingsStore.ts
+++ b/prd-desktop/src/stores/settingsStore.ts
@@ -32,7 +32,7 @@ export const useSettingsStore = create<SettingsState>((set) => ({
       console.error('Failed to load config:', err);
       // 使用默认配置
       set({
-        config: { apiBaseUrl: 'https://pa.759800.com', isDeveloper: false },
+        config: { apiBaseUrl: 'https://map.ebcone.net', isDeveloper: false },
       });
     } finally {
       set({ isLoading: false });

--- a/prd-desktop/src/stores/updateStore.ts
+++ b/prd-desktop/src/stores/updateStore.ts
@@ -1,0 +1,126 @@
+import { create } from 'zustand';
+import { isTauri } from '../lib/tauri';
+
+type UpdatePhase =
+  | 'idle'        // 无更新活动
+  | 'checking'    // 正在检查
+  | 'downloading' // 静默下载中
+  | 'ready'       // 下载完成，等待用户确认安装
+  | 'installing'  // 用户点击安装
+  | 'error';      // 出错
+
+interface UpdateState {
+  phase: UpdatePhase;
+  version: string | null;
+  notes: string | null;
+  downloadProgress: number;
+  error: string | null;
+  /** 用户本次运行是否已关闭了更新通知 */
+  isDismissed: boolean;
+  /** 缓存的 Tauri Update 对象 */
+  _updateObject: any | null;
+
+  /** 静默检查并下载更新 */
+  checkAndDownload: () => Promise<void>;
+  /** 安装已下载的更新（触发重启） */
+  installUpdate: () => Promise<void>;
+  /** 关闭通知（本次运行内不再显示） */
+  dismiss: () => void;
+}
+
+export const useUpdateStore = create<UpdateState>((set, get) => ({
+  phase: 'idle',
+  version: null,
+  notes: null,
+  downloadProgress: 0,
+  error: null,
+  isDismissed: false,
+  _updateObject: null,
+
+  checkAndDownload: async () => {
+    const { phase } = get();
+    // 防重入：非 idle/error 时跳过
+    if (phase !== 'idle' && phase !== 'error') return;
+    if (!isTauri()) return;
+
+    set({ phase: 'checking', error: null });
+
+    try {
+      // 动态导入避免非 Tauri 环境报错
+      const { check } = await import('@tauri-apps/plugin-updater');
+      const update = await check();
+
+      if (!update?.available) {
+        set({ phase: 'idle' });
+        return;
+      }
+
+      set({
+        phase: 'downloading',
+        version: update.version ?? null,
+        notes: (update as any).body ?? null,
+        downloadProgress: 0,
+      });
+
+      // 分步下载：download() 下载到磁盘，后续 install() 安装
+      if (typeof update.download === 'function') {
+        let lastPct = 0;
+        await update.download((event: any) => {
+          if (event?.event === 'Started' && event.data?.contentLength) {
+            // 开始下载
+          } else if (event?.event === 'Progress' && event.data?.chunkLength) {
+            // 增量进度（Tauri 不直接给百分比，仅 chunkLength）
+            // 简单递增避免回退
+            lastPct = Math.min(lastPct + 1, 99);
+            set({ downloadProgress: lastPct });
+          } else if (event?.event === 'Finished') {
+            set({ downloadProgress: 100 });
+          }
+        });
+
+        set({
+          phase: 'ready',
+          downloadProgress: 100,
+          isDismissed: false,
+          _updateObject: update,
+        });
+      } else if (typeof update.downloadAndInstall === 'function') {
+        // 降级：旧版 API 不支持分步，缓存对象后让用户点击时 downloadAndInstall
+        set({
+          phase: 'ready',
+          downloadProgress: 100,
+          isDismissed: false,
+          _updateObject: update,
+        });
+      } else {
+        set({ phase: 'error', error: 'Updater API 不支持下载' });
+      }
+    } catch (e) {
+      console.warn('[updateStore] checkAndDownload failed:', e);
+      set({ phase: 'error', error: String(e) });
+    }
+  },
+
+  installUpdate: async () => {
+    const { _updateObject } = get();
+    if (!_updateObject) return;
+
+    set({ phase: 'installing' });
+
+    try {
+      if (typeof _updateObject.install === 'function') {
+        await _updateObject.install();
+      } else if (typeof _updateObject.downloadAndInstall === 'function') {
+        await _updateObject.downloadAndInstall();
+      }
+      // 正常情况下应用会自动重启，不会执行到这里
+    } catch (e) {
+      console.error('[updateStore] install failed:', e);
+      set({ phase: 'error', error: String(e) });
+    }
+  },
+
+  dismiss: () => {
+    set({ isDismissed: true });
+  },
+}));


### PR DESCRIPTION
## Summary
- **静默更新**：启动 30s 后自动检查更新，后台静默下载，完成后右下角弹窗通知用户点击安装重启，不影响现有手动更新流程
- **动态域名配置**：GitHub Release 产物新增 `client-config.json`，客户端启动时自动拉取预设服务器列表，支持远程更新域名而无需发新版本
- **默认域名替换**：`pa.759800.com` → `map.ebcone.net`

## 变更文件

**新增（4）：**
- `src-tauri/src/commands/client_config.rs` — Rust 远程配置拉取命令
- `src/stores/clientConfigStore.ts` — 远程配置前端 store
- `src/stores/updateStore.ts` — 静默更新状态管理
- `src/components/Feedback/UpdateNotification.tsx` — 右下角更新通知组件

**修改（7）：**
- `api_client.rs`, `SettingsModal.tsx`, `settingsStore.ts` — 域名替换 + 动态配置集成
- `commands/mod.rs`, `lib.rs` — 注册新 Rust 命令
- `App.tsx` — 挂载通知组件 + 自动检查调度 + 启动拉取远程配置
- `desktop-release.yml` — CI 上传 `client-config.json`

## Test plan
- [ ] `cargo build` 编译通过
- [ ] `pnpm build` 编译通过
- [ ] 启动桌面客户端，验证默认域名为 `map.ebcone.net`
- [ ] 设置面板预设服务器列表显示正确
- [ ] 启动 30s 后自动检查更新（控制台无报错）
- [ ] 有可用更新时右下角弹窗出现，点击安装可重启
- [ ] 关闭弹窗后本次运行不再弹出，下次启动重新检测
- [ ] 手动检查更新（设置面板 / 系统菜单）功能不受影响
- [ ] 发版时 `client-config.json` 正确上传到 GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)