### PR TITLE
Add image attachment support to chat messages

### DIFF
--- a/changelogs/2026-03-23_fix-chat-images-avatars.md
+++ b/changelogs/2026-03-23_fix-chat-images-avatars.md
@@ -1,0 +1,5 @@
+| fix | prd-api | 修复机器人头像不显示：AvatarUrlBuilder 使用 User 重载以正确解析 BotKind 默认头像 |
+| fix | prd-api | 修复用户发送消息时附件ID未保存到 Message 实体，导致图片丢失 |
+| fix | prd-api | MessageResponse 和 GroupMessageStreamMessageDto 新增 AttachmentIds 字段 |
+| fix | prd-desktop | 用户消息气泡支持渲染图片附件 |
+| fix | prd-desktop | 发送消息时保留本地附件信息，SSE 合并时不丢失 |

--- a/prd-api/src/PrdAgent.Api/Controllers/ChatRunsController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/ChatRunsController.cs
@@ -180,6 +180,7 @@ public class ChatRunsController : ControllerBase
                 Role = MessageRole.User,
                 Content = request.Content ?? "",
                 ViewRole = effectiveAnswerRole,
+                AttachmentIds = request.AttachmentIds ?? new List<string>(),
                 Timestamp = DateTime.UtcNow
             };
             await _messageRepository.InsertManyAsync(new[] { userMessage });
@@ -248,6 +249,7 @@ public class ChatRunsController : ControllerBase
                 Role = MessageRole.User,
                 Content = request.Content ?? "",
                 ViewRole = effectiveAnswerRole,
+                AttachmentIds = request.AttachmentIds ?? new List<string>(),
                 Timestamp = DateTime.UtcNow
             };
             await _messageRepository.InsertManyAsync(new[] { userMessage });

--- a/prd-api/src/PrdAgent.Api/Controllers/GroupsController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/GroupsController.cs
@@ -931,7 +931,7 @@ public class GroupsController : ControllerBase
             .Where(x => !string.IsNullOrWhiteSpace(x))
             .Distinct()
             .ToList();
-        var senderInfoMap = new Dictionary<string, (string Name, UserRole Role, string? AvatarFileName, List<GroupMemberTag>? Tags)>(StringComparer.Ordinal);
+        var senderInfoMap = new Dictionary<string, (string Name, UserRole Role, string? AvatarUrl, List<GroupMemberTag>? Tags)>(StringComparer.Ordinal);
         if (senderIds.Count > 0)
         {
             var users = await _db.Users
@@ -942,13 +942,13 @@ public class GroupsController : ControllerBase
                 var uid = u.UserId;
                 if (string.IsNullOrWhiteSpace(uid)) continue;
                 var name = (u.DisplayName ?? u.Username ?? uid).Trim();
-                var avatarFileName = u.AvatarFileName;
-                
+                var avatarUrl = AvatarUrlBuilder.Build(_cfg, u);
+
                 // 获取该用户在当前群组的 tags（机器人会有"机器人"标签）
                 var member = members.FirstOrDefault(m => m.UserId == uid);
                 var tags = member?.Tags;
-                
-                senderInfoMap[uid!] = (name, u.Role, avatarFileName, tags);
+
+                senderInfoMap[uid!] = (name, u.Role, avatarUrl, tags);
             }
         }
 
@@ -970,7 +970,7 @@ public class GroupsController : ControllerBase
             {
                 senderName = info.Name;
                 senderRole = info.Role;
-                senderAvatarUrl = AvatarUrlBuilder.Build(_cfg, info.AvatarFileName);
+                senderAvatarUrl = info.AvatarUrl;
                 senderTags = info.Tags;
             }
 
@@ -990,7 +990,8 @@ public class GroupsController : ControllerBase
             ResendOfMessageId = m.ResendOfMessageId,
             ViewRole = m.ViewRole,
             Timestamp = m.Timestamp,
-                TokenUsage = m.TokenUsage
+                TokenUsage = m.TokenUsage,
+                AttachmentIds = m.AttachmentIds != null && m.AttachmentIds.Count > 0 ? m.AttachmentIds : null
             };
         }).ToList();
 
@@ -1157,7 +1158,7 @@ public class GroupsController : ControllerBase
                     var uid = u.UserId;
                     if (string.IsNullOrWhiteSpace(uid)) continue;
                     var name = (u.DisplayName ?? u.Username ?? uid).Trim();
