### PR TITLE
Unify CDS root entrypoints

### DIFF
--- a/cds/exec_cds.sh
+++ b/cds/exec_cds.sh
@@ -1,10 +1,17 @@
 #!/usr/bin/env bash
 # ──────────────────────────────────────────────
-# CDS 一键启动脚本
+# CDS 统一入口脚本
 #
 # 用法：
-#   ./exec_cds.sh                # 前台运行
-#   ./exec_cds.sh --background   # 后台运行
+#   ./exec_cds.sh                  # 前台运行 CDS，并自动准备/启动 nginx
+#   ./exec_cds.sh --background     # 后台运行 CDS，并自动准备/启动 nginx
+#   ./exec_cds.sh setup            # 交互式初始化，唯一用户配置入口是 cds/.cds.env
+#   ./exec_cds.sh nginx up         # 根目录管理 nginx
+#   ./exec_cds.sh nginx restart
+#   ./exec_cds.sh nginx status
+#   ./exec_cds.sh nginx logs
+#   ./exec_cds.sh nginx render     # 只重建内部 nginx 配置
+#   ./exec_cds.sh cert             # 在根目录发起证书签发
 #
 # 环境变量（可选）：
 #   CDS_USERNAME       — 登录用户名（不设置则不启用认证）
@@ -14,7 +21,6 @@
 #   CDS_MAIN_DOMAIN    — 主域名
 #   CDS_PREVIEW_DOMAIN — 预览域名后缀
 #   CDS_CONFIG         — 配置文件路径（默认 cds.config.json）
-#   CDS_NGINX_ENABLE   — 设为 1 启用 nginx 转发（端口 58000）
 # ──────────────────────────────────────────────
 
 set -euo pipefail
@@ -25,9 +31,13 @@ cd "$SCRIPT_DIR"
 CONFIG_FILE="${CDS_CONFIG:-${BT_CONFIG:-cds.config.json}}"
 NGINX_DOMAIN_ENV="$SCRIPT_DIR/nginx/domain.env"
 LOCAL_ENV_FILE="$SCRIPT_DIR/.cds.env"
+NGINX_START_SCRIPT="$SCRIPT_DIR/nginx/start_nginx.sh"
+ACME_SCRIPT="$SCRIPT_DIR/nginx/acme_apply.sh"
 BACKGROUND=false
 LOG_FILE="cds.log"
 PID_FILE=".cds/cds.pid"
+ROOT_COMMAND="${1:-start}"
+ROOT_SUBCOMMAND="${2:-}"
 
 # Parse args
 for arg in "$@"; do
@@ -36,10 +46,16 @@ for arg in "$@"; do
   esac
 done
 
-ensure_domain_bootstrap() {
-  local main_domain="${CDS_MAIN_DOMAIN:-${MAIN_DOMAIN:-}}"
+sync_nginx_internal_files() {
+  if [ ! -f "$LOCAL_ENV_FILE" ]; then
+    return 1
+  fi
+  ./exec_setup.sh --nginx-only >/dev/null
+}
 
-  if [ -f "$NGINX_DOMAIN_ENV" ]; then
+ensure_domain_bootstrap() {
+  if [ -f "$LOCAL_ENV_FILE" ]; then
+    sync_nginx_internal_files
     return 0
   fi
 
@@ -50,17 +66,19 @@ ensure_domain_bootstrap() {
   echo ""
 
   if [ ! -t 0 ]; then
-    echo "ERROR: 当前为非交互环境，且缺少 nginx/domain.env 或 CDS_MAIN_DOMAIN。"
+    echo "ERROR: 当前为非交互环境，且缺少 .cds.env。"
     echo "请先手动执行: ./exec_setup.sh"
     exit 1
   fi
 
   ./exec_setup.sh
 
-  if [ ! -f "$NGINX_DOMAIN_ENV" ]; then
+  if [ ! -f "$LOCAL_ENV_FILE" ]; then
     echo "ERROR: 初始化未完成，已取消启动。"
     exit 1
   fi
+
+  sync_nginx_internal_files
 }
 
 load_domain_env() {
@@ -84,6 +102,51 @@ load_domain_env() {
   export CDS_DASHBOARD_DOMAIN="${CDS_DASHBOARD_DOMAIN:-${DASHBOARD_DOMAIN:-cds.${MAIN_DOMAIN:-}}}"
 }
 
+run_root_nginx_action() {
+  local action="${1:-up}"
+  ensure_domain_bootstrap
+  load_domain_env
+
+  case "$action" in
+    render)
+      ./exec_setup.sh --nginx-only
+      ;;
+    up|down|restart|reload|status|logs)
+      ./exec_setup.sh --nginx-only >/dev/null
+      "$NGINX_START_SCRIPT" "$action"
+      ;;
+    *)
+      echo "Unknown nginx action: $action"
+      echo "Usage: ./exec_cds.sh nginx [up|down|restart|reload|status|logs|render]"
+      exit 1
+      ;;
+  esac
+}
+
+run_root_cert_action() {
+  ensure_domain_bootstrap
+  load_domain_env
+  ./exec_setup.sh --nginx-only >/dev/null
+  "$ACME_SCRIPT" "$@"
+}
+
+case "$ROOT_COMMAND" in
+  setup|init|config)
+    exec ./exec_setup.sh
+    ;;
+  nginx)
+    run_root_nginx_action "${ROOT_SUBCOMMAND:-up}"
+    exit 0
+    ;;
+  cert|tls)
+    shift || true
+    run_root_cert_action "$@"
+    exit 0
+    ;;
+  start|--background|-d)
+    ;;
+esac
+
 echo ""
 echo "  CDS Startup"
 echo "  ─────────────────────"
