### PR TITLE
Exclude image generation prefix from UI display and storage

### DIFF
--- a/changelogs/2026-03-25_exclude-image-gen-prefix-from-display.md
+++ b/changelogs/2026-03-25_exclude-image-gen-prefix-from-display.md
@@ -1,0 +1,2 @@
+| fix | prd-admin | 生图意图前缀 "Generate an image based on the following description:" 不再泄漏到画布元素和投稿展示 |
+| fix | prd-api | 后端存储 ImageAsset.Prompt 和画布占位时自动剥离生图意图前缀 |

--- a/prd-admin/src/pages/ai-chat/AdvancedVisualAgentTab.tsx
+++ b/prd-admin/src/pages/ai-chat/AdvancedVisualAgentTab.tsx
@@ -3470,6 +3470,7 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
       .filter((sha) => sha.length === 64);
 
     let firstPrompt = '';
+    let displayPrompt = ''; // 用户原始提示词（不含生图意图前缀），用于 UI 展示和存储
     if (directPrompt) {
       firstPrompt = stripModelMention(reqText) || stripModelMention(display) || '';
       if (!firstPrompt) {
@@ -3489,6 +3490,8 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
       } catch {
         // 澄清失败不阻断生图流程，静默降级使用原始 prompt
       }
+      // 保存用于展示的提示词（不含前缀）
+      displayPrompt = firstPrompt;
       // 智能模式也需要追加生图意图前缀，与直连模式保持一致
       firstPrompt = `Generate an image based on the following description:\n${firstPrompt}`;
     } else {
@@ -3499,6 +3502,8 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
         pushMsg('Assistant', buildGenErrorContent({ msg, refSrc: refSrc || undefined, prompt: display || reqText || undefined, imageRefShas }));
         return;
       }
+      // 保存用于展示的提示词（不含前缀）
+      displayPrompt = firstPrompt;
       firstPrompt = `Generate an image based on the following description:\n${firstPrompt}`;
     }
 
@@ -3560,7 +3565,7 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
                 // 这样底部白色快捷输入框会消失，同时仍保持加载动画与可选中行为
                 kind: 'image',
                 createdAt: Date.now(),
-                prompt: firstPrompt,
+                prompt: displayPrompt,
                 status: 'running',
                 errorMessage: null,
                 // 保持面板位置与尺寸
@@ -3582,7 +3587,7 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
         key,
         kind: 'image',
         createdAt: Date.now(),
-        prompt: firstPrompt,
+        prompt: displayPrompt,
         src: '',
         status: 'running',
         w: genW,
@@ -3800,7 +3805,7 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
       if (!runRes.success) {
         const msg = runRes.error?.message || '生成失败';
         setCanvas((prev) => prev.map((x) => (x.key === key ? { ...x, status: 'error', errorMessage: msg } : x)));
-        pushMsg('Assistant', buildGenErrorContent({ msg, refSrc: refSrc || undefined, prompt: firstPrompt || undefined, imageRefShas }));
+        pushMsg('Assistant', buildGenErrorContent({ msg, refSrc: refSrc || undefined, prompt: displayPrompt || undefined, imageRefShas }));
         triggerDefectFlash();
         return;
       }
@@ -3809,7 +3814,7 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
       if (!runId) {
         const msg = '未返回 runId';
         setCanvas((prev) => prev.map((x) => (x.key === key ? { ...x, status: 'error', errorMessage: msg } : x)));
-        pushMsg('Assistant', buildGenErrorContent({ msg, refSrc: refSrc || undefined, prompt: firstPrompt || undefined, imageRefShas }));
+        pushMsg('Assistant', buildGenErrorContent({ msg, refSrc: refSrc || undefined, prompt: displayPrompt || undefined, imageRefShas }));
         triggerDefectFlash();
         return;
       }
@@ -3853,7 +3858,7 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
               const emptyMsg = '生成完成但图片数据为空，请重试';
               setCanvas((prev) => prev.map((x) => (x.key === key ? { ...x, status: 'error', errorMessage: emptyMsg } : x)));
               const modelPoolName = pickedModel?.name || pickedModel?.modelName || '';
