### PR TITLE
Add infinite scroll pagination to visual agent workspace list

### DIFF
--- a/changelogs/2026-03-30_fix-typescript-build-errors.md
+++ b/changelogs/2026-03-30_fix-typescript-build-errors.md
@@ -1,0 +1,1 @@
+| fix | prd-admin | 修复 TypeScript 编译错误：移除未使用的导入和变量，修正 CreateImageGenRunInput 类型标注 |

--- a/changelogs/2026-03-30_visual-agent-infinite-scroll.md
+++ b/changelogs/2026-03-30_visual-agent-infinite-scroll.md
@@ -1,0 +1,2 @@
+| feat | prd-api | 视觉创作工作区列表接口支持 skip 分页参数和 hasMore 标记 |
+| feat | prd-admin | 视觉创作工作区列表支持无限滚动，滑动到底部自动加载更多项目 |

--- a/prd-admin/src/components/exchange/ExchangeTestPanel.tsx
+++ b/prd-admin/src/components/exchange/ExchangeTestPanel.tsx
@@ -3,7 +3,7 @@ import { GlassCard } from '@/components/design/GlassCard';
 import { testExchange } from '@/services/real/exchanges';
 import type { ModelExchange, ExchangeTestResult } from '@/types/exchange';
 import type { ApiResponse } from '@/types/api';
-import { apiRequest } from '@/services/real/apiClient';
+
 import { api } from '@/services/api';
 import {
   ArrowRight,

--- a/prd-admin/src/pages/literary-agent/ArticleIllustrationEditorPage.tsx
+++ b/prd-admin/src/pages/literary-agent/ArticleIllustrationEditorPage.tsx
@@ -74,7 +74,7 @@ import { systemDialog } from '@/lib/systemDialog';
 import { toast } from '@/lib/toast';
 import { cn } from '@/lib/cn';
 import type { Model } from '@/types/admin';
-import type { ImageGenPlanItem } from '@/services/contracts/imageGen';
+import type { ImageGenPlanItem, CreateImageGenRunInput } from '@/services/contracts/imageGen';
 
 // 3 个状态：0=upload, 1=editing, 2=markersGenerated
 type WorkflowPhase = 0 | 1 | 2;
@@ -532,18 +532,6 @@ export default function ArticleIllustrationEditorPage({ workspaceId }: { workspa
     } as Model;
   }, [effectiveModel]);
 
-  // mainModel 由 effectiveChatModel 驱动（用于标记生成模型名称显示）
-  const mainModel = useMemo<Model | null>(() => {
-    if (!effectiveChatModel) return null;
-    return {
-      id: effectiveChatModel.id,
-      name: effectiveChatModel.name,
-      modelName: effectiveChatModel.modelName,
-      platformId: effectiveChatModel.platformId,
-      enabled: effectiveChatModel.enabled,
-      isMain: true,
-    } as Model;
-  }, [effectiveChatModel]);
 
   // 生图模型尺寸选项（按分辨率分组，从后端 adapter-info 获取）
   const [sizesByResolutionForPicker, setSizesByResolutionForPicker] = useState<SizesByResolution>({ '1k': [], '2k': [], '4k': [] });
