### PR TITLE
Make preview mode server-authoritative and persistent

### DIFF
--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -1552,6 +1552,24 @@ export function createBranchRouter(deps: RouterDeps): Router {
     res.json({ message: enabled ? '标签页标题已开启' : '标签页标题已关闭', enabled });
   });
 
+  // ── Preview mode (server-authoritative, shared across all users) ──
+
+  router.get('/preview-mode', (_req, res) => {
+    res.json({ mode: stateService.getPreviewMode() });
+  });
+
+  router.put('/preview-mode', (req, res) => {
+    const { mode } = req.body as { mode?: string };
+    if (mode !== 'simple' && mode !== 'port' && mode !== 'multi') {
+      res.status(400).json({ error: "mode 必须是 'simple' | 'port' | 'multi'" });
+      return;
+    }
+    stateService.setPreviewMode(mode);
+    stateService.save();
+    const labels: Record<string, string> = { simple: '简洁', port: '端口直连', multi: '子域名' };
+    res.json({ message: `预览模式已切换为：${labels[mode]}`, mode });
+  });
+
   // ── Config (read-only) ──
 
   router.get('/config', async (_req, res) => {
@@ -1591,6 +1609,7 @@ export function createBranchRouter(deps: RouterDeps): Router {
         Object.entries(config.sharedEnv).map(([k, v]) => [k, k.includes('PASSWORD') || k.includes('SECRET') ? '***' : v]),
       ),
       executors: Object.values(stateService.getExecutors()),
+      previewMode: stateService.getPreviewMode(),
     });
   });
 

--- a/cds/src/services/state.ts
+++ b/cds/src/services/state.ts
@@ -14,6 +14,7 @@ function emptyState(): CdsState {
     defaultBranch: null,
     customEnv: {},
     infraServices: [],
+    previewMode: 'multi',
   };
 }
 
