### PR TITLE
Refactor worktree cleanup to always prune stale references first

### DIFF
--- a/cds/src/services/worktree.ts
+++ b/cds/src/services/worktree.ts
@@ -29,12 +29,14 @@ export class WorktreeService {
       throw new Error(`拉取分支 "${branch}" 失败:\n${combinedOutput(fetchResult)}`);
     }
 
-    // Clean up stale worktree if the directory already exists
+    // Always prune stale worktree references before creating a new one.
+    // This handles the case where git has a registered worktree whose
+    // directory no longer exists (e.g. after a crash or manual rm).
+    await this.shell.exec('git worktree prune', { cwd: this.repoRoot });
+
+    // Remove leftover directory if it still exists
     const checkDir = await this.shell.exec(`test -d "${targetDir}" && echo exists`);
     if (checkDir.stdout.trim() === 'exists') {
-      // Prune stale worktree references first
-      await this.shell.exec('git worktree prune', { cwd: this.repoRoot });
-      // Remove the leftover directory
       await this.shell.exec(`rm -rf "${targetDir}"`);
     }
 

--- a/cds/tests/services/worktree.test.ts
+++ b/cds/tests/services/worktree.test.ts
@@ -14,6 +14,7 @@ describe('WorktreeService', () => {
   describe('create', () => {
     it('should fetch then create a worktree', async () => {
       mock.addResponsePattern(/git fetch/, () => ({ stdout: '', stderr: '', exitCode: 0 }));
+      mock.addResponsePattern(/git worktree prune/, () => ({ stdout: '', stderr: '', exitCode: 0 }));
       mock.addResponsePattern(/test -d/, () => ({ stdout: '', stderr: '', exitCode: 1 }));
       mock.addResponsePattern(/git worktree add/, () => ({ stdout: 'Preparing worktree', stderr: '', exitCode: 0 }));
 
@@ -48,6 +49,7 @@ describe('WorktreeService', () => {
 
     it('should throw if worktree add fails', async () => {
       mock.addResponsePattern(/git fetch/, () => ({ stdout: '', stderr: '', exitCode: 0 }));
+      mock.addResponsePattern(/git worktree prune/, () => ({ stdout: '', stderr: '', exitCode: 0 }));
       mock.addResponsePattern(/test -d/, () => ({ stdout: '', stderr: '', exitCode: 1 }));
       mock.addResponsePattern(/git worktree add/, () => ({
         stdout: '',


### PR DESCRIPTION
## Summary
Reorganized the worktree cleanup logic to always prune stale git worktree references before attempting to remove leftover directories. This ensures proper cleanup even when git has registered worktrees whose directories no longer exist.

## Key Changes
- Moved `git worktree prune` execution to run unconditionally before checking for leftover directories
- Added explanatory comments clarifying the two-step cleanup process:
  1. Prune stale worktree references (handles cases where git metadata exists but the directory is gone)
  2. Remove any leftover directory that still exists on disk
- Updated test mocks to expect the `git worktree prune` call in all relevant test cases

## Implementation Details
The refactoring improves robustness by ensuring stale worktree references are cleaned up first, regardless of whether a leftover directory exists. This handles edge cases like crashes or manual directory removal where git's internal state may be out of sync with the filesystem.

https://claude.ai/code/session_01VBmKmnzFKrbfgq5yNWVs5S