### PR TITLE
Simplify CDS root domain routing

### DIFF
--- a/cds/exec_cds.sh
+++ b/cds/exec_cds.sh
@@ -96,10 +96,16 @@ load_domain_env() {
   . "$NGINX_DOMAIN_ENV"
   set +a
 
-  export CDS_MAIN_DOMAIN="${CDS_MAIN_DOMAIN:-${MAIN_DOMAIN:-}}"
+  local primary_domain="${PRIMARY_DOMAIN:-}"
+  if [ -z "$primary_domain" ] && [ -n "${ROOT_DOMAINS:-}" ]; then
+    primary_domain="$(printf '%s' "${ROOT_DOMAINS}" | cut -d',' -f1 | xargs)"
+  fi
+
+  export CDS_ROOT_DOMAINS="${CDS_ROOT_DOMAINS:-${ROOT_DOMAINS:-}}"
+  export CDS_MAIN_DOMAIN="${CDS_MAIN_DOMAIN:-${MAIN_DOMAIN:-${primary_domain}}}"
   export CDS_SWITCH_DOMAIN="${CDS_SWITCH_DOMAIN:-${SWITCH_DOMAIN:-}}"
-  export CDS_PREVIEW_DOMAIN="${CDS_PREVIEW_DOMAIN:-${PREVIEW_DOMAIN:-${MAIN_DOMAIN:-}}}"
-  export CDS_DASHBOARD_DOMAIN="${CDS_DASHBOARD_DOMAIN:-${DASHBOARD_DOMAIN:-cds.${MAIN_DOMAIN:-}}}"
+  export CDS_PREVIEW_DOMAIN="${CDS_PREVIEW_DOMAIN:-${PREVIEW_DOMAIN:-${primary_domain}}}"
+  export CDS_DASHBOARD_DOMAIN="${CDS_DASHBOARD_DOMAIN:-${DASHBOARD_DOMAIN:-${primary_domain}}}"
 }
 
 run_root_nginx_action() {

--- a/cds/exec_cds.sh
+++ b/cds/exec_cds.sh
@@ -1,10 +1,17 @@
 #!/usr/bin/env bash
 # ──────────────────────────────────────────────
-# CDS 一键启动脚本
+# CDS 统一入口脚本
 #
 # 用法：
-#   ./exec_cds.sh                # 前台运行
-#   ./exec_cds.sh --background   # 后台运行
+#   ./exec_cds.sh                  # 前台运行 CDS，并自动准备/启动 nginx
+#   ./exec_cds.sh --background     # 后台运行 CDS，并自动准备/启动 nginx
+#   ./exec_cds.sh setup            # 交互式初始化，唯一用户配置入口是 cds/.cds.env
+#   ./exec_cds.sh nginx up         # 根目录管理 nginx
+#   ./exec_cds.sh nginx restart
+#   ./exec_cds.sh nginx status
+#   ./exec_cds.sh nginx logs
+#   ./exec_cds.sh nginx render     # 只重建内部 nginx 配置
+#   ./exec_cds.sh cert             # 在根目录发起证书签发
 #
 # 环境变量（可选）：
 #   CDS_USERNAME       — 登录用户名（不设置则不启用认证）
@@ -14,7 +21,6 @@
 #   CDS_MAIN_DOMAIN    — 主域名
 #   CDS_PREVIEW_DOMAIN — 预览域名后缀
 #   CDS_CONFIG         — 配置文件路径（默认 cds.config.json）
-#   CDS_NGINX_ENABLE   — 设为 1 启用 nginx 转发（端口 58000）
 # ──────────────────────────────────────────────
 
 set -euo pipefail
@@ -25,9 +31,13 @@ cd "$SCRIPT_DIR"
 CONFIG_FILE="${CDS_CONFIG:-${BT_CONFIG:-cds.config.json}}"
 NGINX_DOMAIN_ENV="$SCRIPT_DIR/nginx/domain.env"
 LOCAL_ENV_FILE="$SCRIPT_DIR/.cds.env"
+NGINX_START_SCRIPT="$SCRIPT_DIR/nginx/start_nginx.sh"
+ACME_SCRIPT="$SCRIPT_DIR/nginx/acme_apply.sh"
 BACKGROUND=false
 LOG_FILE="cds.log"
 PID_FILE=".cds/cds.pid"
+ROOT_COMMAND="${1:-start}"
+ROOT_SUBCOMMAND="${2:-}"
 
 # Parse args
 for arg in "$@"; do
@@ -36,10 +46,16 @@ for arg in "$@"; do
   esac
 done
 
-ensure_domain_bootstrap() {
-  local main_domain="${CDS_MAIN_DOMAIN:-${MAIN_DOMAIN:-}}"
+sync_nginx_internal_files() {
+  if [ ! -f "$LOCAL_ENV_FILE" ]; then
+    return 1
+  fi
+  ./exec_setup.sh --nginx-only >/dev/null
+}
 
-  if [ -f "$NGINX_DOMAIN_ENV" ]; then
+ensure_domain_bootstrap() {
+  if [ -f "$LOCAL_ENV_FILE" ]; then
+    sync_nginx_internal_files
     return 0
   fi
 
@@ -50,17 +66,19 @@ ensure_domain_bootstrap() {
   echo ""
 
   if [ ! -t 0 ]; then
-    echo "ERROR: 当前为非交互环境，且缺少 nginx/domain.env 或 CDS_MAIN_DOMAIN。"
+    echo "ERROR: 当前为非交互环境，且缺少 .cds.env。"
     echo "请先手动执行: ./exec_setup.sh"
     exit 1
   fi
 
   ./exec_setup.sh
 
-  if [ ! -f "$NGINX_DOMAIN_ENV" ]; then
+  if [ ! -f "$LOCAL_ENV_FILE" ]; then
     echo "ERROR: 初始化未完成，已取消启动。"
     exit 1
   fi
+
+  sync_nginx_internal_files
 }
 
 load_domain_env() {
@@ -84,6 +102,51 @@ load_domain_env() {
   export CDS_DASHBOARD_DOMAIN="${CDS_DASHBOARD_DOMAIN:-${DASHBOARD_DOMAIN:-cds.${MAIN_DOMAIN:-}}}"
 }
 
+run_root_nginx_action() {
+  local action="${1:-up}"
+  ensure_domain_bootstrap
+  load_domain_env
+
+  case "$action" in
+    render)
+      ./exec_setup.sh --nginx-only
+      ;;
+    up|down|restart|reload|status|logs)
+      ./exec_setup.sh --nginx-only >/dev/null
+      "$NGINX_START_SCRIPT" "$action"
+      ;;
+    *)
+      echo "Unknown nginx action: $action"
+      echo "Usage: ./exec_cds.sh nginx [up|down|restart|reload|status|logs|render]"
+      exit 1
+      ;;
+  esac
+}
+
+run_root_cert_action() {
+  ensure_domain_bootstrap
+  load_domain_env
+  ./exec_setup.sh --nginx-only >/dev/null
+  "$ACME_SCRIPT" "$@"
+}
+
+case "$ROOT_COMMAND" in
+  setup|init|config)
+    exec ./exec_setup.sh
+    ;;
+  nginx)
+    run_root_nginx_action "${ROOT_SUBCOMMAND:-up}"
+    exit 0
+    ;;
+  cert|tls)
+    shift || true
+    run_root_cert_action "$@"
+    exit 0
+    ;;
+  start|--background|-d)
+    ;;
+esac
+
 echo ""
 echo "  CDS Startup"
 echo "  ─────────────────────"
@@ -91,8 +154,7 @@ echo "  Directory:  $SCRIPT_DIR"
 echo "  Config:     $CONFIG_FILE"
 CDS_AUTH_USER="${CDS_USERNAME:-${BT_USERNAME:-}}"
 echo "  Auth:       ${CDS_AUTH_USER:+enabled (user: $CDS_AUTH_USER)}${CDS_AUTH_USER:-disabled}"
