### PR TITLE
Add MongoDB CDN domain migration scripts

### DIFF
--- a/changelogs/2026-04-08_replace-cdn-domain-migration.md
+++ b/changelogs/2026-04-08_replace-cdn-domain-migration.md
@@ -1,1 +1,1 @@
-| chore | scripts | 新增 scripts/migrations/ 目录，提供 replace-cdn-domain.js 和 verify-cdn-domain.js，用于将 MongoDB 中残留的旧 CDN 域名 i.pa.759800.com 批量替换为 i.miduo.org（递归扫描所有集合的字符串字段，含 hosted_sites/submissions 等嵌套结构，默认 dry-run） |
+| chore | scripts | 新增 scripts/migrations/ 目录，提供 replace-cdn-domain.js 和 verify-cdn-domain.js，用于将 MongoDB 中残留的旧 CDN 域名 pa.759800.com 批量替换为 map.ebcone.net（递归子串替换所有集合的字符串字段，默认 dry-run） |

--- a/changelogs/2026-04-08_replace-cdn-domain-migration.md
+++ b/changelogs/2026-04-08_replace-cdn-domain-migration.md
@@ -1,0 +1,1 @@
+| chore | scripts | 新增 scripts/migrations/ 目录，提供 replace-cdn-domain.js 和 verify-cdn-domain.js，用于将 MongoDB 中残留的旧 CDN 域名 i.pa.759800.com 批量替换为 i.miduo.org（递归扫描所有集合的字符串字段，含 hosted_sites/submissions 等嵌套结构，默认 dry-run） |

--- a/scripts/migrations/README.md
+++ b/scripts/migrations/README.md
@@ -1,57 +1,39 @@
 # 一次性数据迁移脚本
 
-> 这里放一次性的 mongosh 数据修正脚本。每个脚本都应在文件头注明背景、用法、是否幂等。
+## replace-cdn-domain.js — CDN 域名字符串替换
 
-## replace-cdn-domain.js — CDN 旧域名清理
+把 MongoDB 所有集合里的 `pa.759800.com` 替换成 `map.ebcone.net`。
 
-替换所有集合里残留的旧 CDN 域名 `i.pa.759800.com` 为新域名 `i.miduo.org`。
-
-### 为什么需要
-
-`TencentCosStorage.BuildPublicUrl` 把 `${TENCENT_COS_PUBLIC_BASE_URL}/{key}` 拼成完整 URL 后写入了大量 Model 的 `*Url` 字段(如 `image_assets.Url`、`hosted_sites.SiteUrl`、`submissions.GenerationSnapshot.InitImageUrl` 等)。改 `TENCENT_COS_PUBLIC_BASE_URL` 环境变量只影响**新写入**的数据,**历史数据需要这个脚本批量修复**。
-
-### 用法
+历史数据里的 `*Url` 字段是由 `TencentCosStorage.BuildPublicUrl` 把 `${TENCENT_COS_PUBLIC_BASE_URL}/{key}` 拼好后写入的完整 URL,所以改环境变量只影响新写入,存量需要这个脚本批量修复。
 
 ```bash
-# 1) 备份(强烈建议)
-mongodump --uri "mongodb://user:pwd@host:port/prd_agent" --out backup-$(date +%F)
+# 0) 备份
+mongodump --uri "mongodb://..." --out backup-$(date +%F)
 
-# 2) Dry-run, 看看会改多少
-mongosh "mongodb://user:pwd@host:port/prd_agent" scripts/migrations/replace-cdn-domain.js
+# 1) Dry-run (默认, 不写入)
+mongosh "mongodb://..." scripts/migrations/replace-cdn-domain.js
 
-# 3) 确认无误后, 真正执行
-mongosh "mongodb://user:pwd@host:port/prd_agent" \
-  --eval "var DRY_RUN=false" \
-  scripts/migrations/replace-cdn-domain.js
+# 2) 真正执行
+mongosh "mongodb://..." --eval "var DRY_RUN=false" scripts/migrations/replace-cdn-domain.js
 
-# 4) 验证残留(只读)
-mongosh "mongodb://user:pwd@host:port/prd_agent" scripts/migrations/verify-cdn-domain.js
+# 3) 验证残留
+mongosh "mongodb://..." scripts/migrations/verify-cdn-domain.js
 ```
 
-### 特性
+### 想换其它域名
 
-- **递归扫描** 每个文档的所有字符串字段(任意层级嵌套数组/对象), 不依赖字段白名单
-- **幂等**: 重复执行无害, 已经是新域名的字段不会再被改
-- **DRY_RUN 默认开启**, 不会意外写入
+```bash
+mongosh "..." --eval "var OLD='a.com'; var NEW='b.com'; var DRY_RUN=false" \
+  scripts/migrations/replace-cdn-domain.js
+```
+
+### 说明
+
+- 递归扫所有集合的所有字符串字段,含嵌套数组/子文档
+- 子串替换,不是正则; `pa.759800.com` 出现在哪里都会被替换(包括 `i.pa.759800.com`、`cdn.pa.759800.com` 等任何子域名)
+- **幂等**: 重复执行无害
 - 跳过 `system.*` 集合