@@ -1496,7 +1484,7 @@ export default function ArticleIllustrationEditorPage({ workspaceId }: { workspa
     );
     const idem = `article_img_${workspaceId}_${markerIndex}_${Date.now()}_${Math.random().toString(16).slice(2)}`;
     // 如果用户选择了特定模型，传入 platformId 和 modelId 供后端使用
-    const runInput: Record<string, unknown> = {
+    const runInput: CreateImageGenRunInput = {
       items: [{ prompt: plannedPrompt, count: 1, size: plannedSize }],
       size: plannedSize,
       responseFormat: 'url',
@@ -1504,11 +1492,8 @@ export default function ArticleIllustrationEditorPage({ workspaceId }: { workspa
       workspaceId,
       appKey: 'literary-agent',
       articleMarkerIndex: markerIndex,
+      ...(effectiveModel ? { platformId: effectiveModel.platformId, modelId: effectiveModel.actualModelId } : {}),
     };
-    if (effectiveModel) {
-      runInput.platformId = effectiveModel.platformId;
-      runInput.modelId = effectiveModel.actualModelId;
-    }
     const created = await createLiteraryAgentImageGenRun({
       input: runInput,
       idempotencyKey: idem,

--- a/prd-admin/src/pages/transcript-agent/TranscriptAgentPage.tsx
+++ b/prd-admin/src/pages/transcript-agent/TranscriptAgentPage.tsx
@@ -1,5 +1,4 @@
-import { useEffect, useRef, useState, useCallback } from 'react';
-import { GlassCard } from '@/components/design/GlassCard';
+import { useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/design/Button';
 import { useTranscriptStore } from '@/stores/transcriptStore';
 import { toast } from '@/lib/toast';

--- a/prd-admin/src/pages/visual-agent/VisualAgentWorkspaceListPage.tsx
+++ b/prd-admin/src/pages/visual-agent/VisualAgentWorkspaceListPage.tsx
@@ -1124,11 +1124,7 @@ function ProjectCarousel(props: {
         ))}
       </div>
       {/* 加载更多指示器 + 哨兵 */}
-      {loadingMore && (
-        <div className="flex justify-center py-6">
-          <div className="w-6 h-6 border-2 border-white/20 border-t-white/60 rounded-full animate-spin" />
-        </div>
-      )}
+      {loadingMore && <MapSectionLoader />}
       {hasMore && <div ref={sentinelRef} className="h-1" />}
     </div>
   );

--- a/prd-admin/src/pages/visual-agent/VisualAgentWorkspaceListPage.tsx
+++ b/prd-admin/src/pages/visual-agent/VisualAgentWorkspaceListPage.tsx
@@ -37,7 +37,7 @@ import {
 import { useBreakpoint } from '@/hooks/useBreakpoint';
 import { useAuthStore } from '@/stores/authStore';
 import { useGlobalDefectStore } from '@/stores/globalDefectStore';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { buildInlineImageToken, computeRequestedSizeByRefRatio, readImageSizeFromFile } from '@/lib/visualAgentPromptUtils';
 import { normalizeFileToSquareDataUrl } from '@/lib/imageSquare';
@@ -1060,13 +1060,32 @@ function NewProjectCard(props: { onClick: () => void }) {
 function ProjectCarousel(props: {
   items: VisualAgentWorkspace[];
   loading: boolean;
+  loadingMore: boolean;
+  hasMore: boolean;
+  onLoadMore: () => void;
   onCreate: () => void;
   onRename: (ws: VisualAgentWorkspace) => void;
   onShare: (ws: VisualAgentWorkspace) => void;
   onDelete: (ws: VisualAgentWorkspace) => void;
   onOpen: (ws: VisualAgentWorkspace) => void;
 }) {
-  const { items, loading, onCreate, onRename, onShare, onDelete, onOpen } = props;
+  const { items, loading, loadingMore, hasMore, onLoadMore, onCreate, onRename, onShare, onDelete, onOpen } = props;
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  // 无限滚动：当哨兵元素进入视口时加载更多
+  useEffect(() => {
+    if (!hasMore || loadingMore) return;
+    const el = sentinelRef.current;
+    if (!el) return;
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) onLoadMore();
+      },
+      { rootMargin: '200px' }
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [hasMore, loadingMore, onLoadMore]);
 
   if (loading) {
     return <MapSectionLoader />;
@@ -1104,6 +1123,13 @@ function ProjectCarousel(props: {
           />
         ))}
       </div>
+      {/* 加载更多指示器 + 哨兵 */}
+      {loadingMore && (
+        <div className="flex justify-center py-6">
+          <div className="w-6 h-6 border-2 border-white/20 border-t-white/60 rounded-full animate-spin" />
+        </div>
+      )}
+      {hasMore && <div ref={sentinelRef} className="h-1" />}
     </div>
   );
 }
@@ -1123,6 +1149,8 @@ export default function VisualAgentWorkspaceListPage(props: { fullscreenMode?: b
   };
   const [items, setItems] = useState<VisualAgentWorkspace[]>([]);
   const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
   const [error, setError] = useState<string>('');
   const refreshBusyRef = useRef<Set<string>>(new Set());
   const lastRefreshHashRef = useRef<Map<string, string>>(new Map());
@@ -1148,11 +1176,13 @@ export default function VisualAgentWorkspaceListPage(props: { fullscreenMode?: b
 
   const memberIds = useMemo(() => Array.from(memberSet), [memberSet]);
 
+  const PAGE_SIZE = 30;
+
   const reload = async () => {
     setLoading(true);
     setError('');
     try {
-      const res = await listVisualAgentWorkspaces({ limit: 30 });
+      const res = await listVisualAgentWorkspaces({ limit: PAGE_SIZE, skip: 0 });
       if (!res.success) {
         setError(res.error?.message || '加载 workspace 失败');
         return;
@@ -1160,10 +1190,26 @@ export default function VisualAgentWorkspaceListPage(props: { fullscreenMode?: b
       const list = Array.isArray(res.data?.items) ? res.data.items : [];
       const filtered = list.filter((item) => item.scenarioType !== 'article-illustration');
       setItems(filtered);
+      setHasMore(res.data?.hasMore ?? false);
     } finally {
       setLoading(false);
     }
   };
+
+  const loadMore = useCallback(async () => {
+    if (loadingMore || !hasMore) return;
+    setLoadingMore(true);
+    try {
+      const res = await listVisualAgentWorkspaces({ limit: PAGE_SIZE, skip: items.length });
+      if (!res.success) return;
+      const list = Array.isArray(res.data?.items) ? res.data.items : [];
+      const filtered = list.filter((item) => item.scenarioType !== 'article-illustration');
+      setItems((prev) => [...prev, ...filtered]);
+      setHasMore(res.data?.hasMore ?? false);
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [loadingMore, hasMore, items.length]);
 
   useEffect(() => {
     void reload();
@@ -1494,6 +1540,9 @@ export default function VisualAgentWorkspaceListPage(props: { fullscreenMode?: b
       <ProjectCarousel
         items={items}
         loading={loading}
+        loadingMore={loadingMore}
+        hasMore={hasMore}
+        onLoadMore={loadMore}
         onCreate={onCreate}
         onRename={onRename}
         onShare={openShare}

--- a/prd-admin/src/services/contracts/visualAgent.ts
+++ b/prd-admin/src/services/contracts/visualAgent.ts
@@ -107,7 +107,7 @@ export type DeleteVisualAgentAssetContract = (input: { id: string }) => Promise<
 export type GetVisualAgentCanvasContract = (input: { id: string }) => Promise<ApiResponse<{ canvas: VisualAgentCanvas | null }>>;
 export type SaveVisualAgentCanvasContract = (input: { id: string; schemaVersion?: number; payloadJson: string; idempotencyKey?: string }) => Promise<ApiResponse<{ canvas: VisualAgentCanvas }>>;
 
-export type ListVisualAgentWorkspacesContract = (input?: { limit?: number }) => Promise<ApiResponse<{ items: VisualAgentWorkspace[] }>>;
+export type ListVisualAgentWorkspacesContract = (input?: { limit?: number; skip?: number }) => Promise<ApiResponse<{ items: VisualAgentWorkspace[]; hasMore?: boolean }>>;
 export type CreateVisualAgentWorkspaceContract = (input: { title?: string; scenarioType?: string; idempotencyKey?: string }) => Promise<ApiResponse<{ workspace: VisualAgentWorkspace }>>;
 export type UpdateVisualAgentWorkspaceContract = (input: {
   id: string;

--- a/prd-admin/src/services/real/visualAgent.ts
+++ b/prd-admin/src/services/real/visualAgent.ts
@@ -106,8 +106,10 @@ export const saveVisualAgentCanvasReal: SaveVisualAgentCanvasContract = async (i
 
 export const listVisualAgentWorkspacesReal: ListVisualAgentWorkspacesContract = async (input) => {
   const limit = input?.limit ?? 20;
-  return await apiRequest<{ items: VisualAgentWorkspace[] }>(
-    `${api.visualAgent.imageMaster.workspaces.list()}?limit=${encodeURIComponent(String(limit))}`,
+  const skip = input?.skip ?? 0;
+  const params = new URLSearchParams({ limit: String(limit), skip: String(skip) });
+  return await apiRequest<{ items: VisualAgentWorkspace[]; hasMore?: boolean }>(
+    `${api.visualAgent.imageMaster.workspaces.list()}?${params.toString()}`,
     { method: 'GET' }
   );
 };

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ImageMasterController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ImageMasterController.cs
@@ -168,10 +168,11 @@ public class ImageMasterController : ControllerBase
     // ---------------------------
 
     [HttpGet("workspaces")]
-    public async Task<IActionResult> ListWorkspaces([FromQuery] int limit = 20, CancellationToken ct = default)
+    public async Task<IActionResult> ListWorkspaces([FromQuery] int limit = 20, [FromQuery] int skip = 0, CancellationToken ct = default)
     {
         var adminId = GetAdminId();
         limit = Math.Clamp(limit, 1, 50);
+        skip = Math.Max(skip, 0);
         var filter = Builders<ImageMasterWorkspace>.Filter.Or(
             Builders<ImageMasterWorkspace>.Filter.Eq(x => x.OwnerUserId, adminId),
             Builders<ImageMasterWorkspace>.Filter.AnyEq(x => x.MemberUserIds, adminId)
@@ -179,8 +180,12 @@ public class ImageMasterController : ControllerBase
         var items = await _db.ImageMasterWorkspaces
             .Find(filter)
             .SortByDescending(x => x.UpdatedAt)
-            .Limit(limit)
+            .Skip(skip)
+            .Limit(limit + 1)
             .ToListAsync(ct);
+
+        var hasMore = items.Count > limit;
+        if (hasMore) items = items.Take(limit).ToList();
 
         // Hydrate cover assets (avoid N+1 on client)
         var coverIds = new HashSet<string>(StringComparer.Ordinal);
@@ -260,7 +265,7 @@ public class ImageMasterController : ControllerBase
             };
         }).ToList();
 
-        return Ok(ApiResponse<object>.Ok(new { items = dto }));
+        return Ok(ApiResponse<object>.Ok(new { items = dto, hasMore }));
     }
 
     [HttpPost("workspaces")]


### PR DESCRIPTION
## Summary
Implements infinite scroll pagination for the visual agent workspace list, allowing users to automatically load more projects as they scroll to the bottom of the carousel.

## Key Changes

### Frontend (prd-admin)
- **VisualAgentWorkspaceListPage.tsx**
  - Added `useCallback` import for memoized callback
  - Introduced pagination state: `loadingMore` and `hasMore` flags
  - Implemented `loadMore` callback with pagination logic (PAGE_SIZE = 30)
  - Updated `reload()` to reset pagination and pass `skip: 0` parameter
  - Added IntersectionObserver-based infinite scroll in `ProjectCarousel` component
  - Displays loading spinner and sentinel element for detecting scroll position
  - Passes new pagination props to carousel component

- **visualAgent.ts (service contract)**
  - Updated `ListVisualAgentWorkspacesContract` type to include `skip` parameter
  - Modified API request to use URLSearchParams for cleaner query string handling
  - Updated response type to include optional `hasMore` boolean flag

- **visualAgent.ts (contract definition)**
  - Extended contract type signature to support `skip` pagination parameter
  - Added `hasMore` to response type

### Backend (prd-api)
- **ImageMasterController.cs**
  - Added `skip` parameter to `ListWorkspaces` endpoint (default: 0)
  - Implemented offset-based pagination with validation
  - Fetches `limit + 1` items to determine if more results exist
  - Returns `hasMore` flag in response to indicate additional pages

### Code Quality
- **ArticleIllustrationEditorPage.tsx**
  - Removed unused `mainModel` memoization
  - Improved `CreateImageGenRunInput` type usage with spread operator
  - Fixed TypeScript type annotations

- **TranscriptAgentPage.tsx**
  - Removed unused `GlassCard` import

- **ExchangeTestPanel.tsx**
  - Removed unused `apiRequest` import

## Implementation Details
- Uses IntersectionObserver API with 200px rootMargin for early loading trigger
- Maintains backward compatibility with existing API (skip defaults to 0)
- Filters out 'article-illustration' scenario type consistently in both initial load and pagination
- Prevents duplicate requests with `loadingMore` guard clause

https://claude.ai/code/session_01Y5FvQDZCoa8JmFSxfkYxXd