### PR TITLE
Refactor data migration to streaming pipeline with cross-CDS peer support

### DIFF
--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -1,4 +1,5 @@
 import http from 'node:http';
+import https from 'node:https';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -10,7 +11,7 @@ import type { WorktreeService } from '../services/worktree.js';
 import { resolveProfileWithMode } from '../services/container.js';
 import type { ContainerService } from '../services/container.js';
 import type { SchedulerService } from '../services/scheduler.js';
-import type { BranchEntry, CdsConfig, IShellExecutor, OperationLog, OperationLogEvent, BuildProfile, RoutingRule, ServiceState, InfraService, DataMigration, MongoConnectionConfig } from '../types.js';
+import type { BranchEntry, CdsConfig, IShellExecutor, OperationLog, OperationLogEvent, BuildProfile, RoutingRule, ServiceState, InfraService, DataMigration, MongoConnectionConfig, CdsPeer } from '../types.js';
 import { discoverComposeFiles, parseComposeFile, parseComposeString, toComposeYaml, parseCdsCompose, toCdsCompose } from '../services/compose-parser.js';
 import type { ComposeServiceDef } from '../services/compose-parser.js';
 import { combinedOutput } from '../types.js';
@@ -142,6 +143,137 @@ export function createBranchRouter(deps: RouterDeps): Router {
       );
     }
     send('MongoDB 工具已安装');
+  }
+
+  // ─────────────────────────────────────────────────────────────────
+  //   Migration pipeline helpers (shared by /execute, local-dump, local-restore)
+  // ─────────────────────────────────────────────────────────────────
+
+  /**
+   * Build the mongodump argument list for a resolved connection.
+   * Always uses `--archive --gzip` so the output is a single streamable blob.
+   */
+  function buildMongodumpArgs(
+    host: string,
+    port: number,
+    auth: { username?: string; password?: string; authDatabase?: string },
+    database: string | undefined,
+    collections: string[] | undefined,
+  ): string[] {
+    const args: string[] = ['--host', host, '--port', String(port), '--archive', '--gzip'];
+    if (auth.username) args.push('--username', auth.username);
+    if (auth.password) args.push('--password', auth.password);
+    if (auth.authDatabase) args.push('--authenticationDatabase', auth.authDatabase);
+    if (database) args.push('--db', database);
+    if (collections && collections.length === 1) {
+      // mongodump only supports --collection when --db is set + single collection
+      args.push('--collection', collections[0]);
+    }
+    // For multi-collection migrations, dump the whole db and let --nsInclude filter on restore
+    return args;
+  }
+
+  function buildMongorestoreArgs(
+    host: string,
+    port: number,
+    auth: { username?: string; password?: string; authDatabase?: string },
+    opts: { drop: boolean; sourceDb?: string; targetDb?: string; collections?: string[] },
+  ): string[] {
+    const args: string[] = ['--host', host, '--port', String(port), '--archive', '--gzip'];
+    if (auth.username) args.push('--username', auth.username);
+    if (auth.password) args.push('--password', auth.password);
+    if (auth.authDatabase) args.push('--authenticationDatabase', auth.authDatabase);
+    if (opts.drop) args.push('--drop');
+    // Cross-database rename: --nsFrom="srcDb.*" --nsTo="tgtDb.*"
+    if (opts.sourceDb && opts.targetDb && opts.sourceDb !== opts.targetDb) {
+      args.push('--nsFrom', `${opts.sourceDb}.*`, '--nsTo', `${opts.targetDb}.*`);
+    }
+    if (opts.sourceDb && opts.collections && opts.collections.length > 0) {
+      // Filter to only these collections
+      for (const col of opts.collections) {
+        args.push('--nsInclude', `${opts.sourceDb}.${col}`);
+      }
+    }
+    return args;
+  }
+
+  /**
+   * Parse a line of mongodump/mongorestore progress output and return a
+   * human-readable one-liner, or null if the line carries no useful signal.
+   *
+   * Example inputs:
+   *   "2026-04-10T23:41:12.419+0200 [####........] prdagent.users 500/4105 (12.2%)"
+   *   "2026-04-10T23:41:10.660+0200 writing prdagent.users to /dev/stdout"
+   *   "2026-04-10T23:41:30.660+0200 done dumping prdagent.users (4105 documents)"
+   */
+  function parseMongoProgressLine(line: string): string | null {
+    const trimmed = line.trim();
+    if (!trimmed) return null;
+    // Progress bar line: "[####....] db.col 500/4105 (12.2%)"
+    const bar = trimmed.match(/\]\s+([^\s]+)\s+(\d+)\/(\d+)\s+\(([\d.]+)%\)/);
+    if (bar) return `${bar[1]} ${bar[4]}%  (${bar[2]}/${bar[3]})`;
+    // "writing db.col to ..."
+    const writing = trimmed.match(/writing\s+([^\s]+)\s+to/);
+    if (writing) return `写入 ${writing[1]}...`;
+    // "done dumping db.col (N documents)"
+    const doneDump = trimmed.match(/done dumping\s+([^\s]+)\s+\((\d+)\s+documents?\)/);
+    if (doneDump) return `✓ 导出 ${doneDump[1]} (${doneDump[2]})`;
+    // "finished restoring db.col (N documents, 0 failures)"
+    const doneRestore = trimmed.match(/finished restoring\s+([^\s]+)\s+\((\d+)\s+documents?/);
+    if (doneRestore) return `✓ 导入 ${doneRestore[1]} (${doneRestore[2]})`;
+    // "preparing collections to restore from"
+    if (trimmed.includes('preparing collections')) return '准备还原集合...';
+    // Error-ish lines
+    if (/error|failed|fatal/i.test(trimmed)) return trimmed.slice(0, 200);
+    return null;
+  }
+
+  /**
+   * Build the SSH command prefix used to run mongodump/mongorestore on a
+   * remote jump host. The resulting array starts with 'ssh' and ends with
+   * the username@host argument, ready to be appended with the remote shell
+   * command as the last argv item.
+   */
+  function buildSshBase(tunnel: NonNullable<MongoConnectionConfig['sshTunnel']>): string[] {
+    const args = [
+      '-o', 'BatchMode=yes',
+      '-o', 'StrictHostKeyChecking=no',
+      '-o', 'UserKnownHostsFile=/dev/null',
+      '-o', 'ConnectTimeout=10',
+      // Keepalive: critical for long dumps — send a probe every 30s, tolerate 10 misses.
+      '-o', 'ServerAliveInterval=30',
+      '-o', 'ServerAliveCountMax=10',
+      '-o', 'TCPKeepAlive=yes',
+      '-p', String(tunnel.port || 22),
+    ];
+    if (tunnel.privateKeyPath) args.unshift('-i', tunnel.privateKeyPath);
+    args.push(`${tunnel.username}@${tunnel.host}`);
+    return args;
+  }
+
+  /**
+   * Shell-quote a single argument (single-quote style, safe for POSIX sh).
+   */
+  function shq(s: string): string {
+    return `'${String(s).replace(/'/g, `'"'"'`)}'`;
+  }
+
+  /**
+   * Build the remote command string for mongodump/mongorestore over SSH,
+   * optionally wrapped in `docker exec <container> sh -c ...`.
+   */
+  function buildRemoteMongoCmd(
+    tool: 'mongodump' | 'mongorestore',
+    args: string[],
+    dockerContainer: string | undefined,
+  ): string {
+    const inner = [tool, ...args.map(shq)].join(' ');
+    if (dockerContainer) {
+      // docker exec -i for restore (stdin), no -i for dump
+      const flags = tool === 'mongorestore' ? '-i' : '';
+      return `docker exec ${flags} ${shq(dockerContainer)} sh -c ${shq(inner)}`.replace(/  +/g, ' ');
+    }
+    return inner;
   }
 
   // ── Remote branches ──
@@ -2815,6 +2947,69 @@ export function createBranchRouter(deps: RouterDeps): Router {
     return args;
   }
 
+  /** Get this CDS's own AI access key (used to display to the user for copy/paste) */
+  function getLocalAccessKey(): string | null {
+    return stateService.getCustomEnv()['AI_ACCESS_KEY'] || process.env.AI_ACCESS_KEY || null;
+  }
+
+  /** Best-effort public base URL of this CDS, derived from the current request */
+  function guessLocalBaseUrl(req: import('express').Request): string {
+    const proto = (req.headers['x-forwarded-proto'] as string) || req.protocol || 'https';
+    const host = (req.headers['x-forwarded-host'] as string) || req.headers.host || 'localhost';
+    return `${proto}://${host}`;
+  }
+
+  /**
+   * Make an authenticated HTTP/S request to a CDS peer. Returns the raw
+   * response object so the caller can stream the body.
+   */
+  function peerRequest(
+    peer: CdsPeer,
+    apiPath: string,
+    method: 'GET' | 'POST' | 'PUT' | 'DELETE',
+    body?: unknown,
+  ): Promise<http.IncomingMessage> {
+    return new Promise((resolve, reject) => {
+      let url: URL;
+      try { url = new URL(peer.baseUrl.replace(/\/$/, '') + apiPath); } catch (e) { reject(e); return; }
+      const lib = url.protocol === 'https:' ? https : http;
+      const payload = body !== undefined ? Buffer.from(JSON.stringify(body)) : null;
+      const req = lib.request({
+        method,
+        protocol: url.protocol,
+        hostname: url.hostname,
+        port: url.port || (url.protocol === 'https:' ? 443 : 80),
+        path: url.pathname + url.search,
+        headers: {
+          'X-AI-Access-Key': peer.accessKey,
+          'X-CDS-Peer-Call': '1',
+          Accept: 'application/json, application/octet-stream',
+          ...(payload ? { 'Content-Type': 'application/json', 'Content-Length': String(payload.length) } : {}),
+        },
+        // Large dumps can take many minutes — disable the 2-minute default.
+        timeout: 0,
+      }, (res) => resolve(res));
+      req.on('error', reject);
+      req.setTimeout(0);
+      if (payload) req.write(payload);
+      req.end();
+    });
+  }
+
+  /** Make a peer request and parse the response body as JSON */
+  async function peerRequestJson<T>(peer: CdsPeer, apiPath: string, method: 'GET' | 'POST' | 'PUT' | 'DELETE', body?: unknown): Promise<T> {
+    const res = await peerRequest(peer, apiPath, method, body);
+    const chunks: Buffer[] = [];
+    for await (const c of res) chunks.push(c as Buffer);
+    const text = Buffer.concat(chunks).toString('utf-8');
+    if ((res.statusCode || 500) >= 400) {
+      let err = text;
+      try { const j = JSON.parse(text); err = j.error || j.message || text; } catch { /* raw */ }
+      throw new Error(`远程 CDS 返回 ${res.statusCode}: ${err}`);
+    }
+    try { return JSON.parse(text) as T; } catch { return text as unknown as T; }
+  }
+
   // GET /api/data-migrations — list all migration tasks
   router.get('/data-migrations', (_req, res) => {
     res.json(stateService.getDataMigrations());
@@ -2937,7 +3132,41 @@ export function createBranchRouter(deps: RouterDeps): Router {
     }
   });
 