-CDS_NGINX="${CDS_NGINX_ENABLE:-${BT_NGINX_ENABLE:-}}"
-echo "  Nginx:      ${CDS_NGINX:+enabled (port 58000)}${CDS_NGINX:-disabled}"
+echo "  Nginx:      auto-managed from ./exec_cds.sh nginx <action>"
 echo ""
 
 ensure_domain_bootstrap
@@ -123,22 +185,17 @@ else
   echo "[1/3] Dependencies OK"
 fi
 
-# ── 3. Setup nginx (optional) ──
-if [ "${CDS_NGINX}" = "1" ]; then
-  echo "[2/3] Setting up nginx reverse proxy on :58000..."
-  NGINX_CONF_DIR="/etc/nginx/conf.d"
-  CDS_NGINX_CONF="$SCRIPT_DIR/nginx/cds-nginx.conf"
-
-  if [ -f "$CDS_NGINX_CONF" ]; then
-    if [ -d "$NGINX_CONF_DIR" ]; then
-      sudo cp "$CDS_NGINX_CONF" "$NGINX_CONF_DIR/cds.conf"
-      sudo nginx -t 2>/dev/null && sudo nginx -s reload 2>/dev/null && echo "  Nginx: OK (port 58000)" || echo "  Nginx: config test failed (skipped)"
-    else
-      echo "  Nginx: $NGINX_CONF_DIR not found (skipped)"
-    fi
+# ── 3. Setup nginx ──
+echo "[2/3] Preparing nginx..."
+if [ -x "$NGINX_START_SCRIPT" ]; then
+  ./exec_setup.sh --nginx-only >/dev/null
+  if "$NGINX_START_SCRIPT" up; then
+    echo "  Nginx: OK"
+  else
+    echo "  [WARN] Nginx failed to start automatically. Use ./exec_cds.sh nginx logs to inspect."
   fi
 else
-  echo "[2/3] Nginx: skipped (set CDS_NGINX_ENABLE=1 to enable)"
+  echo "  [WARN] Nginx start script missing: $NGINX_START_SCRIPT"
 fi
 
 # ── 4. Start CDS ──
@@ -274,7 +331,7 @@ reuse_running_cds_if_present() {
   echo "  Log:        $SCRIPT_DIR/$LOG_FILE"
   echo "  Dashboard:  http://localhost:${MASTER_PORT}"
   echo "  Gateway:    http://localhost:${WORKER_PORT}"
-  [ "${CDS_NGINX}" = "1" ] && echo "  Nginx:      http://localhost:58000"
+  echo "  Nginx:      ./exec_cds.sh nginx status"
   echo ""
   echo "  Stop: kill \$(cat $PID_FILE)"
   echo "  Logs: tail -f $LOG_FILE"
@@ -349,7 +406,7 @@ if [ "$BACKGROUND" = true ]; then
   echo "  Log:        $SCRIPT_DIR/$LOG_FILE"
   echo "  Dashboard:  http://localhost:${MASTER_PORT}"
   echo "  Gateway:    http://localhost:${WORKER_PORT}"
-  [ "${CDS_NGINX}" = "1" ] && echo "  Nginx:      http://localhost:58000"
+  echo "  Nginx:      ./exec_cds.sh nginx status"
   echo ""
   echo "  Stop: kill \$(cat $PID_FILE)"
   echo "  Logs: tail -f $LOG_FILE"

--- a/cds/exec_setup.sh
+++ b/cds/exec_setup.sh
@@ -4,8 +4,8 @@
 #
 # 功能：
 #   1. 交互式收集配置（账号密码、域名等）
-#   2. 写入 ~/.bashrc（CDS 系统层环境变量）
-#   3. 生成 CDS 自带 Nginx 配置、Compose 与证书脚本
+#   2. 写入 cds/.cds.env（唯一用户配置入口）
+#   3. 自动生成 CDS 自带 Nginx 配置、Compose 与证书脚本
 #
 # 用法：
 #   ./exec_setup.sh              # 交互式配置
@@ -17,7 +17,6 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TEMPLATE_DIR="$SCRIPT_DIR/nginx"
-BASHRC="$HOME/.bashrc"
 LOCAL_ENV_FILE="$SCRIPT_DIR/.cds.env"
 NGINX_DIR="$SCRIPT_DIR/nginx"
 NGINX_DOMAIN_ENV="$NGINX_DIR/domain.env"
@@ -35,7 +34,7 @@ ok()    { echo -e "${GREEN}[OK]${NC} $*"; }
 warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
 err()   { echo -e "${RED}[ERROR]${NC} $*"; }
 
-# ── Helper: read current value from local env / bashrc ──
+# ── Helper: read current value from local env / legacy env ──
 get_config_var() {
     local var_name="$1"
     local val=""
@@ -46,7 +45,7 @@ get_config_var() {
         printf '%s\n' "$val"
         return 0
     fi
-    grep "^export ${var_name}=" "$BASHRC" 2>/dev/null | tail -1 | sed "s/^export ${var_name}=\"\(.*\)\"/\1/" || echo ""
+    printf '%s\n' "${!var_name:-}"
 }
 
 # ── Helper: prompt with default ──
@@ -127,6 +126,7 @@ generate_nginx() {
     local worker_port="${5:-5500}"
     local master_port="${6:-9900}"
     local output_dir="${7:-$SCRIPT_DIR/nginx}"
+    local source_env="${8:-$LOCAL_ENV_FILE}"
     local domain_env="${output_dir}/domain.env"
     local tls_domains
 
@@ -138,6 +138,8 @@ generate_nginx() {
     mkdir -p "${output_dir}/certs" "${output_dir}/www/.well-known/acme-challenge"
 
     cat > "$domain_env" <<EOF
+# internal generated file; edit cds/.cds.env then rerun ./exec_setup.sh or ./exec_cds.sh nginx render
+# source: ${source_env}
 MAIN_DOMAIN="${main_domain}"
 SWITCH_DOMAIN="${switch_domain}"
 DASHBOARD_DOMAIN="${dashboard_domain}"
@@ -223,7 +225,7 @@ main() {
             dashboard=$(get_config_var "CDS_DASHBOARD_DOMAIN")
             [ -z "$dashboard" ] && dashboard=$(get_config_var "DASHBOARD_DOMAIN")
             [ -z "$dashboard" ] && dashboard="cds.${domain}"
-            generate_nginx "$domain" "$preview" "$switch" "$dashboard"
+            generate_nginx "$domain" "$preview" "$switch" "$dashboard" "5500" "9900" "$NGINX_DIR" "$LOCAL_ENV_FILE"
             return 0
             ;;
     esac
@@ -310,7 +312,7 @@ main() {
     write_local_env "$new_user" "$new_pass" "$new_jwt" "$new_switch" "$new_main" "$new_preview" "$new_dashboard"
 
     info "生成 Nginx 配置 ..."
-    generate_nginx "$new_main" "$new_preview" "$new_switch" "$new_dashboard"
+    generate_nginx "$new_main" "$new_preview" "$new_switch" "$new_dashboard" "5500" "9900" "$NGINX_DIR" "$LOCAL_ENV_FILE"
 
     echo ""
     echo "  ════════════════════════════════"
@@ -318,9 +320,9 @@ main() {
     echo "  ════════════════════════════════"
     echo ""
     echo "  下一步："
-    echo "    1. 启动 Nginx: cd $NGINX_DIR && ./start_nginx.sh"
-    echo "    2. 如需证书: cd $NGINX_DIR && ./acme_apply.sh"
-    echo "    3. cd $SCRIPT_DIR && ./exec_cds.sh"
+    echo "    1. 启动 CDS 与 Nginx: cd $SCRIPT_DIR && ./exec_cds.sh"
+    echo "    2. 如需签发证书:      cd $SCRIPT_DIR && ./exec_cds.sh cert"
+    echo "    3. 查看 Nginx 状态:   cd $SCRIPT_DIR && ./exec_cds.sh nginx status"
     echo "    4. 访问 https://${new_dashboard}"
     echo ""
 }

--- a/cds/exec_setup.sh
+++ b/cds/exec_setup.sh
@@ -87,7 +87,7 @@ show_config() {
     echo -e "  ${BOLD}CDS 当前配置${NC}"
     echo "  ─────────────────────────────"
 
-    local vars=(CDS_USERNAME CDS_PASSWORD CDS_JWT_SECRET CDS_SWITCH_DOMAIN CDS_MAIN_DOMAIN CDS_PREVIEW_DOMAIN CDS_DASHBOARD_DOMAIN)
+    local vars=(CDS_USERNAME CDS_PASSWORD CDS_JWT_SECRET CDS_ROOT_DOMAINS)
     local secrets=(CDS_PASSWORD CDS_JWT_SECRET)
 
     for var in "${vars[@]}"; do
@@ -99,10 +99,7 @@ show_config() {
                 CDS_USERNAME) val=$(get_config_var "BT_USERNAME") ;;
                 CDS_PASSWORD) val=$(get_config_var "BT_PASSWORD") ;;
                 CDS_JWT_SECRET) val=$(get_config_var "JWT_SECRET") ;;
-                CDS_SWITCH_DOMAIN) val=$(get_config_var "SWITCH_DOMAIN") ;;
-                CDS_MAIN_DOMAIN) val=$(get_config_var "MAIN_DOMAIN") ;;
-                CDS_PREVIEW_DOMAIN) val=$(get_config_var "PREVIEW_DOMAIN") ;;
-                CDS_DASHBOARD_DOMAIN) val=$(get_config_var "DASHBOARD_DOMAIN") ;;
+                CDS_ROOT_DOMAINS) val=$(get_config_var "ROOT_DOMAINS") ;;
             esac
         fi
 