-- 大集合可通过 `SKIP_COLLECTIONS` 临时排除
-
-### 可调参数
-
-通过 `--eval` 覆盖:
-
-```bash
-mongosh "..." --eval "var DRY_RUN=false; var OLD_DOMAIN='old.example.com'; var NEW_DOMAIN='new.example.com'" \
-  scripts/migrations/replace-cdn-domain.js
-```
-
-### 注意事项
-
-1. **先重启后端**, 让新的 `TENCENT_COS_PUBLIC_BASE_URL` 环境变量生效, 避免一边迁移一边又写入旧数据
-2. **大集合(`llmrequestlogs` / `apirequestlogs`)** 耗时较长, 建议在低峰执行
-3. 这是**字符串子串替换**, 不是正则; `i.pa.759800.com` 出现在哪里都会被替换(包括子文档/数组里)
-4. 涉及到的主要集合: `image_assets`, `attachments`, `hosted_sites`, `web_page_share_links`, `submissions`(含 `GenerationSnapshot.*Url` 嵌套字段), `desktop_assets`, `desktop_update_caches`, `watermark_font_assets`, `watermark_configs`, `image_master_workspaces`, `workspaces`, `upload_artifacts`, `defect_reports`, `image_gen_run_items`, `video_gen_runs`, `tutorial_email_assets`, `transcript_items`, `llmrequestlogs` 等
 
 ## verify-cdn-domain.js — 残留扫描(只读)
 
-只扫描不写入,列出所有仍包含旧域名的集合、字段路径、样例 `_id`。迁移前后可以各跑一次对比。
+只扫不写,列出所有仍含旧域名的集合、字段路径、样例 `_id`。

--- a/scripts/migrations/README.md
+++ b/scripts/migrations/README.md
@@ -4,36 +4,101 @@
 
 把 MongoDB 所有集合里的 `pa.759800.com` 替换成 `map.ebcone.net`。
 
-历史数据里的 `*Url` 字段是由 `TencentCosStorage.BuildPublicUrl` 把 `${TENCENT_COS_PUBLIC_BASE_URL}/{key}` 拼好后写入的完整 URL,所以改环境变量只影响新写入,存量需要这个脚本批量修复。
+### 为什么需要这个脚本
+
+`prd-api/src/PrdAgent.Infrastructure/Services/AssetStorage/TencentCosStorage.cs:359` 的 `BuildPublicUrl` 把 `${TENCENT_COS_PUBLIC_BASE_URL}/{key}` 拼成**完整 URL** 之后, 作为字符串写入了大量 Model 的 `*Url` 字段:
+
+- `image_assets.Url`, `OriginalUrl`
+- `attachments.Url`, `ThumbnailUrl`
+- `hosted_sites.SiteUrl`, `CoverImageUrl`(网页托管)
+- `submissions.CoverUrl`, `InitImageUrl`, `WatermarkPreviewUrl`
+- `submissions.GenerationSnapshot.InitImageUrl`、`ImageRefs[].Url`(嵌套)
+- `desktop_assets.Url`, `desktop_update_caches.CosPackageUrl`
+- `watermark_font_assets.Url`, `watermark_configs.PreviewUrl`
+- `image_master_workspaces.LatestPreviewUrl`, `PreviewUrl`
+- `workspaces.LatestPreviewUrl`, `PreviewUrl`
+- `upload_artifacts.CosUrl`
+- `defect_reports.Url`, `ThumbnailUrl`
+- `llmrequestlogs.CosUrl`, `Url`, `OriginalUrl`
+- `tutorial_email_assets.FileUrl`, `ThumbnailUrl`
+- `transcript_items.FileUrl`
+- `image_gen_run_items.Url`
+- `video_gen_runs.*Url`
+- ……还有很多
+
+**改 `TENCENT_COS_PUBLIC_BASE_URL` 环境变量只影响新写入的数据**, 老记录里的 URL 仍然带着旧域名, 所以需要这个一次性脚本批量字符串替换存量。
+
+注意: 头像 (`AvatarUrlBuilder`)、`AuthzController` 返回给前端的 `cdnBaseUrl`、水印字体 (`WatermarkFontRegistry`) 这几个路径是**运行时动态拼**的, 重启进程就行, 不需要动数据库。
+
+### 标准操作流程
 
 ```bash
-# 0) 备份
+# 0) 先重启 prd-api 让新 TENCENT_COS_PUBLIC_BASE_URL 生效
+#    (避免一边迁移一边又写入旧数据)
+docker compose restart api
+
+# 1) 备份
 mongodump --uri "mongodb://..." --out backup-$(date +%F)
 
-# 1) Dry-run (默认, 不写入)
+# 2) Dry-run (默认, 不写入)
 mongosh "mongodb://..." scripts/migrations/replace-cdn-domain.js
 
-# 2) 真正执行
+# 3) 真正执行
 mongosh "mongodb://..." --eval "var DRY_RUN=false" scripts/migrations/replace-cdn-domain.js
 
-# 3) 验证残留
+# 4) 验证残留
 mongosh "mongodb://..." scripts/migrations/verify-cdn-domain.js
+# 期望输出: ✅ 未发现任何文档包含 pa.759800.com
 ```
 