-                    var avatarUrl = AvatarUrlBuilder.Build(_cfg, u.AvatarFileName);
+                    var avatarUrl = AvatarUrlBuilder.Build(_cfg, u);
                     var member = batchMembers.FirstOrDefault(m => m.UserId == uid);
                     var tags = member?.Tags;
                     batchSenderInfoMap[uid!] = (name, u.Role, avatarUrl, tags);
@@ -1202,7 +1203,7 @@ public class GroupsController : ControllerBase
             if (u == null) return (null, null, null, null);
             
             var name = (u.DisplayName ?? u.Username ?? u.UserId ?? string.Empty).Trim();
-            var avatarUrl = AvatarUrlBuilder.Build(_cfg, u.AvatarFileName);
+            var avatarUrl = AvatarUrlBuilder.Build(_cfg, u);
             var member = groupMembersCache.FirstOrDefault(m => m.UserId == senderId);
             var tags = member?.Tags;
             
@@ -1362,7 +1363,8 @@ public class GroupsController : ControllerBase
                 ResendOfMessageId = m.ResendOfMessageId,
                 ViewRole = m.ViewRole,
                 Timestamp = m.Timestamp,
-                TokenUsage = m.TokenUsage
+                TokenUsage = m.TokenUsage,
+                AttachmentIds = m.AttachmentIds != null && m.AttachmentIds.Count > 0 ? m.AttachmentIds : null
             }
         };
     }

--- a/prd-api/src/PrdAgent.Api/Controllers/MessagesController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/MessagesController.cs
@@ -171,6 +171,7 @@ public class MessagesController : ControllerBase
                         Role = MessageRole.User,
                         Content = request.Content ?? "",
                         ViewRole = answerAsRole ?? session?.CurrentRole ?? UserRole.PM,
+                        AttachmentIds = request.AttachmentIds ?? new List<string>(),
                         Timestamp = DateTime.UtcNow
                     };
                     await _messageRepository.InsertManyAsync(new[] { userMessage });
@@ -491,7 +492,7 @@ public class MessagesController : ControllerBase
                 var uid = u.UserId;
                 if (string.IsNullOrWhiteSpace(uid)) continue;
                 var name = (u.DisplayName ?? u.Username ?? uid).Trim();
-                var avatarUrl = AvatarUrlBuilder.Build(_configuration, u.AvatarFileName);
+                var avatarUrl = AvatarUrlBuilder.Build(_configuration, u);
                 var member = members.FirstOrDefault(m => m.UserId == uid);
                 var tags = member?.Tags;
                 senderInfoMap[uid!] = (name, u.Role, avatarUrl, tags);
@@ -529,7 +530,8 @@ public class MessagesController : ControllerBase
                 ResendOfMessageId = m.ResendOfMessageId,
                 ViewRole = m.ViewRole,
                 Timestamp = m.Timestamp,
-                TokenUsage = m.TokenUsage
+                TokenUsage = m.TokenUsage,
+                AttachmentIds = m.AttachmentIds != null && m.AttachmentIds.Count > 0 ? m.AttachmentIds : null
             };
         }).ToList();
 
@@ -559,6 +561,7 @@ public class MessageResponse
     public UserRole? ViewRole { get; set; }
     public DateTime Timestamp { get; set; }
     public TokenUsage? TokenUsage { get; set; }
+    public List<string>? AttachmentIds { get; set; }
 }
 
 

--- a/prd-api/src/PrdAgent.Api/Models/Responses/GroupMessageStreamDtos.cs
+++ b/prd-api/src/PrdAgent.Api/Models/Responses/GroupMessageStreamDtos.cs
@@ -53,6 +53,7 @@ public class GroupMessageStreamMessageDto
     public UserRole? ViewRole { get; set; }
     public DateTime Timestamp { get; set; }
     public TokenUsage? TokenUsage { get; set; }
+    public List<string>? AttachmentIds { get; set; }
 }
 
 public class DocCitationDto

--- a/prd-desktop/src-tauri/src/models/mod.rs
+++ b/prd-desktop/src-tauri/src/models/mod.rs
@@ -204,6 +204,8 @@ pub struct MessageHistoryItem {
     pub view_role: Option<String>,
     pub timestamp: String,
     pub token_usage: Option<TokenUsage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attachment_ids: Option<Vec<String>>,
 }
 
 #[allow(dead_code)]

