### PR TITLE
cds: fold nginx init into cds setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,17 @@ __pycache__/
 
 # CDS runtime state (contains env secrets, port allocations, container status)
 .cds/state.json
+cds/.cds/
+cds/.bt/
+cds/cds.log
+cds/.bt.log
+cds/nginx/domain.env
+cds/nginx/certs/
+cds/nginx/www/
+cds/nginx/nginx.conf
+cds/nginx/cds-nginx.conf
+cds/nginx/acme_apply.sh
+cds/.cds.env
 
 # Agent development workspace (per-developer progress tracking)
 .agent-workspace/

--- a/cds/exec_cds.sh
+++ b/cds/exec_cds.sh
@@ -23,6 +23,8 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR"
 
 CONFIG_FILE="${CDS_CONFIG:-${BT_CONFIG:-cds.config.json}}"
+NGINX_DOMAIN_ENV="$SCRIPT_DIR/nginx/domain.env"
+LOCAL_ENV_FILE="$SCRIPT_DIR/.cds.env"
 BACKGROUND=false
 LOG_FILE="cds.log"
 PID_FILE=".cds/cds.pid"
@@ -34,6 +36,53 @@ for arg in "$@"; do
   esac
 done
 
+ensure_domain_bootstrap() {
+  local main_domain="${CDS_MAIN_DOMAIN:-${MAIN_DOMAIN:-}}"
+
+  if [ -f "$NGINX_DOMAIN_ENV" ]; then
+    return 0
+  fi
+
+  echo ""
+  echo "  CDS 首次初始化"
+  echo "  ─────────────────────"
+  echo "  缺少域名初始化信息，将先执行 ./exec_setup.sh"
+  echo ""
+
+  if [ ! -t 0 ]; then
+    echo "ERROR: 当前为非交互环境，且缺少 nginx/domain.env 或 CDS_MAIN_DOMAIN。"
+    echo "请先手动执行: ./exec_setup.sh"
+    exit 1
+  fi
+
+  ./exec_setup.sh
+
+  if [ ! -f "$NGINX_DOMAIN_ENV" ]; then
+    echo "ERROR: 初始化未完成，已取消启动。"
+    exit 1
+  fi
+}
+
+load_domain_env() {
+  if [ -f "$LOCAL_ENV_FILE" ]; then
+    set -a
+    . "$LOCAL_ENV_FILE"
+    set +a
+  fi
+
+  if [ ! -f "$NGINX_DOMAIN_ENV" ]; then
+    return 0
+  fi
+
+  set -a
+  . "$NGINX_DOMAIN_ENV"
+  set +a
+
+  export CDS_MAIN_DOMAIN="${CDS_MAIN_DOMAIN:-${MAIN_DOMAIN:-}}"
+  export CDS_SWITCH_DOMAIN="${CDS_SWITCH_DOMAIN:-${SWITCH_DOMAIN:-}}"
+  export CDS_PREVIEW_DOMAIN="${CDS_PREVIEW_DOMAIN:-${PREVIEW_DOMAIN:-${MAIN_DOMAIN:-}}}"
+}
+
 echo ""
 echo "  CDS Startup"
 echo "  ─────────────────────"
@@ -44,6 +93,9 @@ echo "  Auth:       ${CDS_AUTH_USER:+enabled (user: $CDS_AUTH_USER)}${CDS_AUTH_U
 CDS_NGINX="${CDS_NGINX_ENABLE:-${BT_NGINX_ENABLE:-}}"
 echo "  Nginx:      ${CDS_NGINX:+enabled (port 58000)}${CDS_NGINX:-disabled}"
 echo ""
+
+ensure_domain_bootstrap
+load_domain_env
 
 # ── 1. Check dependencies ──
 if ! command -v pnpm >/dev/null 2>&1; then