-### 想换其它域名
+### DataGrip MongoDB Console 一键版
+
+如果手头只有 DataGrip, 不想装 mongosh, 直接把下面这段粘进 MongoDB Console 跑:
+
+```javascript
+var OLD = "pa.759800.com", NEW = "map.ebcone.net";
+function w(v) {
+  if (typeof v === "string") return v.indexOf(OLD) >= 0 ? v.split(OLD).join(NEW) : v;
+  if (Array.isArray(v)) return v.map(w);
+  if (v && typeof v === "object" && !v._bsontype && !(v instanceof Date)) {
+    var o = {}; for (var k in v) o[k] = w(v[k]); return o;
+  }
+  return v;
+}
+db.getCollectionNames().forEach(function(n) {
+  if (n.indexOf("system.") === 0) return;
+  var c = db.getCollection(n), m = 0;
+  c.find({}).forEach(function(d) {
+    if (JSON.stringify(d).indexOf(OLD) < 0) return;
+    c.replaceOne({ _id: d._id }, w(d));   // dry-run 时把这行注释掉
+    m++;
+  });
+  if (m) print(n + ": " + m);
+});
+```
+
+跑完会打印每个被改的集合 + 改了几条。**先备份**。
+
+### 想换其它域名对
+
+通过 `--eval` 覆盖 `OLD`/`NEW`:
 
 ```bash
 mongosh "..." --eval "var OLD='a.com'; var NEW='b.com'; var DRY_RUN=false" \
   scripts/migrations/replace-cdn-domain.js
 ```
 
-### 说明
+DataGrip 版本则直接改第一行的 `OLD` / `NEW` 即可。
 
-- 递归扫所有集合的所有字符串字段,含嵌套数组/子文档
-- 子串替换,不是正则; `pa.759800.com` 出现在哪里都会被替换(包括 `i.pa.759800.com`、`cdn.pa.759800.com` 等任何子域名)
-- **幂等**: 重复执行无害
-- 跳过 `system.*` 集合
+### 设计要点
+
+- **递归扫所有集合的所有字符串字段**, 含嵌套数组/子文档, 不依赖字段白名单
+- **子串替换**, 不是正则: `pa.759800.com` 出现在哪里都会被替换(包括 `i.pa.759800.com`、`cdn.pa.759800.com` 等任何子域名)
+- **幂等**: 重复执行无害, 已经是新域名的字段不会再被改
+- 默认 `DRY_RUN=true`, 不会意外写入
+- 跳过 `system.*` 集合, 避免误改 MongoDB 元数据
+- 大集合(`llmrequestlogs` / `apirequestlogs`)耗时较长, 建议低峰执行
 
 ## verify-cdn-domain.js — 残留扫描(只读)
 
-只扫不写,列出所有仍含旧域名的集合、字段路径、样例 `_id`。
+只扫不写, 列出所有仍含旧域名的集合、字段路径、样例 `_id`。迁移前后各跑一次对比。

--- a/scripts/migrations/README.md
+++ b/scripts/migrations/README.md
@@ -1,0 +1,57 @@
+# 一次性数据迁移脚本
+
+> 这里放一次性的 mongosh 数据修正脚本。每个脚本都应在文件头注明背景、用法、是否幂等。
+
+## replace-cdn-domain.js — CDN 旧域名清理
+
+替换所有集合里残留的旧 CDN 域名 `i.pa.759800.com` 为新域名 `i.miduo.org`。
+
+### 为什么需要
+
+`TencentCosStorage.BuildPublicUrl` 把 `${TENCENT_COS_PUBLIC_BASE_URL}/{key}` 拼成完整 URL 后写入了大量 Model 的 `*Url` 字段(如 `image_assets.Url`、`hosted_sites.SiteUrl`、`submissions.GenerationSnapshot.InitImageUrl` 等)。改 `TENCENT_COS_PUBLIC_BASE_URL` 环境变量只影响**新写入**的数据,**历史数据需要这个脚本批量修复**。
+
+### 用法
+
+```bash
+# 1) 备份(强烈建议)
+mongodump --uri "mongodb://user:pwd@host:port/prd_agent" --out backup-$(date +%F)
+
+# 2) Dry-run, 看看会改多少
+mongosh "mongodb://user:pwd@host:port/prd_agent" scripts/migrations/replace-cdn-domain.js
+
+# 3) 确认无误后, 真正执行
+mongosh "mongodb://user:pwd@host:port/prd_agent" \
+  --eval "var DRY_RUN=false" \
+  scripts/migrations/replace-cdn-domain.js
+
+# 4) 验证残留(只读)
+mongosh "mongodb://user:pwd@host:port/prd_agent" scripts/migrations/verify-cdn-domain.js
+```
+
+### 特性
+
+- **递归扫描** 每个文档的所有字符串字段(任意层级嵌套数组/对象), 不依赖字段白名单
+- **幂等**: 重复执行无害, 已经是新域名的字段不会再被改
+- **DRY_RUN 默认开启**, 不会意外写入
+- 跳过 `system.*` 集合
+- 大集合可通过 `SKIP_COLLECTIONS` 临时排除
+
+### 可调参数
+
+通过 `--eval` 覆盖:
+
+```bash
+mongosh "..." --eval "var DRY_RUN=false; var OLD_DOMAIN='old.example.com'; var NEW_DOMAIN='new.example.com'" \
+  scripts/migrations/replace-cdn-domain.js
+```
+
+### 注意事项
+
+1. **先重启后端**, 让新的 `TENCENT_COS_PUBLIC_BASE_URL` 环境变量生效, 避免一边迁移一边又写入旧数据
+2. **大集合(`llmrequestlogs` / `apirequestlogs`)** 耗时较长, 建议在低峰执行
+3. 这是**字符串子串替换**, 不是正则; `i.pa.759800.com` 出现在哪里都会被替换(包括子文档/数组里)
+4. 涉及到的主要集合: `image_assets`, `attachments`, `hosted_sites`, `web_page_share_links`, `submissions`(含 `GenerationSnapshot.*Url` 嵌套字段), `desktop_assets`, `desktop_update_caches`, `watermark_font_assets`, `watermark_configs`, `image_master_workspaces`, `workspaces`, `upload_artifacts`, `defect_reports`, `image_gen_run_items`, `video_gen_runs`, `tutorial_email_assets`, `transcript_items`, `llmrequestlogs` 等
+
+## verify-cdn-domain.js — 残留扫描(只读)
+
+只扫描不写入,列出所有仍包含旧域名的集合、字段路径、样例 `_id`。迁移前后可以各跑一次对比。