--- a/prd-desktop/src/components/Chat/ChatContainer.tsx
+++ b/prd-desktop/src/components/Chat/ChatContainer.tsx
@@ -253,6 +253,7 @@ function ChatContainerInner() {
         groupSeq: Number.isFinite(seq) && seq > 0 ? seq : undefined,
         replyToMessageId: m.replyToMessageId ? String(m.replyToMessageId) : undefined,
         resendOfMessageId: m.resendOfMessageId ? String(m.resendOfMessageId) : undefined,
+        attachmentIds: Array.isArray((m as any).attachmentIds) ? (m as any).attachmentIds : undefined,
       };
 
       // 处理 messageUpdated 事件（AI 流式输出完成）

--- a/prd-desktop/src/components/Chat/ChatInput.tsx
+++ b/prd-desktop/src/components/Chat/ChatInput.tsx
@@ -175,6 +175,9 @@ export default function ChatInput() {
   const handleSend = async () => {
     if (!content.trim() || !sessionId || isStreaming || isSubmitting || isDisconnected) return;
 
+    const currentAttachments = [...attachments];
+    const attachmentIds = currentAttachments.length ? currentAttachments.map((a) => a.attachmentId) : undefined;
+
     const userMessage: Message = {
       id: Date.now().toString(),
       role: 'User',
@@ -185,13 +188,13 @@ export default function ChatInput() {
       senderName: user?.displayName ?? undefined,
       senderRole: user?.role ?? undefined,
       senderAvatarUrl: user?.avatarUrl ?? undefined,
+      attachmentIds,
+      attachments: currentAttachments.length > 0 ? currentAttachments : undefined,
     };
 
     setIsSubmitting(true);
     addUserMessageWithPendingAssistant({ userMessage });
     setContent('');
-
-    const attachmentIds = attachments.length ? attachments.map((a) => a.attachmentId) : undefined;
     setAttachments([]);
 
     try {

--- a/prd-desktop/src/components/Chat/MessageList.tsx
+++ b/prd-desktop/src/components/Chat/MessageList.tsx
@@ -990,18 +990,37 @@ function MessageListInner() {
                 }`}
               >
               {message.role === 'User' ? (
-                <p
-                  className={`whitespace-pre-wrap ${isMine ? '' : 'text-text-primary'}`}
-                  style={{
-                    // 当输出 ASCII 表格（依赖空格对齐）时，必须用等宽字体，否则右侧会错乱
-                    fontFamily: 'var(--font-mono)',
-                    fontVariantLigatures: 'none',
-                    // 用户消息也跟随 Assistant 字体缩放设置
-                    ...assistantContentStyle,
-                  }}
-                >
-                  {message.content}
-                </p>
+                <div>
+                  {/* 附件图片 */}
+                  {message.attachments && message.attachments.length > 0 && (
+                    <div className={`flex flex-wrap gap-2 ${message.content ? 'mb-2' : ''}`}>
+                      {message.attachments
+                        .filter((att) => att.mimeType?.startsWith('image/'))
+                        .map((att) => (
+                          <img
+                            key={att.attachmentId}
+                            src={att.url}
+                            alt={att.fileName}
+                            className="max-w-[280px] max-h-[200px] rounded-lg object-contain cursor-pointer"
+                            onClick={() => window.open(att.url, '_blank')}
+                            draggable={false}
+                          />
+                        ))}
+                    </div>
+                  )}
+                  {message.content && (
+                    <p
+                      className={`whitespace-pre-wrap ${isMine ? '' : 'text-text-primary'}`}
+                      style={{
+                        fontFamily: 'var(--font-mono)',
+                        fontVariantLigatures: 'none',
+                        ...assistantContentStyle,
+                      }}
+                    >
+                      {message.content}
+                    </p>
+                  )}
+                </div>
               ) : (
                 <div>
             {/* 思考过程：有实际思考内容时用 ThinkingSection（可折叠），否则用加载动画 */}

--- a/prd-desktop/src/stores/messageStore.ts
+++ b/prd-desktop/src/stores/messageStore.ts
@@ -434,6 +434,7 @@ export const useMessageStore = create<MessageState>()((set, get) => ({
         senderRole: (m as any).senderRole ? ((m as any).senderRole as any) : undefined,
         senderAvatarUrl: (m as any).senderAvatarUrl ? String((m as any).senderAvatarUrl) : undefined,
         senderTags: Array.isArray((m as any).senderTags) ? (m as any).senderTags : undefined,
+        attachmentIds: Array.isArray((m as any).attachmentIds) ? (m as any).attachmentIds : undefined,
       }));
 
       const added = get().prependMessages(mapped);
@@ -488,6 +489,7 @@ export const useMessageStore = create<MessageState>()((set, get) => ({
         senderRole: (m as any).senderRole ? ((m as any).senderRole as any) : undefined,
         senderAvatarUrl: (m as any).senderAvatarUrl ? String((m as any).senderAvatarUrl) : undefined,
         senderTags: Array.isArray((m as any).senderTags) ? (m as any).senderTags : undefined,
+        attachmentIds: Array.isArray((m as any).attachmentIds) ? (m as any).attachmentIds : undefined,
       }));
 
       // 冷启动（本地无缓存）：直接设置
@@ -569,7 +571,10 @@ export const useMessageStore = create<MessageState>()((set, get) => ({
       if (idxFromEnd !== -1) {
         const idx = state.messages.length - 1 - idxFromEnd;
         const next = [...state.messages];
-        next[idx] = { ...next[idx], ...incoming };
+        const existing = next[idx];
+        // 保留本地附件信息（SSE 不携带完整附件详情时不覆盖）
+        const mergedAttachments = incoming.attachments ?? existing.attachments;
+        next[idx] = { ...existing, ...incoming, attachments: mergedAttachments };
         return { messages: maybeSortByGroupSeq(next), localMaxSeq: newMaxSeq, ...clearPending };
       }
     }
@@ -578,7 +583,9 @@ export const useMessageStore = create<MessageState>()((set, get) => ({
     const existingIdx = state.messages.findIndex((m) => m.id === incoming.id);
     if (existingIdx !== -1) {
       const next = [...state.messages];
-      next[existingIdx] = { ...next[existingIdx], ...incoming };
+      const existing = next[existingIdx];
+      const mergedAttachments = incoming.attachments ?? existing.attachments;
+      next[existingIdx] = { ...existing, ...incoming, attachments: mergedAttachments };
       return { messages: maybeSortByGroupSeq(next), localMaxSeq: newMaxSeq, ...clearPending };
     }
 

--- a/prd-desktop/src/types/index.ts
+++ b/prd-desktop/src/types/index.ts
@@ -96,6 +96,9 @@ export interface Message {
   senderRole?: UserRole;
   senderAvatarUrl?: string;  // 新增：发送者头像 URL
   senderTags?: GroupMemberTag[];  // 新增：发送者标签（如机器人标识）
+  // 附件信息（图片/文件）
+  attachmentIds?: string[];
+  attachments?: AttachmentInfo[];
 }
 
 export type MessageBlockKind = 'paragraph' | 'heading' | 'listItem' | 'codeBlock';


### PR DESCRIPTION
## Summary
This PR adds support for displaying image attachments in chat messages across the desktop and API layers. It fixes avatar display issues for bots and ensures attachment metadata is properly persisted and transmitted through the message pipeline.

## Key Changes

**Backend (prd-api)**
- Fixed bot avatar display by updating `AvatarUrlBuilder` calls to use the `User` object overload instead of just `AvatarFileName`, enabling proper BotKind default avatar resolution
- Added `AttachmentIds` field to `Message` entity when creating user messages in `MessagesController`, `ChatRunsController`, and `GroupsController`
- Extended `MessageResponse` and `GroupMessageStreamMessageDto` DTOs with `AttachmentIds` field to include attachment metadata in API responses
- Updated avatar URL building to happen at the data mapping layer rather than response serialization for consistency

**Frontend (prd-desktop)**
- Enhanced user message bubble in `MessageList` to render image attachments with preview thumbnails (max 280x200px, rounded corners, clickable to open in new tab)
- Added `attachmentIds` and `attachments` fields to `Message` type definition
- Updated `ChatInput` to include attachment IDs and attachment objects when creating user messages
- Improved message store merge logic to preserve local attachment information when SSE updates arrive without complete attachment details
- Updated `ChatContainer` to map `attachmentIds` from API responses

**Rust/Tauri**
- Added `attachment_ids` field to `MessageHistoryItem` struct with conditional serialization

## Implementation Details
- Attachments are displayed above message text content with proper spacing
- Image attachments are filtered by MIME type (`image/*`) before rendering
- Local attachment state is preserved during SSE message updates to prevent data loss when server responses don't include full attachment details
- Avatar URLs are now built consistently using the `AvatarUrlBuilder.Build(_cfg, user)` overload throughout the codebase

https://claude.ai/code/session_01QvxB8uM3ybaoXnPWwwrFMy