### PR TITLE
Add Trivial severity level to DefectSeverity

### DIFF
--- a/prd-api/tests/PrdAgent.Api.Tests/Services/DefectAgentTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Services/DefectAgentTests.cs
@@ -79,8 +79,9 @@ public class DefectAgentTests
         Assert.Contains(DefectSeverity.Critical, DefectSeverity.All);
         Assert.Contains(DefectSeverity.Major, DefectSeverity.All);
         Assert.Contains(DefectSeverity.Minor, DefectSeverity.All);
+        Assert.Contains(DefectSeverity.Trivial, DefectSeverity.All);
         Assert.Contains(DefectSeverity.Suggestion, DefectSeverity.All);
-        Assert.Equal(5, DefectSeverity.All.Length);
+        Assert.Equal(6, DefectSeverity.All.Length);
     }
 
     #endregion
@@ -115,7 +116,7 @@ public class DefectAgentTests
             {
                 new() { Key = "title", Label = "问题标题", Type = "text", Required = true },
                 new() { Key = "severity", Label = "严重程度", Type = "select", Required = true,
-                    Options = new List<string> { "blocker", "critical", "major", "minor", "suggestion" } }
+                    Options = new List<string> { "blocker", "critical", "major", "minor", "trivial", "suggestion" } }
             }
         };
 

--- a/prd-api/tests/PrdAgent.Api.Tests/Services/DefectAgentTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Services/DefectAgentTests.cs
@@ -126,7 +126,7 @@ public class DefectAgentTests
         Assert.Equal(2, template.RequiredFields.Count);
         Assert.Equal("title", template.RequiredFields[0].Key);
         Assert.Equal("select", template.RequiredFields[1].Type);
-        Assert.Equal(5, template.RequiredFields[1].Options?.Count);
+        Assert.Equal(6, template.RequiredFields[1].Options?.Count);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
This PR adds support for a new "Trivial" severity level to the defect severity classification system.

## Key Changes
- Added `DefectSeverity.Trivial` to the severity hierarchy between "Minor" and "Suggestion"
- Updated `DefectSeverity.All` collection to include the new Trivial severity (increased from 5 to 6 total severity levels)
- Updated the defect template severity options to include "trivial" in the correct order within the select dropdown

## Implementation Details
The new severity level is positioned in the severity scale as:
1. Blocker
2. Critical
3. Major
4. Minor
5. **Trivial** (new)
6. Suggestion

This change ensures consistency across both the severity enumeration and the UI template options for defect creation.

https://claude.ai/code/session_01DsQ4F4ZDuhiE29jkEy5etF