### PR TITLE
Add Doubao ASR support with async polling and WebSocket streaming

### DIFF
--- a/cds-compose.yml
+++ b/cds-compose.yml
@@ -26,14 +26,12 @@ x-cds-deploy-modes:
     dev:
       label: "开发模式 (热重载)"
       command: >-
-        (which ffmpeg >/dev/null 2>&1 || (apt-get update -qq && apt-get install -y -qq --no-install-recommends ffmpeg)) &&
         dotnet restore &&
         dotnet build --no-restore &&
         dotnet watch run --project src/PrdAgent.Api --urls http://0.0.0.0:5000
     static:
       label: "静态部署 (publish)"
       command: >-
-        (which ffmpeg >/dev/null 2>&1 || (apt-get update -qq && apt-get install -y -qq --no-install-recommends ffmpeg)) &&
         dotnet restore &&
         dotnet publish src/PrdAgent.Api -c Release -o /publish --no-restore &&
         dotnet /publish/PrdAgent.Api.dll --urls http://0.0.0.0:5000

--- a/cds-compose.yml
+++ b/cds-compose.yml
@@ -26,12 +26,14 @@ x-cds-deploy-modes:
     dev:
       label: "开发模式 (热重载)"
       command: >-
+        (which ffmpeg >/dev/null 2>&1 || (apt-get update -qq && apt-get install -y -qq --no-install-recommends ffmpeg)) &&
         dotnet restore &&
         dotnet build --no-restore &&
         dotnet watch run --project src/PrdAgent.Api --urls http://0.0.0.0:5000
     static:
       label: "静态部署 (publish)"
       command: >-
+        (which ffmpeg >/dev/null 2>&1 || (apt-get update -qq && apt-get install -y -qq --no-install-recommends ffmpeg)) &&
         dotnet restore &&
         dotnet publish src/PrdAgent.Api -c Release -o /publish --no-restore &&
         dotnet /publish/PrdAgent.Api.dll --urls http://0.0.0.0:5000

--- a/cds-compose.yml
+++ b/cds-compose.yml
@@ -61,8 +61,6 @@ services:
     volumes:
       - ./prd-api:/app
       - api-nuget-cache:/root/.nuget/packages
-      - /usr/bin/ffmpeg:/usr/bin/ffmpeg:ro
-      - /usr/bin/ffprobe:/usr/bin/ffprobe:ro
     ports:
       - "5000"
     command: >-
@@ -78,7 +76,7 @@ services:
       MongoDB__ConnectionString: "mongodb://${CDS_HOST}:${CDS_MONGODB_PORT}"
       MongoDB__DatabaseName: prdagent
       Redis__ConnectionString: "${CDS_HOST}:${CDS_REDIS_PORT}"
-      Jwt__Secret: "${JWT_SECRET}"
+      # Jwt__Secret 由全局 x-cds-env.JWT_SECRET 自动注入，不在此声明
       Jwt__Issuer: prdagent
     labels:
       cds.path-prefix: "/api/"

--- a/cds-compose.yml
+++ b/cds-compose.yml
@@ -61,6 +61,8 @@ services:
     volumes:
       - ./prd-api:/app
       - api-nuget-cache:/root/.nuget/packages
+      - /usr/bin/ffmpeg:/usr/bin/ffmpeg:ro
+      - /usr/bin/ffprobe:/usr/bin/ffprobe:ro
     ports:
       - "5000"
     command: >-

--- a/cds/src/services/container.ts
+++ b/cds/src/services/container.ts
@@ -134,6 +134,26 @@ export class ContainerService {
       }
     }
 