-  // POST /api/data-migrations/:id/execute — execute a migration task (SSE stream)
+  // PUT /api/data-migrations/:id — edit a migration task (name, source, target, collections)
+  router.put('/data-migrations/:id', (req, res) => {
+    const { id } = req.params;
+    const existing = stateService.getDataMigration(id);
+    if (!existing) { res.status(404).json({ error: '迁移任务不存在' }); return; }
+    if (existing.status === 'running') { res.status(400).json({ error: '任务正在运行中，无法编辑' }); return; }
+    const { name, source, target, collections } = req.body as Partial<DataMigration>;
+    const updates: Partial<DataMigration> = {};
+    if (name !== undefined) updates.name = name;
+    if (source !== undefined) updates.source = source;
+    if (target !== undefined) updates.target = target;
+    // collections === [] means "all collections" (undefined), non-empty = subset
+    if (collections !== undefined) updates.collections = (collections && collections.length) ? collections : undefined;
+    updates.updatedAt = new Date().toISOString();
+    stateService.updateDataMigration(id, updates);
+    stateService.save();
+    res.json(stateService.getDataMigration(id));
+  });
+
+  // POST /api/data-migrations/:id/execute — execute a migration task (SSE stream, streaming pipeline)
+  //
+  // Pipeline:
+  //   source producer (mongodump stdout) → pipe → target consumer (mongorestore stdin)
+  //
+  // Producers (by source.type):
+  //   - local  : spawn mongodump against CDS infra MongoDB
+  //   - remote : spawn mongodump; or ssh jump → remote mongodump (pipe mode, no port forwarding)
+  //   - cds    : HTTP POST to peer's /local-dump endpoint, read response body
+  //
+  // Consumers (by target.type):
+  //   - local  : spawn mongorestore against CDS infra MongoDB, write to stdin
+  //   - remote : spawn mongorestore; or ssh jump → remote mongorestore (stdin pipe)
+  //   - cds    : HTTP POST to peer's /local-restore endpoint, request body is the stream
+  //
+  // Zero temp files. Archive+gzip throughout. SSH keepalive so long dumps don't drop.
   router.post('/data-migrations/:id/execute', async (req, res) => {
     const { id } = req.params;
     const migration = stateService.getDataMigration(id);
@@ -2948,139 +3177,87 @@ export function createBranchRouter(deps: RouterDeps): Router {
     const send = (progress: number, message: string) => {
       sendSSE(res, 'progress', { progress, message });
       stateService.updateDataMigration(id, { progress, progressMessage: message });
-      stateService.save();
     };
+
+    // SSE keepalive — prevents proxies from closing the connection on long dumps
+    const keepAlive = setInterval(() => { try { res.write(`:ka\n\n`); } catch { /* client gone */ } }, 15000);
 
     // Mark as running
     stateService.updateDataMigration(id, { status: 'running', startedAt: new Date().toISOString(), progress: 0, errorMessage: undefined, log: '' });
     stateService.save();
 
     let logOutput = '';
-    const appendLog = (line: string) => { logOutput += line + '\n'; };
+    const MAX_LOG = 64 * 1024;
+    const appendLog = (line: string) => {
+      logOutput += line;
+      if (!line.endsWith('\n')) logOutput += '\n';
+      if (logOutput.length > MAX_LOG) logOutput = '...(truncated)...\n' + logOutput.slice(-MAX_LOG);
+    };
+
+    // Persist log + progress periodically (not on every chunk) to avoid disk thrash
+    let lastPersistAt = 0;
+    const maybePersist = () => {
+      const now = Date.now();
+      if (now - lastPersistAt > 2000) {
+        lastPersistAt = now;
+        stateService.updateDataMigration(id, { log: logOutput });
+        stateService.save();
+      }
+    };
+
+    // Resources to clean up on exit
+    const children: Array<{ kill: () => void }> = [];
+    const cleanup = () => {
+      clearInterval(keepAlive);
+      for (const c of children) { try { c.kill(); } catch { /* */ } }
+    };
+
+    // Track the most recent progress line so we can turn it into SSE progress
+    let fakeProgress = 20; // ratchet 20→90 based on line activity
+    const bumpProgress = (delta: number) => { fakeProgress = Math.min(90, fakeProgress + delta); };
+    const updateProgressFromLine = (line: string) => {
+      const parsed = parseMongoProgressLine(line);
+      if (parsed) {
+        bumpProgress(1);
+        send(fakeProgress, parsed);
+      }
+    };
 
     try {
-      const src = resolveMongoConn(migration.source);
-      const tgt = resolveMongoConn(migration.target);
+      const cols = migration.collections?.length ? migration.collections : undefined;
 
-      send(5, '正在检查迁移工具...');
-      const toolCheck = await shell.exec('which mongodump && which mongorestore');
-      if (toolCheck.exitCode !== 0) {
-        throw new Error('mongodump/mongorestore 未安装。请先在迁移面板点击"初始化工具"');
-      }
+      send(2, '准备迁移管道...');
 
-      // Build SSH tunnel if needed
-      let srcHost = src.host;
-      let srcPort = src.port;
-      let tgtHost = tgt.host;
-      let tgtPort = tgt.port;
+      // ── Build producer ──
+      const producer = await buildSourceProducer(
+        migration.source,
+        cols,
+        { appendLog, onProgressLine: updateProgressFromLine, send },
+      );
+      children.push(producer);
 
-      if (src.sshTunnel?.enabled) {
-        send(10, '正在建立源数据库 SSH 隧道...');
-        const localPort = 27100 + Math.floor(Math.random() * 100);
-        const tunnel = src.sshTunnel;
-        const keyArg = tunnel.privateKeyPath ? `-i ${tunnel.privateKeyPath}` : '';
-        const sshCmd = `ssh -f -N -L ${localPort}:${src.host}:${src.port} ${keyArg} -p ${tunnel.port} ${tunnel.username}@${tunnel.host} -o StrictHostKeyChecking=no -o ConnectTimeout=10`;
-        const sshResult = await shell.exec(sshCmd, { timeout: 15000 });
-        if (sshResult.exitCode !== 0) throw new Error(`SSH 隧道建立失败: ${sshResult.stderr}`);
-        srcHost = '127.0.0.1';
-        srcPort = localPort;
-        appendLog(`SSH tunnel (source): localhost:${localPort} -> ${src.host}:${src.port} via ${tunnel.host}`);
-      }
+      // ── Build consumer ──
+      const consumer = await buildTargetConsumer(
+        migration.target,
+        migration.source,
+        cols,
+        { appendLog, onProgressLine: updateProgressFromLine, send },
+      );
+      children.push(consumer);
 
-      if (tgt.sshTunnel?.enabled) {
-        send(15, '正在建立目标数据库 SSH 隧道...');
-        const localPort = 27200 + Math.floor(Math.random() * 100);
-        const tunnel = tgt.sshTunnel;
-        const keyArg = tunnel.privateKeyPath ? `-i ${tunnel.privateKeyPath}` : '';
-        const sshCmd = `ssh -f -N -L ${localPort}:${tgt.host}:${tgt.port} ${keyArg} -p ${tunnel.port} ${tunnel.username}@${tunnel.host} -o StrictHostKeyChecking=no -o ConnectTimeout=10`;
-        const sshResult = await shell.exec(sshCmd, { timeout: 15000 });
-        if (sshResult.exitCode !== 0) throw new Error(`SSH 隧道建立失败: ${sshResult.stderr}`);
-        tgtHost = '127.0.0.1';
-        tgtPort = localPort;
-        appendLog(`SSH tunnel (target): localhost:${localPort} -> ${tgt.host}:${tgt.port} via ${tunnel.host}`);
-      }
+      send(15, '管道已建立，开始传输...');
 
-      // Prepare dump directory
-      const dumpDir = `/tmp/cds-migration-${id}`;
-      await shell.exec(`rm -rf ${dumpDir} && mkdir -p ${dumpDir}`);
+      // Pipe producer → consumer with error propagation
+      producer.stdout.on('error', (err: Error) => appendLog(`[pipe] producer error: ${err.message}`));
+      consumer.stdin.on('error', (err: Error) => appendLog(`[pipe] consumer error: ${err.message}`));
+      producer.stdout.pipe(consumer.stdin);
 
-      // Build base auth args
-      let srcAuth = '';
-      if (src.username) srcAuth += ` --username=${src.username}`;
-      if (src.password) srcAuth += ` --password=${src.password}`;
-      if (src.authDatabase) srcAuth += ` --authenticationDatabase=${src.authDatabase}`;
-      let tgtAuth = '';
-      if (tgt.username) tgtAuth += ` --username=${tgt.username}`;
-      if (tgt.password) tgtAuth += ` --password=${tgt.password}`;
-      if (tgt.authDatabase) tgtAuth += ` --authenticationDatabase=${tgt.authDatabase}`;
+      // Persist log every few seconds while streaming
+      const persistTimer = setInterval(maybePersist, 2000);
 
-      const cols = migration.collections?.length ? migration.collections : null;
-      const totalSteps = cols ? cols.length * 2 : 2; // dump + restore per collection (or 1 each for full)
-      let currentStep = 0;
-      const stepProgress = (step: number) => Math.round(20 + (step / totalSteps) * 70); // 20% → 90%
-
-      if (cols) {
-        // ── Per-collection migration ──
-        appendLog(`Per-collection migration: ${cols.length} collections`);
-        for (let i = 0; i < cols.length; i++) {
-          const col = cols[i];
-          // Dump
-          send(stepProgress(currentStep), `正在导出 ${col} (${i + 1}/${cols.length})...`);
-          let dumpCmd = `mongodump --host=${srcHost} --port=${srcPort}${srcAuth}`;
-          if (src.database) dumpCmd += ` --db=${src.database}`;
-          dumpCmd += ` --collection=${col} --out=${dumpDir}`;
-          appendLog(`dump: ${col}`);
-          const dumpResult = await shell.exec(dumpCmd, { timeout: 600000, onData: (c) => appendLog(c) });
-          if (dumpResult.exitCode !== 0) throw new Error(`mongodump ${col} 失败: ${dumpResult.stderr || dumpResult.stdout}`);
-          currentStep++;
-
-          // Restore
-          send(stepProgress(currentStep), `正在导入 ${col} (${i + 1}/${cols.length})...`);
-          const restorePath = src.database ? `${dumpDir}/${src.database}` : dumpDir;
-          let restoreCmd = `mongorestore --host=${tgtHost} --port=${tgtPort}${tgtAuth}`;
-          if (tgt.database) restoreCmd += ` --db=${tgt.database}`;
-          restoreCmd += ` --collection=${col} --drop ${restorePath}/${col}.bson`;
-          appendLog(`restore: ${col}`);
-          const restoreResult = await shell.exec(restoreCmd, { timeout: 600000, onData: (c) => appendLog(c) });
-          if (restoreResult.exitCode !== 0) throw new Error(`mongorestore ${col} 失败: ${restoreResult.stderr || restoreResult.stdout}`);
-          currentStep++;
-        }
-      } else {
-        // ── Full database/instance migration ──
-        send(20, '正在导出源数据库...');
-        let dumpCmd = `mongodump --host=${srcHost} --port=${srcPort}${srcAuth}`;
-        if (src.database) dumpCmd += ` --db=${src.database}`;
-        dumpCmd += ` --out=${dumpDir}`;
-        appendLog(`dump: ${src.database || '(all dbs)'}`);
-
-        const dumpResult = await shell.exec(dumpCmd, {
-          timeout: 600000,
-          onData: (chunk) => { appendLog(chunk); if (chunk.includes('done dumping')) send(50, '导出完成，准备导入...'); }
-        });
-        if (dumpResult.exitCode !== 0) throw new Error(`mongodump 失败: ${dumpResult.stderr || dumpResult.stdout}`);
-
-        send(55, '正在导入到目标数据库...');
-        const restorePath = src.database ? `${dumpDir}/${src.database}` : dumpDir;
-        let restoreCmd = `mongorestore --host=${tgtHost} --port=${tgtPort}${tgtAuth}`;
-        if (tgt.database) restoreCmd += ` --db=${tgt.database}`;
-        restoreCmd += ` --drop ${restorePath}`;
-        appendLog(`restore: ${tgt.database || '(all dbs)'}`);
-
-        const restoreResult = await shell.exec(restoreCmd, {
-          timeout: 600000,
-          onData: (chunk) => { appendLog(chunk); if (chunk.includes('done')) send(85, '正在完成导入...'); }
-        });
-        if (restoreResult.exitCode !== 0) throw new Error(`mongorestore 失败: ${restoreResult.stderr || restoreResult.stdout}`);
-      }
-
-      // Cleanup dump files
-      send(95, '正在清理临时文件...');
-      await shell.exec(`rm -rf ${dumpDir}`);
-
-      // Kill SSH tunnels if any
-      if (src.sshTunnel?.enabled || tgt.sshTunnel?.enabled) {
-        await shell.exec('pkill -f "ssh -f -N -L 271"').catch(() => {});
-      }
+      // Wait for both producer and consumer to finish
+      await Promise.all([producer.done, consumer.done]);
+      clearInterval(persistTimer);
 
       send(100, '迁移完成！');
       stateService.updateDataMigration(id, {
@@ -3092,10 +3269,10 @@ export function createBranchRouter(deps: RouterDeps): Router {
       });
       stateService.save();
       sendSSE(res, 'done', { message: '迁移完成' });
+      cleanup();
       res.end();
-
     } catch (e) {
-      const errMsg = (e as Error).message;
+      const errMsg = (e as Error).message || String(e);
       appendLog(`ERROR: ${errMsg}`);
       stateService.updateDataMigration(id, {
         status: 'failed',
@@ -3105,13 +3282,221 @@ export function createBranchRouter(deps: RouterDeps): Router {
       });
       stateService.save();
       sendSSE(res, 'error', { message: errMsg });
+      cleanup();
       res.end();
-
-      // Cleanup
-      await shell.exec(`rm -rf /tmp/cds-migration-${id}`).catch(() => {});
-      await shell.exec('pkill -f "ssh -f -N -L 271"').catch(() => {});
     }
   });
+
+  /**
+   * Build a producer that emits a `mongodump --archive --gzip` byte stream.
+   * Returns a handle with a readable `stdout`, a `done` promise, and `kill()`.
+   */
+  async function buildSourceProducer(
+    source: MongoConnectionConfig,
+    cols: string[] | undefined,
+    cb: {
+      appendLog: (s: string) => void;
+      onProgressLine: (line: string) => void;
+      send: (progress: number, message: string) => void;
+    },
+  ): Promise<{ stdout: NodeJS.ReadableStream; stdin?: NodeJS.WritableStream; done: Promise<void>; kill: () => void }> {
+    // ── CDS peer source ── fetch from peer's local-dump
+    if (source.type === 'cds') {
+      const peer = stateService.getCdsPeer(source.cdsPeerId || '');
+      if (!peer) throw new Error(`源 CDS 密钥不存在: ${source.cdsPeerId}`);
+      cb.send(8, `连接源 CDS 「${peer.name}」...`);
+      const peerRes = await peerRequest(peer, '/api/data-migrations/local-dump', 'POST', {
+        database: source.database,
+        collections: cols,
+      });
+      if ((peerRes.statusCode || 500) >= 400) {
+        const chunks: Buffer[] = [];
+        for await (const c of peerRes) chunks.push(c as Buffer);
+        throw new Error(`源 CDS 返回 ${peerRes.statusCode}: ${Buffer.concat(chunks).toString('utf-8').slice(0, 400)}`);
+      }
+      cb.appendLog(`[source] CDS peer ${peer.name} (${peer.baseUrl}) streaming`);
+      const done = new Promise<void>((resolve, reject) => {
+        peerRes.on('end', resolve);
+        peerRes.on('error', reject);
+      });
+      return {
+        stdout: peerRes,
+        done,
+        kill: () => { try { peerRes.destroy(); } catch { /* */ } },
+      };
+    }
+
+    // ── Local / remote via mongodump ──
+    const eff = source.type === 'local' ? resolveMongoConn(source) : source;
+    const dumpArgs = buildMongodumpArgs(
+      eff.host, eff.port,
+      { username: eff.username, password: eff.password, authDatabase: eff.authDatabase },
+      eff.database, cols,
+    );
+
+    let cmd: string;
+    let argv: string[];
+    if (source.sshTunnel?.enabled) {
+      cb.send(8, `通过 SSH 连接 ${source.sshTunnel.host}...`);
+      const sshBase = buildSshBase(source.sshTunnel);
+      const remoteCmd = buildRemoteMongoCmd('mongodump', dumpArgs, source.sshTunnel.dockerContainer);
+      cb.appendLog(`[source] ssh ${source.sshTunnel.username}@${source.sshTunnel.host}: ${remoteCmd}`);
+      cmd = 'ssh';
+      argv = [...sshBase, remoteCmd];
+    } else {
+      cb.appendLog(`[source] mongodump ${dumpArgs.join(' ')}`);
+      cmd = 'mongodump';
+      argv = dumpArgs;
+    }
+
+    const child = spawn(cmd, argv, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stderrTail = '';
+    child.stderr!.on('data', (d: Buffer) => {
+      const s = d.toString();
+      stderrTail = (stderrTail + s).slice(-2000);
+      for (const line of s.split('\n')) {
+        if (line) { cb.appendLog(`[dump] ${line}`); cb.onProgressLine(line); }
+      }
+    });
+    const done = new Promise<void>((resolve, reject) => {
+      child.on('close', (code) => {
+        if (code === 0) resolve();
+        else reject(new Error(`mongodump 失败 (exit ${code}): ${stderrTail.slice(-400)}`));
+      });
+      child.on('error', (err) => reject(new Error(`无法启动 mongodump: ${err.message}`)));
+    });
+    return {
+      stdout: child.stdout!,
+      done,
+      kill: () => { try { child.kill('SIGKILL'); } catch { /* */ } },
+    };
+  }
+
+  /**
+   * Build a consumer that accepts a `mongodump --archive --gzip` byte stream.
+   * Returns a handle with a writable `stdin`, a `done` promise, and `kill()`.
+   */
+  async function buildTargetConsumer(
+    target: MongoConnectionConfig,
+    source: MongoConnectionConfig,
+    cols: string[] | undefined,
+    cb: {
+      appendLog: (s: string) => void;
+      onProgressLine: (line: string) => void;
+      send: (progress: number, message: string) => void;
+    },
+  ): Promise<{ stdin: NodeJS.WritableStream; done: Promise<void>; kill: () => void }> {
+    // ── CDS peer target ──
+    if (target.type === 'cds') {
+      const peer = stateService.getCdsPeer(target.cdsPeerId || '');
+      if (!peer) throw new Error(`目标 CDS 密钥不存在: ${target.cdsPeerId}`);
+      cb.send(12, `连接目标 CDS 「${peer.name}」...`);
+      // Build URL with query params for target rename + collection filter
+      const qs = new URLSearchParams();
+      if (source.database) qs.set('sourceDb', source.database);
+      if (target.database) qs.set('targetDb', target.database);
+      if (cols && cols.length) qs.set('collections', cols.join(','));
+      const apiPath = '/api/data-migrations/local-restore' + (qs.toString() ? '?' + qs.toString() : '');
+      const url = new URL(peer.baseUrl.replace(/\/$/, '') + apiPath);
+      const lib = url.protocol === 'https:' ? https : http;
+      const httpReq = lib.request({
+        method: 'POST',
+        protocol: url.protocol,
+        hostname: url.hostname,
+        port: url.port || (url.protocol === 'https:' ? 443 : 80),
+        path: url.pathname + url.search,
+        headers: {
+          'X-AI-Access-Key': peer.accessKey,
+          'X-CDS-Peer-Call': '1',
+          'Content-Type': 'application/octet-stream',
+          // Chunked transfer (no Content-Length, just stream)
+          'Transfer-Encoding': 'chunked',
+        },
+        timeout: 0,
+      });
+      httpReq.setTimeout(0);
+      cb.appendLog(`[target] CDS peer ${peer.name} → ${apiPath}`);
+
+      const done = new Promise<void>((resolve, reject) => {
+        httpReq.on('response', (peerRes) => {
+          const chunks: Buffer[] = [];
+          peerRes.on('data', (d) => chunks.push(d as Buffer));
+          peerRes.on('end', () => {
+            const text = Buffer.concat(chunks).toString('utf-8');
+            try {
+              const j = JSON.parse(text);
+              if (j && j.log) for (const line of String(j.log).split('\n')) if (line) { cb.appendLog(`[restore] ${line}`); cb.onProgressLine(line); }
+            } catch { cb.appendLog(`[target] ${text.slice(0, 500)}`); }
+            if ((peerRes.statusCode || 500) >= 400) {
+              reject(new Error(`目标 CDS 返回 ${peerRes.statusCode}: ${text.slice(0, 400)}`));
+            } else {
+              resolve();
+            }
+          });
+          peerRes.on('error', reject);
+        });
+        httpReq.on('error', (err) => reject(new Error(`连接目标 CDS 失败: ${err.message}`)));
+      });
+
+      return {
+        stdin: httpReq,
+        done,
+        kill: () => { try { httpReq.destroy(); } catch { /* */ } },
+      };
+    }
+
+    // ── Local / remote via mongorestore ──
+    const eff = target.type === 'local' ? resolveMongoConn(target) : target;
+    const restoreArgs = buildMongorestoreArgs(
+      eff.host, eff.port,
+      { username: eff.username, password: eff.password, authDatabase: eff.authDatabase },
+      {
+        drop: true,
+        sourceDb: source.type !== 'cds' ? source.database : undefined,
+        targetDb: eff.database,
+        collections: cols,
+      },
+    );
+
+    let cmd: string;
+    let argv: string[];
+    if (target.sshTunnel?.enabled) {
+      cb.send(12, `通过 SSH 连接 ${target.sshTunnel.host}...`);
+      const sshBase = buildSshBase(target.sshTunnel);
+      const remoteCmd = buildRemoteMongoCmd('mongorestore', restoreArgs, target.sshTunnel.dockerContainer);
+      cb.appendLog(`[target] ssh ${target.sshTunnel.username}@${target.sshTunnel.host}: ${remoteCmd}`);
+      cmd = 'ssh';
+      argv = [...sshBase, remoteCmd];
+    } else {
+      cb.appendLog(`[target] mongorestore ${restoreArgs.join(' ')}`);
+      cmd = 'mongorestore';
+      argv = restoreArgs;
+    }
+
+    const child = spawn(cmd, argv, { stdio: ['pipe', 'pipe', 'pipe'] });
+    let stderrTail = '';
+    const mirror = (prefix: string) => (d: Buffer) => {
+      const s = d.toString();
+      stderrTail = (stderrTail + s).slice(-2000);
+      for (const line of s.split('\n')) {
+        if (line) { cb.appendLog(`[${prefix}] ${line}`); cb.onProgressLine(line); }
+      }
+    };
+    child.stderr!.on('data', mirror('restore'));
+    child.stdout!.on('data', mirror('restore'));
+    const done = new Promise<void>((resolve, reject) => {
+      child.on('close', (code) => {
+        if (code === 0) resolve();
+        else reject(new Error(`mongorestore 失败 (exit ${code}): ${stderrTail.slice(-400)}`));
+      });
+      child.on('error', (err) => reject(new Error(`无法启动 mongorestore: ${err.message}`)));
+    });
+    return {
+      stdin: child.stdin!,
+      done,
+      kill: () => { try { child.kill('SIGKILL'); } catch { /* */ } },
+    };
+  }
 
   // POST /api/data-migrations/:id/test-connection — test a MongoDB connection
   router.post('/data-migrations/test-connection', async (req, res) => {
@@ -3222,6 +3607,302 @@ export function createBranchRouter(deps: RouterDeps): Router {
     const migration = stateService.getDataMigration(req.params.id);
     if (!migration) { res.status(404).json({ error: '迁移任务不存在' }); return; }
     res.json({ log: migration.log || '' });
+  });
+
+  // POST /api/data-migrations/test-tunnel — verify an SSH tunnel config
+  // Runs `ssh user@host echo __cds_ok__` with the supplied credentials.
+  router.post('/data-migrations/test-tunnel', async (req, res) => {
+    const { sshTunnel } = req.body as { sshTunnel: MongoConnectionConfig['sshTunnel'] };
+    if (!sshTunnel || !sshTunnel.host || !sshTunnel.username) {
+      res.json({ success: false, error: '请填写 SSH 主机和用户名' });
+      return;
+    }
+    try {
+      const sshBase = buildSshBase(sshTunnel);
+      // Add 'echo __cds_ok__' as the remote command and enforce a 15s timeout on client side
+      const argv = [...sshBase, `echo __cds_ok__`];
+      const result = await new Promise<{ code: number; stdout: string; stderr: string }>((resolve) => {
+        const child = spawn('ssh', argv, { stdio: ['ignore', 'pipe', 'pipe'] });
+        let stdout = ''; let stderr = '';
+        const timer = setTimeout(() => { try { child.kill('SIGKILL'); } catch { /* */ } }, 15000);
+        child.stdout.on('data', (d) => { stdout += d.toString(); });
+        child.stderr.on('data', (d) => { stderr += d.toString(); });
+        child.on('close', (code) => { clearTimeout(timer); resolve({ code: code ?? 1, stdout, stderr }); });
+        child.on('error', (err) => { clearTimeout(timer); resolve({ code: 1, stdout, stderr: err.message }); });
+      });
+      if (result.code === 0 && result.stdout.includes('__cds_ok__')) {
+        // Optional: also check mongodump availability on the remote side
+        let mongoNote = '';
+        if (sshTunnel.dockerContainer) {
+          mongoNote = `（通过容器 ${sshTunnel.dockerContainer}）`;
+        } else {
+          const toolCheck = await new Promise<{ code: number; stdout: string }>((resolve) => {
+            const child = spawn('ssh', [...sshBase, 'which mongodump 2>/dev/null || echo NOT_FOUND'], { stdio: ['ignore', 'pipe', 'pipe'] });
+            let stdout = '';
+            const timer = setTimeout(() => { try { child.kill('SIGKILL'); } catch { /* */ } }, 10000);
+            child.stdout.on('data', (d) => { stdout += d.toString(); });
+            child.on('close', (code) => { clearTimeout(timer); resolve({ code: code ?? 1, stdout }); });
+            child.on('error', () => { clearTimeout(timer); resolve({ code: 1, stdout: '' }); });
+          });
+          if (toolCheck.stdout.includes('NOT_FOUND')) {
+            mongoNote = '（⚠ 远程未找到 mongodump；建议配置 docker 容器名）';
+          } else {
+            mongoNote = '（远程 mongodump 可用）';
+          }
+        }
+        res.json({ success: true, message: `SSH 连接成功 ${mongoNote}` });
+      } else {
+        res.json({ success: false, error: (result.stderr || 'SSH 连接失败').trim().slice(0, 400) });
+      }
+    } catch (e) {
+      res.json({ success: false, error: (e as Error).message });
+    }
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  //   CDS Peer Registry (one-click cross-CDS migration)
+  // ─────────────────────────────────────────────────────────────────
+
+  // GET /api/data-migrations/my-key — return this CDS's own access key so the user can copy it.
+  //
+  // Response:
+  //   { accessKey: string|null, baseUrl: string, label: string, hint: string }
+  //
+  // If no key is configured, `accessKey` is null and the caller can show a
+  // "set AI_ACCESS_KEY first" banner.
+  router.get('/data-migrations/my-key', (req, res) => {
+    const accessKey = getLocalAccessKey();
+    const baseUrl = guessLocalBaseUrl(req);
+    const label = `${baseUrl}`;
+    res.json({
+      accessKey,
+      baseUrl,
+      label,
+      hint: accessKey
+        ? '复制下面的 baseUrl + 访问密钥，在另一台 CDS 的「CDS 密钥管理」中添加即可双向迁移。'
+        : '当前 CDS 未设置 AI_ACCESS_KEY，请先在「设置 → 环境变量」中配置 AI_ACCESS_KEY 后再试。',
+    });
+  });
+
+  // GET /api/data-migrations/peers — list registered peers (access keys are returned masked)
+  router.get('/data-migrations/peers', (_req, res) => {
+    const peers = stateService.getCdsPeers().map(p => ({
+      ...p,
+      // Mask the key — show only last 6 chars so the user can recognize it without leaking it in HTTP logs
+      accessKey: p.accessKey ? `••••${p.accessKey.slice(-6)}` : '',
+    }));
+    res.json(peers);
+  });
+
+  // POST /api/data-migrations/peers — add a new peer. Auto-verifies by calling the peer's /my-key.
+  router.post('/data-migrations/peers', async (req, res) => {
+    const { name, baseUrl, accessKey } = req.body as { name?: string; baseUrl?: string; accessKey?: string };
+    if (!name || !baseUrl || !accessKey) {
+      res.status(400).json({ error: '缺少必填字段: name, baseUrl, accessKey' });
+      return;
+    }
+    try { new URL(baseUrl); } catch { res.status(400).json({ error: 'baseUrl 格式错误' }); return; }
+    const peer: CdsPeer = {
+      id: `peer-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`,
+      name,
+      baseUrl: baseUrl.replace(/\/$/, ''),
+      accessKey,
+      createdAt: new Date().toISOString(),
+    };
+    // Verify — call /my-key to confirm the access key works
+    try {
+      const probe = await peerRequestJson<{ baseUrl: string; accessKey: string | null }>(peer, '/api/data-migrations/my-key', 'GET');
+      peer.lastVerifiedAt = new Date().toISOString();
+      peer.remoteLabel = probe.baseUrl || baseUrl;
+    } catch (e) {
+      res.status(400).json({ error: `验证失败: ${(e as Error).message}` });
+      return;
+    }
+    stateService.addCdsPeer(peer);
+    stateService.save();
+    // Return masked version
+    res.json({ ...peer, accessKey: `••••${accessKey.slice(-6)}` });
+  });
+
+  // PUT /api/data-migrations/peers/:id — update peer (name / baseUrl / accessKey)
+  router.put('/data-migrations/peers/:id', async (req, res) => {
+    const { id } = req.params;
+    const existing = stateService.getCdsPeer(id);
+    if (!existing) { res.status(404).json({ error: 'CDS 密钥不存在' }); return; }
+    const { name, baseUrl, accessKey } = req.body as { name?: string; baseUrl?: string; accessKey?: string };
+    const updates: Partial<CdsPeer> = {};
+    if (name !== undefined) updates.name = name;
+    if (baseUrl !== undefined) updates.baseUrl = baseUrl.replace(/\/$/, '');
+    // Only update accessKey if caller provided a value that doesn't look masked (••••)
+    if (accessKey !== undefined && !accessKey.startsWith('•')) updates.accessKey = accessKey;
+    stateService.updateCdsPeer(id, updates);
+    stateService.save();
+    const updated = stateService.getCdsPeer(id)!;
+    res.json({ ...updated, accessKey: `••••${updated.accessKey.slice(-6)}` });
+  });
+
+  // DELETE /api/data-migrations/peers/:id
+  router.delete('/data-migrations/peers/:id', (req, res) => {
+    const { id } = req.params;
+    if (!stateService.getCdsPeer(id)) { res.status(404).json({ error: 'CDS 密钥不存在' }); return; }
+    stateService.removeCdsPeer(id);
+    stateService.save();
+    res.json({ message: '已删除' });
+  });
+
+  // POST /api/data-migrations/peers/:id/test — verify a peer's connectivity
+  router.post('/data-migrations/peers/:id/test', async (req, res) => {
+    const peer = stateService.getCdsPeer(req.params.id);
+    if (!peer) { res.status(404).json({ error: 'CDS 密钥不存在' }); return; }
+    try {
+      const probe = await peerRequestJson<{ baseUrl: string; accessKey: string | null }>(peer, '/api/data-migrations/my-key', 'GET');
+      stateService.updateCdsPeer(peer.id, { lastVerifiedAt: new Date().toISOString(), remoteLabel: probe.baseUrl });
+      stateService.save();
+      res.json({ success: true, remoteLabel: probe.baseUrl, verifiedAt: new Date().toISOString() });
+    } catch (e) {
+      res.json({ success: false, error: (e as Error).message });
+    }
+  });
+
+  // POST /api/data-migrations/peers/:id/list-databases — proxy to peer's list-databases for its local infra MongoDB
+  router.post('/data-migrations/peers/:id/list-databases', async (req, res) => {
+    const peer = stateService.getCdsPeer(req.params.id);
+    if (!peer) { res.status(404).json({ error: 'CDS 密钥不存在' }); return; }
+    try {
+      const result = await peerRequestJson<{ databases: Array<{ name: string; sizeOnDisk: number }>; error?: string }>(
+        peer,
+        '/api/data-migrations/list-databases',
+        'POST',
+        { connection: { type: 'local', host: '', port: 0 } },
+      );
+      res.json(result);
+    } catch (e) {
+      res.json({ databases: [], error: (e as Error).message });
+    }
+  });
+
+  // POST /api/data-migrations/peers/:id/list-collections — proxy list-collections for a database on the peer
+  router.post('/data-migrations/peers/:id/list-collections', async (req, res) => {
+    const peer = stateService.getCdsPeer(req.params.id);
+    if (!peer) { res.status(404).json({ error: 'CDS 密钥不存在' }); return; }
+    const { database } = req.body as { database?: string };
+    if (!database) { res.status(400).json({ error: '请指定 database' }); return; }
+    try {
+      const result = await peerRequestJson<{ collections: Array<{ name: string; count: number }>; error?: string }>(
+        peer,
+        '/api/data-migrations/list-collections',
+        'POST',
+        { connection: { type: 'local', host: '', port: 0, database } },
+      );
+      res.json(result);
+    } catch (e) {
+      res.json({ collections: [], error: (e as Error).message });
+    }
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  //   Streaming endpoints called by remote peers (auth-protected)
+  // ─────────────────────────────────────────────────────────────────
+
+  // POST /api/data-migrations/local-dump — streams mongodump bytes for this
+  // CDS's local infra MongoDB. Authorized via the standard CDS middleware
+  // (cds cookie / X-AI-Access-Key). Used by remote peers to pull data.
+  //
+  // Body: { database?: string, collections?: string[] }
+  router.post('/data-migrations/local-dump', async (req, res) => {
+    const body = (req.body || {}) as { database?: string; collections?: string[] };
+    let eff: MongoConnectionConfig;
+    try {
+      eff = resolveMongoConn({ type: 'local', host: '', port: 0, database: body.database });
+    } catch (e) {
+      res.status(500).json({ error: (e as Error).message });
+      return;
+    }
+    const dumpArgs = buildMongodumpArgs(
+      eff.host, eff.port,
+      {},
+      body.database,
+      body.collections,
+    );
+    res.writeHead(200, {
+      'Content-Type': 'application/octet-stream',
+      'Cache-Control': 'no-cache',
+      'X-Accel-Buffering': 'no',
+    });
+    const child = spawn('mongodump', dumpArgs, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stderrTail = '';
+    child.stderr.on('data', (d) => { stderrTail = (stderrTail + d.toString()).slice(-2000); });
+    child.stdout.pipe(res);
+    child.on('close', (code) => {
+      if (code !== 0) {
+        // We may already have sent headers — append a trailer-like marker
+        try { res.write(`\n__CDS_DUMP_ERROR__:${stderrTail.slice(-400)}`); } catch { /* */ }
+      }
+      try { res.end(); } catch { /* */ }
+    });
+    child.on('error', (err) => {
+      try {
+        if (!res.headersSent) res.status(500).json({ error: err.message });
+        else res.end();
+      } catch { /* */ }
+    });
+    // If the client disconnects, kill the dump
+    req.on('close', () => { try { child.kill('SIGKILL'); } catch { /* */ } });
+  });
+
+  // POST /api/data-migrations/local-restore — pipes request body into
+  // mongorestore against this CDS's local infra MongoDB.
+  //
+  // Query params: sourceDb, targetDb, collections (comma-separated)
+  router.post('/data-migrations/local-restore', async (req, res) => {
+    const sourceDb = (req.query.sourceDb as string | undefined) || undefined;
+    const targetDb = (req.query.targetDb as string | undefined) || undefined;
+    const colsParam = req.query.collections as string | undefined;
+    const collections = colsParam ? colsParam.split(',').filter(Boolean) : undefined;
+
+    let eff: MongoConnectionConfig;
+    try {
+      eff = resolveMongoConn({ type: 'local', host: '', port: 0, database: targetDb });
+    } catch (e) {
+      res.status(500).json({ error: (e as Error).message });
+      return;
+    }
+    const restoreArgs = buildMongorestoreArgs(
+      eff.host, eff.port,
+      {},
+      { drop: true, sourceDb, targetDb, collections },
+    );
+    const child = spawn('mongorestore', restoreArgs, { stdio: ['pipe', 'pipe', 'pipe'] });
+    let stderrTail = '';
+    const logLines: string[] = [];
+    const mirror = (d: Buffer) => {
+      const s = d.toString();
+      stderrTail = (stderrTail + s).slice(-4000);
+      for (const line of s.split('\n')) if (line) logLines.push(line);
+    };
+    child.stderr.on('data', mirror);
+    child.stdout.on('data', mirror);
+
+    // Pipe request body into mongorestore stdin
+    req.pipe(child.stdin);
+
+    // If the client aborts upload, kill the restore process
+    req.on('error', () => { try { child.kill('SIGKILL'); } catch { /* */ } });
+    req.on('close', () => {
+      // End of request body — close stdin so mongorestore can finish
+      try { child.stdin.end(); } catch { /* */ }
+    });
+
+    child.on('close', (code) => {
+      if (code === 0) {
+        res.json({ success: true, log: logLines.join('\n') });
+      } else {
+        res.status(500).json({ success: false, error: stderrTail.slice(-400) || `mongorestore exited ${code}`, log: logLines.join('\n') });
+      }
+    });
+    child.on('error', (err) => {
+      if (!res.headersSent) res.status(500).json({ success: false, error: err.message });
+    });
   });
 
   // GET /api/self-branches — list git branches of the CDS repo itself

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -3846,8 +3846,14 @@ export function createBranchRouter(deps: RouterDeps): Router {
         else res.end();
       } catch { /* */ }
     });
-    // If the client disconnects, kill the dump
-    req.on('close', () => { try { child.kill('SIGKILL'); } catch { /* */ } });
+    // If the client aborts the download, kill the dump.
+    // IMPORTANT: use res.on('close'), NOT req.on('close'). In Node.js 18+,
+    // req.on('close') fires as soon as express.json() finishes reading the
+    // request body (before the handler even writes output), which would
+    // kill mongodump immediately and return an empty 0-byte response.
+    res.on('close', () => {
+      if (!res.writableEnded) { try { child.kill('SIGKILL'); } catch { /* */ } }
+    });
   });
 
   // POST /api/data-migrations/local-restore — pipes request body into

--- a/cds/src/services/state.ts
+++ b/cds/src/services/state.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import type { CdsState, BranchEntry, BuildProfile, RoutingRule, OperationLog, InfraService, ExecutorNode, DataMigration } from '../types.js';
+import type { CdsState, BranchEntry, BuildProfile, RoutingRule, OperationLog, InfraService, ExecutorNode, DataMigration, CdsPeer } from '../types.js';
 
 const MAX_LOGS_PER_BRANCH = 10;
 /** Max rolling backups of state.json kept on disk. See design.cds-resilience.md §5. */
@@ -92,6 +92,7 @@ export class StateService {
       if (this.state.previewMode === undefined) this.state.previewMode = 'multi';
       if (!this.state.executors) this.state.executors = {};
       if (!this.state.dataMigrations) this.state.dataMigrations = [];
+      if (!this.state.cdsPeers) this.state.cdsPeers = [];
       // Migrate: backfill cacheMounts for existing build profiles
       this.migrateCacheMounts();
       // Migrate: ensure deployModes field exists on profiles (no-op if already present)
@@ -498,6 +499,32 @@ export class StateService {
 
   removeDataMigration(id: string): void {
     this.state.dataMigrations = (this.state.dataMigrations || []).filter(m => m.id !== id);
+  }
+
+  // ── CDS peers (remote CDS instances trusted for data migration) ──
+
+  getCdsPeers(): CdsPeer[] {
+    return this.state.cdsPeers || [];
+  }
+
+  getCdsPeer(id: string): CdsPeer | undefined {
+    return (this.state.cdsPeers || []).find(p => p.id === id);
+  }
+
+  addCdsPeer(peer: CdsPeer): void {
+    if (!this.state.cdsPeers) this.state.cdsPeers = [];
+    this.state.cdsPeers.push(peer);
+  }
+
+  updateCdsPeer(id: string, updates: Partial<CdsPeer>): void {
+    const list = this.state.cdsPeers || [];
+    const idx = list.findIndex(p => p.id === id);
+    if (idx === -1) throw new Error(`CDS 密钥 "${id}" 不存在`);
+    Object.assign(list[idx], updates);
+  }
+
+  removeCdsPeer(id: string): void {
+    this.state.cdsPeers = (this.state.cdsPeers || []).filter(p => p.id !== id);
   }
 
   /**

--- a/cds/src/types.ts
+++ b/cds/src/types.ts
@@ -247,6 +247,33 @@ export interface CdsState {
   executors?: Record<string, ExecutorNode>;
   /** Data migration task history */
   dataMigrations?: DataMigration[];
+  /** Registered remote CDS peers (for one-click cross-CDS data migration) */
+  cdsPeers?: CdsPeer[];
+}
+
+/**
+ * A trusted remote CDS instance. Used as the source or target of a data
+ * migration without having to copy around hostnames, ports, and mongo auth —
+ * the remote CDS exposes its local infra MongoDB via authenticated
+ * streaming endpoints (see /api/data-migrations/local-dump / local-restore).
+ *
+ * Auth = the remote CDS's AI_ACCESS_KEY (same key used by the AI bridge).
+ * Transport = HTTPS (preview.miduo.org terminates TLS), so the stream is
+ * encrypted end-to-end without any manual SSH/tunnel setup.
+ */
+export interface CdsPeer {
+  id: string;
+  /** Human-readable name, e.g. "生产 CDS" */
+  name: string;
+  /** Base URL of the remote CDS API, e.g. "https://main.miduo.org" */
+  baseUrl: string;
+  /** AI_ACCESS_KEY of the remote CDS (sent as X-AI-Access-Key header) */
+  accessKey: string;
+  createdAt: string;
+  /** Last verified connection timestamp */
+  lastVerifiedAt?: string;
+  /** Remote infra MongoDB label captured during last verify (for display) */
+  remoteLabel?: string;
 }
 
 /** SSH tunnel configuration for data migration */
@@ -259,12 +286,25 @@ export interface SshTunnelConfig {
   privateKeyPath?: string;
   /** Password auth (less secure, prefer key-based) */
   password?: string;
+  /**
+   * Optional: when set, the mongodump/mongorestore command on the remote
+   * jump host is wrapped in `docker exec <container> sh -c '...'`. Use this
+   * when the remote host only has MongoDB inside a container and the tools
+   * aren't on the jump host's PATH. Matches the manual recipe:
+   *   ssh root@host "docker exec mongo-container sh -c 'mongodump --archive --gzip'"
+   */
+  dockerContainer?: string;
 }
 
 /** MongoDB connection configuration for data migration */
 export interface MongoConnectionConfig {
-  /** 'local' uses the CDS infra MongoDB, 'remote' uses custom connection */
-  type: 'local' | 'remote';
+  /**
+   * Connection mode:
+   * - 'local'  : the CDS infra MongoDB running on this host
+   * - 'remote' : a custom host:port (optional SSH tunnel)
+   * - 'cds'    : a registered remote CDS peer (auto-auth via X-AI-Access-Key)
+   */
+  type: 'local' | 'remote' | 'cds';
   host: string;
   port: number;
   /** Database name (empty = all databases) */
@@ -275,8 +315,10 @@ export interface MongoConnectionConfig {
   password?: string;
   /** Auth source database */
   authDatabase?: string;
-  /** SSH tunnel for this connection */
+  /** SSH tunnel for this connection (only used when type === 'remote') */
   sshTunnel?: SshTunnelConfig;
+  /** CDS peer id (only used when type === 'cds') */
+  cdsPeerId?: string;
 }
 
 /** A data migration task */
@@ -301,6 +343,8 @@ export interface DataMigration {
   /** Error message if failed */
   errorMessage?: string;
   createdAt: string;
+  /** Last modification timestamp (set by PUT /:id) */
+  updatedAt?: string;
   startedAt?: string;
   finishedAt?: string;
   /** Migration log output */

--- a/cds/web/app.js
+++ b/cds/web/app.js
@@ -4716,9 +4716,16 @@ function escapeHtml(s) {
 let migrationTasks = [];
 let migrationToolInstalled = null;
 let loadedCollections = [];
+let cdsPeers = [];
+/** true when the new-migration modal is in edit mode; stores the id being edited */
+let migrationEditingId = null;
 
 async function loadMigrations() {
   try { migrationTasks = await api('GET', '/data-migrations'); } catch { migrationTasks = []; }
+}
+
+async function loadCdsPeers() {
+  try { cdsPeers = await api('GET', '/data-migrations/peers'); } catch { cdsPeers = []; }
 }
 
 function migStatusColor(s) { return { pending: 'var(--fg-muted)', running: 'var(--blue)', completed: 'var(--green)', failed: 'var(--red)' }[s] || 'var(--fg-muted)'; }
@@ -4729,6 +4736,10 @@ function formatConnSummary(conn) {
   if (!conn) return '—';
   const db = conn.database ? `/${conn.database}` : '';
   if (conn.type === 'local') return `本机 MongoDB${db}`;
+  if (conn.type === 'cds') {
+    const peer = cdsPeers.find(p => p.id === conn.cdsPeerId);
+    return `🔑 ${peer?.name || conn.cdsPeerId || '未知 CDS'}${db}`;
+  }
   return `${conn.host || '?'}:${conn.port || 27017}${db}`;
 }
 
@@ -4782,6 +4793,7 @@ function renderMigrationCard(m) {
       ` : ''}
       <div class="mig-card-actions">
         ${canRun ? `<button class="sm" onclick="executeMigration('${m.id}')">▶ 执行</button>` : ''}
+        ${m.status !== 'running' ? `<button class="sm" onclick="editMigration('${m.id}')">✎ 编辑</button>` : ''}
         <button class="sm" onclick="cloneMigration('${m.id}')">⧉ 克隆</button>
         ${m.log ? `<button class="sm" onclick="showMigrationLog('${m.id}')">📋 日志</button>` : ''}
         ${m.status !== 'running' ? `<button class="sm danger-text" onclick="deleteMigration('${m.id}')">删除</button>` : ''}
@@ -4791,14 +4803,16 @@ function renderMigrationCard(m) {
 }
 
 async function openMigrationModal() {
-  await loadMigrations();
+  await Promise.all([loadMigrations(), loadCdsPeers()]);
   const listHtml = migrationTasks.length === 0
     ? '<div class="config-empty">暂无迁移任务。点击"新建迁移"开始配置。</div>'
     : migrationTasks.slice().reverse().map(renderMigrationCard).join('');
+  const peerCount = cdsPeers.length;
   openConfigModal('数据迁移', `
-    <p class="config-panel-desc">MongoDB 数据迁移。支持全库或指定集合迁移，可配置 SSH 隧道。</p>
+    <p class="config-panel-desc">MongoDB 数据迁移。支持本机 / 远程 / CDS 密钥（跨 CDS 一键直连）。管道流式传输，无临时文件。</p>
     <div class="config-panel-actions" style="margin-bottom:10px;display:flex;gap:6px;flex-wrap:wrap">
       <button class="sm primary" onclick="openNewMigrationModal()">+ 新建迁移</button>
+      <button class="sm" onclick="openPeersModal()">🔑 CDS 密钥管理${peerCount ? ` (${peerCount})` : ''}</button>
       <button class="sm" onclick="checkMigrationTools()">🔧 工具状态</button>
     </div>
     <div id="migrationToolStatus" style="font-size:12px;margin-bottom:8px;display:none"></div>
@@ -4852,52 +4866,76 @@ async function installMigrationTools() {
 function buildConnectionForm(prefix, defaultType, isSource) {
   const mongoSvc = infraServices.find(s => s.id === 'mongodb');
   const hasLocalMongo = !!mongoSvc;
+  const peerOptions = cdsPeers.map(p =>
+    `<option value="${esc(p.id)}">${esc(p.name)} · ${esc((p.baseUrl || '').replace(/^https?:\/\//, ''))}</option>`
+  ).join('');
   return `
     <div class="migration-conn-panel">
-      <div class="form-row" style="margin-bottom:6px">
-        <select id="${prefix}Type" class="form-input" onchange="onConnTypeChange('${prefix}', ${isSource})" style="font-size:12px">
+      <div class="form-row mc-row" style="margin-bottom:6px">
+        <select id="${prefix}Type" class="form-input mc-input" onchange="onConnTypeChange('${prefix}', ${isSource})">
           ${hasLocalMongo ? `<option value="local" ${defaultType === 'local' ? 'selected' : ''}>本机 MongoDB${mongoSvc?.status === 'running' ? ' ●' : ''}</option>` : ''}
+          <option value="cds" ${defaultType === 'cds' ? 'selected' : ''}>🔑 CDS 密钥 (跨 CDS 直连)</option>
           <option value="remote" ${defaultType === 'remote' || !hasLocalMongo ? 'selected' : ''}>远程 MongoDB</option>
         </select>
       </div>
-      <div id="${prefix}RemoteFields" style="${defaultType === 'local' && hasLocalMongo ? 'display:none' : ''}">
-        <div class="form-row">
-          <input id="${prefix}Host" class="form-input" placeholder="主机地址" value="127.0.0.1">
-          <input id="${prefix}Port" class="form-input sm" placeholder="端口" value="27017" type="number" style="flex:0.4">
-        </div>
-        <div class="form-row">
-          <input id="${prefix}Username" class="form-input" placeholder="用户名 (可选)">
-          <input id="${prefix}Password" class="form-input" placeholder="密码 (可选)" type="password">
-        </div>
-        <div class="form-row">
-          <input id="${prefix}AuthDb" class="form-input" placeholder="认证库 (默认 admin)">
+
+      <div id="${prefix}CdsFields" style="${defaultType === 'cds' ? '' : 'display:none'}">
+        <div class="form-row mc-row">
+          <select id="${prefix}CdsPeer" class="form-input mc-input" onchange="onCdsPeerChange('${prefix}', ${isSource})">
+            <option value="">${cdsPeers.length ? '(请选择 CDS 密钥)' : '(未添加，请点击「管理密钥」)'}</option>
+            ${peerOptions}
+          </select>
+          <button type="button" class="sm mc-btn" onclick="openPeersModal()" title="管理 CDS 密钥">🔑</button>
         </div>
       </div>
+
+      <div id="${prefix}RemoteFields" style="${(defaultType === 'local' && hasLocalMongo) || defaultType === 'cds' ? 'display:none' : ''}">
+        <div class="form-row mc-row">
+          <input id="${prefix}Host" class="form-input mc-input mc-host" placeholder="主机地址" value="127.0.0.1">
+          <input id="${prefix}Port" class="form-input mc-input mc-port" placeholder="端口" value="27017" type="number">
+        </div>
+        <div class="form-row mc-row">
+          <input id="${prefix}Username" class="form-input mc-input" placeholder="用户名 (可选)">
+          <input id="${prefix}Password" class="form-input mc-input" placeholder="密码 (可选)" type="password">
+        </div>
+        <div class="form-row mc-row">
+          <input id="${prefix}AuthDb" class="form-input mc-input" placeholder="认证库 (默认 admin)">
+        </div>
+      </div>
+
       <div id="${prefix}DbArea">
-        <div class="form-row">
-          <select id="${prefix}Database" class="form-input" style="font-size:12px" onchange="onDbChange('${prefix}', ${isSource})">
+        <div class="form-row mc-row">
+          <select id="${prefix}Database" class="form-input mc-input" onchange="onDbChange('${prefix}', ${isSource})">
             <option value="">加载中...</option>
           </select>
         </div>
       </div>
       ${isSource ? `<div id="srcCollectionPicker" style="margin-top:4px"></div>` : ''}
-      <div style="margin-top:6px">
+
+      <div id="${prefix}SshArea" style="margin-top:6px;${defaultType === 'cds' ? 'display:none' : ''}">
         <label style="font-size:11px;display:flex;align-items:center;gap:6px;cursor:pointer;color:var(--fg-muted)">
           <input type="checkbox" id="${prefix}SshEnabled" onchange="toggleSshTunnel('${prefix}')">
           SSH 隧道
         </label>
         <div id="${prefix}SshFields" style="display:none;margin-top:6px">
-          <div class="form-row">
-            <input id="${prefix}SshHost" class="form-input" placeholder="SSH 主机">
-            <input id="${prefix}SshPort" class="form-input sm" placeholder="SSH 端口" value="22" type="number" style="flex:0.3">
+          <div class="form-row mc-row">
+            <input id="${prefix}SshHost" class="form-input mc-input mc-host" placeholder="SSH 主机">
+            <input id="${prefix}SshPort" class="form-input mc-input mc-port" placeholder="端口" value="22" type="number">
           </div>
-          <div class="form-row">
-            <input id="${prefix}SshUser" class="form-input" placeholder="SSH 用户名">
-            <input id="${prefix}SshKey" class="form-input" placeholder="私钥路径">
+          <div class="form-row mc-row">
+            <input id="${prefix}SshUser" class="form-input mc-input" placeholder="SSH 用户名">
+            <input id="${prefix}SshKey" class="form-input mc-input" placeholder="私钥路径 (可选)">
+          </div>
+          <div class="form-row mc-row">
+            <input id="${prefix}SshContainer" class="form-input mc-input" placeholder="docker 容器名 (可选, 走 docker exec)">
+          </div>
+          <div class="form-row mc-row" style="gap:6px">
+            <button type="button" class="sm" onclick="testSshTunnel('${prefix}')" style="flex:0 0 auto">🔧 测试隧道</button>
+            <div id="${prefix}SshTestStatus" style="font-size:11px;flex:1;align-self:center;color:var(--fg-muted);min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap"></div>
           </div>
         </div>
       </div>
-      <div id="${prefix}ConnStatus" style="font-size:11px;margin-top:6px;color:var(--fg-muted)"></div>
+      <div id="${prefix}ConnStatus" style="font-size:11px;margin-top:6px;color:var(--fg-muted);word-break:break-all"></div>
     </div>
   `;
 }
@@ -4910,9 +4948,37 @@ function toggleSshTunnel(prefix) {
 function onConnTypeChange(prefix, isSource) {
   const type = document.getElementById(`${prefix}Type`)?.value;
   const remoteFields = document.getElementById(`${prefix}RemoteFields`);
-  if (remoteFields) remoteFields.style.display = type === 'local' ? 'none' : '';
+  const cdsFields = document.getElementById(`${prefix}CdsFields`);
+  const sshArea = document.getElementById(`${prefix}SshArea`);
+  if (remoteFields) remoteFields.style.display = type === 'remote' ? '' : 'none';
+  if (cdsFields) cdsFields.style.display = type === 'cds' ? '' : 'none';
+  // SSH is irrelevant for CDS-peer connections (peer handles transport via HTTPS)
+  if (sshArea) sshArea.style.display = type === 'cds' ? 'none' : '';
   // Auto-load databases for this connection
   loadDatabases(prefix, isSource);
+}
+
+function onCdsPeerChange(prefix, isSource) {
+  // When the peer changes, refresh the database list
+  loadDatabases(prefix, isSource);
+}
+
+async function testSshTunnel(prefix) {
+  const statusEl = document.getElementById(`${prefix}SshTestStatus`);
+  if (!statusEl) return;
+  statusEl.innerHTML = '<span class="btn-spinner"></span> 正在测试 SSH 隧道...';
+  const conn = readConnectionConfig(prefix);
+  if (!conn.sshTunnel || !conn.sshTunnel.host) {
+    statusEl.innerHTML = '<span style="color:var(--red)">✗ 请先填写 SSH 信息</span>';
+    return;
+  }
+  try {
+    const d = await api('POST', '/data-migrations/test-tunnel', { sshTunnel: conn.sshTunnel });
+    if (d.success) statusEl.innerHTML = `<span style="color:var(--green)" title="${esc(d.message || '')}">✓ ${esc(d.message || '连接成功')}</span>`;
+    else statusEl.innerHTML = `<span style="color:var(--red)" title="${esc(d.error || '')}">✗ ${esc(d.error || '连接失败')}</span>`;
+  } catch (e) {
+    statusEl.innerHTML = `<span style="color:var(--red)">✗ ${esc(e.message)}</span>`;
+  }
 }
 
 async function loadDatabases(prefix, isSource) {
@@ -4925,7 +4991,18 @@ async function loadDatabases(prefix, isSource) {
 
   try {
     const conn = readConnectionConfig(prefix);
-    const d = await api('POST', '/data-migrations/list-databases', { connection: conn });
+    let d;
+    if (conn.type === 'cds') {
+      if (!conn.cdsPeerId) {
+        if (statusEl) statusEl.innerHTML = '<span style="color:var(--fg-muted)">请先选择 CDS 密钥</span>';
+        dbSelect.innerHTML = '<option value="">(请先选择 CDS 密钥)</option>';
+        dbSelect.disabled = false;
+        return;
+      }
+      d = await api('POST', `/data-migrations/peers/${conn.cdsPeerId}/list-databases`);
+    } else {
+      d = await api('POST', '/data-migrations/list-databases', { connection: conn });
+    }
     const dbs = d.databases || [];
     if (d.error) throw new Error(d.error);
     if (dbs.length === 0) throw new Error('无法获取数据库列表');
@@ -4942,7 +5019,7 @@ async function loadDatabases(prefix, isSource) {
     // Fallback: allow manual input
     const dbArea = document.getElementById(`${prefix}DbArea`);
     if (dbArea) {
-      dbArea.innerHTML = `<div class="form-row"><input id="${prefix}Database" class="form-input" placeholder="手动输入数据库名" style="font-size:12px" oninput="onDbChange('${prefix}', ${isSource})"></div>`;
+      dbArea.innerHTML = `<div class="form-row mc-row"><input id="${prefix}Database" class="form-input mc-input" placeholder="手动输入数据库名" oninput="onDbChange('${prefix}', ${isSource})"></div>`;
     }
   }
 }
@@ -4976,13 +5053,19 @@ function onDbChange(prefix, isSource) {
 function autoGenerateName() {
   const nameEl = document.getElementById('migName');
   if (!nameEl || (nameEl.value && !nameEl.dataset.autoGenerated)) return;
-  const srcType = document.getElementById('srcType')?.value;
-  const tgtType = document.getElementById('tgtType')?.value;
+  const labelFor = (prefix) => {
+    const type = document.getElementById(`${prefix}Type`)?.value;
+    if (type === 'local') return '本机';
+    if (type === 'cds') {
+      const peerId = document.getElementById(`${prefix}CdsPeer`)?.value;
+      const peer = cdsPeers.find(p => p.id === peerId);
+      return peer ? `🔑 ${peer.name}` : '🔑 CDS';
+    }
+    return document.getElementById(`${prefix}Host`)?.value || '远程';
+  };
   const srcDb = document.getElementById('srcDatabase')?.value || '';
-  const srcLabel = srcType === 'local' ? '本机' : (document.getElementById('srcHost')?.value || '远程');
-  const tgtLabel = tgtType === 'local' ? '本机' : (document.getElementById('tgtHost')?.value || '远程');
   const db = srcDb ? `/${srcDb}` : '';
-  nameEl.value = `${srcLabel}${db} → ${tgtLabel}`;
+  nameEl.value = `${labelFor('src')}${db} → ${labelFor('tgt')}`;
   nameEl.dataset.autoGenerated = 'true';
 }
 
@@ -4999,14 +5082,20 @@ function readConnectionConfig(prefix) {
     password: document.getElementById(`${prefix}Password`)?.value?.trim() || undefined,
     authDatabase: document.getElementById(`${prefix}AuthDb`)?.value?.trim() || undefined,
   };
+  if (type === 'cds') {
+    conn.cdsPeerId = document.getElementById(`${prefix}CdsPeer`)?.value || undefined;
+  }
+  // SSH is only meaningful for 'remote' connections, but we still read the form values so
+  // the test-tunnel button can work before the user commits the type choice.
   const sshEnabled = document.getElementById(`${prefix}SshEnabled`)?.checked;
-  if (sshEnabled) {
+  if (sshEnabled && type !== 'cds') {
     conn.sshTunnel = {
       enabled: true,
       host: document.getElementById(`${prefix}SshHost`)?.value?.trim() || '',
       port: parseInt(document.getElementById(`${prefix}SshPort`)?.value) || 22,
       username: document.getElementById(`${prefix}SshUser`)?.value?.trim() || '',
       privateKeyPath: document.getElementById(`${prefix}SshKey`)?.value?.trim() || undefined,
+      dockerContainer: document.getElementById(`${prefix}SshContainer`)?.value?.trim() || undefined,
     };
   }
   return conn;
@@ -5023,7 +5112,12 @@ async function loadCollections() {
   if (!conn.database) { picker.innerHTML = ''; loadedCollections = []; return; }
   picker.innerHTML = '<div style="font-size:11px"><span class="btn-spinner"></span> 加载集合...</div>';
   try {
-    const d = await api('POST', '/data-migrations/list-collections', { connection: conn });
+    let d;
+    if (conn.type === 'cds' && conn.cdsPeerId) {
+      d = await api('POST', `/data-migrations/peers/${conn.cdsPeerId}/list-collections`, { database: conn.database });
+    } else {
+      d = await api('POST', '/data-migrations/list-collections', { connection: conn });
+    }
     loadedCollections = d.collections || [];
     if (loadedCollections.length === 0) {
       picker.innerHTML = '<div style="font-size:11px;color:var(--fg-muted)">该库暂无集合</div>';
@@ -5060,10 +5154,17 @@ function toggleAllCollections(sel) {
 
 // ── New Migration Modal ──
 
-function openNewMigrationModal(prefill) {
+async function openNewMigrationModal(prefill, opts) {
+  const editMode = !!(opts && opts.editMode);
+  migrationEditingId = editMode && prefill ? prefill.id : null;
+  // Ensure peers list is available for the peer picker
+  if (cdsPeers.length === 0) { await loadCdsPeers(); }
+  const title = editMode ? '编辑数据迁移' : '新建数据迁移';
+  const primaryLabel = editMode ? '💾 保存修改' : '▶ 创建并执行';
+  const primaryHandler = editMode ? 'saveMigrationEdits()' : 'createAndExecuteMigration()';
   const html = `
     <div class="form-row" style="margin-bottom:10px">
-      <input id="migName" class="form-input" placeholder="任务名称 (自动生成)" style="flex:1" oninput="this.dataset.autoGenerated=''">
+      <input id="migName" class="form-input" placeholder="任务名称 (自动生成)" style="flex:1;min-width:0" oninput="this.dataset.autoGenerated=''">
     </div>
     <div class="migration-dual-panel">
       <div class="migration-side">
@@ -5078,13 +5179,13 @@ function openNewMigrationModal(prefill) {
         ${buildConnectionForm('tgt', prefill?.target?.type || 'remote', false)}
       </div>
     </div>
-    <div class="form-row" style="margin-top:12px;gap:6px">
-      <button class="primary sm" onclick="createAndExecuteMigration()">▶ 创建并执行</button>
-      <button class="sm" onclick="saveMigrationOnly()">💾 仅保存</button>
+    <div class="form-row" style="margin-top:12px;gap:6px;flex-wrap:wrap">
+      <button class="primary sm" onclick="${primaryHandler}">${primaryLabel}</button>
+      ${editMode ? '' : '<button class="sm" onclick="saveMigrationOnly()">💾 仅保存</button>'}
       <button class="sm" onclick="openMigrationModal()">取消</button>
     </div>
   `;
-  openConfigModal('新建数据迁移', html);
+  openConfigModal(title, html);
 
   // Auto-load databases on open (or prefill)
   setTimeout(() => {
@@ -5092,7 +5193,19 @@ function openNewMigrationModal(prefill) {
       fillConnectionFields('src', prefill.source);
       fillConnectionFields('tgt', prefill.target);
       const nameEl = document.getElementById('migName');
-      if (nameEl) { nameEl.value = prefill.name + ' (副本)'; nameEl.dataset.autoGenerated = ''; }
+      if (nameEl) {
+        nameEl.value = editMode ? prefill.name : (prefill.name + ' (副本)');
+        nameEl.dataset.autoGenerated = '';
+      }
+      // Restore selected collections after loading
+      if (editMode && prefill.collections?.length) {
+        const targetCols = new Set(prefill.collections);
+        setTimeout(() => {
+          document.querySelectorAll('input[name="migCollection"]').forEach(cb => {
+            if (targetCols.has(cb.value)) cb.checked = true;
+          });
+        }, 400);
+      }
     } else {
       // Auto-load for default connection types
       loadDatabases('src', true);
@@ -5101,13 +5214,35 @@ function openNewMigrationModal(prefill) {
   }, 50);
 }
 
+async function editMigration(id) {
+  if (cdsPeers.length === 0) await loadCdsPeers();
+  const m = migrationTasks.find(t => t.id === id);
+  if (!m) { showToast('迁移任务不存在', 'error'); return; }
+  openNewMigrationModal(m, { editMode: true });
+}
+
+async function saveMigrationEdits() {
+  if (!migrationEditingId) { showToast('非编辑模式', 'error'); return; }
+  const body = collectMigrationBody();
+  try {
+    await api('PUT', `/data-migrations/${migrationEditingId}`, body);
+    showToast('已保存', 'success');
+    migrationEditingId = null;
+    openMigrationModal();
+  } catch (e) { showToast(e.message, 'error'); }
+}
+
 function fillConnectionFields(prefix, conn) {
   if (!conn) return;
   const typeEl = document.getElementById(`${prefix}Type`);
   if (typeEl) {
     typeEl.value = conn.type || 'remote';
     const remoteFields = document.getElementById(`${prefix}RemoteFields`);
-    if (remoteFields) remoteFields.style.display = conn.type === 'local' ? 'none' : '';
+    const cdsFields = document.getElementById(`${prefix}CdsFields`);
+    const sshArea = document.getElementById(`${prefix}SshArea`);
+    if (remoteFields) remoteFields.style.display = conn.type === 'remote' ? '' : 'none';
+    if (cdsFields) cdsFields.style.display = conn.type === 'cds' ? '' : 'none';
+    if (sshArea) sshArea.style.display = conn.type === 'cds' ? 'none' : '';
   }
   const set = (id, val) => { const el = document.getElementById(id); if (el && val != null) el.value = val; };
   set(`${prefix}Host`, conn.host);
@@ -5115,6 +5250,9 @@ function fillConnectionFields(prefix, conn) {
   set(`${prefix}Username`, conn.username);
   set(`${prefix}Password`, conn.password);
   set(`${prefix}AuthDb`, conn.authDatabase);
+  if (conn.type === 'cds') {
+    set(`${prefix}CdsPeer`, conn.cdsPeerId);
+  }
   if (conn.sshTunnel?.enabled) {
     const sshCb = document.getElementById(`${prefix}SshEnabled`);
     if (sshCb) { sshCb.checked = true; toggleSshTunnel(prefix); }
@@ -5122,6 +5260,7 @@ function fillConnectionFields(prefix, conn) {
     set(`${prefix}SshPort`, conn.sshTunnel.port);
     set(`${prefix}SshUser`, conn.sshTunnel.username);
     set(`${prefix}SshKey`, conn.sshTunnel.privateKeyPath);
+    set(`${prefix}SshContainer`, conn.sshTunnel.dockerContainer);
   }
   // Load databases then select the right one
   loadDatabases(prefix, prefix === 'src').then(() => {
@@ -5257,6 +5396,166 @@ async function deleteMigration(id) {
   if (!confirm('确定删除此迁移任务？')) return;
   try { await api('DELETE', `/data-migrations/${id}`); showToast('已删除', 'success'); openMigrationModal(); }
   catch (e) { showToast(e.message, 'error'); }
+}
+
+// ── CDS Peers (cross-CDS migration via access keys) ──
+
+async function openPeersModal() {
+  await loadCdsPeers();
+  // Also fetch own key so the user can copy it
+  let myKey = null;
+  try { myKey = await api('GET', '/data-migrations/my-key'); } catch { /* */ }
+
+  const myKeySection = myKey && myKey.accessKey ? `
+    <div class="peer-mykey-box">
+      <div class="peer-mykey-title">🔑 本机 CDS 密钥 <span class="peer-mykey-hint">（复制后在对方 CDS 中添加，即可实现双向数据迁移）</span></div>
+      <div class="form-row mc-row" style="margin-bottom:4px">
+        <input class="form-input mc-input" value="${esc(myKey.baseUrl || '')}" readonly onfocus="this.select()" title="本机 CDS 地址">
+        <button type="button" class="sm" onclick="copyToClipboard('${esc(myKey.baseUrl || '').replace(/'/g, "\\'")}')">复制地址</button>
+      </div>
+      <div class="form-row mc-row">
+        <input class="form-input mc-input" value="${esc(myKey.accessKey)}" readonly onfocus="this.select()" title="本机 AI 访问密钥" style="font-family:monospace">
+        <button type="button" class="sm" onclick="copyToClipboard('${esc(myKey.accessKey).replace(/'/g, "\\'")}')">复制密钥</button>
+      </div>
+    </div>
+  ` : `
+    <div class="peer-mykey-box" style="border-color:var(--yellow)">
+      <div class="peer-mykey-title">⚠ 本机 CDS 未配置 AI_ACCESS_KEY</div>
+      <div class="peer-mykey-hint" style="font-size:12px;margin-top:4px">${esc(myKey?.hint || '请在「设置 → 环境变量」中配置 AI_ACCESS_KEY 后再试。')}</div>
+    </div>
+  `;
+
+  const peersList = cdsPeers.length === 0
+    ? '<div class="config-empty" style="padding:16px">尚未添加任何 CDS 密钥。点击下方「+ 添加」即可注册第一个远程 CDS。</div>'
+    : cdsPeers.map(p => `
+      <div class="peer-card">
+        <div class="peer-card-main">
+          <div class="peer-card-name">${esc(p.name)}</div>
+          <div class="peer-card-url">${esc(p.baseUrl)}</div>
+          <div class="peer-card-meta">
+            <span title="访问密钥（已遮蔽）">${esc(p.accessKey)}</span>
+            ${p.lastVerifiedAt ? `<span title="上次验证时间" style="color:var(--green)">✓ ${relativeTime(p.lastVerifiedAt)}</span>` : '<span style="color:var(--yellow)">未验证</span>'}
+          </div>
+        </div>
+        <div class="peer-card-actions">
+          <button type="button" class="sm" onclick="testCdsPeer('${p.id}')" title="重新验证连接">🔧 测试</button>
+          <button type="button" class="sm" onclick="editCdsPeer('${p.id}')">✎ 编辑</button>
+          <button type="button" class="sm danger-text" onclick="deleteCdsPeer('${p.id}')">删除</button>
+        </div>
+      </div>
+    `).join('');
+
+  openConfigModal('CDS 密钥管理', `
+    <p class="config-panel-desc">注册远程 CDS 的访问密钥，即可在数据迁移中一键选择源/目标，跨 CDS 直连，无需 SSH 或复杂配置。</p>
+    ${myKeySection}
+    <div style="margin:12px 0 6px;font-size:12px;color:var(--fg-muted);font-weight:600">远程 CDS 密钥</div>
+    <div id="peersList">${peersList}</div>
+    <div class="form-row" style="margin-top:10px;gap:6px;flex-wrap:wrap">
+      <button class="sm primary" onclick="openAddPeerForm()">+ 添加 CDS 密钥</button>
+      <button class="sm" onclick="openMigrationModal()">← 返回迁移列表</button>
+    </div>
+    <div id="addPeerFormArea"></div>
+  `);
+}
+
+function openAddPeerForm(prefill) {
+  const area = document.getElementById('addPeerFormArea');
+  if (!area) return;
+  const editingId = prefill?.id || '';
+  area.innerHTML = `
+    <div class="peer-form">
+      <div class="peer-form-title">${editingId ? '编辑 CDS 密钥' : '添加 CDS 密钥'}</div>
+      <div class="form-row mc-row">
+        <input id="peerName" class="form-input mc-input" placeholder="名称 (如: 生产 CDS)" value="${esc(prefill?.name || '')}">
+      </div>
+      <div class="form-row mc-row">
+        <input id="peerBaseUrl" class="form-input mc-input" placeholder="https://main.miduo.org" value="${esc(prefill?.baseUrl || '')}">
+      </div>
+      <div class="form-row mc-row">
+        <input id="peerAccessKey" class="form-input mc-input" placeholder="${editingId ? '留空则保留现有密钥' : 'AI 访问密钥 (remote AI_ACCESS_KEY)'}" style="font-family:monospace">
+      </div>
+      <div class="form-row mc-row" style="gap:6px">
+        <button class="sm primary" onclick="submitPeerForm('${editingId}')">${editingId ? '保存' : '添加并验证'}</button>
+        <button class="sm" onclick="document.getElementById('addPeerFormArea').innerHTML=''">取消</button>
+        <div id="peerFormStatus" style="font-size:11px;align-self:center;min-width:0;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap"></div>
+      </div>
+    </div>
+  `;
+}
+
+async function submitPeerForm(editingId) {
+  const name = document.getElementById('peerName')?.value?.trim();
+  const baseUrl = document.getElementById('peerBaseUrl')?.value?.trim();
+  const accessKey = document.getElementById('peerAccessKey')?.value?.trim();
+  const status = document.getElementById('peerFormStatus');
+  if (!name || !baseUrl) {
+    if (status) status.innerHTML = '<span style="color:var(--red)">✗ 请填写名称和地址</span>';
+    return;
+  }
+  if (!editingId && !accessKey) {
+    if (status) status.innerHTML = '<span style="color:var(--red)">✗ 请填写访问密钥</span>';
+    return;
+  }
+  if (status) status.innerHTML = '<span class="btn-spinner"></span> 验证中...';
+  try {
+    if (editingId) {
+      const body = { name, baseUrl };
+      if (accessKey) body.accessKey = accessKey;
+      await api('PUT', `/data-migrations/peers/${editingId}`, body);
+    } else {
+      await api('POST', '/data-migrations/peers', { name, baseUrl, accessKey });
+    }
+    showToast(editingId ? 'CDS 密钥已更新' : 'CDS 密钥已添加并验证', 'success');
+    openPeersModal();
+  } catch (e) {
+    if (status) status.innerHTML = `<span style="color:var(--red)" title="${esc(e.message)}">✗ ${esc(e.message)}</span>`;
+  }
+}
+
+function editCdsPeer(id) {
+  const peer = cdsPeers.find(p => p.id === id);
+  if (!peer) return;
+  openAddPeerForm(peer);
+}
+
+async function testCdsPeer(id) {
+  try {
+    const d = await api('POST', `/data-migrations/peers/${id}/test`);
+    if (d.success) { showToast(`连接成功: ${d.remoteLabel || ''}`, 'success'); openPeersModal(); }
+    else showToast(`连接失败: ${d.error || '未知错误'}`, 'error');
+  } catch (e) { showToast(e.message, 'error'); }
+}
+
+async function deleteCdsPeer(id) {
+  const peer = cdsPeers.find(p => p.id === id);
+  if (!confirm(`确定删除 CDS 密钥「${peer?.name || id}」？`)) return;
+  try {
+    await api('DELETE', `/data-migrations/peers/${id}`);
+    showToast('已删除', 'success');
+    openPeersModal();
+  } catch (e) { showToast(e.message, 'error'); }
+}
+
+function copyToClipboard(text) {
+  try {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(() => showToast('已复制', 'success')).catch(() => fallbackCopy(text));
+    } else {
+      fallbackCopy(text);
+    }
+  } catch { fallbackCopy(text); }
+}
+
+function fallbackCopy(text) {
+  const ta = document.createElement('textarea');
+  ta.value = text;
+  ta.style.position = 'fixed';
+  ta.style.left = '-9999px';
+  document.body.appendChild(ta);
+  ta.select();
+  try { document.execCommand('copy'); showToast('已复制', 'success'); }
+  catch { showToast('复制失败', 'error'); }
+  document.body.removeChild(ta);
 }
 
 // ── Init activity monitor & AI pairing ──

--- a/cds/web/style.css
+++ b/cds/web/style.css
@@ -3241,6 +3241,90 @@ a.branch-name:hover { color: var(--accent); }
 .migration-conn-panel .form-row { margin-bottom: 5px; }
 .migration-conn-panel .form-input { font-size: 12px; padding: 4px 8px; }
 
+/* mc-row / mc-input: strictly clamped rows for the connection form. */
+/* All inputs shrink freely (min-width: 0) so host + port never overflow the panel. */
+.mc-row {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 5px;
+  align-items: center;
+}
+.mc-input {
+  flex: 1 1 0;
+  min-width: 0;
+  box-sizing: border-box;
+  max-width: 100% !important;
+}
+.mc-host { flex: 2 1 0; }
+.mc-port { flex: 0 0 68px; max-width: 68px !important; }
+.mc-btn  { flex: 0 0 auto; white-space: nowrap; }
+
+/* CDS peer registry */
+.peer-mykey-box {
+  border: 1px dashed var(--border);
+  border-radius: 8px;
+  padding: 10px 12px;
+  background: var(--bg-tertiary);
+  margin-bottom: 10px;
+}
+.peer-mykey-title {
+  font-size: 12px;
+  font-weight: 600;
+  margin-bottom: 6px;
+  color: var(--fg-muted);
+}
+.peer-mykey-hint {
+  font-weight: 400;
+  font-size: 11px;
+  color: var(--fg-muted);
+}
+.peer-card {
+  display: flex;
+  gap: 10px;
+  padding: 10px 12px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  margin-bottom: 6px;
+  align-items: center;
+}
+.peer-card-main { flex: 1; min-width: 0; }
+.peer-card-name { font-size: 13px; font-weight: 600; }
+.peer-card-url {
+  font-size: 11px;
+  color: var(--fg-muted);
+  font-family: monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.peer-card-meta {
+  font-size: 11px;
+  color: var(--fg-muted);
+  display: flex;
+  gap: 10px;
+  margin-top: 2px;
+}
+.peer-card-actions {
+  display: flex;
+  gap: 4px;
+  flex-shrink: 0;
+}
+.peer-card-actions .sm { font-size: 11px; padding: 2px 8px; }
+.peer-form {
+  margin-top: 10px;
+  padding: 10px 12px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+.peer-form-title {
+  font-size: 12px;
+  font-weight: 600;
+  margin-bottom: 8px;
+  color: var(--fg-muted);
+}
+
 /* Collection picker */
 .coll-picker {
   border: 1px solid var(--border);

--- a/changelogs/2026-04-10_cds-data-migration-v2.md
+++ b/changelogs/2026-04-10_cds-data-migration-v2.md
@@ -1,0 +1,9 @@
+| feat | cds | 数据迁移支持跨 CDS 密钥一键直连：新增「CDS 密钥管理」面板，可复制本机访问密钥、注册远程 CDS，源/目标均可选择密钥，HTTPS 流式传输，无需 SSH 或复杂配置 |
+| feat | cds | 数据迁移重构为流式管道（mongodump \| mongorestore），彻底去除临时文件，使用 `--archive --gzip` 单流传输，修复大库迁移 `use of closed network connection` 断连问题 |
+| feat | cds | SSH 迁移改用命令模式而非端口转发：`ssh jump "mongodump --archive --gzip" \| mongorestore`，加入 ServerAliveInterval=30 保活，长时间 dump 不再断流 |
+| feat | cds | SSH 隧道新增「测试隧道」按钮，直接验证 ssh 连通性与远端 mongodump 可用性，不再被迫等到「无法获取数据库列表」才发现问题 |
+| feat | cds | SSH 隧道新增「docker 容器名」字段，支持 `ssh jump "docker exec <container> sh -c 'mongodump...'"` 模式，兼容远端 mongo 仅以容器形态存在的场景 |
+| feat | cds | 数据迁移任务卡片新增「编辑」按钮，可修改名称、源/目标、集合选择（运行中禁用）；新增 PUT /api/data-migrations/:id |
+| fix | cds | 修复「新建数据迁移」对话框输入框溢出问题：主机+端口改为严格 flex 约束（mc-input / mc-host / mc-port），port 固定 68px，其他字段 `min-width:0` 防止溢出 |
+| feat | cds | 新增对等 CDS 端点：/my-key /peers CRUD /peers/:id/{test,list-databases,list-collections} /local-dump /local-restore /test-tunnel，均复用现有 X-AI-Access-Key 鉴权 |
+| feat | cds | MongoConnectionConfig 新增 `type: 'cds'` 与 `cdsPeerId` 字段，CdsPeer 存储于 state.json（加载时自动迁移旧状态） |


### PR DESCRIPTION
## Summary

This PR completely redesigns the data migration system to use a streaming pipeline architecture instead of temporary files, and adds support for one-click cross-CDS data migration via authenticated peer connections.

## Key Changes

### Streaming Pipeline Architecture
- **Replaced temp-file approach with direct pipe**: `mongodump --archive --gzip` output now pipes directly to `mongorestore --archive --gzip` stdin, eliminating temporary file I/O
- **Zero-copy streaming**: Large database migrations no longer require disk space for intermediate dumps
- **SSH keepalive support**: Added TCP keepalive configuration (30s interval, 10 retries) to prevent connection drops during long-running dumps over SSH

### Cross-CDS Peer Migration
- **New CDS peer registry**: Added `CdsPeer` type to store trusted remote CDS instances with base URL and access key
- **Peer management UI**: New "CDS 密钥管理" modal to register remote CDS peers, display local access key, and verify connections
- **Authenticated peer requests**: Implemented `peerRequest()` and `peerRequestJson()` helpers using `X-AI-Access-Key` header for secure peer-to-peer communication
- **New streaming endpoints**: 
  - `POST /api/data-migrations/local-dump` - exposes local MongoDB dump as HTTP response stream
  - `POST /api/data-migrations/local-restore` - accepts HTTP request body stream for restore
  - `GET /data-migrations/peers` - list registered peers
  - `POST /data-migrations/peers/{id}/list-databases` - query peer's databases

### Connection Type Expansion
- **Three connection types**: `local` (CDS infra MongoDB), `remote` (direct host:port), `cds` (peer via HTTPS)
- **Unified producer/consumer builders**: `buildSourceProducer()` and `buildTargetConsumer()` abstract away connection type differences
- **SSH tunnel improvements**: Added optional `dockerContainer` field to run mongodump/mongorestore inside a container via `docker exec`

### Progress & Logging
- **Line-by-line progress parsing**: `parseMongoProgressLine()` extracts meaningful progress from mongodump/mongorestore stderr (collection names, percentages, document counts)
- **Bounded log buffer**: Logs capped at 64KB with truncation marker to prevent unbounded memory growth
- **SSE keepalive**: 15-second heartbeat to prevent proxy timeouts during long migrations
- **Periodic persistence**: Log and progress saved every 2 seconds instead of on every chunk to reduce disk I/O

### Helper Functions
- **`buildMongodumpArgs()` / `buildMongorestoreArgs()`**: Centralized argument construction with support for cross-database rename (`--nsFrom`/`--nsTo`) and collection filtering
- **`buildSshBase()` / `buildRemoteMongoCmd()`**: SSH command construction with proper shell quoting and docker exec wrapping
- **`shq()`**: POSIX shell-safe single-quote escaping for remote command arguments

### UI Enhancements
- **Responsive connection form**: New `.mc-row` / `.mc-input` CSS classes ensure host + port fields never overflow
- **Peer selection dropdown**: Quick access to registered CDS peers with visual indicator (🔑)
- **SSH tunnel testing**: `testSshTunnel()` endpoint to verify connectivity before migration
- **Edit migration**: New PUT endpoint and UI button to modify task name, source, target, and collections without re-creating
- **Improved status display**: Connection status shows peer names and URLs with proper text wrapping

## Implementation Details

- **No breaking changes**: Existing local and remote migrations continue to work; CDS peer is an opt-in feature
- **Error resilience**: Child process cleanup on error; proper promise rejection handling for stream errors
- **Resource cleanup**: Explicit `kill()` calls and interval clearing to prevent zombie processes and memory leaks
- **Type safety**: New `CdsPeer` interface and updated imports across state, types, and router modules

https://claude.ai/code/session_011zahfFVnv5Ya4d2MogRuxV