### PR TITLE
Fix API label for GET /branches endpoint

### DIFF
--- a/cds/src/server.ts
+++ b/cds/src/server.ts
@@ -56,7 +56,7 @@ function resolveApiLabel(method: string, path: string): string {
 
   // Static exact matches
   const staticMap: Record<string, string> = {
-    'GET /branches': '获取分支列表',
+    'GET /branches': '获取系统状态信息',
     'POST /branches': '注册新分支',
     'GET /remote-branches': '获取远程分支',
     'GET /build-profiles': '获取构建配置',


### PR DESCRIPTION
## Summary
Updated the API label for the `GET /branches` endpoint to accurately reflect its actual functionality.

## Changes
- Changed the label for `GET /branches` from '获取分支列表' (Get branch list) to '获取系统状态信息' (Get system status information)

## Details
The API endpoint label in the `resolveApiLabel` function was corrected to match the actual purpose of the endpoint. This ensures that API documentation and UI labels accurately represent what the endpoint returns.

https://claude.ai/code/session_01DqjurELT9tf3SKeUHHdZBe