--- a/scripts/migrations/replace-cdn-domain.js
+++ b/scripts/migrations/replace-cdn-domain.js
@@ -1,178 +1,78 @@
-// 替换 MongoDB 中所有存量 URL 字段的旧 CDN 域名为新域名
-//
-// 背景:
-//   TencentCosStorage.BuildPublicUrl 把 ${TENCENT_COS_PUBLIC_BASE_URL}/{key} 拼好后
-//   作为完整 URL 写入了大量 Model 的 *Url 字段。环境变量改了之后, 老数据里的 URL
-//   仍然带着旧域名, 因此需要这个一次性扫描脚本把所有集合里的字符串字段
-//   "https://i.pa.759800.com" 替换成 "https://i.miduo.org"。
+// MongoDB 字符串查找替换: pa.759800.com → map.ebcone.net
 //
 // 用法:
-//   1. 先 dry-run 看看会改多少条:
-//        mongosh "mongodb://user:pwd@host:port/prd_agent" scripts/migrations/replace-cdn-domain.js
-//   2. 确认无误后, 把 DRY_RUN 改成 false 再执行:
-//        mongosh "mongodb://..." --eval "var DRY_RUN=false" scripts/migrations/replace-cdn-domain.js
+//   # 1) Dry-run (默认, 不写入)
+//   mongosh "mongodb://user:pwd@host:port/prd_agent" scripts/migrations/replace-cdn-domain.js
 //
-// 特性:
-//   - 递归扫描每个文档的所有字符串字段(任意层级嵌套数组/对象), 不依赖字段白名单
-//   - 即使将来新增了 URL 字段也不用改这个脚本, 重新跑一遍即可
-//   - DRY_RUN 默认 true, 不会真的写入
-//   - 支持通过环境变量覆盖: OLD_DOMAIN / NEW_DOMAIN
-//   - 跳过 system.* 集合, 避免误改 MongoDB 元数据
+//   # 2) 真正执行
+//   mongosh "mongodb://..." --eval "var DRY_RUN=false" scripts/migrations/replace-cdn-domain.js
 //
-// 注意:
-//   - 大集合(如 llmrequestlogs, apirequestlogs)耗时较长, 建议先在副本集的 secondary 上试跑
-//   - 执行前最好做一次 mongodump 备份
-//   - 这是字符串子串替换, 不是正则; "i.pa.759800.com" 出现在哪里都会被替换
+// 也可以覆盖默认域名:
+//   mongosh "..." --eval "var OLD='a.com'; var NEW='b.com'; var DRY_RUN=false" scripts/migrations/replace-cdn-domain.js
 
-// ── 配置 ────────────────────────────────────────────────────────────────
-var OLD_DOMAIN_DEFAULT = "i.pa.759800.com";
-var NEW_DOMAIN_DEFAULT = "i.miduo.org";
-
-if (typeof OLD_DOMAIN === "undefined") { var OLD_DOMAIN = OLD_DOMAIN_DEFAULT; }
-if (typeof NEW_DOMAIN === "undefined") { var NEW_DOMAIN = NEW_DOMAIN_DEFAULT; }
+if (typeof OLD === "undefined") { var OLD = "pa.759800.com"; }
+if (typeof NEW === "undefined") { var NEW = "map.ebcone.net"; }
 if (typeof DRY_RUN === "undefined") { var DRY_RUN = true; }
 
