### PR TITLE
fix: precheck return actionable 4xx instead of opaque 502

### DIFF
--- a/changelogs/2026-04-09_pr-review-prism-complete.md
+++ b/changelogs/2026-04-09_pr-review-prism-complete.md
@@ -58,3 +58,4 @@
 | feat | prd-admin | 仓库级顶设依据管理区新增“一键复制6文件模板”，可直接粘贴生成 top-design 与 pr-architect 配置，降低新仓库手工配置门槛 |
 | feat | prd-api | PR审查棱镜新增 submissions/precheck 提交前可达性预检接口，先校验 GitHub PR 可访问性再允许创建记录 |
 | feat | prd-admin | PR审查棱镜提交流程新增“先预检后提交”，预检失败直接提示明确原因且不再落库失败记录 |
+| fix | prd-api | PR审查棱镜 precheck 将“PR不存在/无权限/Token缺失”分别映射为 404/403/400，避免统一返回 502 导致前端仅见网关错误 |

--- a/doc/spec.srs.md
+++ b/doc/spec.srs.md
@@ -2175,6 +2175,12 @@ sequenceDiagram
 - `PUT /api/pr-review-prism/token-config` — 保存/清空 Token（写入 AppSettings 加密字段，要求 `settings.write`）
 - `POST /api/pr-review-prism/bootstrap-skill-package` — 导出仓库专属接入 zip（含 scripts + skill 模板 + onboarding 指南）
 - `POST /api/pr-review-prism/submissions/precheck` — 提交前预检 PR 可达性（仅校验 GitHub 可访问与 PR 存在，不落库）
+  - 错误映射：
+    - PR 链接格式错误：`400 INVALID_FORMAT`
+    - GitHub Token 未配置：`400 INVALID_FORMAT`
+    - Token 对目标仓库无权限：`403 PERMISSION_DENIED`
+    - 目标 PR 不存在或不可见：`404 NOT_FOUND`
+    - 其他 GitHub/网络异常：`502 LLM_ERROR`
 - `POST /api/pr-review-prism/submissions` — 提交 PR 链接并创建/复用记录
 - `GET /api/pr-review-prism/submissions` — 当前用户提交列表（支持 `q` 检索与 `repo` 仓库过滤，`repo` 可为 `owner/repo` 或 PR URL）
 - `GET /api/pr-review-prism/submissions?gateStatus={status}` — 按 Gate 状态筛选（`pending/completed/missing/error`）

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/PrReviewPrismController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/PrReviewPrismController.cs
@@ -353,6 +353,23 @@ public sealed class PrReviewPrismController : ControllerBase
                 checkedAt = snapshot.CheckedAt
             }));
         }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("缺少 GitHub Token", StringComparison.Ordinal))
+        {
+            _logger.LogWarning(ex, "PrReviewPrism precheck blocked by missing token");
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, ex.Message));
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("无访问权限", StringComparison.Ordinal))
+        {
+            _logger.LogWarning(ex, "PrReviewPrism precheck denied: {Owner}/{Repo}#{Pr}", normalizedOwner, normalizedRepo, prNumber);
+            return StatusCode(
+                StatusCodes.Status403Forbidden,
+                ApiResponse<object>.Fail(ErrorCodes.PERMISSION_DENIED, ex.Message));
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("未找到该 PR", StringComparison.Ordinal))
+        {
+            _logger.LogWarning(ex, "PrReviewPrism precheck target not found: {Owner}/{Repo}#{Pr}", normalizedOwner, normalizedRepo, prNumber);
+            return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, ex.Message));
+        }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "PrReviewPrism precheck failed: {Owner}/{Repo}#{Pr}", normalizedOwner, normalizedRepo, prNumber);

--- a/prd-api/tests/PrdAgent.Api.Tests/Integration/PrReviewPrismApiIntegrationTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Integration/PrReviewPrismApiIntegrationTests.cs
@@ -485,6 +485,31 @@ public class PrReviewPrismApiIntegrationTests : IClassFixture<WebApplicationFact
     }
 
     [Fact]
+    public async Task Precheck_NotFoundPullRequest_ShouldReturn404()
+    {
+        if (!HasToken)
+        {
+            Log("[Skip] no token");
+            return;
+        }
+
+        var client = CreateAuthenticatedClient();
+        if (!await EnsurePrReviewPrismAccessibleAsync(client))
+        {
+            return;
+        }
+
+        var response = await client.PostAsJsonAsync("/api/pr-review-prism/submissions/precheck", new
+        {
+            pullRequestUrl = "https://github.com/octocat/hello-world/pull/999999999",
+        });
+        var body = await response.Content.ReadAsStringAsync();
+        Log($"[PrecheckNotFound] {response.StatusCode} - {Truncate(body, 200)}");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        AssertErrorCode(body, "NOT_FOUND");
+    }
+
+    [Fact]
     public async Task BatchRefresh_EmptyIds_ShouldReturn400()
     {
         if (!HasToken)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- map known PR Review Prism precheck failures to API contract status codes instead of returning 502 for all exceptions
- add integration coverage for not-found precheck path
- update PR Prism SRS section and changelog fragment for the new precheck error mapping behavior

## Why
Users were seeing a Cloudflare `error code: 502` page for inaccessible/non-existent PR links (especially private repos), which hid the real reason and made the review feature appear broken.

## Changes
- `PrReviewPrismController.PrecheckSubmission`
  - missing GitHub token -> `400 INVALID_FORMAT`
  - GitHub access denied -> `403 PERMISSION_DENIED`
  - PR not found/inaccessible -> `404 NOT_FOUND`
  - unknown errors keep `502 LLM_ERROR`
- `PrReviewPrismApiIntegrationTests`
  - add `Precheck_NotFoundPullRequest_ShouldReturn404`
- docs/changelog
  - update `doc/spec.srs.md` PRP-001 endpoint behavior note
  - append changelog entry in `changelogs/2026-04-09_pr-review-prism-complete.md`

## Validation
- `dotnet build prd-api`
- `dotnet test prd-api/PrdAgent.sln --filter "FullyQualifiedName~Precheck_NotFoundPullRequest_ShouldReturn404"`
- CDS deploy verification on branch `cursor/pr-prism-precheck-error-mapping-7021`
  - `POST /api/pr-review-prism/submissions/precheck` with `https://github.com/MiDouTech/mdimp/pull/11` => `404` JSON with `NOT_FOUND`
  - control case `https://github.com/octocat/Hello-World/pull/1` => `200` success
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b49548a7-8e36-4da5-8c1b-8d749d757021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b49548a7-8e36-4da5-8c1b-8d749d757021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

