### PR TITLE
Add slug-based branch matching for remote branch resolution

### DIFF
--- a/cds/src/index.ts
+++ b/cds/src/index.ts
@@ -361,6 +361,11 @@ proxyService.setOnAutoBuild(async (branchSlug, _req, res) => {
     resolvedBranch = await worktreeService.findBranchBySuffix(branchSlug);
   }
 
+  // If still not found, try slug matching (e.g. slug "claude-fix-xxx" → branch "claude/fix-xxx")
+  if (!resolvedBranch) {
+    resolvedBranch = await worktreeService.findBranchBySlug(branchSlug);
+  }
+
   if (!resolvedBranch) {
     res.writeHead(200, {
       'Content-Type': 'text/event-stream',

--- a/cds/src/services/proxy.ts
+++ b/cds/src/services/proxy.ts
@@ -341,10 +341,12 @@ export class ProxyService {
     // Resolve original branch name from state (preserve "/" and casing)
     let originalBranch = matchedSlug ? state.branches[matchedSlug]?.branch : null;
 
-    // If not found locally, try remote (full path first, then last segment)
+    // If not found locally, try remote (full path first, then last segment, then slug matching)
     if (!matchedSlug && this.worktreeService) {
       const remoteBranch = await this.worktreeService.findBranchBySuffix(fullPath)
-        || (fullPath !== lastSegment ? await this.worktreeService.findBranchBySuffix(lastSegment) : null);
+        || (fullPath !== lastSegment ? await this.worktreeService.findBranchBySuffix(lastSegment) : null)
+        || await this.worktreeService.findBranchBySlug(fullPath)
+        || (fullPath !== lastSegment ? await this.worktreeService.findBranchBySlug(lastSegment) : null);
       if (remoteBranch) {
         matchedSlug = StateService.slugify(remoteBranch);
         originalBranch = remoteBranch;  // keep original name like "claude/fix-login-password-issue-CQBMO"

--- a/cds/src/services/worktree.ts
+++ b/cds/src/services/worktree.ts
@@ -1,5 +1,6 @@
 import type { IShellExecutor } from '../types.js';
 import { combinedOutput } from '../types.js';
+import { StateService } from './state.js';
 
 export class WorktreeService {
   private _repoRoot: string;
@@ -133,5 +134,25 @@ export class WorktreeService {
       return lower.endsWith(`/${lowerSuffix}`) || lower.endsWith(`-${lowerSuffix}`);
     });
     return suffixMatch || null;
+  }
+
+  /**
+   * Find a remote branch whose slugified name matches the given slug.
+   * This handles cases where the slug (e.g. "claude-fix-software-defects-dlxzp")
+   * was derived from a branch with "/" (e.g. "claude/fix-software-defects-dlxzp").
+   */
+  async findBranchBySlug(slug: string): Promise<string | null> {
+    const result = await this.shell.exec(
+      `git ls-remote --heads origin`,
+      { cwd: this.repoRoot },
+    );
+    if (result.exitCode !== 0) return null;
+
+    const branches = result.stdout.trim().split('\n')
+      .map(line => line.replace(/^.*refs\/heads\//, '').trim())
+      .filter(Boolean);
+
+    const lowerSlug = slug.toLowerCase();
+    return branches.find(b => StateService.slugify(b) === lowerSlug) || null;
   }
 }

--- a/cds/tests/services/worktree.test.ts
+++ b/cds/tests/services/worktree.test.ts
@@ -173,4 +173,54 @@ describe('WorktreeService', () => {
       expect(exists).toBe(false);
     });
   });
+
+  describe('findBranchBySlug', () => {
+    it('should match branch by slugified name (slash to hyphen)', async () => {
+      mock.addResponsePattern(/git ls-remote/, () => ({
+        stdout: [
+          'abc123\trefs/heads/main',
+          'def456\trefs/heads/claude/fix-software-defects-dlxzp',
+          'ghi789\trefs/heads/feature/new-ui',
+        ].join('\n'),
+        stderr: '',
+        exitCode: 0,
+      }));
+
+      const result = await service.findBranchBySlug('claude-fix-software-defects-dlxzp');
+      expect(result).toBe('claude/fix-software-defects-dlxzp');
+    });
+
+    it('should return null when no branch slug matches', async () => {
+      mock.addResponsePattern(/git ls-remote/, () => ({
+        stdout: 'abc123\trefs/heads/main\ndef456\trefs/heads/develop\n',
+        stderr: '',
+        exitCode: 0,
+      }));
+
+      const result = await service.findBranchBySlug('claude-nonexistent-branch');
+      expect(result).toBeNull();
+    });
+
+    it('should handle case-insensitive slug matching', async () => {
+      mock.addResponsePattern(/git ls-remote/, () => ({
+        stdout: 'abc123\trefs/heads/Claude/Fix-Login-ISSUE\n',
+        stderr: '',
+        exitCode: 0,
+      }));
+
+      const result = await service.findBranchBySlug('claude-fix-login-issue');
+      expect(result).toBe('Claude/Fix-Login-ISSUE');
+    });
+
+    it('should return null on git command failure', async () => {
+      mock.addResponsePattern(/git ls-remote/, () => ({
+        stdout: '',
+        stderr: 'fatal: error',
+        exitCode: 128,
+      }));
+
+      const result = await service.findBranchBySlug('anything');
+      expect(result).toBeNull();
+    });
+  });
 });

--- a/changelogs/2026-03-19_cds-branch-slug-resolution.md
+++ b/changelogs/2026-03-19_cds-branch-slug-resolution.md
@@ -1,0 +1,1 @@
+| fix | cds | 修复 CDS 通过 slug 查找分支失败的问题（如 claude/fix-xxx 被 slugify 为 claude-fix-xxx 后无法反向匹配远程分支） |


### PR DESCRIPTION
## Summary
This PR adds a new `findBranchBySlug()` method to resolve remote branches by their slugified names, enabling reverse matching of branches that contain slashes (e.g., matching slug "claude-fix-xxx" back to branch "claude/fix-xxx").

## Key Changes
- **WorktreeService**: Added `findBranchBySlug()` method that queries remote branches via `git ls-remote` and performs case-insensitive slug matching
- **ProxyService**: Integrated slug-based matching as a fallback in the branch resolution chain (after suffix matching)
- **Index.ts**: Added slug matching fallback in the auto-build branch resolution logic
- **Tests**: Added comprehensive test coverage for the new method including:
  - Slash-to-hyphen conversion matching
  - Case-insensitive matching
  - Null returns for non-matching slugs and git failures

## Implementation Details
- The method converts branch names to lowercase slugs using `StateService.slugify()` for comparison
- Returns the original branch name (preserving slashes and casing) when a match is found
- Gracefully handles git command failures by returning null
- Integrated into existing branch resolution fallback chain in both ProxyService and auto-build handlers

https://claude.ai/code/session_01Kbatk5cegam23tU583MESo