### PR TITLE
Fix hardcoded localhost:5000 in lab SSE stream URLs

### DIFF
--- a/changelogs/2026-03-20_lab-stream-url-fix.md
+++ b/changelogs/2026-03-20_lab-stream-url-fix.md
@@ -1,0 +1,1 @@
+| fix | prd-admin | 修复实验室 SSE 流地址硬编码 localhost:5000 导致 CDS 环境下 Failed to fetch |

--- a/prd-admin/src/pages/lab-desktop/DesktopLabTab.tsx
+++ b/prd-admin/src/pages/lab-desktop/DesktopLabTab.tsx
@@ -20,7 +20,7 @@ type Actor = {
 };
 
 function getApiBaseUrl() {
-  const raw = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? 'http://localhost:5000';
+  const raw = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? '';
   return raw.trim().replace(/\/+$/, '');
 }
 

--- a/prd-admin/src/services/real/modelLab.ts
+++ b/prd-admin/src/services/real/modelLab.ts
@@ -53,7 +53,7 @@ function normalizeExperimentFromApi(exp: unknown): ModelLabExperiment {
 }
 
 function getApiBaseUrl() {
-  const raw = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? 'http://localhost:5000';
+  const raw = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? '';
   return raw.trim().replace(/\/+$/, '');
 }
 


### PR DESCRIPTION
## Summary
Fixes an issue where the API base URL was hardcoded to `http://localhost:5000` as a fallback, causing SSE stream requests to fail in non-local environments like CDS.

## Changes
- Updated `getApiBaseUrl()` in `DesktopLabTab.tsx` to use an empty string as the fallback instead of `http://localhost:5000`
- Updated `getApiBaseUrl()` in `modelLab.ts` to use an empty string as the fallback instead of `http://localhost:5000`

## Details
The fallback value is now an empty string, which allows the application to use relative URLs when `VITE_API_BASE_URL` is not explicitly configured. This enables the frontend to make requests to the same origin/host where it's deployed, rather than always attempting to connect to a hardcoded localhost address. The `trim()` and `replace(/\/+$/, '')` operations that follow ensure proper URL formatting regardless of the fallback value.

https://claude.ai/code/session_01CL9JA4wqT9MKZB95nG45WT