### PR TITLE
Fix branch card styling for AI-occupied state with updates

### DIFF
--- a/cds/web/style.css
+++ b/cds/web/style.css
@@ -1170,13 +1170,22 @@ a.branch-name:hover { color: var(--accent); }
   background: linear-gradient(90deg, rgba(56, 189, 248, 0.04) 0%, var(--bg-card) 40%);
 }
 .branch-card.has-updates.active {
-  background: linear-gradient(90deg, rgba(56, 189, 248, 0.03) 0%, rgba(16, 185, 129, 0.03) 20%, var(--bg-card) 40%);
+  background: linear-gradient(90deg, rgba(56, 189, 248, 0.04) 0%, var(--bg-card) 40%);
 }
 
 /* Card-level recently-touched indicator — bold blue border so you know which card you just operated on */
 .branch-card.recently-touched {
   border: 3px solid var(--blue);
   box-shadow: 0 0 12px rgba(56, 189, 248, 0.35), 0 0 4px rgba(56, 189, 248, 0.2);
+}
+/* has-updates / recently-touched must override ai-occupied rainbow border */
+.branch-card.has-updates.is-ai-occupied,
+.branch-card.recently-touched.is-ai-occupied {
+  background-image: none;
+  background-clip: padding-box;
+  background-origin: padding-box;
+  background-size: auto;
+  animation: none;
 }
 
 /* Duplicate-add: gold flash 3 times then settle to blue */


### PR DESCRIPTION
## Summary
This PR fixes visual styling conflicts when a branch card is both AI-occupied and has updates or was recently touched. The changes ensure that the AI-occupied rainbow border animation doesn't conflict with other card state indicators.

## Key Changes
- Simplified the `.branch-card.has-updates.active` gradient to match the standard has-updates state, removing the redundant green gradient component
- Added new CSS rules for `.branch-card.has-updates.is-ai-occupied` and `.branch-card.recently-touched.is-ai-occupied` to disable background animations and gradients, allowing the AI-occupied border styling to display cleanly without visual conflicts

## Implementation Details
The fix uses `background-image: none`, `background-clip: padding-box`, and `animation: none` to override any conflicting gradient or animation properties when the AI-occupied state is combined with has-updates or recently-touched states. This ensures proper visual hierarchy and prevents overlapping visual effects.

https://claude.ai/code/session_01FjbnFtVUH6NbMwgzZPfEvJ