### PR TITLE
Sync user roles across projects and refactor role selection

### DIFF
--- a/changelogs/2026-03-22_sync-user-roles.md
+++ b/changelogs/2026-03-22_sync-user-roles.md
@@ -1,0 +1,2 @@
+| fix | prd-admin | 创建用户对话框角色选项从硬编码4个改为使用 ALL_ROLES 动态渲染全部12个角色 |
+| fix | prd-desktop | 同步 UserRole 类型定义，补全 HR/FINANCE/RD/TEST/COPYWRITER/CSM/SUPPORT/SALES 8个新角色 |

--- a/prd-admin/src/pages/UsersPage.tsx
+++ b/prd-admin/src/pages/UsersPage.tsx
@@ -1350,31 +1350,29 @@ export default function UsersPage() {
               <div className="flex flex-col">
                 <div className="text-sm font-semibold mb-2" style={{ color: 'var(--text-secondary)' }}>角色</div>
                 <div
-                  className="rounded-[10px] p-2 space-y-1 flex-1"
+                  className="rounded-[10px] p-2 space-y-1 flex-1 overflow-y-auto max-h-[260px]"
                   style={{ background: 'var(--nested-block-bg)', border: '1px solid var(--border-subtle)' }}
                 >
-                  {([
-                    { key: 'PM', label: 'PM', desc: '产品经理' },
-                    { key: 'DEV', label: 'DEV', desc: '开发' },
-                    { key: 'QA', label: 'QA', desc: '测试' },
-                    { key: 'ADMIN', label: 'ADMIN', desc: '管理员' },
-                  ] as const).map((r) => (
-                    <label
-                      key={r.key}
-                      className="flex items-center gap-2 px-2 py-1.5 rounded-[6px] cursor-pointer transition-colors hover:bg-white/5"
-                    >
-                      <input
-                        type="radio"
-                        name="createRole"
-                        value={r.key}
-                        checked={createRole === r.key}
-                        onChange={() => setCreateRole(r.key)}
-                        className="accent-[var(--accent-gold)]"
-                      />
-                      <span className="text-[12px] font-medium" style={{ color: 'var(--text-primary)' }}>{r.label}</span>
-                      <span className="text-[11px]" style={{ color: 'var(--text-muted)' }}>{r.desc}</span>
-                    </label>
-                  ))}
+                  {ALL_ROLES.map((key) => {
+                    const meta = getRoleMeta(key);
+                    return (
+                      <label
+                        key={key}
+                        className="flex items-center gap-2 px-2 py-1.5 rounded-[6px] cursor-pointer transition-colors hover:bg-white/5"
+                      >
+                        <input
+                          type="radio"
+                          name="createRole"
+                          value={key}
+                          checked={createRole === key}
+                          onChange={() => setCreateRole(key)}
+                          className="accent-[var(--accent-gold)]"
+                        />
+                        <span className="text-[12px] font-medium" style={{ color: 'var(--text-primary)' }}>{key}</span>
+                        <span className="text-[11px]" style={{ color: 'var(--text-muted)' }}>{meta.label}</span>
+                      </label>
+                    );
+                  })}
                 </div>
               </div>
 

--- a/prd-desktop/src/types/index.ts
+++ b/prd-desktop/src/types/index.ts
@@ -1,4 +1,4 @@
-export type UserRole = 'PM' | 'DEV' | 'QA' | 'ADMIN';
+export type UserRole = 'PM' | 'DEV' | 'QA' | 'ADMIN' | 'HR' | 'FINANCE' | 'RD' | 'TEST' | 'COPYWRITER' | 'CSM' | 'SUPPORT' | 'SALES';
 export type InteractionMode = 'QA' | 'Knowledge' | 'PrdPreview' | 'AssetsDiag' | 'Defect';
 export type MessageRole = 'User' | 'Assistant' | 'System';
 


### PR DESCRIPTION
## Summary
This PR synchronizes the UserRole type definition across prd-admin and prd-desktop, expanding support from 4 hardcoded roles to 12 total roles. The role selection UI in the user creation dialog is refactored to dynamically render roles from a centralized `ALL_ROLES` constant instead of maintaining a hardcoded list.

## Key Changes
- **prd-admin**: Refactored the role selection component to use `ALL_ROLES` constant and `getRoleMeta()` helper function instead of hardcoded role definitions
  - Dynamically renders all available roles instead of just 4 (PM, DEV, QA, ADMIN)
  - Added `overflow-y-auto max-h-[260px]` styling to handle scrolling for the expanded role list
  
- **prd-desktop**: Extended `UserRole` type definition to include 8 additional roles
  - Added: HR, FINANCE, RD, TEST, COPYWRITER, CSM, SUPPORT, SALES
  - Maintains backward compatibility with existing 4 roles

## Implementation Details
- The role selection now sources from a centralized `ALL_ROLES` array, making it easier to maintain role definitions across the codebase
- Role metadata (labels, descriptions) is retrieved via `getRoleMeta()` function, decoupling UI from role configuration
- The container now has a max-height with vertical scrolling to accommodate the expanded role list without breaking the layout

https://claude.ai/code/session_019RzP6qFBZX4KRMSXq5QQ5T