@@ -51,6 +52,7 @@ export class StateService {
       if (!this.state.infraServices) this.state.infraServices = [];
       if (this.state.mirrorEnabled === undefined) this.state.mirrorEnabled = false;
       if (this.state.tabTitleEnabled === undefined) this.state.tabTitleEnabled = true;
+      if (this.state.previewMode === undefined) this.state.previewMode = 'multi';
       if (!this.state.executors) this.state.executors = {};
       if (!this.state.dataMigrations) this.state.dataMigrations = [];
       // Migrate: backfill cacheMounts for existing build profiles
@@ -341,6 +343,16 @@ export class StateService {
 
   setTabTitleEnabled(enabled: boolean): void {
     this.state.tabTitleEnabled = enabled;
+  }
+
+  // ── Preview mode ──
+
+  getPreviewMode(): 'simple' | 'port' | 'multi' {
+    return this.state.previewMode || 'multi';
+  }
+
+  setPreviewMode(mode: 'simple' | 'port' | 'multi'): void {
+    this.state.previewMode = mode;
   }
 
   // ── Executor management ──

--- a/cds/src/types.ts
+++ b/cds/src/types.ts
@@ -195,6 +195,8 @@ export interface CdsState {
   mirrorEnabled?: boolean;
   /** Tab title override enabled (updates browser tab title with tag or branch short name) */
   tabTitleEnabled?: boolean;
+  /** Preview mode: 'simple' (cookie switch + main domain), 'port' (dynamic preview port), 'multi' (subdomain per branch). Default: 'multi' */
+  previewMode?: 'simple' | 'port' | 'multi';
   /** Registered executor nodes (scheduler mode) */
   executors?: Record<string, ExecutorNode>;
   /** Data migration task history */

--- a/cds/web/app.js
+++ b/cds/web/app.js
@@ -54,8 +54,10 @@ let branchUpdates = JSON.parse(localStorage.getItem('cds_branch_updates') || '{}
 const recentlyTouched = new Map(); // { branchId: timestamp } — branches user just operated on
 let isCheckingUpdates = false;
 
-// ── Preview mode: 'simple' (set default + open main) or 'multi' (subdomain per branch) ──
-let previewMode = localStorage.getItem('cds_preview_mode') || 'simple';
+// ── Preview mode: 'simple' (set default + open main) | 'port' (dynamic port) | 'multi' (subdomain per branch) ──
+// Server-authoritative: loaded from GET /config, persisted via PUT /preview-mode.
+// Default 'multi' matches server; overridden by loadConfig() on init.
+let previewMode = 'multi';
 
 // ── Mirror acceleration (npm/docker registry mirrors) ──
 let mirrorEnabled = false;
@@ -276,6 +278,10 @@ async function loadConfig() {
     workerPort = data.workerPort || '';
     cdsMode = data.mode || 'standalone';
     executors = data.executors || [];
+    // Server-authoritative preview mode (shared across all users)
+    if (data.previewMode === 'simple' || data.previewMode === 'port' || data.previewMode === 'multi') {
+      previewMode = data.previewMode;
+    }
     renderExecutorPanel();
     // Show CDS commit hash in header
     if (data.cdsCommitHash) {
@@ -436,19 +442,30 @@ function copyBranchName(name) {
   });
 }
 
-function cyclePreviewMode() {
+async function cyclePreviewMode() {
   // Cycle: simple → port → multi → simple
   const modes = ['simple', 'port', 'multi'];
   const idx = modes.indexOf(previewMode);
-  previewMode = modes[(idx + 1) % modes.length];
-  localStorage.setItem('cds_preview_mode', previewMode);
+  const nextMode = modes[(idx + 1) % modes.length];
+  // Persist to server (shared across all users). Revert UI on failure.
+  const prev = previewMode;
+  previewMode = nextMode;
   updatePreviewModeUI();
   renderBranches();
+  try {
+    await api('PUT', '/preview-mode', { mode: nextMode });
+  } catch (e) {
+    previewMode = prev;
+    updatePreviewModeUI();
+    renderBranches();
+    showToast('切换预览模式失败: ' + e.message, 'error');
+    return;
+  }
   const labels = { simple: '简洁模式（cookie 切换）', port: '端口直连模式（无缓存问题）', multi: '子域名模式（需 PREVIEW_DOMAIN）' };
-  if (previewMode === 'multi' && !previewDomain) {
+  if (nextMode === 'multi' && !previewDomain) {
     showToast('已开启子域名预览模式，但 PREVIEW_DOMAIN 未配置，预览将回退到简洁模式。请在「变量」中设置 PREVIEW_DOMAIN。', 'error');
   } else {
-    showToast(`预览：${labels[previewMode]}`, 'info');
+    showToast(`预览：${labels[nextMode]}`, 'info');
   }
 }
 

--- a/changelogs/2026-04-08_cds-preview-mode-server-authority.md
+++ b/changelogs/2026-04-08_cds-preview-mode-server-authority.md
@@ -1,0 +1,1 @@
+| fix | cds | 预览模式改为服务器权威：默认值改为「子域名」，切换后落库共享，移除 localStorage 独立存储（修复分享链接打开后总是默认 `simple` 模式、误触 `set-default` 污染 defaultBranch 的问题） |


### PR DESCRIPTION
## Summary
Migrates preview mode from client-side localStorage to server-authoritative state, ensuring consistent configuration across all users and fixing issues with shared links defaulting to 'simple' mode.

## Key Changes

- **Server-authoritative preview mode**: Preview mode is now stored in the server state service and persisted to disk, rather than in browser localStorage
  - Default value changed from 'simple' to 'multi' (matches server default)
  - All users share the same preview mode configuration
  - Eliminates inconsistency when opening shared links

- **API endpoints**: Added new endpoints for preview mode management
  - `GET /preview-mode`: Retrieve current preview mode
  - `PUT /preview-mode`: Update preview mode with validation and persistence
  - Preview mode included in `/config` response for client initialization

- **Client-side updates**: 
  - `cyclePreviewMode()` now persists changes to server via `PUT /preview-mode`
  - Optimistic UI update with automatic rollback on server error
  - Loads server-authoritative mode during `loadConfig()` initialization
  - Removed localStorage-based persistence

- **State management**: 
  - Added `previewMode` field to `CdsState` interface with type safety
  - Implemented getter/setter methods in `StateService`
  - Migration logic to backfill 'multi' default for existing state

## Implementation Details

- Preview mode cycling maintains the sequence: simple → port → multi → simple
- Server validation ensures only valid modes ('simple', 'port', 'multi') are accepted
- Error handling reverts UI state if server persistence fails
- Chinese error messages provide user feedback on mode switch failures

https://claude.ai/code/session_01JHFfejhZyvdC5gdMpQWfVh