### PR TITLE
Add preview-url skill for generating preview verification addresses

### DIFF
--- a/.claude/skills/preview-url/SKILL.md
+++ b/.claude/skills/preview-url/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: preview-url
+description: 根据当前 Git 分支名自动生成预览验证地址。分支名中的 `/` 替换为 `-`，拼接 `.miduo.org` 域名后缀。用于需要人工验收的场景，快速提供可访问的预览环境链接。触发词："预览地址"、"验收地址"、"preview url"、"/preview"。
+---
+
+# Preview URL — 预览验收地址生成
+
+根据当前 Git 分支名自动生成预览环境的访问地址，便于人工验收。
+
+## 触发词
+
+- "预览地址"
+- "验收地址"
+- "preview url"
+- `/preview`
+
+## URL 生成规则
+
+```
+分支名: claude/fix-safari-article-display-yyusg
+       ↓ 将 `/` 替换为 `-`
+前缀:   claude-fix-safari-article-display-yyusg
+       ↓ 拼接域名后缀
+URL:    https://claude-fix-safari-article-display-yyusg.miduo.org/
+```
+
+## 执行流程
+
+### Step 1: 获取当前分支名
+
+```bash
+git branch --show-current
+```
+
+### Step 2: 生成预览 URL
+
+将分支名中的 `/` 替换为 `-`，拼接 `https://` 前缀和 `.miduo.org/` 后缀。
+
+### Step 3: 输出结果
+
+输出格式：
+
+```markdown
+**预览验收地址**: https://{branch-slug}.miduo.org/
+
+> 分支: `{branch-name}`
+```
+
+如果涉及具体页面路径（从交接清单或上下文中获取），同时输出完整的验收路径：
+
+```markdown
+**预览验收地址**: https://{branch-slug}.miduo.org/
+
+**验收路径**:
+1. 打开 https://{branch-slug}.miduo.org/{page-path}
+2. {具体验收步骤}
+```
+
+## 注意事项
+
+1. 分支名为空时（detached HEAD），提示用户先切换到功能分支
+2. 仅替换 `/` 为 `-`，其他字符保持不变
+3. 此技能可被 `/handoff` 自动调用，也可单独使用

--- a/.claude/skills/task-handoff-checklist/SKILL.md
+++ b/.claude/skills/task-handoff-checklist/SKILL.md
@@ -122,6 +122,24 @@ git diff --stat main...HEAD 2>/dev/null || git diff --stat HEAD~10
 | 页面测试 | ✅/➖ | ⚠️ 需人工 | {页面} |
 | 回归测试 | ✅/➖ | ⚠️ 需人工 | {受影响功能} |
 
+### 预览验收地址（需人工验收时必填）
+
+当测试矩阵中存在"⚠️ 需人工"的项目时，自动生成预览地址：
+
+```bash
+# 获取分支名并生成预览 URL
+BRANCH=$(git branch --show-current)
+SLUG=$(echo "$BRANCH" | tr '/' '-')
+echo "https://${SLUG}.miduo.org/"
+```
+
+> **预览地址**: https://{branch-slug}.miduo.org/
+>
+> **验收路径**:
+> 1. 打开 https://{branch-slug}.miduo.org/{页面路径}
+> 2. {具体操作步骤}
+> 3. {期望结果}
+
 ### 推荐顺序
 
 第 1 步: ... → 第 2 步: ... → 第 3 步: ...
@@ -130,6 +148,7 @@ git diff --stat main...HEAD 2>/dev/null || git diff --stat HEAD~10
 
 - [ ] `/smoke {模块}` → 冒烟测试
 - [ ] `/verify` → 多角度验证
+- [ ] `/preview` → 生成预览验收地址
 - [ ] `fix unused imports` → 清理导入
 
 ---

--- a/.claude/skills/task-handoff-checklist/reference/example.md
+++ b/.claude/skills/task-handoff-checklist/reference/example.md
@@ -71,11 +71,20 @@
 | 冒烟测试 | ⚠️ 未完成 | 模板 CRUD + 缺陷提交 |
 | 页面测试 | ⚠️ 需人工 | 模板管理页 + 缺陷列表页 |
 
-**顺序**: 单元测试 → `/smoke defect-agent` → 页面手动验证 → 权限测试
+**预览验收地址**: https://claude-add-defect-agent-abcde.miduo.org/
+
+**验收路径**:
+1. 打开 https://claude-add-defect-agent-abcde.miduo.org/defect-agent/templates
+2. 创建/编辑缺陷模板 → 期望正常保存
+3. 打开 https://claude-add-defect-agent-abcde.miduo.org/defect-agent/reports
+4. 查看缺陷列表 → 期望显示已提交的缺陷
+
+**顺序**: 单元测试 → `/smoke defect-agent` → 预览地址手动验证 → 权限测试
 
 **技能串联**:
 - [ ] `/smoke defect-agent` → 冒烟测试
 - [ ] `/verify` → 多角度验证
