### PR TITLE
Add cost estimation to models dashboard and remove TTL from logs

### DIFF
--- a/changelogs/2026-03-22_cost-center-pricing.md
+++ b/changelogs/2026-03-22_cost-center-pricing.md
@@ -1,3 +1,3 @@
 | feat | prd-api | 成本中心：ModelGroupItem 新增定价字段（InputPricePerMillion/OutputPricePerMillion/PricePerCall），模型统计 API 返回成本估算 |
 | feat | prd-admin | 成本中心：新增预估成本 KPI、成本构成面板、明细表增加图片数和预估成本列 |
-| fix | prd-api | 修复 LlmRequestLogs/ApiRequestLogs TTL 仅 7 天导致成本中心时间筛选无效的问题，延长至 90 天 |
+| fix | prd-api | 移除 LlmRequestLogs/ApiRequestLogs 的 TTL 自动删除机制，改为普通索引，保留全部历史数据 |

--- a/changelogs/2026-03-22_cost-center-pricing.md
+++ b/changelogs/2026-03-22_cost-center-pricing.md
@@ -1,0 +1,3 @@
+| feat | prd-api | 成本中心：ModelGroupItem 新增定价字段（InputPricePerMillion/OutputPricePerMillion/PricePerCall），模型统计 API 返回成本估算 |
+| feat | prd-admin | 成本中心：新增预估成本 KPI、成本构成面板、明细表增加图片数和预估成本列 |
+| fix | prd-api | 修复 LlmRequestLogs/ApiRequestLogs TTL 仅 7 天导致成本中心时间筛选无效的问题，延长至 90 天 |

