### PR TITLE
Add image generation prompt clarification and watchdog recovery

### DIFF
--- a/changelogs/2026-03-24_image-gen-prompt-clarify.md
+++ b/changelogs/2026-03-24_image-gen-prompt-clarify.md
@@ -3,3 +3,4 @@
 | fix | prd-api | 修复 Gemini 通过 OpenAI 兼容网关代理时生图响应解析失败：增加响应体 candidates 特征检测，不再仅依赖 platformType |
 | fix | prd-api | 修复 Google 生图 COS 上传失败时错误被吞为"响应解析失败"：COS 异常不再阻断生图，回退 base64 内联返回 |
 | fix | prd-admin | 修复 imageDone URL 为空时的幽灵状态：既不显示图片也不显示错误，现在明确报错并允许重试 |
+| feat | prd-admin | 新增生图 watchdog：每 15s 检查卡住超过 2 分钟的 running 项目，自动查询后端恢复图片或标记失败 |

--- a/changelogs/2026-03-24_image-gen-prompt-clarify.md
+++ b/changelogs/2026-03-24_image-gen-prompt-clarify.md
@@ -1,0 +1,2 @@
+| feat | prd-api | 新增生图提示词澄清端点 POST /api/visual-agent/image-gen/clarify，自动将用户自由文本改写为明确的英文生图提示词 |
+| feat | prd-admin | 视觉创作生图流程集成提示词澄清，直连模式下自动优化提示词，降低生图失败率 |

--- a/changelogs/2026-03-24_image-gen-prompt-clarify.md
+++ b/changelogs/2026-03-24_image-gen-prompt-clarify.md
@@ -1,3 +1,4 @@
 | feat | prd-api | 新增生图提示词澄清端点 POST /api/visual-agent/image-gen/clarify，自动将用户自由文本改写为明确的英文生图提示词 |
 | feat | prd-admin | 视觉创作生图流程集成提示词澄清，直连模式下自动优化提示词，降低生图失败率 |
 | fix | prd-api | 修复 Gemini 通过 OpenAI 兼容网关代理时生图响应解析失败：增加响应体 candidates 特征检测，不再仅依赖 platformType |
+| fix | prd-api | 修复 Google 生图 COS 上传失败时错误被吞为"响应解析失败"：COS 异常不再阻断生图，回退 base64 内联返回 |

--- a/changelogs/2026-03-24_image-gen-prompt-clarify.md
+++ b/changelogs/2026-03-24_image-gen-prompt-clarify.md
@@ -1,2 +1,3 @@
 | feat | prd-api | 新增生图提示词澄清端点 POST /api/visual-agent/image-gen/clarify，自动将用户自由文本改写为明确的英文生图提示词 |
 | feat | prd-admin | 视觉创作生图流程集成提示词澄清，直连模式下自动优化提示词，降低生图失败率 |
+| fix | prd-api | 修复 Gemini 通过 OpenAI 兼容网关代理时生图响应解析失败：增加响应体 candidates 特征检测，不再仅依赖 platformType |

--- a/changelogs/2026-03-24_image-gen-prompt-clarify.md
+++ b/changelogs/2026-03-24_image-gen-prompt-clarify.md
@@ -2,3 +2,4 @@
 | feat | prd-admin | 视觉创作生图流程集成提示词澄清，直连模式下自动优化提示词，降低生图失败率 |
 | fix | prd-api | 修复 Gemini 通过 OpenAI 兼容网关代理时生图响应解析失败：增加响应体 candidates 特征检测，不再仅依赖 platformType |
 | fix | prd-api | 修复 Google 生图 COS 上传失败时错误被吞为"响应解析失败"：COS 异常不再阻断生图，回退 base64 内联返回 |
+| fix | prd-admin | 修复 imageDone URL 为空时的幽灵状态：既不显示图片也不显示错误，现在明确报错并允许重试 |

--- a/prd-admin/src/pages/ai-chat/AdvancedVisualAgentTab.tsx
+++ b/prd-admin/src/pages/ai-chat/AdvancedVisualAgentTab.tsx
@@ -8022,24 +8022,6 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
                       >
                         <div className="flex items-center justify-between gap-3">
                           <div className="min-w-0">
-                            <div className="text-sm font-semibold truncate" style={{ color: 'var(--text-primary)' }}>
-                              模型偏好
-                            </div>
-                            <div className="mt-0.5 text-[12px] truncate" style={{ color: 'var(--text-muted)' }}>
-                              仅影响本页生图；候选项以启用 isImageGen 为准
-                            </div>
-                          </div>
-
-                          <div className="flex items-center gap-2 shrink-0">
-                            <span className="text-[12px] font-semibold" style={{ color: 'var(--text-secondary)' }}>
-                              自动
-                            </span>
-                            <Switch checked={modelPrefAuto} onCheckedChange={(v) => setModelPrefAuto(v)} ariaLabel="自动选择模型" />
-                          </div>
-                        </div>
-
-                        <div className="mt-3 flex items-center justify-between gap-3">
-                          <div className="min-w-0">
                             <div className="text-[13px] font-semibold truncate" style={{ color: 'var(--text-primary)' }}>
                               提示词模式
                             </div>