@@ -91,8 +154,7 @@ echo "  Directory:  $SCRIPT_DIR"
 echo "  Config:     $CONFIG_FILE"
 CDS_AUTH_USER="${CDS_USERNAME:-${BT_USERNAME:-}}"
 echo "  Auth:       ${CDS_AUTH_USER:+enabled (user: $CDS_AUTH_USER)}${CDS_AUTH_USER:-disabled}"
-CDS_NGINX="${CDS_NGINX_ENABLE:-${BT_NGINX_ENABLE:-}}"
-echo "  Nginx:      ${CDS_NGINX:+enabled (port 58000)}${CDS_NGINX:-disabled}"
+echo "  Nginx:      auto-managed from ./exec_cds.sh nginx <action>"
 echo ""
 
 ensure_domain_bootstrap
@@ -123,22 +185,17 @@ else
   echo "[1/3] Dependencies OK"
 fi
 
-# ── 3. Setup nginx (optional) ──
-if [ "${CDS_NGINX}" = "1" ]; then
-  echo "[2/3] Setting up nginx reverse proxy on :58000..."
-  NGINX_CONF_DIR="/etc/nginx/conf.d"
-  CDS_NGINX_CONF="$SCRIPT_DIR/nginx/cds-nginx.conf"
-
-  if [ -f "$CDS_NGINX_CONF" ]; then
-    if [ -d "$NGINX_CONF_DIR" ]; then
-      sudo cp "$CDS_NGINX_CONF" "$NGINX_CONF_DIR/cds.conf"
-      sudo nginx -t 2>/dev/null && sudo nginx -s reload 2>/dev/null && echo "  Nginx: OK (port 58000)" || echo "  Nginx: config test failed (skipped)"
-    else
-      echo "  Nginx: $NGINX_CONF_DIR not found (skipped)"
-    fi
+# ── 3. Setup nginx ──
+echo "[2/3] Preparing nginx..."
+if [ -x "$NGINX_START_SCRIPT" ]; then
+  ./exec_setup.sh --nginx-only >/dev/null
+  if "$NGINX_START_SCRIPT" up; then
+    echo "  Nginx: OK"
+  else
+    echo "  [WARN] Nginx failed to start automatically. Use ./exec_cds.sh nginx logs to inspect."
   fi
 else
-  echo "[2/3] Nginx: skipped (set CDS_NGINX_ENABLE=1 to enable)"
+  echo "  [WARN] Nginx start script missing: $NGINX_START_SCRIPT"
 fi
 
 # ── 4. Start CDS ──
