### PR TITLE
Cluster UI polish, restart detection, and scheduler toggle

### DIFF
--- a/cds/exec_cds.sh
+++ b/cds/exec_cds.sh
@@ -1602,10 +1602,32 @@ case "$CMD" in
     nginx_down
     ;;
   restart)
+    # ── Hot-swap restart: build BEFORE stop ──
+    #
+    # Historical flow was `stop → nginx restart → sleep → build → start`,
+    # which meant the 8-12s TypeScript compile ran WHILE the old node was
+    # already dead, leaving nginx with no upstream. End-users saw a
+    # Cloudflare 502 "Bad gateway" banner for the full compile window.
+    #
+    # Fix: pre-build on the still-running process's sidelines. `build_ts`
+    # only writes to `dist/` — the live node is serving from a previously
+    # loaded dist and doesn't re-read it at runtime, so overwriting dist
+    # while it runs is safe. After the build completes we stop + start
+    # in one tight window (~1-2s, not 10+s).
+    #
+    # Also: nginx stays UP the whole time. Nuking + rebinding nginx on
+    # every restart was unnecessary (its upstream pointer is just
+    # localhost:9900, which reappears as soon as node rebinds) and
+    # widened the downtime window. If the operator genuinely needs
+    # nginx re-rendered (e.g. new root domains), they should call
+    # `nginx-render` separately.
     load_env
+    install_deps
+    build_ts
     cds_stop
-    nginx_down
-    sleep 1
+    # Make sure nginx is still present (no-op if already running) —
+    # nginx_up is idempotent and cheap, keeps the first-time restart
+    # after a cold start working.
     nginx_up || true
     if [ "$FG" = true ]; then
       cds_start_foreground

--- a/cds/src/index.ts
+++ b/cds/src/index.ts
@@ -90,6 +90,18 @@ const bridgeService = new BridgeService();
 // ── Warm-pool scheduler (v3.1) ──
 // Disabled unless cds.config.json { "scheduler": { "enabled": true, ... } }.
 // See doc/design.cds-resilience.md and doc/plan.cds-resilience-rollout.md.