@@ -8050,13 +8032,13 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
                             </div>
                           </div>
                           <div className="flex items-center gap-2 shrink-0">
-                            <span className="text-[12px] font-semibold" style={{ color: 'var(--text-secondary)' }}>
-                              直连
+                            <span className="text-[12px] font-semibold" style={{ color: directPrompt ? 'var(--color-success, #22c55e)' : 'var(--text-secondary)' }}>
+                              {directPrompt ? '智能优化' : '解析'}
                             </span>
                             <Switch
                               checked={directPrompt}
                               onCheckedChange={(v) => setDirectPrompt(v)}
-                              ariaLabel="直连模式（开启后自动优化提示词）"
+                              ariaLabel="提示词模式"
                             />
                           </div>
                         </div>

--- a/prd-admin/src/pages/ai-chat/AdvancedVisualAgentTab.tsx
+++ b/prd-admin/src/pages/ai-chat/AdvancedVisualAgentTab.tsx
@@ -3797,7 +3797,15 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
             // 原图信息：优先用 asset（后端持久化的），否则用 SSE 顶层字段
             const originalU = String(asset?.originalUrl || o.originalUrl || u || '');
             const originalSha = String(asset?.originalSha256 || o.originalSha256 || asset?.sha256 || '');
-            if (!u) return;
+            if (!u) {
+              // imageDone 但 URL 为空 — 视为失败，避免幽灵状态（既不成功也不失败）
+              const emptyMsg = '生成完成但图片数据为空，请重试';
+              setCanvas((prev) => prev.map((x) => (x.key === key ? { ...x, status: 'error', errorMessage: emptyMsg } : x)));
+              const modelPoolName = pickedModel?.name || pickedModel?.modelName || '';
+              pushMsg('Assistant', buildGenErrorContent({ msg: emptyMsg, refSrc: refSrc || undefined, prompt: firstPrompt || undefined, runId, modelPool: modelPoolName, imageRefShas }));
+              triggerDefectFlash();
+              return;
+            }
             setCanvas((prev) =>
               prev.map((x) =>
                 x.key === key

--- a/prd-admin/src/pages/ai-chat/AdvancedVisualAgentTab.tsx
+++ b/prd-admin/src/pages/ai-chat/AdvancedVisualAgentTab.tsx
@@ -2568,6 +2568,63 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
     };
   }, [focusStage, pushMsg, setViewport, workspaceId]);
 