@@ -102,7 +154,7 @@ mkdir -p .cds
 kill_cds_on_port() {
   local port="$1"
   local pids
-  pids=$(lsof -ti :"$port" 2>/dev/null || true)
+  pids=$(ss -tlnp "( sport = :$port )" 2>/dev/null | grep -o 'pid=[0-9]*' | cut -d= -f2 | sort -u || true)
   [ -z "$pids" ] && return 0
 
   local killed=false
@@ -134,13 +186,13 @@ kill_cds_on_port() {
   if [ "$killed" = true ]; then
     # Wait up to 5 seconds for process to exit (increased from 3 for reliability)
     for i in 1 2 3 4 5; do
-      if ! lsof -ti :"$port" >/dev/null 2>&1; then
+      if ! ss -tlnp "( sport = :$port )" 2>/dev/null | grep -q 'pid='; then
         return 0
       fi
       sleep 1
     done
     # Force kill only node/tsx processes still alive (by process group)
-    pids=$(lsof -ti :"$port" 2>/dev/null || true)
+    pids=$(ss -tlnp "( sport = :$port )" 2>/dev/null | grep -o 'pid=[0-9]*' | cut -d= -f2 | sort -u || true)
     for pid in $pids; do
       local cmd
       cmd=$(ps -p "$pid" -o comm= 2>/dev/null || true)
@@ -162,10 +214,70 @@ kill_cds_on_port() {
   fi
 
   # Final check: if port still occupied (by non-CDS process), warn and abort
-  if lsof -ti :"$port" >/dev/null 2>&1; then
+  if ss -tlnp "( sport = :$port )" 2>/dev/null | grep -q 'pid='; then
     echo "  [ERROR] Port $port is still in use by another program. Please free it manually."
     exit 1
   fi
+}
+
+find_cds_listener_pid() {
+  local port="$1"
+  local pids
+  pids=$(ss -tlnp "( sport = :$port )" 2>/dev/null | grep -o 'pid=[0-9]*' | cut -d= -f2 | sort -u || true)
+  [ -z "$pids" ] && return 1
+
+  for pid in $pids; do
+    local cmd
+    cmd=$(ps -p "$pid" -o comm= 2>/dev/null || true)
+    case "$cmd" in
+      node|tsx|ts-node|npx)
+        printf '%s\n' "$pid"
+        return 0
+        ;;
+    esac
+  done
+
+  return 1
+}
+
+wait_for_cds_listener() {
+  local port="$1"
+  local timeout_seconds="${2:-20}"
+  local elapsed=0
+
+  while [ "$elapsed" -lt "$timeout_seconds" ]; do
+    local pid=""
+    pid=$(find_cds_listener_pid "$port" || true)
+    if [ -n "$pid" ]; then
+      printf '%s\n' "$pid"
+      return 0
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+
+  return 1
+}
+
+reuse_running_cds_if_present() {
+  local pid=""
+  pid=$(find_cds_listener_pid "$MASTER_PORT" || true)
+  if [ -z "$pid" ]; then
+    return 1
+  fi
+
+  echo "$pid" > "$PID_FILE"
+  echo ""
+  echo "  CDS already running"
+  echo "  PID:        $pid"
+  echo "  Log:        $SCRIPT_DIR/$LOG_FILE"
+  echo "  Dashboard:  http://localhost:${MASTER_PORT}"
+  echo "  Gateway:    http://localhost:${WORKER_PORT}"
+  [ "${CDS_NGINX}" = "1" ] && echo "  Nginx:      http://localhost:58000"
+  echo ""
+  echo "  Stop: kill \$(cat $PID_FILE)"
+  echo "  Logs: tail -f $LOG_FILE"
+  return 0
 }
 
 # Read masterPort and workerPort from config
@@ -176,6 +288,10 @@ if [ -f "$CONFIG_FILE" ]; then
   _wp=$(grep -o '"workerPort"\s*:\s*[0-9]*' "$CONFIG_FILE" 2>/dev/null | grep -o '[0-9]*' || true)
   [ -n "$_mp" ] && MASTER_PORT="$_mp"
   [ -n "$_wp" ] && WORKER_PORT="$_wp"
+fi
+
+if [ "$BACKGROUND" = true ] && reuse_running_cds_if_present; then
+  exit 0
 fi
 
 echo "[3/3] Starting CDS..."
@@ -212,15 +328,26 @@ if [ "$BACKGROUND" = true ]; then
   # during self-update (git pull changes files → tsx watch restarts → two instances
   # compete for port 9900 → ~20% chance of 502). Background mode doesn't need hot-reload.
   nohup pnpm serve -- "$CONFIG_FILE" > "$LOG_FILE" 2>&1 &
-  CDS_PID=$!
+  BOOTSTRAP_PID=$!
+
+  CDS_PID="$(wait_for_cds_listener "$MASTER_PORT" 20 || true)"
+  if [ -z "$CDS_PID" ]; then
+    echo "  [ERROR] CDS 未能在 ${MASTER_PORT} 端口完成启动。"
+    echo "  请检查日志: $SCRIPT_DIR/$LOG_FILE"
+    exit 1
+  fi
+
   echo "$CDS_PID" > "$PID_FILE"
 
   echo ""
   echo "  CDS started in background"
   echo "  PID:        $CDS_PID"
+  if [ "$BOOTSTRAP_PID" != "$CDS_PID" ]; then
+    echo "  Bootstrap:  $BOOTSTRAP_PID"
+  fi
   echo "  Log:        $SCRIPT_DIR/$LOG_FILE"
-  echo "  Dashboard:  http://localhost:9900"
-  echo "  Gateway:    http://localhost:5500"
+  echo "  Dashboard:  http://localhost:${MASTER_PORT}"
+  echo "  Gateway:    http://localhost:${WORKER_PORT}"
   [ "${CDS_NGINX}" = "1" ] && echo "  Nginx:      http://localhost:58000"
   echo ""
   echo "  Stop: kill \$(cat $PID_FILE)"

--- a/cds/exec_setup.sh
+++ b/cds/exec_setup.sh
@@ -5,8 +5,7 @@
 # 功能：
 #   1. 交互式收集配置（账号密码、域名等）
 #   2. 写入 ~/.bashrc（CDS 系统层环境变量）
-#   3. 生成 Nginx 配置文件（从模板渲染）
-#   4. 可选：重载 Nginx 容器
+#   3. 生成 CDS 自带 Nginx 配置与证书脚本
 #
 # 用法：
 #   ./exec_setup.sh              # 交互式配置
@@ -19,6 +18,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TEMPLATE_DIR="$SCRIPT_DIR/nginx"
 BASHRC="$HOME/.bashrc"
+LOCAL_ENV_FILE="$SCRIPT_DIR/.cds.env"
+NGINX_DIR="$SCRIPT_DIR/nginx"
+NGINX_DOMAIN_ENV="$NGINX_DIR/domain.env"
 
 # ── Colors ──
 RED='\033[0;31m'
@@ -33,9 +35,17 @@ ok()    { echo -e "${GREEN}[OK]${NC} $*"; }
 warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
 err()   { echo -e "${RED}[ERROR]${NC} $*"; }
 
-# ── Helper: read current value from bashrc ──
-get_bashrc_var() {
+# ── Helper: read current value from local env / bashrc ──
+get_config_var() {
     local var_name="$1"
+    local val=""
+    if [ -f "$LOCAL_ENV_FILE" ]; then
+        val=$(grep "^export ${var_name}=" "$LOCAL_ENV_FILE" 2>/dev/null | tail -1 | sed "s/^export ${var_name}=\"\(.*\)\"/\1/" || true)
+    fi
+    if [ -n "$val" ]; then
+        printf '%s\n' "$val"
+        return 0
+    fi
     grep "^export ${var_name}=" "$BASHRC" 2>/dev/null | tail -1 | sed "s/^export ${var_name}=\"\(.*\)\"/\1/" || echo ""
 }
 
@@ -83,16 +93,16 @@ show_config() {
 
     for var in "${vars[@]}"; do
         local val
-        val=$(get_bashrc_var "$var")
+        val=$(get_config_var "$var")
         if [ -z "$val" ]; then
             # Try legacy names
             case "$var" in
-                CDS_USERNAME) val=$(get_bashrc_var "BT_USERNAME") ;;
-                CDS_PASSWORD) val=$(get_bashrc_var "BT_PASSWORD") ;;
-                CDS_JWT_SECRET) val=$(get_bashrc_var "JWT_SECRET") ;;
-                CDS_SWITCH_DOMAIN) val=$(get_bashrc_var "SWITCH_DOMAIN") ;;
-                CDS_MAIN_DOMAIN) val=$(get_bashrc_var "MAIN_DOMAIN") ;;
-                CDS_PREVIEW_DOMAIN) val=$(get_bashrc_var "PREVIEW_DOMAIN") ;;
+                CDS_USERNAME) val=$(get_config_var "BT_USERNAME") ;;
+                CDS_PASSWORD) val=$(get_config_var "BT_PASSWORD") ;;
+                CDS_JWT_SECRET) val=$(get_config_var "JWT_SECRET") ;;
+                CDS_SWITCH_DOMAIN) val=$(get_config_var "SWITCH_DOMAIN") ;;
+                CDS_MAIN_DOMAIN) val=$(get_config_var "MAIN_DOMAIN") ;;
+                CDS_PREVIEW_DOMAIN) val=$(get_config_var "PREVIEW_DOMAIN") ;;
             esac
         fi
 