@@ -274,7 +331,7 @@ reuse_running_cds_if_present() {
   echo "  Log:        $SCRIPT_DIR/$LOG_FILE"
   echo "  Dashboard:  http://localhost:${MASTER_PORT}"
   echo "  Gateway:    http://localhost:${WORKER_PORT}"
-  [ "${CDS_NGINX}" = "1" ] && echo "  Nginx:      http://localhost:58000"
+  echo "  Nginx:      ./exec_cds.sh nginx status"
   echo ""
   echo "  Stop: kill \$(cat $PID_FILE)"
   echo "  Logs: tail -f $LOG_FILE"
@@ -349,7 +406,7 @@ if [ "$BACKGROUND" = true ]; then
   echo "  Log:        $SCRIPT_DIR/$LOG_FILE"
   echo "  Dashboard:  http://localhost:${MASTER_PORT}"
   echo "  Gateway:    http://localhost:${WORKER_PORT}"
-  [ "${CDS_NGINX}" = "1" ] && echo "  Nginx:      http://localhost:58000"
+  echo "  Nginx:      ./exec_cds.sh nginx status"
   echo ""
   echo "  Stop: kill \$(cat $PID_FILE)"
   echo "  Logs: tail -f $LOG_FILE"

--- a/cds/exec_setup.sh
+++ b/cds/exec_setup.sh
@@ -4,8 +4,8 @@
 #
 # 功能：
 #   1. 交互式收集配置（账号密码、域名等）
-#   2. 写入 ~/.bashrc（CDS 系统层环境变量）
-#   3. 生成 CDS 自带 Nginx 配置、Compose 与证书脚本
+#   2. 写入 cds/.cds.env（唯一用户配置入口）
+#   3. 自动生成 CDS 自带 Nginx 配置、Compose 与证书脚本
 #
 # 用法：
 #   ./exec_setup.sh              # 交互式配置
@@ -17,7 +17,6 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TEMPLATE_DIR="$SCRIPT_DIR/nginx"
-BASHRC="$HOME/.bashrc"
 LOCAL_ENV_FILE="$SCRIPT_DIR/.cds.env"
 NGINX_DIR="$SCRIPT_DIR/nginx"
 NGINX_DOMAIN_ENV="$NGINX_DIR/domain.env"
@@ -35,7 +34,7 @@ ok()    { echo -e "${GREEN}[OK]${NC} $*"; }
 warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
 err()   { echo -e "${RED}[ERROR]${NC} $*"; }
 
-# ── Helper: read current value from local env / bashrc ──
+# ── Helper: read current value from local env / legacy env ──
 get_config_var() {
     local var_name="$1"
     local val=""
@@ -46,7 +45,7 @@ get_config_var() {
         printf '%s\n' "$val"
         return 0
     fi
-    grep "^export ${var_name}=" "$BASHRC" 2>/dev/null | tail -1 | sed "s/^export ${var_name}=\"\(.*\)\"/\1/" || echo ""
+    printf '%s\n' "${!var_name:-}"
 }
 
 # ── Helper: prompt with default ──
@@ -127,6 +126,7 @@ generate_nginx() {
     local worker_port="${5:-5500}"
     local master_port="${6:-9900}"
     local output_dir="${7:-$SCRIPT_DIR/nginx}"
+    local source_env="${8:-$LOCAL_ENV_FILE}"
     local domain_env="${output_dir}/domain.env"
     local tls_domains
 
@@ -138,6 +138,8 @@ generate_nginx() {
     mkdir -p "${output_dir}/certs" "${output_dir}/www/.well-known/acme-challenge"
 
     cat > "$domain_env" <<EOF
+# internal generated file; edit cds/.cds.env then rerun ./exec_setup.sh or ./exec_cds.sh nginx render
+# source: ${source_env}
 MAIN_DOMAIN="${main_domain}"
 SWITCH_DOMAIN="${switch_domain}"
 DASHBOARD_DOMAIN="${dashboard_domain}"
@@ -223,7 +225,7 @@ main() {
             dashboard=$(get_config_var "CDS_DASHBOARD_DOMAIN")
             [ -z "$dashboard" ] && dashboard=$(get_config_var "DASHBOARD_DOMAIN")
             [ -z "$dashboard" ] && dashboard="cds.${domain}"
-            generate_nginx "$domain" "$preview" "$switch" "$dashboard"
+            generate_nginx "$domain" "$preview" "$switch" "$dashboard" "5500" "9900" "$NGINX_DIR" "$LOCAL_ENV_FILE"
             return 0
             ;;
     esac
@@ -310,7 +312,7 @@ main() {
     write_local_env "$new_user" "$new_pass" "$new_jwt" "$new_switch" "$new_main" "$new_preview" "$new_dashboard"
 
     info "生成 Nginx 配置 ..."
-    generate_nginx "$new_main" "$new_preview" "$new_switch" "$new_dashboard"
+    generate_nginx "$new_main" "$new_preview" "$new_switch" "$new_dashboard" "5500" "9900" "$NGINX_DIR" "$LOCAL_ENV_FILE"
 
     echo ""
     echo "  ════════════════════════════════"
@@ -318,9 +320,9 @@ main() {
     echo "  ════════════════════════════════"
     echo ""
     echo "  下一步："
-    echo "    1. 启动 Nginx: cd $NGINX_DIR && ./start_nginx.sh"
-    echo "    2. 如需证书: cd $NGINX_DIR && ./acme_apply.sh"
-    echo "    3. cd $SCRIPT_DIR && ./exec_cds.sh"
+    echo "    1. 启动 CDS 与 Nginx: cd $SCRIPT_DIR && ./exec_cds.sh"
+    echo "    2. 如需签发证书:      cd $SCRIPT_DIR && ./exec_cds.sh cert"
+    echo "    3. 查看 Nginx 状态:   cd $SCRIPT_DIR && ./exec_cds.sh nginx status"
     echo "    4. 访问 https://${new_dashboard}"
     echo ""
 }

--- a/cds/nginx/domain.env.example
+++ b/cds/nginx/domain.env.example
@@ -1,5 +1,7 @@
-# 复制为 domain.env 后修改，再执行:
-#   ./init_domain.sh
+# 这是内部模板。正常使用请编辑 cds/.cds.env，
+# 然后在 cds 根目录执行:
+#   ./exec_setup.sh
+#   ./exec_cds.sh nginx render
 
 MAIN_DOMAIN="miduo.org"
 SWITCH_DOMAIN="switch.miduo.org"

--- a/cds/nginx/init_domain.sh
+++ b/cds/nginx/init_domain.sh
@@ -13,7 +13,8 @@ Usage:
   ./nginx/init_domain.sh --config /path/to/domain.env
 
 作用:
-  - 从 domain.env 生成 nginx.conf / cds-nginx.conf / acme_apply.sh
+  - 从内部 domain.env 生成 nginx.conf / cds-nginx.conf / acme_apply.sh
+  - 正常使用请在 cds 根目录执行: ./exec_cds.sh nginx render
 EOF
 }
 
@@ -40,8 +41,8 @@ while [ $# -gt 0 ]; do
 done
 
 if [ ! -f "$CONFIG_FILE" ]; then
-  echo "ERROR: 配置文件不存在: $CONFIG_FILE"
-  echo "先执行: cp ${SCRIPT_DIR}/domain.env.example ${SCRIPT_DIR}/domain.env"
+  echo "ERROR: 内部配置文件不存在: $CONFIG_FILE"
+  echo "请回到 cds 根目录执行: ./exec_setup.sh"
   exit 1
 fi
 

--- a/cds/nginx/start_nginx.sh
+++ b/cds/nginx/start_nginx.sh
@@ -20,7 +20,8 @@ Usage:
 
 说明:
   - 默认动作是 up
-  - 会读取 ./domain.env 中的 NGINX_CONTAINER
+  - 会读取内部生成的 ./domain.env
+  - 正常使用请在 cds 根目录执行: ./exec_cds.sh nginx <action>
   - 会自动检查 ./nginx.conf 与 ./cds-nginx.conf 是否存在
 EOF
 }
@@ -28,10 +29,11 @@ EOF
 ACTION="${1:-up}"
 
 if [ ! -f "$CONFIG_FILE" ]; then
-  echo "ERROR: 配置文件不存在: $CONFIG_FILE"
-  echo "先执行:"
-  echo "  cp ${SCRIPT_DIR}/domain.env.example ${SCRIPT_DIR}/domain.env"
-  echo "  ${SCRIPT_DIR}/init_domain.sh"
+  echo "ERROR: 内部配置文件不存在: $CONFIG_FILE"
+  echo "请回到 cds 根目录执行:"
+  echo "  ./exec_setup.sh"
+  echo "或"
+  echo "  ./exec_cds.sh nginx render"
   exit 1
 fi
 
@@ -60,8 +62,8 @@ render_compose() {
 
 ensure_rendered() {
   if [ ! -f "${SCRIPT_DIR}/nginx.conf" ] || [ ! -f "${SCRIPT_DIR}/cds-nginx.conf" ]; then
-    echo "ERROR: nginx 配置不存在，请先执行:"
-    echo "  ${SCRIPT_DIR}/init_domain.sh"
+    echo "ERROR: nginx 配置不存在，请回到 cds 根目录执行:"
+    echo "  ./exec_cds.sh nginx render"
     exit 1
   fi
   mkdir -p "${SCRIPT_DIR}/certs" "${SCRIPT_DIR}/www/.well-known/acme-challenge"
@@ -71,7 +73,7 @@ ensure_rendered() {
     SERVER_CONF_FILE="cds-nginx.http.conf"
     if [ ! -f "${SCRIPT_DIR}/${SERVER_CONF_FILE}" ]; then
       echo "ERROR: 缺少 HTTP bootstrap 配置: ${SCRIPT_DIR}/${SERVER_CONF_FILE}"
-      echo "请先执行: ${SCRIPT_DIR}/init_domain.sh"
+      echo "请回到 cds 根目录执行: ./exec_cds.sh nginx render"
       exit 1
     fi
     echo "No certificate found for ${MAIN_DOMAIN}, starting nginx in HTTP bootstrap mode."


### PR DESCRIPTION
## Summary
- make `cds/.cds.env` the primary user-facing config entrypoint
- add root-level nginx/cert commands to `cds/exec_cds.sh`
- treat `cds/nginx/domain.env` as generated internal state instead of a user-edited file
- update nginx helper messaging to keep users in the `cds` root directory

## Validation
- `bash -n cds/exec_setup.sh`
- `bash -n cds/exec_cds.sh`
- `bash -n cds/nginx/start_nginx.sh`
- `bash -n cds/nginx/init_domain.sh`
- `cd cds && ./exec_setup.sh --nginx-only`
- `cd cds && ./exec_cds.sh nginx render`
- `cd cds && ./exec_cds.sh nginx status`