-              pushMsg('Assistant', buildGenErrorContent({ msg: emptyMsg, refSrc: refSrc || undefined, prompt: firstPrompt || undefined, runId, modelPool: modelPoolName, imageRefShas }));
+              pushMsg('Assistant', buildGenErrorContent({ msg: emptyMsg, refSrc: refSrc || undefined, prompt: displayPrompt || undefined, runId, modelPool: modelPoolName, imageRefShas }));
               triggerDefectFlash();
               return;
             }
@@ -3876,7 +3881,7 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
               )
             );
             const modelPoolName = pickedModel?.name || pickedModel?.modelName || '';
-            pushMsg('Assistant', buildGenDoneContent({ src: u, refSrc: refSrc || undefined, prompt: firstPrompt || undefined, runId, modelPool: modelPoolName, imageRefShas }));
+            pushMsg('Assistant', buildGenDoneContent({ src: u, refSrc: refSrc || undefined, prompt: displayPrompt || undefined, runId, modelPool: modelPoolName, imageRefShas }));
             // 自动投稿：生图完成后自动提交到作品广场（受开关控制）
             if (asset?.id && autoSubmitEnabledRef.current) {
               autoSubmitImages([asset.id]).catch(() => {});
@@ -3885,7 +3890,7 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
             const msg = String(o.errorMessage ?? '生成失败');
             setCanvas((prev) => prev.map((x) => (x.key === key ? { ...x, status: 'error', errorMessage: msg } : x)));
             const modelPoolName = pickedModel?.name || pickedModel?.modelName || '';
-            pushMsg('Assistant', buildGenErrorContent({ msg, refSrc: refSrc || undefined, prompt: firstPrompt || undefined, runId, modelPool: modelPoolName, imageRefShas }));
+            pushMsg('Assistant', buildGenErrorContent({ msg, refSrc: refSrc || undefined, prompt: displayPrompt || undefined, runId, modelPool: modelPoolName, imageRefShas }));
             triggerDefectFlash();
           }
         },
@@ -3895,7 +3900,7 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
         setCanvas((prev) => {
           const item = prev.find((x) => x.key === key);
           if (item && item.status === 'running') {
-            pushMsg('Assistant', buildGenErrorContent({ msg: '生成超时或连接中断，请重试', refSrc: refSrc || undefined, prompt: firstPrompt || undefined, runId, modelPool: pickedModel?.name || pickedModel?.modelName || '', imageRefShas }));
+            pushMsg('Assistant', buildGenErrorContent({ msg: '生成超时或连接中断，请重试', refSrc: refSrc || undefined, prompt: displayPrompt || undefined, runId, modelPool: pickedModel?.name || pickedModel?.modelName || '', imageRefShas }));
             triggerDefectFlash();
           }
           return prev.map((x) =>
@@ -3908,7 +3913,7 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
     } catch (e) {
       const msg = e instanceof Error ? e.message : '生成失败';
       setCanvas((prev) => prev.map((x) => (x.key === key ? { ...x, status: 'error', errorMessage: msg } : x)));
-      pushMsg('Assistant', buildGenErrorContent({ msg, refSrc: refSrc || undefined, prompt: firstPrompt || undefined, imageRefShas }));
+      pushMsg('Assistant', buildGenErrorContent({ msg, refSrc: refSrc || undefined, prompt: displayPrompt || undefined, imageRefShas }));
       triggerDefectFlash();
     }
   };

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ImageMasterController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ImageMasterController.cs
@@ -1359,6 +1359,12 @@ public class ImageMasterController : ControllerBase
             var prompt = (request?.Prompt ?? string.Empty).Trim();
             if (string.IsNullOrWhiteSpace(prompt)) return BadRequest(ApiResponse<object>.Fail(ErrorCodes.CONTENT_EMPTY, "prompt 不能为空"));
 
+            // 剥离前端追加的生图意图前缀（该前缀仅用于 LLM 调用，不应存入展示字段）
+            const string imageGenPrefix = "Generate an image based on the following description:\n";
+            var displayPrompt = prompt.StartsWith(imageGenPrefix, StringComparison.Ordinal)
+                ? prompt[imageGenPrefix.Length..].Trim()
+                : prompt;
+
             // 风格统一：若 workspace 设置了 StylePrompt，自动拼接到用户 prompt 后面
             var stylePrompt = (ws.StylePrompt ?? string.Empty).Trim();
             if (!string.IsNullOrWhiteSpace(stylePrompt))
@@ -1411,12 +1417,13 @@ public class ImageMasterController : ControllerBase
                 initSha = null;
             }
 