@@ -111,38 +121,41 @@ show_config() {
 generate_nginx() {
     local main_domain="$1"
     local preview_domain="$2"
-    local worker_port="${3:-5500}"
-    local master_port="${4:-9900}"
-    local output_dir="${5:-$SCRIPT_DIR/nginx}"
+    local switch_domain="${3:-switch.${main_domain}}"
+    local worker_port="${4:-5500}"
+    local master_port="${5:-9900}"
+    local output_dir="${6:-$SCRIPT_DIR/nginx}"
+    local domain_env="${output_dir}/domain.env"
 
-    local template="$TEMPLATE_DIR/cds-nginx.conf.template"
-    if [ ! -f "$template" ]; then
-        err "模板文件不存在: $template"
+    mkdir -p "${output_dir}/certs" "${output_dir}/www/.well-known/acme-challenge"
+
+    cat > "$domain_env" <<EOF
+MAIN_DOMAIN="${main_domain}"
+SWITCH_DOMAIN="${switch_domain}"
+DASHBOARD_DOMAIN="cds.${main_domain}"
+PREVIEW_DOMAIN="${preview_domain}"
+ENABLE_PREVIEW_SERVER="1"
+WORKER_PORT="${worker_port}"
+DASHBOARD_PORT="${master_port}"
+CERT_EMAIL="admin@${main_domain}"
+NGINX_CONTAINER="nginx_miduo"
+LOCAL_TLS_HOST="127.0.0.1"
+TLS_DOMAINS="${main_domain},${switch_domain},cds.${main_domain}"
+EOF
+
+    if [ ! -f "$output_dir/init_domain.sh" ]; then
+        err "初始化脚本不存在: $output_dir/init_domain.sh"
         return 1
     fi
 
-    local output="$output_dir/cds-nginx.conf"
-    sed \
-        -e "s/{{MAIN_DOMAIN}}/${main_domain}/g" \
-        -e "s/{{PREVIEW_DOMAIN}}/${preview_domain}/g" \
-        -e "s/{{WORKER_PORT}}/${worker_port}/g" \
-        -e "s/{{MASTER_PORT}}/${master_port}/g" \
-        "$template" > "$output"
-
-    ok "Nginx 配置已生成: $output"
-
-    # Also generate the main nginx.conf if it doesn't exist
-    local main_nginx="$output_dir/nginx.conf"
-    if [ ! -f "$main_nginx" ]; then
-        cp "$TEMPLATE_DIR/nginx.conf.template" "$main_nginx"
-        ok "主 nginx.conf 已生成: $main_nginx"
-    fi
-
-    echo "$output"
+    bash "$output_dir/init_domain.sh" --config "$domain_env" >/dev/null
+    ok "Nginx 配置已生成: ${output_dir}/nginx.conf"
+    ok "CDS Nginx 配置已生成: ${output_dir}/cds-nginx.conf"
+    ok "证书脚本已生成: ${output_dir}/acme_apply.sh"
 }
 
-# ── Write bashrc ──
-write_bashrc() {
+# ── Write local runtime env ──
+write_local_env() {
     local username="$1"
     local password="$2"
     local jwt_secret="$3"
@@ -150,18 +163,8 @@ write_bashrc() {
     local main_domain="$5"
     local preview_domain="$6"
 
-    # Remove existing CDS_ and legacy BT_ entries
-    local tmp
-    tmp=$(mktemp)
-    grep -v -E "^export (CDS_USERNAME|CDS_PASSWORD|CDS_JWT_SECRET|CDS_SWITCH_DOMAIN|CDS_MAIN_DOMAIN|CDS_PREVIEW_DOMAIN|BT_USERNAME|BT_PASSWORD|JWT_SECRET|SWITCH_DOMAIN|MAIN_DOMAIN|PREVIEW_DOMAIN)=" "$BASHRC" > "$tmp" 2>/dev/null || true
-
-    # Remove old marker block if exists
-    sed -i '/^# ── CDS 系统配置/,/^$/d' "$tmp"
-
-    # Append new config
-    cat >> "$tmp" << EOF
-
-# ── CDS 系统配置 (由 exec_setup.sh 生成，$(date +%Y-%m-%d)) ──
+    cat > "$LOCAL_ENV_FILE" << EOF
+# ── CDS 本地环境配置 (由 exec_setup.sh 生成，$(date +%Y-%m-%d)) ──
 export CDS_USERNAME="${username}"
 export CDS_PASSWORD="${password}"
 export CDS_JWT_SECRET="${jwt_secret}"
@@ -170,10 +173,8 @@ export CDS_MAIN_DOMAIN="${main_domain}"
 export CDS_PREVIEW_DOMAIN="${preview_domain}"
 EOF
 
-    cp "$tmp" "$BASHRC"
-    rm -f "$tmp"
-
-    ok "~/.bashrc 已更新"
+    chmod 600 "$LOCAL_ENV_FILE"
+    ok "本地环境文件已更新: $LOCAL_ENV_FILE"
 }
 
 # ── Main ──
@@ -191,37 +192,41 @@ main() {
             ;;
         --nginx-only)
             local domain
-            domain=$(get_bashrc_var "CDS_MAIN_DOMAIN")
+            domain=$(get_config_var "CDS_MAIN_DOMAIN")
             if [ -z "$domain" ]; then
-                domain=$(get_bashrc_var "MAIN_DOMAIN")
+                domain=$(get_config_var "MAIN_DOMAIN")
             fi
             if [ -z "$domain" ]; then
                 err "未找到 CDS_MAIN_DOMAIN，请先运行 ./exec_setup.sh 完成完整配置"
                 return 1
             fi
             local preview
-            preview=$(get_bashrc_var "CDS_PREVIEW_DOMAIN")
-            [ -z "$preview" ] && preview=$(get_bashrc_var "PREVIEW_DOMAIN")
+            preview=$(get_config_var "CDS_PREVIEW_DOMAIN")
+            [ -z "$preview" ] && preview=$(get_config_var "PREVIEW_DOMAIN")
             [ -z "$preview" ] && preview="$domain"
-            generate_nginx "$domain" "$preview"
+            local switch
+            switch=$(get_config_var "CDS_SWITCH_DOMAIN")
+            [ -z "$switch" ] && switch=$(get_config_var "SWITCH_DOMAIN")
+            [ -z "$switch" ] && switch="switch.${domain}"
+            generate_nginx "$domain" "$preview" "$switch"
             return 0
             ;;
     esac
 
     # ── Step 1: Collect current values as defaults ──
     local cur_user cur_pass cur_jwt cur_switch cur_main cur_preview
-    cur_user=$(get_bashrc_var "CDS_USERNAME")
-    [ -z "$cur_user" ] && cur_user=$(get_bashrc_var "BT_USERNAME")
-    cur_pass=$(get_bashrc_var "CDS_PASSWORD")
-    [ -z "$cur_pass" ] && cur_pass=$(get_bashrc_var "BT_PASSWORD")
-    cur_jwt=$(get_bashrc_var "CDS_JWT_SECRET")
-    [ -z "$cur_jwt" ] && cur_jwt=$(get_bashrc_var "JWT_SECRET")
-    cur_switch=$(get_bashrc_var "CDS_SWITCH_DOMAIN")
-    [ -z "$cur_switch" ] && cur_switch=$(get_bashrc_var "SWITCH_DOMAIN")
-    cur_main=$(get_bashrc_var "CDS_MAIN_DOMAIN")
-    [ -z "$cur_main" ] && cur_main=$(get_bashrc_var "MAIN_DOMAIN")
-    cur_preview=$(get_bashrc_var "CDS_PREVIEW_DOMAIN")
-    [ -z "$cur_preview" ] && cur_preview=$(get_bashrc_var "PREVIEW_DOMAIN")
+    cur_user=$(get_config_var "CDS_USERNAME")
+    [ -z "$cur_user" ] && cur_user=$(get_config_var "BT_USERNAME")
+    cur_pass=$(get_config_var "CDS_PASSWORD")
+    [ -z "$cur_pass" ] && cur_pass=$(get_config_var "BT_PASSWORD")
+    cur_jwt=$(get_config_var "CDS_JWT_SECRET")
+    [ -z "$cur_jwt" ] && cur_jwt=$(get_config_var "JWT_SECRET")
+    cur_switch=$(get_config_var "CDS_SWITCH_DOMAIN")
+    [ -z "$cur_switch" ] && cur_switch=$(get_config_var "SWITCH_DOMAIN")
+    cur_main=$(get_config_var "CDS_MAIN_DOMAIN")
+    [ -z "$cur_main" ] && cur_main=$(get_config_var "MAIN_DOMAIN")
+    cur_preview=$(get_config_var "CDS_PREVIEW_DOMAIN")
+    [ -z "$cur_preview" ] && cur_preview=$(get_config_var "PREVIEW_DOMAIN")
 
     # ── Step 2: Interactive prompts ──
     echo -e "  ${CYAN}步骤 1/4${NC}: Dashboard 认证"
@@ -282,78 +287,11 @@ main() {
 
     # ── Step 4: Write ──
     echo ""
-    info "写入 ~/.bashrc ..."
-    write_bashrc "$new_user" "$new_pass" "$new_jwt" "$new_switch" "$new_main" "$new_preview"
+    info "写入 CDS 本地环境文件 ..."
+    write_local_env "$new_user" "$new_pass" "$new_jwt" "$new_switch" "$new_main" "$new_preview"
 
     info "生成 Nginx 配置 ..."
-    generate_nginx "$new_main" "$new_preview"
-
-    # ── Step 5: Optional nginx reload ──
-    echo ""
-    local nginx_conf="$SCRIPT_DIR/nginx/cds-nginx.conf"
-    local nginx_main="$SCRIPT_DIR/nginx/nginx.conf"
-
-    echo -e "  ${BOLD}Nginx 部署说明${NC}"
-    echo "  ──────────────────────────"
-    echo ""
-    echo "  生成的文件："
-    echo "    主配置:  $nginx_main"
-    echo "    CDS 配置: $nginx_conf"
-    echo ""
-    echo "  部署方式（二选一）："
-    echo ""
-    echo "  方式 A: 替换宿主机 nginx（推荐）"
-    echo "    cp $nginx_main /root/inernoro/nginx/nginx.conf"
-    echo "    cp $nginx_conf /root/inernoro/nginx/conf.d/cds.conf"
-    echo "    docker exec nginx_miduo nginx -t && docker exec nginx_miduo nginx -s reload"
-    echo ""
-    echo "  方式 B: 仅添加 CDS 配置（不动主 nginx.conf）"
-    echo "    mkdir -p /root/inernoro/nginx/conf.d"
-    echo "    cp $nginx_conf /root/inernoro/nginx/conf.d/cds.conf"
-    echo "    # 需要在主 nginx.conf 的 http {} 块末尾加一行："
-    echo "    #   include /etc/nginx/conf.d/*.conf;"
-    echo "    docker exec nginx_miduo nginx -t && docker exec nginx_miduo nginx -s reload"
-    echo ""
-
-    echo -en "  是否自动部署 Nginx 配置到宿主机? [y/N]: "
-    read -r auto_deploy
-    if [[ "$auto_deploy" =~ ^[Yy] ]]; then
-        echo -en "  Nginx 配置目录 [/root/inernoro/nginx]: "
-        read -r nginx_dir
-        nginx_dir="${nginx_dir:-/root/inernoro/nginx}"
-
-        echo -en "  Nginx 容器名 [nginx_miduo]: "
-        read -r nginx_container
-        nginx_container="${nginx_container:-nginx_miduo}"
-
-        echo -en "  使用方式 A (替换主配置) 还是 B (仅添加 CDS conf)? [A/b]: "
-        read -r deploy_mode
-        deploy_mode="${deploy_mode:-A}"
-
-        if [[ "$deploy_mode" =~ ^[Aa] ]]; then
-            info "复制主 nginx.conf ..."
-            cp "$nginx_main" "$nginx_dir/nginx.conf"
-            mkdir -p "$nginx_dir/conf.d"
-            info "复制 CDS nginx 配置 ..."
-            cp "$nginx_conf" "$nginx_dir/conf.d/cds.conf"
-        else
-            mkdir -p "$nginx_dir/conf.d"
-            info "复制 CDS nginx 配置 ..."
-            cp "$nginx_conf" "$nginx_dir/conf.d/cds.conf"
-            warn "请确保主 nginx.conf 中包含: include /etc/nginx/conf.d/*.conf;"
-        fi
-
-        # Mount conf.d into container if not already mounted
-        info "测试 Nginx 配置 ..."
-        if docker exec "$nginx_container" nginx -t 2>&1; then
-            info "重载 Nginx ..."
-            docker exec "$nginx_container" nginx -s reload
-            ok "Nginx 已重载"
-        else
-            err "Nginx 配置测试失败，请手动检查"
-            return 1
-        fi
-    fi
+    generate_nginx "$new_main" "$new_preview" "$new_switch"
 
     echo ""
     echo "  ════════════════════════════════"
@@ -361,7 +299,7 @@ main() {
     echo "  ════════════════════════════════"
     echo ""
     echo "  下一步："
-    echo "    1. source ~/.bashrc"
+    echo "    1. 如需证书: cd $NGINX_DIR && ./acme_apply.sh"
     echo "    2. cd $SCRIPT_DIR && ./exec_cds.sh"
     echo "    3. 访问 https://cds.${new_main}"
     echo ""

--- a/cds/nginx/acme.sh.template
+++ b/cds/nginx/acme.sh.template
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONFIG_FILE="__CONFIG_FILE__"
+
+if [ ! -f "$CONFIG_FILE" ]; then
+  echo "ERROR: 配置文件不存在: $CONFIG_FILE"
+  exit 1
+fi
+
+set -a
+. "$CONFIG_FILE"
+set +a
+
+MAIN_DOMAIN="${MAIN_DOMAIN:-}"
+CERT_EMAIL="${CERT_EMAIL:-admin@${MAIN_DOMAIN}}"
+NGINX_CONTAINER="${NGINX_CONTAINER:-nginx_miduo}"
+LOCAL_TLS_HOST="${LOCAL_TLS_HOST:-127.0.0.1}"
+TLS_DOMAINS="${TLS_DOMAINS:-${MAIN_DOMAIN}}"
+
+FORCE_RENEW=0
+CHECK_ONLY=0
+
+for arg in "$@"; do
+  case "${arg}" in
+    --force)
+      FORCE_RENEW=1
+      ;;
+    --check-only)
+      CHECK_ONLY=1
+      ;;
+    *)
+      echo "Usage: $0 [--force] [--check-only]"
+      exit 1
+      ;;
+  esac
+done
+
+BASE_DIR="$SCRIPT_DIR"
+CERT_DIR="${BASE_DIR}/certs"
+WEBROOT_DIR="${BASE_DIR}/www"
+ACME_HOME="${HOME}/.acme.sh"
+ACME="${ACME_HOME}/acme.sh"
+
+if [ -z "$MAIN_DOMAIN" ]; then
+  echo "ERROR: MAIN_DOMAIN 不能为空"
+  exit 1
+fi
+
+mkdir -p "${CERT_DIR}" "${WEBROOT_DIR}/.well-known/acme-challenge"
+
+if [ "${CHECK_ONLY}" -eq 1 ]; then
+  echo | openssl s_client -connect "${LOCAL_TLS_HOST}:443" -servername "${MAIN_DOMAIN}" 2>/dev/null | openssl x509 -noout -dates -issuer -subject || true
+  exit 0
+fi
+
+if ! docker ps --format '{{.Names}}' | grep -qx "${NGINX_CONTAINER}"; then
+  echo "ERROR: 找不到正在运行的 nginx 容器: ${NGINX_CONTAINER}"
+  exit 1
+fi
+
+if ! docker inspect "${NGINX_CONTAINER}" --format '{{json .Mounts}}' | grep -q "/var/www/html"; then
+  echo "ERROR: nginx 容器未挂载 /var/www/html"
+  exit 1
+fi
+
+if [ ! -f "${ACME}" ]; then
+  curl -fsSL https://get.acme.sh | sh -s email="${CERT_EMAIL}"
+fi
+
+"${ACME}" --set-default-ca --server letsencrypt
+
+ISSUE_ARGS=(--issue -w "${WEBROOT_DIR}" --keylength ec-256)
+IFS=',' read -r -a tls_domain_array <<< "${TLS_DOMAINS}"
+for domain in "${tls_domain_array[@]}"; do
+  domain="$(echo "$domain" | xargs)"
+  [ -n "$domain" ] && ISSUE_ARGS+=(-d "$domain")
+done
+
+if [ "${FORCE_RENEW}" -eq 1 ]; then
+  ISSUE_ARGS+=(--force)
+fi
+
+ISSUE_OUTPUT="$("${ACME}" "${ISSUE_ARGS[@]}" 2>&1)" || ISSUE_STATUS=$?
+ISSUE_STATUS=${ISSUE_STATUS:-0}
+printf '%s\n' "${ISSUE_OUTPUT}"
+
+if [ "${ISSUE_STATUS}" -ne 0 ] && ! printf '%s\n' "${ISSUE_OUTPUT}" | grep -q "Skipping. Next renewal time is:"; then
+  exit "${ISSUE_STATUS}"
+fi
+
+"${ACME}" --install-cert -d "${MAIN_DOMAIN}" \
+  --ecc \
+  --key-file       "${CERT_DIR}/${MAIN_DOMAIN}.key" \
+  --fullchain-file "${CERT_DIR}/${MAIN_DOMAIN}.crt" \
+  --reloadcmd      "docker exec ${NGINX_CONTAINER} nginx -s reload"
+
+echo | openssl s_client -connect "${LOCAL_TLS_HOST}:443" -servername "${MAIN_DOMAIN}" 2>/dev/null | openssl x509 -noout -dates -issuer -subject || true

--- a/cds/nginx/domain.env.example
+++ b/cds/nginx/domain.env.example
@@ -1,0 +1,20 @@
+# 复制为 domain.env 后修改，再执行:
+#   ./init_domain.sh
+
+MAIN_DOMAIN="miduo.org"
+SWITCH_DOMAIN="switch.miduo.org"
+DASHBOARD_DOMAIN="cds.miduo.org"
+
+# 默认跟 MAIN_DOMAIN 相同，用于 *.PREVIEW_DOMAIN
+PREVIEW_DOMAIN="miduo.org"
+ENABLE_PREVIEW_SERVER="1"
+
+WORKER_PORT="5500"
+DASHBOARD_PORT="9900"
+
+CERT_EMAIL="admin@miduo.org"
+NGINX_CONTAINER="nginx_miduo"
+LOCAL_TLS_HOST="127.0.0.1"
+
+# webroot 模式只支持显式域名；若要给 *.PREVIEW_DOMAIN 配 HTTPS，请改 DNS challenge
+TLS_DOMAINS="miduo.org,switch.miduo.org,cds.miduo.org"

--- a/cds/nginx/init_domain.sh
+++ b/cds/nginx/init_domain.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONFIG_FILE="${SCRIPT_DIR}/domain.env"
+SHOW_ONLY=0
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./nginx/init_domain.sh
+  ./nginx/init_domain.sh --show
+  ./nginx/init_domain.sh --config /path/to/domain.env
+
+作用:
+  - 从 domain.env 生成 nginx.conf / cds-nginx.conf / acme_apply.sh
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --config)
+      CONFIG_FILE="$2"
+      shift 2
+      ;;
+    --show)
+      SHOW_ONLY=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [ ! -f "$CONFIG_FILE" ]; then
+  echo "ERROR: 配置文件不存在: $CONFIG_FILE"
+  echo "先执行: cp ${SCRIPT_DIR}/domain.env.example ${SCRIPT_DIR}/domain.env"
+  exit 1
+fi
+
+set -a
+. "$CONFIG_FILE"
+set +a
+
+MAIN_DOMAIN="${MAIN_DOMAIN:-}"
+SWITCH_DOMAIN="${SWITCH_DOMAIN:-switch.${MAIN_DOMAIN}}"
+DASHBOARD_DOMAIN="${DASHBOARD_DOMAIN:-cds.${MAIN_DOMAIN}}"
+PREVIEW_DOMAIN="${PREVIEW_DOMAIN:-${MAIN_DOMAIN}}"
+ENABLE_PREVIEW_SERVER="${ENABLE_PREVIEW_SERVER:-1}"
+WORKER_PORT="${WORKER_PORT:-5500}"
+DASHBOARD_PORT="${DASHBOARD_PORT:-9900}"
+CERT_EMAIL="${CERT_EMAIL:-admin@${MAIN_DOMAIN}}"
+NGINX_CONTAINER="${NGINX_CONTAINER:-nginx_miduo}"
+TLS_DOMAINS="${TLS_DOMAINS:-${MAIN_DOMAIN},${SWITCH_DOMAIN},${DASHBOARD_DOMAIN}}"
+
+if [ -z "$MAIN_DOMAIN" ]; then
+  echo "ERROR: MAIN_DOMAIN 不能为空"
+  exit 1
+fi
+
+if [ "$SHOW_ONLY" = "1" ]; then
+  cat <<EOF
+MAIN_DOMAIN=${MAIN_DOMAIN}
+SWITCH_DOMAIN=${SWITCH_DOMAIN}
+DASHBOARD_DOMAIN=${DASHBOARD_DOMAIN}
+PREVIEW_DOMAIN=${PREVIEW_DOMAIN}
+ENABLE_PREVIEW_SERVER=${ENABLE_PREVIEW_SERVER}
+WORKER_PORT=${WORKER_PORT}
+DASHBOARD_PORT=${DASHBOARD_PORT}
+CERT_EMAIL=${CERT_EMAIL}
+NGINX_CONTAINER=${NGINX_CONTAINER}
+TLS_DOMAINS=${TLS_DOMAINS}
+EOF
+  exit 0
+fi
+
+mkdir -p "${SCRIPT_DIR}/certs" "${SCRIPT_DIR}/www/.well-known/acme-challenge"
+
+sed \
+  -e "s/{{MAIN_DOMAIN}}/${MAIN_DOMAIN}/g" \
+  -e "s/{{PREVIEW_DOMAIN}}/${PREVIEW_DOMAIN}/g" \
+  -e "s/{{WORKER_PORT}}/${WORKER_PORT}/g" \
+  -e "s/{{MASTER_PORT}}/${DASHBOARD_PORT}/g" \
+  "${SCRIPT_DIR}/cds-nginx.conf.template" > "${SCRIPT_DIR}/cds-nginx.conf"
+
+cp "${SCRIPT_DIR}/nginx.conf.template" "${SCRIPT_DIR}/nginx.conf"
+
+sed \
+  -e "s|__CONFIG_FILE__|${CONFIG_FILE}|g" \
+  "${SCRIPT_DIR}/acme.sh.template" > "${SCRIPT_DIR}/acme_apply.sh"
+
+chmod +x "${SCRIPT_DIR}/acme_apply.sh"
+
+echo "已生成:"
+echo "  ${SCRIPT_DIR}/nginx.conf"
+echo "  ${SCRIPT_DIR}/cds-nginx.conf"
+echo "  ${SCRIPT_DIR}/acme_apply.sh"


### PR DESCRIPTION
## Summary
- fold CDS nginx/domain bootstrap into `cds/` so setup is self-contained
- add `cds/nginx/domain.env.example`, `init_domain.sh`, and `acme.sh.template`
- make `exec_cds.sh` trigger interactive setup on first run when nginx/domain config is missing
- store CDS local runtime env in `cds/.cds.env` instead of writing `~/.bashrc`
- ignore generated nginx config, certs, webroot challenge files, and local env files

## What To Test
1. `cd prd_agent/cds && ./exec_cds.sh`
2. On first run, enter the main domain when prompted and accept the default preview domain.
3. Confirm these files are generated under `cds/nginx/`: `domain.env`, `nginx.conf`, `cds-nginx.conf`, `acme_apply.sh`
4. Optionally run `cd cds/nginx && ./acme_apply.sh` on a server that should issue certificates.
5. Re-run `./exec_cds.sh` and confirm CDS starts with the generated local config.

## Notes
- certificate files and generated nginx artifacts are gitignored intentionally
- wildcard preview HTTPS still requires DNS challenge if you want `*.preview-domain` certificates