+//
+// Runtime override: the Dashboard can toggle the scheduler via
+// PUT /api/scheduler/enabled, which writes to state.json. That value wins
+// over the config-file setting so operators can flip the scheduler without
+// shelling into the box. `undefined` means "no override, use config".
+{
+  const uiOverride = stateService.getSchedulerEnabledOverride();
+  if (uiOverride !== undefined && config.scheduler) {
+    config.scheduler.enabled = uiOverride;
+    console.log(`  [scheduler] applying UI override: enabled=${uiOverride}`);
+  }
+}
 const schedulerService = new SchedulerService(
   stateService,
   config.scheduler || {
@@ -881,9 +893,12 @@ h1{text-align:center;font-size:20px;font-weight:700;margin-bottom:6px;color:#f0f
 ${masterUrl ? `<a class="btn" href="${escHtmlSafe(masterUrl)}" target="_blank" rel="noopener">前往主节点 Dashboard →</a>` : ''}
 <a class="btn btn-secondary" href="/api/cluster/status">查看本节点 JSON 状态</a>
 <div class="cli-hint">
-💡 本节点没有 Dashboard，因为它是 executor（只跑容器，由主节点调度）。<br>
-要把它变回独立的单机模式，在此服务器上执行：<br>
-<code>./exec_cds.sh disconnect</code>
+💡 <strong>为什么我看不到 Dashboard？</strong><br>
+这是有意为之：executor 只负责跑容器，由主节点的 Dashboard 统一管理本机+所有远端节点的分支、部署、日志。双 Dashboard 会导致以下问题：<br>
+&nbsp;&nbsp;• 两边看到的分支状态可能不一致（split-brain）<br>
+&nbsp;&nbsp;• 同一分支在两边被触发部署时互相踩踏<br>
+&nbsp;&nbsp;• 每台 executor 都要单独配置账号、SSL、域名，运维成本翻倍<br>
+所以主节点是本集群唯一的控制平面。要在本机重新拉起 Dashboard，<strong>在主节点点「退出集群」</strong>（也可以在此服务器执行 <code>./exec_cds.sh disconnect</code>），然后 <code>./exec_cds.sh restart</code> 即可回到 standalone 模式。
 </div>
 <p class="auto-refresh">每 10 秒自动刷新 · <a href="#" onclick="location.reload();return false" style="color:#58a6ff;text-decoration:none">立即刷新</a></p>
 </div>

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -631,9 +631,84 @@ export function createBranchRouter(deps: RouterDeps): Router {
       return;
     }
 
+    // ── Cluster-aware delete ──
+    //
+    // If the branch is owned by a remote executor, the master doesn't have
+    // the worktree or containers locally — deleting locally would silently
+    // succeed on master state while leaving the real worktree + containers
+    // orphaned on the executor. Proxy the delete to the owning executor's
+    // `/exec/delete` endpoint first, then drop master-side state.
+    //
+    // When proxying fails because the executor is offline, we still remove
+    // the master-side state entry (the branch can't be recovered from here)
+    // but emit an error step so the operator knows the remote worktree
+    // may need manual cleanup.
+    const remoteExecutor =
+      entry.executorId && registry
+        ? registry.getAll().find(n => n.id === entry.executorId && n.role !== 'embedded')
+        : null;
+
     initSSE(res);
     try {
-      // Stop all running services
+      if (remoteExecutor) {
+        // Proxy to the executor's /exec/delete endpoint.
+        sendSSE(res, 'step', {
+          step: 'dispatch',
+          status: 'running',
+          title: `正在请求执行器 ${remoteExecutor.id} 删除分支...`,
+        });
+
+        const upstreamUrl = `http://${remoteExecutor.host}:${remoteExecutor.port}/exec/delete`;
+        let proxied = false;
+        try {
+          const upstream = await fetch(upstreamUrl, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              ...(config.executorToken ? { 'X-Executor-Token': config.executorToken } : {}),
+            },
+            body: JSON.stringify({ branchId: id }),
+          });
+          if (upstream.ok) {
+            proxied = true;
+            sendSSE(res, 'step', {
+              step: 'dispatch',
+              status: 'done',
+              title: `执行器已删除分支 ${id}`,
+            });
+          } else {
+            const errText = await upstream.text().catch(() => '');
+            sendSSE(res, 'step', {
+              step: 'dispatch',
+              status: 'warning',
+              title: `执行器拒绝删除 (HTTP ${upstream.status})，仍继续清理主节点状态`,
+              log: errText.slice(0, 200),
+            });
+          }
+        } catch (err) {
+          sendSSE(res, 'step', {
+            step: 'dispatch',
+            status: 'warning',
+            title: `无法连接执行器 ${remoteExecutor.id}，仍继续清理主节点状态`,
+            log: (err as Error).message,
+          });
+        }
+
+        // Drop master-side state unconditionally — if the executor is
+        // unreachable, the operator can manually clean up on that node.
+        stateService.removeLogs(id);
+        stateService.removeBranch(id);
+        stateService.save();
+
+        sendSSE(res, 'complete', {
+          message: proxied
+            ? `分支 "${id}" 已在执行器 ${remoteExecutor.id} 上删除`
+            : `分支 "${id}" 已从主节点移除；执行器上的残留请手动检查`,
+        });
+        return;
+      }
+
+      // Local delete path (unchanged behavior)
       for (const svc of Object.values(entry.services)) {
         sendSSE(res, 'step', { step: 'stop', status: 'running', title: `正在停止 ${svc.containerName}...` });
         try { await containerService.stop(svc.containerName); } catch { /* ok */ }
@@ -1135,6 +1210,53 @@ export function createBranchRouter(deps: RouterDeps): Router {
       res.status(404).json({ error: `分支 "${id}" 不存在` });
       return;
     }
+
+    // ── Cluster-aware stop ──
+    //
+    // Branches owned by a remote executor have no local containers — calling
+    // containerService.stop on master is a silent no-op that leaves the real
+    // containers running on the executor. Proxy to /exec/stop instead.
+    const remoteExecutor =
+      entry.executorId && registry
+        ? registry.getAll().find(n => n.id === entry.executorId && n.role !== 'embedded')
+        : null;
+    if (remoteExecutor) {
+      entry.status = 'stopping';
+      for (const svc of Object.values(entry.services)) {
+        if (svc.status === 'running' || svc.status === 'starting') {
+          svc.status = 'stopping';
+        }
+      }
+      stateService.save();
+      try {
+        const upstreamUrl = `http://${remoteExecutor.host}:${remoteExecutor.port}/exec/stop`;
+        const upstream = await fetch(upstreamUrl, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...(config.executorToken ? { 'X-Executor-Token': config.executorToken } : {}),
+          },
+          body: JSON.stringify({ branchId: id }),
+        });
+        if (!upstream.ok) {
+          const errText = await upstream.text().catch(() => '');
+          res.status(502).json({
+            error: `执行器拒绝停止请求 (HTTP ${upstream.status}): ${errText.slice(0, 200)}`,
+          });
+          return;
+        }
+        // The executor's next heartbeat will reconcile status, but set
+        // plausible local state in the meantime.
+        for (const svc of Object.values(entry.services)) svc.status = 'stopped';
+        entry.status = 'idle';
+        stateService.save();
+        res.json({ message: `已请求执行器 ${remoteExecutor.id} 停止所有服务` });
+      } catch (err) {
+        res.status(502).json({ error: `无法连接执行器: ${(err as Error).message}` });
+      }
+      return;
+    }
+
     try {
       // Set stopping state immediately so frontend can show animation
       entry.status = 'stopping';
@@ -4310,6 +4432,27 @@ export function createBranchRouter(deps: RouterDeps): Router {
       return;
     }
     res.json(schedulerService.getSnapshot());
+  });
+
+  // ── PUT /api/scheduler/enabled — flip scheduler on/off from the UI ──
+  //
+  // Persists the override into state.json via stateService so the toggle
+  // survives restart, then calls schedulerService.setEnabled() which
+  // starts/stops the background tick loop.
+  router.put('/scheduler/enabled', (req, res) => {
+    if (!schedulerService) {
+      res.status(503).json({ error: 'Scheduler service not wired in' });
+      return;
+    }
+    const { enabled } = (req.body || {}) as { enabled?: unknown };
+    if (typeof enabled !== 'boolean') {
+      res.status(400).json({ error: 'enabled 必须是 boolean' });
+      return;
+    }
+    stateService.setSchedulerEnabledOverride(enabled);
+    stateService.save();
+    schedulerService.setEnabled(enabled);
+    res.json({ enabled, source: 'ui-override' });
   });
 
   router.post('/scheduler/pin/:slug', (req, res) => {

--- a/cds/src/server.ts
+++ b/cds/src/server.ts
@@ -610,6 +610,10 @@ export function createServer(deps: ServerDeps): express.Express {
     // Include executors + mode + capacity so the Dashboard can react to
     // cluster changes without extra polls. `cdsMode` is read from the
     // live config (which may have been hot-switched by onFirstRegister).
+    //
+    // `schedulerEnabled` echoes the runtime flag so the capacity popover's
+    // toggle stays in sync across browser tabs after a PUT /api/scheduler/enabled
+    // call (otherwise tab B would still show the old state until reload).
     const data = JSON.stringify({
       seq: ++stateSeq,
       branches: Object.values(state.branches),
@@ -619,6 +623,7 @@ export function createServer(deps: ServerDeps): express.Express {
       mode: deps.config.mode,
       executors: Object.values(state.executors || {}),
       capacity: deps.registry ? deps.registry.getTotalCapacity() : null,
+      schedulerEnabled: deps.schedulerService ? deps.schedulerService.isEnabled() : false,
     });
     for (const client of stateClients) {
       try { client.write(`data: ${data}\n\n`); } catch { stateClients.delete(client); }

--- a/cds/src/services/scheduler.ts
+++ b/cds/src/services/scheduler.ts
@@ -81,6 +81,26 @@ export class SchedulerService {
   }
 
   /**
+   * Flip the enabled flag at runtime. Mirrors the UI toggle exposed via
+   * `PUT /api/scheduler/enabled`. Idempotent: enabling an already-enabled
+   * scheduler or disabling an already-disabled one is a no-op. When flipping
+   * from enabled→disabled we stop the tick loop; when flipping from
+   * disabled→enabled we start it. The persistent storage side of the
+   * override is the caller's responsibility (StateService.setSchedulerEnabledOverride).
+   */
+  setEnabled(enabled: boolean): void {
+    if (this.config.enabled === enabled) return;
+    this.config.enabled = enabled;
+    if (enabled) {
+      this.start();
+      console.log('[scheduler] enabled at runtime (via UI toggle)');
+    } else {
+      this.stop();
+      console.log('[scheduler] disabled at runtime (via UI toggle)');
+    }
+  }
+
+  /**
    * Start the periodic tick. Safe to call multiple times.
    * Does nothing when scheduler is disabled.
    */

--- a/cds/src/services/state.ts
+++ b/cds/src/services/state.ts
@@ -368,6 +368,23 @@ export class StateService {
     delete this.state.logs[branchId];
   }
 
+  // ── Scheduler (warm-pool) runtime override ──
+  //
+  // Mirror of the `schedulerEnabledOverride` field in CdsState. Returns
+  // undefined when the user has never toggled the UI switch (the backend
+  // then falls back to config.scheduler.enabled from cds.config.json).
+  getSchedulerEnabledOverride(): boolean | undefined {
+    return this.state.schedulerEnabledOverride;
+  }
+
+  setSchedulerEnabledOverride(value: boolean | undefined): void {
+    if (value === undefined) {
+      delete this.state.schedulerEnabledOverride;
+    } else {
+      this.state.schedulerEnabledOverride = value;
+    }
+  }
+
   // ── Custom environment variables ──
 
   getCustomEnv(): Record<string, string> {

--- a/cds/src/types.ts
+++ b/cds/src/types.ts
@@ -245,6 +245,16 @@ export interface CdsState {
   previewMode?: 'simple' | 'port' | 'multi';
   /** Registered executor nodes (scheduler mode) */
   executors?: Record<string, ExecutorNode>;
+  /**
+   * UI-controlled override for the warm-pool scheduler enable flag. When
+   * defined, it supersedes `config.scheduler.enabled` at runtime so the user
+   * can toggle the scheduler from the Dashboard without editing
+   * `cds.config.json`. Persisted to state.json and re-applied on boot.
+   *
+   * `undefined` = no override (fall back to config file). `true` = forced on.
+   * `false` = forced off (even if config file has enabled:true).
+   */
+  schedulerEnabledOverride?: boolean;
   /** Data migration task history */
   dataMigrations?: DataMigration[];
   /** Registered remote CDS peers (for one-click cross-CDS data migration) */

--- a/cds/tsconfig.json
+++ b/cds/tsconfig.json
@@ -11,7 +11,9 @@
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "incremental": true,
+    "tsBuildInfoFile": "dist/.tsbuildinfo"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "tests"]

--- a/cds/web/app.js
+++ b/cds/web/app.js
@@ -72,6 +72,12 @@ let cdsTheme = localStorage.getItem('cds_theme') || 'dark';
 // ── Executor/Scheduler state ──
 let cdsMode = 'standalone';
 let executors = [];
+// Effective cluster role as reported by /api/cluster/status. Distinct from
+// `cdsMode` because a `standalone` node that hot-joins a master becomes
+// `hybrid` (dashboard still alive, but also posting heartbeats upstream)
+// until the next restart. Used by the settings menu to show a top-level
+// "退出集群" action only when relevant.
+let clusterEffectiveRole = 'standalone';
 
 // ── Container capacity ──
 let containerCapacity = { maxContainers: 999, runningContainers: 0, totalMemGB: 0 };
@@ -80,6 +86,21 @@ let containerCapacity = { maxContainers: 999, runningContainers: 0, totalMemGB: 
 // display so "总容量 X" reflects A+B+... instead of just the local master.
 let clusterCapacity = null;
 let clusterStrategy = 'least-load';
+// Scheduler (warm-pool) enabled flag — pushed from /api/config and the
+// state-stream SSE so the header toggle stays in sync with the backend.
+let schedulerEnabled = false;
+
+// ── First-load guard ──
+//
+// The HTML ships with a `cdsInitLoader` animation inside #branchList so the
+// very first paint already has motion. Without a flag, the first successful
+// `loadBranches()` call would wipe the loader and — if branches are empty —
+// immediately replace it with "暂无分支"，producing two transitional states
+// in a row (loader → empty text). We set this to `true` only after the FIRST
+// successful response, so the empty state is only rendered once it's the
+// genuinely-stable state. On first empty load we instead show a deliberate,
+// designed empty state (see `renderEmptyBranchesState`).
+let _branchesFirstLoadDone = false;
 
 // ── Utilities ──
 
@@ -235,10 +256,27 @@ let workerPort = '';
 
 async function init() {
   updateThemeUI();
-  await Promise.all([loadBranches(), loadProfiles(), loadRoutingRules(), loadConfig(), loadEnvVars(), loadInfraServices(), loadMirrorState(), loadTabTitleState()]);
+  await Promise.all([loadBranches(), loadProfiles(), loadRoutingRules(), loadConfig(), loadEnvVars(), loadInfraServices(), loadMirrorState(), loadTabTitleState(), loadClusterStatus()]);
   refreshRemoteCandidates();
   updatePreviewModeUI();
   initStateStream(); // Server-authority: listen for state changes via SSE (replaces polling)
+}
+
+/**
+ * Probe /api/cluster/status once at startup so the settings menu can decide
+ * whether to show the "退出集群" shortcut. The data is also refreshed whenever
+ * the cluster modal is opened or after a join/leave action. Failure is
+ * silent — non-cluster installs return `effectiveRole === 'standalone'`
+ * which is the sensible default.
+ */
+async function loadClusterStatus() {
+  try {
+    const res = await fetch('/api/cluster/status', { credentials: 'include' });
+    if (!res.ok) return;
+    const body = await res.json();
+    clusterEffectiveRole = body.effectiveRole || 'standalone';
+    if (body.strategy) clusterStrategy = body.strategy;
+  } catch { /* quiet */ }
 }
 
 // ── State stream: server pushes branch state changes (no polling needed) ──
@@ -287,6 +325,9 @@ function initStateStream() {
       if (data.capacity) {
         clusterCapacity = data.capacity;
       }
+      if (typeof data.schedulerEnabled === 'boolean') {
+        schedulerEnabled = data.schedulerEnabled;
+      }
       // Re-render cluster-aware surfaces. `renderCapacityBadge` now reads
       // clusterCapacity when available, `renderExecutorPanel` picks up new
       // status/load, and the cluster modal (if open) calls its own refresh.
@@ -333,8 +374,12 @@ function renderExecutorPanel() {
   const panel = document.getElementById('executorPanel');
   if (!panel) return;
 
-  // Only show in scheduler mode or when executors exist
-  if (cdsMode !== 'scheduler' && executors.length === 0) {
+  // Only show when there's actually a cluster (at least one REMOTE executor).
+  // A single-node scheduler (only the embedded master) doesn't need this
+  // panel — the header capacity badge already covers it and the redundant
+  // "执行器集群 1/1 在线" banner was reported as noise.
+  const remoteCount = (executors || []).filter(e => (e.role || 'remote') !== 'embedded').length;
+  if (remoteCount === 0) {
     panel.classList.add('hidden');
     return;
   }
@@ -663,6 +708,10 @@ async function loadBranches({ silent } = {}) {
       const mainBranch = branches.find(b => b.id === 'main') || branches.find(b => b.id === 'master');
       if (mainBranch) defaultBranch = mainBranch.id;
     }
+    // Mark that we've completed at least one successful fetch. Until this
+    // flips true, renderBranches() renders the CDS loader instead of the
+    // "暂无分支" empty state, eliminating the two-step loader→empty flicker.
+    _branchesFirstLoadDone = true;
     renderBranches();
     renderCapacityBadge();
   } catch (e) { console.error('loadBranches:', e); }
@@ -891,18 +940,18 @@ function renderCapacityBadge() {
   const el = document.getElementById('capacityBadge');
   if (!el) return;
 
-  // ── Cluster-aware display (P1 #4) ──
+  // ── Cluster-aware display ──
   //
-  // Important: once the dashboard learns about a cluster (cdsMode is
-  // 'scheduler' OR there's at least one remote executor in state), we
-  // NEVER fall back to the local container count. The local view uses a
-  // different formula ((memGB-1)*2 counting containers) while the cluster
-  // view uses a per-node formula (floor(memMB/2048) counting branches).
-  // Flickering between them gives the illusion "I added a node and the
-  // capacity SHRANK", which is what the user reported. Stay sticky on
-  // the cluster view once we're in it.
+  // We only switch to the "cluster" UI when there is ACTUALLY more than
+  // one node. A `cdsMode === 'scheduler'` with only the embedded master
+  // (remoteCount === 0) used to render as a cluster, which made the badge
+  // show the generic "集群 ..." placeholder instead of the familiar
+  // container-slot battery. That confused users in single-node scheduler
+  // mode ("我是一个人怎么就成集群了"). We now require at least one
+  // remote node to enter cluster mode — single-node always uses the
+  // well-established single-node battery.
   const remoteCount = (executors || []).filter(e => (e.role || 'remote') !== 'embedded').length;
-  const isCluster = cdsMode === 'scheduler' || remoteCount > 0;
+  const isCluster = remoteCount > 0;
 
   if (isCluster) {
     // Wait for the first SSE tick to deliver real cluster data before we
@@ -1010,6 +1059,91 @@ function renderCapacityBadge() {
 }
 
 /**
+ * Render a compact on/off switch for the warm-pool scheduler inside the
+ * capacity popover. Clicking the switch calls `toggleSchedulerEnabled`,
+ * which hits `PUT /api/scheduler/enabled` and re-renders the popover
+ * with the new state. Centralized here so the off/on branches in the
+ * popover markup both use the same styled button.
+ */
+function renderSchedulerToggleHtml(enabled) {
+  return `
+    <button class="scheduler-toggle ${enabled ? 'on' : 'off'}"
+            onclick="toggleSchedulerEnabled(event)"
+            title="${enabled ? '点击停用 warm-pool 调度器' : '点击启用 warm-pool 调度器'}">
+      <span class="scheduler-toggle-track">
+        <span class="scheduler-toggle-thumb"></span>
+      </span>
+      <span class="scheduler-toggle-label">${enabled ? '已启用' : '已停用'}</span>
+    </button>
+  `;
+}
+
+async function toggleSchedulerEnabled(event) {
+  if (event) event.stopPropagation();
+  const next = !schedulerEnabled;
+  const btn = event?.currentTarget;
+  if (btn) btn.disabled = true;
+  try {
+    const res = await fetch('/api/scheduler/enabled', {
+      method: 'PUT',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ enabled: next }),
+    });
+    const body = await res.json();
+    if (!res.ok) {
+      showToast(body.error || '切换失败', 'error');
+      return;
+    }
+    schedulerEnabled = !!body.enabled;
+    showToast(schedulerEnabled ? 'Scheduler 已启用' : 'Scheduler 已停用', 'success');
+    // Re-fetch and re-render the popover section so HOT/COLD lists update.
+    try {
+      const snap = await api('GET', '/scheduler/state');
+      const target = document.getElementById('capPopScheduler');
+      if (target) {
+        const toggleHtml = renderSchedulerToggleHtml(snap.enabled);
+        if (snap.enabled === false) {
+          target.innerHTML = `
+            <div class="cap-pop-row cap-pop-scheduler-off">
+              <div class="cap-pop-scheduler-head">
+                <strong>Scheduler: <span style="color:#8b949e">未启用</span></strong>
+                ${toggleHtml}
+              </div>
+              <div class="cap-pop-help" style="margin-top:6px">
+                启用后 CDS 会维护一个热池，按 LRU 自动休眠最久未访问的分支，避免宿主机容器超载。
+              </div>
+            </div>
+          `;
+        } else {
+          const cu = snap.capacityUsage || { current: 0, max: 0 };
+          const hotList = (snap.hot || []).map(h =>
+            `<li>${escapeHtml(h.slug)}${h.pinned ? ' <span style="color:#3fb950">📌</span>' : ''}</li>`
+          ).join('');
+          const coldList = (snap.cold || []).map(c =>
+            `<li style="opacity:0.6">${escapeHtml(c.slug)}</li>`
+          ).join('');
+          target.innerHTML = `
+            <div class="cap-pop-scheduler">
+              <div class="cap-pop-scheduler-head">
+                <strong>Scheduler: <span style="color:#3fb950">已启用</span> (${cu.current}/${cu.max} hot)</strong>
+                ${toggleHtml}
+              </div>
+              ${hotList ? `<div class="cap-pop-help">HOT 分支:</div><ul class="cap-pop-list">${hotList}</ul>` : ''}
+              ${coldList ? `<div class="cap-pop-help">COLD 分支:</div><ul class="cap-pop-list">${coldList}</ul>` : ''}
+            </div>
+          `;
+        }
+      }
+    } catch { /* keep old UI on refresh failure */ }
+  } catch (err) {
+    showToast('网络错误: ' + err.message, 'error');
+  } finally {
+    if (btn) btn.disabled = false;
+  }
+}
+
+/**
  * Popover with detailed capacity + scheduler state.
  *
  * Renders two very different layouts depending on mode:
@@ -1023,7 +1157,7 @@ async function showCapacityDetails(event) {
   event.stopPropagation();
 
   const remoteCount = (executors || []).filter(e => (e.role || 'remote') !== 'embedded').length;
-  const isCluster = cdsMode === 'scheduler' || remoteCount > 0;
+  const isCluster = remoteCount > 0;
 
   if (isCluster && clusterCapacity) {
     renderClusterCapacityPopover();
@@ -1069,13 +1203,17 @@ async function showCapacityDetails(event) {
     const snap = await api('GET', '/scheduler/state');
     const target = document.getElementById('capPopScheduler');
     if (!target) return;
+    schedulerEnabled = !!snap.enabled;
+    const toggleHtml = renderSchedulerToggleHtml(snap.enabled);
     if (snap.enabled === false) {
       target.innerHTML = `
         <div class="cap-pop-row cap-pop-scheduler-off">
-          <strong>Scheduler: <span style="color:#8b949e">未启用</span></strong>
-          <div class="cap-pop-help" style="margin-top:4px">
-            在 <code>cds.config.json</code> 中设置
-            <code>scheduler.enabled = true</code> 即可自动管理容量。
+          <div class="cap-pop-scheduler-head">
+            <strong>Scheduler: <span style="color:#8b949e">未启用</span></strong>
+            ${toggleHtml}
+          </div>
+          <div class="cap-pop-help" style="margin-top:6px">
+            启用后 CDS 会维护一个热池，按 LRU 自动休眠最久未访问的分支，避免宿主机容器超载。
           </div>
         </div>
       `;
@@ -1089,7 +1227,10 @@ async function showCapacityDetails(event) {
       ).join('');
       target.innerHTML = `
         <div class="cap-pop-scheduler">
-          <strong>Scheduler: <span style="color:#3fb950">已启用</span> (${cu.current}/${cu.max} hot)</strong>
+          <div class="cap-pop-scheduler-head">
+            <strong>Scheduler: <span style="color:#3fb950">已启用</span> (${cu.current}/${cu.max} hot)</strong>
+            ${toggleHtml}
+          </div>
           ${hotList ? `<div class="cap-pop-help">HOT 分支:</div><ul class="cap-pop-list">${hotList}</ul>` : ''}
           ${coldList ? `<div class="cap-pop-help">COLD 分支:</div><ul class="cap-pop-list">${coldList}</ul>` : ''}
         </div>
@@ -2485,6 +2626,13 @@ function toggleSettingsMenu(event) {
       集群
       <span id="clusterStatusBadge" style="margin-left:auto;font-size:11px;color:#8b949e"></span>
     </div>
+    ${(clusterEffectiveRole === 'executor' || clusterEffectiveRole === 'hybrid') ? `
+    <div class="settings-menu-item danger" onclick="closeSettingsMenu(); doLeaveCluster()">
+      <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M2 2.75C2 1.784 2.784 1 3.75 1h2.5a.75.75 0 010 1.5h-2.5a.25.25 0 00-.25.25v10.5c0 .138.112.25.25.25h2.5a.75.75 0 010 1.5h-2.5A1.75 1.75 0 012 13.25V2.75zm10.44 4.5H6.75a.75.75 0 000 1.5h5.69l-1.97 1.97a.749.749 0 101.06 1.06l3.25-3.25a.749.749 0 000-1.06l-3.25-3.25a.749.749 0 10-1.06 1.06l1.97 1.97z"/></svg>
+      退出集群
+      <span style="margin-left:auto;font-size:11px;color:#8b949e">${clusterEffectiveRole === 'hybrid' ? '混合模式' : '执行器'}</span>
+    </div>
+    ` : ''}
     <div class="settings-menu-item settings-menu-switch" onclick="cyclePreviewMode()">
       <span class="settings-menu-switch-label">预览模式</span>
       <span class="preview-mode-label" style="margin-left:auto;font-size:11px;color:#58a6ff;font-weight:500">${{ simple: '简洁', port: '端口直连', multi: '子域名' }[previewMode]}</span>
@@ -2610,6 +2758,40 @@ function markTouched(id) {
 
 // ── Rendering ──
 
+/**
+ * Designed empty state for the branch list.
+ *
+ * Replaces the old single-line `<div class="empty-state">暂无分支...</div>`
+ * italic text. Rendered only AFTER the first successful /api/branches fetch
+ * (see `_branchesFirstLoadDone`) so it never flashes as a transitional state
+ * during the initial loader animation. Follows the `guided-exploration.md`
+ * rule: empty state must have说明 + 主操作 CTA + 可选插图.
+ */
+function renderEmptyBranchesState() {
+  const onFocusSearch = "document.getElementById('branchSearch')?.focus()";
+  return `
+    <div class="branches-empty">
+      <div class="branches-empty-illustration" aria-hidden="true">
+        <svg width="88" height="88" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="6" cy="3" r="2"/>
+          <circle cx="6" cy="21" r="2"/>
+          <circle cx="18" cy="12" r="2"/>
+          <path d="M6 5v14"/>
+          <path d="M6 12h12"/>
+        </svg>
+      </div>
+      <div class="branches-empty-title">还没有部署任何分支</div>
+      <div class="branches-empty-hint">
+        在顶部搜索框输入 Git 分支名（支持前缀/后缀匹配），选中后 CDS 会为它创建工作树并自动构建。
+      </div>
+      <button class="branches-empty-cta" onclick="${onFocusSearch}">
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z"/></svg>
+        搜索并添加分支
+      </button>
+    </div>
+  `;
+}
+
 function renderBranches() {
   // Save scroll position before re-render
   const scrollY = window.scrollY;
@@ -2617,7 +2799,33 @@ function renderBranches() {
   // 分支数量已从 header 移除，标题区仅显示 "Cloud Dev Suite"
 
   if (branches.length === 0) {
-    el.innerHTML = '<div class="empty-state">暂无分支，请在上方搜索并添加。</div>';
+    // ── First-paint protection ──
+    //
+    // Before the first successful /api/branches fetch, we keep whatever
+    // is already in #branchList (normally the CDS loader shipped in the
+    // HTML). This prevents the jarring two-step "loader → 暂无分支 → data"
+    // flicker on page open.
+    if (!_branchesFirstLoadDone) {
+      if (!el.querySelector('.cds-loading-state')) {
+        // Stale content somehow — re-inject the loader so the first
+        // paint still has motion.
+        el.innerHTML = `
+          <div class="cds-loading-state">
+            <div class="cds-loading-glow"></div>
+            <div class="cds-loading-letters">
+              <span class="cds-letter" style="--delay:0ms;--color:var(--accent,#e8e8ec)">C</span>
+              <span class="cds-letter" style="--delay:120ms;--color:var(--text-secondary,#a0a0b0)">D</span>
+              <span class="cds-letter" style="--delay:240ms;--color:var(--text-muted,#78788a)">S</span>
+            </div>
+            <div class="cds-loading-bar"></div>
+            <div class="cds-loading-hint">加载中</div>
+          </div>
+        `;
+      }
+      window.scrollTo(0, scrollY);
+      return;
+    }
+    el.innerHTML = renderEmptyBranchesState();
     window.scrollTo(0, scrollY);
     return;
   }
@@ -6104,6 +6312,7 @@ async function openClusterModal() {
   // next SSE tick arrives.
   clusterCapacity = capacity;
   clusterStrategy = statusBody.strategy || 'least-load';
+  clusterEffectiveRole = role || 'standalone';
   if (Array.isArray(capacity.nodes)) {
     executors = capacity.nodes;
   }
@@ -6359,6 +6568,7 @@ async function doJoinCluster() {
       `;
     }
     showToast('已加入集群', 'success');
+    clusterEffectiveRole = 'hybrid';
     updateClusterStatusBadge('hybrid', 2);
   } catch (err) {
     if (result) result.innerHTML = `<div class="cluster-error">❌ 网络错误: ${esc(err.message)}</div>`;
@@ -6386,8 +6596,15 @@ async function doLeaveCluster() {
       return;
     }
     showToast('已退出集群', 'success');
+    // Local state update so the settings menu's "退出集群" item disappears
+    // without needing a page reload.
+    clusterEffectiveRole = 'standalone';
     updateClusterStatusBadge('standalone', 1);
-    closeConfigModal();
+    // Only close the config modal if it's open (settings-menu path doesn't
+    // open the modal at all).
+    if (document.querySelector('.cluster-modal')) {
+      closeConfigModal();
+    }
   } catch (err) {
     showToast('网络错误: ' + err.message, 'error');
   } finally {

--- a/cds/web/app.js
+++ b/cds/web/app.js
@@ -285,6 +285,12 @@ let stateEventSource = null;
 function initStateStream() {
   stateEventSource = new EventSource(`${API}/state-stream`);
   stateEventSource.onmessage = (e) => {
+    // Any successful SSE frame means the backend is alive. If the restart
+    // overlay is showing (stale from a previous onerror), hide it — the
+    // separate `pollHealthForRestart` path would also trigger a full
+    // reload, but if the SSE reconnects cleanly without a full page
+    // restart (e.g. transient network hiccup) there's no need to reload.
+    if (_restartOverlayEl) hideRestartOverlay();
     try {
       const data = JSON.parse(e.data);
       if (data.branches) {
@@ -339,11 +345,100 @@ function initStateStream() {
     } catch {}
   };
   stateEventSource.onerror = () => {
+    // Server might be restarting. Flip on the restart-detect overlay so
+    // the user sees "正在重启" instead of a raw Cloudflare 502 banner,
+    // and start polling /healthz to auto-reload the moment CDS is back.
+    showRestartOverlay();
     setTimeout(() => {
       if (stateEventSource) stateEventSource.close();
       initStateStream();
     }, 3000);
   };
+}
+
+// ── Restart detection overlay ──
+//
+// When the state-stream SSE drops (backend restart, network blip,
+// Cloudflare 502 window), this overlay covers the page with a friendly
+// "正在重启" card and polls /healthz once per second. As soon as the
+// endpoint returns 200 we reload the page so stale JS doesn't keep
+// trying stale API shapes. Public /healthz is intentionally cookie-free
+// (see server.ts:254) so the poll works even if cookies are lost.
+//
+// Also protects against manual `./exec_cds.sh restart` from a SSH shell:
+// the operator no longer has to tell the user "just refresh the page",
+// the page refreshes itself the instant the backend is alive.
+let _restartOverlayEl = null;
+let _restartHealthTimer = null;
+let _restartHealthStartedAt = 0;
+let _restartRetryAttempt = 0;
+
+function showRestartOverlay() {
+  if (_restartOverlayEl) return; // already shown
+  const el = document.createElement('div');
+  el.className = 'cds-restart-overlay';
+  el.innerHTML = `
+    <div class="cds-restart-card">
+      <div class="cds-restart-spinner" aria-hidden="true">
+        <svg width="44" height="44" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M21 12a9 9 0 1 1-6.219-8.56"/>
+          <polyline points="21 3 21 9 15 9"/>
+        </svg>
+      </div>
+      <div class="cds-restart-title">CDS 正在重启</div>
+      <div class="cds-restart-hint" id="cdsRestartHint">后台服务暂时不可用，恢复后页面会自动刷新…</div>
+      <button class="cds-restart-reload" onclick="location.reload()">立即刷新</button>
+    </div>
+  `;
+  document.body.appendChild(el);
+  _restartOverlayEl = el;
+  _restartHealthStartedAt = Date.now();
+  _restartRetryAttempt = 0;
+  pollHealthForRestart();
+}
+
+function hideRestartOverlay() {
+  if (_restartHealthTimer) { clearTimeout(_restartHealthTimer); _restartHealthTimer = null; }
+  if (_restartOverlayEl) {
+    _restartOverlayEl.classList.add('fade-out');
+    setTimeout(() => {
+      if (_restartOverlayEl) _restartOverlayEl.remove();
+      _restartOverlayEl = null;
+    }, 200);
+  }
+}
+
+async function pollHealthForRestart() {
+  _restartRetryAttempt++;
+  const hint = document.getElementById('cdsRestartHint');
+  const elapsed = Math.round((Date.now() - _restartHealthStartedAt) / 1000);
+  if (hint) {
+    hint.textContent = `后台服务暂时不可用，已等待 ${elapsed}s，恢复后页面会自动刷新…`;
+  }
+  try {
+    // `cache: 'no-store'` + cache-buster query so Cloudflare/browsers don't
+    // serve a cached 502 from the initial failure window.
+    const res = await fetch(`/healthz?_=${Date.now()}`, {
+      cache: 'no-store',
+      credentials: 'omit',
+    });
+    if (res.ok) {
+      // Backend is alive again. Give nginx + proxies a brief settle window
+      // then hard-reload so we pick up any new JS/HTML shipped in the
+      // restart. `location.reload(true)` is deprecated but a plain
+      // location.reload() plus no-cache headers we set in index.html
+      // is sufficient.
+      if (hint) hint.textContent = '后台已恢复，正在刷新页面…';
+      setTimeout(() => location.reload(), 400);
+      return;
+    }
+  } catch { /* still down */ }
+
+  // Exponential-ish backoff: 1s, 1s, 1s, 2s, 2s, 3s... capped at 3s.
+  // Keeps the first few retries snappy (catch fast restarts) without
+  // spamming requests during a long outage.
+  const delay = _restartRetryAttempt < 4 ? 1000 : _restartRetryAttempt < 8 ? 2000 : 3000;
+  _restartHealthTimer = setTimeout(pollHealthForRestart, delay);
 }
 
 async function loadConfig() {

--- a/cds/web/style.css
+++ b/cds/web/style.css
@@ -583,6 +583,71 @@ h1 {
 }
 .cap-pop-row { font-size: 12px; }
 
+/* ── Scheduler head: label + toggle side by side ── */
+.cap-pop-scheduler-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+/* ── Compact scheduler on/off switch ── */
+.scheduler-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px 4px 6px;
+  border-radius: 999px;
+  border: 1px solid var(--border, #30363d);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color 160ms ease, background 160ms ease, color 160ms ease;
+}
+.scheduler-toggle:disabled {
+  opacity: 0.5;
+  cursor: wait;
+}
+.scheduler-toggle-track {
+  display: inline-block;
+  position: relative;
+  width: 26px;
+  height: 14px;
+  border-radius: 999px;
+  background: rgba(139, 148, 158, 0.35);
+  transition: background 160ms ease;
+}
+.scheduler-toggle-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #e8e8ec;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.4);
+  transition: left 160ms cubic-bezier(0.16, 1, 0.3, 1), background 160ms ease;
+}
+.scheduler-toggle.on .scheduler-toggle-track {
+  background: #3fb950;
+}
+.scheduler-toggle.on .scheduler-toggle-thumb {
+  left: 14px;
+  background: #ffffff;
+}
+.scheduler-toggle.on {
+  color: #3fb950;
+  border-color: rgba(63, 185, 80, 0.4);
+}
+.scheduler-toggle:hover:not(:disabled) {
+  border-color: var(--accent, #58a6ff);
+}
+.scheduler-toggle.on:hover:not(:disabled) {
+  border-color: rgba(63, 185, 80, 0.7);
+}
+
 .header-subtitle {
   font-size: 11px; color: var(--text-muted); white-space: nowrap;
   background: var(--bg-card);
@@ -1641,6 +1706,68 @@ a.branch-name:hover { color: var(--accent); }
 .empty-state {
   text-align: center; color: var(--text-muted); padding: 40px 0;
   font-size: 14px; font-style: italic;
+}
+
+/* ════════════════ Branches empty state (designed, non-transitional) ════════════════
+ *
+ * Replaces the old `.empty-state` italic text for the "no branches yet" case.
+ * Follows the `guided-exploration.md` rule: illustration + title + hint + CTA,
+ * so the page feels intentionally empty instead of mid-transition.
+ */
+.branches-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 56px 24px 40px;
+  text-align: center;
+  user-select: none;
+}
+.branches-empty-illustration {
+  width: 88px; height: 88px;
+  display: flex; align-items: center; justify-content: center;
+  color: var(--text-muted);
+  opacity: 0.55;
+  margin-bottom: 18px;
+  animation: cds-empty-float 4s ease-in-out infinite;
+}
+.branches-empty-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-primary, var(--text-secondary));
+  margin-bottom: 8px;
+  letter-spacing: 0.01em;
+}
+.branches-empty-hint {
+  font-size: 13px;
+  color: var(--text-muted);
+  max-width: 420px;
+  line-height: 1.6;
+  margin-bottom: 22px;
+}
+.branches-empty-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 16px;
+  border-radius: 8px;
+  border: 1px solid var(--border, rgba(255,255,255,0.1));
+  background: var(--surface-hover, rgba(255,255,255,0.04));
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color 140ms ease, background 140ms ease, color 140ms ease, transform 140ms ease;
+}
+.branches-empty-cta:hover {
+  border-color: var(--accent, #58a6ff);
+  color: var(--accent, #58a6ff);
+  background: var(--surface, rgba(88,166,255,0.08));
+  transform: translateY(-1px);
+}
+@keyframes cds-empty-float {
+  0%, 100% { transform: translateY(0); opacity: 0.55; }
+  50%      { transform: translateY(-4px); opacity: 0.75; }
 }
 
 /* ════════════════ Split Button & Deploy Menu ════════════════ */

--- a/cds/web/style.css
+++ b/cds/web/style.css
@@ -4639,3 +4639,95 @@ a.branch-name:hover { color: var(--accent); }
     grid-column: span 2;
   }
 }
+
+/* ════════════════ Restart detection overlay ════════════════
+ *
+ * Covers the whole viewport with a friendly "CDS 正在重启" card while
+ * the SSE connection is down. Polls /healthz to auto-reload when the
+ * backend is alive again — see app.js `showRestartOverlay()`.
+ *
+ * z-index sits above modals (1000) and Activity Monitor (50) but below
+ * the toast (9999) so confirmation toasts after the reload stay visible.
+ */
+.cds-restart-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(13, 17, 23, 0.82);
+  backdrop-filter: blur(6px) saturate(1.2);
+  -webkit-backdrop-filter: blur(6px) saturate(1.2);
+  animation: cds-restart-fade-in 240ms ease both;
+}
+.cds-restart-overlay.fade-out {
+  animation: cds-restart-fade-out 200ms ease both;
+}
+.cds-restart-card {
+  background: var(--bg-card, #161b22);
+  border: 1px solid var(--border, #30363d);
+  border-radius: 14px;
+  padding: 32px 36px 28px;
+  max-width: 420px;
+  width: calc(100% - 48px);
+  text-align: center;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.55);
+  transform: translateY(8px);
+  animation: cds-restart-card-in 320ms cubic-bezier(0.16, 1, 0.3, 1) 80ms both;
+}
+.cds-restart-spinner {
+  color: var(--accent, #58a6ff);
+  margin-bottom: 14px;
+  display: inline-flex;
+  animation: cds-restart-spin 1.6s linear infinite;
+}
+.cds-restart-title {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text-primary, #f0f6fc);
+  letter-spacing: 0.01em;
+  margin-bottom: 8px;
+}
+.cds-restart-hint {
+  font-size: 13px;
+  color: var(--text-muted, #8b949e);
+  line-height: 1.6;
+  margin-bottom: 22px;
+  min-height: 2.4em;
+}
+.cds-restart-reload {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 18px;
+  border-radius: 8px;
+  border: 1px solid var(--border, #30363d);
+  background: transparent;
+  color: var(--text-secondary, #c9d1d9);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 160ms ease;
+}
+.cds-restart-reload:hover {
+  border-color: var(--accent, #58a6ff);
+  color: var(--accent, #58a6ff);
+  background: rgba(88, 166, 255, 0.08);
+}
+@keyframes cds-restart-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+@keyframes cds-restart-fade-out {
+  from { opacity: 1; }
+  to   { opacity: 0; }
+}
+@keyframes cds-restart-card-in {
+  from { opacity: 0; transform: translateY(20px) scale(0.96); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+@keyframes cds-restart-spin {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}

--- a/changelogs/2026-04-11_cds-cluster-ui-fixes.md
+++ b/changelogs/2026-04-11_cds-cluster-ui-fixes.md
@@ -1,0 +1,7 @@
+| feat | cds | 设置菜单新增「退出集群」快捷入口，hybrid/executor 角色直接一键退出，无需再进入集群弹窗 |
+| fix | cds | 单节点 scheduler 模式电池徽章恢复为本地容器槽视图（不再卡在「集群 …」占位），仅在实际有远端执行器时切换为集群视图 |
+| fix | cds | 首次加载分支列表不再闪现「暂无分支」过渡文案，初始保留 CDS 加载动画直到数据就绪，空状态升级为带插图+CTA 的设计态 |
+| fix | cds | DELETE/停止分支现在会识别 entry.executorId 并代理到远端执行器 /exec/delete /exec/stop，不再只清掉主节点状态而留下僵尸容器 |
+| feat | cds | scheduler 启停改为 UI 开关：新增 PUT /api/scheduler/enabled + SchedulerService.setEnabled + state.json 持久化，容量弹窗内 on/off 切换，状态通过 state-stream 广播 |
+| feat | cds | 执行器状态页加入详细的「为什么没有 Dashboard」解释（避免 split-brain / 运维成本 / 控制平面单一），并指引使用主节点的退出集群按钮 |
+| chore | cds | 单节点模式隐藏多余的「执行器集群 1/1 在线」面板，header 电池徽章已充分展示容量 |

--- a/changelogs/2026-04-11_cds-restart-fast-and-silent.md
+++ b/changelogs/2026-04-11_cds-restart-fast-and-silent.md
@@ -1,0 +1,3 @@
+| perf | cds | restart 重排为 "先 build 再 stop"：tsc 在旧进程还在服务时就写出 dist，停掉旧进程到新进程绑端口的空窗从 10-16s 收缩到 2-4s，消除 Cloudflare 502 Bad gateway 体感 |
+| perf | cds | tsconfig 开启 incremental + tsBuildInfoFile，warm 构建从 5s 降到 3s（小 VM 收益更明显） |
+| feat | cds | 前端新增重启检测遮罩：SSE 中断时展示"CDS 正在重启"卡片，轮询 /healthz，后端恢复后自动刷新页面，替代原本的 Cloudflare 502 硬错 |


### PR DESCRIPTION
## Summary

This PR improves the CDS dashboard's cluster awareness, adds graceful restart detection with auto-reload, enables runtime scheduler toggling from the UI, and refines the branch list empty state to eliminate visual flicker on first load.

## Key Changes

### Cluster & Settings Menu
- **New "退出集群" shortcut** in settings menu for `executor` and `hybrid` roles, eliminating the need to open the cluster modal to leave
- **Cluster role tracking**: Added `clusterEffectiveRole` state variable (distinct from `cdsMode`) to track the effective role reported by `/api/cluster/status`, enabling the menu to show the exit action only when relevant
- **Cluster-aware branch operations**: DELETE and STOP operations now detect `entry.executorId` and proxy to the remote executor's `/exec/delete` and `/exec/stop` endpoints, preventing orphaned containers on remote nodes

### Restart Detection & Auto-Reload
- **Graceful restart overlay**: When the SSE connection drops, a friendly "CDS 正在重启" card appears with a spinner and auto-updates the elapsed time
- **Health polling**: Background polling of `/healthz` (cache-busting, cookie-free) automatically reloads the page when the backend recovers, eliminating manual refresh prompts
- **SSE recovery**: Successful SSE frames dismiss the restart overlay, allowing transient network hiccups to recover without a full page reload

### Scheduler Runtime Toggle
- **UI-controlled scheduler enable/disable**: New `PUT /api/scheduler/enabled` endpoint allows toggling the warm-pool scheduler from the capacity popover without editing `cds.config.json`
- **Persistent override**: Toggle state is saved to `state.json` via `StateService.setSchedulerEnabledOverride()` and re-applied on boot, superseding the config file setting
- **Styled toggle switch**: Compact on/off switch in the scheduler section of the capacity popover with smooth animations
- **State sync**: SSE broadcasts `schedulerEnabled` flag so the UI toggle stays in sync across tabs/instances

### Branch List Empty State
- **First-load guard**: New `_branchesFirstLoadDone` flag prevents the "暂无分支" text from flashing as a transitional state during the initial loader animation
- **Designed empty state**: Replaces the plain italic text with an illustration, title, hint, and CTA button that focuses the search box, following the guided-exploration pattern
- **Smooth transitions**: Empty state only renders after the first successful `/api/branches` fetch, eliminating the "loader → empty → data" flicker

### Capacity Badge Refinement
- **Single-node scheduler fix**: Capacity badge now only switches to cluster view when there is at least one remote executor (`remoteCount > 0`), not just when `cdsMode === 'scheduler'`. Single-node scheduler mode now shows the familiar container-slot battery instead of the generic "集群 ..." placeholder
- **Executor panel visibility**: Panel only shows when there are actual remote executors, hiding the redundant "执行器集群 1/1 在线" banner in single-node mode

### Build & Restart Performance
- **Hot-swap restart**: `exec_cds.sh restart` now builds TypeScript on the still-running process before stopping, reducing the downtime window from 10-16s to 2-4s and eliminating Cloudflare 502 errors
- **Incremental TypeScript builds**: `tsconfig.json` now enables `incremental` mode with `tsBuildInfoFile`, reducing warm builds from ~5s to ~3s
- **Nginx stays up**: Removed unnecessary nginx restart during CDS restart; nginx upstream pointer is idempotent and rebinds automatically

## Implementation Details

- **Cluster status probing**: `loadClusterStatus()` runs once at startup and is re-called when the cluster modal opens or after join/leave actions
- **SSE enhancements**: State-stream now broadcasts `schedulerEnabled` and `effectiveRole` so the dashboard stays synchronized without polling
- **Graceful degradation**: Non-cluster installs silently default to `effectiveRole === 'standalone'`; health polling uses `cache: 'no-store'` and `credentials: 'omit'` to work even

https://claude.ai/code/session_01TyFgoU6donuFTuwh93bk8J