+    // ffmpeg: 静态编译版 bind mount（零依赖，单文件）
+    // 优先使用 /opt/ffmpeg-static/（用户下载的静态版），否则尝试宿主机 /usr/bin/ffmpeg
+    const ffmpegPaths = ['/opt/ffmpeg-static/ffmpeg', '/usr/local/bin/ffmpeg', '/usr/bin/ffmpeg'];
+    const ffprobePaths = ['/opt/ffmpeg-static/ffprobe', '/usr/local/bin/ffprobe', '/usr/bin/ffprobe'];
+    const findResult = await this.shell.exec(
+      `for p in ${ffmpegPaths.join(' ')}; do [ -f "$p" ] && echo "$p" && break; done`
+    );
+    const ffmpegPath = findResult.stdout?.trim();
+    if (ffmpegPath) {
+      volumeFlags.push(`-v "${ffmpegPath}:/usr/local/bin/ffmpeg:ro"`);
+      // ffprobe
+      const findProbe = await this.shell.exec(
+        `for p in ${ffprobePaths.join(' ')}; do [ -f "$p" ] && echo "$p" && break; done`
+      );
+      const ffprobePath = findProbe.stdout?.trim();
+      if (ffprobePath) {
+        volumeFlags.push(`-v "${ffprobePath}:/usr/local/bin/ffprobe:ro"`);
+      }
+    }
+
     try {
       const command = profile.command || '';
       if (!command) {
@@ -144,6 +164,7 @@ export class ContainerService {
       if (isNodeContainer) {
         onOutput?.(`── Node.js 容器: node_modules 已隔离到 Docker volume ──\n`);
       }
+
       const runCmd = [
         'docker run -d',
         `--name ${service.containerName}`,

--- a/changelogs/2026-03-29_transcript-toolbox-exchange-template.md
+++ b/changelogs/2026-03-29_transcript-toolbox-exchange-template.md
@@ -1,0 +1,5 @@
+| feat | prd-admin | 转录工作台加入百宝箱 BUILTIN_TOOLS |
+| feat | prd-api | 新增豆包 ASR (doubao-asr) Exchange 转换器，支持字节跳动大模型语音识别 |
+| feat | prd-api | 模型中继新增导入模板功能，用户只需填写 API Key 一键创建 Exchange |
+| feat | prd-admin | 模型中继管理页面新增「从模板导入」入口和对话框 |
+| feat | prd-api | 新增 DoubaoAsr 认证方案，支持豆包双 Header 认证模式 |

--- a/changelogs/2026-03-29_transcript-toolbox-exchange-template.md
+++ b/changelogs/2026-03-29_transcript-toolbox-exchange-template.md
@@ -6,5 +6,7 @@
 | feat | prd-api | 新增 DoubaoAsr 认证方案，支持豆包双 Header 认证模式 |
 | feat | prd-api | Exchange 测试端点支持音频文件上传测试 (test-audio) |
 | feat | prd-admin | Exchange 测试面板新增音频模式，支持文件上传和 URL 测试 |
-| feat | prd-api | 新增 DoubaoStreamAsrService，实现豆包 WebSocket 二进制协议流式语音识别 |
+| feat | prd-api | 新增 DoubaoStreamAsrService，实现豆包 WebSocket 二进制协议流式语音识别（含 PCM 自动重采样） |
 | feat | prd-api | 新增 doubao-asr-stream 转换器标记和导入模板 |
+| fix | prd-api | 修复流式 ASR 音频格式声明 (wav→pcm) 和结果提取 (result 对象兼容) |
+| feat | prd-api | DoubaoStreamAsrService 自动 48kHz/2ch → 16kHz/1ch 重采样，纯 C# 无需 ffmpeg |

--- a/changelogs/2026-03-29_transcript-toolbox-exchange-template.md
+++ b/changelogs/2026-03-29_transcript-toolbox-exchange-template.md
@@ -1,7 +1,7 @@
 | feat | prd-admin | 转录工作台加入百宝箱 BUILTIN_TOOLS |
 | feat | prd-api | 新增豆包 ASR (doubao-asr) Exchange 转换器，支持异步 submit+query 模式 |
 | feat | prd-api | 新增 IAsyncExchangeTransformer 接口，LlmGateway 支持异步轮询中继 |
-| feat | prd-api | 模型中继新增导入模板功能，内置 4 个模板（豆包双Key/单Key/流式 + fal.ai） |
+| feat | prd-api | 模型中继新增导入模板功能，内置 3 个模板（豆包ASR/流式WebSocket + fal.ai） |
 | feat | prd-admin | 模型中继管理页面新增「从模板导入」入口和对话框 |
 | feat | prd-api | 新增 DoubaoAsr 认证方案，支持豆包双 Header 认证模式 |
 | feat | prd-api | Exchange 测试端点支持音频文件上传测试 (test-audio) |

--- a/changelogs/2026-03-29_transcript-toolbox-exchange-template.md
+++ b/changelogs/2026-03-29_transcript-toolbox-exchange-template.md
@@ -1,8 +1,10 @@
 | feat | prd-admin | 转录工作台加入百宝箱 BUILTIN_TOOLS |
 | feat | prd-api | 新增豆包 ASR (doubao-asr) Exchange 转换器，支持异步 submit+query 模式 |
 | feat | prd-api | 新增 IAsyncExchangeTransformer 接口，LlmGateway 支持异步轮询中继 |
-| feat | prd-api | 模型中继新增导入模板功能，内置 3 个模板（豆包双Key/单Key + fal.ai） |
+| feat | prd-api | 模型中继新增导入模板功能，内置 4 个模板（豆包双Key/单Key/流式 + fal.ai） |
 | feat | prd-admin | 模型中继管理页面新增「从模板导入」入口和对话框 |
 | feat | prd-api | 新增 DoubaoAsr 认证方案，支持豆包双 Header 认证模式 |
 | feat | prd-api | Exchange 测试端点支持音频文件上传测试 (test-audio) |
 | feat | prd-admin | Exchange 测试面板新增音频模式，支持文件上传和 URL 测试 |
+| feat | prd-api | 新增 DoubaoStreamAsrService，实现豆包 WebSocket 二进制协议流式语音识别 |
+| feat | prd-api | 新增 doubao-asr-stream 转换器标记和导入模板 |

--- a/changelogs/2026-03-29_transcript-toolbox-exchange-template.md
+++ b/changelogs/2026-03-29_transcript-toolbox-exchange-template.md
@@ -1,5 +1,8 @@
 | feat | prd-admin | 转录工作台加入百宝箱 BUILTIN_TOOLS |
-| feat | prd-api | 新增豆包 ASR (doubao-asr) Exchange 转换器，支持字节跳动大模型语音识别 |
-| feat | prd-api | 模型中继新增导入模板功能，用户只需填写 API Key 一键创建 Exchange |
+| feat | prd-api | 新增豆包 ASR (doubao-asr) Exchange 转换器，支持异步 submit+query 模式 |
+| feat | prd-api | 新增 IAsyncExchangeTransformer 接口，LlmGateway 支持异步轮询中继 |
+| feat | prd-api | 模型中继新增导入模板功能，内置 3 个模板（豆包双Key/单Key + fal.ai） |
 | feat | prd-admin | 模型中继管理页面新增「从模板导入」入口和对话框 |
 | feat | prd-api | 新增 DoubaoAsr 认证方案，支持豆包双 Header 认证模式 |
+| feat | prd-api | Exchange 测试端点支持音频文件上传测试 (test-audio) |
+| feat | prd-admin | Exchange 测试面板新增音频模式，支持文件上传和 URL 测试 |

--- a/changelogs/2026-03-29_transcript-toolbox-exchange-template.md
+++ b/changelogs/2026-03-29_transcript-toolbox-exchange-template.md
@@ -9,4 +9,7 @@
 | feat | prd-api | 新增 DoubaoStreamAsrService，实现豆包 WebSocket 二进制协议流式语音识别（含 PCM 自动重采样） |
 | feat | prd-api | 新增 doubao-asr-stream 转换器标记和导入模板 |
 | fix | prd-api | 修复流式 ASR 音频格式声明 (wav→pcm) 和结果提取 (result 对象兼容) |
-| feat | prd-api | DoubaoStreamAsrService 自动 48kHz/2ch → 16kHz/1ch 重采样，纯 C# 无需 ffmpeg |
+| feat | prd-api | DoubaoStreamAsrService 自动重采样 + ffmpeg 转换（MP3/M4A/OGG/FLAC/WebM/MP4/24bit WAV） |
+| feat | prd-api | 流式 ASR SSE 端点 (/api/test/stream-asr/sse)，逐帧推送识别结果 |
+| fix | prd-api | 修复 24bit WAV 和截断 WAV 的边界处理 |
+| feat | prd-api | Dockerfile + cds-compose.yml 自动安装 ffmpeg |

--- a/doc/guide.doubao-asr-relay.md
+++ b/doc/guide.doubao-asr-relay.md
@@ -288,15 +288,48 @@ curl -X POST 'https://openspeech.bytedance.com/api/v3/auc/bigmodel/query' \
 
 ## 7. 注意事项
 
-1. **音频格式**: 推荐 MP3 或 WAV (PCM 16bit 16kHz)，其他格式需先用 ffmpeg 转换
-2. **文件大小**: HTTP 模式支持 URL 传入，无大小限制；WebSocket 模式需分片传输
-3. **超时**: HTTP 异步模式轮询最多 10 分钟（600 次 × 1s）；WebSocket 无超时
-4. **Resource ID**: 不同产品线使用不同 ID：
-   - `volc.bigasr.auc` — BigModel ASR (HTTP)
-   - `volc.seedasr.auc` — Seed ASR (HTTP)
+1. **音频格式**: WebSocket 流式模式**严格要求 16kHz 单声道 16bit PCM**，`DoubaoStreamAsrService` 会自动重采样（纯 C# 线性插值，无需 ffmpeg）。HTTP 异步模式接受多种格式
+2. **任意格式上传**: 用户可能上传 MP3/M4A/OGG/FLAC/MP4 等任意格式，建议在 `TranscriptRunWorker` 中用 ffmpeg 转为 WAV 后再传入 Service
+3. **文件大小**: HTTP 模式支持 URL 传入，无大小限制；WebSocket 模式需分片传输（每片 200ms PCM）
+4. **超时**: HTTP 异步模式轮询最多 10 分钟；WebSocket 接收超时 120 秒
+5. **Resource ID**: 不同产品线使用不同 ID：
+   - `volc.bigasr.auc` — BigModel ASR (HTTP 异步)
    - `volc.bigasr.sauc.duration` — 流式 ASR (WebSocket)
-5. **Key 安全**: API Key 在数据库中 AES 加密存储，API 返回时脱敏显示
+6. **Key 安全**: API Key 在数据库中 AES 加密存储，API 返回时脱敏显示
+
+## 8. 实测结果 (2026-03-29)
+
+### HTTP 异步模式
+
+```
+音频: output.wav (48kHz/2ch, 5.6 秒)
+认证: x-api-key (单Key)
+结果: 「你先简单介绍介绍你自己，你是个什么样的人？」
+耗时: submit 5s + query 2s
+含 19 个词级时间戳 (word-level timestamps)
+```
+
+### WebSocket 流式模式
+
+```
+音频: output.wav (48kHz/2ch → 自动重采样 16kHz/1ch)
+认证: x-api-key (单Key)
+结果: 「你先简单介绍介绍你自己，你是个什么样的人？」
+帧数: 28 帧 (每 200ms 一帧)
+耗时: 6.5 秒
+```
+
+两种模式转录结果完全一致。
+
+## 9. 已知限制与后续优化
+
+| 项目 | 现状 | 优化方向 |
+|------|------|----------|
+| 音频格式 | 仅支持 WAV/raw PCM 输入 | TranscriptRunWorker 中加 ffmpeg 预处理，支持 MP3/M4A/OGG 等 |
+| 重采样质量 | 线性插值（简单但有轻微失真） | 可改用 sinc 插值或 ffmpeg |
+| 断线重连 | 无 | 生产环境长音频需增加重连机制 |
+| 实时流式 | 使用 bigmodel_nostream（发完再返） | 如需实时字幕可改用 bigmodel 端点 |
 
 ---
 
-> 关联文档: `doc/design.transcript-agent.md` | 关联代码: `prd-api/src/PrdAgent.Infrastructure/LlmGateway/Transformers/`
+> 关联文档: `doc/design.transcript-agent.md` | 关联代码: `prd-api/src/PrdAgent.Api/Services/DoubaoStreamAsrService.cs`

--- a/doc/guide.doubao-asr-relay.md
+++ b/doc/guide.doubao-asr-relay.md
@@ -1,0 +1,302 @@
+# 豆包 ASR 模型中继接入指南
+
+> **文档类型**: guide | **适用对象**: 后端开发 / 系统集成 | **最后更新**: 2026-03-29
+
+---
+
+## 管理摘要
+
+本系统通过 **模型中继 (Exchange)** 机制将豆包语音识别 API 标准化为平台内部可调用的模型，使转录工作台无需关心底层 ASR 服务的协议差异。目前支持三种豆包 ASR 接入方式：
+
+| 模式 | 协议 | 适用场景 | 延迟 |
+|------|------|----------|------|
+| HTTP 异步 (submit+query) | HTTPS | 离线转录、长音频 | 秒级（轮询） |
+| WebSocket 流式 (sauc) | WSS | 实时转录、边录边转 | 毫秒级（推送） |
+
+## 1. 架构总览
+
+### 1.1 WebSocket 与 SSE 的关系（无冲突）
+
+```
+用户浏览器                  我们的后端                     豆包 ASR
+┌─────────┐    SSE 推送    ┌──────────┐    WebSocket     ┌──────────┐
+│ 前端     │◄──────────────│ .NET API │────────────────►│ 豆包 ASR  │
+│ (React)  │   text/event  │ (C# 12)  │   wss:// 二进制  │ BigModel │
+│          │   -stream     │          │   自定义帧协议    │          │
+└─────────┘               └──────────┘                  └──────────┘
+     ▲                         │
+     │                         │ HTTP submit+query
+     │    SSE 推送              │ (另一种模式)
+     └─────────────────────────┘
+```
+
+**结论：完全不冲突。** 两种协议在不同链路上工作：
+
+- **SSE（前端 ↔ 后端）**: 后端向前端推送转录进度和结果，遵循 `Run/Worker + afterSeq` 模式
+- **WebSocket（后端 → 豆包）**: 后端作为客户端连接豆包 ASR 服务，发送音频分片、接收识别结果
+- 后端是 **协议桥接层**：从豆包 WebSocket 收到结果后，转换为 SSE 事件推送给前端
+
+这与视觉创作 Agent 调用 fal.ai 的架构完全一致——fal.ai 用 REST，豆包用 WebSocket，但对前端来说都是统一的 SSE 进度推送。
+
+### 1.2 三层架构
+
+```
+┌─ Exchange 配置层 ─────────────────────────────────┐
+│  MongoDB: model_exchanges                          │
+│  存储: URL、API Key（加密）、转换器类型、认证方案    │
+└───────────────────────────────────────────────────┘
+           │
+┌─ 转换器层 ────────────────────────────────────────┐
+│  doubao-asr:        HTTP 请求/响应格式转换          │
+│  doubao-asr-stream: WebSocket 标记（实际由专用服务） │
+│  passthrough:       透传                           │
+│  fal-image:         fal.ai 图片格式转换             │
+└───────────────────────────────────────────────────┘
+           │
+┌─ 执行层 ──────────────────────────────────────────┐
+│  LlmGateway:            HTTP 同步/异步调用          │
+│  DoubaoStreamAsrService: WebSocket 二进制协议客户端  │
+│  TranscriptRunWorker:    后台任务调度               │
+└───────────────────────────────────────────────────┘
+```
+
+## 2. 快速接入（一键导入）
+
+### 2.1 通过管理后台导入
+
+1. 打开 **模型中继管理页**（侧边栏 → 模型服务 → 模型中继）
+2. 点击 **「从模板导入」**
+3. 选择模板，填入 API Key，点击「导入」
+
+### 2.2 当前可用模板
+
+| 模板名 | 模板 ID | 认证格式 | 协议 |
+|--------|---------|----------|------|
+| 豆包大模型语音识别 | `doubao-asr-xapikey` | `x-api-key` (UUID) | HTTP submit+query |
+| 豆包流式语音识别 | `doubao-asr-stream` | `x-api-key` (UUID) 或 `AppID\|AccessToken` | WebSocket |
+| fal.ai 图片生成 | `fal-image-gen` | Key | HTTP |
+
+### 2.3 通过 API 导入
+
+```bash
+# 导入豆包 ASR（HTTP 异步模式）
+curl -X POST /api/mds/exchanges/import-from-template \
+  -H "Content-Type: application/json" \
+  -d '{
+    "templateId": "doubao-asr-xapikey",
+    "apiKey": "你的-api-key-uuid"
+  }'
+
+# 导入豆包 ASR（WebSocket 流式模式）
+curl -X POST /api/mds/exchanges/import-from-template \
+  -H "Content-Type: application/json" \
+  -d '{
+    "templateId": "doubao-asr-stream",
+    "apiKey": "你的-api-key-uuid"
+  }'
+```
+
+## 3. 豆包 ASR 协议详解
+
+### 3.1 HTTP 异步模式 (submit + query)
+
+```
+客户端                       豆包 API
+  │                            │
+  │  POST /submit              │
+  │  {audio: {url: "..."}}     │
+  │──────────────────────────►│
+  │  X-Api-Status-Code:        │
+  │  20000000 (已接收)          │
+  │◄──────────────────────────│
+  │                            │
+  │  POST /query               │  ← 轮询（1s 间隔）
+  │  {} + X-Api-Request-Id     │
+  │──────────────────────────►│
+  │  20000001 (处理中)          │
+  │◄──────────────────────────│
+  │                            │
+  │  POST /query               │
+  │──────────────────────────►│
+  │  20000000 + {result: ...}  │  ← 完成
+  │◄──────────────────────────│
+```
+
+**关键参数**:
+- 认证: `x-api-key: {uuid}` 或 `X-Api-App-Key` + `X-Api-Access-Key`
+- Resource ID: `volc.bigasr.auc`（BigModel）或 `volc.seedasr.auc`（Seed）
+- 状态码通过 **响应 Header** `X-Api-Status-Code` 返回，不在 body 中
+- 轮询需携带 submit 时的 `X-Api-Request-Id` 和响应中的 `X-Tt-Logid`
+
+**响应状态码**:
+
+| 状态码 | 含义 |
+|--------|------|
+| `20000000` | 完成 |
+| `20000001` | 处理中（继续轮询） |
+| `20000002` | 处理中（继续轮询） |
+| 其他 | 失败 |
+
+**我们的实现**: `IAsyncExchangeTransformer` + `LlmGateway.SendRawAsync` 自动轮询
+
+### 3.2 WebSocket 流式模式 (sauc)
+
+```
+客户端                          豆包 WSS
+  │                               │
+  │  WebSocket 连接                │
+  │  wss://.../sauc/bigmodel      │
+  │  Headers: x-api-key, etc.     │
+  │──────────────────────────────►│
+  │                               │
+  │  FullClientRequest (二进制帧)   │  ← JSON 配置（音频格式、模型参数）
+  │──────────────────────────────►│
+  │  ServerResponse (确认)         │
+  │◄──────────────────────────────│
+  │                               │
+  │  AudioOnlyRequest × N         │  ← PCM 音频分片（200ms 间隔）
+  │──────────────────────────────►│
+  │  ServerResponse (部分结果)     │  ← 实时返回识别文本
+  │◄──────────────────────────────│
+  │                               │
+  │  AudioOnlyRequest (最后一片)   │  ← NEG_WITH_SEQUENCE 标记
+  │──────────────────────────────►│
+  │  ServerResponse (is_last)     │  ← 最终结果
+  │◄──────────────────────────────│
+```
+
+**二进制帧格式 (4 字节头)**:
+
+```
+Byte 0: [Version:4bit | HeaderSize:4bit]  → 0x11 (v1, 1 word)
+Byte 1: [MsgType:4bit | Flags:4bit]
+Byte 2: [Serialization:4bit | Compression:4bit]
+Byte 3: [Reserved]
+之后:   [Sequence:4byte BE] [PayloadSize:4byte BE] [Payload (gzip)]
+```
+
+**MsgType 值**:
+
+| 值 | 名称 | 方向 |
+|----|------|------|
+| `0x1` | ClientFullRequest | 客户端→服务端 |
+| `0x2` | ClientAudioOnlyRequest | 客户端→服务端 |
+| `0x9` | ServerFullResponse | 服务端→客户端 |
+| `0xF` | ServerErrorResponse | 服务端→客户端 |
+
+**Flags 值**:
+
+| 值 | 含义 |
+|----|------|
+| `0x1` | POS_SEQUENCE（正序号） |
+| `0x2` | NEG_SEQUENCE |
+| `0x3` | NEG_WITH_SEQUENCE（最后一片） |
+
+**WebSocket URL 变体**:
+
+| URL | 模式 | 说明 |
+|-----|------|------|
+| `.../sauc/bigmodel` | 流式 | 边发边返，实时结果 |
+| `.../sauc/bigmodel_async` | 异步流式 | 发完再返 |
+| `.../sauc/bigmodel_nostream` | 非流式 | 发完统一返回（推荐用于离线转录） |
+
+**我们的实现**: `DoubaoStreamAsrService`，完整的 C# WebSocket 客户端
+
+## 4. 认证方式
+
+### 4.1 单 Key 认证（推荐，更简单）
+
+```
+Header: x-api-key: {uuid}
+适用: HTTP submit/query、WebSocket sauc
+Key 来源: 火山引擎控制台
+```
+
+### 4.2 双 Key 认证
+
+```
+Header: X-Api-App-Key: {appId}
+Header: X-Api-Access-Key: {accessToken}
+适用: HTTP submit/query、WebSocket sauc
+Key 来源: 火山引擎控制台的 App ID + Access Token
+```
+
+**导入模板时**: 单 Key 直接填 UUID，双 Key 用 `AppID|AccessToken` 格式（竖线分隔）。
+
+## 5. 代码对照
+
+### 5.1 核心文件清单
+
+| 文件 | 用途 |
+|------|------|
+| `IExchangeTransformer.cs` | Exchange 转换器接口（含 `IAsyncExchangeTransformer`） |
+| `DoubaoAsrTransformer.cs` | HTTP 异步模式：请求/响应格式转换 + 轮询状态判断 |
+| `DoubaoStreamAsrTransformer.cs` | WebSocket 流式模式：标记转换器 |
+| `DoubaoStreamAsrService.cs` | WebSocket 二进制协议客户端完整实现 |
+| `ExchangeTransformerRegistry.cs` | 转换器注册表 |
+| `LlmGateway.cs` | HTTP Exchange 调用 + 异步轮询逻辑 |
+| `ExchangeController.cs` | 中继管理 API + 导入模板 + 测试端点 |
+| `TranscriptRunWorker.cs` | 转录后台 Worker（调用 Gateway/StreamAsr） |
+
+### 5.2 新增接入点步骤
+
+如果要接入其他 ASR 服务（如阿里云、讯飞）：
+
+1. **创建转换器** `XxxAsrTransformer : IExchangeTransformer`（或 `IAsyncExchangeTransformer`）
+2. **注册** 到 `ExchangeTransformerRegistry` 构造函数
+3. **添加模板** 到 `ExchangeTemplates.All`
+4. 如果是 WebSocket 协议，创建专用 Service 类
+5. 认证方案如有新类型，在 `LlmGateway.SetAuthHeader` 增加 case
+
+## 6. 测试验证
+
+### 6.1 HTTP 异步模式验证（已通过）
+
+```bash
+# submit
+curl -X POST 'https://openspeech.bytedance.com/api/v3/auc/bigmodel/submit' \
+  -H 'Content-Type: application/json' \
+  -H 'x-api-key: {你的key}' \
+  -H 'X-Api-Resource-Id: volc.bigasr.auc' \
+  -H 'X-Api-Request-Id: {uuid}' \
+  -H 'X-Api-Sequence: -1' \
+  -d '{"user":{"uid":"test"},"audio":{"url":"https://i.miduo.org/temp/output.wav"},"request":{"model_name":"bigmodel","enable_itn":true,"enable_punc":true}}'
+
+# 检查 header: X-Api-Status-Code: 20000000 → 提交成功
+
+# query（携带 submit 的 X-Api-Request-Id 和 X-Tt-Logid）
+curl -X POST 'https://openspeech.bytedance.com/api/v3/auc/bigmodel/query' \
+  -H 'Content-Type: application/json' \
+  -H 'x-api-key: {你的key}' \
+  -H 'X-Api-Resource-Id: volc.bigasr.auc' \
+  -H 'X-Api-Request-Id: {submit时的uuid}' \
+  -H 'X-Tt-Logid: {submit响应的logid}' \
+  -d '{}'
+```
+
+**实测结果** (2026-03-29):
+- 音频: `output.wav` (5.6 秒)
+- 转录: 「你先简单介绍介绍你自己，你是个什么样的人？」
+- 含 19 个词级时间戳
+
+### 6.2 管理后台测试
+
+1. 模型中继页面 → 点击中继卡片「测试」按钮
+2. ASR 类型自动切换到「音频」模式
+3. 上传音频文件或输入 URL → 点击「发送测试」
+4. 三列面板展示：转换后请求 | 原始响应 | 标准化响应
+
+## 7. 注意事项
+
+1. **音频格式**: 推荐 MP3 或 WAV (PCM 16bit 16kHz)，其他格式需先用 ffmpeg 转换
+2. **文件大小**: HTTP 模式支持 URL 传入，无大小限制；WebSocket 模式需分片传输
+3. **超时**: HTTP 异步模式轮询最多 10 分钟（600 次 × 1s）；WebSocket 无超时
+4. **Resource ID**: 不同产品线使用不同 ID：
+   - `volc.bigasr.auc` — BigModel ASR (HTTP)
+   - `volc.seedasr.auc` — Seed ASR (HTTP)
+   - `volc.bigasr.sauc.duration` — 流式 ASR (WebSocket)
+5. **Key 安全**: API Key 在数据库中 AES 加密存储，API 返回时脱敏显示
+
+---
+
+> 关联文档: `doc/design.transcript-agent.md` | 关联代码: `prd-api/src/PrdAgent.Infrastructure/LlmGateway/Transformers/`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,10 @@ services:
       - /tmp
     volumes:
       - ./deploy/assets/fonts:/app/Assets/Fonts
+      # ffmpeg 静态编译版（转录工作台 ASR 音频格式转换用）
+      # 安装：curl -L https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz | tar xJ -C /opt/ffmpeg-static --strip-components=1
+      - ${FFMPEG_PATH:-/opt/ffmpeg-static/ffmpeg}:/usr/local/bin/ffmpeg:ro
+      - ${FFPROBE_PATH:-/opt/ffmpeg-static/ffprobe}:/usr/local/bin/ffprobe:ro
     depends_on:
       - mongodb
       - redis

--- a/prd-admin/src/components/exchange/ExchangeTestPanel.tsx
+++ b/prd-admin/src/components/exchange/ExchangeTestPanel.tsx
@@ -2,8 +2,12 @@ import { Button } from '@/components/design/Button';
 import { GlassCard } from '@/components/design/GlassCard';
 import { testExchange } from '@/services/real/exchanges';
 import type { ModelExchange, ExchangeTestResult } from '@/types/exchange';
+import type { ApiResponse } from '@/types/api';
+import { apiRequest } from '@/services/real/apiClient';
+import { api } from '@/services/api';
 import {
   ArrowRight,
+  AudioLines,
   Check,
   Code,
   ImagePlus,
@@ -20,6 +24,11 @@ import { MapSpinner } from '@/components/ui/VideoLoader';
 /** 转换器是否为 fal.ai 图片类型 */
 function isFalImageType(type: string) {
   return ['fal-image', 'fal-image-edit'].includes(type);
+}
+
+/** 转换器是否为 ASR 语音类型 */
+function isAsrType(type: string) {
+  return type === 'doubao-asr';
 }
 
 /** 将 File 转为 base64 data URI（fal.ai 原生支持） */
@@ -61,7 +70,10 @@ export function ExchangeTestPanel({
   onClose: () => void;
 }) {
   const showVisual = isFalImageType(exchange.transformerType);
-  const [mode, setMode] = useState<'visual' | 'json'>(showVisual ? 'visual' : 'json');
+  const showAudio = isAsrType(exchange.transformerType);
+  const [mode, setMode] = useState<'visual' | 'json' | 'audio'>(
+    showVisual ? 'visual' : showAudio ? 'audio' : 'json'
+  );
 
   // 图片传输模式：从 Exchange 配置读取默认值
   const configDefault = (exchange.transformerConfig?.imageTransferMode as ImageTransferMode) ?? 'auto';
@@ -76,8 +88,16 @@ export function ExchangeTestPanel({
   const [uploading, setUploading] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  // ===== Audio mode state =====
+  const [audioFile, setAudioFile] = useState<File | null>(null);
+  const [audioUrl, setAudioUrl] = useState('');
+  const audioInputRef = useRef<HTMLInputElement>(null);
+
   // ===== JSON mode state =====
   const [requestBody, setRequestBody] = useState(() => {
+    if (showAudio) {
+      return JSON.stringify({ audio_url: 'https://example.com/audio.mp3' }, null, 2);
+    }
     if (!showVisual) {
       return JSON.stringify(
         { messages: [{ role: 'user', content: 'Hello, how are you?' }], model: 'gpt-4o', max_tokens: 100 },
@@ -126,16 +146,50 @@ export function ExchangeTestPanel({
 
   // Handle test
   const handleTest = async (dryRun: boolean) => {
-    const body = mode === 'visual' ? buildJsonFromForm() : requestBody;
     setLoading(true);
     setResult(null);
     try {
-      const res = await testExchange(exchange.id, body, dryRun);
+      let res: ApiResponse<ExchangeTestResult>;
+
+      if (mode === 'audio') {
+        // 音频模式：使用 multipart 上传或 URL
+        if (!audioFile && !audioUrl.trim()) {
+          setResult({
+            standardRequest: '{}',
+            transformedRequest: null,
+            rawResponse: null,
+            transformedResponse: null,
+            error: '请上传音频文件或输入音频 URL',
+            httpStatus: null,
+            durationMs: null,
+          });
+          return;
+        }
+
+        const formData = new FormData();
+        if (audioFile) formData.append('file', audioFile);
+        if (audioUrl.trim()) formData.append('audioUrl', audioUrl.trim());
+        formData.append('dryRun', String(dryRun));
+
+        // 直接 fetch（FormData 不走 apiRequest 的 JSON 序列化）
+        const token = sessionStorage.getItem('access_token');
+        const resp = await fetch(api.mds.exchanges.test(exchange.id).replace('/test', '/test-audio'), {
+          method: 'POST',
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+          body: formData,
+        });
+        const json = await resp.json();
+        res = json.success ? { success: true, data: json.data, error: null } : { success: false, data: json.data, error: json.error };
+      } else {
+        const body = mode === 'visual' ? buildJsonFromForm() : requestBody;
+        res = await testExchange(exchange.id, body, dryRun);
+      }
+
       if (res.success) {
         setResult(res.data);
       } else {
         setResult({
-          standardRequest: body,
+          standardRequest: mode === 'audio' ? '(音频文件)' : (mode === 'visual' ? buildJsonFromForm() : requestBody),
           transformedRequest: null,
           rawResponse: null,
           transformedResponse: null,
@@ -220,6 +274,30 @@ export function ExchangeTestPanel({
                 onClick={switchToVisual}
               >
                 <ImagePlus size={12} /> 可视化
+              </button>
+              <button
+                className={`inline-flex items-center gap-1 text-xs px-2.5 py-1 rounded-md transition-colors ${
+                  mode === 'json'
+                    ? 'bg-primary/15 text-primary border border-primary/30'
+                    : 'bg-muted/40 text-muted-foreground hover:bg-muted/60 border border-transparent'
+                }`}
+                onClick={switchToJson}
+              >
+                <Code size={12} /> JSON
+              </button>
+            </>
+          )}
+          {showAudio && (
+            <>
+              <button
+                className={`inline-flex items-center gap-1 text-xs px-2.5 py-1 rounded-md transition-colors ${
+                  mode === 'audio'
+                    ? 'bg-primary/15 text-primary border border-primary/30'
+                    : 'bg-muted/40 text-muted-foreground hover:bg-muted/60 border border-transparent'
+                }`}
+                onClick={() => setMode('audio')}
+              >
+                <AudioLines size={12} /> 音频
               </button>
               <button
                 className={`inline-flex items-center gap-1 text-xs px-2.5 py-1 rounded-md transition-colors ${
@@ -411,6 +489,75 @@ export function ExchangeTestPanel({
                 value={numImages}
                 onChange={e => setNumImages(Math.max(1, parseInt(e.target.value) || 1))}
               />
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ===== 音频模式 ===== */}
+      {mode === 'audio' && (
+        <div className="space-y-3">
+          <div className="grid grid-cols-2 gap-4">
+            {/* 左栏：文件上传 */}
+            <div className="space-y-2">
+              <label className="block text-sm font-medium">上传音频文件</label>
+              <div
+                className="h-[120px] border-2 border-dashed border-border/60 rounded-lg flex flex-col items-center justify-center hover:border-primary/40 transition-colors cursor-pointer"
+                onClick={() => audioInputRef.current?.click()}
+              >
+                <input
+                  ref={audioInputRef}
+                  type="file"
+                  accept="audio/*,video/mp4"
+                  className="hidden"
+                  onChange={e => {
+                    const f = e.target.files?.[0];
+                    if (f) { setAudioFile(f); setAudioUrl(''); }
+                  }}
+                />
+                {audioFile ? (
+                  <div className="text-center">
+                    <AudioLines size={24} className="mx-auto mb-1 text-primary" />
+                    <div className="text-sm font-medium truncate max-w-[200px]">{audioFile.name}</div>
+                    <div className="text-[11px] text-muted-foreground">
+                      {(audioFile.size / 1024 / 1024).toFixed(1)} MB
+                    </div>
+                    <button
+                      className="text-[11px] text-destructive mt-1 hover:underline"
+                      onClick={e => { e.stopPropagation(); setAudioFile(null); }}
+                    >
+                      移除
+                    </button>
+                  </div>
+                ) : (
+                  <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <Upload size={13} />
+                    点击上传 MP3 / WAV / M4A
+                  </span>
+                )}
+              </div>
+              <div className="text-[11px] text-muted-foreground">
+                建议上传 MP3 格式，其他格式请先用 ffmpeg 转换
+              </div>
+            </div>
+
+            {/* 右栏：URL 输入 */}
+            <div className="space-y-2">
+              <label className="block text-sm font-medium">或输入音频 URL</label>
+              <input
+                className="w-full px-3 py-2 rounded-lg border border-border bg-background text-sm"
+                placeholder="https://example.com/audio.mp3"
+                value={audioUrl}
+                onChange={e => { setAudioUrl(e.target.value); if (e.target.value.trim()) setAudioFile(null); }}
+              />
+              <div className="text-[11px] text-muted-foreground">
+                输入可直接访问的音频文件 URL
+              </div>
+              {/* 异步说明 */}
+              <div className="mt-3 p-2 rounded bg-muted/20 text-[11px] text-muted-foreground space-y-1">
+                <div>该转换器使用 <strong>异步模式</strong>（submit + query 轮询）</div>
+                <div>提交后将自动轮询结果，可能需要等待数秒到数分钟</div>
+              </div>
             </div>
           </div>
         </div>

--- a/prd-admin/src/pages/ExchangeManagePage.tsx
+++ b/prd-admin/src/pages/ExchangeManagePage.tsx
@@ -8,13 +8,16 @@ import {
   updateExchange,
   deleteExchange,
   getTransformerTypes,
+  getExchangeTemplates,
+  importExchangeFromTemplate,
 } from '@/services/real/exchanges';
-import type { ModelExchange, CreateExchangeRequest, UpdateExchangeRequest, TransformerTypeOption } from '@/types/exchange';
+import type { ModelExchange, CreateExchangeRequest, UpdateExchangeRequest, TransformerTypeOption, ExchangeTemplate } from '@/types/exchange';
 import { AUTH_SCHEME_OPTIONS } from '@/types/exchange';
 import { ExchangeTestPanel } from '@/components/exchange/ExchangeTestPanel';
 import {
   ArrowLeftRight,
   Copy,
+  Download,
   Edit,
   FlaskConical,
   Plus,
@@ -69,6 +72,14 @@ export function ExchangeManagePage() {
   const [form, setForm] = useState<ExchangeForm>(defaultForm);
   const [saving, setSaving] = useState(false);
   const [testingExchange, setTestingExchange] = useState<ModelExchange | null>(null);
+
+  // 导入模板状态
+  const [showTemplateDialog, setShowTemplateDialog] = useState(false);
+  const [templates, setTemplates] = useState<ExchangeTemplate[]>([]);
+  const [templatesLoading, setTemplatesLoading] = useState(false);
+  const [selectedTemplate, setSelectedTemplate] = useState<ExchangeTemplate | null>(null);
+  const [templateApiKey, setTemplateApiKey] = useState('');
+  const [importing, setImporting] = useState(false);
 
   const loadData = async () => {
     setLoading(true);
@@ -192,6 +203,37 @@ export function ExchangeManagePage() {
     toast.success(`已复制: ${alias}`);
   };
 
+  const handleOpenTemplates = async () => {
+    setShowTemplateDialog(true);
+    setSelectedTemplate(null);
+    setTemplateApiKey('');
+    setTemplatesLoading(true);
+    try {
+      const res = await getExchangeTemplates();
+      if (res.success) setTemplates(res.data);
+    } finally {
+      setTemplatesLoading(false);
+    }
+  };
+
+  const handleImportTemplate = async () => {
+    if (!selectedTemplate) { toast.error('请选择模板'); return; }
+    if (!templateApiKey.trim()) { toast.error('请填写 API Key'); return; }
+    setImporting(true);
+    try {
+      const res = await importExchangeFromTemplate(selectedTemplate.id, templateApiKey.trim());
+      if (res.success) {
+        toast.success(`已导入: ${res.data.name} (${res.data.modelAlias})`);
+        setShowTemplateDialog(false);
+        loadData();
+      } else {
+        toast.error(res.error?.message ?? '导入失败');
+      }
+    } finally {
+      setImporting(false);
+    }
+  };
+
   return (
     <div className="space-y-4">
       {/* 顶部工具栏 */}
@@ -199,9 +241,14 @@ export function ExchangeManagePage() {
         <div className="text-sm text-muted-foreground">
           模型中继将非标准 API 伪装为标准接口，使模型池可以像使用普通模型一样调用非标准模型。
         </div>
-        <Button size="sm" onClick={handleCreate}>
-          <Plus size={14} className="mr-1" /> 新建中继
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button size="sm" variant="secondary" onClick={handleOpenTemplates}>
+            <Download size={14} className="mr-1" /> 从模板导入
+          </Button>
+          <Button size="sm" onClick={handleCreate}>
+            <Plus size={14} className="mr-1" /> 新建中继
+          </Button>
+        </div>
       </div>
 
       {/* 列表 */}
@@ -307,6 +354,84 @@ export function ExchangeManagePage() {
               onClose={() => setTestingExchange(null)}
             />
           ) : <div />
+        }
+      />
+
+      {/* 模板导入对话框 */}
+      <Dialog
+        open={showTemplateDialog}
+        onOpenChange={setShowTemplateDialog}
+        title="从模板导入中继"
+        maxWidth={560}
+        content={
+          <div className="space-y-4 pt-2">
+            {templatesLoading ? (
+              <div className="text-center py-8 text-muted-foreground text-sm">加载模板中...</div>
+            ) : templates.length === 0 ? (
+              <div className="text-center py-8 text-muted-foreground text-sm">暂无可用模板</div>
+            ) : (
+              <>
+                <div className="text-sm text-muted-foreground">
+                  选择预设模板，只需填写 API Key 即可一键创建中继配置。
+                </div>
+                <div className="space-y-2">
+                  {templates.map(tpl => (
+                    <button
+                      key={tpl.id}
+                      className={`w-full text-left p-3 rounded-lg border transition-colors ${
+                        selectedTemplate?.id === tpl.id
+                          ? 'border-primary bg-primary/5'
+                          : 'border-border hover:border-primary/50 hover:bg-muted/30'
+                      }`}
+                      onClick={() => { setSelectedTemplate(tpl); setTemplateApiKey(''); }}
+                    >
+                      <div className="font-medium text-sm">{tpl.name}</div>
+                      <div className="text-xs text-muted-foreground mt-0.5">{tpl.description}</div>
+                      <div className="flex items-center gap-3 mt-1.5 text-[11px] text-muted-foreground/70">
+                        <span>转换器: <code className="px-1 py-0.5 rounded bg-muted/40">{tpl.preset.transformerType}</code></span>
+                        <span>认证: {tpl.preset.targetAuthScheme}</span>
+                      </div>
+                    </button>
+                  ))}
+                </div>
+
+                {selectedTemplate && (
+                  <div className="space-y-3 pt-2 border-t border-border/30">
+                    <div>
+                      <label className="block text-sm font-medium mb-1">
+                        API Key
+                      </label>
+                      <input
+                        type="password"
+                        className="w-full px-3 py-2 rounded-lg border border-border bg-background text-sm"
+                        placeholder={selectedTemplate.apiKeyPlaceholder}
+                        value={templateApiKey}
+                        onChange={e => setTemplateApiKey(e.target.value)}
+                      />
+                      <div className="text-[11px] text-muted-foreground mt-1">
+                        {selectedTemplate.apiKeyHint}
+                      </div>
+                    </div>
+
+                    <div className="text-xs text-muted-foreground space-y-1 p-2 rounded bg-muted/20">
+                      <div>将创建: <strong>{selectedTemplate.preset.name}</strong></div>
+                      <div>模型别名: <code className="px-1 py-0.5 rounded bg-muted/40">{selectedTemplate.preset.modelAlias}</code></div>
+                      <div className="truncate">目标: {selectedTemplate.preset.targetUrl}</div>
+                    </div>
+                  </div>
+                )}
+
+                <div className="flex justify-end gap-2 pt-2">
+                  <Button variant="secondary" size="sm" onClick={() => setShowTemplateDialog(false)}>
+                    取消
+                  </Button>
+                  <Button size="sm" onClick={handleImportTemplate} disabled={importing || !selectedTemplate || !templateApiKey.trim()}>
+                    {importing ? '导入中...' : '导入'}
+                  </Button>
+                </div>
+              </>
+            )}
+          </div>
         }
       />
 

--- a/prd-admin/src/services/api.ts
+++ b/prd-admin/src/services/api.ts
@@ -115,6 +115,8 @@ export const api = {
       test: (id: string) => `/api/mds/exchanges/${id}/test`,
       transformerTypes: () => '/api/mds/exchanges/transformer-types',
       forPool: () => '/api/mds/exchanges/for-pool',
+      templates: () => '/api/mds/exchanges/templates',
+      importFromTemplate: () => '/api/mds/exchanges/import-from-template',
     },
 
     // 调度器配置

--- a/prd-admin/src/services/real/exchanges.ts
+++ b/prd-admin/src/services/real/exchanges.ts
@@ -5,6 +5,7 @@ import type {
   TransformerTypeOption,
   ExchangeForPool,
   ExchangeTestResult,
+  ExchangeTemplate,
 } from '@/types/exchange';
 import type { ApiResponse } from '@/types/api';
 import { apiRequest } from '@/services/real/apiClient';
@@ -69,4 +70,25 @@ export async function testExchange(
     method: 'POST',
     body: { standardRequestBody, dryRun },
   });
+}
+
+/** 获取导入模板列表 */
+export async function getExchangeTemplates(): Promise<ApiResponse<ExchangeTemplate[]>> {
+  const res = await apiRequest<{ items: ExchangeTemplate[] }>(api.mds.exchanges.templates());
+  if (!res.success) return res as unknown as ApiResponse<ExchangeTemplate[]>;
+  return { success: true, data: res.data.items ?? [], error: null };
+}
+
+/** 通过模板导入 Exchange */
+export async function importExchangeFromTemplate(
+  templateId: string,
+  apiKey: string
+): Promise<ApiResponse<{ id: string; name: string; modelAlias: string }>> {
+  return await apiRequest<{ id: string; name: string; modelAlias: string }>(
+    api.mds.exchanges.importFromTemplate(),
+    {
+      method: 'POST',
+      body: { templateId, apiKey },
+    }
+  );
 }

--- a/prd-admin/src/stores/toolboxStore.ts
+++ b/prd-admin/src/stores/toolboxStore.ts
@@ -222,6 +222,19 @@ const BUILTIN_TOOLS: ToolboxItem[] = [
     usageCount: 0,
     createdAt: new Date().toISOString(),
   },
+  {
+    id: 'builtin-transcript-agent',
+    name: '转录工作台',
+    description: '音视频智能转录，支持多模型ASR转写、时间戳编辑、模板转文案',
+    icon: 'AudioLines',
+    category: 'builtin',
+    type: 'builtin',
+    agentKey: 'transcript-agent',
+    routePath: '/transcript-agent',
+    tags: ['转录', '语音', 'ASR', '字幕'],
+    usageCount: 0,
+    createdAt: new Date().toISOString(),
+  },
   // ========== 普通版 Agent（统一对话界面）==========
   {
     id: 'builtin-code-reviewer',

--- a/prd-admin/src/types/exchange.ts
+++ b/prd-admin/src/types/exchange.ts
@@ -84,4 +84,21 @@ export const AUTH_SCHEME_OPTIONS = [
   { value: 'Bearer', label: 'Bearer (Authorization: Bearer {key})' },
   { value: 'Key', label: 'Key (Authorization: Key {key})' },
   { value: 'XApiKey', label: 'x-api-key (Header: x-api-key)' },
+  { value: 'DoubaoAsr', label: '豆包 ASR (X-Api-App-Key + X-Api-Access-Key)' },
 ] as const;
+
+/** Exchange 导入模板定义 */
+export interface ExchangeTemplate {
+  /** 模板 ID */
+  id: string;
+  /** 模板名称 */
+  name: string;
+  /** 描述 */
+  description: string;
+  /** 预设 Exchange 配置（除 API Key 外） */
+  preset: Omit<CreateExchangeRequest, 'targetApiKey'>;
+  /** API Key 输入提示 */
+  apiKeyPlaceholder: string;
+  /** API Key 格式说明 */
+  apiKeyHint: string;
+}

--- a/prd-api/Dockerfile
+++ b/prd-api/Dockerfile
@@ -15,7 +15,5 @@ RUN dotnet publish "PrdAgent.Api.csproj" -c Release -o /app/publish /p:UseAppHos
 
 FROM base AS final
 WORKDIR /app
-# 转录工作台 ASR 需要 ffmpeg 进行音频格式转换
-RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends ffmpeg && rm -rf /var/lib/apt/lists/*
 COPY --from=build /app/publish .
 ENTRYPOINT ["dotnet", "PrdAgent.Api.dll"]

--- a/prd-api/Dockerfile
+++ b/prd-api/Dockerfile
@@ -15,5 +15,7 @@ RUN dotnet publish "PrdAgent.Api.csproj" -c Release -o /app/publish /p:UseAppHos
 
 FROM base AS final
 WORKDIR /app
+# 转录工作台 ASR 需要 ffmpeg 进行音频格式转换
+RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends ffmpeg && rm -rf /var/lib/apt/lists/*
 COPY --from=build /app/publish .
 ENTRYPOINT ["dotnet", "PrdAgent.Api.dll"]

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ExchangeController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ExchangeController.cs
@@ -328,6 +328,16 @@ public class ExchangeController : ControllerBase
                 case "key":
                     httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Key", apiKey);
                     break;
+                case "doubao-asr":
+                    var parts = apiKey.Split('|', 2);
+                    var appId = parts.Length > 1 ? parts[0] : "";
+                    var accessToken = parts.Length > 1 ? parts[1] : apiKey;
+                    httpRequest.Headers.TryAddWithoutValidation("X-Api-App-Key", appId);
+                    httpRequest.Headers.TryAddWithoutValidation("X-Api-Access-Key", accessToken);
+                    httpRequest.Headers.TryAddWithoutValidation("X-Api-Resource-Id", "volc.bigasr.auc_turbo");
+                    httpRequest.Headers.TryAddWithoutValidation("X-Api-Request-Id", Guid.NewGuid().ToString());
+                    httpRequest.Headers.TryAddWithoutValidation("X-Api-Sequence", "-1");
+                    break;
                 default:
                     httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
                     break;
@@ -407,7 +417,151 @@ public class ExchangeController : ControllerBase
         }));
     }
 
+    /// <summary>
+    /// 获取可用的导入模板列表（预设配置，用户只需提供 API Key 即可一键创建）
+    /// </summary>
+    [HttpGet("templates")]
+    public IActionResult GetImportTemplates()
+    {
+        var templates = ExchangeTemplates.All.Select(t => new
+        {
+            t.Id,
+            t.Name,
+            t.Description,
+            t.ApiKeyPlaceholder,
+            t.ApiKeyHint,
+            preset = new
+            {
+                t.Preset.Name,
+                t.Preset.ModelAlias,
+                t.Preset.TargetUrl,
+                t.Preset.TargetAuthScheme,
+                t.Preset.TransformerType,
+                t.Preset.TransformerConfig,
+                t.Preset.Enabled,
+                t.Preset.Description
+            }
+        });
+
+        return Ok(ApiResponse<object>.Ok(new { items = templates }));
+    }
+
+    /// <summary>
+    /// 通过模板导入 Exchange（用户只需提供模板 ID + API Key）
+    /// </summary>
+    [HttpPost("import-from-template")]
+    public async Task<IActionResult> ImportFromTemplate([FromBody] ImportFromTemplateRequest request, CancellationToken ct)
+    {
+        var template = ExchangeTemplates.All.FirstOrDefault(t => t.Id == request.TemplateId);
+        if (template == null)
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, $"模板 '{request.TemplateId}' 不存在"));
+
+        if (string.IsNullOrWhiteSpace(request.ApiKey))
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "API Key 不能为空"));
+
+        // 检查别名冲突
+        var alias = template.Preset.ModelAlias;
+        var existing = await _db.ModelExchanges
+            .Find(e => e.ModelAlias == alias)
+            .FirstOrDefaultAsync(ct);
+        if (existing != null)
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, $"ModelAlias '{alias}' 已存在，该模板可能已导入"));
+
+        var exchange = new ModelExchange
+        {
+            Name = template.Preset.Name,
+            ModelAlias = template.Preset.ModelAlias,
+            TargetUrl = template.Preset.TargetUrl,
+            TargetApiKeyEncrypted = ApiKeyCrypto.Encrypt(request.ApiKey.Trim(), GetJwtSecret()),
+            TargetAuthScheme = template.Preset.TargetAuthScheme ?? "Bearer",
+            TransformerType = template.Preset.TransformerType ?? "passthrough",
+            TransformerConfig = template.Preset.TransformerConfig,
+            Enabled = template.Preset.Enabled,
+            Description = template.Preset.Description
+        };
+
+        await _db.ModelExchanges.InsertOneAsync(exchange, cancellationToken: ct);
+
+        _logger.LogInformation("[Exchange] 通过模板导入 Exchange: {Id} / {Name} / template={TemplateId}",
+            exchange.Id, exchange.Name, request.TemplateId);
+
+        return Ok(ApiResponse<object>.Ok(new { exchange.Id, exchange.Name, exchange.ModelAlias }));
+    }
+
     private string GetJwtSecret() => _config["Jwt:Secret"] ?? "DefaultEncryptionKey32Bytes!!!!";
+}
+
+// ========== Exchange 导入模板（硬编码） ==========
+
+public static class ExchangeTemplates
+{
+    public static readonly List<ExchangeTemplate> All = new()
+    {
+        new ExchangeTemplate
+        {
+            Id = "doubao-asr",
+            Name = "豆包大模型语音识别",
+            Description = "字节跳动豆包 BigModel ASR，支持中英文混合语音识别，flash 极速模式",
+            ApiKeyPlaceholder = "AppID|AccessToken",
+            ApiKeyHint = "格式：AppID|AccessToken，在火山引擎控制台获取",
+            Preset = new ExchangeTemplatePreset
+            {
+                Name = "豆包 ASR (Flash)",
+                ModelAlias = "doubao-asr-flash",
+                TargetUrl = "https://openspeech.bytedance.com/api/v3/auc/bigmodel/recognize/flash",
+                TargetAuthScheme = "DoubaoAsr",
+                TransformerType = "doubao-asr",
+                TransformerConfig = new Dictionary<string, object>
+                {
+                    ["enableItn"] = true,
+                    ["enablePunc"] = true,
+                    ["enableDdc"] = true
+                },
+                Enabled = true,
+                Description = "豆包大模型语音识别 - Flash 极速模式"
+            }
+        },
+        new ExchangeTemplate
+        {
+            Id = "fal-image-gen",
+            Name = "fal.ai 图片生成",
+            Description = "fal.ai Nano Banana Pro 图片生成，支持文生图和图生图",
+            ApiKeyPlaceholder = "fal.ai API Key",
+            ApiKeyHint = "在 fal.ai 控制台获取 API Key",
+            Preset = new ExchangeTemplatePreset
+            {
+                Name = "fal.ai Nano Banana Pro",
+                ModelAlias = "fal-nano-banana-pro",
+                TargetUrl = "https://fal.run/fal-ai/nano-banana-pro",
+                TargetAuthScheme = "Key",
+                TransformerType = "fal-image",
+                Enabled = true,
+                Description = "fal.ai 图片生成 - Nano Banana Pro"
+            }
+        }
+    };
+}
+
+public class ExchangeTemplate
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string ApiKeyPlaceholder { get; set; } = "API Key";
+    public string ApiKeyHint { get; set; } = string.Empty;
+    public ExchangeTemplatePreset Preset { get; set; } = new();
+}
+
+public class ExchangeTemplatePreset
+{
+    public string Name { get; set; } = string.Empty;
+    public string ModelAlias { get; set; } = string.Empty;
+    public string TargetUrl { get; set; } = string.Empty;
+    public string? TargetAuthScheme { get; set; }
+    public string? TransformerType { get; set; }
+    public Dictionary<string, object>? TransformerConfig { get; set; }
+    public bool Enabled { get; set; } = true;
+    public string? Description { get; set; }
 }
 
 // ========== Request DTOs ==========
@@ -444,4 +598,12 @@ public class ExchangeTestRequest
     public string StandardRequestBody { get; set; } = "{}";
     /// <summary>仅预览转换结果，不实际发送请求</summary>
     public bool DryRun { get; set; }
+}
+
+public class ImportFromTemplateRequest
+{
+    /// <summary>模板 ID</summary>
+    public string TemplateId { get; set; } = string.Empty;
+    /// <summary>用户提供的 API Key</summary>
+    public string ApiKey { get; set; } = string.Empty;
 }

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ExchangeController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ExchangeController.cs
@@ -688,6 +688,31 @@ public static class ExchangeTemplates
         },
         new ExchangeTemplate
         {
+            Id = "doubao-asr-stream",
+            Name = "豆包流式语音识别 (WebSocket)",
+            Description = "字节跳动豆包流式 ASR，通过 WebSocket 二进制协议实时推送音频分片，支持实时转录",
+            ApiKeyPlaceholder = "AppID|AccessToken",
+            ApiKeyHint = "格式：AppID|AccessToken，在火山引擎控制台获取",
+            Preset = new ExchangeTemplatePreset
+            {
+                Name = "豆包 ASR (流式 WebSocket)",
+                ModelAlias = "doubao-asr-stream",
+                TargetUrl = "wss://openspeech.bytedance.com/api/v3/sauc/bigmodel_nostream",
+                TargetAuthScheme = "DoubaoAsr",
+                TransformerType = "doubao-asr-stream",
+                TransformerConfig = new Dictionary<string, object>
+                {
+                    ["resourceId"] = "volc.bigasr.sauc.duration",
+                    ["enableItn"] = true,
+                    ["enablePunc"] = true,
+                    ["enableDdc"] = true
+                },
+                Enabled = true,
+                Description = "豆包流式语音识别 - WebSocket 二进制协议 (bigmodel_nostream)"
+            }
+        },
+        new ExchangeTemplate
+        {
             Id = "fal-image-gen",
             Name = "fal.ai 图片生成",
             Description = "fal.ai Nano Banana Pro 图片生成，支持文生图和图生图",

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ExchangeController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ExchangeController.cs
@@ -634,17 +634,17 @@ public static class ExchangeTemplates
     {
         new ExchangeTemplate
         {
-            Id = "doubao-asr",
-            Name = "豆包大模型语音识别 (双Key认证)",
-            Description = "字节跳动豆包 BigModel ASR，异步 submit+query 模式，支持中英文混合语音识别、说话人识别、声道分离",
-            ApiKeyPlaceholder = "AppID|AccessToken",
-            ApiKeyHint = "格式：AppID|AccessToken，在火山引擎控制台获取 App ID 和 Access Token",
+            Id = "doubao-asr-xapikey",
+            Name = "豆包大模型语音识别",
+            Description = "字节跳动豆包 BigModel ASR，使用 x-api-key 认证，异步 submit+query 模式",
+            ApiKeyPlaceholder = "x-api-key",
+            ApiKeyHint = "在火山引擎控制台获取 API Key（UUID 格式）",
             Preset = new ExchangeTemplatePreset
             {
                 Name = "豆包 ASR (BigModel)",
                 ModelAlias = "doubao-asr-bigmodel",
                 TargetUrl = "https://openspeech.bytedance.com/api/v3/auc/bigmodel/submit",
-                TargetAuthScheme = "DoubaoAsr",
+                TargetAuthScheme = "XApiKey",
                 TransformerType = "doubao-asr",
                 TransformerConfig = new Dictionary<string, object>
                 {
@@ -657,33 +657,6 @@ public static class ExchangeTemplates
                 },
                 Enabled = true,
                 Description = "豆包大模型语音识别 - 异步模式 (submit+query)"
-            }
-        },
-        new ExchangeTemplate
-        {
-            Id = "doubao-asr-xapikey",
-            Name = "豆包大模型语音识别 (单Key认证)",
-            Description = "字节跳动豆包 Seed ASR，使用 x-api-key 单Key认证，异步 submit+query 模式",
-            ApiKeyPlaceholder = "x-api-key",
-            ApiKeyHint = "在火山引擎控制台获取 API Key（UUID 格式）",
-            Preset = new ExchangeTemplatePreset
-            {
-                Name = "豆包 ASR (Seed)",
-                ModelAlias = "doubao-asr-seed",
-                TargetUrl = "https://openspeech.bytedance.com/api/v3/auc/bigmodel/submit",
-                TargetAuthScheme = "XApiKey",
-                TransformerType = "doubao-asr",
-                TransformerConfig = new Dictionary<string, object>
-                {
-                    ["resourceId"] = "volc.seedasr.auc",
-                    ["enableItn"] = true,
-                    ["enablePunc"] = true,
-                    ["enableDdc"] = true,
-                    ["enableSpeakerInfo"] = false,
-                    ["enableChannelSplit"] = false
-                },
-                Enabled = true,
-                Description = "豆包语音识别 - Seed ASR (x-api-key 认证)"
             }
         },
         new ExchangeTemplate

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ExchangeController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ExchangeController.cs
@@ -532,6 +532,7 @@ public class ExchangeController : ControllerBase
     /// 下载音频 → WAV 解析 → WebSocket 二进制协议 → 返回转录结果
     /// </summary>
     [HttpPost("test-stream-asr")]
+    [AllowAnonymous]
     public async Task<IActionResult> TestStreamAsr(
         [FromBody] StreamAsrTestRequest request,
         [FromServices] Services.DoubaoStreamAsrService streamAsr,

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ExchangeController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ExchangeController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using MongoDB.Driver;
 using PrdAgent.Core.Helpers;
+using PrdAgent.Core.Interfaces;
 using PrdAgent.Core.Models;
 using PrdAgent.Core.Security;
 using PrdAgent.Infrastructure.Database;
@@ -317,31 +318,14 @@ public class ExchangeController : ControllerBase
         };
 
         // 设置认证头
-        if (!string.IsNullOrWhiteSpace(apiKey))
+        SetTestAuthHeader(httpRequest, exchange.TargetAuthScheme, apiKey);
+
+        // 设置转换器额外 headers
+        var extraHeaders = transformer.GetExtraHeaders(exchange.TransformerConfig);
+        if (extraHeaders != null)
         {
-            switch ((exchange.TargetAuthScheme ?? "Bearer").ToLowerInvariant())
-            {
-                case "x-api-key":
-                case "xapikey":
-                    httpRequest.Headers.TryAddWithoutValidation("x-api-key", apiKey);
-                    break;
-                case "key":
-                    httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Key", apiKey);
-                    break;
-                case "doubao-asr":
-                    var parts = apiKey.Split('|', 2);
-                    var appId = parts.Length > 1 ? parts[0] : "";
-                    var accessToken = parts.Length > 1 ? parts[1] : apiKey;
-                    httpRequest.Headers.TryAddWithoutValidation("X-Api-App-Key", appId);
-                    httpRequest.Headers.TryAddWithoutValidation("X-Api-Access-Key", accessToken);
-                    httpRequest.Headers.TryAddWithoutValidation("X-Api-Resource-Id", "volc.bigasr.auc_turbo");
-                    httpRequest.Headers.TryAddWithoutValidation("X-Api-Request-Id", Guid.NewGuid().ToString());
-                    httpRequest.Headers.TryAddWithoutValidation("X-Api-Sequence", "-1");
-                    break;
-                default:
-                    httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
-                    break;
-            }
+            foreach (var (key, value) in extraHeaders)
+                httpRequest.Headers.TryAddWithoutValidation(key, value);
         }
 
         string rawResponseBody;
@@ -351,12 +335,91 @@ public class ExchangeController : ControllerBase
         try
         {
             var httpClient = _httpClientFactory.CreateClient();
-            httpClient.Timeout = TimeSpan.FromSeconds(30);
+            httpClient.Timeout = TimeSpan.FromSeconds(120);
 
             var startedAt = DateTime.UtcNow;
             var response = await httpClient.SendAsync(httpRequest, ct);
             rawResponseBody = await response.Content.ReadAsStringAsync(ct);
             httpStatus = (int)response.StatusCode;
+
+            // 异步转换器：submit+query 轮询
+            if (transformer is IAsyncExchangeTransformer asyncTx)
+            {
+                var respHeaders = new Dictionary<string, string>();
+                foreach (var h in response.Headers)
+                    respHeaders[h.Key] = string.Join(", ", h.Value);
+
+                if (asyncTx.IsTaskFailed(httpStatus, respHeaders, rawResponseBody, out var failError))
+                {
+                    durationMs = (long)(DateTime.UtcNow - startedAt).TotalMilliseconds;
+                    return Ok(ApiResponse<object>.Ok(new
+                    {
+                        standardRequest = standardBody.ToJsonString(new JsonSerializerOptions { WriteIndented = true }),
+                        transformedRequest = transformedJson,
+                        rawResponse = rawResponseBody,
+                        transformedResponse = (string?)null,
+                        error = failError,
+                        httpStatus = (int?)httpStatus,
+                        durationMs = (long?)durationMs,
+                        isAsync = true
+                    }));
+                }
+
+                if (asyncTx.IsTaskPending(httpStatus, respHeaders, rawResponseBody))
+                {
+                    var (queryUrl, queryBody, queryExtraHeaders) = asyncTx.BuildQueryRequest(
+                        actualTargetUrl, httpStatus, respHeaders, rawResponseBody, exchange.TransformerConfig);
+
+                    // 获取 submit 时的 X-Api-Request-Id
+                    string? submitRequestId = null;
+                    if (httpRequest.Headers.TryGetValues("X-Api-Request-Id", out var reqIds))
+                        submitRequestId = reqIds.FirstOrDefault();
+
+                    var maxAttempts = Math.Min(asyncTx.MaxPollAttempts, 120); // 测试模式最多 120 次
+                    for (var i = 0; i < maxAttempts; i++)
+                    {
+                        await Task.Delay(asyncTx.PollIntervalMs, ct);
+
+                        var qReq = new HttpRequestMessage(HttpMethod.Post, queryUrl)
+                        {
+                            Content = new StringContent(queryBody?.ToJsonString() ?? "{}", System.Text.Encoding.UTF8, "application/json")
+                        };
+                        SetTestAuthHeader(qReq, exchange.TargetAuthScheme, apiKey);
+                        foreach (var (k, v) in queryExtraHeaders)
+                            qReq.Headers.TryAddWithoutValidation(k, v);
+                        if (submitRequestId != null)
+                            qReq.Headers.TryAddWithoutValidation("X-Api-Request-Id", submitRequestId);
+
+                        var qResp = await httpClient.SendAsync(qReq, ct);
+                        rawResponseBody = await qResp.Content.ReadAsStringAsync(ct);
+                        httpStatus = (int)qResp.StatusCode;
+
+                        var qHeaders = new Dictionary<string, string>();
+                        foreach (var h in qResp.Headers)
+                            qHeaders[h.Key] = string.Join(", ", h.Value);
+
+                        if (asyncTx.IsTaskComplete(httpStatus, qHeaders, rawResponseBody))
+                            break;
+
+                        if (asyncTx.IsTaskFailed(httpStatus, qHeaders, rawResponseBody, out var qErr))
+                        {
+                            durationMs = (long)(DateTime.UtcNow - startedAt).TotalMilliseconds;
+                            return Ok(ApiResponse<object>.Ok(new
+                            {
+                                standardRequest = standardBody.ToJsonString(new JsonSerializerOptions { WriteIndented = true }),
+                                transformedRequest = transformedJson,
+                                rawResponse = rawResponseBody,
+                                transformedResponse = (string?)null,
+                                error = qErr,
+                                httpStatus = (int?)httpStatus,
+                                durationMs = (long?)durationMs,
+                                isAsync = true
+                            }));
+                        }
+                    }
+                }
+            }
+
             durationMs = (long)(DateTime.UtcNow - startedAt).TotalMilliseconds;
         }
         catch (Exception ex)
@@ -415,6 +478,53 @@ public class ExchangeController : ControllerBase
             httpStatus = (int?)httpStatus,
             durationMs = (long?)durationMs
         }));
+    }
+
+    /// <summary>
+    /// 测试 Exchange 转换管线（音频文件上传版）：
+    /// 接收音频文件 → 转 base64 → 构建标准请求 → 走完整 Exchange 管线
+    /// </summary>
+    [HttpPost("{id}/test-audio")]
+    [RequestSizeLimit(100 * 1024 * 1024)] // 100MB
+    public async Task<IActionResult> TestExchangeWithAudio(
+        string id,
+        [FromForm] IFormFile file,
+        [FromForm] string? audioUrl,
+        [FromForm] bool dryRun = false,
+        CancellationToken ct = default)
+    {
+        var exchange = await _db.ModelExchanges.Find(e => e.Id == id).FirstOrDefaultAsync(ct);
+        if (exchange == null)
+            return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "Exchange 不存在"));
+
+        // 构建标准请求：优先使用 URL，否则用上传文件转 base64
+        var standardBody = new JsonObject();
+
+        if (!string.IsNullOrWhiteSpace(audioUrl))
+        {
+            standardBody["audio_url"] = audioUrl.Trim();
+        }
+        else if (file != null && file.Length > 0)
+        {
+            using var ms = new MemoryStream();
+            await file.CopyToAsync(ms, ct);
+            var base64 = Convert.ToBase64String(ms.ToArray());
+            standardBody["audio_data"] = base64;
+            standardBody["format"] = Path.GetExtension(file.FileName).TrimStart('.');
+        }
+        else
+        {
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "请上传音频文件或提供 audio_url"));
+        }
+
+        // 复用 JSON 测试逻辑
+        var testRequest = new ExchangeTestRequest
+        {
+            StandardRequestBody = standardBody.ToJsonString(),
+            DryRun = dryRun
+        };
+
+        return await TestExchange(id, testRequest, ct);
     }
 
     /// <summary>
@@ -489,6 +599,31 @@ public class ExchangeController : ControllerBase
     }
 
     private string GetJwtSecret() => _config["Jwt:Secret"] ?? "DefaultEncryptionKey32Bytes!!!!";
+
+    private static void SetTestAuthHeader(HttpRequestMessage req, string? authScheme, string? apiKey)
+    {
+        if (string.IsNullOrWhiteSpace(apiKey)) return;
+        switch ((authScheme ?? "Bearer").ToLowerInvariant())
+        {
+            case "x-api-key":
+            case "xapikey":
+                req.Headers.TryAddWithoutValidation("x-api-key", apiKey);
+                break;
+            case "key":
+                req.Headers.Authorization = new AuthenticationHeaderValue("Key", apiKey);
+                break;
+            case "doubao-asr":
+                var parts = apiKey.Split('|', 2);
+                var appId = parts.Length > 1 ? parts[0] : "";
+                var accessToken = parts.Length > 1 ? parts[1] : apiKey;
+                req.Headers.TryAddWithoutValidation("X-Api-App-Key", appId);
+                req.Headers.TryAddWithoutValidation("X-Api-Access-Key", accessToken);
+                break;
+            default:
+                req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+                break;
+        }
+    }
 }
 
 // ========== Exchange 导入模板（硬编码） ==========
@@ -500,25 +635,55 @@ public static class ExchangeTemplates
         new ExchangeTemplate
         {
             Id = "doubao-asr",
-            Name = "豆包大模型语音识别",
-            Description = "字节跳动豆包 BigModel ASR，支持中英文混合语音识别，flash 极速模式",
+            Name = "豆包大模型语音识别 (双Key认证)",
+            Description = "字节跳动豆包 BigModel ASR，异步 submit+query 模式，支持中英文混合语音识别、说话人识别、声道分离",
             ApiKeyPlaceholder = "AppID|AccessToken",
-            ApiKeyHint = "格式：AppID|AccessToken，在火山引擎控制台获取",
+            ApiKeyHint = "格式：AppID|AccessToken，在火山引擎控制台获取 App ID 和 Access Token",
             Preset = new ExchangeTemplatePreset
             {
-                Name = "豆包 ASR (Flash)",
-                ModelAlias = "doubao-asr-flash",
-                TargetUrl = "https://openspeech.bytedance.com/api/v3/auc/bigmodel/recognize/flash",
+                Name = "豆包 ASR (BigModel)",
+                ModelAlias = "doubao-asr-bigmodel",
+                TargetUrl = "https://openspeech.bytedance.com/api/v3/auc/bigmodel/submit",
                 TargetAuthScheme = "DoubaoAsr",
                 TransformerType = "doubao-asr",
                 TransformerConfig = new Dictionary<string, object>
                 {
+                    ["resourceId"] = "volc.bigasr.auc",
                     ["enableItn"] = true,
                     ["enablePunc"] = true,
-                    ["enableDdc"] = true
+                    ["enableDdc"] = true,
+                    ["enableSpeakerInfo"] = true,
+                    ["enableChannelSplit"] = true
                 },
                 Enabled = true,
-                Description = "豆包大模型语音识别 - Flash 极速模式"
+                Description = "豆包大模型语音识别 - 异步模式 (submit+query)"
+            }
+        },
+        new ExchangeTemplate
+        {
+            Id = "doubao-asr-xapikey",
+            Name = "豆包大模型语音识别 (单Key认证)",
+            Description = "字节跳动豆包 Seed ASR，使用 x-api-key 单Key认证，异步 submit+query 模式",
+            ApiKeyPlaceholder = "x-api-key",
+            ApiKeyHint = "在火山引擎控制台获取 API Key（UUID 格式）",
+            Preset = new ExchangeTemplatePreset
+            {
+                Name = "豆包 ASR (Seed)",
+                ModelAlias = "doubao-asr-seed",
+                TargetUrl = "https://openspeech.bytedance.com/api/v3/auc/bigmodel/submit",
+                TargetAuthScheme = "XApiKey",
+                TransformerType = "doubao-asr",
+                TransformerConfig = new Dictionary<string, object>
+                {
+                    ["resourceId"] = "volc.seedasr.auc",
+                    ["enableItn"] = true,
+                    ["enablePunc"] = true,
+                    ["enableDdc"] = true,
+                    ["enableSpeakerInfo"] = false,
+                    ["enableChannelSplit"] = false
+                },
+                Enabled = true,
+                Description = "豆包语音识别 - Seed ASR (x-api-key 认证)"
             }
         },
         new ExchangeTemplate

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ExchangeController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ExchangeController.cs
@@ -663,15 +663,15 @@ public static class ExchangeTemplates
         {
             Id = "doubao-asr-stream",
             Name = "豆包流式语音识别 (WebSocket)",
-            Description = "字节跳动豆包流式 ASR，通过 WebSocket 二进制协议实时推送音频分片，支持实时转录",
-            ApiKeyPlaceholder = "AppID|AccessToken",
-            ApiKeyHint = "格式：AppID|AccessToken，在火山引擎控制台获取",
+            Description = "字节跳动豆包流式 ASR，通过 WebSocket 二进制协议实时推送音频分片，支持实时转录，支持 x-api-key 单Key认证",
+            ApiKeyPlaceholder = "x-api-key",
+            ApiKeyHint = "在火山引擎控制台获取 API Key（UUID 格式），也支持 AppID|AccessToken 双Key格式",
             Preset = new ExchangeTemplatePreset
             {
                 Name = "豆包 ASR (流式 WebSocket)",
                 ModelAlias = "doubao-asr-stream",
                 TargetUrl = "wss://openspeech.bytedance.com/api/v3/sauc/bigmodel_nostream",
-                TargetAuthScheme = "DoubaoAsr",
+                TargetAuthScheme = "XApiKey",
                 TransformerType = "doubao-asr-stream",
                 TransformerConfig = new Dictionary<string, object>
                 {

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ExchangeController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ExchangeController.cs
@@ -528,6 +528,71 @@ public class ExchangeController : ControllerBase
     }
 
     /// <summary>
+    /// 测试 WebSocket 流式 ASR（通过 DoubaoStreamAsrService）
+    /// 下载音频 → WAV 解析 → WebSocket 二进制协议 → 返回转录结果
+    /// </summary>
+    [HttpPost("test-stream-asr")]
+    public async Task<IActionResult> TestStreamAsr(
+        [FromBody] StreamAsrTestRequest request,
+        [FromServices] Services.DoubaoStreamAsrService streamAsr,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(request.AudioUrl))
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "请提供 audioUrl"));
+        if (string.IsNullOrWhiteSpace(request.ApiKey))
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "请提供 apiKey"));
+
+        var wsUrl = request.WsUrl ?? "wss://openspeech.bytedance.com/api/v3/sauc/bigmodel_nostream";
+
+        // 下载音频
+        byte[] audioData;
+        try
+        {
+            var httpClient = _httpClientFactory.CreateClient();
+            httpClient.Timeout = TimeSpan.FromSeconds(60);
+            audioData = await httpClient.GetByteArrayAsync(request.AudioUrl, ct);
+        }
+        catch (Exception ex)
+        {
+            return Ok(ApiResponse<object>.Ok(new { error = $"下载音频失败: {ex.Message}" }));
+        }
+
+        // 解析 apiKey：支持单Key和双Key
+        string appKey = "", accessKey = request.ApiKey;
+        if (request.ApiKey.Contains('|'))
+        {
+            var parts = request.ApiKey.Split('|', 2);
+            appKey = parts[0];
+            accessKey = parts[1];
+        }
+
+        var config = new Dictionary<string, object>
+        {
+            ["resourceId"] = request.ResourceId ?? "volc.bigasr.sauc.duration",
+            ["enableItn"] = true,
+            ["enablePunc"] = true,
+            ["enableDdc"] = true
+        };
+
+        var startedAt = DateTime.UtcNow;
+        var result = await streamAsr.TranscribeAsync(wsUrl, appKey, accessKey, audioData, config, ct);
+        var durationMs = (long)(DateTime.UtcNow - startedAt).TotalMilliseconds;
+
+        return Ok(ApiResponse<object>.Ok(new
+        {
+            success = result.Success,
+            text = result.FullText,
+            segmentCount = result.Segments.Count,
+            segments = result.Segments.Select(s => new { s.Text, s.DurationSec }),
+            responseFrameCount = result.Responses.Count,
+            error = result.Error,
+            durationMs,
+            audioSizeBytes = audioData.Length,
+            wsUrl
+        }));
+    }
+
+    /// <summary>
     /// 获取可用的导入模板列表（预设配置，用户只需提供 API Key 即可一键创建）
     /// </summary>
     [HttpGet("templates")]
@@ -769,4 +834,16 @@ public class ImportFromTemplateRequest
     public string TemplateId { get; set; } = string.Empty;
     /// <summary>用户提供的 API Key</summary>
     public string ApiKey { get; set; } = string.Empty;
+}
+
+public class StreamAsrTestRequest
+{
+    /// <summary>音频文件 URL</summary>
+    public string AudioUrl { get; set; } = string.Empty;
+    /// <summary>API Key（单Key 或 AppID|AccessToken）</summary>
+    public string ApiKey { get; set; } = string.Empty;
+    /// <summary>WebSocket URL（可选，默认 bigmodel_nostream）</summary>
+    public string? WsUrl { get; set; }
+    /// <summary>Resource ID（可选）</summary>
+    public string? ResourceId { get; set; }
 }

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/StreamAsrTestController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/StreamAsrTestController.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
 using PrdAgent.Api.Services;
 using PrdAgent.Core.Models;
@@ -20,7 +21,7 @@ public class StreamAsrTestController : ControllerBase
     }
 
     /// <summary>
-    /// 测试 WebSocket 流式 ASR
+    /// 测试 WebSocket 流式 ASR（一次性返回）
     /// POST /api/test/stream-asr
     /// </summary>
     [HttpPost("stream-asr")]
@@ -29,45 +30,18 @@ public class StreamAsrTestController : ControllerBase
         [FromServices] DoubaoStreamAsrService streamAsr,
         CancellationToken ct)
     {
-        if (string.IsNullOrWhiteSpace(input.AudioUrl))
-            return BadRequest(ApiResponse<object>.Fail("INVALID", "请提供 audioUrl"));
+        var (audioData, error) = await DownloadAudio(input.AudioUrl, ct);
+        if (error != null) return Ok(ApiResponse<object>.Ok(new { error }));
         if (string.IsNullOrWhiteSpace(input.ApiKey))
             return BadRequest(ApiResponse<object>.Fail("INVALID", "请提供 apiKey"));
 
-        var wsUrl = input.WsUrl ?? "wss://openspeech.bytedance.com/api/v3/sauc/bigmodel_nostream";
-
-        // 下载音频
-        byte[] audioData;
-        try
-        {
-            var httpClient = _httpClientFactory.CreateClient();
-            httpClient.Timeout = TimeSpan.FromSeconds(60);
-            audioData = await httpClient.GetByteArrayAsync(input.AudioUrl, ct);
-        }
-        catch (Exception ex)
-        {
-            return Ok(ApiResponse<object>.Ok(new { error = $"下载音频失败: {ex.Message}" }));
-        }
-
-        // 解析 apiKey
-        string appKey = "", accessKey = input.ApiKey;
-        if (input.ApiKey.Contains('|'))
-        {
-            var parts = input.ApiKey.Split('|', 2);
-            appKey = parts[0];
-            accessKey = parts[1];
-        }
-
-        var config = new Dictionary<string, object>
-        {
-            ["resourceId"] = input.ResourceId ?? "volc.bigasr.sauc.duration",
-            ["enableItn"] = true,
-            ["enablePunc"] = true,
-            ["enableDdc"] = true
-        };
+        var (appKey, accessKey) = ParseApiKey(input.ApiKey);
+        var config = BuildConfig(input.ResourceId);
 
         var startedAt = DateTime.UtcNow;
-        var result = await streamAsr.TranscribeAsync(wsUrl, appKey, accessKey, audioData, config, ct);
+        var result = await streamAsr.TranscribeAsync(
+            input.WsUrl ?? "wss://openspeech.bytedance.com/api/v3/sauc/bigmodel_nostream",
+            appKey, accessKey, audioData!, config, ct);
         var durationMs = (long)(DateTime.UtcNow - startedAt).TotalMilliseconds;
 
         return Ok(ApiResponse<object>.Ok(new
@@ -79,9 +53,137 @@ public class StreamAsrTestController : ControllerBase
             responseFrameCount = result.Responses.Count,
             error = result.Error,
             durationMs,
-            audioSizeBytes = audioData.Length,
-            wsUrl
+            audioSizeBytes = audioData!.Length,
+            wsUrl = input.WsUrl ?? "wss://openspeech.bytedance.com/api/v3/sauc/bigmodel_nostream"
         }));
+    }
+
+    /// <summary>
+    /// 测试 WebSocket 流式 ASR（SSE 逐帧推送，实时显示进度）
+    /// POST /api/test/stream-asr/sse
+    ///
+    /// SSE 事件类型：
+    /// - stage:    阶段变化（downloading / converting / connecting / sending / result / done / error）
+    /// - progress: 发送进度（sent=5, total=28）
+    /// - frame:    每帧识别结果（seq, text, isLast）
+    /// - result:   最终汇总
+    /// </summary>
+    [HttpPost("stream-asr/sse")]
+    public async Task TestStreamAsrSse(
+        [FromBody] StreamAsrTestInput input,
+        [FromServices] DoubaoStreamAsrService streamAsr,
+        CancellationToken ct)
+    {
+        Response.ContentType = "text/event-stream";
+        Response.Headers.Append("Cache-Control", "no-cache");
+        Response.Headers.Append("X-Accel-Buffering", "no");
+
+        async Task SendEvent(string eventType, object data)
+        {
+            var json = JsonSerializer.Serialize(data, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+            try
+            {
+                await Response.WriteAsync($"event: {eventType}\ndata: {json}\n\n", ct);
+                await Response.Body.FlushAsync(ct);
+            }
+            catch (OperationCanceledException) { /* 客户端断开 */ }
+        }
+
+        var startedAt = DateTime.UtcNow;
+
+        try
+        {
+            // 1. 下载音频
+            await SendEvent("stage", new { stage = "downloading", message = "正在下载音频文件..." });
+            var (audioData, dlError) = await DownloadAudio(input.AudioUrl, ct);
+            if (dlError != null)
+            {
+                await SendEvent("error", new { error = dlError });
+                return;
+            }
+            await SendEvent("stage", new { stage = "downloaded", message = $"音频下载完成 ({audioData!.Length / 1024}KB)", sizeBytes = audioData.Length });
+
+            if (string.IsNullOrWhiteSpace(input.ApiKey))
+            {
+                await SendEvent("error", new { error = "请提供 apiKey" });
+                return;
+            }
+
+            var (appKey, accessKey) = ParseApiKey(input.ApiKey);
+            var config = BuildConfig(input.ResourceId);
+            var wsUrl = input.WsUrl ?? "wss://openspeech.bytedance.com/api/v3/sauc/bigmodel_nostream";
+
+            // 2. 使用带回调的转录方法
+            await SendEvent("stage", new { stage = "processing", message = "正在处理音频..." });
+
+            var result = await streamAsr.TranscribeWithCallbackAsync(
+                wsUrl, appKey, accessKey, audioData, config,
+                onStage: async (stage, msg) => await SendEvent("stage", new { stage, message = msg }),
+                onProgress: async (sent, total) => await SendEvent("progress", new { sent, total }),
+                onFrame: async (seq, text, isLast) => await SendEvent("frame", new { seq, text, isLast }),
+                ct: ct);
+
+            var durationMs = (long)(DateTime.UtcNow - startedAt).TotalMilliseconds;
+
+            // 3. 最终结果
+            await SendEvent("result", new
+            {
+                success = result.Success,
+                text = result.FullText,
+                segmentCount = result.Segments.Count,
+                segments = result.Segments.Select(s => new { s.Text, s.DurationSec }),
+                responseFrameCount = result.Responses.Count,
+                error = result.Error,
+                durationMs,
+                audioSizeBytes = audioData.Length
+            });
+
+            await SendEvent("stage", new { stage = "done", message = $"转录完成 ({durationMs}ms)" });
+        }
+        catch (Exception ex)
+        {
+            await SendEvent("error", new { error = ex.Message });
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════
+
+    private async Task<(byte[]? data, string? error)> DownloadAudio(string? url, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+            return (null, "请提供 audioUrl");
+        try
+        {
+            var httpClient = _httpClientFactory.CreateClient();
+            httpClient.Timeout = TimeSpan.FromSeconds(60);
+            var data = await httpClient.GetByteArrayAsync(url, ct);
+            return (data, null);
+        }
+        catch (Exception ex)
+        {
+            return (null, $"下载音频失败: {ex.Message}");
+        }
+    }
+
+    private static (string appKey, string accessKey) ParseApiKey(string apiKey)
+    {
+        if (apiKey.Contains('|'))
+        {
+            var parts = apiKey.Split('|', 2);
+            return (parts[0], parts[1]);
+        }
+        return ("", apiKey);
+    }
+
+    private static Dictionary<string, object> BuildConfig(string? resourceId)
+    {
+        return new Dictionary<string, object>
+        {
+            ["resourceId"] = resourceId ?? "volc.bigasr.sauc.duration",
+            ["enableItn"] = true,
+            ["enablePunc"] = true,
+            ["enableDdc"] = true
+        };
     }
 }
 

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/StreamAsrTestController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/StreamAsrTestController.cs
@@ -1,0 +1,94 @@
+using Microsoft.AspNetCore.Mvc;
+using PrdAgent.Api.Services;
+using PrdAgent.Core.Helpers;
+
+namespace PrdAgent.Api.Controllers.Api;
+
+/// <summary>
+/// 流式 ASR 测试端点（独立 Controller，无权限限制）
+/// 用于验证 DoubaoStreamAsrService 的 WebSocket 二进制协议
+/// </summary>
+[ApiController]
+[Route("api/test")]
+public class StreamAsrTestController : ControllerBase
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    public StreamAsrTestController(IHttpClientFactory httpClientFactory)
+    {
+        _httpClientFactory = httpClientFactory;
+    }
+
+    /// <summary>
+    /// 测试 WebSocket 流式 ASR
+    /// POST /api/test/stream-asr
+    /// </summary>
+    [HttpPost("stream-asr")]
+    public async Task<IActionResult> TestStreamAsr(
+        [FromBody] StreamAsrTestInput input,
+        [FromServices] DoubaoStreamAsrService streamAsr,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(input.AudioUrl))
+            return BadRequest(ApiResponse<object>.Fail("INVALID", "请提供 audioUrl"));
+        if (string.IsNullOrWhiteSpace(input.ApiKey))
+            return BadRequest(ApiResponse<object>.Fail("INVALID", "请提供 apiKey"));
+
+        var wsUrl = input.WsUrl ?? "wss://openspeech.bytedance.com/api/v3/sauc/bigmodel_nostream";
+
+        // 下载音频
+        byte[] audioData;
+        try
+        {
+            var httpClient = _httpClientFactory.CreateClient();
+            httpClient.Timeout = TimeSpan.FromSeconds(60);
+            audioData = await httpClient.GetByteArrayAsync(input.AudioUrl, ct);
+        }
+        catch (Exception ex)
+        {
+            return Ok(ApiResponse<object>.Ok(new { error = $"下载音频失败: {ex.Message}" }));
+        }
+
+        // 解析 apiKey
+        string appKey = "", accessKey = input.ApiKey;
+        if (input.ApiKey.Contains('|'))
+        {
+            var parts = input.ApiKey.Split('|', 2);
+            appKey = parts[0];
+            accessKey = parts[1];
+        }
+
+        var config = new Dictionary<string, object>
+        {
+            ["resourceId"] = input.ResourceId ?? "volc.bigasr.sauc.duration",
+            ["enableItn"] = true,
+            ["enablePunc"] = true,
+            ["enableDdc"] = true
+        };
+
+        var startedAt = DateTime.UtcNow;
+        var result = await streamAsr.TranscribeAsync(wsUrl, appKey, accessKey, audioData, config, ct);
+        var durationMs = (long)(DateTime.UtcNow - startedAt).TotalMilliseconds;
+
+        return Ok(ApiResponse<object>.Ok(new
+        {
+            success = result.Success,
+            text = result.FullText,
+            segmentCount = result.Segments.Count,
+            segments = result.Segments.Select(s => new { s.Text, s.DurationSec }),
+            responseFrameCount = result.Responses.Count,
+            error = result.Error,
+            durationMs,
+            audioSizeBytes = audioData.Length,
+            wsUrl
+        }));
+    }
+}
+
+public class StreamAsrTestInput
+{
+    public string AudioUrl { get; set; } = "";
+    public string ApiKey { get; set; } = "";
+    public string? WsUrl { get; set; }
+    public string? ResourceId { get; set; }
+}

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/StreamAsrTestController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/StreamAsrTestController.cs
@@ -1,6 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using PrdAgent.Api.Services;
-using PrdAgent.Core.Helpers;
+using PrdAgent.Core.Models;
 
 namespace PrdAgent.Api.Controllers.Api;
 

--- a/prd-api/src/PrdAgent.Api/Program.cs
+++ b/prd-api/src/PrdAgent.Api/Program.cs
@@ -221,6 +221,7 @@ builder.Services.AddHostedService<PrdAgent.Api.Services.ArenaRunWorker>();
 
 // 转录 Agent 后台执行器（ASR 转写 + 模板转文案）
 builder.Services.AddHostedService<PrdAgent.Api.Services.TranscriptRunWorker>();
+builder.Services.AddSingleton<PrdAgent.Api.Services.DoubaoStreamAsrService>();
 
 // 权限字符串迁移服务（启动时自动迁移旧格式 admin.xxx → 新格式 appKey.action）
 builder.Services.AddHostedService<PrdAgent.Api.Services.PermissionMigrationService>();

--- a/prd-api/src/PrdAgent.Api/Services/DoubaoStreamAsrService.cs
+++ b/prd-api/src/PrdAgent.Api/Services/DoubaoStreamAsrService.cs
@@ -79,7 +79,7 @@ public class DoubaoStreamAsrService
         var segmentDurationMs = 200;
         var sampleRate = 16000;
 
-        // 解析 WAV 获取音频参数和 PCM 数据
+        // 解析音频：WAV 直接提取 PCM，其他格式用 ffmpeg 转换为 16kHz/1ch WAV
         byte[] pcmData;
         int channels = 1, bitsPerSample = 16, actualRate = sampleRate;
 
@@ -95,8 +95,21 @@ public class DoubaoStreamAsrService
         }
         else
         {
-            pcmData = audioData;
-            _logger.LogInformation("[DoubaoStreamAsr] 非 WAV 格式, 按 raw PCM 处理, size={Size}bytes", pcmData.Length);
+            // 非 WAV 格式（MP3/M4A/OGG/FLAC/WebM/MP4 等）→ ffmpeg 转 16kHz/1ch WAV
+            _logger.LogInformation("[DoubaoStreamAsr] 非 WAV 格式, 使用 ffmpeg 转换, input={Size}bytes", audioData.Length);
+            var convertedWav = await ConvertToWavWithFfmpeg(audioData);
+            if (convertedWav == null)
+            {
+                result.Error = "ffmpeg 转换失败：不支持的音频格式或 ffmpeg 未安装";
+                return result;
+            }
+            var wavInfo = ReadWavInfo(convertedWav);
+            channels = wavInfo.Channels;
+            bitsPerSample = wavInfo.BitsPerSample;
+            actualRate = wavInfo.SampleRate;
+            pcmData = wavInfo.PcmData;
+            _logger.LogInformation("[DoubaoStreamAsr] ffmpeg 转换完成: channels={Ch}, bits={Bits}, rate={Rate}, pcm={PcmLen}bytes",
+                channels, bitsPerSample, actualRate, pcmData.Length);
         }
 
         // 豆包 WebSocket ASR 要求 16kHz 单声道 16bit PCM，需要重采样
@@ -529,6 +542,66 @@ public class DoubaoStreamAsrService
     // ═══════════════════════════════════════════════════════════
     // WAV 解析
     // ═══════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// 使用 ffmpeg 将任意音频格式转换为 16kHz 单声道 16bit WAV
+    /// </summary>
+    private async Task<byte[]?> ConvertToWavWithFfmpeg(byte[] inputData)
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"asr_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        var inputPath = Path.Combine(tempDir, "input");
+        var outputPath = Path.Combine(tempDir, "output.wav");
+
+        try
+        {
+            await File.WriteAllBytesAsync(inputPath, inputData);
+
+            var psi = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "ffmpeg",
+                Arguments = $"-i \"{inputPath}\" -acodec pcm_s16le -ac 1 -ar 16000 -f wav -y \"{outputPath}\"",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using var process = System.Diagnostics.Process.Start(psi);
+            if (process == null)
+            {
+                _logger.LogError("[DoubaoStreamAsr] ffmpeg 进程启动失败");
+                return null;
+            }
+
+            var stderr = await process.StandardError.ReadToEndAsync();
+            await process.WaitForExitAsync();
+
+            if (process.ExitCode != 0)
+            {
+                _logger.LogWarning("[DoubaoStreamAsr] ffmpeg 退出码={ExitCode}, stderr={Stderr}",
+                    process.ExitCode, stderr.Length > 500 ? stderr[^500..] : stderr);
+                return null;
+            }
+
+            if (!File.Exists(outputPath))
+            {
+                _logger.LogWarning("[DoubaoStreamAsr] ffmpeg 输出文件不存在");
+                return null;
+            }
+
+            return await File.ReadAllBytesAsync(outputPath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[DoubaoStreamAsr] ffmpeg 转换异常");
+            return null;
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, true); } catch { /* ignore */ }
+        }
+    }
 
     private static bool IsWavFile(byte[] data)
     {

--- a/prd-api/src/PrdAgent.Api/Services/DoubaoStreamAsrService.cs
+++ b/prd-api/src/PrdAgent.Api/Services/DoubaoStreamAsrService.cs
@@ -95,9 +95,20 @@ public class DoubaoStreamAsrService
         }
         else
         {
-            // 非 WAV 直接作为 raw PCM 处理
             pcmData = audioData;
             _logger.LogInformation("[DoubaoStreamAsr] 非 WAV 格式, 按 raw PCM 处理, size={Size}bytes", pcmData.Length);
+        }
+
+        // 豆包 WebSocket ASR 要求 16kHz 单声道 16bit PCM，需要重采样
+        const int targetRate = 16000;
+        const int targetChannels = 1;
+        if (actualRate != targetRate || channels != targetChannels)
+        {
+            pcmData = ResamplePcm(pcmData, channels, bitsPerSample, actualRate, targetChannels, targetRate);
+            _logger.LogInformation("[DoubaoStreamAsr] PCM 重采样: {SrcRate}Hz/{SrcCh}ch → {DstRate}Hz/{DstCh}ch, 新大小={Len}bytes",
+                actualRate, channels, targetRate, targetChannels, pcmData.Length);
+            channels = targetChannels;
+            actualRate = targetRate;
         }
 
         // 计算分片大小
@@ -555,6 +566,52 @@ public class DoubaoStreamAsrService
         var bytes = data[..4].ToArray();
         if (BitConverter.IsLittleEndian) Array.Reverse(bytes);
         return BitConverter.ToUInt32(bytes, 0);
+    }
+
+    /// <summary>
+    /// PCM 重采样：多声道→单声道（取左声道）+ 采样率转换（线性插值）
+    /// 仅支持 16bit PCM
+    /// </summary>
+    private static byte[] ResamplePcm(byte[] pcm, int srcChannels, int srcBits, int srcRate, int dstChannels, int dstRate)
+    {
+        var bytesPerSample = srcBits / 8; // 2 for 16bit
+        var srcFrameSize = srcChannels * bytesPerSample;
+        var srcFrameCount = pcm.Length / srcFrameSize;
+
+        // 1. 提取左声道（或单声道直接用）为 short[]
+        var srcSamples = new short[srcFrameCount];
+        for (var i = 0; i < srcFrameCount; i++)
+        {
+            srcSamples[i] = BitConverter.ToInt16(pcm, i * srcFrameSize);
+        }
+
+        // 2. 采样率转换（线性插值）
+        var ratio = (double)srcRate / dstRate;
+        var dstFrameCount = (int)(srcFrameCount / ratio);
+        var dstSamples = new short[dstFrameCount];
+
+        for (var i = 0; i < dstFrameCount; i++)
+        {
+            var srcPos = i * ratio;
+            var idx = (int)srcPos;
+            var frac = srcPos - idx;
+
+            if (idx + 1 < srcFrameCount)
+                dstSamples[i] = (short)(srcSamples[idx] * (1 - frac) + srcSamples[idx + 1] * frac);
+            else if (idx < srcFrameCount)
+                dstSamples[i] = srcSamples[idx];
+        }
+
+        // 3. 转回 byte[]
+        var result = new byte[dstFrameCount * dstChannels * bytesPerSample];
+        for (var i = 0; i < dstFrameCount; i++)
+        {
+            var bytes = BitConverter.GetBytes(dstSamples[i]);
+            result[i * 2] = bytes[0];
+            result[i * 2 + 1] = bytes[1];
+        }
+
+        return result;
     }
 
     private static List<byte[]> SplitAudio(byte[] data, int segmentSize)

--- a/prd-api/src/PrdAgent.Api/Services/DoubaoStreamAsrService.cs
+++ b/prd-api/src/PrdAgent.Api/Services/DoubaoStreamAsrService.cs
@@ -156,39 +156,49 @@ public class DoubaoStreamAsrService
                 return result;
             }
 
-            // 3. 发送音频分片 + 接收响应
+            // 3. 发送音频分片（独立 seq 变量避免并发问题）
+            var sendSeq = seq;
             var sendTask = Task.Run(async () =>
             {
                 for (var i = 0; i < segments.Count; i++)
                 {
                     var isLast = i == segments.Count - 1;
-                    var audioRequest = BuildAudioOnlyRequest(seq, segments[i], isLast);
+                    var audioRequest = BuildAudioOnlyRequest(sendSeq, segments[i], isLast);
                     await ws.SendAsync(new ArraySegment<byte>(audioRequest), WebSocketMessageType.Binary, true, CancellationToken.None);
+                    _logger.LogDebug("[DoubaoStreamAsr] 发送分片 {Idx}/{Total}, seq={Seq}, last={Last}, size={Size}",
+                        i + 1, segments.Count, sendSeq, isLast, segments[i].Length);
 
                     if (!isLast)
                     {
-                        seq++;
+                        sendSeq++;
                         await Task.Delay(segmentDurationMs, CancellationToken.None);
                     }
                 }
-                _logger.LogInformation("[DoubaoStreamAsr] 所有音频分片已发送");
+                _logger.LogInformation("[DoubaoStreamAsr] 所有音频分片已发送, 最终 seq={Seq}", sendSeq);
             }, CancellationToken.None);
 
             // 4. 持续接收响应直到最后一个包
             var responses = new List<AsrResponseFrame>();
-            while (true)
+            var recvTimeout = TimeSpan.FromSeconds(120);
+            var recvDeadline = DateTime.UtcNow + recvTimeout;
+            while (DateTime.UtcNow < recvDeadline)
             {
-                var resp = await ReceiveOneAsync(ws, CancellationToken.None);
-                responses.Add(resp);
-
-                if (resp.PayloadMsg != null)
+                try
                 {
-                    _logger.LogDebug("[DoubaoStreamAsr] 收到响应: seq={Seq}, last={Last}",
-                        resp.PayloadSequence, resp.IsLastPackage);
-                }
+                    var resp = await ReceiveOneAsync(ws, CancellationToken.None);
+                    responses.Add(resp);
 
-                if (resp.IsLastPackage || resp.Code != 0)
+                    _logger.LogInformation("[DoubaoStreamAsr] 收到响应帧: seq={Seq}, last={Last}, code={Code}, hasPayload={HasPayload}",
+                        resp.PayloadSequence, resp.IsLastPackage, resp.Code, resp.PayloadMsg != null);
+
+                    if (resp.IsLastPackage || resp.Code != 0)
+                        break;
+                }
+                catch (WebSocketException ex)
+                {
+                    _logger.LogWarning(ex, "[DoubaoStreamAsr] WebSocket 接收异常, state={State}", ws.State);
                     break;
+                }
             }
 
             await sendTask;

--- a/prd-api/src/PrdAgent.Api/Services/DoubaoStreamAsrService.cs
+++ b/prd-api/src/PrdAgent.Api/Services/DoubaoStreamAsrService.cs
@@ -79,38 +79,83 @@ public class DoubaoStreamAsrService
         var segmentDurationMs = 200;
         var sampleRate = 16000;
 
-        // 解析音频：WAV 直接提取 PCM，其他格式用 ffmpeg 转换为 16kHz/1ch WAV
+        // 统一转换策略：
+        // 1. 标准 16bit WAV → 直接解析 PCM（最快）
+        // 2. 非标准 WAV（24bit 等）或非 WAV → ffmpeg 转 16kHz/1ch/16bit WAV
+        // 3. 任何解析失败 → ffmpeg 兜底
         byte[] pcmData;
         int channels = 1, bitsPerSample = 16, actualRate = sampleRate;
+        var needFfmpeg = false;
 
         if (IsWavFile(audioData))
         {
-            var wavInfo = ReadWavInfo(audioData);
-            channels = wavInfo.Channels;
-            bitsPerSample = wavInfo.BitsPerSample;
-            actualRate = wavInfo.SampleRate;
-            pcmData = wavInfo.PcmData;
-            _logger.LogInformation("[DoubaoStreamAsr] WAV 解析: channels={Ch}, bits={Bits}, rate={Rate}, pcm={PcmLen}bytes",
-                channels, bitsPerSample, actualRate, pcmData.Length);
+            try
+            {
+                var wavInfo = ReadWavInfo(audioData);
+                if (wavInfo.BitsPerSample != 16 || wavInfo.PcmData.Length == 0)
+                {
+                    // 非 16bit WAV（如 24bit）或空数据 → ffmpeg 转换
+                    _logger.LogInformation("[DoubaoStreamAsr] WAV 非标准格式 (bits={Bits}, pcm={Len}), 走 ffmpeg",
+                        wavInfo.BitsPerSample, wavInfo.PcmData.Length);
+                    needFfmpeg = true;
+                }
+                else
+                {
+                    channels = wavInfo.Channels;
+                    bitsPerSample = wavInfo.BitsPerSample;
+                    actualRate = wavInfo.SampleRate;
+                    pcmData = wavInfo.PcmData;
+                    _logger.LogInformation("[DoubaoStreamAsr] WAV 解析: channels={Ch}, bits={Bits}, rate={Rate}, pcm={PcmLen}bytes",
+                        channels, bitsPerSample, actualRate, pcmData.Length);
+                    goto wavParsed;
+                }
+            }
+            catch (Exception ex)
+            {
+                // WAV 头损坏/截断 → ffmpeg 兜底
+                _logger.LogWarning(ex, "[DoubaoStreamAsr] WAV 解析失败, 走 ffmpeg 兜底");
+                needFfmpeg = true;
+            }
         }
         else
         {
-            // 非 WAV 格式（MP3/M4A/OGG/FLAC/WebM/MP4 等）→ ffmpeg 转 16kHz/1ch WAV
-            _logger.LogInformation("[DoubaoStreamAsr] 非 WAV 格式, 使用 ffmpeg 转换, input={Size}bytes", audioData.Length);
+            needFfmpeg = true;
+        }
+
+        // ffmpeg 转换路径
+        if (needFfmpeg)
+        {
+            _logger.LogInformation("[DoubaoStreamAsr] 使用 ffmpeg 转换, input={Size}bytes", audioData.Length);
             var convertedWav = await ConvertToWavWithFfmpeg(audioData);
             if (convertedWav == null)
             {
-                result.Error = "ffmpeg 转换失败：不支持的音频格式或 ffmpeg 未安装";
+                result.Error = "音频格式转换失败：不支持的格式或文件已损坏";
                 return result;
             }
-            var wavInfo = ReadWavInfo(convertedWav);
-            channels = wavInfo.Channels;
-            bitsPerSample = wavInfo.BitsPerSample;
-            actualRate = wavInfo.SampleRate;
-            pcmData = wavInfo.PcmData;
-            _logger.LogInformation("[DoubaoStreamAsr] ffmpeg 转换完成: channels={Ch}, bits={Bits}, rate={Rate}, pcm={PcmLen}bytes",
-                channels, bitsPerSample, actualRate, pcmData.Length);
+            try
+            {
+                var wavInfo = ReadWavInfo(convertedWav);
+                channels = wavInfo.Channels;
+                bitsPerSample = wavInfo.BitsPerSample;
+                actualRate = wavInfo.SampleRate;
+                pcmData = wavInfo.PcmData;
+                _logger.LogInformation("[DoubaoStreamAsr] ffmpeg 转换完成: channels={Ch}, bits={Bits}, rate={Rate}, pcm={PcmLen}bytes",
+                    channels, bitsPerSample, actualRate, pcmData.Length);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "[DoubaoStreamAsr] ffmpeg 输出 WAV 解析失败");
+                result.Error = $"音频处理失败: {ex.Message}";
+                return result;
+            }
         }
+        else
+        {
+            // 不会走到这里，编译器需要
+            result.Error = "未知音频处理错误";
+            return result;
+        }
+        wavParsed:
 
         // 豆包 WebSocket ASR 要求 16kHz 单声道 16bit PCM，需要重采样
         const int targetRate = 16000;
@@ -250,6 +295,164 @@ public class DoubaoStreamAsrService
             {
                 try { await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, "done", CancellationToken.None); }
                 catch { /* ignore close errors */ }
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// 带回调的流式 ASR 转录（SSE 实时推送用）
+    /// 每个阶段、每帧结果都通过回调通知调用方
+    /// </summary>
+    public async Task<StreamAsrResult> TranscribeWithCallbackAsync(
+        string wsUrl, string appKey, string accessKey, byte[] audioData,
+        Dictionary<string, object>? config = null,
+        Func<string, string, Task>? onStage = null,
+        Func<int, int, Task>? onProgress = null,
+        Func<int, string, bool, Task>? onFrame = null,
+        CancellationToken ct = default)
+    {
+        var result = new StreamAsrResult();
+
+        // 音频预处理（复用 TranscribeAsync 的逻辑）
+        byte[] pcmData;
+        int channels = 1, bitsPerSample = 16, actualRate = 16000;
+
+        if (onStage != null) await onStage("converting", "音频格式检测与转换...");
+
+        if (IsWavFile(audioData))
+        {
+            try
+            {
+                var wavInfo = ReadWavInfo(audioData);
+                if (wavInfo.BitsPerSample != 16 || wavInfo.PcmData.Length == 0)
+                {
+                    if (onStage != null) await onStage("converting", "非标准 WAV, ffmpeg 转换中...");
+                    var converted = await ConvertToWavWithFfmpeg(audioData);
+                    if (converted == null) { result.Error = "音频格式转换失败"; return result; }
+                    wavInfo = ReadWavInfo(converted);
+                }
+                channels = wavInfo.Channels; bitsPerSample = wavInfo.BitsPerSample;
+                actualRate = wavInfo.SampleRate; pcmData = wavInfo.PcmData;
+            }
+            catch
+            {
+                if (onStage != null) await onStage("converting", "WAV 解析失败, ffmpeg 兜底转换...");
+                var converted = await ConvertToWavWithFfmpeg(audioData);
+                if (converted == null) { result.Error = "音频格式转换失败"; return result; }
+                var wi = ReadWavInfo(converted);
+                channels = wi.Channels; bitsPerSample = wi.BitsPerSample;
+                actualRate = wi.SampleRate; pcmData = wi.PcmData;
+            }
+        }
+        else
+        {
+            if (onStage != null) await onStage("converting", "非 WAV 格式, ffmpeg 转换中...");
+            var converted = await ConvertToWavWithFfmpeg(audioData);
+            if (converted == null) { result.Error = "音频格式转换失败"; return result; }
+            var wi = ReadWavInfo(converted);
+            channels = wi.Channels; bitsPerSample = wi.BitsPerSample;
+            actualRate = wi.SampleRate; pcmData = wi.PcmData;
+        }
+
+        // 重采样
+        const int targetRate = 16000; const int targetCh = 1;
+        if (actualRate != targetRate || channels != targetCh)
+        {
+            pcmData = ResamplePcm(pcmData, channels, bitsPerSample, actualRate, targetCh, targetRate);
+            channels = targetCh; actualRate = targetRate;
+        }
+
+        if (onStage != null) await onStage("converted", $"音频就绪: {pcmData.Length / 1024}KB, 16kHz/1ch");
+
+        // 分片
+        var segDurMs = 200;
+        var bytesPerSec = channels * (bitsPerSample / 8) * actualRate;
+        var segSize = bytesPerSec * segDurMs / 1000;
+        if (segSize <= 0) segSize = 3200;
+        var segments = SplitAudio(pcmData, segSize);
+
+        // WebSocket
+        var resourceId = config?.GetValueOrDefault("resourceId")?.ToString() ?? "volc.bigasr.sauc.duration";
+        var headers = new Dictionary<string, string>
+        {
+            ["X-Api-Resource-Id"] = resourceId,
+            ["X-Api-Request-Id"] = Guid.NewGuid().ToString(),
+        };
+        if (!string.IsNullOrEmpty(appKey))
+        {
+            headers["X-Api-App-Key"] = appKey;
+            headers["X-Api-Access-Key"] = accessKey;
+        }
+        else
+        {
+            headers["x-api-key"] = accessKey;
+        }
+
+        using var ws = new System.Net.WebSockets.ClientWebSocket();
+        foreach (var (key, value) in headers) ws.Options.SetRequestHeader(key, value);
+
+        try
+        {
+            if (onStage != null) await onStage("connecting", $"连接 {wsUrl}...");
+            await ws.ConnectAsync(new Uri(wsUrl), ct);
+
+            var seq = 1;
+            var fullReq = BuildFullClientRequest(seq, channels, bitsPerSample, actualRate, config);
+            await ws.SendAsync(new ArraySegment<byte>(fullReq), System.Net.WebSockets.WebSocketMessageType.Binary, true, ct);
+            seq++;
+            var initResp = await ReceiveOneAsync(ws, ct);
+            if (initResp.Code != 0) { result.Error = $"初始化失败: code={initResp.Code}"; return result; }
+
+            if (onStage != null) await onStage("sending", $"开始发送 {segments.Count} 个音频分片...");
+
+            // 并发发送 + 接收
+            var sendSeq = seq;
+            var sendTask = Task.Run(async () =>
+            {
+                for (var i = 0; i < segments.Count; i++)
+                {
+                    var isLast = i == segments.Count - 1;
+                    var audioReq = BuildAudioOnlyRequest(sendSeq, segments[i], isLast);
+                    await ws.SendAsync(new ArraySegment<byte>(audioReq), System.Net.WebSockets.WebSocketMessageType.Binary, true, CancellationToken.None);
+                    if (onProgress != null) await onProgress(i + 1, segments.Count);
+                    if (!isLast) { sendSeq++; await Task.Delay(segDurMs, CancellationToken.None); }
+                }
+            }, CancellationToken.None);
+
+            var responses = new List<AsrResponseFrame>();
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(120);
+            while (DateTime.UtcNow < deadline)
+            {
+                try
+                {
+                    var resp = await ReceiveOneAsync(ws, CancellationToken.None);
+                    responses.Add(resp);
+                    var frameText = ExtractTextFromPayload(resp);
+                    if (onFrame != null) await onFrame(resp.PayloadSequence, frameText, resp.IsLastPackage);
+                    if (resp.IsLastPackage || resp.Code != 0) break;
+                }
+                catch (System.Net.WebSockets.WebSocketException) { break; }
+            }
+
+            await sendTask;
+
+            result.Responses = responses;
+            result.Success = responses.All(r => r.Code == 0);
+            result.FullText = ExtractFullText(responses);
+            result.Segments = ExtractSegments(responses);
+        }
+        catch (Exception ex)
+        {
+            result.Error = ex.Message;
+        }
+        finally
+        {
+            if (ws.State == System.Net.WebSockets.WebSocketState.Open)
+            {
+                try { await ws.CloseAsync(System.Net.WebSockets.WebSocketCloseStatus.NormalClosure, "done", CancellationToken.None); }
+                catch { /* ignore */ }
             }
         }
 

--- a/prd-api/src/PrdAgent.Api/Services/DoubaoStreamAsrService.cs
+++ b/prd-api/src/PrdAgent.Api/Services/DoubaoStreamAsrService.cs
@@ -424,25 +424,42 @@ public class DoubaoStreamAsrService
 
     private static string ExtractFullText(List<AsrResponseFrame> responses)
     {
-        var sb = new StringBuilder();
-        foreach (var resp in responses)
+        // 取最后一个有 text 的帧（nostream 模式最后一帧包含完整文本）
+        for (var i = responses.Count - 1; i >= 0; i--)
         {
-            if (resp.PayloadMsg == null) continue;
-            try
-            {
-                var payload = resp.PayloadMsg.Value;
-                if (payload.TryGetProperty("result", out var resultArr) && resultArr.ValueKind == JsonValueKind.Array)
-                {
-                    foreach (var item in resultArr.EnumerateArray())
-                    {
-                        if (item.TryGetProperty("text", out var text))
-                            sb.Append(text.GetString());
-                    }
-                }
-            }
-            catch { /* skip */ }
+            var text = ExtractTextFromPayload(responses[i]);
+            if (!string.IsNullOrEmpty(text)) return text;
         }
-        return sb.ToString();
+        return "";
+    }
+
+    private static string ExtractTextFromPayload(AsrResponseFrame resp)
+    {
+        if (resp.PayloadMsg == null) return "";
+        try
+        {
+            var payload = resp.PayloadMsg.Value;
+            if (!payload.TryGetProperty("result", out var result)) return "";
+
+            // result 可能是对象（WebSocket 模式）或数组（HTTP 模式）
+            if (result.ValueKind == JsonValueKind.Object)
+            {
+                if (result.TryGetProperty("text", out var text))
+                    return text.GetString() ?? "";
+            }
+            else if (result.ValueKind == JsonValueKind.Array)
+            {
+                var sb = new StringBuilder();
+                foreach (var item in result.EnumerateArray())
+                {
+                    if (item.TryGetProperty("text", out var text))
+                        sb.Append(text.GetString());
+                }
+                return sb.ToString();
+            }
+        }
+        catch { /* skip */ }
+        return "";
     }
 
     private static List<StreamAsrSegment> ExtractSegments(List<AsrResponseFrame> responses)
@@ -454,23 +471,53 @@ public class DoubaoStreamAsrService
             try
             {
                 var payload = resp.PayloadMsg.Value;
-                if (payload.TryGetProperty("result", out var resultArr) && resultArr.ValueKind == JsonValueKind.Array)
+                if (!payload.TryGetProperty("result", out var result)) continue;
+
+                // result 是对象（WebSocket）：提取 utterances 或直接 text
+                if (result.ValueKind == JsonValueKind.Object)
                 {
-                    foreach (var item in resultArr.EnumerateArray())
+                    // 尝试 utterances（含时间戳的细粒度分段）
+                    if (result.TryGetProperty("utterances", out var utts) && utts.ValueKind == JsonValueKind.Array)
+                    {
+                        foreach (var utt in utts.EnumerateArray())
+                        {
+                            var text = utt.TryGetProperty("text", out var t) ? t.GetString() ?? "" : "";
+                            if (string.IsNullOrWhiteSpace(text)) continue;
+                            double startMs = utt.TryGetProperty("start_time", out var st) ? st.GetDouble() : 0;
+                            double endMs = utt.TryGetProperty("end_time", out var et) ? et.GetDouble() : 0;
+                            segments.Add(new StreamAsrSegment
+                            {
+                                Text = text,
+                                DurationSec = (endMs - startMs) / 1000.0
+                            });
+                        }
+                    }
+                    else
+                    {
+                        // 没有 utterances，用顶层 text + additions.duration
+                        var text = result.TryGetProperty("text", out var t) ? t.GetString() ?? "" : "";
+                        if (!string.IsNullOrWhiteSpace(text))
+                        {
+                            double duration = 0;
+                            if (result.TryGetProperty("additions", out var adds) &&
+                                adds.TryGetProperty("duration", out var dur))
+                            {
+                                var durStr = dur.GetString() ?? "0";
+                                double.TryParse(durStr, out duration);
+                                duration /= 1000.0;
+                            }
+                            segments.Add(new StreamAsrSegment { Text = text, DurationSec = duration });
+                        }
+                    }
+                }
+                // result 是数组（HTTP 模式兜底）
+                else if (result.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (var item in result.EnumerateArray())
                     {
                         var text = item.TryGetProperty("text", out var t) ? t.GetString() ?? "" : "";
                         if (string.IsNullOrWhiteSpace(text)) continue;
-
-                        double duration = 0;
-                        if (item.TryGetProperty("additions", out var additions) &&
-                            additions.TryGetProperty("duration", out var dur))
-                        {
-                            var durStr = dur.GetString() ?? "0";
-                            double.TryParse(durStr, out duration);
-                            duration /= 1000.0;
-                        }
-
-                        segments.Add(new StreamAsrSegment { Text = text, DurationSec = duration });
+                        segments.Add(new StreamAsrSegment { Text = text });
                     }
                 }
             }

--- a/prd-api/src/PrdAgent.Api/Services/DoubaoStreamAsrService.cs
+++ b/prd-api/src/PrdAgent.Api/Services/DoubaoStreamAsrService.cs
@@ -262,8 +262,8 @@ public class DoubaoStreamAsrService
             ["user"] = new JsonObject { ["uid"] = "prd-agent" },
             ["audio"] = new JsonObject
             {
-                ["format"] = "wav",
-                ["codec"] = "raw",
+                ["format"] = "pcm",
+                ["codec"] = "pcm",
                 ["rate"] = rate,
                 ["bits"] = bits,
                 ["channel"] = channels

--- a/prd-api/src/PrdAgent.Api/Services/DoubaoStreamAsrService.cs
+++ b/prd-api/src/PrdAgent.Api/Services/DoubaoStreamAsrService.cs
@@ -109,16 +109,26 @@ public class DoubaoStreamAsrService
         var segments = SplitAudio(pcmData, segmentSize);
         _logger.LogInformation("[DoubaoStreamAsr] 音频分片: {Count} 片, 每片 {Size} bytes", segments.Count, segmentSize);
 
-        // 构建认证头
+        // 构建认证头（支持双Key和单Key两种模式）
         var resourceId = config?.GetValueOrDefault("resourceId")?.ToString() ?? "volc.bigasr.sauc.duration";
         var requestId = Guid.NewGuid().ToString();
         var headers = new Dictionary<string, string>
         {
             ["X-Api-Resource-Id"] = resourceId,
             ["X-Api-Request-Id"] = requestId,
-            ["X-Api-Access-Key"] = accessKey,
-            ["X-Api-App-Key"] = appKey
         };
+
+        if (!string.IsNullOrEmpty(appKey))
+        {
+            // 双Key模式：X-Api-App-Key + X-Api-Access-Key
+            headers["X-Api-App-Key"] = appKey;
+            headers["X-Api-Access-Key"] = accessKey;
+        }
+        else
+        {
+            // 单Key模式：x-api-key
+            headers["x-api-key"] = accessKey;
+        }
 
         using var ws = new ClientWebSocket();
         foreach (var (key, value) in headers)

--- a/prd-api/src/PrdAgent.Api/Services/DoubaoStreamAsrService.cs
+++ b/prd-api/src/PrdAgent.Api/Services/DoubaoStreamAsrService.cs
@@ -150,6 +150,9 @@ public class DoubaoStreamAsrService
 
             // 接收 FullClientRequest 的响应
             var initResp = await ReceiveOneAsync(ws, ct);
+            _logger.LogInformation("[DoubaoStreamAsr] 初始响应: code={Code}, seq={Seq}, last={Last}, hasPayload={HasPayload}, payload={Payload}",
+                initResp.Code, initResp.PayloadSequence, initResp.IsLastPackage, initResp.PayloadMsg != null,
+                initResp.PayloadMsg?.ToString()?.Substring(0, Math.Min(initResp.PayloadMsg?.ToString()?.Length ?? 0, 300)) ?? "null");
             if (initResp.Code != 0)
             {
                 result.Error = $"初始化失败: code={initResp.Code}";
@@ -316,6 +319,8 @@ public class DoubaoStreamAsrService
 
         if (wsResult.MessageType == WebSocketMessageType.Close)
         {
+            _logger.LogWarning("[DoubaoStreamAsr] 收到 WebSocket Close 帧, closeStatus={Status}, desc={Desc}",
+                ws.CloseStatus, ws.CloseStatusDescription);
             return new AsrResponseFrame { IsLastPackage = true };
         }
 

--- a/prd-api/src/PrdAgent.Api/Services/DoubaoStreamAsrService.cs
+++ b/prd-api/src/PrdAgent.Api/Services/DoubaoStreamAsrService.cs
@@ -1,0 +1,590 @@
+using System.IO.Compression;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace PrdAgent.Api.Services;
+
+/// <summary>
+/// 豆包流式 ASR WebSocket 客户端
+/// 实现 ByteDance 自定义二进制帧协议，通过 WebSocket 发送音频分片并接收转录结果。
+///
+/// 协议帧格式（4 字节 header）：
+/// [version(4bit)|headerSize(4bit)] [msgType(4bit)|flags(4bit)] [serialization(4bit)|compression(4bit)] [reserved]
+/// 之后跟 seq(4bytes, big-endian) + payloadSize(4bytes, big-endian) + payload(gzip)
+///
+/// 流程：
+/// 1. WebSocket 连接 → 发送 FullClientRequest（JSON 配置）
+/// 2. 循环发送 AudioOnlyRequest（PCM 音频分片）
+/// 3. 最后一片标记 NEG_WITH_SEQUENCE
+/// 4. 接收 ServerFullResponse 直到 is_last_package
+/// </summary>
+public class DoubaoStreamAsrService
+{
+    private readonly ILogger<DoubaoStreamAsrService> _logger;
+
+    public DoubaoStreamAsrService(ILogger<DoubaoStreamAsrService> logger)
+    {
+        _logger = logger;
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // 协议常量
+    // ═══════════════════════════════════════════════════════════
+
+    private static class ProtocolVersion { public const byte V1 = 0b0001; }
+
+    private static class MessageType
+    {
+        public const byte ClientFullRequest = 0b0001;
+        public const byte ClientAudioOnlyRequest = 0b0010;
+        public const byte ServerFullResponse = 0b1001;
+        public const byte ServerErrorResponse = 0b1111;
+    }
+
+    private static class MsgFlags
+    {
+        public const byte PosSequence = 0b0001;
+        public const byte NegSequence = 0b0010;
+        public const byte NegWithSequence = 0b0011;
+    }
+
+    private static class Serialization { public const byte Json = 0b0001; }
+    private static class Compression { public const byte Gzip = 0b0001; }
+
+    // ═══════════════════════════════════════════════════════════
+    // 公共方法
+    // ═══════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// 执行流式 ASR 转录
+    /// </summary>
+    /// <param name="wsUrl">WebSocket URL (wss://openspeech.bytedance.com/api/v3/sauc/bigmodel_nostream)</param>
+    /// <param name="appKey">豆包 App Key</param>
+    /// <param name="accessKey">豆包 Access Key</param>
+    /// <param name="audioData">音频文件原始字节（WAV 或其他格式，非 WAV 会尝试解析为 raw PCM）</param>
+    /// <param name="config">额外配置</param>
+    /// <param name="ct">取消令牌</param>
+    /// <returns>完整的转录结果（所有响应合并）</returns>
+    public async Task<StreamAsrResult> TranscribeAsync(
+        string wsUrl,
+        string appKey,
+        string accessKey,
+        byte[] audioData,
+        Dictionary<string, object>? config = null,
+        CancellationToken ct = default)
+    {
+        var result = new StreamAsrResult();
+        var segmentDurationMs = 200;
+        var sampleRate = 16000;
+
+        // 解析 WAV 获取音频参数和 PCM 数据
+        byte[] pcmData;
+        int channels = 1, bitsPerSample = 16, actualRate = sampleRate;
+
+        if (IsWavFile(audioData))
+        {
+            var wavInfo = ReadWavInfo(audioData);
+            channels = wavInfo.Channels;
+            bitsPerSample = wavInfo.BitsPerSample;
+            actualRate = wavInfo.SampleRate;
+            pcmData = wavInfo.PcmData;
+            _logger.LogInformation("[DoubaoStreamAsr] WAV 解析: channels={Ch}, bits={Bits}, rate={Rate}, pcm={PcmLen}bytes",
+                channels, bitsPerSample, actualRate, pcmData.Length);
+        }
+        else
+        {
+            // 非 WAV 直接作为 raw PCM 处理
+            pcmData = audioData;
+            _logger.LogInformation("[DoubaoStreamAsr] 非 WAV 格式, 按 raw PCM 处理, size={Size}bytes", pcmData.Length);
+        }
+
+        // 计算分片大小
+        var bytesPerSec = channels * (bitsPerSample / 8) * actualRate;
+        var segmentSize = bytesPerSec * segmentDurationMs / 1000;
+        if (segmentSize <= 0) segmentSize = 3200;
+
+        // 分片
+        var segments = SplitAudio(pcmData, segmentSize);
+        _logger.LogInformation("[DoubaoStreamAsr] 音频分片: {Count} 片, 每片 {Size} bytes", segments.Count, segmentSize);
+
+        // 构建认证头
+        var resourceId = config?.GetValueOrDefault("resourceId")?.ToString() ?? "volc.bigasr.sauc.duration";
+        var requestId = Guid.NewGuid().ToString();
+        var headers = new Dictionary<string, string>
+        {
+            ["X-Api-Resource-Id"] = resourceId,
+            ["X-Api-Request-Id"] = requestId,
+            ["X-Api-Access-Key"] = accessKey,
+            ["X-Api-App-Key"] = appKey
+        };
+
+        using var ws = new ClientWebSocket();
+        foreach (var (key, value) in headers)
+            ws.Options.SetRequestHeader(key, value);
+
+        try
+        {
+            // 1. 连接
+            await ws.ConnectAsync(new Uri(wsUrl), ct);
+            _logger.LogInformation("[DoubaoStreamAsr] WebSocket 已连接: {Url}", wsUrl);
+
+            var seq = 1;
+
+            // 2. 发送 FullClientRequest
+            var fullRequest = BuildFullClientRequest(seq, channels, bitsPerSample, actualRate, config);
+            await ws.SendAsync(new ArraySegment<byte>(fullRequest), WebSocketMessageType.Binary, true, ct);
+            _logger.LogInformation("[DoubaoStreamAsr] 已发送 FullClientRequest, seq={Seq}", seq);
+            seq++;
+
+            // 接收 FullClientRequest 的响应
+            var initResp = await ReceiveOneAsync(ws, ct);
+            if (initResp.Code != 0)
+            {
+                result.Error = $"初始化失败: code={initResp.Code}";
+                return result;
+            }
+
+            // 3. 发送音频分片 + 接收响应
+            var sendTask = Task.Run(async () =>
+            {
+                for (var i = 0; i < segments.Count; i++)
+                {
+                    var isLast = i == segments.Count - 1;
+                    var audioRequest = BuildAudioOnlyRequest(seq, segments[i], isLast);
+                    await ws.SendAsync(new ArraySegment<byte>(audioRequest), WebSocketMessageType.Binary, true, CancellationToken.None);
+
+                    if (!isLast)
+                    {
+                        seq++;
+                        await Task.Delay(segmentDurationMs, CancellationToken.None);
+                    }
+                }
+                _logger.LogInformation("[DoubaoStreamAsr] 所有音频分片已发送");
+            }, CancellationToken.None);
+
+            // 4. 持续接收响应直到最后一个包
+            var responses = new List<AsrResponseFrame>();
+            while (true)
+            {
+                var resp = await ReceiveOneAsync(ws, CancellationToken.None);
+                responses.Add(resp);
+
+                if (resp.PayloadMsg != null)
+                {
+                    _logger.LogDebug("[DoubaoStreamAsr] 收到响应: seq={Seq}, last={Last}",
+                        resp.PayloadSequence, resp.IsLastPackage);
+                }
+
+                if (resp.IsLastPackage || resp.Code != 0)
+                    break;
+            }
+
+            await sendTask;
+
+            // 5. 合并结果
+            result.Responses = responses;
+            result.Success = responses.All(r => r.Code == 0);
+            result.FullText = ExtractFullText(responses);
+            result.Segments = ExtractSegments(responses);
+
+            _logger.LogInformation("[DoubaoStreamAsr] 转录完成, text_length={Len}, segments={SegCount}",
+                result.FullText.Length, result.Segments.Count);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[DoubaoStreamAsr] 转录失败");
+            result.Error = ex.Message;
+        }
+        finally
+        {
+            if (ws.State == WebSocketState.Open)
+            {
+                try { await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, "done", CancellationToken.None); }
+                catch { /* ignore close errors */ }
+            }
+        }
+
+        return result;
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // 帧构建
+    // ═══════════════════════════════════════════════════════════
+
+    private byte[] BuildFullClientRequest(int seq, int channels, int bits, int rate, Dictionary<string, object>? config)
+    {
+        var header = new byte[]
+        {
+            (byte)((ProtocolVersion.V1 << 4) | 1),
+            (byte)((MessageType.ClientFullRequest << 4) | MsgFlags.PosSequence),
+            (byte)((Serialization.Json << 4) | Compression.Gzip),
+            0x00
+        };
+
+        var payload = new JsonObject
+        {
+            ["user"] = new JsonObject { ["uid"] = "prd-agent" },
+            ["audio"] = new JsonObject
+            {
+                ["format"] = "wav",
+                ["codec"] = "raw",
+                ["rate"] = rate,
+                ["bits"] = bits,
+                ["channel"] = channels
+            },
+            ["request"] = new JsonObject
+            {
+                ["model_name"] = "bigmodel",
+                ["enable_itn"] = GetBool(config, "enableItn", true),
+                ["enable_punc"] = GetBool(config, "enablePunc", true),
+                ["enable_ddc"] = GetBool(config, "enableDdc", true),
+                ["show_utterances"] = true,
+                ["enable_nonstream"] = false
+            }
+        };
+
+        var payloadBytes = GzipCompress(Encoding.UTF8.GetBytes(payload.ToJsonString()));
+
+        using var ms = new MemoryStream();
+        ms.Write(header, 0, header.Length);
+        WriteInt32BigEndian(ms, seq);
+        WriteUInt32BigEndian(ms, (uint)payloadBytes.Length);
+        ms.Write(payloadBytes, 0, payloadBytes.Length);
+        return ms.ToArray();
+    }
+
+    private static byte[] BuildAudioOnlyRequest(int seq, byte[] segment, bool isLast)
+    {
+        var flags = isLast ? MsgFlags.NegWithSequence : MsgFlags.PosSequence;
+        var actualSeq = isLast ? -seq : seq;
+
+        var header = new byte[]
+        {
+            (byte)((ProtocolVersion.V1 << 4) | 1),
+            (byte)((MessageType.ClientAudioOnlyRequest << 4) | flags),
+            (byte)((0 << 4) | Compression.Gzip), // 无序列化，有压缩
+            0x00
+        };
+
+        var compressed = GzipCompress(segment);
+
+        using var ms = new MemoryStream();
+        ms.Write(header, 0, header.Length);
+        WriteInt32BigEndian(ms, actualSeq);
+        WriteUInt32BigEndian(ms, (uint)compressed.Length);
+        ms.Write(compressed, 0, compressed.Length);
+        return ms.ToArray();
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // 帧解析
+    // ═══════════════════════════════════════════════════════════
+
+    private async Task<AsrResponseFrame> ReceiveOneAsync(ClientWebSocket ws, CancellationToken ct)
+    {
+        var buffer = new byte[1024 * 1024]; // 1MB buffer
+        using var ms = new MemoryStream();
+        WebSocketReceiveResult wsResult;
+
+        do
+        {
+            wsResult = await ws.ReceiveAsync(new ArraySegment<byte>(buffer), ct);
+            ms.Write(buffer, 0, wsResult.Count);
+        } while (!wsResult.EndOfMessage);
+
+        if (wsResult.MessageType == WebSocketMessageType.Close)
+        {
+            return new AsrResponseFrame { IsLastPackage = true };
+        }
+
+        return ParseResponse(ms.ToArray());
+    }
+
+    private AsrResponseFrame ParseResponse(byte[] msg)
+    {
+        var response = new AsrResponseFrame();
+
+        if (msg.Length < 4) return response;
+
+        var headerSize = msg[0] & 0x0f;
+        var messageType = (byte)(msg[1] >> 4);
+        var flags = (byte)(msg[1] & 0x0f);
+        var serializationMethod = (byte)(msg[2] >> 4);
+        var compression = (byte)(msg[2] & 0x0f);
+
+        var payload = msg.AsSpan(headerSize * 4);
+
+        // 解析 flags
+        if ((flags & 0x01) != 0 && payload.Length >= 4)
+        {
+            response.PayloadSequence = ReadInt32BigEndian(payload);
+            payload = payload[4..];
+        }
+        if ((flags & 0x02) != 0)
+        {
+            response.IsLastPackage = true;
+        }
+        if ((flags & 0x04) != 0 && payload.Length >= 4)
+        {
+            response.Event = ReadInt32BigEndian(payload);
+            payload = payload[4..];
+        }
+
+        // 解析 message type
+        if (messageType == MessageType.ServerFullResponse && payload.Length >= 4)
+        {
+            response.PayloadSize = ReadUInt32BigEndian(payload);
+            payload = payload[4..];
+        }
+        else if (messageType == MessageType.ServerErrorResponse && payload.Length >= 8)
+        {
+            response.Code = ReadInt32BigEndian(payload);
+            response.PayloadSize = ReadUInt32BigEndian(payload[4..]);
+            payload = payload[8..];
+        }
+
+        if (payload.IsEmpty) return response;
+
+        // 解压缩
+        byte[] decompressed;
+        if (compression == Compression.Gzip)
+        {
+            try
+            {
+                decompressed = GzipDecompress(payload.ToArray());
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "[DoubaoStreamAsr] Gzip 解压失败");
+                return response;
+            }
+        }
+        else
+        {
+            decompressed = payload.ToArray();
+        }
+
+        // 解析 JSON payload
+        if (serializationMethod == Serialization.Json && decompressed.Length > 0)
+        {
+            try
+            {
+                response.PayloadMsg = JsonSerializer.Deserialize<JsonElement>(decompressed);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "[DoubaoStreamAsr] JSON 解析失败");
+            }
+        }
+
+        return response;
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // 结果提取
+    // ═══════════════════════════════════════════════════════════
+
+    private static string ExtractFullText(List<AsrResponseFrame> responses)
+    {
+        var sb = new StringBuilder();
+        foreach (var resp in responses)
+        {
+            if (resp.PayloadMsg == null) continue;
+            try
+            {
+                var payload = resp.PayloadMsg.Value;
+                if (payload.TryGetProperty("result", out var resultArr) && resultArr.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (var item in resultArr.EnumerateArray())
+                    {
+                        if (item.TryGetProperty("text", out var text))
+                            sb.Append(text.GetString());
+                    }
+                }
+            }
+            catch { /* skip */ }
+        }
+        return sb.ToString();
+    }
+
+    private static List<StreamAsrSegment> ExtractSegments(List<AsrResponseFrame> responses)
+    {
+        var segments = new List<StreamAsrSegment>();
+        foreach (var resp in responses)
+        {
+            if (resp.PayloadMsg == null) continue;
+            try
+            {
+                var payload = resp.PayloadMsg.Value;
+                if (payload.TryGetProperty("result", out var resultArr) && resultArr.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (var item in resultArr.EnumerateArray())
+                    {
+                        var text = item.TryGetProperty("text", out var t) ? t.GetString() ?? "" : "";
+                        if (string.IsNullOrWhiteSpace(text)) continue;
+
+                        double duration = 0;
+                        if (item.TryGetProperty("additions", out var additions) &&
+                            additions.TryGetProperty("duration", out var dur))
+                        {
+                            var durStr = dur.GetString() ?? "0";
+                            double.TryParse(durStr, out duration);
+                            duration /= 1000.0;
+                        }
+
+                        segments.Add(new StreamAsrSegment { Text = text, DurationSec = duration });
+                    }
+                }
+            }
+            catch { /* skip */ }
+        }
+        return segments;
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // WAV 解析
+    // ═══════════════════════════════════════════════════════════
+
+    private static bool IsWavFile(byte[] data)
+    {
+        return data.Length >= 44 &&
+               data[0] == 'R' && data[1] == 'I' && data[2] == 'F' && data[3] == 'F' &&
+               data[8] == 'W' && data[9] == 'A' && data[10] == 'V' && data[11] == 'E';
+    }
+
+    private static WavInfo ReadWavInfo(byte[] data)
+    {
+        var channels = BitConverter.ToInt16(data, 22);
+        var sampleRate = BitConverter.ToInt32(data, 24);
+        var bitsPerSample = BitConverter.ToInt16(data, 34);
+
+        // 查找 data 子块
+        var pos = 36;
+        while (pos < data.Length - 8)
+        {
+            var subId = Encoding.ASCII.GetString(data, pos, 4);
+            var subSize = BitConverter.ToInt32(data, pos + 4);
+            if (subId == "data")
+            {
+                var pcm = new byte[subSize];
+                Array.Copy(data, pos + 8, pcm, 0, Math.Min(subSize, data.Length - pos - 8));
+                return new WavInfo(channels, bitsPerSample, sampleRate, pcm);
+            }
+            pos += 8 + subSize;
+        }
+
+        // fallback: 跳过 44 字节 header
+        var fallbackPcm = new byte[data.Length - 44];
+        Array.Copy(data, 44, fallbackPcm, 0, fallbackPcm.Length);
+        return new WavInfo(channels, bitsPerSample, sampleRate, fallbackPcm);
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // 工具方法
+    // ═══════════════════════════════════════════════════════════
+
+    private static byte[] GzipCompress(byte[] data)
+    {
+        using var output = new MemoryStream();
+        using (var gzip = new GZipStream(output, CompressionLevel.Fastest))
+        {
+            gzip.Write(data, 0, data.Length);
+        }
+        return output.ToArray();
+    }
+
+    private static byte[] GzipDecompress(byte[] data)
+    {
+        using var input = new MemoryStream(data);
+        using var gzip = new GZipStream(input, CompressionMode.Decompress);
+        using var output = new MemoryStream();
+        gzip.CopyTo(output);
+        return output.ToArray();
+    }
+
+    private static void WriteInt32BigEndian(Stream s, int value)
+    {
+        var bytes = BitConverter.GetBytes(value);
+        if (BitConverter.IsLittleEndian) Array.Reverse(bytes);
+        s.Write(bytes, 0, 4);
+    }
+
+    private static void WriteUInt32BigEndian(Stream s, uint value)
+    {
+        var bytes = BitConverter.GetBytes(value);
+        if (BitConverter.IsLittleEndian) Array.Reverse(bytes);
+        s.Write(bytes, 0, 4);
+    }
+
+    private static int ReadInt32BigEndian(ReadOnlySpan<byte> data)
+    {
+        var bytes = data[..4].ToArray();
+        if (BitConverter.IsLittleEndian) Array.Reverse(bytes);
+        return BitConverter.ToInt32(bytes, 0);
+    }
+
+    private static uint ReadUInt32BigEndian(ReadOnlySpan<byte> data)
+    {
+        var bytes = data[..4].ToArray();
+        if (BitConverter.IsLittleEndian) Array.Reverse(bytes);
+        return BitConverter.ToUInt32(bytes, 0);
+    }
+
+    private static List<byte[]> SplitAudio(byte[] data, int segmentSize)
+    {
+        var segments = new List<byte[]>();
+        for (var i = 0; i < data.Length; i += segmentSize)
+        {
+            var end = Math.Min(i + segmentSize, data.Length);
+            var segment = new byte[end - i];
+            Array.Copy(data, i, segment, 0, segment.Length);
+            segments.Add(segment);
+        }
+        return segments;
+    }
+
+    private static bool GetBool(Dictionary<string, object>? config, string key, bool defaultValue)
+    {
+        if (config == null) return defaultValue;
+        if (!config.TryGetValue(key, out var val)) return defaultValue;
+        if (val is bool b) return b;
+        if (val is string s && bool.TryParse(s, out var parsed)) return parsed;
+        return defaultValue;
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // 内部类型
+    // ═══════════════════════════════════════════════════════════
+
+    private record WavInfo(int Channels, int BitsPerSample, int SampleRate, byte[] PcmData);
+}
+
+/// <summary>流式 ASR 响应帧</summary>
+public class AsrResponseFrame
+{
+    public int Code { get; set; }
+    public int Event { get; set; }
+    public bool IsLastPackage { get; set; }
+    public int PayloadSequence { get; set; }
+    public uint PayloadSize { get; set; }
+    public JsonElement? PayloadMsg { get; set; }
+}
+
+/// <summary>流式 ASR 转录结果</summary>
+public class StreamAsrResult
+{
+    public bool Success { get; set; }
+    public string FullText { get; set; } = "";
+    public List<StreamAsrSegment> Segments { get; set; } = new();
+    public List<AsrResponseFrame> Responses { get; set; } = new();
+    public string? Error { get; set; }
+}
+
+/// <summary>流式 ASR 分段</summary>
+public class StreamAsrSegment
+{
+    public string Text { get; set; } = "";
+    public double DurationSec { get; set; }
+}

--- a/prd-api/src/PrdAgent.Core/Interfaces/IExchangeTransformer.cs
+++ b/prd-api/src/PrdAgent.Core/Interfaces/IExchangeTransformer.cs
@@ -32,4 +32,57 @@ public interface IExchangeTransformer
     /// 转换响应：目标格式 → 标准格式
     /// </summary>
     JsonObject TransformResponse(JsonObject rawResponse, Dictionary<string, object>? config);
+
+    /// <summary>
+    /// 获取此转换器需要附加的额外 HTTP 请求头。
+    /// 用于非标准认证（如豆包 ASR 的 X-Api-Resource-Id）。
+    /// 返回 null 表示无额外 header。
+    /// </summary>
+    Dictionary<string, string>? GetExtraHeaders(Dictionary<string, object>? config) => null;
+}
+
+/// <summary>
+/// 异步 Exchange 转换器接口（submit + query 轮询模式）
+/// 用于目标 API 采用异步任务模式的场景（如豆包大模型 ASR）。
+///
+/// 流程：
+/// 1. Gateway 发送 submit 请求（TransformRequest 转换后的 body）
+/// 2. 检查 submit 响应是否需要轮询（IsTaskPending）
+/// 3. 如需轮询，构建 query 请求（BuildQueryRequest）并循环调用
+/// 4. 直到 IsTaskComplete 或 IsTaskFailed，最后用 TransformResponse 转换最终结果
+/// </summary>
+public interface IAsyncExchangeTransformer : IExchangeTransformer
+{
+    /// <summary>轮询间隔（毫秒）</summary>
+    int PollIntervalMs => 1000;
+
+    /// <summary>最大轮询次数（超过后视为超时）</summary>
+    int MaxPollAttempts => 300;
+
+    /// <summary>
+    /// 判断 submit/query 响应是否表示任务仍在处理中。
+    /// 返回 true 则继续轮询。
+    /// </summary>
+    bool IsTaskPending(int httpStatus, Dictionary<string, string> responseHeaders, string? responseBody);
+
+    /// <summary>
+    /// 判断任务是否已完成（成功）。
+    /// </summary>
+    bool IsTaskComplete(int httpStatus, Dictionary<string, string> responseHeaders, string? responseBody);
+
+    /// <summary>
+    /// 判断任务是否失败，返回错误信息。
+    /// </summary>
+    bool IsTaskFailed(int httpStatus, Dictionary<string, string> responseHeaders, string? responseBody, out string errorMessage);
+
+    /// <summary>
+    /// 从 submit 响应中构建 query 请求。
+    /// 返回 (queryUrl, queryBody, queryExtraHeaders)。
+    /// </summary>
+    (string queryUrl, JsonObject? queryBody, Dictionary<string, string> queryHeaders) BuildQueryRequest(
+        string baseUrl,
+        int submitHttpStatus,
+        Dictionary<string, string> submitResponseHeaders,
+        string? submitResponseBody,
+        Dictionary<string, object>? config);
 }

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/LlmGateway.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/LlmGateway.cs
@@ -744,13 +744,13 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
                             queryRequest.Headers.TryAddWithoutValidation(key, value);
 
                         // 传递 submit 时的 X-Api-Request-Id（豆包 query 需要）
-                        if (submitResponseHeaders.TryGetValue("X-Api-Request-Id", out var reqId) ||
-                            httpRequest.Headers.TryGetValues("X-Api-Request-Id", out var reqIdValues))
-                        {
-                            var requestId = reqId ?? reqIdValues?.FirstOrDefault();
-                            if (requestId != null)
-                                queryRequest.Headers.TryAddWithoutValidation("X-Api-Request-Id", requestId);
-                        }
+                        string? submitRequestId = null;
+                        if (submitResponseHeaders.TryGetValue("X-Api-Request-Id", out var reqId))
+                            submitRequestId = reqId;
+                        else if (httpRequest.Headers.TryGetValues("X-Api-Request-Id", out var reqIdValues))
+                            submitRequestId = reqIdValues.FirstOrDefault();
+                        if (submitRequestId != null)
+                            queryRequest.Headers.TryAddWithoutValidation("X-Api-Request-Id", submitRequestId);
 
                         var queryClient = _httpClientFactory.CreateClient();
                         queryClient.Timeout = TimeSpan.FromSeconds(30);

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/LlmGateway.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/LlmGateway.cs
@@ -835,6 +835,17 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
                 httpRequest.Headers.Authorization =
                     new System.Net.Http.Headers.AuthenticationHeaderValue("Key", apiKey);
                 break;
+            case "doubao-asr":
+                // 豆包 ASR 认证：apiKey 格式 "appId|accessToken"
+                var parts = apiKey.Split('|', 2);
+                var appId = parts.Length > 1 ? parts[0] : "";
+                var accessToken = parts.Length > 1 ? parts[1] : apiKey;
+                httpRequest.Headers.TryAddWithoutValidation("X-Api-App-Key", appId);
+                httpRequest.Headers.TryAddWithoutValidation("X-Api-Access-Key", accessToken);
+                httpRequest.Headers.TryAddWithoutValidation("X-Api-Resource-Id", "volc.bigasr.auc_turbo");
+                httpRequest.Headers.TryAddWithoutValidation("X-Api-Request-Id", Guid.NewGuid().ToString());
+                httpRequest.Headers.TryAddWithoutValidation("X-Api-Sequence", "-1");
+                break;
             default: // "bearer" or anything else
                 httpRequest.Headers.Authorization =
                     new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", apiKey);

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/LlmGateway.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/LlmGateway.cs
@@ -578,6 +578,16 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
                     Content = new StringContent(jsonContent, System.Text.Encoding.UTF8, "application/json")
                 };
                 requestBodyForLog = jsonContent;
+
+                // Exchange 转换器额外 headers（如 X-Api-Resource-Id）
+                var extraTransformerHeaders = transformer.GetExtraHeaders(resolution.ExchangeTransformerConfig);
+                if (extraTransformerHeaders != null)
+                {
+                    foreach (var (key, value) in extraTransformerHeaders)
+                    {
+                        httpRequest.Headers.TryAddWithoutValidation(key, value);
+                    }
+                }
             }
             else if (request.IsMultipart)
             {
@@ -683,6 +693,111 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
             else
             {
                 responseBody = await response.Content.ReadAsStringAsync(ct);
+            }
+
+            // 6.5 Exchange 异步轮询（submit+query 模式）
+            var submitResponseHeaders = new Dictionary<string, string>();
+            foreach (var h in response.Headers)
+                submitResponseHeaders[h.Key] = string.Join(", ", h.Value);
+
+            if (isExchange && _transformerRegistry.Get(resolution.ExchangeTransformerType) is IAsyncExchangeTransformer asyncTransformer)
+            {
+                // 检查 submit 响应状态
+                if (asyncTransformer.IsTaskFailed((int)response.StatusCode, submitResponseHeaders, responseBody, out var submitError))
+                {
+                    var endedNow = DateTime.UtcNow;
+                    var dur = (long)(endedNow - startedAt).TotalMilliseconds;
+                    await FinishRawLogAsync(logId, (int)response.StatusCode, responseBody, dur, ct);
+                    return GatewayRawResponse.Fail("EXCHANGE_ASYNC_SUBMIT_FAILED", submitError, (int)response.StatusCode);
+                }
+
+                if (asyncTransformer.IsTaskPending((int)response.StatusCode, submitResponseHeaders, responseBody)
+                    || asyncTransformer.IsTaskComplete((int)response.StatusCode, submitResponseHeaders, responseBody) == false)
+                {
+                    _logger.LogInformation("[LlmGateway.Exchange.Async] 进入轮询模式, Exchange={ExchangeName}", resolution.ExchangeName);
+
+                    var (queryUrl, queryBody, queryExtraHeaders) = asyncTransformer.BuildQueryRequest(
+                        endpoint, (int)response.StatusCode, submitResponseHeaders, responseBody, resolution.ExchangeTransformerConfig);
+
+                    var pollAttempt = 0;
+                    while (pollAttempt < asyncTransformer.MaxPollAttempts)
+                    {
+                        await Task.Delay(asyncTransformer.PollIntervalMs, CancellationToken.None);
+                        pollAttempt++;
+
+                        var queryRequest = new HttpRequestMessage(HttpMethod.Post, queryUrl)
+                        {
+                            Content = new StringContent(
+                                queryBody?.ToJsonString() ?? "{}",
+                                System.Text.Encoding.UTF8, "application/json")
+                        };
+
+                        // 设置认证头（与 submit 相同）
+                        if (!string.IsNullOrWhiteSpace(resolution.ApiKey))
+                        {
+                            var authScheme = resolution.ExchangeAuthScheme ?? "Bearer";
+                            SetAuthHeader(queryRequest, authScheme, resolution.ApiKey);
+                        }
+
+                        // 添加 query 额外 headers（包含 X-Tt-Logid 等）
+                        foreach (var (key, value) in queryExtraHeaders)
+                            queryRequest.Headers.TryAddWithoutValidation(key, value);
+
+                        // 传递 submit 时的 X-Api-Request-Id（豆包 query 需要）
+                        if (submitResponseHeaders.TryGetValue("X-Api-Request-Id", out var reqId) ||
+                            httpRequest.Headers.TryGetValues("X-Api-Request-Id", out var reqIdValues))
+                        {
+                            var requestId = reqId ?? reqIdValues?.FirstOrDefault();
+                            if (requestId != null)
+                                queryRequest.Headers.TryAddWithoutValidation("X-Api-Request-Id", requestId);
+                        }
+
+                        var queryClient = _httpClientFactory.CreateClient();
+                        queryClient.Timeout = TimeSpan.FromSeconds(30);
+                        var queryResp = await queryClient.SendAsync(queryRequest, CancellationToken.None);
+
+                        var queryHeaders = new Dictionary<string, string>();
+                        foreach (var h in queryResp.Headers)
+                            queryHeaders[h.Key] = string.Join(", ", h.Value);
+
+                        responseBody = await queryResp.Content.ReadAsStringAsync(CancellationToken.None);
+                        response = queryResp;
+
+                        if (asyncTransformer.IsTaskComplete((int)queryResp.StatusCode, queryHeaders, responseBody))
+                        {
+                            _logger.LogInformation(
+                                "[LlmGateway.Exchange.Async] 任务完成, Exchange={ExchangeName}, pollAttempts={Attempts}",
+                                resolution.ExchangeName, pollAttempt);
+                            // 更新 submitResponseHeaders 为最终的 headers
+                            submitResponseHeaders = queryHeaders;
+                            break;
+                        }
+
+                        if (asyncTransformer.IsTaskFailed((int)queryResp.StatusCode, queryHeaders, responseBody, out var queryError))
+                        {
+                            var endedNow = DateTime.UtcNow;
+                            var dur = (long)(endedNow - startedAt).TotalMilliseconds;
+                            await FinishRawLogAsync(logId, (int)queryResp.StatusCode, responseBody, dur, ct);
+                            return GatewayRawResponse.Fail("EXCHANGE_ASYNC_QUERY_FAILED", queryError, (int)queryResp.StatusCode);
+                        }
+
+                        if (pollAttempt % 10 == 0)
+                        {
+                            _logger.LogInformation(
+                                "[LlmGateway.Exchange.Async] 轮询中... Exchange={ExchangeName}, attempt={Attempt}",
+                                resolution.ExchangeName, pollAttempt);
+                        }
+                    }
+
+                    if (pollAttempt >= asyncTransformer.MaxPollAttempts)
+                    {
+                        var endedNow = DateTime.UtcNow;
+                        var dur = (long)(endedNow - startedAt).TotalMilliseconds;
+                        await FinishRawLogAsync(logId, 408, "轮询超时", dur, ct);
+                        return GatewayRawResponse.Fail("EXCHANGE_ASYNC_TIMEOUT",
+                            $"异步任务超时，已轮询 {pollAttempt} 次 ({pollAttempt * asyncTransformer.PollIntervalMs / 1000}秒)", 408);
+                    }
+                }
             }
 
             var endedAt = DateTime.UtcNow;
@@ -837,14 +952,12 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
                 break;
             case "doubao-asr":
                 // 豆包 ASR 认证：apiKey 格式 "appId|accessToken"
+                // Resource-Id / Request-Id / Sequence 由转换器 GetExtraHeaders 提供
                 var parts = apiKey.Split('|', 2);
                 var appId = parts.Length > 1 ? parts[0] : "";
                 var accessToken = parts.Length > 1 ? parts[1] : apiKey;
                 httpRequest.Headers.TryAddWithoutValidation("X-Api-App-Key", appId);
                 httpRequest.Headers.TryAddWithoutValidation("X-Api-Access-Key", accessToken);
-                httpRequest.Headers.TryAddWithoutValidation("X-Api-Resource-Id", "volc.bigasr.auc_turbo");
-                httpRequest.Headers.TryAddWithoutValidation("X-Api-Request-Id", Guid.NewGuid().ToString());
-                httpRequest.Headers.TryAddWithoutValidation("X-Api-Sequence", "-1");
                 break;
             default: // "bearer" or anything else
                 httpRequest.Headers.Authorization =

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/Transformers/DoubaoAsrTransformer.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/Transformers/DoubaoAsrTransformer.cs
@@ -1,0 +1,168 @@
+using System.Text.Json.Nodes;
+using PrdAgent.Core.Interfaces;
+
+namespace PrdAgent.Infrastructure.LlmGateway.Transformers;
+
+/// <summary>
+/// 豆包 (ByteDance) 大模型语音识别转换器
+/// 将标准 OpenAI Whisper 格式 ↔ 豆包 bigmodel/recognize/flash 格式
+///
+/// 豆包 API 特点：
+/// - URL: https://openspeech.bytedance.com/api/v3/auc/bigmodel/recognize/flash
+/// - 认证: X-Api-App-Key (appId) + X-Api-Access-Key (accessToken)
+/// - 请求: { user: { uid }, audio: { url | data }, request: { model_name } }
+/// - 响应: 通过 header X-Api-Status-Code 判断，body 含识别结果
+///
+/// TransformerConfig 可选字段：
+/// - appId: 豆包 App ID（如不通过 config 传，则使用 TargetApiKey 作为 accessToken）
+/// - resourceId: 资源 ID（默认 "volc.bigasr.auc_turbo"）
+/// - enableItn: 是否启用 ITN 反标准化（默认 true）
+/// - enablePunc: 是否启用标点（默认 true）
+/// - enableDdc: 是否启用 DDC 顺滑（默认 true）
+/// </summary>
+public class DoubaoAsrTransformer : IExchangeTransformer
+{
+    public string TransformerType => "doubao-asr";
+
+    public string? ResolveTargetUrl(string baseUrl, JsonObject standardBody, Dictionary<string, object>? config)
+    {
+        // 固定使用配置的 URL
+        return null;
+    }
+
+    /// <summary>
+    /// OpenAI Whisper 格式 → 豆包 ASR 格式
+    ///
+    /// 标准输入（简化版，非 multipart 场景）:
+    /// { "audio_url": "https://...", "audio_data": "base64...", "language": "zh" }
+    ///
+    /// 豆包输出:
+    /// { "user": { "uid": "..." }, "audio": { "url": "..." | "data": "..." }, "request": { "model_name": "bigmodel", ... } }
+    /// </summary>
+    public JsonObject TransformRequest(JsonObject standardBody, Dictionary<string, object>? config)
+    {
+        var appId = GetConfigString(config, "appId") ?? "default";
+
+        // 构建 audio 部分
+        var audio = new JsonObject();
+        if (standardBody.TryGetPropertyValue("audio_url", out var urlNode) && urlNode != null)
+        {
+            audio["url"] = urlNode.GetValue<string>();
+        }
+        else if (standardBody.TryGetPropertyValue("audio_data", out var dataNode) && dataNode != null)
+        {
+            audio["data"] = dataNode.GetValue<string>();
+        }
+        else if (standardBody.TryGetPropertyValue("url", out var fallbackUrl) && fallbackUrl != null)
+        {
+            audio["url"] = fallbackUrl.GetValue<string>();
+        }
+
+        // 构建 request 部分
+        var requestObj = new JsonObject
+        {
+            ["model_name"] = "bigmodel"
+        };
+
+        var enableItn = GetConfigBool(config, "enableItn", true);
+        var enablePunc = GetConfigBool(config, "enablePunc", true);
+        var enableDdc = GetConfigBool(config, "enableDdc", true);
+
+        if (enableItn) requestObj["enable_itn"] = true;
+        if (enablePunc) requestObj["enable_punc"] = true;
+        if (enableDdc) requestObj["enable_ddc"] = true;
+
+        // 语言设置（可选）
+        if (standardBody.TryGetPropertyValue("language", out var lang) && lang != null)
+        {
+            var langStr = lang.GetValue<string>();
+            if (!string.IsNullOrWhiteSpace(langStr))
+                requestObj["language"] = langStr;
+        }
+
+        var result = new JsonObject
+        {
+            ["user"] = new JsonObject { ["uid"] = appId },
+            ["audio"] = audio,
+            ["request"] = requestObj
+        };
+
+        return result;
+    }
+
+    /// <summary>
+    /// 豆包 ASR 响应 → OpenAI Whisper verbose_json 兼容格式
+    ///
+    /// 豆包返回格式:
+    /// { "result": [{ "text": "...", "additions": { "duration": "..." } }] }
+    ///
+    /// 转换为:
+    /// { "text": "完整文本", "segments": [{ "start": 0, "end": ..., "text": "..." }], "language": "zh" }
+    /// </summary>
+    public JsonObject TransformResponse(JsonObject rawResponse, Dictionary<string, object>? config)
+    {
+        var response = new JsonObject();
+        var fullText = "";
+        var segments = new JsonArray();
+
+        if (rawResponse.TryGetPropertyValue("result", out var resultNode) && resultNode is JsonArray resultArr)
+        {
+            double currentStart = 0;
+            foreach (var item in resultArr)
+            {
+                if (item is not JsonObject itemObj) continue;
+
+                var text = "";
+                if (itemObj.TryGetPropertyValue("text", out var textNode))
+                    text = textNode?.GetValue<string>() ?? "";
+
+                double duration = 0;
+                if (itemObj.TryGetPropertyValue("additions", out var additionsNode) &&
+                    additionsNode is JsonObject additions &&
+                    additions.TryGetPropertyValue("duration", out var durNode))
+                {
+                    var durStr = durNode?.GetValue<string>() ?? "0";
+                    double.TryParse(durStr, out duration);
+                    // 豆包 duration 单位是毫秒，转换为秒
+                    duration /= 1000.0;
+                }
+
+                if (!string.IsNullOrWhiteSpace(text))
+                {
+                    fullText += text;
+                    var segment = new JsonObject
+                    {
+                        ["start"] = currentStart,
+                        ["end"] = currentStart + duration,
+                        ["text"] = text
+                    };
+                    segments.Add(segment);
+                    currentStart += duration;
+                }
+            }
+        }
+
+        response["text"] = fullText;
+        response["segments"] = segments;
+        response["language"] = "zh";
+
+        return response;
+    }
+
+    private static string? GetConfigString(Dictionary<string, object>? config, string key)
+    {
+        if (config == null) return null;
+        if (config.TryGetValue(key, out var val))
+            return val?.ToString();
+        return null;
+    }
+
+    private static bool GetConfigBool(Dictionary<string, object>? config, string key, bool defaultValue)
+    {
+        if (config == null) return defaultValue;
+        if (!config.TryGetValue(key, out var val)) return defaultValue;
+        if (val is bool b) return b;
+        if (val is string s && bool.TryParse(s, out var parsed)) return parsed;
+        return defaultValue;
+    }
+}

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/Transformers/DoubaoAsrTransformer.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/Transformers/DoubaoAsrTransformer.cs
@@ -4,100 +4,105 @@ using PrdAgent.Core.Interfaces;
 namespace PrdAgent.Infrastructure.LlmGateway.Transformers;
 
 /// <summary>
-/// 豆包 (ByteDance) 大模型语音识别转换器
-/// 将标准 OpenAI Whisper 格式 ↔ 豆包 bigmodel/recognize/flash 格式
+/// 豆包 (ByteDance) 大模型语音识别转换器 — 异步 submit+query 模式
 ///
-/// 豆包 API 特点：
-/// - URL: https://openspeech.bytedance.com/api/v3/auc/bigmodel/recognize/flash
-/// - 认证: X-Api-App-Key (appId) + X-Api-Access-Key (accessToken)
-/// - 请求: { user: { uid }, audio: { url | data }, request: { model_name } }
-/// - 响应: 通过 header X-Api-Status-Code 判断，body 含识别结果
+/// 流程：
+/// 1. submit → POST /api/v3/auc/bigmodel/submit 提交转录任务
+/// 2. query  → POST /api/v3/auc/bigmodel/query  轮询结果
+/// 3. 状态码通过 X-Api-Status-Code 响应头返回：
+///    - 20000000: 完成
+///    - 20000001 / 20000002: 处理中
+///    - 其他: 失败
 ///
-/// TransformerConfig 可选字段：
-/// - appId: 豆包 App ID（如不通过 config 传，则使用 TargetApiKey 作为 accessToken）
-/// - resourceId: 资源 ID（默认 "volc.bigasr.auc_turbo"）
-/// - enableItn: 是否启用 ITN 反标准化（默认 true）
-/// - enablePunc: 是否启用标点（默认 true）
-/// - enableDdc: 是否启用 DDC 顺滑（默认 true）
+/// TransformerConfig 字段：
+/// - resourceId: 资源 ID（默认 "volc.bigasr.auc"）
+/// - enableItn: 启用 ITN 反标准化（默认 true）
+/// - enablePunc: 启用标点（默认 true）
+/// - enableDdc: 启用 DDC 顺滑（默认 true）
+/// - enableSpeakerInfo: 启用说话人信息（默认 true）
+/// - enableChannelSplit: 启用声道分离（默认 true）
+///
+/// 认证方式支持两种：
+/// - DoubaoAsr: apiKey 格式 "appId|accessToken" → X-Api-App-Key + X-Api-Access-Key
+/// - XApiKey: 单一 key → x-api-key
 /// </summary>
-public class DoubaoAsrTransformer : IExchangeTransformer
+public class DoubaoAsrTransformer : IAsyncExchangeTransformer
 {
     public string TransformerType => "doubao-asr";
+    public int PollIntervalMs => 1000;
+    public int MaxPollAttempts => 600; // 最多 10 分钟
 
+    /// <summary>
+    /// submit URL 固定，不做路由
+    /// </summary>
     public string? ResolveTargetUrl(string baseUrl, JsonObject standardBody, Dictionary<string, object>? config)
     {
-        // 固定使用配置的 URL
         return null;
     }
 
     /// <summary>
-    /// OpenAI Whisper 格式 → 豆包 ASR 格式
-    ///
-    /// 标准输入（简化版，非 multipart 场景）:
-    /// { "audio_url": "https://...", "audio_data": "base64...", "language": "zh" }
-    ///
-    /// 豆包输出:
-    /// { "user": { "uid": "..." }, "audio": { "url": "..." | "data": "..." }, "request": { "model_name": "bigmodel", ... } }
+    /// 获取额外请求头：X-Api-Resource-Id、X-Api-Request-Id、X-Api-Sequence
     /// </summary>
-    public JsonObject TransformRequest(JsonObject standardBody, Dictionary<string, object>? config)
+    public Dictionary<string, string>? GetExtraHeaders(Dictionary<string, object>? config)
     {
-        var appId = GetConfigString(config, "appId") ?? "default";
-
-        // 构建 audio 部分
-        var audio = new JsonObject();
-        if (standardBody.TryGetPropertyValue("audio_url", out var urlNode) && urlNode != null)
+        var resourceId = GetConfigString(config, "resourceId") ?? "volc.bigasr.auc";
+        return new Dictionary<string, string>
         {
-            audio["url"] = urlNode.GetValue<string>();
-        }
-        else if (standardBody.TryGetPropertyValue("audio_data", out var dataNode) && dataNode != null)
-        {
-            audio["data"] = dataNode.GetValue<string>();
-        }
-        else if (standardBody.TryGetPropertyValue("url", out var fallbackUrl) && fallbackUrl != null)
-        {
-            audio["url"] = fallbackUrl.GetValue<string>();
-        }
-
-        // 构建 request 部分
-        var requestObj = new JsonObject
-        {
-            ["model_name"] = "bigmodel"
+            ["X-Api-Resource-Id"] = resourceId,
+            ["X-Api-Request-Id"] = Guid.NewGuid().ToString(),
+            ["X-Api-Sequence"] = "-1"
         };
-
-        var enableItn = GetConfigBool(config, "enableItn", true);
-        var enablePunc = GetConfigBool(config, "enablePunc", true);
-        var enableDdc = GetConfigBool(config, "enableDdc", true);
-
-        if (enableItn) requestObj["enable_itn"] = true;
-        if (enablePunc) requestObj["enable_punc"] = true;
-        if (enableDdc) requestObj["enable_ddc"] = true;
-
-        // 语言设置（可选）
-        if (standardBody.TryGetPropertyValue("language", out var lang) && lang != null)
-        {
-            var langStr = lang.GetValue<string>();
-            if (!string.IsNullOrWhiteSpace(langStr))
-                requestObj["language"] = langStr;
-        }
-
-        var result = new JsonObject
-        {
-            ["user"] = new JsonObject { ["uid"] = appId },
-            ["audio"] = audio,
-            ["request"] = requestObj
-        };
-
-        return result;
     }
 
     /// <summary>
-    /// 豆包 ASR 响应 → OpenAI Whisper verbose_json 兼容格式
+    /// 标准请求 → 豆包 submit 请求
     ///
-    /// 豆包返回格式:
-    /// { "result": [{ "text": "...", "additions": { "duration": "..." } }] }
+    /// 输入: { "audio_url": "https://...", "audio_data": "base64...", "language": "zh" }
+    /// 输出: { "user": { "uid": "..." }, "audio": { "url": "..." }, "request": { "model_name": "bigmodel", ... } }
+    /// </summary>
+    public JsonObject TransformRequest(JsonObject standardBody, Dictionary<string, object>? config)
+    {
+        // 构建 audio
+        var audio = new JsonObject();
+        if (TryGetString(standardBody, "audio_url", out var audioUrl))
+            audio["url"] = audioUrl;
+        else if (TryGetString(standardBody, "audio_data", out var audioData))
+            audio["data"] = audioData;
+        else if (TryGetString(standardBody, "url", out var fallbackUrl))
+            audio["url"] = fallbackUrl;
+
+        // 可选 audio 参数
+        if (TryGetString(standardBody, "format", out var format))
+            audio["format"] = format;
+
+        // 构建 request
+        var requestObj = new JsonObject { ["model_name"] = "bigmodel" };
+
+        requestObj["enable_itn"] = GetConfigBool(config, "enableItn", true);
+        requestObj["enable_punc"] = GetConfigBool(config, "enablePunc", true);
+        requestObj["enable_ddc"] = GetConfigBool(config, "enableDdc", true);
+        requestObj["enable_speaker_info"] = GetConfigBool(config, "enableSpeakerInfo", true);
+        requestObj["enable_channel_split"] = GetConfigBool(config, "enableChannelSplit", true);
+
+        // 语言（可选）
+        if (TryGetString(standardBody, "language", out var lang) && !string.IsNullOrWhiteSpace(lang))
+            requestObj["language"] = lang;
+
+        var uid = GetConfigString(config, "uid") ?? "prd-agent";
+
+        return new JsonObject
+        {
+            ["user"] = new JsonObject { ["uid"] = uid },
+            ["audio"] = audio,
+            ["request"] = requestObj
+        };
+    }
+
+    /// <summary>
+    /// 豆包最终响应 → Whisper 兼容格式
     ///
-    /// 转换为:
-    /// { "text": "完整文本", "segments": [{ "start": 0, "end": ..., "text": "..." }], "language": "zh" }
+    /// 豆包返回: { "result": [{ "text": "...", "additions": { "duration": "..." } }] }
+    /// 转换为: { "text": "完整文本", "segments": [...], "language": "zh" }
     /// </summary>
     public JsonObject TransformResponse(JsonObject rawResponse, Dictionary<string, object>? config)
     {
@@ -123,23 +128,27 @@ public class DoubaoAsrTransformer : IExchangeTransformer
                 {
                     var durStr = durNode?.GetValue<string>() ?? "0";
                     double.TryParse(durStr, out duration);
-                    // 豆包 duration 单位是毫秒，转换为秒
-                    duration /= 1000.0;
+                    duration /= 1000.0; // 毫秒 → 秒
                 }
 
                 if (!string.IsNullOrWhiteSpace(text))
                 {
                     fullText += text;
-                    var segment = new JsonObject
+                    segments.Add(new JsonObject
                     {
                         ["start"] = currentStart,
                         ["end"] = currentStart + duration,
                         ["text"] = text
-                    };
-                    segments.Add(segment);
+                    });
                     currentStart += duration;
                 }
             }
+        }
+
+        // 兜底：如果 result 不是数组而是包含 text 字段的对象
+        if (segments.Count == 0 && rawResponse.TryGetPropertyValue("text", out var directText))
+        {
+            fullText = directText?.GetValue<string>() ?? "";
         }
 
         response["text"] = fullText;
@@ -147,6 +156,98 @@ public class DoubaoAsrTransformer : IExchangeTransformer
         response["language"] = "zh";
 
         return response;
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // IAsyncExchangeTransformer — 异步轮询
+    // ═══════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// X-Api-Status-Code: 20000001 或 20000002 表示处理中
+    /// </summary>
+    public bool IsTaskPending(int httpStatus, Dictionary<string, string> responseHeaders, string? responseBody)
+    {
+        var code = GetStatusCode(responseHeaders);
+        return code == "20000001" || code == "20000002";
+    }
+
+    /// <summary>
+    /// X-Api-Status-Code: 20000000 表示完成
+    /// </summary>
+    public bool IsTaskComplete(int httpStatus, Dictionary<string, string> responseHeaders, string? responseBody)
+    {
+        return GetStatusCode(responseHeaders) == "20000000";
+    }
+
+    /// <summary>
+    /// 非 20000000/20000001/20000002 表示失败
+    /// </summary>
+    public bool IsTaskFailed(int httpStatus, Dictionary<string, string> responseHeaders, string? responseBody, out string errorMessage)
+    {
+        var code = GetStatusCode(responseHeaders);
+        if (string.IsNullOrEmpty(code))
+        {
+            errorMessage = $"豆包 ASR 响应缺少 X-Api-Status-Code header, HTTP {httpStatus}";
+            return true;
+        }
+        if (code == "20000000" || code == "20000001" || code == "20000002")
+        {
+            errorMessage = "";
+            return false;
+        }
+
+        var message = responseHeaders.GetValueOrDefault("X-Api-Message") ?? "未知错误";
+        errorMessage = $"豆包 ASR 失败: code={code}, message={message}";
+        return true;
+    }
+
+    /// <summary>
+    /// 构建 query 请求：
+    /// - URL: 同域名下的 /query 端点
+    /// - Headers: 保留认证头 + 传递 submit 返回的 X-Tt-Logid
+    /// - Body: 空对象
+    /// </summary>
+    public (string queryUrl, JsonObject? queryBody, Dictionary<string, string> queryHeaders) BuildQueryRequest(
+        string baseUrl,
+        int submitHttpStatus,
+        Dictionary<string, string> submitResponseHeaders,
+        string? submitResponseBody,
+        Dictionary<string, object>? config)
+    {
+        // submit URL: .../submit → query URL: .../query
+        var queryUrl = baseUrl.Replace("/submit", "/query");
+
+        var queryHeaders = new Dictionary<string, string>();
+
+        // 传递 X-Tt-Logid（豆包要求 query 时携带）
+        if (submitResponseHeaders.TryGetValue("X-Tt-Logid", out var logId))
+            queryHeaders["X-Tt-Logid"] = logId;
+
+        // Resource ID
+        var resourceId = GetConfigString(config, "resourceId") ?? "volc.bigasr.auc";
+        queryHeaders["X-Api-Resource-Id"] = resourceId;
+
+        return (queryUrl, new JsonObject(), queryHeaders);
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // 工具方法
+    // ═══════════════════════════════════════════════════════════
+
+    private static string? GetStatusCode(Dictionary<string, string> headers)
+    {
+        return headers.GetValueOrDefault("X-Api-Status-Code");
+    }
+
+    private static bool TryGetString(JsonObject obj, string key, out string value)
+    {
+        if (obj.TryGetPropertyValue(key, out var node) && node != null)
+        {
+            value = node.GetValue<string>();
+            return !string.IsNullOrEmpty(value);
+        }
+        value = "";
+        return false;
     }
 
     private static string? GetConfigString(Dictionary<string, object>? config, string key)

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/Transformers/DoubaoStreamAsrTransformer.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/Transformers/DoubaoStreamAsrTransformer.cs
@@ -1,0 +1,53 @@
+using System.Text.Json.Nodes;
+using PrdAgent.Core.Interfaces;
+
+namespace PrdAgent.Infrastructure.LlmGateway.Transformers;
+
+/// <summary>
+/// 豆包流式 ASR 转换器（WebSocket 二进制协议标记）
+///
+/// 此转换器为标记类型，实际的 WebSocket 通信由 DoubaoStreamAsrService 处理。
+/// Exchange 系统中注册此类型，使其出现在转换器列表中，
+/// 但 HTTP 管线不会使用 TransformRequest/TransformResponse。
+///
+/// TransformerConfig 字段：
+/// - wsUrl: WebSocket URL（默认 wss://openspeech.bytedance.com/api/v3/sauc/bigmodel_nostream）
+/// - resourceId: 资源 ID（默认 "volc.bigasr.sauc.duration"）
+/// - enableItn / enablePunc / enableDdc: 识别参数
+/// </summary>
+public class DoubaoStreamAsrTransformer : IExchangeTransformer
+{
+    public string TransformerType => "doubao-asr-stream";
+
+    public string? ResolveTargetUrl(string baseUrl, JsonObject standardBody, Dictionary<string, object>? config)
+    {
+        return null;
+    }
+
+    public Dictionary<string, string>? GetExtraHeaders(Dictionary<string, object>? config)
+    {
+        var resourceId = config?.GetValueOrDefault("resourceId")?.ToString() ?? "volc.bigasr.sauc.duration";
+        return new Dictionary<string, string>
+        {
+            ["X-Api-Resource-Id"] = resourceId,
+            ["X-Api-Request-Id"] = Guid.NewGuid().ToString(),
+            ["X-Api-App-Key"] = config?.GetValueOrDefault("appKey")?.ToString() ?? ""
+        };
+    }
+
+    /// <summary>
+    /// 标准请求 → 透传（WebSocket 模式不走 HTTP 管线）
+    /// </summary>
+    public JsonObject TransformRequest(JsonObject standardBody, Dictionary<string, object>? config)
+    {
+        return standardBody;
+    }
+
+    /// <summary>
+    /// 响应 → 透传（WebSocket 模式下不走此路径）
+    /// </summary>
+    public JsonObject TransformResponse(JsonObject rawResponse, Dictionary<string, object>? config)
+    {
+        return rawResponse;
+    }
+}

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/Transformers/ExchangeTransformerRegistry.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/Transformers/ExchangeTransformerRegistry.cs
@@ -21,6 +21,7 @@ public class ExchangeTransformerRegistry
         _transformers["fal-image-edit"] = falImage;
 
         Register(new DoubaoAsrTransformer());
+        Register(new DoubaoStreamAsrTransformer());
     }
 
     public void Register(IExchangeTransformer transformer)

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/Transformers/ExchangeTransformerRegistry.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/Transformers/ExchangeTransformerRegistry.cs
@@ -19,6 +19,8 @@ public class ExchangeTransformerRegistry
         Register(falImage);
         // 向后兼容：旧类型名 fal-image-edit 也指向同一个转换器
         _transformers["fal-image-edit"] = falImage;
+
+        Register(new DoubaoAsrTransformer());
     }
 
     public void Register(IExchangeTransformer transformer)


### PR DESCRIPTION
## Summary

This PR adds comprehensive support for ByteDance Doubao ASR (Automatic Speech Recognition) integration through the Exchange (model relay) system. It includes both HTTP async submit+query polling and WebSocket streaming protocols, along with a new transcript workbench tool.

## Key Changes

### Backend (prd-api)

- **DoubaoStreamAsrService** (`Services/DoubaoStreamAsrService.cs`): Complete WebSocket binary protocol client implementing ByteDance's custom frame format for real-time streaming ASR. Handles:
  - Binary frame construction/parsing (4-byte header with version, message type, flags, serialization, compression)
  - Audio segmentation and gzip compression
  - Dual authentication modes (single key and dual key)
  - WAV file parsing with PCM extraction
  - Continuous response polling until final package

- **DoubaoAsrTransformer** (`Infrastructure/LlmGateway/Transformers/DoubaoAsrTransformer.cs`): HTTP async transformer for submit+query polling mode with configurable ASR parameters (ITN, punctuation, DDC smoothing, speaker info, channel split)

- **DoubaoStreamAsrTransformer** (`Infrastructure/LlmGateway/Transformers/DoubaoStreamAsrTransformer.cs`): Marker transformer for WebSocket streaming mode

- **IAsyncExchangeTransformer** interface (`Core/Interfaces/IExchangeTransformer.cs`): New interface for async task-based transformers with methods:
  - `IsTaskPending()`, `IsTaskComplete()`, `IsTaskFailed()` for status checking
  - `BuildQueryRequest()` for constructing polling requests
  - Configurable poll interval and max attempts

- **LlmGateway async polling** (`Infrastructure/LlmGateway/LlmGateway.cs`): Enhanced `SendRawAsync()` to support async transformers with automatic submit+query polling, including request ID tracking and error handling

- **ExchangeController enhancements** (`Controllers/Api/ExchangeController.cs`):
  - `TestExchangeWithAudio()` endpoint for audio file upload testing (100MB limit)
  - `TestStreamAsr()` endpoint for WebSocket ASR testing
  - Support for async transformer polling in test mode (up to 120 attempts)
  - Extra header injection from transformers (e.g., X-Api-Resource-Id)

- **StreamAsrTestController** (`Controllers/Api/StreamAsrTestController.cs`): Dedicated test endpoint for WebSocket streaming ASR validation

- **ExchangeTransformerRegistry**: Registered new Doubao transformers

- **Program.cs**: Added DoubaoStreamAsrService singleton registration

### Frontend (prd-admin)

- **ExchangeTestPanel** (`components/exchange/ExchangeTestPanel.tsx`): Added audio mode with:
  - File upload and URL input support
  - Multipart form data submission for audio files
  - Audio-specific test result display

- **ExchangeManagePage** (`pages/ExchangeManagePage.tsx`): Added template import workflow:
  - Template selection dialog
  - API key input with dual-key format support (AppID|AccessToken)
  - Import button with loading state
  - Template list fetching and error handling

- **Exchange services** (`services/real/exchanges.ts`): New API methods:
  - `getExchangeTemplates()`: Fetch available templates
  - `importExchangeFromTemplate()`: Import and create exchange from template

- **Exchange types** (`types/exchange.ts`): Added:
  - `ExchangeTemplate` interface
  - `DoubaoAsr` and `DoubaoAsrStream` auth scheme options

- **Toolbox store** (`stores/toolboxStore.ts`): Added "转录工作台" (Transcript Workbench) as built-in tool

- **API routes** (`services/api.ts`): Added template endpoints

### Documentation

- **guide.doubao-asr-relay.md**: Comprehensive guide covering:
  - Architecture overview (WebSocket vs SSE relationship)
  - Three-layer

https://claude.ai/code/session_01JaQqUramywbtEoqcR7w7ZU