### PR TITLE
fix: remove env var masking in CDS env editor

### DIFF
--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -1225,7 +1225,7 @@ export function createBranchRouter(deps: RouterDeps): Router {
   // ── Custom environment variables ──
 
   router.get('/env', (_req, res) => {
-    res.json({ env: maskSecrets(stateService.getCustomEnv()) });
+    res.json({ env: stateService.getCustomEnv() });
   });
 
   // Helper: sync CDS-relevant env vars into runtime config
@@ -1251,7 +1251,7 @@ export function createBranchRouter(deps: RouterDeps): Router {
     stateService.setCustomEnv(env);
     stateService.save();
     syncCdsConfig();
-    res.json({ message: '环境变量已更新', env: maskSecrets(env) });
+    res.json({ message: '环境变量已更新', env });
   });
 
   router.put('/env/:key', (req, res) => {

--- a/cds/web/app.js
+++ b/cds/web/app.js
@@ -2224,7 +2224,6 @@ async function loadEnvVars() {
 }
 
 function maskValue(key, val) {
-  if (/password|secret|key/i.test(key)) return '••••••••';
   return val;
 }
 
@@ -2284,7 +2283,6 @@ function openEnvModal() {
   const html = `
     <p class="config-panel-desc">
       自定义环境变量将注入到所有容器中，可覆盖自动检测的主机变量。
-      键名中包含 <code>PASSWORD</code> 或 <code>SECRET</code> 的值在显示时会被遮蔽。
     </p>
     <div class="config-panel-actions" style="margin-bottom:10px">
       <button class="sm" onclick="openBulkEnvModal()">批量编辑</button>


### PR DESCRIPTION
## Summary
- 后端 `GET /PUT /env` 接口之前通过 `maskSecrets()` 把含 SECRET/KEY/PASSWORD 的值替换为 `***`，导致前端编辑框拿到的是假值
- 前端 `maskValue()` 再次将显示值替换为 `••••••••`
- 移除这两层掩码，环境变量编辑器现在显示和编辑真实值
- 部署 SSE 和构建配置等日志场景的掩码保持不变

## Test plan
- [ ] 打开 CDS 环境变量编辑器，确认 JWT_SECRET 等敏感变量显示真实值
- [ ] 编辑 JWT_SECRET，确认输入框预填真实值而非 `***`
- [ ] 保存后确认值正确持久化
- [ ] 部署时 SSE 日志中敏感变量仍然掩码

https://claude.ai/code/session_01W4wRxduCe7i62QA3r63Gjw