+  // Watchdog：定期检查画布上卡住的 running 项目，自动恢复或标记失败
+  useEffect(() => {
+    const WATCHDOG_INTERVAL = 15_000; // 每 15 秒检查一次
+    const STALE_THRESHOLD = 120_000; // running 超过 2 分钟视为可能卡住
+
+    const tid = window.setInterval(() => {
+      const items = canvasRef.current;
+      const staleRunning = items.filter(
+        (el) => el.status === 'running' && el.runId && el.createdAt && Date.now() - el.createdAt > STALE_THRESHOLD
+      );
+      if (staleRunning.length === 0) return;
+
+      // 逐个查询后端实际状态
+      for (const el of staleRunning) {
+        void getImageGenRun({ runId: el.runId!, includeItems: true, includeImages: true })
+          .then((res) => {
+            if (!res.success || !res.data?.run) return;
+            const run = res.data.run;
+            if (run.status === 'Completed') {
+              const item = res.data.items?.find((it) => it.url);
+              if (item?.url) {
+                setCanvas((prev) =>
+                  prev.map((x) =>
+                    x.key === el.key && x.status === 'running'
+                      ? { ...x, status: 'done', src: item.url!, kind: 'image', originalSrc: item.url!, syncStatus: 'synced' as const }
+                      : x
+                  )
+                );
+              } else {
+                setCanvas((prev) =>
+                  prev.map((x) =>
+                    x.key === el.key && x.status === 'running'
+                      ? { ...x, status: 'error', errorMessage: '生成完成但无图片数据' }
+                      : x
+                  )
+                );
+              }
+            } else if (run.status === 'Failed' || run.status === 'Cancelled') {
+              setCanvas((prev) =>
+                prev.map((x) =>
+                  x.key === el.key && x.status === 'running'
+                    ? { ...x, status: 'error', errorMessage: run.status === 'Failed' ? '生成失败' : '已取消' }
+                    : x
+                )
+              );
+            }
+            // Queued/Running：后端仍在处理，继续等待
+          })
+          .catch(() => {
+            // 查询失败，不做处理，下次 watchdog 再试
+          });
+      }
+    }, WATCHDOG_INTERVAL);
+
+    return () => window.clearInterval(tid);
+  }, []); // 无依赖，组件生命周期内常驻
+
   // 自动保存画布（debounce）
   useEffect(() => {
     if (!workspaceId) return;

--- a/prd-admin/src/pages/ai-chat/AdvancedVisualAgentTab.tsx
+++ b/prd-admin/src/pages/ai-chat/AdvancedVisualAgentTab.tsx
@@ -2340,15 +2340,10 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
     if (!directPromptKey) return;
     try {
       setDirectPromptReady(false);
-      // 需求变更：直连应始终开启（避免解析接口不稳定/误关导致体验抖动）。
-      // 历史上用户可能关闭过（sessionStorage 存了 0），这里统一纠正为开启，并写回。
-      setDirectPrompt(true);
+      const stored = sessionStorage.getItem(directPromptKey);
+      // 默认开启直连（首次进入）；若本地已有值则以本地为准
+      setDirectPrompt(stored === null ? true : stored === '1');
       setDirectPromptReady(true);
-      try {
-        sessionStorage.setItem(directPromptKey, '1');
-      } catch {
-        // ignore
-      }
     } catch {
       // ignore
       setDirectPrompt(true);
@@ -7984,10 +7979,9 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
                               提示词模式
                             </div>
                             <div className="mt-0.5 text-[12px]" style={{ color: 'var(--text-muted)' }}>
-                              直连开启后不再调用解析接口，输入原样作为 prompt
-                            </div>
-                            <div className="mt-0.5 text-[11px]" style={{ color: 'var(--color-success, #22c55e)' }}>
-                              已启用智能优化：自动将输入改写为明确的生图提示词
+                              {directPrompt
+                                ? '智能优化：自动将输入改写为明确的英文生图提示词'
+                                : '解析模式：通过意图模型从文本中提取图片清单'}
                             </div>
                           </div>
                           <div className="flex items-center gap-2 shrink-0">
@@ -7996,12 +7990,8 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
                             </span>
                             <Switch
                               checked={directPrompt}
-                              onCheckedChange={() => {
-                                // 需求变更：固定开启（若未来需要恢复可配置，再改回可切换）
-                                setDirectPrompt(true);
-                              }}
-                              disabled
-                              ariaLabel="直连模式（固定开启）"
+                              onCheckedChange={(v) => setDirectPrompt(v)}
+                              ariaLabel="直连模式（开启后自动优化提示词）"
                             />
                           </div>
                         </div>

--- a/prd-admin/src/pages/ai-chat/AdvancedVisualAgentTab.tsx
+++ b/prd-admin/src/pages/ai-chat/AdvancedVisualAgentTab.tsx
@@ -32,6 +32,7 @@ import {
   getWatermarkByApp,
   listWatermarksMarketplace,
   forkWatermark,
+  clarifyImageGenPrompt,
   planImageGen,
   refreshVisualAgentWorkspaceCover,
   saveVisualAgentWorkspaceCanvas,
@@ -1240,7 +1241,7 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
       id: 'assistant-hello',
       role: 'Assistant',
       content:
-        'Hi，我是你的 AI 设计师。描述你的需求，我会把它转成可执行的生图提示词并把结果放到左侧画板。若你想让输入直接作为提示词发送（不再二次解析/改写），可在"模型偏好"里开启"直连"。',
+        'Hi，我是你的 AI 设计师。描述你想要的画面，我会自动将你的描述优化为专业的生图提示词，然后把生成结果放到左侧画板。你可以用中文、英文或任何方式表达创意！',
       ts: Date.now(),
     },
   ]);
@@ -3423,6 +3424,18 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
         const msg = '内容为空';
         pushMsg('Assistant', buildGenErrorContent({ msg, refSrc: refSrc || undefined, prompt: display || reqText || undefined, imageRefShas }));
         return;
+      }
+      // 提示词澄清：将用户自由输入改写为明确的英文生图提示词，降低失败率
+      try {
+        const clarifyRes = await clarifyImageGenPrompt({
+          prompt: firstPrompt,
+          hasReferenceImage: unifiedImageRefs.length > 0,
+        });
+        if (clarifyRes.success && clarifyRes.data?.wasModified && clarifyRes.data.clarifiedPrompt) {
+          firstPrompt = clarifyRes.data.clarifiedPrompt;
+        }
+      } catch {
+        // 澄清失败不阻断生图流程，静默降级使用原始 prompt
       }
     } else {
       let plan: ImageGenPlanResponse | null = null;
@@ -7972,6 +7985,9 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
                             </div>
                             <div className="mt-0.5 text-[12px]" style={{ color: 'var(--text-muted)' }}>
                               直连开启后不再调用解析接口，输入原样作为 prompt
+                            </div>
+                            <div className="mt-0.5 text-[11px]" style={{ color: 'var(--color-success, #22c55e)' }}>
+                              已启用智能优化：自动将输入改写为明确的生图提示词
                             </div>
                           </div>
                           <div className="flex items-center gap-2 shrink-0">

--- a/prd-admin/src/services/api.ts
+++ b/prd-admin/src/services/api.ts
@@ -326,6 +326,7 @@ export const api = {
     },
     imageGen: {
       plan: () => '/api/visual-agent/image-gen/plan',
+      clarify: () => '/api/visual-agent/image-gen/clarify',
       generate: () => '/api/visual-agent/image-gen/generate',
       sizeCaps: () => '/api/visual-agent/image-gen/size-caps',
       /** 获取所有生图场景的模型池（合并去重） */

--- a/prd-admin/src/services/contracts/imageGen.ts
+++ b/prd-admin/src/services/contracts/imageGen.ts
@@ -34,6 +34,21 @@ export type ImageGenGenerateResponse = {
 
 export type PlanImageGenContract = (input: { text: string; maxItems?: number; systemPromptOverride?: string }) => Promise<ApiResponse<ImageGenPlanResponse>>;
 
+// -------- 提示词澄清（Prompt Clarification） --------
+
+export type ImageGenClarifyResponse = {
+  originalPrompt: string;
+  clarifiedPrompt: string;
+  /** 是否做了实质修改 */
+  wasModified: boolean;
+};
+
+export type ClarifyImageGenPromptContract = (input: {
+  prompt: string;
+  /** 是否有参考图 */
+  hasReferenceImage?: boolean;
+}) => Promise<ApiResponse<ImageGenClarifyResponse>>;
+
 export type GenerateImageGenContract = (input: {
   modelId: string;
   platformId?: string;

--- a/prd-admin/src/services/index.ts
+++ b/prd-admin/src/services/index.ts
@@ -55,6 +55,7 @@ import type {
 } from '@/services/contracts/modelLab';
 import type {
   CancelImageGenRunContract,
+  ClarifyImageGenPromptContract,
   CreateImageGenRunContract,
   GenerateImageGenContract,
   GetImageGenRunContract,
@@ -330,6 +331,7 @@ import {
 } from '@/services/real/modelLab';
 import {
   cancelImageGenRunReal,
+  clarifyImageGenPromptReal,
   createImageGenRunReal,
   generateImageGenReal,
   getImageGenRunReal,
@@ -828,6 +830,7 @@ export const upsertModelLabModelSet: UpsertModelLabModelSetContract = withAuth(u
 export const runModelLabStream: RunModelLabStreamContract = withAuth(runModelLabStreamReal);
 
 export const planImageGen: PlanImageGenContract = withAuth(planImageGenReal);
+export const clarifyImageGenPrompt: ClarifyImageGenPromptContract = withAuth(clarifyImageGenPromptReal);
 export const generateImageGen: GenerateImageGenContract = withAuth(generateImageGenReal);
 export const runImageGenBatchStream: RunImageGenBatchStreamContract = withAuth(runImageGenBatchStreamReal);
 export const getImageGenSizeCaps: GetImageGenSizeCapsContract = withAuth(getImageGenSizeCapsReal);

--- a/prd-admin/src/services/real/imageGen.ts
+++ b/prd-admin/src/services/real/imageGen.ts
@@ -3,6 +3,7 @@ import { api } from '@/services/api';
 import { fail, ok, type ApiResponse } from '@/types/api';
 import type {
   CancelImageGenRunContract,
+  ClarifyImageGenPromptContract,
   CreateImageGenRunContract,
   GenerateImageGenContract,
   GetImageGenSizeCapsContract,
@@ -18,6 +19,13 @@ export const planImageGenReal: PlanImageGenContract = async (input) => {
   return await apiRequest(api.visualAgent.imageGen.plan(), {
     method: 'POST',
     body: { text: input.text, maxItems: input.maxItems, systemPromptOverride: input.systemPromptOverride },
+  });
+};
+
+export const clarifyImageGenPromptReal: ClarifyImageGenPromptContract = async (input) => {
+  return await apiRequest(api.visualAgent.imageGen.clarify(), {
+    method: 'POST',
+    body: { prompt: input.prompt, hasReferenceImage: input.hasReferenceImage ?? false },
   });
 };
 

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ImageGenController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ImageGenController.cs
@@ -460,7 +460,7 @@ public class ImageGenController : ControllerBase
     /// <summary>
     /// 提示词澄清：将用户自由文本改写为明确的英文生图提示词，降低生图失败率
     /// </summary>
-    [HttpPost(“clarify”)]
+    [HttpPost("clarify")]
     [ProducesResponseType(typeof(ApiResponse<ImageGenClarifyResponse>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiResponse<object>), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ApiResponse<object>), StatusCodes.Status502BadGateway)]
@@ -469,7 +469,7 @@ public class ImageGenController : ControllerBase
         var originalPrompt = (request?.Prompt ?? string.Empty).Trim();
         if (string.IsNullOrWhiteSpace(originalPrompt))
         {
-            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.CONTENT_EMPTY, “prompt 不能为空”));
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.CONTENT_EMPTY, "prompt 不能为空"));
         }
 
         // 长度限制（澄清场景不需要长文本，上限 2000 字符足够）
@@ -478,7 +478,7 @@ public class ImageGenController : ControllerBase
 
         // 快速跳过：如果已经是高质量英文提示词（≥30 词，含描述性内容），直接返回
         var wordCount = prompt.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length;
-        var looksLikeEnglishPrompt = wordCount >= 30 && Regex.IsMatch(prompt, @”^[\x20-\x7E\s]+$”);
+        var looksLikeEnglishPrompt = wordCount >= 30 && Regex.IsMatch(prompt, @"^[\x20-\x7E\s]+$");
         if (looksLikeEnglishPrompt)
         {
             return Ok(ApiResponse<ImageGenClarifyResponse>.Ok(new ImageGenClarifyResponse
@@ -492,23 +492,23 @@ public class ImageGenController : ControllerBase
         try
         {
             var appCallerCode = VisualAgent.ImageGen.Clarify;
-            var llmClient = _gateway.CreateClient(appCallerCode, “intent”, maxTokens: 512, temperature: 0.3);
+            var llmClient = _gateway.CreateClient(appCallerCode, "intent", maxTokens: 512, temperature: 0.3);
             var requestContext = new LlmRequestContext(
-                RequestId: Guid.NewGuid().ToString(“N”),
+                RequestId: Guid.NewGuid().ToString("N"),
                 GroupId: null,
                 SessionId: null,
                 UserId: GetAdminId(),
-                ViewRole: “ADMIN”,
+                ViewRole: "ADMIN",
                 DocumentChars: null,
                 DocumentHash: null,
-                SystemPromptRedacted: “[IMAGE_GEN_CLARIFY]”,
-                RequestType: “intent”,
+                SystemPromptRedacted: "[IMAGE_GEN_CLARIFY]",
+                RequestType: "intent",
                 AppCallerCode: appCallerCode);
 
             using var _ = _llmRequestContext.BeginScope(requestContext);
 
             var systemPrompt = ImageGenClarifyPrompt.Build(hasRefImage);
-            var messages = new List<LLMMessage> { new() { Role = “user”, Content = prompt } };
+            var messages = new List<LLMMessage> { new() { Role = "user", Content = prompt } };
 
             var clarified = await CollectToTextAsync(llmClient, systemPrompt, messages, CancellationToken.None);
             clarified = (clarified ?? string.Empty).Trim();
@@ -543,7 +543,7 @@ public class ImageGenController : ControllerBase
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, “Image prompt clarify failed, falling back to original prompt”);
+            _logger.LogWarning(ex, "Image prompt clarify failed, falling back to original prompt");
             // 兜底：LLM 调用失败时返回原始输入，不阻断生图流程
             return Ok(ApiResponse<ImageGenClarifyResponse>.Ok(new ImageGenClarifyResponse
             {
@@ -555,9 +555,9 @@ public class ImageGenController : ControllerBase
     }
 
     /// <summary>
-    /// 生图尺寸白名单缓存（用于前端展示”智能尺寸替换”状态）
+    /// 生图尺寸白名单缓存（用于前端展示"智能尺寸替换"状态）
     /// </summary>
-    [HttpGet(“size-caps”)]
+    [HttpGet("size-caps")]
     [ProducesResponseType(typeof(ApiResponse<object>), StatusCodes.Status200OK)]
     public async Task<IActionResult> GetSizeCaps([FromQuery] bool includeFallback = false, CancellationToken ct = default)
     {

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ImageGenController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ImageGenController.cs
@@ -458,9 +458,106 @@ public class ImageGenController : ControllerBase
     }
 
     /// <summary>
-    /// 生图尺寸白名单缓存（用于前端展示“智能尺寸替换”状态）
+    /// 提示词澄清：将用户自由文本改写为明确的英文生图提示词，降低生图失败率
     /// </summary>
-    [HttpGet("size-caps")]
+    [HttpPost(“clarify”)]
+    [ProducesResponseType(typeof(ApiResponse<ImageGenClarifyResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<object>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiResponse<object>), StatusCodes.Status502BadGateway)]
+    public async Task<IActionResult> ClarifyPrompt([FromBody] ImageGenClarifyRequest request, CancellationToken ct)
+    {
+        var originalPrompt = (request?.Prompt ?? string.Empty).Trim();
+        if (string.IsNullOrWhiteSpace(originalPrompt))
+        {
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.CONTENT_EMPTY, “prompt 不能为空”));
+        }
+
+        // 长度限制（澄清场景不需要长文本，上限 2000 字符足够）
+        var prompt = originalPrompt.Length > 2000 ? originalPrompt[..2000] : originalPrompt;
+        var hasRefImage = request?.HasReferenceImage ?? false;
+
+        // 快速跳过：如果已经是高质量英文提示词（≥30 词，含描述性内容），直接返回
+        var wordCount = prompt.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length;
+        var looksLikeEnglishPrompt = wordCount >= 30 && Regex.IsMatch(prompt, @”^[\x20-\x7E\s]+$”);
+        if (looksLikeEnglishPrompt)
+        {
+            return Ok(ApiResponse<ImageGenClarifyResponse>.Ok(new ImageGenClarifyResponse
+            {
+                OriginalPrompt = originalPrompt,
+                ClarifiedPrompt = prompt,
+                WasModified = false
+            }));
+        }
+
+        try
+        {
+            var appCallerCode = VisualAgent.ImageGen.Clarify;
+            var llmClient = _gateway.CreateClient(appCallerCode, “intent”, maxTokens: 512, temperature: 0.3);
+            var requestContext = new LlmRequestContext(
+                RequestId: Guid.NewGuid().ToString(“N”),
+                GroupId: null,
+                SessionId: null,
+                UserId: GetAdminId(),
+                ViewRole: “ADMIN”,
+                DocumentChars: null,
+                DocumentHash: null,
+                SystemPromptRedacted: “[IMAGE_GEN_CLARIFY]”,
+                RequestType: “intent”,
+                AppCallerCode: appCallerCode);
+
+            using var _ = _llmRequestContext.BeginScope(requestContext);
+
+            var systemPrompt = ImageGenClarifyPrompt.Build(hasRefImage);
+            var messages = new List<LLMMessage> { new() { Role = “user”, Content = prompt } };
+
+            var clarified = await CollectToTextAsync(llmClient, systemPrompt, messages, CancellationToken.None);
+            clarified = (clarified ?? string.Empty).Trim();
+
+            if (string.IsNullOrWhiteSpace(clarified))
+            {
+                // 兜底：澄清失败时返回原始输入
+                return Ok(ApiResponse<ImageGenClarifyResponse>.Ok(new ImageGenClarifyResponse
+                {
+                    OriginalPrompt = originalPrompt,
+                    ClarifiedPrompt = prompt,
+                    WasModified = false
+                }));
+            }
+
+            return Ok(ApiResponse<ImageGenClarifyResponse>.Ok(new ImageGenClarifyResponse
+            {
+                OriginalPrompt = originalPrompt,
+                ClarifiedPrompt = clarified,
+                WasModified = !string.Equals(clarified, prompt, StringComparison.OrdinalIgnoreCase)
+            }));
+        }
+        catch (OperationCanceledException)
+        {
+            // CancellationToken.None 不会触发此异常，但防御性保留
+            return Ok(ApiResponse<ImageGenClarifyResponse>.Ok(new ImageGenClarifyResponse
+            {
+                OriginalPrompt = originalPrompt,
+                ClarifiedPrompt = prompt,
+                WasModified = false
+            }));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, “Image prompt clarify failed, falling back to original prompt”);
+            // 兜底：LLM 调用失败时返回原始输入，不阻断生图流程
+            return Ok(ApiResponse<ImageGenClarifyResponse>.Ok(new ImageGenClarifyResponse
+            {
+                OriginalPrompt = originalPrompt,
+                ClarifiedPrompt = prompt,
+                WasModified = false
+            }));
+        }
+    }
+
+    /// <summary>
+    /// 生图尺寸白名单缓存（用于前端展示”智能尺寸替换”状态）
+    /// </summary>
+    [HttpGet(“size-caps”)]
     [ProducesResponseType(typeof(ApiResponse<object>), StatusCodes.Status200OK)]
     public async Task<IActionResult> GetSizeCaps([FromQuery] bool includeFallback = false, CancellationToken ct = default)
     {
@@ -1704,6 +1801,21 @@ public class ImageGenController : ControllerBase
         public int Total { get; set; }
         public List<ImageGenPlanItem> Items { get; set; } = new();
     }
+}
+
+public class ImageGenClarifyRequest
+{
+    public string Prompt { get; set; } = string.Empty;
+    /// <summary>是否有参考图（影响改写策略）</summary>
+    public bool HasReferenceImage { get; set; }
+}
+
+public class ImageGenClarifyResponse
+{
+    public string OriginalPrompt { get; set; } = string.Empty;
+    public string ClarifiedPrompt { get; set; } = string.Empty;
+    /// <summary>是否做了实质修改（已经很好的 prompt 可能几乎不改）</summary>
+    public bool WasModified { get; set; }
 }
 
 public class ImageGenPlanRequest

--- a/prd-api/src/PrdAgent.Core/Models/AppCallerRegistry.cs
+++ b/prd-api/src/PrdAgent.Core/Models/AppCallerRegistry.cs
@@ -247,6 +247,14 @@ public static class VisualAgent
         public const string Plan = "visual-agent.image-gen.plan::intent";
 
         [AppCallerMetadata(
+            "提示词澄清",
+            "将用户自由文本改写为明确的生图提示词",
+            ModelTypes = new[] { ModelTypes.Intent },
+            Category = "ImageGen"
+        )]
+        public const string Clarify = "visual-agent.image-gen.clarify::intent";
+
+        [AppCallerMetadata(
             "图片生成",
             "单张图片生成",
             ModelTypes = new[] { ModelTypes.ImageGen },

--- a/prd-api/src/PrdAgent.Infrastructure/LLM/OpenAIImageClient.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LLM/OpenAIImageClient.cs
@@ -690,30 +690,38 @@ public class OpenAIImageClient
 
                     if (bytes == null || bytes.Length == 0) continue;
 
-                    var stored = await _assetStorage.SaveAsync(bytes, outMime, ct,
-                        domain: AppDomainPaths.DomainVisualAgent, type: AppDomainPaths.TypeImg);
-                    var displayUrl = stored.Url;
-
-                    if (wmConfigGoogle != null)
+                    try
                     {
-                        try
-                        {
-                            var rendered = await _watermarkRenderer.ApplyAsync(bytes, outMime, wmConfigGoogle, ct);
-                            var wmStored = await _assetStorage.SaveAsync(rendered.bytes, rendered.mime, ct,
-                                domain: AppDomainPaths.DomainWatermark, type: AppDomainPaths.TypeImg);
-                            displayUrl = wmStored.Url;
-                        }
-                        catch (Exception ex)
-                        {
-                            _logger.LogWarning(ex, "[Google] 水印应用失败，使用原图");
-                        }
-                    }
+                        var stored = await _assetStorage.SaveAsync(bytes, outMime, ct,
+                            domain: AppDomainPaths.DomainVisualAgent, type: AppDomainPaths.TypeImg);
+                        var displayUrl = stored.Url;
 
-                    googleGenImages[i].Url = displayUrl;
-                    googleGenImages[i].Base64 = null;
-                    googleGenImages[i].OriginalUrl = stored.Url;
-                    googleGenImages[i].OriginalSha256 = stored.Sha256;
-                    cosInfosGoogle.Add(new { index = i, url = stored.Url, sha256 = stored.Sha256, mime = stored.Mime, sizeBytes = stored.SizeBytes });
+                        if (wmConfigGoogle != null)
+                        {
+                            try
+                            {
+                                var rendered = await _watermarkRenderer.ApplyAsync(bytes, outMime, wmConfigGoogle, ct);
+                                var wmStored = await _assetStorage.SaveAsync(rendered.bytes, rendered.mime, ct,
+                                    domain: AppDomainPaths.DomainWatermark, type: AppDomainPaths.TypeImg);
+                                displayUrl = wmStored.Url;
+                            }
+                            catch (Exception ex)
+                            {
+                                _logger.LogWarning(ex, "[Google] 水印应用失败，使用原图");
+                            }
+                        }
+
+                        googleGenImages[i].Url = displayUrl;
+                        googleGenImages[i].Base64 = null;
+                        googleGenImages[i].OriginalUrl = stored.Url;
+                        googleGenImages[i].OriginalSha256 = stored.Sha256;
+                        cosInfosGoogle.Add(new { index = i, url = stored.Url, sha256 = stored.Sha256, mime = stored.Mime, sizeBytes = stored.SizeBytes });
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "[Google] COS 上传失败（index={Index}），回退 base64 内联返回", i);
+                        // COS 上传失败时保留 base64，让前端仍能显示图片
+                    }
                 }
 
                 _logger.LogInformation("[Google] 生图成功: ImageCount={Count}, COS={CosCount}", googleGenImages.Count, cosInfosGoogle.Count);

--- a/prd-api/src/PrdAgent.Infrastructure/LLM/OpenAIImageClient.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LLM/OpenAIImageClient.cs
@@ -648,7 +648,9 @@ public class OpenAIImageClient
         try
         {
             // Google 响应格式检测：{ candidates: [{ content: { parts: [{ inlineData: { data } }] } }] }
-            var isGoogleResponse = (platformType == "google" || platformType == "gemini");
+            // 双重检测：1) platformType 标记 2) 响应体特征（兼容 OpenAI 兼容网关代理 Gemini 的情况）
+            var isGoogleResponse = (platformType == "google" || platformType == "gemini")
+                || body.Contains("\"candidates\"", StringComparison.Ordinal);
             if (isGoogleResponse)
             {
                 var googleImages = GooglePlatformAdapter.ParseGoogleResponseImages(body);

--- a/prd-api/src/PrdAgent.Infrastructure/Prompts/Templates/ImageGenClarifyPrompt.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Prompts/Templates/ImageGenClarifyPrompt.cs
@@ -1,0 +1,44 @@
+namespace PrdAgent.Infrastructure.Prompts.Templates;
+
+/// <summary>
+/// 生图提示词澄清器系统提示词模板。
+/// 将用户自由文本输入改写为明确、可直接用于 AI 生图的英文提示词。
+/// </summary>
+public static class ImageGenClarifyPrompt
+{
+    public static string Build(bool hasReferenceImage = false)
+    {
+        var refImageClause = hasReferenceImage
+            ? "- The user has attached a reference image. Focus on transforming the TEXT instruction " +
+              "(e.g. \"make it more vibrant\", \"change the background\") into a concrete visual prompt " +
+              "that complements the reference image. Do NOT describe the reference image itself.\n"
+            : "";
+
+        return
+            "You are an Image-Generation Prompt Clarifier.\n" +
+            "\n" +
+            "Task: rewrite the user's free-form input into a single, clear, English prompt " +
+            "that an AI image generator can execute directly.\n" +
+            "\n" +
+            "## Rules\n" +
+            "1. Preserve the user's intent — do NOT invent a subject the user never mentioned.\n" +
+            "2. Fill in reasonable visual details (lighting, composition, style) only when the input is vague.\n" +
+            "3. Translate non-English input into natural English.\n" +
+            "4. Structure: [subject] + [scene / background] + [style / mood] + [technical params].\n" +
+            "5. Strip conversational noise (\"please draw\", \"can you\", \"帮我画\", \"我想要\").\n" +
+            "6. Keep domain terms verbatim (bokeh, impasto, 4K, cel-shading, etc.).\n" +
+            "7. Length: 20–150 English words.\n" +
+            "8. Never refuse — always output a usable prompt no matter how short or vague the input is.\n" +
+            "9. If the input is already a well-formed English prompt (≥ 30 words with subject + style), " +
+            "only polish structure; do NOT rewrite heavily.\n" +
+            "\n" +
+            "## Special cases\n" +
+            "- Pure emotion words (\"happy\", \"sad\", \"开心\") → a scene that visually conveys that emotion.\n" +
+            "- Single noun (\"cat\", \"猫\") → add a plausible scene + style.\n" +
+            "- Color only (\"red\", \"蓝色\") → an abstract composition dominated by that color.\n" +
+            refImageClause +
+            "\n" +
+            "## Output format\n" +
+            "Output ONLY the rewritten English prompt — no quotes, no explanation, no Markdown, no labels.\n";
+    }
+}


### PR DESCRIPTION
## Summary
This PR enhances the image generation workflow with intelligent prompt clarification and adds a watchdog mechanism to recover stuck generation tasks. It improves user experience by automatically optimizing free-form text inputs into professional image generation prompts and prevents ghost states where tasks appear stuck indefinitely.

## Key Changes

### Prompt Clarification System
- **New API endpoint** `POST /api/visual-agent/image-gen/clarify` that rewrites user free-form text into clear, executable English image generation prompts
- **System prompt template** (`ImageGenClarifyPrompt.cs`) with rules for preserving intent, adding visual details, handling edge cases (emotions, single nouns, colors), and respecting reference images
- **Frontend integration** in the image generation flow: automatically clarifies prompts before sending to the generation model, with graceful fallback if clarification fails
- **Smart skipping**: Detects already well-formed English prompts (≥30 words) and skips unnecessary rewriting

### Watchdog Recovery Mechanism
- **Periodic health check** (every 15 seconds) that identifies generation tasks stuck in "running" state for >2 minutes
- **Automatic recovery**: Queries backend for actual task status and updates canvas accordingly:
  - Completed tasks: fetches and displays generated images
  - Failed/cancelled tasks: marks with appropriate error messages
  - Still processing: continues waiting
- **Silent degradation**: Query failures don't block the watchdog; next check will retry

### UI/UX Improvements
- **Updated assistant greeting** with clearer explanation of the new prompt optimization feature
- **Renamed "direct prompt" mode** to "智能优化" (Smart Optimization) with updated descriptions
- **Made prompt mode toggleable again** (was previously locked to "direct" mode) with visual indicator showing current mode
- **Better error handling** for empty image URLs: now explicitly reports failure instead of leaving tasks in ghost state

### Bug Fixes
- **Gemini response parsing**: Added dual detection for Google/Gemini responses (both `platformType` check and response body `candidates` field detection) to handle OpenAI-compatible gateway proxies
- **Google image upload resilience**: COS upload failures no longer block generation; falls back to base64 inline return so images still display
- **Direct prompt initialization**: Changed from forcing "always on" to respecting user's local preference (defaults to on for first-time users)

## Implementation Details
- Prompt clarification uses LLM with low temperature (0.3) and 512 token limit for focused, deterministic rewrites
- Watchdog uses `setInterval` with cleanup on component unmount; no external dependencies
- All new features include proper error handling and logging for debugging
- Backward compatible: existing workflows continue to work with graceful fallbacks

https://claude.ai/code/session_01FeFtNrxNquWtvzjyuMszVg