### PR TITLE
fix: CSS MIME type errors — CDS loading page + startup signal + nginx fallback

### DIFF
--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -1207,6 +1207,10 @@ export function createBranchRouter(deps: RouterDeps): Router {
         command: `${nodeCmd.installPrefix}${nodeCmd.runPrefix}vite --host 0.0.0.0 --port 5173`,
         containerPort: 5173,
         cacheMounts: nodeCmd.cacheMounts,
+        // Wait for Vite to fully initialize (CSS/plugin pipeline ready) before routing traffic.
+        // Without this, the proxy forwards requests while Vite is still starting, causing
+        // CSS MIME type errors (Vite returns HTML fallback before transforms are ready).
+        startupSignal: '➜  Network:',
       },
     ];
 

--- a/cds/src/services/proxy.ts
+++ b/cds/src/services/proxy.ts
@@ -267,8 +267,8 @@ export class ProxyService {
     const state = this.stateService.getState();
     const branch = state.branches[branchSlug];
 
-    // Branch doesn't exist or isn't running — trigger auto-build
-    if (!branch || branch.status !== 'running') {
+    // Branch doesn't exist or isn't running — trigger auto-build or show loading
+    if (!branch || (branch.status !== 'running' && branch.status !== 'starting')) {
       if (this.onAutoBuild) {
         this.onAutoBuild(branchRef, req, res);
         return;
@@ -282,6 +282,12 @@ export class ProxyService {
       return;
     }
 
+    // Branch-level starting: all services still initializing
+    if (branch.status === 'starting') {
+      this.serveStartingPage(res, branchSlug, branch);
+      return;
+    }
+
     // Find the upstream URL for this branch
     if (!this.resolveUpstream) {
       res.writeHead(500, { 'Content-Type': 'application/json' });
@@ -290,6 +296,19 @@ export class ProxyService {
     }
 
     const profileId = this.detectProfileFromRequest(req, branch);
+
+    // Service-level starting: branch is "running" (some services up) but
+    // the specific service for this request is still initializing.
+    // Show loading page instead of proxying to a half-ready server
+    // (prevents CSS MIME type errors from Vite returning HTML before ready).
+    if (profileId) {
+      const svc = branch.services[profileId];
+      if (svc && svc.status === 'starting') {
+        this.serveStartingPage(res, branchSlug, branch, profileId);
+        return;
+      }
+    }
+
     const upstream = this.resolveUpstream(branchSlug, profileId);
 
     if (!upstream) {
@@ -300,6 +319,50 @@ export class ProxyService {
 
     console.log(`[proxy] ${req.method} ${req.url} → ${upstream} (branch=${branchSlug}, profile=${profileId || 'default'})`);
     this.proxyRequest(req, res, upstream, { branchId: branchSlug, branchName: branchRef, trackAccess: true, profileId });
+  }
+
+  /**
+   * Serve a loading page when a branch or service is in 'starting' state.
+   * Auto-refreshes every 2 seconds until the service is ready.
+   */
+  private serveStartingPage(res: http.ServerResponse, branchSlug: string, branch: BranchEntry, waitingProfileId?: string): void {
+    const services = Object.values(branch.services);
+    const serviceRows = services.map(svc => {
+      const icon = svc.status === 'running' ? '✓' : svc.status === 'starting' ? '◌' : svc.status === 'error' ? '✗' : '·';
+      const color = svc.status === 'running' ? '#3fb950' : svc.status === 'starting' ? '#58a6ff' : svc.status === 'error' ? '#f85149' : '#8b949e';
+      const label = waitingProfileId === svc.profileId ? `${svc.profileId} (等待就绪...)` : svc.profileId;
+      return `<div class="svc"><span style="color:${color}">${icon}</span> ${label}</div>`;
+    }).join('');
+
+    const html = `<!DOCTYPE html>
+<html lang="zh"><head>
+<meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>启动中 — ${branchSlug}</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;background:#0d1117;color:#c9d1d9;display:flex;align-items:center;justify-content:center;min-height:100vh;padding:20px}
+.card{max-width:420px;width:100%;padding:32px;background:#161b22;border:1px solid #30363d;border-radius:12px;text-align:center}
+.spinner{width:28px;height:28px;border:3px solid #30363d;border-top-color:#58a6ff;border-radius:50%;animation:spin .8s linear infinite;margin:0 auto 16px}
+@keyframes spin{to{transform:rotate(360deg)}}
+h2{font-size:16px;font-weight:600;color:#f0f6fc;margin-bottom:8px}
+.branch{font-family:ui-monospace,SFMono-Regular,monospace;font-size:13px;color:#58a6ff;background:#21262d;padding:4px 8px;border-radius:4px;margin-bottom:20px;display:inline-block;word-break:break-all}
+.services{display:flex;flex-direction:column;gap:6px;margin-bottom:16px;text-align:left}
+.svc{font-size:13px;padding:6px 10px;background:#0d1117;border:1px solid #21262d;border-radius:6px;font-family:ui-monospace,monospace}
+.hint{font-size:12px;color:#8b949e}
+</style>
+</head><body>
+<div class="card">
+  <div class="spinner"></div>
+  <h2>服务正在启动中</h2>
+  <div class="branch">${branchSlug}</div>
+  <div class="services">${serviceRows}</div>
+  <div class="hint">页面将在服务就绪后自动刷新...</div>
+</div>
+<script>setTimeout(function(){location.reload()},2000)</script>
+</body></html>`;
+
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-cache, no-store' });
+    res.end(html);
   }
 
   /**

--- a/cds/tests/services/proxy.test.ts
+++ b/cds/tests/services/proxy.test.ts
@@ -122,6 +122,109 @@ describe('ProxyService', () => {
     });
   });
 
+  describe('handleRequest — starting state loading page', () => {
+    function makeRes(): { res: http.ServerResponse; written: { statusCode: number; headers: Record<string, string>; body: string } } {
+      const written = { statusCode: 0, headers: {} as Record<string, string>, body: '' };
+      const res = {
+        writeHead(code: number, headers: Record<string, string>) { written.statusCode = code; written.headers = headers; },
+        end(body?: string) { written.body = body || ''; },
+      } as unknown as http.ServerResponse;
+      return { res, written };
+    }
+
+    function addBranch(id: string, status: 'running' | 'starting' | 'building', services: Record<string, { profileId: string; status: string }> = {}) {
+      const svcState: Record<string, any> = {};
+      for (const [k, v] of Object.entries(services)) {
+        svcState[k] = { profileId: v.profileId, containerName: `cds-${id}-${k}`, hostPort: 9000, status: v.status };
+      }
+      stateService.addBranch({
+        id, branch: id, worktreePath: `/tmp/${id}`,
+        services: svcState, status, createdAt: new Date().toISOString(),
+      });
+      stateService.save();
+    }
+
+    it('should serve loading page when branch status is starting', () => {
+      addBranch('my-branch', 'starting', {
+        admin: { profileId: 'admin', status: 'starting' },
+      });
+      stateService.setDefaultBranch('my-branch');
+      stateService.save();
+
+      const req = makeReq({ host: 'localhost' });
+      const { res, written } = makeRes();
+      proxy.handleRequest(req, res);
+
+      expect(written.statusCode).toBe(200);
+      expect(written.headers['Content-Type']).toContain('text/html');
+      expect(written.body).toContain('启动中');
+      expect(written.body).toContain('setTimeout');
+    });
+
+    it('should serve loading page when target service is starting but branch is running', () => {
+      addBranch('my-branch', 'running', {
+        api: { profileId: 'api', status: 'running' },
+        admin: { profileId: 'admin', status: 'starting' },
+      });
+      stateService.addBuildProfile({
+        id: 'api', name: 'API', dockerImage: 'dotnet:8', workDir: 'api',
+        containerPort: 5000, pathPrefixes: ['/api/'],
+      });
+      stateService.addBuildProfile({
+        id: 'admin', name: 'Admin', dockerImage: 'node:20', workDir: 'admin',
+        containerPort: 5173,
+      });
+      stateService.setDefaultBranch('my-branch');
+      stateService.save();
+
+      // Must set resolveUpstream — proxy checks it before profile detection
+      proxy.setResolveUpstream(() => 'http://localhost:9000');
+
+      // Request to admin (non-API path) → should hit the starting admin service
+      const req = makeReq({ host: 'localhost' }, '/dashboard');
+      const { res, written } = makeRes();
+      proxy.handleRequest(req, res);
+
+      expect(written.statusCode).toBe(200);
+      expect(written.headers['Content-Type']).toContain('text/html');
+      expect(written.body).toContain('启动中');
+      expect(written.body).toContain('admin');
+    });
+
+    it('should proxy to upstream when target service is running', () => {
+      addBranch('my-branch', 'running', {
+        admin: { profileId: 'admin', status: 'running' },
+      });
+      stateService.setDefaultBranch('my-branch');
+      stateService.save();
+
+      let resolvedUpstream = '';
+      proxy.setResolveUpstream((_branchSlug, _profileId) => { resolvedUpstream = 'http://localhost:9000'; return resolvedUpstream; });
+
+      // Use a mock req with pipe to avoid TypeError in proxyRequest
+      const req = { headers: { host: 'localhost' }, url: '/', pipe: () => {} } as unknown as http.IncomingMessage;
+      const { res } = makeRes();
+      proxy.handleRequest(req, res);
+
+      expect(resolvedUpstream).toBe('http://localhost:9000');
+    });
+
+    it('should still trigger auto-build for building/idle/error states', () => {
+      addBranch('my-branch', 'building', {});
+      stateService.setDefaultBranch('my-branch');
+      stateService.save();
+
+      let autoBuildCalled = false;
+      proxy.setOnAutoBuild(() => { autoBuildCalled = true; });
+
+      const req = makeReq({ host: 'localhost' }, '/');
+      const { res } = makeRes();
+      proxy.handleRequest(req, res);
+
+      expect(autoBuildCalled).toBe(true);
+    });
+  });
+
   describe('matchRule', () => {
     it('should match domain rule and extract capture group', () => {
       const result = proxy.matchRule(

--- a/changelogs/2026-03-24_fix-css-mime-type.md
+++ b/changelogs/2026-03-24_fix-css-mime-type.md
@@ -1,1 +1,3 @@
 | fix | prd-admin | 修复 _disconnected.conf 缺少静态资源处理，CSS/JS 文件被 SPA fallback 以 text/html 返回导致模块加载失败 |
+| feat | cds | CDS proxy 在服务启动中 (starting) 时展示 loading 页面，避免请求打到半就绪的 Vite 导致 CSS MIME 错误 |
+| feat | cds | Vite 默认构建配置添加 startupSignal，等待 Vite 完全就绪后才路由流量 |

--- a/changelogs/2026-03-24_fix-css-mime-type.md
+++ b/changelogs/2026-03-24_fix-css-mime-type.md
@@ -1,0 +1,1 @@
+| fix | prd-admin | 修复 _disconnected.conf 缺少静态资源处理，CSS/JS 文件被 SPA fallback 以 text/html 返回导致模块加载失败 |

--- a/deploy/nginx/conf.d/branches/_disconnected.conf
+++ b/deploy/nginx/conf.d/branches/_disconnected.conf
@@ -14,6 +14,21 @@ server {
         return 502 '{"error":"No active branch connected"}';
     }
 
+    # Hashed assets under /assets/ — serve directly, 404 if missing
+    location ^~ /assets/ {
+        try_files $uri =404;
+        expires 7d;
+        add_header Cache-Control "public, max-age=604800" always;
+    }
+
+    # Other static files (favicon, manifest, etc.) — 404 if missing, not SPA fallback
+    location ~* \.(?:js|css|map|png|jpg|jpeg|gif|webp|svg|ico|woff2?|json|txt)$ {
+        try_files $uri =404;
+        expires 7d;
+        add_header Cache-Control "public, max-age=604800" always;
+    }
+
+    # SPA fallback — only for client-side routes (not static files)
     location / {
         try_files $uri /index.html;
     }


### PR DESCRIPTION
## Summary

**根因**：CDS 部署分支时，Vite dev server 端口就绪后 CSS 转换管道还没初始化完成。这个窗口期内浏览器请求 CSS 模块会得到 Vite 的 SPA fallback（index.html, text/html），导致 "Failed to load module script" 错误。刷新后就好了。

**修复**（三层防御）：

- **CDS proxy loading page**: 当分支或服务处于 `starting` 状态时，展示友好的 loading 页面（2秒自动刷新），而非把请求打到半就绪的 Vite
- **Vite startupSignal**: 默认 admin 构建配置添加 `startupSignal: '➜  Network:'`，让 Vite 完全就绪后才标记为 `running`，确保 proxy 在此之前显示 loading 页
- **nginx _disconnected.conf**: 添加静态文件处理 location blocks，缺失的静态文件返回 404 而非 index.html

## Test plan

- [ ] CDS 部署新分支，观察 Vite 启动过程中浏览器显示 loading 页而非白屏/CSS 错误
- [ ] Loading 页面在 Vite 就绪后自动刷新进入应用
- [ ] 已有分支（无 startupSignal）不受影响，仍然正常路由
- [ ] `docker-compose.yml` 部署，静态文件返回正确 MIME type

https://claude.ai/code/session_01HRsrQixpv15H7ZKXiuMneR