@@ -117,37 +114,46 @@ show_config() {
     echo ""
 }
 
+cleanup_generated_nginx() {
+    local output_dir="${1:-$NGINX_DIR}"
+    rm -f \
+      "${output_dir}/domain.env" \
+      "${output_dir}/nginx.conf" \
+      "${output_dir}/cds-nginx.conf" \
+      "${output_dir}/cds-nginx.http.conf" \
+      "${output_dir}/acme_apply.sh" \
+      "${output_dir}/nginx.compose.yml"
+}
+
 # ── Generate nginx config from template ──
 generate_nginx() {
-    local main_domain="$1"
-    local preview_domain="$2"
-    local switch_domain="${3:-switch.${main_domain}}"
-    local dashboard_domain="${4:-cds.${main_domain}}"
-    local worker_port="${5:-5500}"
-    local master_port="${6:-9900}"
-    local output_dir="${7:-$SCRIPT_DIR/nginx}"
-    local source_env="${8:-$LOCAL_ENV_FILE}"
+    local root_domains_csv="$1"
+    local worker_port="${2:-5500}"
+    local master_port="${3:-9900}"
+    local output_dir="${4:-$SCRIPT_DIR/nginx}"
+    local source_env="${5:-$LOCAL_ENV_FILE}"
     local domain_env="${output_dir}/domain.env"
-    local tls_domains
+    local primary_domain tls_domains
 
-    tls_domains="${main_domain},${switch_domain}"
-    if [ "$dashboard_domain" != "$main_domain" ] && [ "$dashboard_domain" != "$switch_domain" ]; then
-        tls_domains="${tls_domains},${dashboard_domain}"
+    primary_domain="$(printf '%s' "$root_domains_csv" | cut -d',' -f1 | xargs)"
+    if [ -z "$primary_domain" ]; then
+        err "ROOT_DOMAINS 不能为空"
+        return 1
     fi
 
+    tls_domains="$root_domains_csv"
+
+    cleanup_generated_nginx "$output_dir"
     mkdir -p "${output_dir}/certs" "${output_dir}/www/.well-known/acme-challenge"
 
     cat > "$domain_env" <<EOF
 # internal generated file; edit cds/.cds.env then rerun ./exec_setup.sh or ./exec_cds.sh nginx render
 # source: ${source_env}
-MAIN_DOMAIN="${main_domain}"
-SWITCH_DOMAIN="${switch_domain}"
-DASHBOARD_DOMAIN="${dashboard_domain}"
-PREVIEW_DOMAIN="${preview_domain}"
-ENABLE_PREVIEW_SERVER="1"
+ROOT_DOMAINS="${root_domains_csv}"
+PRIMARY_DOMAIN="${primary_domain}"
 WORKER_PORT="${worker_port}"
 DASHBOARD_PORT="${master_port}"
-CERT_EMAIL="admin@${main_domain}"
+CERT_EMAIL="admin@${primary_domain}"
 NGINX_CONTAINER="nginx_miduo"
 LOCAL_TLS_HOST="127.0.0.1"
 TLS_DOMAINS="${tls_domains}"
@@ -170,20 +176,19 @@ write_local_env() {
     local username="$1"
     local password="$2"
     local jwt_secret="$3"
-    local switch_domain="$4"
-    local main_domain="$5"
-    local preview_domain="$6"
-    local dashboard_domain="${7:-cds.${main_domain}}"
+    local root_domains_csv="$4"
+    local primary_domain
+    primary_domain="$(printf '%s' "$root_domains_csv" | cut -d',' -f1 | xargs)"
 
     cat > "$LOCAL_ENV_FILE" << EOF
 # ── CDS 本地环境配置 (由 exec_setup.sh 生成，$(date +%Y-%m-%d)) ──
 export CDS_USERNAME="${username}"
 export CDS_PASSWORD="${password}"
 export CDS_JWT_SECRET="${jwt_secret}"
-export CDS_SWITCH_DOMAIN="${switch_domain}"
-export CDS_MAIN_DOMAIN="${main_domain}"
-export CDS_PREVIEW_DOMAIN="${preview_domain}"
-export CDS_DASHBOARD_DOMAIN="${dashboard_domain}"
+export CDS_ROOT_DOMAINS="${root_domains_csv}"
+export CDS_MAIN_DOMAIN="${primary_domain}"
+export CDS_PREVIEW_DOMAIN="${primary_domain}"
+export CDS_DASHBOARD_DOMAIN="${primary_domain}"
 EOF
 
     chmod 600 "$LOCAL_ENV_FILE"
@@ -204,48 +209,44 @@ main() {
             return 0
             ;;
         --nginx-only)
-            local domain
-            domain=$(get_config_var "CDS_MAIN_DOMAIN")
-            if [ -z "$domain" ]; then
-                domain=$(get_config_var "MAIN_DOMAIN")
+            local root_domains
+            root_domains=$(get_config_var "CDS_ROOT_DOMAINS")
+            if [ -z "$root_domains" ]; then
+                root_domains=$(get_config_var "ROOT_DOMAINS")
             fi
-            if [ -z "$domain" ]; then
-                err "未找到 CDS_MAIN_DOMAIN，请先运行 ./exec_setup.sh 完成完整配置"
+            if [ -z "$root_domains" ]; then
+                local legacy_domain
+                legacy_domain=$(get_config_var "CDS_MAIN_DOMAIN")
+                [ -z "$legacy_domain" ] && legacy_domain=$(get_config_var "MAIN_DOMAIN")
+                [ -z "$legacy_domain" ] && legacy_domain=$(get_config_var "CDS_DASHBOARD_DOMAIN")
+                [ -z "$legacy_domain" ] && legacy_domain=$(get_config_var "DASHBOARD_DOMAIN")
+                root_domains="$legacy_domain"
+            fi
+            if [ -z "$root_domains" ]; then
+                err "未找到 CDS_ROOT_DOMAINS，请先运行 ./exec_setup.sh 完成完整配置"
                 return 1
             fi
-            local preview
-            preview=$(get_config_var "CDS_PREVIEW_DOMAIN")
-            [ -z "$preview" ] && preview=$(get_config_var "PREVIEW_DOMAIN")
-            [ -z "$preview" ] && preview="$domain"
-            local switch
-            switch=$(get_config_var "CDS_SWITCH_DOMAIN")
-            [ -z "$switch" ] && switch=$(get_config_var "SWITCH_DOMAIN")
-            [ -z "$switch" ] && switch="switch.${domain}"
-            local dashboard
-            dashboard=$(get_config_var "CDS_DASHBOARD_DOMAIN")
-            [ -z "$dashboard" ] && dashboard=$(get_config_var "DASHBOARD_DOMAIN")
-            [ -z "$dashboard" ] && dashboard="cds.${domain}"
-            generate_nginx "$domain" "$preview" "$switch" "$dashboard" "5500" "9900" "$NGINX_DIR" "$LOCAL_ENV_FILE"
+            generate_nginx "$root_domains" "5500" "9900" "$NGINX_DIR" "$LOCAL_ENV_FILE"
             return 0
             ;;
     esac
 
     # ── Step 1: Collect current values as defaults ──
-    local cur_user cur_pass cur_jwt cur_switch cur_main cur_preview cur_dashboard
+    local cur_user cur_pass cur_jwt cur_roots
     cur_user=$(get_config_var "CDS_USERNAME")
     [ -z "$cur_user" ] && cur_user=$(get_config_var "BT_USERNAME")
     cur_pass=$(get_config_var "CDS_PASSWORD")
     [ -z "$cur_pass" ] && cur_pass=$(get_config_var "BT_PASSWORD")
     cur_jwt=$(get_config_var "CDS_JWT_SECRET")
     [ -z "$cur_jwt" ] && cur_jwt=$(get_config_var "JWT_SECRET")
-    cur_switch=$(get_config_var "CDS_SWITCH_DOMAIN")
-    [ -z "$cur_switch" ] && cur_switch=$(get_config_var "SWITCH_DOMAIN")
-    cur_main=$(get_config_var "CDS_MAIN_DOMAIN")
-    [ -z "$cur_main" ] && cur_main=$(get_config_var "MAIN_DOMAIN")
-    cur_preview=$(get_config_var "CDS_PREVIEW_DOMAIN")
-    [ -z "$cur_preview" ] && cur_preview=$(get_config_var "PREVIEW_DOMAIN")
-    cur_dashboard=$(get_config_var "CDS_DASHBOARD_DOMAIN")
-    [ -z "$cur_dashboard" ] && cur_dashboard=$(get_config_var "DASHBOARD_DOMAIN")
+    cur_roots=$(get_config_var "CDS_ROOT_DOMAINS")
+    [ -z "$cur_roots" ] && cur_roots=$(get_config_var "ROOT_DOMAINS")
+    if [ -z "$cur_roots" ]; then
+        cur_roots=$(get_config_var "CDS_MAIN_DOMAIN")
+        [ -z "$cur_roots" ] && cur_roots=$(get_config_var "MAIN_DOMAIN")
+        [ -z "$cur_roots" ] && cur_roots=$(get_config_var "CDS_DASHBOARD_DOMAIN")
+        [ -z "$cur_roots" ] && cur_roots=$(get_config_var "DASHBOARD_DOMAIN")
+    fi
 
     # ── Step 2: Interactive prompts ──
     echo -e "  ${CYAN}步骤 1/4${NC}: Dashboard 认证"
@@ -277,15 +278,12 @@ main() {
 
     echo -e "  ${CYAN}步骤 3/4${NC}: 域名配置"
     echo "  ──────────────────────────"
-    local new_main new_switch new_preview new_dashboard
-    prompt new_main    "主分支域名 (如 miduo.org)" "${cur_main:-}"
-    if [ -z "$new_main" ]; then
-        err "主域名不能为空"
+    local new_roots
+    prompt new_roots "根域名列表（逗号分隔，如 miduo.org,example.com）" "${cur_roots:-}"
+    if [ -z "$new_roots" ]; then
+        err "根域名不能为空"
         return 1
     fi
-    prompt new_dashboard "CDS 控制台域名" "${cur_dashboard:-cds.${new_main}}"
-    prompt new_switch  "分支切换域名" "${cur_switch:-switch.${new_main}}"
-    prompt new_preview "预览域名后缀" "${cur_preview:-${new_main}}"
     echo ""
 
     # ── Step 3: Confirm ──
@@ -294,10 +292,8 @@ main() {
     echo -e "  用户名:       ${GREEN}${new_user}${NC}"
     echo -e "  密码:         ****${new_pass: -4}"
     echo -e "  JWT Secret:   ****${new_jwt: -4}"
-    echo -e "  主域名:       ${GREEN}${new_main}${NC}"
-    echo -e "  CDS 域名:     ${GREEN}${new_dashboard}${NC}"
-    echo -e "  切换域名:     ${GREEN}${new_switch}${NC}"
-    echo -e "  预览域名:     ${GREEN}${new_preview}${NC}"
+    echo -e "  根域名:       ${GREEN}${new_roots}${NC}"
+    echo -e "  路由规则:     ${GREEN}根域名 → Dashboard；任意子域名 → Preview${NC}"
     echo ""
     echo -en "  确认写入? [Y/n]: "
     read -r confirm
@@ -309,10 +305,13 @@ main() {
     # ── Step 4: Write ──
     echo ""
     info "写入 CDS 本地环境文件 ..."
-    write_local_env "$new_user" "$new_pass" "$new_jwt" "$new_switch" "$new_main" "$new_preview" "$new_dashboard"
+    write_local_env "$new_user" "$new_pass" "$new_jwt" "$new_roots"
 
     info "生成 Nginx 配置 ..."
-    generate_nginx "$new_main" "$new_preview" "$new_switch" "$new_dashboard" "5500" "9900" "$NGINX_DIR" "$LOCAL_ENV_FILE"
+    generate_nginx "$new_roots" "5500" "9900" "$NGINX_DIR" "$LOCAL_ENV_FILE"
+
+    local first_domain
+    first_domain="$(printf '%s' "$new_roots" | cut -d',' -f1 | xargs)"
 
     echo ""
     echo "  ════════════════════════════════"
@@ -323,7 +322,7 @@ main() {
     echo "    1. 启动 CDS 与 Nginx: cd $SCRIPT_DIR && ./exec_cds.sh"
     echo "    2. 如需签发证书:      cd $SCRIPT_DIR && ./exec_cds.sh cert"
     echo "    3. 查看 Nginx 状态:   cd $SCRIPT_DIR && ./exec_cds.sh nginx status"
-    echo "    4. 访问 https://${new_dashboard}"
+    echo "    4. 访问 https://${first_domain}"
     echo ""
 }
 

--- a/cds/nginx/acme.sh.template
+++ b/cds/nginx/acme.sh.template
@@ -13,11 +13,11 @@ set -a
 . "$CONFIG_FILE"
 set +a
 
-MAIN_DOMAIN="${MAIN_DOMAIN:-}"
-CERT_EMAIL="${CERT_EMAIL:-admin@${MAIN_DOMAIN}}"
+PRIMARY_DOMAIN="${PRIMARY_DOMAIN:-${MAIN_DOMAIN:-}}"
+CERT_EMAIL="${CERT_EMAIL:-admin@${PRIMARY_DOMAIN}}"
 NGINX_CONTAINER="${NGINX_CONTAINER:-nginx_miduo}"
 LOCAL_TLS_HOST="${LOCAL_TLS_HOST:-127.0.0.1}"
-TLS_DOMAINS="${TLS_DOMAINS:-${MAIN_DOMAIN}}"
+TLS_DOMAINS="${TLS_DOMAINS:-${PRIMARY_DOMAIN}}"
 
 FORCE_RENEW=0
 CHECK_ONLY=0
@@ -44,15 +44,15 @@ ACME_HOME="${HOME}/.acme.sh"
 ACME="${ACME_HOME}/acme.sh"
 START_NGINX="${BASE_DIR}/start_nginx.sh"
 
-if [ -z "$MAIN_DOMAIN" ]; then
-  echo "ERROR: MAIN_DOMAIN 不能为空"
+if [ -z "$PRIMARY_DOMAIN" ]; then
+  echo "ERROR: PRIMARY_DOMAIN 不能为空"
   exit 1
 fi
 
 mkdir -p "${CERT_DIR}" "${WEBROOT_DIR}/.well-known/acme-challenge"
 
 if [ "${CHECK_ONLY}" -eq 1 ]; then
-  echo | openssl s_client -connect "${LOCAL_TLS_HOST}:443" -servername "${MAIN_DOMAIN}" 2>/dev/null | openssl x509 -noout -dates -issuer -subject || true
+  echo | openssl s_client -connect "${LOCAL_TLS_HOST}:443" -servername "${PRIMARY_DOMAIN}" 2>/dev/null | openssl x509 -noout -dates -issuer -subject || true
   exit 0
 fi
 
@@ -92,14 +92,14 @@ if [ "${ISSUE_STATUS}" -ne 0 ] && ! printf '%s\n' "${ISSUE_OUTPUT}" | grep -q "S
   exit "${ISSUE_STATUS}"
 fi
 
-"${ACME}" --install-cert -d "${MAIN_DOMAIN}" \
+"${ACME}" --install-cert -d "${PRIMARY_DOMAIN}" \
   --ecc \
-  --key-file       "${CERT_DIR}/${MAIN_DOMAIN}.key" \
-  --fullchain-file "${CERT_DIR}/${MAIN_DOMAIN}.crt" \
+  --key-file       "${CERT_DIR}/${PRIMARY_DOMAIN}.key" \
+  --fullchain-file "${CERT_DIR}/${PRIMARY_DOMAIN}.crt" \
   --reloadcmd      "docker exec ${NGINX_CONTAINER} nginx -s reload"
 
 if [ -x "${START_NGINX}" ]; then
   "${START_NGINX}" restart
 fi
 
-echo | openssl s_client -connect "${LOCAL_TLS_HOST}:443" -servername "${MAIN_DOMAIN}" 2>/dev/null | openssl x509 -noout -dates -issuer -subject || true
+echo | openssl s_client -connect "${LOCAL_TLS_HOST}:443" -servername "${PRIMARY_DOMAIN}" 2>/dev/null | openssl x509 -noout -dates -issuer -subject || true

--- a/cds/nginx/domain.env.example
+++ b/cds/nginx/domain.env.example
@@ -3,13 +3,13 @@
 #   ./exec_setup.sh
 #   ./exec_cds.sh nginx render
 
-MAIN_DOMAIN="miduo.org"
-SWITCH_DOMAIN="switch.miduo.org"
-DASHBOARD_DOMAIN="cds.miduo.org"
+# 逗号分隔的根域名列表。规则统一：
+# - 精确命中根域名 -> Dashboard
+# - 任意子域名 -> Preview
+ROOT_DOMAINS="miduo.org,example.com"
 
-# 预览域名后缀。分支访问形如: <branch>.PREVIEW_DOMAIN
-PREVIEW_DOMAIN="miduo.org"
-ENABLE_PREVIEW_SERVER="1"
+# 主证书文件名，默认使用 ROOT_DOMAINS 的第一个域名。
+PRIMARY_DOMAIN="miduo.org"
 
 WORKER_PORT="5500"
 DASHBOARD_PORT="9900"
@@ -18,6 +18,7 @@ CERT_EMAIL="admin@miduo.org"
 NGINX_CONTAINER="nginx_miduo"
 LOCAL_TLS_HOST="127.0.0.1"
 
-# webroot 模式只支持显式域名；若要给 *.PREVIEW_DOMAIN 配 HTTPS，请改 DNS challenge
-# 当 MAIN_DOMAIN 和 DASHBOARD_DOMAIN 相同时，裸域名优先进入 Dashboard，主分支不再占用同一个精确匹配。
-TLS_DOMAINS="miduo.org,switch.miduo.org,cds.miduo.org"
+# webroot 模式默认只覆盖显式根域名。
+# 如果你要给 *.domain 提供 HTTPS，需要让这里包含通配符 SAN，
+# 并改用 DNS challenge 方式签发。
+TLS_DOMAINS="miduo.org,example.com"

--- a/cds/nginx/domain.env.example
+++ b/cds/nginx/domain.env.example
@@ -1,5 +1,7 @@
-# 复制为 domain.env 后修改，再执行:
-#   ./init_domain.sh
+# 这是内部模板。正常使用请编辑 cds/.cds.env，
+# 然后在 cds 根目录执行:
+#   ./exec_setup.sh
+#   ./exec_cds.sh nginx render
 
 MAIN_DOMAIN="miduo.org"
 SWITCH_DOMAIN="switch.miduo.org"

--- a/cds/nginx/init_domain.sh
+++ b/cds/nginx/init_domain.sh
@@ -13,7 +13,7 @@ Usage:
   ./nginx/init_domain.sh --config /path/to/domain.env
 
 作用:
-  - 从内部 domain.env 生成 nginx.conf / cds-nginx.conf / acme_apply.sh
+  - 从内部 domain.env 生成 nginx.conf / cds-nginx.conf / cds-nginx.http.conf / acme_apply.sh
   - 正常使用请在 cds 根目录执行: ./exec_cds.sh nginx render
 EOF
 }
@@ -50,35 +50,48 @@ set -a
 . "$CONFIG_FILE"
 set +a
 
-MAIN_DOMAIN="${MAIN_DOMAIN:-}"
-SWITCH_DOMAIN="${SWITCH_DOMAIN:-switch.${MAIN_DOMAIN}}"
-DASHBOARD_DOMAIN="${DASHBOARD_DOMAIN:-cds.${MAIN_DOMAIN}}"
-PREVIEW_DOMAIN="${PREVIEW_DOMAIN:-${MAIN_DOMAIN}}"
-ENABLE_PREVIEW_SERVER="${ENABLE_PREVIEW_SERVER:-1}"
+ROOT_DOMAINS="${ROOT_DOMAINS:-}"
+PRIMARY_DOMAIN="${PRIMARY_DOMAIN:-}"
 WORKER_PORT="${WORKER_PORT:-5500}"
 DASHBOARD_PORT="${DASHBOARD_PORT:-9900}"
-CERT_EMAIL="${CERT_EMAIL:-admin@${MAIN_DOMAIN}}"
+CERT_EMAIL="${CERT_EMAIL:-}"
 NGINX_CONTAINER="${NGINX_CONTAINER:-nginx_miduo}"
 
-if [ -z "${TLS_DOMAINS:-}" ]; then
-  TLS_DOMAINS="${MAIN_DOMAIN},${SWITCH_DOMAIN}"
-  if [ "$DASHBOARD_DOMAIN" != "$MAIN_DOMAIN" ] && [ "$DASHBOARD_DOMAIN" != "$SWITCH_DOMAIN" ]; then
-    TLS_DOMAINS="${TLS_DOMAINS},${DASHBOARD_DOMAIN}"
-  fi
+if [ -z "$ROOT_DOMAINS" ]; then
+  echo "ERROR: ROOT_DOMAINS 不能为空"
+  exit 1
 fi
 
-if [ -z "$MAIN_DOMAIN" ]; then
-  echo "ERROR: MAIN_DOMAIN 不能为空"
+if [ -z "$PRIMARY_DOMAIN" ]; then
+  PRIMARY_DOMAIN="$(printf '%s' "$ROOT_DOMAINS" | cut -d',' -f1 | xargs)"
+fi
+
+if [ -z "${TLS_DOMAINS:-}" ]; then
+  TLS_DOMAINS="$ROOT_DOMAINS"
+fi
+
+parse_domains() {
+  local raw="$1"
+  local -n out_ref="$2"
+  local item
+  IFS=',' read -r -a out_ref <<< "$raw"
+  for item in "${!out_ref[@]}"; do
+    out_ref[$item]="$(printf '%s' "${out_ref[$item]}" | xargs)"
+  done
+}
+
+DOMAIN_ARRAY=()
+parse_domains "$ROOT_DOMAINS" DOMAIN_ARRAY
+
+if [ "${#DOMAIN_ARRAY[@]}" -eq 0 ] || [ -z "${DOMAIN_ARRAY[0]}" ]; then
+  echo "ERROR: ROOT_DOMAINS 不能为空"
   exit 1
 fi
 
 if [ "$SHOW_ONLY" = "1" ]; then
   cat <<EOF
-MAIN_DOMAIN=${MAIN_DOMAIN}
-SWITCH_DOMAIN=${SWITCH_DOMAIN}
-DASHBOARD_DOMAIN=${DASHBOARD_DOMAIN}
-PREVIEW_DOMAIN=${PREVIEW_DOMAIN}
-ENABLE_PREVIEW_SERVER=${ENABLE_PREVIEW_SERVER}
+ROOT_DOMAINS=${ROOT_DOMAINS}
+PRIMARY_DOMAIN=${PRIMARY_DOMAIN}
 WORKER_PORT=${WORKER_PORT}
 DASHBOARD_PORT=${DASHBOARD_PORT}
 CERT_EMAIL=${CERT_EMAIL}
@@ -90,15 +103,9 @@ fi
 
 mkdir -p "${SCRIPT_DIR}/certs" "${SCRIPT_DIR}/www/.well-known/acme-challenge"
 
-build_worker_exact_server() {
-  if [ "$MAIN_DOMAIN" = "$DASHBOARD_DOMAIN" ]; then
-    echo "# Worker exact domain omitted because MAIN_DOMAIN equals DASHBOARD_DOMAIN."
-    return
-  fi
+build_dashboard_server_tls() {
+  local domain="$1"
   cat <<EOF
-# ────────────────────────────────────────
-# 1. Main domain → CDS Worker (gateway)
-# ────────────────────────────────────────
 server {
     listen 80;
     listen [::]:80;
@@ -106,7 +113,7 @@ server {
     listen [::]:443 ssl;
     http2 on;
 
-    server_name ${MAIN_DOMAIN};
+    server_name ${domain};
 
     location ^~ /.well-known/acme-challenge/ {
         root /var/www/html;
@@ -114,13 +121,11 @@ server {
     }
 
     location / {
-        proxy_pass http://cds_worker;
+        proxy_pass http://cds_dashboard;
         proxy_http_version 1.1;
         proxy_set_header Host              \$host;
         proxy_set_header X-Real-IP         \$remote_addr;
         proxy_set_header X-Forwarded-For   \$proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto \$scheme;
-        proxy_set_header X-Forwarded-Host  \$host;
         proxy_set_header X-Forwarded-Port  \$server_port;
         proxy_set_header Upgrade           \$http_upgrade;
         proxy_set_header Connection        \$connection_upgrade;
@@ -128,24 +133,88 @@ server {
         proxy_cache     off;
         proxy_read_timeout 3600s;
         proxy_send_timeout 3600s;
-        add_header Cache-Control    "no-store, must-revalidate" always;
-        add_header Vary             "Cookie" always;
-        add_header X-Accel-Buffering "no" always;
     }
 }
 EOF
 }
 
-build_worker_http_exact_server() {
-  if [ "$MAIN_DOMAIN" = "$DASHBOARD_DOMAIN" ]; then
-    echo "# Worker HTTP exact domain omitted because MAIN_DOMAIN equals DASHBOARD_DOMAIN."
-    return
-  fi
+build_preview_server_tls() {
+  local domain="$1"
   cat <<EOF
 server {
     listen 80;
     listen [::]:80;
-    server_name ${MAIN_DOMAIN};
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
+
+    server_name *.${domain};
+
+    location ^~ /.well-known/acme-challenge/ {
+        root /var/www/html;
+        allow all;
+    }
+
+    location / {
+        proxy_pass http://cds_worker;
+        proxy_http_version 1.1;
+        proxy_set_header Host              \$host;
+        proxy_set_header X-Real-IP         \$remote_addr;
+        proxy_set_header X-Forwarded-For   \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+        proxy_set_header X-Forwarded-Host  \$host;
+        proxy_set_header X-Forwarded-Port  \$server_port;
+        proxy_set_header Upgrade           \$http_upgrade;
+        proxy_set_header Connection        \$connection_upgrade;
+        proxy_buffering off;
+        proxy_cache     off;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+        add_header Cache-Control    "no-cache" always;
+        add_header X-Accel-Buffering "no"      always;
+    }
+}
+EOF
+}
+
+build_dashboard_server_http() {
+  local domain="$1"
+  cat <<EOF
+server {
+    listen 80;
+    listen [::]:80;
+    server_name ${domain};
+
+    location ^~ /.well-known/acme-challenge/ {
+        root /var/www/html;
+        allow all;
+    }
+
+    location / {
+        proxy_pass http://cds_dashboard;
+        proxy_http_version 1.1;
+        proxy_set_header Host              \$host;
+        proxy_set_header X-Real-IP         \$remote_addr;
+        proxy_set_header X-Forwarded-For   \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Port  \$server_port;
+        proxy_set_header Upgrade           \$http_upgrade;
+        proxy_set_header Connection        \$connection_upgrade;
+        proxy_buffering off;
+        proxy_cache     off;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+}
+EOF
+}
+
+build_preview_server_http() {
+  local domain="$1"
+  cat <<EOF
+server {
+    listen 80;
+    listen [::]:80;
+    server_name *.${domain};
 
     location ^~ /.well-known/acme-challenge/ {
         root /var/www/html;
@@ -172,28 +241,72 @@ server {
 EOF
 }
 
-WORKER_EXACT_SERVER="$(build_worker_exact_server)"
-WORKER_HTTP_EXACT_SERVER="$(build_worker_http_exact_server)"
+{
+  cat <<EOF
+# ──────────────────────────────────────────────────────────────
+# CDS Nginx Configuration (generated)
+#
+# Routing:
+#   - Any exact root domain -> CDS Dashboard (:${DASHBOARD_PORT})
+#   - Any subdomain under each root domain -> CDS Worker (:${WORKER_PORT})
+#   - Example: feature.${PRIMARY_DOMAIN} -> preview branch
+#
+# TLS:
+#   - Shared certificate file: /etc/nginx/certs/${PRIMARY_DOMAIN}.crt
+#   - If you need HTTPS for *.domain, ensure the certificate SANs include wildcard entries.
+# ──────────────────────────────────────────────────────────────
 
-sed \
-  -e "s/{{MAIN_DOMAIN}}/${MAIN_DOMAIN}/g" \
-  -e "s/{{DASHBOARD_DOMAIN}}/${DASHBOARD_DOMAIN}/g" \
-  -e "s/{{PREVIEW_DOMAIN}}/${PREVIEW_DOMAIN}/g" \
-  -e "s/{{WORKER_PORT}}/${WORKER_PORT}/g" \
-  -e "s/{{MASTER_PORT}}/${DASHBOARD_PORT}/g" \
-  "${SCRIPT_DIR}/cds-nginx.conf.template" | awk -v block="$WORKER_EXACT_SERVER" '
-    { if ($0 == "__WORKER_EXACT_SERVER__") print block; else print }
-  ' > "${SCRIPT_DIR}/cds-nginx.conf"
+ssl_certificate     /etc/nginx/certs/${PRIMARY_DOMAIN}.crt;
+ssl_certificate_key /etc/nginx/certs/${PRIMARY_DOMAIN}.key;
+ssl_protocols       TLSv1.2 TLSv1.3;
 
-sed \
-  -e "s/{{MAIN_DOMAIN}}/${MAIN_DOMAIN}/g" \
-  -e "s/{{DASHBOARD_DOMAIN}}/${DASHBOARD_DOMAIN}/g" \
-  -e "s/{{PREVIEW_DOMAIN}}/${PREVIEW_DOMAIN}/g" \
-  -e "s/{{WORKER_PORT}}/${WORKER_PORT}/g" \
-  -e "s/{{MASTER_PORT}}/${DASHBOARD_PORT}/g" \
-  "${SCRIPT_DIR}/cds-nginx.http.conf.template" | awk -v block="$WORKER_HTTP_EXACT_SERVER" '
-    { if ($0 == "__WORKER_HTTP_EXACT_SERVER__") print block; else print }
-  ' > "${SCRIPT_DIR}/cds-nginx.http.conf"
+upstream cds_worker {
+    server 127.0.0.1:${WORKER_PORT};
+    keepalive 16;
+}
+
+upstream cds_dashboard {
+    server 127.0.0.1:${DASHBOARD_PORT};
+    keepalive 8;
+}
+
+EOF
+
+  for domain in "${DOMAIN_ARRAY[@]}"; do
+    [ -n "$domain" ] || continue
+    build_dashboard_server_tls "$domain"
+    printf '\n'
+    build_preview_server_tls "$domain"
+    printf '\n'
+  done
+} > "${SCRIPT_DIR}/cds-nginx.conf"
+
+{
+  cat <<EOF
+# ──────────────────────────────────────────────────────────────
+# CDS HTTP Bootstrap Config (generated)
+# ──────────────────────────────────────────────────────────────
+
+upstream cds_worker {
+    server 127.0.0.1:${WORKER_PORT};
+    keepalive 16;
+}
+
+upstream cds_dashboard {
+    server 127.0.0.1:${DASHBOARD_PORT};
+    keepalive 8;
+}
+
+EOF
+
+  for domain in "${DOMAIN_ARRAY[@]}"; do
+    [ -n "$domain" ] || continue
+    build_dashboard_server_http "$domain"
+    printf '\n'
+    build_preview_server_http "$domain"
+    printf '\n'
+  done
+} > "${SCRIPT_DIR}/cds-nginx.http.conf"
 
 cp "${SCRIPT_DIR}/nginx.conf.template" "${SCRIPT_DIR}/nginx.conf"
 

--- a/cds/nginx/init_domain.sh
+++ b/cds/nginx/init_domain.sh
@@ -13,7 +13,8 @@ Usage:
   ./nginx/init_domain.sh --config /path/to/domain.env
 
 作用:
-  - 从 domain.env 生成 nginx.conf / cds-nginx.conf / acme_apply.sh
+  - 从内部 domain.env 生成 nginx.conf / cds-nginx.conf / acme_apply.sh
+  - 正常使用请在 cds 根目录执行: ./exec_cds.sh nginx render
 EOF
 }
 
@@ -40,8 +41,8 @@ while [ $# -gt 0 ]; do
 done
 
 if [ ! -f "$CONFIG_FILE" ]; then
-  echo "ERROR: 配置文件不存在: $CONFIG_FILE"
-  echo "先执行: cp ${SCRIPT_DIR}/domain.env.example ${SCRIPT_DIR}/domain.env"
+  echo "ERROR: 内部配置文件不存在: $CONFIG_FILE"
+  echo "请回到 cds 根目录执行: ./exec_setup.sh"
   exit 1
 fi
 

--- a/cds/nginx/start_nginx.sh
+++ b/cds/nginx/start_nginx.sh
@@ -20,7 +20,8 @@ Usage:
 
 说明:
   - 默认动作是 up
-  - 会读取 ./domain.env 中的 NGINX_CONTAINER
+  - 会读取内部生成的 ./domain.env
+  - 正常使用请在 cds 根目录执行: ./exec_cds.sh nginx <action>
   - 会自动检查 ./nginx.conf 与 ./cds-nginx.conf 是否存在
 EOF
 }
@@ -28,10 +29,11 @@ EOF
 ACTION="${1:-up}"
 
 if [ ! -f "$CONFIG_FILE" ]; then
-  echo "ERROR: 配置文件不存在: $CONFIG_FILE"
-  echo "先执行:"
-  echo "  cp ${SCRIPT_DIR}/domain.env.example ${SCRIPT_DIR}/domain.env"
-  echo "  ${SCRIPT_DIR}/init_domain.sh"
+  echo "ERROR: 内部配置文件不存在: $CONFIG_FILE"
+  echo "请回到 cds 根目录执行:"
+  echo "  ./exec_setup.sh"
+  echo "或"
+  echo "  ./exec_cds.sh nginx render"
   exit 1
 fi
 
@@ -60,8 +62,8 @@ render_compose() {
 
 ensure_rendered() {
   if [ ! -f "${SCRIPT_DIR}/nginx.conf" ] || [ ! -f "${SCRIPT_DIR}/cds-nginx.conf" ]; then
-    echo "ERROR: nginx 配置不存在，请先执行:"
-    echo "  ${SCRIPT_DIR}/init_domain.sh"
+    echo "ERROR: nginx 配置不存在，请回到 cds 根目录执行:"
+    echo "  ./exec_cds.sh nginx render"
     exit 1
   fi
   mkdir -p "${SCRIPT_DIR}/certs" "${SCRIPT_DIR}/www/.well-known/acme-challenge"
@@ -71,7 +73,7 @@ ensure_rendered() {
     SERVER_CONF_FILE="cds-nginx.http.conf"
     if [ ! -f "${SCRIPT_DIR}/${SERVER_CONF_FILE}" ]; then
       echo "ERROR: 缺少 HTTP bootstrap 配置: ${SCRIPT_DIR}/${SERVER_CONF_FILE}"
-      echo "请先执行: ${SCRIPT_DIR}/init_domain.sh"
+      echo "请回到 cds 根目录执行: ./exec_cds.sh nginx render"
       exit 1
     fi
     echo "No certificate found for ${MAIN_DOMAIN}, starting nginx in HTTP bootstrap mode."

--- a/cds/nginx/start_nginx.sh
+++ b/cds/nginx/start_nginx.sh
@@ -47,10 +47,10 @@ set -a
 set +a
 
 NGINX_CONTAINER="${NGINX_CONTAINER:-nginx_miduo}"
-MAIN_DOMAIN="${MAIN_DOMAIN:-}"
+PRIMARY_DOMAIN="${PRIMARY_DOMAIN:-${MAIN_DOMAIN:-}}"
 
 has_cert() {
-  [ -f "${SCRIPT_DIR}/certs/${MAIN_DOMAIN}.crt" ] && [ -f "${SCRIPT_DIR}/certs/${MAIN_DOMAIN}.key" ]
+  [ -f "${SCRIPT_DIR}/certs/${PRIMARY_DOMAIN}.crt" ] && [ -f "${SCRIPT_DIR}/certs/${PRIMARY_DOMAIN}.key" ]
 }
 
 render_compose() {
@@ -76,7 +76,7 @@ ensure_rendered() {
       echo "请回到 cds 根目录执行: ./exec_cds.sh nginx render"
       exit 1
     fi
-    echo "No certificate found for ${MAIN_DOMAIN}, starting nginx in HTTP bootstrap mode."
+    echo "No certificate found for ${PRIMARY_DOMAIN}, starting nginx in HTTP bootstrap mode."
   fi
   render_compose
 }

--- a/cds/src/config.ts
+++ b/cds/src/config.ts
@@ -2,11 +2,20 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { CdsConfig, CdsMode } from './types.js';
 
+function parseCsv(value: string | undefined): string[] | undefined {
+  if (!value) return undefined;
+  const items = value.split(',').map(v => v.trim()).filter(Boolean);
+  return items.length > 0 ? items : undefined;
+}
+
 function resolveMode(): CdsMode {
   const env = (process.env.CDS_MODE || '').toLowerCase();
   if (env === 'scheduler' || env === 'executor') return env;
   return 'standalone';
 }
+
+const configuredRootDomains = parseCsv(process.env.CDS_ROOT_DOMAINS || process.env.ROOT_DOMAINS);
+const primaryRootDomain = configuredRootDomains?.[0];
 
 const DEFAULT_CONFIG: CdsConfig = {
   repoRoot: path.resolve(process.cwd(), '..'),
@@ -18,9 +27,10 @@ const DEFAULT_CONFIG: CdsConfig = {
   sharedEnv: {},
   // CDS_ prefix preferred; legacy names (SWITCH_DOMAIN, etc.) kept for backward compat
   switchDomain: process.env.CDS_SWITCH_DOMAIN || process.env.SWITCH_DOMAIN || undefined,
-  mainDomain: process.env.CDS_MAIN_DOMAIN || process.env.MAIN_DOMAIN || undefined,
-  dashboardDomain: process.env.CDS_DASHBOARD_DOMAIN || process.env.DASHBOARD_DOMAIN || undefined,
-  previewDomain: process.env.CDS_PREVIEW_DOMAIN || process.env.PREVIEW_DOMAIN || undefined,
+  mainDomain: process.env.CDS_MAIN_DOMAIN || process.env.MAIN_DOMAIN || primaryRootDomain || undefined,
+  dashboardDomain: process.env.CDS_DASHBOARD_DOMAIN || process.env.DASHBOARD_DOMAIN || primaryRootDomain || undefined,
+  rootDomains: configuredRootDomains,
+  previewDomain: process.env.CDS_PREVIEW_DOMAIN || process.env.PREVIEW_DOMAIN || primaryRootDomain || undefined,
   jwt: {
     secret: process.env.CDS_JWT_SECRET ?? process.env.JWT_SECRET ?? 'dev-only-change-me-32bytes-minimum!!',
     issuer: 'prdagent',

--- a/cds/src/index.ts
+++ b/cds/src/index.ts
@@ -18,6 +18,12 @@ import { createExecutorRouter } from './executor/routes.js';
 import { ExecutorRegistry } from './scheduler/executor-registry.js';
 import { createSchedulerRouter } from './scheduler/routes.js';
 
+function parseCsv(value: string | undefined): string[] | undefined {
+  if (!value) return undefined;
+  const items = value.split(',').map(v => v.trim()).filter(Boolean);
+  return items.length > 0 ? items : undefined;
+}
+
 const configPath = process.argv[2] || undefined;
 const config = loadConfig(configPath);
 
@@ -53,10 +59,16 @@ stateService.load();
 // Users set these in CDS custom env vars (UI),
 // but config.ts only reads process.env at startup. Merge them here.
 const customEnv = stateService.getCustomEnv();
+if (customEnv.ROOT_DOMAINS && !config.rootDomains?.length) config.rootDomains = parseCsv(customEnv.ROOT_DOMAINS);
 if (customEnv.SWITCH_DOMAIN && !config.switchDomain) config.switchDomain = customEnv.SWITCH_DOMAIN;
 if (customEnv.MAIN_DOMAIN && !config.mainDomain) config.mainDomain = customEnv.MAIN_DOMAIN;
 if (customEnv.DASHBOARD_DOMAIN && !config.dashboardDomain) config.dashboardDomain = customEnv.DASHBOARD_DOMAIN;
 if (customEnv.PREVIEW_DOMAIN && !config.previewDomain) config.previewDomain = customEnv.PREVIEW_DOMAIN;
+if (config.rootDomains?.length) {
+  if (!config.dashboardDomain) config.dashboardDomain = config.rootDomains[0];
+  if (!config.previewDomain) config.previewDomain = config.rootDomains[0];
+  if (!config.mainDomain) config.mainDomain = config.rootDomains[0];
+}
 // Directory isolation: allow UI to override repo root and worktree base
 if (customEnv.CDS_REPO_ROOT) config.repoRoot = customEnv.CDS_REPO_ROOT;
 if (customEnv.CDS_WORKTREE_BASE) config.worktreeBase = customEnv.CDS_WORKTREE_BASE;
@@ -664,9 +676,9 @@ if (mode === 'executor') {
     console.log(`  Dashboard:  http://localhost:${config.masterPort}`);
     console.log(`  Worker:     http://localhost:${config.workerPort}`);
     console.log(`  Bridge:     http://localhost:${config.masterPort}/api/bridge/ (HTTP polling)`);
-    if (config.dashboardDomain) console.log(`  Dashboard Domain: https://${config.dashboardDomain}`);
-    if (config.switchDomain) console.log(`  Switch:     ${config.switchDomain} → ${config.mainDomain || '(main domain not set)'}`);
-    if (config.previewDomain) console.log(`  Preview:    *.<${config.previewDomain}>`);
+    if (config.rootDomains?.length) console.log(`  Domains:    ${config.rootDomains.join(', ')}`);
+    if (config.dashboardDomain) console.log(`  Routing:    exact root domain -> Dashboard (${config.dashboardDomain})`);
+    if (config.rootDomains?.length) console.log(`  Preview:    any subdomain under configured root domains`);
     console.log(`  State file: ${stateFile}`);
     console.log(`  Repo root:  ${config.repoRoot}`);
     console.log('');

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -1475,10 +1475,16 @@ export function createBranchRouter(deps: RouterDeps): Router {
   // Helper: sync CDS-relevant env vars into runtime config
   function syncCdsConfig() {
     const env = stateService.getCustomEnv();
+    if (env.ROOT_DOMAINS) config.rootDomains = env.ROOT_DOMAINS.split(',').map(v => v.trim()).filter(Boolean);
     if (env.SWITCH_DOMAIN) config.switchDomain = env.SWITCH_DOMAIN;
     if (env.MAIN_DOMAIN) config.mainDomain = env.MAIN_DOMAIN;
     if (env.DASHBOARD_DOMAIN) config.dashboardDomain = env.DASHBOARD_DOMAIN;
     if (env.PREVIEW_DOMAIN) config.previewDomain = env.PREVIEW_DOMAIN;
+    if (config.rootDomains?.length) {
+      if (!env.MAIN_DOMAIN) config.mainDomain = config.rootDomains[0];
+      if (!env.DASHBOARD_DOMAIN) config.dashboardDomain = config.rootDomains[0];
+      if (!env.PREVIEW_DOMAIN) config.previewDomain = config.rootDomains[0];
+    }
     // Repo root & worktree base: allow UI override for directory isolation
     if (env.CDS_REPO_ROOT) {
       config.repoRoot = env.CDS_REPO_ROOT;

--- a/cds/src/services/proxy.ts
+++ b/cds/src/services/proxy.ts
@@ -175,12 +175,16 @@ export class ProxyService {
    * Returns the branch slug extracted from the subdomain, or null.
    */
   private extractPreviewBranch(host: string): string | null {
-    const previewDomain = this.config?.previewDomain;
-    if (!previewDomain) return null;
     const h = host.split(':')[0].toLowerCase();
-    const suffix = `.${previewDomain.toLowerCase()}`;
-    if (h.endsWith(suffix) && h.length > suffix.length) {
-      return h.slice(0, -suffix.length);
+    const rootDomains = this.config?.rootDomains?.length
+      ? this.config.rootDomains
+      : (this.config?.previewDomain ? [this.config.previewDomain] : []);
+
+    for (const rootDomain of rootDomains) {
+      const suffix = `.${rootDomain.toLowerCase()}`;
+      if (h.endsWith(suffix) && h.length > suffix.length) {
+        return h.slice(0, -suffix.length);
+      }
     }
     return null;
   }

--- a/cds/src/types.ts
+++ b/cds/src/types.ts
@@ -349,6 +349,8 @@ export interface CdsConfig {
   mainDomain?: string;
   /** Dashboard domain for CDS UI (e.g., "cds.example.com" or "example.com") */
   dashboardDomain?: string;
+  /** Root domains handled by nginx. Exact root -> dashboard, any subdomain -> preview. */
+  rootDomains?: string[];
   /** Preview domain suffix for subdomain-based preview (e.g., "preview.example.com").
    *  Each branch gets its own subdomain: <slug>.preview.example.com */
   previewDomain?: string;


### PR DESCRIPTION
## Summary
- simplify CDS domain setup to a single `CDS_ROOT_DOMAINS` config entry
- route every exact root domain to the dashboard and every subdomain to preview traffic
- regenerate nginx state from scratch on each initialization/render pass
- update runtime config so multi-root preview matching works in the worker proxy

## Validation
- `bash -n cds/exec_setup.sh`
- `bash -n cds/exec_cds.sh`
- `bash -n cds/nginx/init_domain.sh`
- `bash -n cds/nginx/start_nginx.sh`
- `cd cds && pnpm exec tsc --noEmit`
- `cd cds && ./exec_setup.sh --nginx-only`
- `cd cds && ./exec_cds.sh nginx render`
- `cd cds && ./exec_cds.sh nginx status`
- `bash cds/nginx/init_domain.sh --config cds/nginx/domain.env.example`
- verified generated nginx contains both exact-root and wildcard preview servers for multiple root domains