### PR TITLE
Remove unused 'Upload' import in DefectSubmitPanel

### DIFF
--- a/prd-admin/src/pages/defect-agent/components/DefectSubmitPanel.tsx
+++ b/prd-admin/src/pages/defect-agent/components/DefectSubmitPanel.tsx
@@ -17,7 +17,6 @@ import {
   Send,
   Paperclip,
   FileText,
-  Upload,
   Sparkles,
   Check,
   Eye,


### PR DESCRIPTION
## Summary
- Remove unused `Upload` import from `lucide-react` in `DefectSubmitPanel.tsx` to fix TS6133 CI error

## Test plan
- [x] `pnpm tsc --noEmit` passes with no errors

https://claude.ai/code/session_0163cBWdAuagiALk1yPscS4F