### PR TITLE
Add commit pinning, deploy animations, and branch deletion UX

### DIFF
--- a/cds/src/index.ts
+++ b/cds/src/index.ts
@@ -143,6 +143,7 @@ proxyService.setOnAccess((branchId, method, reqPath, status, duration, profileId
   if (now - lastSent < 2000) return; // throttle: 1 event per 2 seconds per branch
   webAccessThrottle.set(branchId, now);
 
+  const branchTags = stateService.getBranch(branchId)?.tags ?? [];
   const event: ActivityEvent = {
     id: nextActivitySeq(),
     ts: new Date().toISOString(),
@@ -153,6 +154,7 @@ proxyService.setOnAccess((branchId, method, reqPath, status, duration, profileId
     type: 'web',
     source: 'user',
     branchId,
+    branchTags: branchTags.length ? branchTags : undefined,
     profileId,
   };
   broadcastActivity(event);

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -310,6 +310,11 @@ export function createBranchRouter(deps: RouterDeps): Router {
       const pullResult = await worktreeService.pull(entry.branch, entry.worktreePath);
       logEvent({ step: 'pull', status: 'done', title: `已拉取: ${pullResult.head}`, detail: pullResult as unknown as Record<string, unknown>, timestamp: new Date().toISOString() });
 
+      // Clear pinned commit — deploy always restores to branch HEAD
+      if (entry.pinnedCommit) {
+        entry.pinnedCommit = undefined;
+        logEvent({ step: 'pull', status: 'done', title: '已取消固定提交，恢复到分支最新', timestamp: new Date().toISOString() });
+      }
       stateService.save();
 
       // ── Compute startup layers (topological sort by dependsOn) ──
@@ -563,6 +568,13 @@ export function createBranchRouter(deps: RouterDeps): Router {
       logEvent({ step: 'pull', status: 'running', title: '正在拉取最新代码...', timestamp: new Date().toISOString() });
       const pullResult = await worktreeService.pull(entry.branch, entry.worktreePath);
       logEvent({ step: 'pull', status: 'done', title: `已拉取: ${pullResult.head}`, detail: pullResult as unknown as Record<string, unknown>, timestamp: new Date().toISOString() });
+
+      // Clear pinned commit — deploy always restores to branch HEAD
+      if (entry.pinnedCommit) {
+        entry.pinnedCommit = undefined;
+        logEvent({ step: 'pull', status: 'done', title: '已取消固定提交，恢复到分支最新', timestamp: new Date().toISOString() });
+        stateService.save();
+      }
 
       // Build & run the single profile
       logEvent({ step: `build-${profile.id}`, status: 'running', title: `正在构建 ${profile.name}...`, timestamp: new Date().toISOString() });
@@ -867,6 +879,93 @@ export function createBranchRouter(deps: RouterDeps): Router {
           return { hash, subject, author, date };
         });
       res.json({ commits });
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // ── Checkout specific commit (pin to historical commit) ──
+
+  router.post('/branches/:id/checkout/:hash', async (req, res) => {
+    const { id, hash } = req.params;
+    const entry = stateService.getBranch(id);
+    if (!entry) {
+      res.status(404).json({ error: `分支 "${id}" 不存在` });
+      return;
+    }
+    if (entry.status === 'building' || entry.status === 'starting') {
+      res.status(409).json({ error: '分支正在构建/启动中，无法切换提交' });
+      return;
+    }
+
+    try {
+      // Validate the commit hash exists
+      const verify = await shell.exec(
+        `git cat-file -t ${hash}`,
+        { cwd: entry.worktreePath, timeout: 5_000 },
+      );
+      if (verify.exitCode !== 0 || verify.stdout.trim() !== 'commit') {
+        res.status(400).json({ error: `无效的提交: ${hash}` });
+        return;
+      }
+
+      // Checkout the specific commit (detached HEAD)
+      const result = await shell.exec(
+        `git checkout ${hash}`,
+        { cwd: entry.worktreePath, timeout: 10_000 },
+      );
+      if (result.exitCode !== 0) {
+        throw new Error(combinedOutput(result));
+      }
+
+      // Get full short hash + subject for display
+      const logResult = await shell.exec(
+        'git log --oneline -1',
+        { cwd: entry.worktreePath, timeout: 5_000 },
+      );
+      const [pinnedHash, ...subjectParts] = logResult.stdout.trim().split(' ');
+      const pinnedSubject = subjectParts.join(' ');
+
+      entry.pinnedCommit = pinnedHash || hash;
+      stateService.save();
+
+      res.json({
+        message: `已切换到提交 ${pinnedHash}`,
+        pinnedCommit: entry.pinnedCommit,
+        subject: pinnedSubject,
+      });
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // ── Unpin commit (restore to branch HEAD) ──
+
+  router.post('/branches/:id/unpin', async (req, res) => {
+    const { id } = req.params;
+    const entry = stateService.getBranch(id);
+    if (!entry) {
+      res.status(404).json({ error: `分支 "${id}" 不存在` });
+      return;
+    }
+
+    try {
+      const result = await shell.exec(
+        `git checkout ${entry.branch}`,
+        { cwd: entry.worktreePath, timeout: 10_000 },
+      );
+      if (result.exitCode !== 0) {
+        // Worktree may not have local branch, reset to origin
+        const reset = await shell.exec(
+          `git checkout -B ${entry.branch} origin/${entry.branch}`,
+          { cwd: entry.worktreePath, timeout: 10_000 },
+        );
+        if (reset.exitCode !== 0) throw new Error(combinedOutput(reset));
+      }
+
+      entry.pinnedCommit = undefined;
+      stateService.save();
+      res.json({ message: '已恢复到分支最新提交' });
     } catch (err) {
       res.status(500).json({ error: (err as Error).message });
     }

--- a/cds/src/server.ts
+++ b/cds/src/server.ts
@@ -45,6 +45,8 @@ export interface ActivityEvent {
   query?: string;
   /** Branch ID extracted from path (for AI occupation tracking) */
   branchId?: string;
+  /** Branch tags for activity display (resolved server-side to avoid timing issues) */
+  branchTags?: string[];
   /** Build profile ID that handled the request (e.g. 'api', 'admin') */
   profileId?: string;
   /** Remote address of the client */
@@ -469,6 +471,8 @@ export function createServer(deps: ServerDeps): express.Express {
     // Extract branch ID from path for AI occupation tracking
     const branchMatch = req.path.match(/^\/branches\/([^/]+)/);
     const branchId = branchMatch ? branchMatch[1] : undefined;
+    // Resolve branch tags for activity display (avoids frontend timing issues)
+    const branchTags = branchId ? (stateService.getBranch(branchId)?.tags ?? []) : [];
 
     (res as any).end = function (...args: any[]) {
       const duration = Date.now() - start;
@@ -487,6 +491,7 @@ export function createServer(deps: ServerDeps): express.Express {
         body: reqBody,
         query: reqQuery,
         branchId,
+        branchTags: branchTags.length ? branchTags : undefined,
         remoteAddr: (req.headers['cf-connecting-ip'] as string) || (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() || req.ip || req.socket?.remoteAddress,
         userAgent: req.headers['user-agent'],
         referer: req.headers['referer'] || req.headers['origin'],

--- a/cds/src/server.ts
+++ b/cds/src/server.ts
@@ -472,7 +472,7 @@ export function createServer(deps: ServerDeps): express.Express {
     const branchMatch = req.path.match(/^\/branches\/([^/]+)/);
     const branchId = branchMatch ? branchMatch[1] : undefined;
     // Resolve branch tags for activity display (avoids frontend timing issues)
-    const branchTags = branchId ? (stateService.getBranch(branchId)?.tags ?? []) : [];
+    const branchTags = branchId ? (deps.stateService.getBranch(branchId)?.tags ?? []) : [];
 
     (res as any).end = function (...args: any[]) {
       const duration = Date.now() - start;

--- a/cds/src/types.ts
+++ b/cds/src/types.ts
@@ -112,6 +112,8 @@ export interface BranchEntry {
   tags?: string[];
   /** Color marker — marks branch as actively debugging, prevents priority stop */
   isColorMarked?: boolean;
+  /** Pinned to a specific commit hash (detached HEAD). Cleared on next deploy. */
+  pinnedCommit?: string;
   /** ID of the executor this branch is deployed on (scheduler mode) */
   executorId?: string;
 }

--- a/cds/src/widget-script.ts
+++ b/cds/src/widget-script.ts
@@ -69,6 +69,7 @@ export function buildWidgetScript(branchId: string, branchName: string): string 
   var branchStatus='';
   var commitSha='';
   var commitMsg='';
+  var branchTags=[];
   var steps=[];
   var resultMsg='';
   var resultOk=true;
@@ -162,7 +163,8 @@ export function buildWidgetScript(branchId: string, branchName: string): string 
     h+=ICON_BRANCH;
     h+='<span class="cds-branch">'+BRANCH_NAME+'</span>';
     if(commitSha)h+='<span class="cds-sha" title="'+commitSha+'">'+commitSha+'</span>';
-    h+='<span class="cds-tag">CDS</span>';
+    if(branchTags.length){for(var ti=0;ti<branchTags.length;ti++){h+='<span class="cds-tag">'+branchTags[ti]+'</span>';}}
+    else{h+='<span class="cds-tag">CDS</span>';}
     h+='<button data-action="toggle" title="'+(expanded?'收起':'展开更新面板')+'">'+(expanded?ICON_DOWN:ICON_UP)+'</button>';
     h+='<button data-action="dismiss">'+ICON_X+'</button>';
     h+='</div>';
@@ -208,7 +210,16 @@ export function buildWidgetScript(branchId: string, branchName: string): string 
       branchStatus=found?found.status:'';
       commitSha=found&&found.commitSha?found.commitSha:'';
       commitMsg=found&&found.subject?found.subject:'';
+      branchTags=(found&&found.tags)||[];
       profiles=(res[1]&&res[1].profiles)||[];
+
+      // Update page title with branch tags for easy tab identification
+      if(branchTags.length){
+        var tagStr=branchTags.join(' · ');
+        var origTitle=document.title.replace(/\\[.*?\\]\\s*/,'');
+        document.title='['+tagStr+'] '+origTitle;
+      }
+
       render();
     }).catch(function(){
       branchStatus='';

--- a/cds/web/app.js
+++ b/cds/web/app.js
@@ -2093,6 +2093,14 @@ function renderBranches() {
     const card = document.querySelector(`.branch-card[data-branch-id="${branchId}"]`);
     if (card) card.classList.add('is-previewing');
   }
+
+  // Update page title with branch tags for tab identification
+  const allTags = [...new Set(branches.flatMap(b => b.tags || []))];
+  if (allTags.length) {
+    document.title = `[${allTags.join(' · ')}] Cloud Dev Suite`;
+  } else {
+    document.title = 'Cloud Development Suite';
+  }
 }
 
 // ── Build profiles (data only) ──

--- a/cds/web/app.js
+++ b/cds/web/app.js
@@ -95,7 +95,7 @@ function showToast(msg, type = 'info', duration) {
 }
 
 function statusLabel(s) {
-  const map = { running: '运行中', starting: '启动中', building: '构建中', stopping: '正在停止', idle: '空闲', stopped: '已停止', error: '错误' };
+  const map = { running: '运行中', starting: '启动中', building: '构建中', stopping: '正在停止', deleting: '删除中', idle: '空闲', stopped: '已停止', error: '错误' };
   return map[s] || s;
 }
 
@@ -1112,12 +1112,26 @@ async function previewBranch(id) {
 async function removeBranch(id) {
   if (!confirm(`确定删除分支 "${id}"？将停止所有服务并删除工作区。`)) return;
   busyBranches.add(id);
+  // Immediately set deleting state for visual feedback (borrowing stopping-pulse style)
+  const br = branches.find(b => b.id === id);
+  if (br) {
+    br.status = 'deleting';
+    for (const svc of Object.values(br.services || {})) {
+      svc.status = 'stopping';
+    }
+  }
   renderBranches();
   try {
     const res = await fetch(`${API}/branches/${id}`, { method: 'DELETE' });
     // SSE stream — just consume it
     const reader = res.body.getReader();
     while (!(await reader.read()).done) {}
+    // Collapse animation before removing from DOM
+    const card = document.querySelector(`.branch-card[data-branch-id="${CSS.escape(id)}"]`);
+    if (card) {
+      card.classList.add('deleting-collapse');
+      await new Promise(r => card.addEventListener('animationend', r, { once: true }));
+    }
     showToast(`分支 "${id}" 已删除`, 'success');
   } catch (e) { showToast(e.message, 'error'); }
   busyBranches.delete(id);

--- a/cds/web/app.js
+++ b/cds/web/app.js
@@ -3801,10 +3801,14 @@ function toUTC8Time(isoStr) {
   return full;
 }
 
-// Get display label for branch: prefer tags, fallback to last segment of ID
-function getBranchDisplayLabel(branchId) {
+// Get display label for branch: prefer tags from event, then branches array, fallback to last segment of ID
+function getBranchDisplayLabel(branchId, eventTags) {
+  // 1. Server-side resolved tags (reliable, no timing issues)
+  if (eventTags?.length) return eventTags.join(' · ');
+  // 2. Fallback: lookup from branches array (may be empty on early events)
   const branch = branches.find(b => b.id === branchId);
   if (branch?.tags?.length) return branch.tags.join(' · ');
+  // 3. Last resort: tail of branch ID
   const lastDash = branchId.lastIndexOf('-');
   const tail = lastDash >= 0 ? branchId.slice(lastDash + 1) : branchId;
   return tail.length > 16 ? tail.slice(0, 13) + '…' : tail;
@@ -3833,7 +3837,7 @@ function renderActivityItem(event) {
   let html = '';
   // Branch label: prefer tags, fallback to last ID segment
   if (event.branchId) {
-    const branchLabel = getBranchDisplayLabel(event.branchId);
+    const branchLabel = getBranchDisplayLabel(event.branchId, event.branchTags);
     html += `<span class="activity-source" style="background:var(--accent-bg);color:var(--accent);font-size:9px;font-weight:600;padding:1px 4px;border-radius:3px" title="${escapeHtml(event.branchId)}">${escapeHtml(branchLabel)}</span>`;
   }
   // AI badge if applicable
@@ -3888,7 +3892,7 @@ function renderWebActivityItem(event) {
   let html = '';
   // Branch label: prefer tags, fallback to last ID segment
   if (event.branchId) {
-    const branchLabel = getBranchDisplayLabel(event.branchId);
+    const branchLabel = getBranchDisplayLabel(event.branchId, event.branchTags);
     html += `<span class="activity-source" style="background:var(--accent-bg);color:var(--accent);font-size:9px;font-weight:600;padding:1px 4px;border-radius:3px" title="${escapeHtml(event.branchId)}">${escapeHtml(branchLabel)}</span>`;
   }
   html += `<span class="web-container-badge" style="background:${containerBg};color:${containerColor}">${containerLabel}</span>`;

--- a/cds/web/app.js
+++ b/cds/web/app.js
@@ -20,7 +20,7 @@ const ICON = {
   pr: '<svg class="inline-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M5.45 5.154A4.25 4.25 0 009.25 7.5h1.378a2.251 2.251 0 110 1.5H9.25A5.734 5.734 0 015 7.123v3.505a2.25 2.25 0 11-1.5 0V5.372a2.25 2.25 0 111.95-.218zM4.25 13.5a.75.75 0 100-1.5.75.75 0 000 1.5zm8.5-4.5a.75.75 0 100-1.5.75.75 0 000 1.5zM5 3.25a.75.75 0 10-1.5 0 .75.75 0 001.5 0z"/></svg>',
   pull: '<svg class="inline-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 2.004a.75.75 0 01.75.75v5.689l1.97-1.97a.749.749 0 111.06 1.06l-3.25 3.25a.749.749 0 01-1.06 0L4.22 7.533a.749.749 0 111.06-1.06l1.97 1.97V2.754a.75.75 0 01.75-.75zM2.75 12.5h10.5a.75.75 0 010 1.5H2.75a.75.75 0 010-1.5z"/></svg>',
   preview: '<svg class="inline-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M0 8s3-5.5 8-5.5S16 8 16 8s-3 5.5-8 5.5S0 8 0 8zm8 3.5a3.5 3.5 0 100-7 3.5 3.5 0 000 7zm0-1.5a2 2 0 110-4 2 2 0 010 4z"/></svg>',
-  deploy: '<svg class="inline-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 12-8.373 8.373a1 1 0 1 1-3-3L12 9"/><path d="m18 15 4-4"/><path d="m21.5 11.5c.7-1 .5-2.4-.3-3.2L17 4.2c-.8-.8-2.2-1-3.2-.3L12 5.5l6.5 6.5z"/></svg>',
+  deploy: '<svg class="inline-icon deploy-hammer-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 12-8.373 8.373a1 1 0 1 1-3-3L12 9"/><path d="m18 15 4-4"/><path d="m21.5 11.5c.7-1 .5-2.4-.3-3.2L17 4.2c-.8-.8-2.2-1-3.2-.3L12 5.5l6.5 6.5z"/></svg>',
   trash: '<svg class="inline-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M6.5 1.75a.25.25 0 01.25-.25h2.5a.25.25 0 01.25.25V3h-3V1.75zM11 3V1.75A1.75 1.75 0 009.25 0h-2.5A1.75 1.75 0 005 1.75V3H2.75a.75.75 0 000 1.5h.3l.8 8.2A1.75 1.75 0 005.6 14.5h4.8a1.75 1.75 0 001.75-1.8l.8-8.2h.3a.75.75 0 000-1.5H11z"/></svg>',
   reset: '<svg class="inline-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 2.5a5.487 5.487 0 00-4.131 1.869l1.204 1.204A.25.25 0 014.896 6H1.25A.25.25 0 011 5.75V2.104a.25.25 0 01.427-.177l1.38 1.38A7.002 7.002 0 0115 8a.75.75 0 01-1.5 0A5.5 5.5 0 008 2.5z"/></svg>',
   star: '<svg class="inline-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25z"/></svg>',
@@ -1949,7 +1949,7 @@ function renderBranches() {
       `;
       actionsRightHtml = `
         <div class="split-btn">
-          <button class="sm split-btn-main" onclick="deployBranch('${esc(b.id)}')" ${isBusy ? 'disabled' : ''} title="重新部署">${ICON.deploy} 部署</button>
+          <button class="sm split-btn-main deploy-glow-btn" onclick="deployBranch('${esc(b.id)}')" ${isBusy ? 'disabled' : ''} title="重新部署">${ICON.deploy} 部署</button>
           <button class="sm split-btn-toggle" onclick="toggleDeployMenu('${esc(b.id)}', event)" ${isBusy ? 'disabled' : ''}>
             <svg width="10" height="6" viewBox="0 0 10 6" fill="currentColor"><path d="M1 1l4 4 4-4"/></svg>
           </button>
@@ -1965,7 +1965,7 @@ function renderBranches() {
     } else if (isStopped) {
       // Container exists but stopped — neutral deploy, not primary
       actionsLeftHtml = `
-        <button class="sm" onclick="deployBranch('${esc(b.id)}')" ${isBusy ? 'disabled' : ''} title="部署">${ICON.deploy} 部署</button>
+        <button class="sm deploy-glow-btn" onclick="deployBranch('${esc(b.id)}')" ${isBusy ? 'disabled' : ''} title="部署">${ICON.deploy} 部署</button>
       `;
       actionsRightHtml = `
         <button class="sm danger" onclick="removeBranch('${esc(b.id)}')" ${isBusy ? 'disabled' : ''}>${ICON.trash}</button>
@@ -1973,7 +1973,7 @@ function renderBranches() {
     } else {
       // Idle (never deployed) or building — neutral deploy button
       actionsLeftHtml = `
-        <button class="sm" onclick="deployBranch('${esc(b.id)}')" ${isBusy ? 'disabled' : ''} title="部署">${ICON.deploy} 部署</button>
+        <button class="sm deploy-glow-btn" onclick="deployBranch('${esc(b.id)}')" ${isBusy ? 'disabled' : ''} title="部署">${ICON.deploy} 部署</button>
       `;
       actionsRightHtml = `
         ${hasError ? `<button class="sm" onclick="resetBranch('${esc(b.id)}')" ${btnDisabled('reset')}>${btnLabel('reset', ICON.reset + ' 重置')}</button>` : ''}
@@ -1982,18 +1982,31 @@ function renderBranches() {
     }
 
     const deployLog = inlineDeployLogs.get(b.id);
-    const isDeploying = !!deployLog && deployLog.status === 'building';
+    const localDeploying = !!deployLog && deployLog.status === 'building';
+    // Server-authority: also treat server-pushed 'building'/'starting' as deploying
+    const serverDeploying = !localDeploying && (b.status === 'building' || b.status === 'starting');
+    const isDeploying = localDeploying || serverDeploying;
     const deployFailed = !!deployLog && deployLog.status === 'error';
     const isJustDeployed = justDeployed.has(b.id);
 
     // Commit area in actions row — shows commit info or deploy log during deployment
     let commitAreaHtml = '';
-    if (isDeploying && deployLog) {
+    if (localDeploying && deployLog) {
+      // Local deploy — show live log lines
       const compactLines = deployLog.lines.filter(l => l.trim()).slice(-2);
       commitAreaHtml = `
         <div class="branch-actions-deploy-status" title="部署中，点击查看完整日志" onclick="event.stopPropagation(); openFullDeployLog('${esc(b.id)}', event)">
           <span class="live-dot"></span>
           <pre class="deploy-status-log">${esc(compactLines.join('\n')) || '正在启动...'}</pre>
+        </div>
+      `;
+    } else if (serverDeploying) {
+      // Server-driven deploy (triggered externally) — simplified indicator
+      const statusLabel = b.status === 'building' ? '构建中...' : '启动中...';
+      commitAreaHtml = `
+        <div class="branch-actions-deploy-status">
+          <span class="live-dot"></span>
+          <pre class="deploy-status-log">${statusLabel}</pre>
         </div>
       `;
     } else if (b.subject) {

--- a/cds/web/app.js
+++ b/cds/web/app.js
@@ -2022,7 +2022,7 @@ function renderBranches() {
     // Deploy logs are accessible via the log button in toolbar.
 
     return `
-      <div class="branch-card status-${b.status || 'idle'} ${isDefault ? 'active' : ''} ${isBusy ? 'is-busy' : ''} ${hasError ? 'has-error' : ''} expanded ${b.isFavorite ? 'is-favorite' : ''} ${hasUpdates ? 'has-updates' : ''} ${recentlyTouched.has(b.id) ? 'recently-touched' : ''} ${isDeploying ? 'is-deploying' : ''} ${b.isColorMarked ? 'is-color-marked' : ''} ${getAiOccupant(b.id) ? 'is-ai-occupied' : ''}" data-branch-id="${esc(b.id)}">
+      <div class="branch-card status-${b.status || 'idle'} ${isDefault ? 'active' : ''} ${isBusy ? 'is-busy' : ''} ${hasError ? 'has-error' : ''} expanded ${b.isFavorite ? 'is-favorite' : ''} ${hasUpdates ? 'has-updates' : ''} ${recentlyTouched.has(b.id) ? 'recently-touched' : ''} ${isDeploying ? 'is-deploying' : ''} ${b.isColorMarked ? 'is-color-marked' : ''} ${getAiOccupant(b.id) ? 'is-ai-occupied' : ''} ${b.pinnedCommit ? 'is-pinned' : ''}" data-branch-id="${esc(b.id)}">
         ${isDeploying ? '<div class="deploy-progress-bar"><div class="deploy-progress-bar-fill"></div></div>' : ''}
         <div class="branch-card-toolbar">
           ${!isBusy ? `<span class="update-pull-group" onclick="event.stopPropagation(); pullBranch('${esc(b.id)}')" title="${hasUpdates ? branchUpdates[b.id].behind + ' 个新提交，点击拉取' : '点击拉取最新代码'}">
@@ -2060,7 +2060,10 @@ function renderBranches() {
             </span>
             <a class="branch-name" href="${githubRepoUrl ? githubRepoUrl.replace('github.com', 'github.dev') + '/tree/' + encodeURIComponent(b.branch) : '#'}" target="_blank" onclick="event.stopPropagation(); return confirmOpenGithub(event)" title="在 GitHub.dev 中浏览代码">${ICON.branch} ${esc(b.branch)}</a>
           </div>
-          ${b.subject ? `<div class="branch-card-row2"><span class="branch-commit-msg" title="${esc(b.subject)}">${commitIcon(b.subject)} ${esc(b.subject)}</span></div>` : ''}
+          ${b.subject ? `<div class="branch-card-row2">
+            ${b.pinnedCommit ? `<span class="pinned-commit-badge" onclick="event.stopPropagation(); checkoutCommit('${esc(b.id)}', '', true, '')" title="已固定到历史提交 ${esc(b.pinnedCommit)}，点击恢复最新">📌 ${esc(b.pinnedCommit)}</span>` : ''}
+            <span class="branch-commit-msg" title="${esc(b.subject)}">${commitIcon(b.subject)} ${esc(b.subject)}</span>
+          </div>` : ''}
           ${portBadgesHtml ? `<div class="branch-card-ports">${portBadgesHtml}</div>` : ''}
           ${b.executorId ? `<span class="executor-tag" title="部署在执行器 ${esc(b.executorId)}">⚡ ${esc(b.executorId.replace(/^executor-/, '').slice(0, 20))}</span>` : ''}
         </div>
@@ -3588,15 +3591,57 @@ async function toggleCommitLog(id, triggerEl) {
       el.innerHTML = '<div class="commit-log-empty">暂无提交记录</div>';
       return;
     }
-    el.innerHTML = commits.map((c, i) => `
-      <div class="commit-log-item ${i === 0 ? 'latest' : ''}">
-        ${commitIcon(c.subject)}<code class="commit-hash">${esc(c.hash)}</code>
+    const branch = branches.find(br => br.id === id);
+    const isPinned = branch?.pinnedCommit;
+    el.innerHTML = commits.map((c, i) => {
+      const isCurrent = isPinned ? c.hash === isPinned : i === 0;
+      const isLatest = i === 0;
+      return `
+      <div class="commit-log-item ${isLatest ? 'latest' : ''} ${isCurrent ? 'current' : ''}" onclick="event.stopPropagation(); checkoutCommit('${esc(id)}', '${esc(c.hash)}', ${isLatest}, ${JSON.stringify(esc(c.subject))})" title="点击切换到此提交进行构建">
+        ${isCurrent ? '<span class="commit-current-dot"></span>' : ''}${commitIcon(c.subject)}<code class="commit-hash">${esc(c.hash)}</code>
         <span class="commit-subject">${esc(c.subject)}</span>
         <span class="commit-meta">${esc(c.author)} · ${esc(c.date)}</span>
       </div>
-    `).join('');
+    `;
+    }).join('');
   } catch (e) {
     el.innerHTML = `<div class="commit-log-empty" style="color:var(--red)">${esc(e.message)}</div>`;
+  }
+}
+
+async function checkoutCommit(branchId, hash, isLatest, subject) {
+  closeCommitLog();
+  const branch = branches.find(b => b.id === branchId);
+  if (!branch) return;
+
+  // If clicking on the latest commit and currently pinned, unpin
+  if (isLatest && branch.pinnedCommit) {
+    if (!confirm(`恢复到分支最新提交？\n\n当前固定在: ${branch.pinnedCommit}`)) return;
+    try {
+      await api('POST', `/branches/${encodeURIComponent(branchId)}/unpin`);
+      branch.pinnedCommit = undefined;
+      showToast('已恢复到分支最新提交', 'success');
+      renderBranches();
+    } catch (e) {
+      showToast(`恢复失败: ${e.message}`, 'error');
+    }
+    return;
+  }
+
+  // If clicking on the latest commit and not pinned, nothing to do
+  if (isLatest && !branch.pinnedCommit) return;
+
+  // Confirm checkout to historical commit
+  const msg = `切换到历史提交进行构建？\n\n${hash}  ${subject}\n\n⚠️ 切换后卡片将显示警示状态\n点击「部署」会自动恢复到分支最新`;
+  if (!confirm(msg)) return;
+
+  try {
+    const data = await api('POST', `/branches/${encodeURIComponent(branchId)}/checkout/${encodeURIComponent(hash)}`);
+    branch.pinnedCommit = data.pinnedCommit || hash;
+    showToast(`已切换到提交 ${hash}`, 'success');
+    renderBranches();
+  } catch (e) {
+    showToast(`切换失败: ${e.message}`, 'error');
   }
 }
 

--- a/cds/web/app.js
+++ b/cds/web/app.js
@@ -3801,6 +3801,15 @@ function toUTC8Time(isoStr) {
   return full;
 }
 
+// Get display label for branch: prefer tags, fallback to last segment of ID
+function getBranchDisplayLabel(branchId) {
+  const branch = branches.find(b => b.id === branchId);
+  if (branch?.tags?.length) return branch.tags.join(' · ');
+  const lastDash = branchId.lastIndexOf('-');
+  const tail = lastDash >= 0 ? branchId.slice(lastDash + 1) : branchId;
+  return tail.length > 16 ? tail.slice(0, 13) + '…' : tail;
+}
+
 function renderActivityItem(event) {
   const body = document.getElementById('activityBody');
   if (!body) return;
@@ -3822,12 +3831,10 @@ function renderActivityItem(event) {
   });
 
   let html = '';
-  // Branch ID first (last segment after '-') to identify which preview is making requests
+  // Branch label: prefer tags, fallback to last ID segment
   if (event.branchId) {
-    const lastDash = event.branchId.lastIndexOf('-');
-    const branchTail = lastDash >= 0 ? event.branchId.slice(lastDash + 1) : event.branchId;
-    const branchShort = branchTail.length > 16 ? branchTail.slice(0, 13) + '…' : branchTail;
-    html += `<span class="activity-source" style="background:var(--accent-bg);color:var(--accent);font-size:9px;font-weight:600;padding:1px 4px;border-radius:3px" title="${escapeHtml(event.branchId)}">${escapeHtml(branchShort)}</span>`;
+    const branchLabel = getBranchDisplayLabel(event.branchId);
+    html += `<span class="activity-source" style="background:var(--accent-bg);color:var(--accent);font-size:9px;font-weight:600;padding:1px 4px;border-radius:3px" title="${escapeHtml(event.branchId)}">${escapeHtml(branchLabel)}</span>`;
   }
   // AI badge if applicable
   if (isAi) {
@@ -3879,12 +3886,10 @@ function renderWebActivityItem(event) {
   const containerBg = isApi ? 'rgba(56,139,253,0.12)' : 'rgba(63,185,80,0.12)';
 
   let html = '';
-  // Branch first, then container badge
+  // Branch label: prefer tags, fallback to last ID segment
   if (event.branchId) {
-    const lastDash = event.branchId.lastIndexOf('-');
-    const branchTail = lastDash >= 0 ? event.branchId.slice(lastDash + 1) : event.branchId;
-    const branchShort = branchTail.length > 16 ? branchTail.slice(0, 13) + '…' : branchTail;
-    html += `<span class="activity-source" style="background:var(--accent-bg);color:var(--accent);font-size:9px;font-weight:600;padding:1px 4px;border-radius:3px" title="${escapeHtml(event.branchId)}">${escapeHtml(branchShort)}</span>`;
+    const branchLabel = getBranchDisplayLabel(event.branchId);
+    html += `<span class="activity-source" style="background:var(--accent-bg);color:var(--accent);font-size:9px;font-weight:600;padding:1px 4px;border-radius:3px" title="${escapeHtml(event.branchId)}">${escapeHtml(branchLabel)}</span>`;
   }
   html += `<span class="web-container-badge" style="background:${containerBg};color:${containerColor}">${containerLabel}</span>`;
   html += `<span class="activity-path" title="${escapeHtml(event.path)}">${escapeHtml(shortPath)}</span>`;

--- a/cds/web/style.css
+++ b/cds/web/style.css
@@ -854,9 +854,9 @@ button.text-btn:hover { color: var(--accent); }
 @keyframes ai-icon-spin {
   to { transform: rotate(360deg); }
 }
-/* During deploy, AI spinner blinks instead of rotating */
+/* During deploy, hide AI spinner entirely */
 .branch-card.is-deploying .ai-mark-spinner {
-  animation: hammer-blink 1.2s ease-in-out infinite;
+  display: none;
 }
 /* During deploy, AI card border stops spinning — use deploy glow instead */
 .branch-card.is-ai-occupied.is-deploying {

--- a/cds/web/style.css
+++ b/cds/web/style.css
@@ -1801,11 +1801,7 @@ a.branch-name:hover { color: var(--accent); }
   .branch-tag { padding: 3px 8px; }
   .branch-tag-remove { width: 18px; height: 18px; font-size: 14px; }
 
-  /* Busy spinner: reposition to avoid overlap with right-side elements */
-  .branch-card.is-busy::after {
-    top: auto; bottom: 12px; right: 12px;
-    width: 14px; height: 14px;
-  }
+  /* Busy spinner removed — see main styles */
 
   /* Modal: slight margin on mobile */
   .modal-dialog { max-height: 90vh; margin: 0 12px; }

--- a/cds/web/style.css
+++ b/cds/web/style.css
@@ -1425,6 +1425,10 @@ a.branch-name:hover { color: var(--accent); }
   border-top-color: var(--yellow); border-radius: 50%;
   animation: spin 0.7s linear infinite;
 }
+/* During deploy, hide the busy spinner — hammer blink + progress bar are enough */
+.branch-card.is-deploying.is-busy::after {
+  display: none;
+}
 
 /* ════════════════ Toast ════════════════ */
 
@@ -1848,8 +1852,6 @@ a.branch-name:hover { color: var(--accent); }
   opacity: 0.35;
   flex-shrink: 0;
 }
-/* Hide color-mark button during deploy */
-.branch-card.is-deploying .color-mark-btn { display: none; }
 .color-mark-btn svg { display: block; }
 .color-mark-btn .cm-q1,
 .color-mark-btn .cm-q2,

--- a/cds/web/style.css
+++ b/cds/web/style.css
@@ -252,6 +252,7 @@
 [data-theme="light"] .branch-card.status-starting { border-left-color: var(--yellow); }
 [data-theme="light"] .branch-card.status-error { border-left-color: var(--red); }
 [data-theme="light"] .branch-card.status-stopping { border-left-color: var(--red); }
+[data-theme="light"] .branch-card.status-deleting { border-left-color: var(--red); }
 
 [data-theme="light"] .port-badge.run-port {
   color: var(--green); background: var(--green-bg); border-color: var(--green-border);
@@ -778,6 +779,14 @@ button.text-btn:hover { color: var(--accent); }
 .branch-card.status-stopping {
   animation: stopping-pulse 1.2s ease-in-out infinite;
 }
+.branch-card.status-deleting {
+  animation: stopping-pulse 0.8s ease-in-out infinite;
+  opacity: 0.85;
+}
+.branch-card.deleting-collapse {
+  animation: deleting-collapse 0.5s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+  pointer-events: none;
+}
 @keyframes stopping-pulse {
   0%, 100% {
     box-shadow: 0 0 0 0 rgba(244, 63, 94, 0), 0 1px 3px rgba(0, 0, 0, 0.2);
@@ -787,6 +796,11 @@ button.text-btn:hover { color: var(--accent); }
     box-shadow: 0 0 12px 2px rgba(244, 63, 94, 0.3), 0 0 24px 4px rgba(244, 63, 94, 0.1);
     border-color: rgba(244, 63, 94, 0.4);
   }
+}
+@keyframes deleting-collapse {
+  0% { transform: scale(1); opacity: 0.85; max-height: 600px; margin-bottom: 12px; }
+  60% { transform: scale(0.95); opacity: 0.3; }
+  100% { transform: scale(0.9); opacity: 0; max-height: 0; margin-bottom: 0; overflow: hidden; }
 }
 /* Human web access — blinking footprint icon in toolbar */
 .human-access-icon {
@@ -969,6 +983,10 @@ button.text-btn:hover { color: var(--accent); }
 .status-badge-stopping {
   color: var(--red); background: var(--red-bg); border: 1px solid var(--red-border);
   animation: port-stopping-blink 1s ease-in-out infinite;
+}
+.status-badge-deleting {
+  color: var(--red); background: var(--red-bg); border: 1px solid var(--red-border);
+  animation: port-stopping-blink 0.7s ease-in-out infinite;
 }
 .status-badge-starting {
   color: var(--yellow); background: var(--yellow-bg); border: 1px solid rgba(251, 191, 36, 0.2);

--- a/cds/web/style.css
+++ b/cds/web/style.css
@@ -1848,6 +1848,8 @@ a.branch-name:hover { color: var(--accent); }
   opacity: 0.35;
   flex-shrink: 0;
 }
+/* Hide color-mark button during deploy */
+.branch-card.is-deploying .color-mark-btn { display: none; }
 .color-mark-btn svg { display: block; }
 .color-mark-btn .cm-q1,
 .color-mark-btn .cm-q2,

--- a/cds/web/style.css
+++ b/cds/web/style.css
@@ -1289,10 +1289,18 @@ a.branch-name:hover { color: var(--accent); }
   padding: 7px 12px; font-size: 12px;
   border-bottom: 1px solid var(--border);
   transition: background var(--transition);
+  cursor: pointer; position: relative;
 }
 .commit-log-item:last-child { border-bottom: none; }
 .commit-log-item:hover { background: var(--bg-hover); }
 .commit-log-item.latest { background: rgba(163, 230, 53, 0.04); }
+.commit-log-item.current { background: rgba(251, 191, 36, 0.08); }
+.commit-log-item.current .commit-hash { color: var(--yellow); }
+.commit-current-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--yellow); flex-shrink: 0;
+  align-self: center;
+}
 .commit-hash {
   color: var(--accent); font-family: var(--font-mono);
   font-size: 11px; flex-shrink: 0; letter-spacing: 0.01em;
@@ -1428,6 +1436,46 @@ a.branch-name:hover { color: var(--accent); }
 /* During deploy, hide the busy spinner — hammer blink + progress bar are enough */
 .branch-card.is-deploying.is-busy::after {
   display: none;
+}
+
+/* ════════════════ Pinned Commit State ════════════════ */
+
+.branch-card.is-pinned {
+  border: 2px solid rgba(251, 146, 60, 0.5);
+  box-shadow:
+    0 0 0 1px rgba(251, 146, 60, 0.15),
+    0 0 12px 1px rgba(251, 146, 60, 0.08),
+    0 2px 8px rgba(0,0,0,0.2);
+}
+.branch-card.is-pinned .branch-card-row2 {
+  background: rgba(251, 146, 60, 0.06);
+  border-radius: 4px;
+  padding: 2px 6px;
+  margin: -2px -6px;
+}
+.pinned-commit-badge {
+  display: inline-flex; align-items: center; gap: 3px;
+  font-size: 11px; font-family: var(--font-mono);
+  color: var(--yellow); background: rgba(251, 191, 36, 0.12);
+  padding: 1px 8px; border-radius: 10px;
+  cursor: pointer; flex-shrink: 0;
+  border: 1px solid rgba(251, 191, 36, 0.2);
+  transition: background var(--transition), border-color var(--transition);
+}
+.pinned-commit-badge:hover {
+  background: rgba(251, 191, 36, 0.2);
+  border-color: rgba(251, 191, 36, 0.4);
+}
+[data-theme="light"] .branch-card.is-pinned {
+  border-color: rgba(234, 118, 22, 0.5);
+  box-shadow:
+    0 0 0 1px rgba(234, 118, 22, 0.15),
+    0 0 12px 1px rgba(234, 118, 22, 0.06),
+    0 2px 8px rgba(0,0,0,0.08);
+}
+[data-theme="light"] .pinned-commit-badge {
+  color: #b45309; background: rgba(234, 118, 22, 0.1);
+  border-color: rgba(234, 118, 22, 0.25);
 }
 
 /* ════════════════ Toast ════════════════ */

--- a/cds/web/style.css
+++ b/cds/web/style.css
@@ -1627,6 +1627,35 @@ a.branch-name:hover { color: var(--accent); }
 /* Card deploying state */
 .branch-card.is-deploying {
   border-color: var(--accent-border);
+  animation: deploying-glow 2s ease-in-out infinite;
+}
+@keyframes deploying-glow {
+  0%, 100% {
+    box-shadow: 0 0 0 0 rgba(16, 185, 129, 0), 0 1px 3px rgba(0, 0, 0, 0.2);
+  }
+  50% {
+    box-shadow: 0 0 10px 1px rgba(16, 185, 129, 0.15), 0 0 20px 3px rgba(16, 185, 129, 0.06);
+  }
+}
+
+/* Hammer icon blink during deploy */
+.branch-card.is-deploying .deploy-hammer-icon {
+  animation: hammer-blink 1.2s ease-in-out infinite;
+}
+@keyframes hammer-blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+/* Deploy button glow during deploy */
+.branch-card.is-deploying .deploy-glow-btn {
+  box-shadow: 0 0 6px 1px rgba(16, 185, 129, 0.4), inset 0 0 4px rgba(16, 185, 129, 0.1);
+  border-color: var(--accent-border) !important;
+  animation: deploy-btn-glow 2s ease-in-out infinite;
+}
+@keyframes deploy-btn-glow {
+  0%, 100% { box-shadow: 0 0 4px 0px rgba(16, 185, 129, 0.2); }
+  50% { box-shadow: 0 0 10px 2px rgba(16, 185, 129, 0.45), inset 0 0 4px rgba(16, 185, 129, 0.1); }
 }
 
 

--- a/cds/web/style.css
+++ b/cds/web/style.css
@@ -1426,17 +1426,8 @@ a.branch-name:hover { color: var(--accent); }
   border-color: rgba(224, 180, 58, 0.25);
   position: relative;
 }
-.branch-card.is-busy::after {
-  content: ''; position: absolute; top: 12px; right: 14px;
-  width: 16px; height: 16px;
-  border: 2px solid rgba(224, 180, 58, 0.15);
-  border-top-color: var(--yellow); border-radius: 50%;
-  animation: spin 0.7s linear infinite;
-}
-/* During deploy, hide the busy spinner — hammer blink + progress bar are enough */
-.branch-card.is-deploying.is-busy::after {
-  display: none;
-}
+/* Busy spinner removed — it overlaps toolbar buttons (lightbulb/ai-mark).
+   Busy state is already indicated by the yellow border on .branch-card.is-busy. */
 
 /* ════════════════ Pinned Commit State ════════════════ */
 

--- a/cds/web/style.css
+++ b/cds/web/style.css
@@ -854,6 +854,16 @@ button.text-btn:hover { color: var(--accent); }
 @keyframes ai-icon-spin {
   to { transform: rotate(360deg); }
 }
+/* During deploy, AI spinner blinks instead of rotating */
+.branch-card.is-deploying .ai-mark-spinner {
+  animation: hammer-blink 1.2s ease-in-out infinite;
+}
+/* During deploy, AI card border stops spinning — use deploy glow instead */
+.branch-card.is-ai-occupied.is-deploying {
+  background-image: none;
+  border: 1px solid var(--accent-border);
+  animation: deploying-glow 2s ease-in-out infinite;
+}
 
 /* AI branch activity feed — single-line roller in card */
 .ai-branch-feed {

--- a/changelogs/2026-03-23_cds-animation-sync.md
+++ b/changelogs/2026-03-23_cds-animation-sync.md
@@ -1,0 +1,2 @@
+| fix | cds | 构建时锤子图标改为闪烁 + 按钮边缘发光，替代旋转动画 |
+| fix | cds | branch-card 支持 server-driven 构建状态动画，外部触发的部署也能联动 |


### PR DESCRIPTION
## Summary
This PR enhances the branch management UI with commit pinning capabilities, improved deploy state animations, better branch deletion feedback, and server-driven deployment status synchronization.

## Key Changes

### Commit Pinning & Checkout
- Added ability to pin branches to historical commits via new `/checkout/:hash` and `/unpin` endpoints
- Commit log now shows clickable items to switch between commits with visual indicators
- Pinned commits display a badge in the branch card with orange accent styling
- Deploying automatically unpins and restores to branch HEAD
- Added `pinnedCommit` field to `BranchEntry` type

### Deploy State Animations & Visual Feedback
- Replaced spinning busy indicator with deploy-specific animations:
  - Hammer icon blinks during deployment
  - Deploy button glows with pulsing box-shadow
  - Branch card has deploying-glow animation
- Added support for server-driven deployment states (`building`/`starting` from server)
- Deploy progress bar displays during active deployments
- Local and server-driven deployments both trigger visual feedback

### Branch Deletion UX
- Added `deleting` status state with faster pulse animation (0.8s vs 1.2s)
- Implemented collapse animation when branch is removed from DOM
- Immediate visual feedback when deletion is initiated
- Services show `stopping` status during deletion

### Activity & Display Improvements
- Added `branchTags` field to `ActivityEvent` for server-side tag resolution
- Branch labels in activity feed now prefer tags over ID segments
- Page title updates with branch tags for better tab identification
- Widget script displays branch tags instead of generic "CDS" label

### Status Label Expansion
- Added `deleting` status to the status label map (Chinese: '删除中')
- Added corresponding CSS styling for deleting state

### Code Quality
- Extracted `getBranchDisplayLabel()` helper to centralize branch label logic
- Improved commit log rendering with proper escaping and state tracking
- Better separation of local vs server-driven deployment indicators

## Implementation Details
- Commit checkout uses git detached HEAD state
- Unpin restores to either local branch or `origin/<branch>` if needed
- Deploy animations use CSS keyframes for smooth, performant effects
- Branch deletion uses `animationend` event for proper cleanup timing
- Server-side tag resolution prevents timing issues with early activity events

https://claude.ai/code/session_01UNMh27MsPU4dnxmGc7SBqd