### PR TITLE
Dim branch names and tags when not deployed

### DIFF
--- a/cds/web/app.js
+++ b/cds/web/app.js
@@ -2103,12 +2103,13 @@ function renderBranches() {
               </span>`;
     }).join('') : '';
 
-    // Tags — shown below header
+    // Tags — shown below header (dimmed when not deployed)
     const branchTags = b.tags || [];
+    const tagDimClass = isRunning ? '' : ' branch-tag-dim';
     const tagsHtml = `
       <div class="branch-tags-line">
         ${branchTags.map(t => `
-          <span class="branch-tag" onclick="event.stopPropagation(); filterByTag('${esc(t)}')" title="筛选标签: ${esc(t)}">
+          <span class="branch-tag${tagDimClass}" onclick="event.stopPropagation(); filterByTag('${esc(t)}')" title="筛选标签: ${esc(t)}">
             ${ICON.tag} ${esc(t)}
             <span class="branch-tag-remove" onclick="event.stopPropagation(); removeTagFromBranch('${esc(b.id)}', '${esc(t)}', event)" title="删除标签">&times;</span>
           </span>

--- a/cds/web/app.js
+++ b/cds/web/app.js
@@ -2869,7 +2869,7 @@ async function openSelfUpdate() {
       </div>
     </div>
     <div class="form-row" style="margin-top:4px;font-size:12px;color:var(--fg-muted)">
-      当前分支：<code>${esc(current)}</code>${commitHash ? ` @ <code style="color:var(--blue)">${esc(commitHash)}</code>` : ''}
+      当前分支：<code style="word-break:break-all">${esc(current)}</code>${commitHash ? `<span style="white-space:nowrap"> @ <code style="color:var(--blue)">${esc(commitHash)}</code></span>` : ''}
     </div>
     <div id="selfUpdateProgress" style="display:none;margin-top:12px">
       <div id="selfUpdateSteps" style="display:flex;flex-direction:column;gap:6px"></div>

--- a/cds/web/style.css
+++ b/cds/web/style.css
@@ -1299,6 +1299,8 @@ a.branch-name:hover { color: var(--accent); }
   transition: all var(--transition);
 }
 .branch-tag:hover { background: rgba(179, 136, 255, 0.15); border-color: rgba(179, 136, 255, 0.3); }
+.branch-tag-dim { color: var(--text-muted); background: transparent; border-color: var(--border); opacity: 0.5; }
+.branch-tag-dim:hover { color: var(--purple); background: rgba(179, 136, 255, 0.08); border-color: rgba(179, 136, 255, 0.18); opacity: 1; }
 .branch-tag svg.inline-icon { width: 11px; height: 11px; }
 .branch-tag-remove {
   display: inline-flex; align-items: center; justify-content: center;

--- a/cds/web/style.css
+++ b/cds/web/style.css
@@ -1054,6 +1054,11 @@ button.text-btn:hover { color: var(--accent); }
   transition: color var(--transition);
 }
 a.branch-name:hover { color: var(--accent); }
+/* Dim branch name when not deployed */
+.branch-card.status-idle .branch-name,
+.branch-card.status-error .branch-name { opacity: 0.5; }
+.branch-card.status-idle .branch-name:hover,
+.branch-card.status-error .branch-name:hover { opacity: 1; }
 /* Quick actions (copy + jump) — visible on row hover, uses visibility to avoid layout shift */
 .branch-quick-actions {
   display: inline-flex; gap: 2px; align-items: center; flex-shrink: 0;


### PR DESCRIPTION
## Summary
This PR improves visual feedback by dimming branch names and tags when branches are not actively running or have errors, making it clearer which branches are deployed and operational.

## Key Changes
- **Branch name dimming**: Added opacity reduction (0.5) to branch names for idle and error status branches, with full opacity restored on hover for better discoverability
- **Tag dimming**: Tags now display with reduced opacity and muted styling when branches are not running (`isRunning` is false), with hover states that restore visibility and apply accent colors
- **Text wrapping improvements**: Enhanced the self-update dialog to properly handle long branch names with `word-break: break-all` and kept the commit hash on the same line with `white-space: nowrap`

## Implementation Details
- Added `.branch-tag-dim` CSS class that applies muted colors, transparent background, and 0.5 opacity
- Hover states for dimmed elements restore full opacity and apply accent styling for better interactivity
- The dimming is applied conditionally in the template based on the `isRunning` state
- CSS transitions ensure smooth opacity changes between states

https://claude.ai/code/session_011R8N7B5rBabLK3uXQtZkcN