-// 跳过这些集合(纯日志/会变得非常大, 且不影响业务展示; 如需迁移可手动放开)
-var SKIP_COLLECTIONS = new Set([
-    // 如果想跳过日志集合, 把它们加进来即可
-    // "apirequestlogs",
-    // "openplatformrequestlogs",
-]);
-
-// ── 工具函数 ────────────────────────────────────────────────────────────
-function isPlainObject(v) {
-    if (v === null || typeof v !== "object") return false;
-    if (Array.isArray(v)) return false;
-    // BSON 特殊类型: ObjectId / Date / Decimal128 / Binary 等都不是 plain object
-    if (v._bsontype) return false;
-    if (v instanceof Date) return false;
-    if (typeof ObjectId !== "undefined" && v instanceof ObjectId) return false;
-    return true;
-}
-
-// 递归替换字符串。返回 {value, changed}
-function walk(value) {
-    if (typeof value === "string") {
-        if (value.indexOf(OLD_DOMAIN) === -1) return { value: value, changed: false };
-        // split/join 比 replace 更安全, 不受正则元字符影响
-        var newVal = value.split(OLD_DOMAIN).join(NEW_DOMAIN);
-        return { value: newVal, changed: true };
+// 递归把任意值里的字符串子串 OLD 替换成 NEW, 返回 {value, changed}
+function walk(v) {
+    if (typeof v === "string") {
+        if (v.indexOf(OLD) === -1) return { value: v, changed: false };
+        return { value: v.split(OLD).join(NEW), changed: true };
     }
-    if (Array.isArray(value)) {
-        var changedAny = false;
-        var newArr = [];
-        for (var i = 0; i < value.length; i++) {
-            var r = walk(value[i]);
-            if (r.changed) changedAny = true;
-            newArr.push(r.value);
+    if (Array.isArray(v)) {
+        var arr = [], chg = false;
+        for (var i = 0; i < v.length; i++) {
+            var r = walk(v[i]);
+            if (r.changed) chg = true;
+            arr.push(r.value);
         }
-        return { value: newArr, changed: changedAny };
+        return { value: arr, changed: chg };
     }
-    if (isPlainObject(value)) {
-        var changedAny2 = false;
-        var newObj = {};
-        var keys = Object.keys(value);
+    if (v && typeof v === "object" && !v._bsontype && !(v instanceof Date)) {
+        var obj = {}, chg2 = false;
+        var keys = Object.keys(v);
         for (var k = 0; k < keys.length; k++) {
-            var key = keys[k];
-            var r2 = walk(value[key]);
-            if (r2.changed) changedAny2 = true;
-            newObj[key] = r2.value;
+            var r2 = walk(v[keys[k]]);
+            if (r2.changed) chg2 = true;
+            obj[keys[k]] = r2.value;
         }
-        return { value: newObj, changed: changedAny2 };
+        return { value: obj, changed: chg2 };
     }
-    return { value: value, changed: false };
+    return { value: v, changed: false };
 }
 
-// ── 主流程 ──────────────────────────────────────────────────────────────
-print("======================================================");
-print("CDN 域名迁移脚本");
-print("  数据库: " + db.getName());
-print("  旧域名: " + OLD_DOMAIN);
-print("  新域名: " + NEW_DOMAIN);
-print("  模式  : " + (DRY_RUN ? "DRY RUN (不写入)" : "*** 实际写入 ***"));
-print("======================================================");
-print("");
+print("DB=" + db.getName() + "  " + OLD + " → " + NEW + "  " + (DRY_RUN ? "[DRY RUN]" : "[WRITE]"));
 
-var allCollections = db.getCollectionNames().sort();
-var totalScanned = 0;
-var totalMatched = 0;
-var totalUpdated = 0;
-var perCollectionStats = [];
+var totalMatched = 0, totalUpdated = 0;
+var collections = db.getCollectionNames().sort();
 
-for (var ci = 0; ci < allCollections.length; ci++) {
-    var collName = allCollections[ci];
-    if (collName.indexOf("system.") === 0) continue;
-    if (SKIP_COLLECTIONS.has(collName)) {
-        print("[SKIP] " + collName);
-        continue;
-    }
+for (var ci = 0; ci < collections.length; ci++) {
+    var name = collections[ci];
+    if (name.indexOf("system.") === 0) continue;
 
-    var coll = db.getCollection(collName);
-
-    // 用 $regex 在顶层 BSON 文本里粗筛一下, 减少需要走 walk() 的文档量。
-    // 注意: $regex 只能匹配字符串字段; 但我们 walk() 是递归的, 所以即使字段
-    // 嵌在数组/子对象里, 只要 BSON 里包含这个子串, 索引就会扫到。
-    // 用 $text 不行, 因为没建文本索引。这里用 aggregate + $match 不可行(同样问题)。
-    // 最稳妥的方式: 直接 find 所有文档逐一检查。对小集合无所谓, 大集合靠 batchSize 控制。
+    var coll = db.getCollection(name);
+    var matched = 0, updated = 0;
     var cursor = coll.find({}).batchSize(500);
-
-    var scanned = 0;
-    var matched = 0;
-    var updated = 0;
-    var failed = 0;
 
     while (cursor.hasNext()) {
         var doc = cursor.next();
-        scanned++;
         var r = walk(doc);
         if (!r.changed) continue;
         matched++;
-
-        if (DRY_RUN) continue;
-
-        try {
-            // 用 replaceOne 而不是 updateOne, 因为我们有完整新文档, 一次写入更简洁
-            var res = coll.replaceOne({ _id: doc._id }, r.value);
-            if (res && (res.modifiedCount === 1 || res.matchedCount === 1)) {
-                updated++;
-            } else {
-                failed++;
-                print("  [WARN] replace 未匹配: " + collName + " _id=" + tojsononeline(doc._id));
-            }
-        } catch (e) {
-            failed++;
-            print("  [ERROR] " + collName + " _id=" + tojsononeline(doc._id) + " : " + e.message);
+        if (!DRY_RUN) {
+            coll.replaceOne({ _id: doc._id }, r.value);
+            updated++;
         }
     }
 
     if (matched > 0) {
-        var line = "  " + collName.padEnd(40) + " scanned=" + scanned +
-            " matched=" + matched +
-            (DRY_RUN ? "" : " updated=" + updated + (failed > 0 ? " failed=" + failed : ""));
-        print(line);
-        perCollectionStats.push({ collection: collName, scanned: scanned, matched: matched, updated: updated, failed: failed });
+        print("  " + name + ": matched=" + matched + (DRY_RUN ? "" : " updated=" + updated));
+        totalMatched += matched;
+        totalUpdated += updated;
     }
-
-    totalScanned += scanned;
-    totalMatched += matched;
-    totalUpdated += updated;
 }
 
 print("");
-print("======================================================");
-print("汇总:");
-print("  扫描集合数  : " + allCollections.length);
-print("  命中集合数  : " + perCollectionStats.length);
-print("  扫描文档总数: " + totalScanned);
-print("  含旧域名文档: " + totalMatched);
-if (!DRY_RUN) {
-    print("  实际更新文档: " + totalUpdated);
-}
-print("======================================================");
-
-if (DRY_RUN) {
-    print("");
-    print("【DRY RUN】未做任何写入。确认上面的命中数后, 用以下命令真正执行:");
-    print("  mongosh \"<connection-string>\" --eval \"var DRY_RUN=false\" " +
-        "scripts/migrations/replace-cdn-domain.js");
-}
+print("Total: matched=" + totalMatched + (DRY_RUN ? "" : " updated=" + totalUpdated));
+if (DRY_RUN) print("DRY RUN — 加 --eval \"var DRY_RUN=false\" 真正执行");

--- a/scripts/migrations/replace-cdn-domain.js
+++ b/scripts/migrations/replace-cdn-domain.js
@@ -1,0 +1,178 @@
+// 替换 MongoDB 中所有存量 URL 字段的旧 CDN 域名为新域名
+//
+// 背景:
+//   TencentCosStorage.BuildPublicUrl 把 ${TENCENT_COS_PUBLIC_BASE_URL}/{key} 拼好后
+//   作为完整 URL 写入了大量 Model 的 *Url 字段。环境变量改了之后, 老数据里的 URL
+//   仍然带着旧域名, 因此需要这个一次性扫描脚本把所有集合里的字符串字段
+//   "https://i.pa.759800.com" 替换成 "https://i.miduo.org"。
+//
+// 用法:
+//   1. 先 dry-run 看看会改多少条:
+//        mongosh "mongodb://user:pwd@host:port/prd_agent" scripts/migrations/replace-cdn-domain.js
+//   2. 确认无误后, 把 DRY_RUN 改成 false 再执行:
+//        mongosh "mongodb://..." --eval "var DRY_RUN=false" scripts/migrations/replace-cdn-domain.js
+//
+// 特性:
+//   - 递归扫描每个文档的所有字符串字段(任意层级嵌套数组/对象), 不依赖字段白名单
+//   - 即使将来新增了 URL 字段也不用改这个脚本, 重新跑一遍即可
+//   - DRY_RUN 默认 true, 不会真的写入
+//   - 支持通过环境变量覆盖: OLD_DOMAIN / NEW_DOMAIN
+//   - 跳过 system.* 集合, 避免误改 MongoDB 元数据
+//
+// 注意:
+//   - 大集合(如 llmrequestlogs, apirequestlogs)耗时较长, 建议先在副本集的 secondary 上试跑
+//   - 执行前最好做一次 mongodump 备份
+//   - 这是字符串子串替换, 不是正则; "i.pa.759800.com" 出现在哪里都会被替换
+
+// ── 配置 ────────────────────────────────────────────────────────────────
+var OLD_DOMAIN_DEFAULT = "i.pa.759800.com";
+var NEW_DOMAIN_DEFAULT = "i.miduo.org";
+
+if (typeof OLD_DOMAIN === "undefined") { var OLD_DOMAIN = OLD_DOMAIN_DEFAULT; }
+if (typeof NEW_DOMAIN === "undefined") { var NEW_DOMAIN = NEW_DOMAIN_DEFAULT; }
+if (typeof DRY_RUN === "undefined") { var DRY_RUN = true; }
+
+// 跳过这些集合(纯日志/会变得非常大, 且不影响业务展示; 如需迁移可手动放开)
+var SKIP_COLLECTIONS = new Set([
+    // 如果想跳过日志集合, 把它们加进来即可
+    // "apirequestlogs",
+    // "openplatformrequestlogs",
+]);
+
+// ── 工具函数 ────────────────────────────────────────────────────────────
+function isPlainObject(v) {
+    if (v === null || typeof v !== "object") return false;
+    if (Array.isArray(v)) return false;
+    // BSON 特殊类型: ObjectId / Date / Decimal128 / Binary 等都不是 plain object
+    if (v._bsontype) return false;
+    if (v instanceof Date) return false;
+    if (typeof ObjectId !== "undefined" && v instanceof ObjectId) return false;
+    return true;
+}
+
+// 递归替换字符串。返回 {value, changed}
+function walk(value) {
+    if (typeof value === "string") {
+        if (value.indexOf(OLD_DOMAIN) === -1) return { value: value, changed: false };
+        // split/join 比 replace 更安全, 不受正则元字符影响
+        var newVal = value.split(OLD_DOMAIN).join(NEW_DOMAIN);
+        return { value: newVal, changed: true };
+    }
+    if (Array.isArray(value)) {
+        var changedAny = false;
+        var newArr = [];
+        for (var i = 0; i < value.length; i++) {
+            var r = walk(value[i]);
+            if (r.changed) changedAny = true;
+            newArr.push(r.value);
+        }
+        return { value: newArr, changed: changedAny };
+    }
+    if (isPlainObject(value)) {
+        var changedAny2 = false;
+        var newObj = {};
+        var keys = Object.keys(value);
+        for (var k = 0; k < keys.length; k++) {
+            var key = keys[k];
+            var r2 = walk(value[key]);
+            if (r2.changed) changedAny2 = true;
+            newObj[key] = r2.value;
+        }
+        return { value: newObj, changed: changedAny2 };
+    }
+    return { value: value, changed: false };
+}
+
+// ── 主流程 ──────────────────────────────────────────────────────────────
+print("======================================================");
+print("CDN 域名迁移脚本");
+print("  数据库: " + db.getName());
+print("  旧域名: " + OLD_DOMAIN);
+print("  新域名: " + NEW_DOMAIN);
+print("  模式  : " + (DRY_RUN ? "DRY RUN (不写入)" : "*** 实际写入 ***"));
+print("======================================================");
+print("");
+
+var allCollections = db.getCollectionNames().sort();
+var totalScanned = 0;
+var totalMatched = 0;
+var totalUpdated = 0;
+var perCollectionStats = [];
+
+for (var ci = 0; ci < allCollections.length; ci++) {
+    var collName = allCollections[ci];
+    if (collName.indexOf("system.") === 0) continue;
+    if (SKIP_COLLECTIONS.has(collName)) {
+        print("[SKIP] " + collName);
+        continue;
+    }
+
+    var coll = db.getCollection(collName);
+
+    // 用 $regex 在顶层 BSON 文本里粗筛一下, 减少需要走 walk() 的文档量。
+    // 注意: $regex 只能匹配字符串字段; 但我们 walk() 是递归的, 所以即使字段
+    // 嵌在数组/子对象里, 只要 BSON 里包含这个子串, 索引就会扫到。
+    // 用 $text 不行, 因为没建文本索引。这里用 aggregate + $match 不可行(同样问题)。
+    // 最稳妥的方式: 直接 find 所有文档逐一检查。对小集合无所谓, 大集合靠 batchSize 控制。
+    var cursor = coll.find({}).batchSize(500);
+
+    var scanned = 0;
+    var matched = 0;
+    var updated = 0;
+    var failed = 0;
+
+    while (cursor.hasNext()) {
+        var doc = cursor.next();
+        scanned++;
+        var r = walk(doc);
+        if (!r.changed) continue;
+        matched++;
+
+        if (DRY_RUN) continue;
+
+        try {
+            // 用 replaceOne 而不是 updateOne, 因为我们有完整新文档, 一次写入更简洁
+            var res = coll.replaceOne({ _id: doc._id }, r.value);
+            if (res && (res.modifiedCount === 1 || res.matchedCount === 1)) {
+                updated++;
+            } else {
+                failed++;
+                print("  [WARN] replace 未匹配: " + collName + " _id=" + tojsononeline(doc._id));
+            }
+        } catch (e) {
+            failed++;
+            print("  [ERROR] " + collName + " _id=" + tojsononeline(doc._id) + " : " + e.message);
+        }
+    }
+
+    if (matched > 0) {
+        var line = "  " + collName.padEnd(40) + " scanned=" + scanned +
+            " matched=" + matched +
+            (DRY_RUN ? "" : " updated=" + updated + (failed > 0 ? " failed=" + failed : ""));
+        print(line);
+        perCollectionStats.push({ collection: collName, scanned: scanned, matched: matched, updated: updated, failed: failed });
+    }
+
+    totalScanned += scanned;
+    totalMatched += matched;
+    totalUpdated += updated;
+}
+
+print("");
+print("======================================================");
+print("汇总:");
+print("  扫描集合数  : " + allCollections.length);
+print("  命中集合数  : " + perCollectionStats.length);
+print("  扫描文档总数: " + totalScanned);
+print("  含旧域名文档: " + totalMatched);
+if (!DRY_RUN) {
+    print("  实际更新文档: " + totalUpdated);
+}
+print("======================================================");
+
+if (DRY_RUN) {
+    print("");
+    print("【DRY RUN】未做任何写入。确认上面的命中数后, 用以下命令真正执行:");
+    print("  mongosh \"<connection-string>\" --eval \"var DRY_RUN=false\" " +
+        "scripts/migrations/replace-cdn-domain.js");
+}

--- a/scripts/migrations/verify-cdn-domain.js
+++ b/scripts/migrations/verify-cdn-domain.js
@@ -1,0 +1,107 @@
+// 只读验证脚本: 扫描所有集合, 列出仍然包含旧 CDN 域名的字段路径与样例。
+// 用于迁移前后的核对, 不会写入任何数据。
+//
+// 用法:
+//   mongosh "mongodb://user:pwd@host:port/prd_agent" scripts/migrations/verify-cdn-domain.js
+//
+// 输出:
+//   - 每个命中的集合: 命中文档数 + 命中字段路径(去重) + 一条样例 _id
+//   - 总命中集合/文档数
+
+if (typeof OLD_DOMAIN === "undefined") { var OLD_DOMAIN = "i.pa.759800.com"; }
+if (typeof MAX_PATHS_PER_COLLECTION === "undefined") { var MAX_PATHS_PER_COLLECTION = 30; }
+
+function isPlainObject(v) {
+    if (v === null || typeof v !== "object") return false;
+    if (Array.isArray(v)) return false;
+    if (v._bsontype) return false;
+    if (v instanceof Date) return false;
+    return true;
+}
+
+// 递归收集包含 OLD_DOMAIN 的字段路径
+function findPaths(value, prefix, out) {
+    if (typeof value === "string") {
+        if (value.indexOf(OLD_DOMAIN) !== -1) {
+            out.add(prefix || "(root)");
+        }
+        return;
+    }
+    if (Array.isArray(value)) {
+        for (var i = 0; i < value.length; i++) {
+            findPaths(value[i], prefix + "[]", out);
+        }
+        return;
+    }
+    if (isPlainObject(value)) {
+        var keys = Object.keys(value);
+        for (var k = 0; k < keys.length; k++) {
+            var key = keys[k];
+            findPaths(value[key], prefix ? prefix + "." + key : key, out);
+        }
+    }
+}
+
+print("======================================================");
+print("CDN 域名残留扫描 (只读)");
+print("  数据库: " + db.getName());
+print("  关键词: " + OLD_DOMAIN);
+print("======================================================");
+
+var allCollections = db.getCollectionNames().sort();
+var hitSummary = [];
+var totalHitDocs = 0;
+
+for (var ci = 0; ci < allCollections.length; ci++) {
+    var collName = allCollections[ci];
+    if (collName.indexOf("system.") === 0) continue;
+
+    var coll = db.getCollection(collName);
+    var cursor = coll.find({}).batchSize(500);
+
+    var hitDocs = 0;
+    var pathSet = new Set();
+    var sampleId = null;
+
+    while (cursor.hasNext()) {
+        var doc = cursor.next();
+        var pathsInDoc = new Set();
+        findPaths(doc, "", pathsInDoc);
+        if (pathsInDoc.size > 0) {
+            hitDocs++;
+            if (sampleId === null) sampleId = doc._id;
+            pathsInDoc.forEach(function (p) { pathSet.add(p); });
+        }
+    }
+
+    if (hitDocs > 0) {
+        hitSummary.push({ name: collName, hits: hitDocs, paths: pathSet, sampleId: sampleId });
+        totalHitDocs += hitDocs;
+    }
+}
+
+if (hitSummary.length === 0) {
+    print("");
+    print("✅ 未发现任何文档包含 " + OLD_DOMAIN + " - 迁移已干净。");
+} else {
+    print("");
+    print("命中明细 (按集合):");
+    print("");
+    for (var i = 0; i < hitSummary.length; i++) {
+        var s = hitSummary[i];
+        print("  " + s.name + "  (" + s.hits + " 个文档)");
+        print("    样例 _id: " + tojsononeline(s.sampleId));
+        var pathArr = Array.from(s.paths).sort();
+        var shown = pathArr.slice(0, MAX_PATHS_PER_COLLECTION);
+        for (var j = 0; j < shown.length; j++) {
+            print("      - " + shown[j]);
+        }
+        if (pathArr.length > shown.length) {
+            print("      … (" + (pathArr.length - shown.length) + " more)");
+        }
+        print("");
+    }
+    print("======================================================");
+    print("汇总: " + hitSummary.length + " 个集合, " + totalHitDocs + " 个文档仍含旧域名");
+    print("======================================================");
+}

--- a/scripts/migrations/verify-cdn-domain.js
+++ b/scripts/migrations/verify-cdn-domain.js
@@ -8,7 +8,7 @@
 //   - 每个命中的集合: 命中文档数 + 命中字段路径(去重) + 一条样例 _id
 //   - 总命中集合/文档数
 
-if (typeof OLD_DOMAIN === "undefined") { var OLD_DOMAIN = "i.pa.759800.com"; }
+if (typeof OLD_DOMAIN === "undefined") { var OLD_DOMAIN = "pa.759800.com"; }
 if (typeof MAX_PATHS_PER_COLLECTION === "undefined") { var MAX_PATHS_PER_COLLECTION = 30; }
 
 function isPlainObject(v) {


### PR DESCRIPTION
## Summary

Add one-time migration scripts to handle bulk replacement of legacy CDN domain names in MongoDB collections. This addresses the need to update hardcoded URLs stored in database records after changing the `TENCENT_COS_PUBLIC_BASE_URL` environment variable.

## Changes

- **replace-cdn-domain.js**: Recursively scans all MongoDB collections and replaces substring occurrences of `pa.759800.com` with `map.ebcone.net` across all string fields (including nested arrays and subdocuments). Defaults to dry-run mode for safety.

- **verify-cdn-domain.js**: Read-only verification script that scans all collections and reports which documents still contain the old domain, along with affected field paths and sample document IDs. Used for pre/post-migration validation.

- **scripts/migrations/README.md**: Comprehensive documentation including:
  - Rationale for the migration (URLs are written as complete strings to many model fields)
  - Standard operation workflow with backup and verification steps
  - DataGrip MongoDB Console one-liner alternative
  - Configuration options for custom domain pairs
  - Design principles (recursive traversal, substring replacement, idempotency, dry-run by default)

## Implementation Details

- Both scripts recursively traverse all document structures (objects, arrays, nested fields) without relying on field whitelists
- Substring-based replacement (not regex) ensures all domain variations are caught
- Idempotent design allows safe re-execution
- System collections are skipped to avoid corrupting MongoDB metadata
- Batch size of 500 for efficient processing of large collections
- Default `DRY_RUN=true` prevents accidental data writes
- Domain pairs are configurable via `--eval` parameters

https://claude.ai/code/session_01F4mVWzSH4kbS3q3YLdzyAi