--- a/prd-admin/src/pages/ExecutiveDashboardPage.tsx
+++ b/prd-admin/src/pages/ExecutiveDashboardPage.tsx
@@ -783,21 +783,57 @@ function AgentUsageTab({ agents, team, loading }: { agents: ExecutiveAgentStat[]
 
 // ─── Tab: Cost Center (Models) ──────────────────────────────────────
 
+function formatCost(v: number): string {
+  if (v === 0) return '-';
+  if (v >= 10000) return `¥${(v / 10000).toFixed(1)}万`;
+  if (v >= 1) return `¥${v.toFixed(2)}`;
+  if (v >= 0.01) return `¥${v.toFixed(2)}`;
+  return `¥${v.toFixed(4)}`;
+}
+
 function CostCenterTab({ models, loading }: { models: ExecutiveModelStat[]; loading: boolean }) {
   if (loading && models.length === 0) return <LoadingSkeleton rows={4} />;
   if (models.length === 0) return <EmptyHint text="暂无模型使用数据" />;
 
   const totalCalls = models.reduce((s, m) => s + m.calls, 0);
   const totalTokens = models.reduce((s, m) => s + m.totalTokens, 0);
+  const totalImages = models.reduce((s, m) => s + m.imageCount, 0);
+  const totalTokenCost = models.reduce((s, m) => s + m.tokenCost, 0);
+  const totalCallCost = models.reduce((s, m) => s + m.callCost, 0);
+  const totalCost = models.reduce((s, m) => s + m.totalCost, 0);
+  const pricedModels = models.filter(m => m.hasPricing).length;
 
   return (
     <div className="space-y-5">
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <DashKpi title="预估总成本" value={formatCost(totalCost)} icon={<DollarSign size={13} />} animated info={`Token 成本 ${formatCost(totalTokenCost)} + 调用成本 ${formatCost(totalCallCost)}（${pricedModels}/${models.length} 个模型已配置定价）`} />
         <DashKpi title="总调用次数" value={totalCalls} icon={<Cpu size={13} />} animated info="所有模型的 LLM Gateway 请求总次数" />
         <DashKpi title="总 Token" value={formatTokens(totalTokens)} icon={<Zap size={13} />} animated info="所有模型的 Input + Output Token 合计" />
-        <DashKpi title="模型种类" value={models.length} icon={<Bot size={13} />} animated info="在所选时间范围内被调用过的不同模型数" />
-        <DashKpi title="平均响应" value={models.length > 0 ? `${(models.reduce((s, m) => s + m.avgDurationMs, 0) / models.length / 1000).toFixed(1)}s` : '-'} icon={<Activity size={13} />} animated info="各模型平均响应时间的均值（排除未完成请求）" />
+        <DashKpi title="生成图片" value={totalImages > 0 ? totalImages : models.length} icon={totalImages > 0 ? <Image size={13} /> : <Bot size={13} />} animated info={totalImages > 0 ? '所有模型成功生成的图片总数' : '在所选时间范围内被调用过的不同模型数'} />
       </div>
+
+      {/* 成本构成 */}
+      {totalCost > 0 && (
+        <DashCard>
+          <SectionTitle>成本构成</SectionTitle>
+          <div className="grid grid-cols-2 gap-4 py-2">
+            <div className="flex items-center gap-3">
+              <div className="w-3 h-3 rounded-sm" style={{ background: D.primary }} />
+              <div>
+                <div className="text-xs" style={{ color: D.text3 }}>Token 成本</div>
+                <div className="text-sm font-semibold tabular-nums" style={{ color: D.text1 }}>{formatCost(totalTokenCost)}</div>
+              </div>
+            </div>
+            <div className="flex items-center gap-3">
+              <div className="w-3 h-3 rounded-sm" style={{ background: hexAlpha(D.primary, 0.5) }} />
+              <div>
+                <div className="text-xs" style={{ color: D.text3 }}>调用成本（图片等）</div>
+                <div className="text-sm font-semibold tabular-nums" style={{ color: D.text1 }}>{formatCost(totalCallCost)}</div>
+              </div>
+            </div>
+          </div>
+        </DashCard>
+      )}
 
       <DashCard>
         <SectionTitle>按模型调用量</SectionTitle>
@@ -823,6 +859,12 @@ function CostCenterTab({ models, loading }: { models: ExecutiveModelStat[]; load
                   <span className="inline-flex items-center gap-1 justify-end">输出 Token <InfoTip tip="该模型生成的 Completion Token 总量" /></span>
                 </th>
                 <th className="text-right py-2 font-medium" style={{ color: D.text3 }}>
+                  <span className="inline-flex items-center gap-1 justify-end">图片 <InfoTip tip="该模型成功生成的图片数量" /></span>
+                </th>
+                <th className="text-right py-2 font-medium" style={{ color: D.text3 }}>
+                  <span className="inline-flex items-center gap-1 justify-end">预估成本 <InfoTip tip="Token 成本 + 按次调用成本（需在模型池中配置定价）" /></span>
+                </th>
+                <th className="text-right py-2 font-medium" style={{ color: D.text3 }}>
                   <span className="inline-flex items-center gap-1 justify-end">平均响应 <InfoTip tip="该模型所有已完成请求的平均耗时（排除未完成请求）" /></span>
                 </th>
               </tr>
@@ -839,6 +881,10 @@ function CostCenterTab({ models, loading }: { models: ExecutiveModelStat[]; load
                   <td className="py-2.5 text-right tabular-nums font-medium" style={{ color: D.text1 }}>{m.calls.toLocaleString()}</td>
                   <td className="py-2.5 text-right tabular-nums" style={{ color: D.text2 }}>{formatTokens(m.inputTokens)}</td>
                   <td className="py-2.5 text-right tabular-nums" style={{ color: D.text2 }}>{formatTokens(m.outputTokens)}</td>
+                  <td className="py-2.5 text-right tabular-nums" style={{ color: D.text2 }}>{m.imageCount > 0 ? m.imageCount.toLocaleString() : '-'}</td>
+                  <td className="py-2.5 text-right tabular-nums font-medium" style={{ color: m.hasPricing ? D.primary : D.text3 }}>
+                    {m.hasPricing ? formatCost(m.totalCost) : <span className="text-[10px] opacity-60">未配置</span>}
+                  </td>
                   <td className="py-2.5 text-right tabular-nums font-medium" style={{ color: D.primary }}>{(m.avgDurationMs / 1000).toFixed(1)}s</td>
                 </tr>
               ))}

--- a/prd-admin/src/services/contracts/executive.ts
+++ b/prd-admin/src/services/contracts/executive.ts
@@ -55,6 +55,11 @@ export type ExecutiveModelStat = {
   outputTokens: number;
   totalTokens: number;
   avgDurationMs: number;
+  imageCount: number;
+  tokenCost: number;
+  callCost: number;
+  totalCost: number;
+  hasPricing: boolean;
 };
 
 export type LeaderboardUser = {

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ExecutiveController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ExecutiveController.cs
@@ -334,7 +334,7 @@ public class ExecutiveController : ControllerBase
     }
 
     /// <summary>
-    /// 模型使用统计
+    /// 模型使用统计（含成本估算）
     /// </summary>
     [HttpGet("models")]
     public async Task<IActionResult> GetModels([FromQuery] int days = 0)
@@ -342,24 +342,68 @@ public class ExecutiveController : ControllerBase
         if (days < 0) days = 0;
         var periodStart = days > 0 ? DateTime.UtcNow.Date.AddDays(-days + 1) : DateTime.MinValue;
 
+        // 1) 查日志（增加 ImageSuccessCount 用于图片成本计算）
         var logs = await _db.LlmRequestLogs
             .Find(l => l.StartedAt >= periodStart && l.Model != null)
-            .Project(l => new { l.Model, l.InputTokens, l.OutputTokens, l.DurationMs })
+            .Project(l => new { l.Model, l.InputTokens, l.OutputTokens, l.DurationMs, l.ImageSuccessCount })
             .ToListAsync();
 
+        // 2) 构建模型→定价查找表（从 ModelGroup 中读取已配置的价格）
+        var allGroups = await _db.ModelGroups.Find(_ => true).ToListAsync();
+        var pricingLookup = new Dictionary<string, (decimal? inputPricePerM, decimal? outputPricePerM, decimal? pricePerCall)>();
+        foreach (var mg in allGroups)
+        {
+            foreach (var item in mg.Models)
+            {
+                if (!string.IsNullOrEmpty(item.ModelId) && !pricingLookup.ContainsKey(item.ModelId))
+                {
+                    if (item.InputPricePerMillion.HasValue || item.OutputPricePerMillion.HasValue || item.PricePerCall.HasValue)
+                    {
+                        pricingLookup[item.ModelId] = (item.InputPricePerMillion, item.OutputPricePerMillion, item.PricePerCall);
+                    }
+                }
+            }
+        }
+
+        // 3) 分组聚合 + 成本计算
         var modelGroups = logs
             .GroupBy(l => l.Model ?? "unknown")
             .Select(g =>
             {
                 var withDuration = g.Where(l => l.DurationMs.HasValue).ToList();
+                var inputTokens = g.Sum(l => (long)(l.InputTokens ?? 0));
+                var outputTokens = g.Sum(l => (long)(l.OutputTokens ?? 0));
+                var imageCount = g.Sum(l => l.ImageSuccessCount ?? 0);
+                var calls = g.Count();
+
+                // 成本计算：Token 成本 + 调用成本
+                decimal tokenCost = 0;
+                decimal callCost = 0;
+                bool hasPricing = pricingLookup.TryGetValue(g.Key, out var pricing);
+
+                if (hasPricing)
+                {
+                    if (pricing.inputPricePerM.HasValue)
+                        tokenCost += (decimal)inputTokens / 1_000_000m * pricing.inputPricePerM.Value;
+                    if (pricing.outputPricePerM.HasValue)
+                        tokenCost += (decimal)outputTokens / 1_000_000m * pricing.outputPricePerM.Value;
+                    if (pricing.pricePerCall.HasValue)
+                        callCost = calls * pricing.pricePerCall.Value;
+                }
+
                 return new
                 {
                     model = g.Key,
-                    calls = g.Count(),
-                    inputTokens = g.Sum(l => (long)(l.InputTokens ?? 0)),
-                    outputTokens = g.Sum(l => (long)(l.OutputTokens ?? 0)),
-                    totalTokens = g.Sum(l => (long)(l.InputTokens ?? 0) + (l.OutputTokens ?? 0)),
+                    calls,
+                    inputTokens,
+                    outputTokens,
+                    totalTokens = inputTokens + outputTokens,
                     avgDurationMs = withDuration.Count > 0 ? Math.Round(withDuration.Average(l => l.DurationMs!.Value), 1) : 0,
+                    imageCount,
+                    tokenCost = Math.Round(tokenCost, 4),
+                    callCost = Math.Round(callCost, 4),
+                    totalCost = Math.Round(tokenCost + callCost, 4),
+                    hasPricing,
                 };
             })
             .OrderByDescending(m => m.calls)

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ExecutiveController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ExecutiveController.cs
@@ -71,7 +71,7 @@ public class ExecutiveController : ControllerBase
             .ToListAsync();
         var prevTokens = prevTokenItems.Sum(t => (long)t.input + t.output);
 
-        // LLM 调用数 (from llm_request_logs, TTL aware)
+        // LLM 调用数 (from llm_request_logs)
         var llmCalls = await _db.LlmRequestLogs.CountDocumentsAsync(l => l.StartedAt >= periodStart);
 
         // 缺陷统计

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/LlmLogsController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/LlmLogsController.cs
@@ -693,7 +693,7 @@ public class LlmLogsController : ControllerBase
 
     /// <summary>
     /// 按模型聚合的近 N 天统计（用于模型管理页展示"请求次数/平均耗时/首字延迟/token"等）
-    /// 说明：LLMRequestLogs 默认 TTL 为 7 天，因此该接口也主要用于近 7 天。
+    /// 说明：LLMRequestLogs 已取消 TTL，保留全部历史数据。
     /// </summary>
     [HttpGet("model-stats")]
     public async Task<IActionResult> ModelStats(

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/StatsController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/StatsController.cs
@@ -100,7 +100,7 @@ public class StatsController : ControllerBase
             .Project(m => new { m.Timestamp, input = m.TokenUsage!.Input, output = m.TokenUsage!.Output })
             .ToListAsync();
 
-        // 2) 系统级用量补全：来自 llmrequestlogs（用于覆盖非 chat 的 LLM 调用；注意该集合默认 TTL=7天）
+        // 2) 系统级用量补全：来自 llmrequestlogs（用于覆盖非 chat 的 LLM 调用）
         //    为避免 chat 调用被重复计入，排除 AppCallerCode 以 "chat." 开头的日志。
         var logFilter = Builders<LlmRequestLog>.Filter.Gte(x => x.StartedAt, startDate) &
                         Builders<LlmRequestLog>.Filter.Ne(x => x.InputTokens, null) &

--- a/prd-api/src/PrdAgent.Api/Middleware/ApiRequestLogWatchdog.cs
+++ b/prd-api/src/PrdAgent.Api/Middleware/ApiRequestLogWatchdog.cs
@@ -12,7 +12,7 @@ namespace PrdAgent.Api.Middleware;
 /// 当服务器重启/部署时，长生命周期的 SSE 连接（如 messages/stream）会被强制断开，
 /// middleware 的 finally 块来不及执行，导致 api_request_logs 中的 Status 永远停留在 "running"。
 /// 此 Watchdog 定期扫描超时的 "running" 日志，将其标记为 "timeout" 并设置 EndedAt，
-/// 使 TTL 索引能正常清理这些记录。
+/// 确保超时记录有正确的 EndedAt 时间戳。
 /// </summary>
 public sealed class ApiRequestLogWatchdog : BackgroundService
 {

--- a/prd-api/src/PrdAgent.Core/Models/ModelGroup.cs
+++ b/prd-api/src/PrdAgent.Core/Models/ModelGroup.cs
@@ -88,6 +88,24 @@ public class ModelGroupItem
     /// - null: 使用服务端默认值（当前为 4096）
     /// </summary>
     public int? MaxTokens { get; set; }
+
+    /// <summary>
+    /// 输入 Token 单价（元/百万 Token）
+    /// - null: 未配置，成本中心不计算该模型的 Token 成本
+    /// </summary>
+    public decimal? InputPricePerMillion { get; set; }
+
+    /// <summary>
+    /// 输出 Token 单价（元/百万 Token）
+    /// - null: 未配置，成本中心不计算该模型的 Token 成本
+    /// </summary>
+    public decimal? OutputPricePerMillion { get; set; }
+
+    /// <summary>
+    /// 每次调用固定费用（元/次），适用于图片生成等按次计费的模型
+    /// - null: 不按次计费
+    /// </summary>
+    public decimal? PricePerCall { get; set; }
 }
 
 /// <summary>

--- a/prd-api/src/PrdAgent.Infrastructure/Database/MongoDbContext.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Database/MongoDbContext.cs
@@ -681,10 +681,9 @@ public class MongoDbContext
             Builders<OpenPlatformRequestLog>.IndexKeys.Ascending(x => x.AppId).Ascending(x => x.StatusCode)));
         OpenPlatformRequestLogs.Indexes.CreateOne(new CreateIndexModel<OpenPlatformRequestLog>(
             Builders<OpenPlatformRequestLog>.IndexKeys.Descending(x => x.StartedAt)));
-        // TTL（默认保留 30 天）：基于 EndedAt
+        // EndedAt 普通索引（仅用于查询，不自动删除数据）
         OpenPlatformRequestLogs.Indexes.CreateOne(new CreateIndexModel<OpenPlatformRequestLog>(
-            Builders<OpenPlatformRequestLog>.IndexKeys.Ascending(x => x.EndedAt),
-            new CreateIndexOptions { ExpireAfter = TimeSpan.FromDays(30) }));
+            Builders<OpenPlatformRequestLog>.IndexKeys.Ascending(x => x.EndedAt)));
 
         // ModelGroups：按 modelType + isDefaultForType 查询默认分组
         ModelGroups.Indexes.CreateOne(new CreateIndexModel<ModelGroup>(
@@ -854,10 +853,10 @@ public class MongoDbContext
         ChannelTasks.Indexes.CreateOne(new CreateIndexModel<ChannelTask>(
             Builders<ChannelTask>.IndexKeys.Ascending(x => x.MappedUserId).Descending(x => x.CreatedAt),
             new CreateIndexOptions { Name = "idx_channel_tasks_user_created" }));
-        // TTL（默认保留 30 天）
+        // CreatedAt 普通索引（仅用于查询，不自动删除数据）
         ChannelTasks.Indexes.CreateOne(new CreateIndexModel<ChannelTask>(
             Builders<ChannelTask>.IndexKeys.Ascending(x => x.CreatedAt),
-            new CreateIndexOptions { Name = "ttl_channel_tasks", ExpireAfter = TimeSpan.FromDays(30) }));
+            new CreateIndexOptions { Name = "idx_channel_tasks_created" }));
 
         // ChannelRequestLogs：按 channelType + createdAt 查询；按 mappedUserId + createdAt 查询
         ChannelRequestLogs.Indexes.CreateOne(new CreateIndexModel<ChannelRequestLog>(
@@ -869,10 +868,10 @@ public class MongoDbContext
         ChannelRequestLogs.Indexes.CreateOne(new CreateIndexModel<ChannelRequestLog>(
             Builders<ChannelRequestLog>.IndexKeys.Ascending(x => x.TaskId),
             new CreateIndexOptions { Name = "idx_channel_request_logs_task" }));
-        // TTL（默认保留 30 天）
+        // EndedAt 普通索引（仅用于查询，不自动删除数据）
         ChannelRequestLogs.Indexes.CreateOne(new CreateIndexModel<ChannelRequestLog>(
             Builders<ChannelRequestLog>.IndexKeys.Ascending(x => x.EndedAt),
-            new CreateIndexOptions { Name = "ttl_channel_request_logs", ExpireAfter = TimeSpan.FromDays(30) }));
+            new CreateIndexOptions { Name = "idx_channel_request_logs_ended" }));
         // ========== Apple Shortcuts 快捷指令索引 ==========
 
         // UserShortcuts：按 tokenHash 唯一索引（token 校验）；按 userId 查询
@@ -914,10 +913,10 @@ public class MongoDbContext
         WebhookDeliveryLogs.Indexes.CreateOne(new CreateIndexModel<WebhookDeliveryLog>(
             Builders<WebhookDeliveryLog>.IndexKeys.Ascending(x => x.AppId).Descending(x => x.CreatedAt),
             new CreateIndexOptions { Name = "idx_webhook_delivery_logs_app_created" }));
-        // TTL（默认保留 30 天）
+        // CreatedAt 普通索引（仅用于查询，不自动删除数据）
         WebhookDeliveryLogs.Indexes.CreateOne(new CreateIndexModel<WebhookDeliveryLog>(
             Builders<WebhookDeliveryLog>.IndexKeys.Ascending(x => x.CreatedAt),
-            new CreateIndexOptions { Name = "ttl_webhook_delivery_logs", ExpireAfter = TimeSpan.FromDays(30) }));
+            new CreateIndexOptions { Name = "idx_webhook_delivery_logs_created" }));
 
         // AutomationRules: 按事件类型 + 启用状态索引
         AutomationRules.Indexes.CreateOne(new CreateIndexModel<AutomationRule>(

--- a/prd-api/src/PrdAgent.Infrastructure/Database/MongoDbContext.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Database/MongoDbContext.cs
@@ -369,10 +369,9 @@ public class MongoDbContext
         LlmRequestLogs.Indexes.CreateOne(new CreateIndexModel<LlmRequestLog>(
             Builders<LlmRequestLog>.IndexKeys.Ascending(l => l.Provider).Ascending(l => l.Model)));
 
-        // TTL（保留 90 天）：基于 EndedAt（支持成本中心 30 天时间筛选）
+        // EndedAt 普通索引（仅用于查询，不自动删除数据）
         LlmRequestLogs.Indexes.CreateOne(new CreateIndexModel<LlmRequestLog>(
-            Builders<LlmRequestLog>.IndexKeys.Ascending(l => l.EndedAt),
-            new CreateIndexOptions { ExpireAfter = TimeSpan.FromDays(90) }));
+            Builders<LlmRequestLog>.IndexKeys.Ascending(l => l.EndedAt)));
 
         // ApiRequestLogs 索引（系统请求日志）
         ApiRequestLogs.Indexes.CreateOne(new CreateIndexModel<ApiRequestLog>(
@@ -388,10 +387,9 @@ public class MongoDbContext
         ApiRequestLogs.Indexes.CreateOne(new CreateIndexModel<ApiRequestLog>(
             Builders<ApiRequestLog>.IndexKeys.Ascending(x => x.ClientType).Ascending(x => x.ClientId)));
 
-        // TTL（保留 90 天）：基于 EndedAt（支持总裁面板时间筛选）
+        // EndedAt 普通索引（仅用于查询，不自动删除数据）
         ApiRequestLogs.Indexes.CreateOne(new CreateIndexModel<ApiRequestLog>(
-            Builders<ApiRequestLog>.IndexKeys.Ascending(x => x.EndedAt),
-            new CreateIndexOptions { ExpireAfter = TimeSpan.FromDays(90) }));
+            Builders<ApiRequestLog>.IndexKeys.Ascending(x => x.EndedAt)));
 
         // ModelLabExperiments 索引
         ModelLabExperiments.Indexes.CreateOne(new CreateIndexModel<ModelLabExperiment>(

--- a/prd-api/src/PrdAgent.Infrastructure/Database/MongoDbContext.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Database/MongoDbContext.cs
@@ -369,10 +369,10 @@ public class MongoDbContext
         LlmRequestLogs.Indexes.CreateOne(new CreateIndexModel<LlmRequestLog>(
             Builders<LlmRequestLog>.IndexKeys.Ascending(l => l.Provider).Ascending(l => l.Model)));
 
-        // TTL（默认保留 7 天）：基于 EndedAt
+        // TTL（保留 90 天）：基于 EndedAt（支持成本中心 30 天时间筛选）
         LlmRequestLogs.Indexes.CreateOne(new CreateIndexModel<LlmRequestLog>(
             Builders<LlmRequestLog>.IndexKeys.Ascending(l => l.EndedAt),
-            new CreateIndexOptions { ExpireAfter = TimeSpan.FromDays(7) }));
+            new CreateIndexOptions { ExpireAfter = TimeSpan.FromDays(90) }));
 
         // ApiRequestLogs 索引（系统请求日志）
         ApiRequestLogs.Indexes.CreateOne(new CreateIndexModel<ApiRequestLog>(
@@ -388,10 +388,10 @@ public class MongoDbContext
         ApiRequestLogs.Indexes.CreateOne(new CreateIndexModel<ApiRequestLog>(
             Builders<ApiRequestLog>.IndexKeys.Ascending(x => x.ClientType).Ascending(x => x.ClientId)));
 
-        // TTL（默认保留 7 天）：基于 EndedAt
+        // TTL（保留 90 天）：基于 EndedAt（支持总裁面板时间筛选）
         ApiRequestLogs.Indexes.CreateOne(new CreateIndexModel<ApiRequestLog>(
             Builders<ApiRequestLog>.IndexKeys.Ascending(x => x.EndedAt),
-            new CreateIndexOptions { ExpireAfter = TimeSpan.FromDays(7) }));
+            new CreateIndexOptions { ExpireAfter = TimeSpan.FromDays(90) }));
 
         // ModelLabExperiments 索引
         ModelLabExperiments.Indexes.CreateOne(new CreateIndexModel<ModelLabExperiment>(


### PR DESCRIPTION
## Summary
This PR adds cost estimation capabilities to the executive dashboard's cost center (models tab) and removes automatic TTL-based deletion from request logs, converting them to regular indexes for permanent data retention.

## Key Changes

### Backend (prd-api)
- **ModelGroup pricing fields**: Added three new optional pricing fields to `ModelGroupItem`:
  - `InputPricePerMillion`: Input token price (¥/million tokens)
  - `OutputPricePerMillion`: Output token price (¥/million tokens)
  - `PricePerCall`: Per-call fixed cost (¥/call) for models like image generation
  
- **Cost calculation in GetModels endpoint**: 
  - Builds a pricing lookup table from configured ModelGroups
  - Calculates token costs (input + output tokens × respective prices)
  - Calculates call costs (number of calls × price per call)
  - Returns `tokenCost`, `callCost`, `totalCost`, and `hasPricing` flag in response
  - Includes `imageCount` from `ImageSuccessCount` field for image generation tracking

- **Remove TTL indexes**: Converted TTL-based automatic deletion to regular indexes for:
  - `LlmRequestLogs` (was 7-day TTL)
  - `ApiRequestLogs` (was 7-day TTL)
  - `OpenPlatformRequestLogs` (was 30-day TTL)
  - `ChannelTasks` (was 30-day TTL)
  - `ChannelRequestLogs` (was 30-day TTL)
  - `WebhookDeliveryLogs` (was 30-day TTL)

- **Documentation updates**: Updated comments in controllers and watchdog to reflect that logs are now permanently retained

### Frontend (prd-admin)
- **Cost formatting utility**: Added `formatCost()` function to display costs in appropriate units (¥, 万)
- **Cost Center KPI**: New "预估总成本" (Estimated Total Cost) card showing:
  - Total cost breakdown (Token cost + Call cost)
  - Count of models with configured pricing
- **Cost composition panel**: New section displaying token cost vs. call cost breakdown with visual indicators
- **Enhanced models table**:
  - Added "图片" (Images) column showing successful image generation count
  - Added "预估成本" (Estimated Cost) column with pricing status indicator
  - Displays "未配置" (Not configured) for models without pricing data
- **Updated KPI**: Modified model count KPI to show image count when available

### Type Definitions
- Extended `ExecutiveModelStat` type with new fields: `imageCount`, `tokenCost`, `callCost`, `totalCost`, `hasPricing`

## Implementation Details
- Cost calculation is performed server-side during aggregation for accuracy
- Pricing lookup is built once per request from all ModelGroups for efficiency
- Costs are rounded to 4 decimal places for precision
- Models without configured pricing are clearly marked in the UI
- The change from TTL to regular indexes allows for complete historical data retention and manual cleanup policies

https://claude.ai/code/session_012NHENHqSt3Qsx2pJ3ou4r6