### PR TITLE
fix: resolve TypeScript build errors in prd-admin

### DIFF
--- a/changelogs/2026-03-24_fix-typescript-errors.md
+++ b/changelogs/2026-03-24_fix-typescript-errors.md
@@ -1,0 +1,1 @@
+| fix | prd-admin | 修复 VideoLoader 未使用变量、toast 缺少 loading/dismiss 方法、SuggestedQuestions 图标类型不兼容等 TypeScript 编译错误 |

--- a/prd-admin/src/components/ui/VideoLoader.tsx
+++ b/prd-admin/src/components/ui/VideoLoader.tsx
@@ -9,8 +9,6 @@ const VIDEO_CDN_DOMAIN = 'https://i.pa.759800.com';
 const VIDEO_PATH = '/icon/title/home.mp4';
 const VIDEO_SRC = `${VIDEO_CDN_DOMAIN}${VIDEO_PATH}`;
 
-/** 视频至少显示的时间（ms），避免闪烁 */
-const MIN_DISPLAY_MS = 600;
 
 export function VideoLoader({ className }: { className?: string }) {
   const videoRef = useRef<HTMLVideoElement>(null);

--- a/prd-admin/src/lib/toast.tsx
+++ b/prd-admin/src/lib/toast.tsx
@@ -77,4 +77,19 @@ export const toast = {
       duration,
     });
   },
+
+  /** 显示持续加载提示，返回 toastId 用于后续 dismiss */
+  loading: (title: string, message?: string): string => {
+    const id = `toast-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+    const store = useToastStore.getState();
+    store.addToast({ type: 'info' as ToastType, title, message, duration: 60_000 });
+    // addToast 内部生成 id，这里用最新添加的 toast id
+    const toasts = useToastStore.getState().toasts;
+    return toasts[toasts.length - 1]?.id ?? id;
+  },
+
+  /** 移除指定 toast */
+  dismiss: (id: string) => {
+    useToastStore.getState().removeToast(id);
+  },
 };

--- a/prd-admin/src/pages/ai-chat/components/SuggestedQuestions.tsx
+++ b/prd-admin/src/pages/ai-chat/components/SuggestedQuestions.tsx
@@ -2,7 +2,7 @@ import { memo } from 'react';
 import { MessageCircle, FileText, Wrench, ChevronRight } from 'lucide-react';
 import type { AiChatSuggestedQuestion } from '@/services/contracts/aiChat';
 
-const ICON_MAP: Record<string, React.ComponentType<{ size?: number; className?: string }>> = {
+const ICON_MAP: Record<string, React.ComponentType<{ size?: number | string; className?: string }>> = {
   chat: MessageCircle,
   doc: FileText,
   tool: Wrench,


### PR DESCRIPTION
## Summary
- Remove unused `MIN_DISPLAY_MS` constant in `VideoLoader.tsx` (TS6133)
- Add `loading()` and `dismiss()` methods to toast API, used by `AiChatPage.tsx` file detection flow (TS2339)
- Widen `ICON_MAP` type in `SuggestedQuestions.tsx` to accept lucide-react's `size` prop type (`number | string`) (TS2322)

## Test plan
- [ ] Run `pnpm tsc` in prd-admin — no code errors
- [ ] Verify file format detection toast works in AI chat attachment upload
- [ ] Verify suggested questions render correctly with icons

https://claude.ai/code/session_01RLj1AecZ7S6kPRBZwi5rCU