+- [ ] `/preview` → 生成预览验收地址
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ cd prd-api && dotnet build --no-restore 2>&1 | grep -E "error CS|warning CS" | h
 ## 质量保障技能链
 
 ```
-需求 → /validate → 设计 → /risk → /trace → 实现 → /verify → /smoke → /handoff → /weekly
+需求 → /validate → 设计 → /risk → /trace → 实现 → /verify → /smoke → /preview → /handoff → /weekly
 ```
 
 | 技能 | 触发词 | 用途 |
@@ -103,6 +103,7 @@ cd prd-api && dotnet build --no-restore 2>&1 | grep -E "error CS|warning CS" | h
 | **human-verify** | `/verify` | 多角度模拟验证 |
 | **smoke-test** | `/smoke` | 链式 curl 端到端测试 |
 | **task-handoff-checklist** | `/handoff` | 8 维度交接清单 |
+| **preview-url** | `/preview` | 分支名生成预览验收地址 |
 | **conflict-resolution** | `/resolve` | PR 前预合并 main |
 | **weekly-update-summary** | `/weekly` | git 历史生成周报 |
 | **doc-writer** | `/doc` | doc/ 文档类型守护 |
@@ -117,8 +118,9 @@ cd prd-api && dotnet build --no-restore 2>&1 | grep -E "error CS|warning CS" | h
 1. **新需求提出时** → `/validate` 验证需求质量和价值（中大型功能必跑）
 3. **方案评审时** → 先 `/risk` 评估风险，再 `/trace` 追踪关键链路
 4. **开发完成后** → 先 `/verify` 交叉验证，再 `/smoke-test` 跑端到端
-5. **提 PR 前** → `/resolve` 预合并主分支，AI 代替人类解决冲突
-6. **准备上线时** → `/handoff` 生成交接清单（涉及 3+ 文件时自动触发）
-7. **周五收尾时** → `/weekly` 生成本周总结（完成后自动触发 `/doc-sync`）
-8. **写文档时** → `/doc` 查看类型速查，或直接创建文档时自动套用模板
-9. **迁移/重构后** → `/hygiene`
+5. **需人工验收时** → `/preview` 生成预览地址，用户直接打开验收
+6. **提 PR 前** → `/resolve` 预合并主分支，AI 代替人类解决冲突
+7. **准备上线时** → `/handoff` 生成交接清单（涉及 3+ 文件时自动触发）
+8. **周五收尾时** → `/weekly` 生成本周总结（完成后自动触发 `/doc-sync`）
+9. **写文档时** → `/doc` 查看类型速查，或直接创建文档时自动套用模板
+10. **迁移/重构后** → `/hygiene`


### PR DESCRIPTION
## Summary

Introduces a new `/preview` skill that automatically generates preview environment URLs based on the current Git branch name, enabling quick access to verification environments for manual testing scenarios.

## Key Changes

- **New skill**: `preview-url` - Generates preview verification addresses by converting branch names (replacing `/` with `-`) and appending `.miduo.org` domain
  - Triggered by keywords: "预览地址", "验收地址", "preview url", "/preview"
  - Outputs formatted preview URL and optional verification paths
  - Handles edge cases like detached HEAD state

- **Updated task-handoff-checklist**: Integrated preview URL generation into the handoff workflow
  - Automatically generates preview addresses when manual verification is required
  - Includes example verification paths and steps
  - Added `/preview` to the recommended action checklist

- **Updated CLAUDE.md**: 
  - Added `preview-url` to the quality assurance skill chain
  - Positioned `/preview` between `/smoke` and `/handoff` in the workflow
  - Updated usage guidelines to include preview address generation for manual verification scenarios
  - Renumbered subsequent workflow steps

- **Updated example.md**: Demonstrates preview URL usage in a real handoff scenario with concrete verification paths

## Implementation Details

- URL generation rule: `https://{branch-name-with-slashes-as-dashes}.miduo.org/`
- Can be invoked standalone or automatically by `/handoff` when manual verification is needed
- Provides both basic preview URL and detailed verification paths with step-by-step instructions

https://claude.ai/code/session_011Ba9VkR5Z1RiTwZMBisKkB