-            // 关键：先把“占位元素”写入画布（服务端写入，避免前端关闭导致元素不存在）
+            // 关键：先把”占位元素”写入画布（服务端写入，避免前端关闭导致元素不存在）
+            // 使用 displayPrompt（不含生图意图前缀），避免前缀泄漏到 UI 展示
             await UpsertWorkspaceCanvasPlaceholderAsync(
                 workspaceId: wid,
                 ownerUserId: ws.OwnerUserId,
                 targetKey: targetKey,
-                prompt: prompt,
+                prompt: displayPrompt,
                 x: request?.X,
                 y: request?.Y,
                 w: request?.W,

--- a/prd-api/src/PrdAgent.Api/Services/ImageGenRunWorker.cs
+++ b/prd-api/src/PrdAgent.Api/Services/ImageGenRunWorker.cs
@@ -910,6 +910,15 @@ public class ImageGenRunWorker : BackgroundService
         }
     }
 
+    /// <summary>
+    /// 剥离前端追加的生图意图前缀，该前缀仅用于 LLM 调用，不应存入展示字段。
+    /// </summary>
+    private static string StripImageGenPrefix(string prompt)
+    {
+        const string prefix = "Generate an image based on the following description:\n";
+        return prompt.StartsWith(prefix, StringComparison.Ordinal) ? prompt[prefix.Length..].Trim() : prompt;
+    }
+
     private static bool TryParseWxH(string? raw, out int w, out int h)
     {
         w = 0;
@@ -988,7 +997,7 @@ public class ImageGenRunWorker : BackgroundService
             Mime = assetMime,
             SizeBytes = assetSizeBytes,
             Url = url ?? assetUrl,  // 展示用（有水印时是 watermark URL，无水印时是 imagemaster URL）
-            Prompt = (prompt ?? string.Empty).Trim(),
+            Prompt = StripImageGenPrefix((prompt ?? string.Empty).Trim()),
             CreatedAt = DateTime.UtcNow,
             OriginalUrl = assetUrl,
             OriginalSha256 = assetSha256,


### PR DESCRIPTION
## Summary
This PR prevents the image generation intent prefix ("Generate an image based on the following description:\n") from leaking into UI displays and persistent storage. The prefix is now stripped before storing prompts in the database and displaying them on canvas elements.

## Key Changes

**Frontend (prd-admin)**
- Introduced `displayPrompt` variable to track the user's original prompt without the generation prefix
- Updated all canvas element creation and error message building to use `displayPrompt` instead of `firstPrompt`
- The prefix is still appended to `firstPrompt` for LLM processing, but the clean version is used for UI/storage

**Backend (prd-api)**
- Added prefix stripping logic in `ImageMasterController.CreateWorkspaceImageGenRun()` to extract `displayPrompt` before database operations
- Updated canvas placeholder insertion to use the cleaned `displayPrompt`
- Added `StripImageGenPrefix()` utility method in `ImageGenRunWorker` to consistently remove the prefix when storing `ImageAsset.Prompt`

## Implementation Details
- The prefix stripping is performed at multiple layers (frontend before storage, backend before database writes) to ensure consistency
- The prefix is only used internally for LLM API calls and is never exposed to users
- Both direct and intelligent image generation modes now handle the prefix consistently

https://claude.ai/code/session_014Thqe2pqrf9CSddkJU1oHw