### PR TITLE
Fix landing page i18n and mockup rendering issues

### DIFF
--- a/changelogs/2026-04-12_fix-landing-page-load-language.md
+++ b/changelogs/2026-04-12_fix-landing-page-load-language.md
@@ -1,0 +1,4 @@
+| fix | prd-admin | 修复首页 ProductMockup 在首屏加载时因 IntersectionObserver 阈值不满足而不显示的问题 |
+| fix | prd-admin | 修复 FeatureDeepDive 各 mockup 示意文案未跟随语言切换（hardcoded 中文），现已全部接入 i18n |
+| fix | prd-admin | 修复周报 ReportMockup 柱状图因 flex 子元素缺少 h-full 导致百分比高度为 0、柱子不显示的问题 |
+| fix | prd-admin | CompatibilityStack 中文平台名（阿里通义/智谱/百度/字节）切换英文时显示国际品牌名 |

--- a/prd-admin/src/app/App.tsx
+++ b/prd-admin/src/app/App.tsx
@@ -236,8 +236,12 @@ export default function App() {
       <NavigationBridge />
       <Suspense fallback={<SuspenseVideoLoader />}>
       <Routes location={location}>
-        {/* Landing page - public */}
-        <Route path="/home" element={<LandingPage />} />
+        {/* Landing page - public · 用透明 fallback，避免 MAP 闪屏打断朦胧动效节奏 */}
+        <Route path="/home" element={
+          <Suspense fallback={<div style={{ position: 'fixed', inset: 0, background: '#030306' }} />}>
+            <LandingPage />
+          </Suspense>
+        } />
 
         <Route path="/login" element={<LoginPage />} />
 

--- a/prd-admin/src/pages/home/components/Reveal.tsx
+++ b/prd-admin/src/pages/home/components/Reveal.tsx
@@ -35,7 +35,7 @@ interface RevealProps {
   className?: string;
   /** 初始位移 px，默认 16 */
   offset?: number;
-  /** animation-duration ms，默认 1100 */
+  /** animation-duration ms，默认 2000（长 duration + 极端 ease-out = "快显慢散"） */
   duration?: number;
   /** 初始模糊度 px，默认 0 */
   blur?: number;
@@ -62,7 +62,7 @@ export function Reveal({
   delay = 0,
   className,
   offset = 16,
-  duration = 1100,
+  duration = 2000,
   blur = 0,
   as = 'div',
   debugLabel,

--- a/prd-admin/src/pages/home/components/Reveal.tsx
+++ b/prd-admin/src/pages/home/components/Reveal.tsx
@@ -1,35 +1,35 @@
-import type { ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { useInView } from '../hooks/useInView';
 
 interface RevealProps {
   children: ReactNode;
+  /** JS 延迟 ms：控制元素何时"亮起"（不再依赖 CSS transition-delay） */
   delay?: number;
   className?: string;
   /** 进入视口后的位移距离，默认 16px */
   offset?: number;
   /** 持续时间，默认 1100ms */
   duration?: number;
-  /** 初始模糊度，默认 8px（0 = 禁用模糊） */
+  /** 初始模糊度，默认 0（只有大标题才用 blur，其他元素不需要） */
   blur?: number;
   /** 作为内联 span 而不是 div（避免破坏布局） */
   as?: 'div' | 'span';
-  /** 调试标签，启用后在 console 打印时序日志 */
+  /** 调试标签 */
   debugLabel?: string;
 }
 
 /**
- * Reveal — 滚动进入视口时从朦胧到清晰，徐徐点亮（Linear.app 风格）
+ * Reveal — 滚动进入视口时从朦胧到清晰，徐徐点亮
  *
- * 动效分解：
- *  1. opacity 0 → 1          让内容从黑暗中浮现
- *  2. filter blur → 0        制造"雾气散开"的朦胧感（仅大标题使用，小元素不要 blur）
- *  3. translateY → 0         极轻的上浮，不喧宾夺主
+ * 核心改动：
+ *   delay 不再走 CSS transition-delay，而是用 JavaScript setTimeout 控制
+ *   每个元素 "何时开始动"。这样每个元素的 CSS transition 是从真正不同的
+ *   时间点启动的，而不是靠浏览器同帧处理 delay 值来区分。
  *
- * 呼吸设计原则：
- *  · 主标题第一个亮起（它是焦点），用重 blur
- *  · 副标题/eyebrow 等辅助文字不用 blur，只做 opacity+translateY
- *  · 按钮/logo 等外围元素最后，更轻的动效
- *  → 从"焦点向外辐射"，不是"从上到下瀑布"
+ * 呼吸设计：
+ *  · 大标题 delay=0, blur=12 — 第一个从雾中亮起，它是焦点
+ *  · 辅助文字 delay=大, blur=0 — 干净 fade，不和标题抢
+ *  · 按钮/logo delay=更大, blur=0 — 纯 opacity+rise，最后出场
  */
 export function Reveal({
   children,
@@ -37,30 +37,43 @@ export function Reveal({
   className,
   offset = 16,
   duration = 1100,
-  blur = 8,
+  blur = 0,
   as = 'div',
   debugLabel,
 }: RevealProps) {
-  const [ref, inView] = useInView<HTMLDivElement>(undefined, debugLabel);
-  const Tag = as;
+  const [ref, inViewRaw] = useInView<HTMLDivElement>(undefined, debugLabel);
+  // JS 控制的延迟 — 真正的 stagger 入口
+  const [active, setActive] = useState(false);
 
+  useEffect(() => {
+    if (!inViewRaw || active) return;
+    if (delay <= 0) {
+      setActive(true);
+      if (debugLabel) console.log(`[Reveal:${debugLabel}] → active (immediate)`);
+      return;
+    }
+    const timer = setTimeout(() => {
+      setActive(true);
+      if (debugLabel) console.log(`[Reveal:${debugLabel}] → active (after ${delay}ms JS delay)`);
+    }, delay);
+    return () => clearTimeout(timer);
+  }, [inViewRaw, delay, active, debugLabel]);
+
+  const Tag = as;
   const useBlur = blur > 0;
-  const filterValue = useBlur
-    ? (inView ? 'blur(0px)' : `blur(${blur}px)`)
-    : undefined;
 
   return (
     <Tag
       ref={ref as React.RefObject<HTMLDivElement>}
       className={className}
       style={{
-        opacity: inView ? 1 : 0,
-        filter: filterValue,
-        transform: inView ? 'translateY(0)' : `translateY(${offset}px)`,
+        opacity: active ? 1 : 0,
+        filter: useBlur ? (active ? 'blur(0px)' : `blur(${blur}px)`) : undefined,
+        transform: active ? 'translateY(0)' : `translateY(${offset}px)`,
         transition: [
-          `opacity ${duration}ms cubic-bezier(0.16, 1, 0.3, 1) ${delay}ms`,
-          useBlur ? `filter ${Math.round(duration * 0.85)}ms cubic-bezier(0.16, 1, 0.3, 1) ${delay}ms` : '',
-          `transform ${duration}ms cubic-bezier(0.16, 1, 0.3, 1) ${delay}ms`,
+          `opacity ${duration}ms cubic-bezier(0.16, 1, 0.3, 1)`,
+          useBlur ? `filter ${Math.round(duration * 0.85)}ms cubic-bezier(0.16, 1, 0.3, 1)` : '',
+          `transform ${duration}ms cubic-bezier(0.16, 1, 0.3, 1)`,
         ].filter(Boolean).join(', '),
         willChange: 'opacity, transform, filter',
       }}

--- a/prd-admin/src/pages/home/components/Reveal.tsx
+++ b/prd-admin/src/pages/home/components/Reveal.tsx
@@ -5,7 +5,7 @@ interface RevealProps {
   children: ReactNode;
   delay?: number;
   className?: string;
-  /** 进入视口后的位移距离，默认 16px（Linear 风格用更小的位移） */
+  /** 进入视口后的位移距离，默认 16px */
   offset?: number;
   /** 持续时间，默认 1100ms */
   duration?: number;
@@ -13,6 +13,8 @@ interface RevealProps {
   blur?: number;
   /** 作为内联 span 而不是 div（避免破坏布局） */
   as?: 'div' | 'span';
+  /** 调试标签，启用后在 console 打印时序日志 */
+  debugLabel?: string;
 }
 
 /**
@@ -20,17 +22,14 @@ interface RevealProps {
  *
  * 动效分解：
  *  1. opacity 0 → 1          让内容从黑暗中浮现
- *  2. filter blur(8px) → 0   制造"雾气散开"的朦胧感
- *  3. translateY(16px) → 0   极轻的上浮，不喧宾夺主
- *  4. 缓动：ease-out 的加速版 cubic-bezier(0.16, 1, 0.3, 1)
- *     前 20% 快速破雾，后 80% 缓缓归位 —— 像灯光从远处渐近
+ *  2. filter blur → 0        制造"雾气散开"的朦胧感（仅大标题使用，小元素不要 blur）
+ *  3. translateY → 0         极轻的上浮，不喧宾夺主
  *
- * 用法：
- *   <Reveal><h2>标题</h2></Reveal>
- *   <Reveal delay={100} blur={12}>大标题（更浓的雾）</Reveal>
- *   <Reveal blur={0}>不需要模糊的元素</Reveal>
- *
- * 尊重 prefers-reduced-motion —— 用户禁用动效时立即显示，无过渡。
+ * 呼吸设计原则：
+ *  · 主标题第一个亮起（它是焦点），用重 blur
+ *  · 副标题/eyebrow 等辅助文字不用 blur，只做 opacity+translateY
+ *  · 按钮/logo 等外围元素最后，更轻的动效
+ *  → 从"焦点向外辐射"，不是"从上到下瀑布"
  */
 export function Reveal({
   children,
@@ -40,11 +39,13 @@ export function Reveal({
   duration = 1100,
   blur = 8,
   as = 'div',
+  debugLabel,
 }: RevealProps) {
-  const [ref, inView] = useInView<HTMLDivElement>();
+  const [ref, inView] = useInView<HTMLDivElement>(undefined, debugLabel);
   const Tag = as;
 
-  const filterValue = blur > 0
+  const useBlur = blur > 0;
+  const filterValue = useBlur
     ? (inView ? 'blur(0px)' : `blur(${blur}px)`)
     : undefined;
 
@@ -58,7 +59,7 @@ export function Reveal({
         transform: inView ? 'translateY(0)' : `translateY(${offset}px)`,
         transition: [
           `opacity ${duration}ms cubic-bezier(0.16, 1, 0.3, 1) ${delay}ms`,
-          blur > 0 ? `filter ${duration * 0.85}ms cubic-bezier(0.16, 1, 0.3, 1) ${delay}ms` : '',
+          useBlur ? `filter ${Math.round(duration * 0.85)}ms cubic-bezier(0.16, 1, 0.3, 1) ${delay}ms` : '',
           `transform ${duration}ms cubic-bezier(0.16, 1, 0.3, 1) ${delay}ms`,
         ].filter(Boolean).join(', '),
         willChange: 'opacity, transform, filter',

--- a/prd-admin/src/pages/home/components/Reveal.tsx
+++ b/prd-admin/src/pages/home/components/Reveal.tsx
@@ -1,35 +1,61 @@
 import { useEffect, useState, type ReactNode } from 'react';
 import { useInView } from '../hooks/useInView';
 
+const KEYFRAMES_ID = 'map-reveal-keyframes';
+
+/** 注入一次全局 @keyframes（避免重复注入） */
+function injectRevealKeyframes() {
+  if (document.getElementById(KEYFRAMES_ID)) return;
+  const style = document.createElement('style');
+  style.id = KEYFRAMES_ID;
+  style.textContent = `
+@keyframes map-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(var(--reveal-y, 16px));
+    filter: blur(var(--reveal-blur, 0px));
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+    filter: blur(0px);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .map-reveal-active { animation: none !important; opacity: 1 !important; }
+}
+  `;
+  document.head.appendChild(style);
+}
+
 interface RevealProps {
   children: ReactNode;
-  /** JS 延迟 ms：控制元素何时"亮起"（不再依赖 CSS transition-delay） */
+  /** animation-delay ms — 由 CSS 原生控制，可靠的时序保证 */
   delay?: number;
   className?: string;
-  /** 进入视口后的位移距离，默认 16px */
+  /** 初始位移 px，默认 16 */
   offset?: number;
-  /** 持续时间，默认 1100ms */
+  /** animation-duration ms，默认 1100 */
   duration?: number;
-  /** 初始模糊度，默认 0（只有大标题才用 blur，其他元素不需要） */
+  /** 初始模糊度 px，默认 0 */
   blur?: number;
-  /** 作为内联 span 而不是 div（避免破坏布局） */
   as?: 'div' | 'span';
-  /** 调试标签 */
   debugLabel?: string;
 }
 
 /**
- * Reveal — 滚动进入视口时从朦胧到清晰，徐徐点亮
+ * Reveal — CSS @keyframes animation 驱动的进场动效
  *
- * 核心改动：
- *   delay 不再走 CSS transition-delay，而是用 JavaScript setTimeout 控制
- *   每个元素 "何时开始动"。这样每个元素的 CSS transition 是从真正不同的
- *   时间点启动的，而不是靠浏览器同帧处理 delay 值来区分。
+ * 学习 Linear.app 的做法：
+ *  · 用 @keyframes animation + animation-delay，不用 CSS transition
+ *  · animation-fill-mode: both 保证元素在 delay 期间保持 from 态（不可见）
+ *  · animation-delay 是 CSS 动画规范的一部分，不依赖 "上一帧的样式"
+ *  · 缓动曲线 cubic-bezier(0.19, 1, 0.22, 1) — 极端 ease-out，"冲进来然后漂浮归位"
  *
- * 呼吸设计：
- *  · 大标题 delay=0, blur=12 — 第一个从雾中亮起，它是焦点
- *  · 辅助文字 delay=大, blur=0 — 干净 fade，不和标题抢
- *  · 按钮/logo delay=更大, blur=0 — 纯 opacity+rise，最后出场
+ * 按重要性编排：
+ *  · 核心信息（标题+副标题+CTA）delay=0~350ms，几乎同时
+ *  · 装饰元素（HUD、logos）delay=1200ms+，配角晚到
+ *  · 视觉证据（产品 Mockup）delay=1800ms+，最后浮出
  */
 export function Reveal({
   children,
@@ -41,40 +67,31 @@ export function Reveal({
   as = 'div',
   debugLabel,
 }: RevealProps) {
-  const [ref, inViewRaw] = useInView<HTMLDivElement>(undefined, debugLabel);
-  // JS 控制的延迟 — 真正的 stagger 入口
-  const [active, setActive] = useState(false);
+  const [ref, inView] = useInView<HTMLDivElement>(undefined, debugLabel);
+  const [injected, setInjected] = useState(false);
 
   useEffect(() => {
-    if (!inViewRaw || active) return;
-    if (delay <= 0) {
-      setActive(true);
-      if (debugLabel) console.log(`[Reveal:${debugLabel}] → active (immediate)`);
-      return;
-    }
-    const timer = setTimeout(() => {
-      setActive(true);
-      if (debugLabel) console.log(`[Reveal:${debugLabel}] → active (after ${delay}ms JS delay)`);
-    }, delay);
-    return () => clearTimeout(timer);
-  }, [inViewRaw, delay, active, debugLabel]);
+    injectRevealKeyframes();
+    setInjected(true);
+  }, []);
 
   const Tag = as;
-  const useBlur = blur > 0;
+  const ready = injected && inView;
 
   return (
     <Tag
       ref={ref as React.RefObject<HTMLDivElement>}
-      className={className}
+      className={`${ready ? 'map-reveal-active' : ''} ${className ?? ''}`}
       style={{
-        opacity: active ? 1 : 0,
-        filter: useBlur ? (active ? 'blur(0px)' : `blur(${blur}px)`) : undefined,
-        transform: active ? 'translateY(0)' : `translateY(${offset}px)`,
-        transition: [
-          `opacity ${duration}ms cubic-bezier(0.16, 1, 0.3, 1)`,
-          useBlur ? `filter ${Math.round(duration * 0.85)}ms cubic-bezier(0.16, 1, 0.3, 1)` : '',
-          `transform ${duration}ms cubic-bezier(0.16, 1, 0.3, 1)`,
-        ].filter(Boolean).join(', '),
+        // 动画未就绪时：不可见
+        opacity: ready ? undefined : 0,
+        // 就绪后：用 CSS @keyframes animation 驱动全部进场
+        animation: ready
+          ? `map-reveal ${duration}ms cubic-bezier(0.19, 1, 0.22, 1) ${delay}ms both`
+          : 'none',
+        // CSS 变量传递给 @keyframes
+        ['--reveal-y' as string]: `${offset}px`,
+        ['--reveal-blur' as string]: `${blur}px`,
         willChange: 'opacity, transform, filter',
       }}
     >

--- a/prd-admin/src/pages/home/components/Reveal.tsx
+++ b/prd-admin/src/pages/home/components/Reveal.tsx
@@ -5,20 +5,30 @@ interface RevealProps {
   children: ReactNode;
   delay?: number;
   className?: string;
-  /** 进入视口后的位移距离，默认 28px */
+  /** 进入视口后的位移距离，默认 16px（Linear 风格用更小的位移） */
   offset?: number;
-  /** 持续时间，默认 900ms */
+  /** 持续时间，默认 1100ms */
   duration?: number;
+  /** 初始模糊度，默认 8px（0 = 禁用模糊） */
+  blur?: number;
   /** 作为内联 span 而不是 div（避免破坏布局） */
   as?: 'div' | 'span';
 }
 
 /**
- * Reveal — 滚动进入视口时 fade-up 一次
+ * Reveal — 滚动进入视口时从朦胧到清晰，徐徐点亮（Linear.app 风格）
+ *
+ * 动效分解：
+ *  1. opacity 0 → 1          让内容从黑暗中浮现
+ *  2. filter blur(8px) → 0   制造"雾气散开"的朦胧感
+ *  3. translateY(16px) → 0   极轻的上浮，不喧宾夺主
+ *  4. 缓动：ease-out 的加速版 cubic-bezier(0.16, 1, 0.3, 1)
+ *     前 20% 快速破雾，后 80% 缓缓归位 —— 像灯光从远处渐近
  *
  * 用法：
  *   <Reveal><h2>标题</h2></Reveal>
- *   <Reveal delay={100}>...</Reveal>
+ *   <Reveal delay={100} blur={12}>大标题（更浓的雾）</Reveal>
+ *   <Reveal blur={0}>不需要模糊的元素</Reveal>
  *
  * 尊重 prefers-reduced-motion —— 用户禁用动效时立即显示，无过渡。
  */
@@ -26,12 +36,17 @@ export function Reveal({
   children,
   delay = 0,
   className,
-  offset = 28,
-  duration = 900,
+  offset = 16,
+  duration = 1100,
+  blur = 8,
   as = 'div',
 }: RevealProps) {
   const [ref, inView] = useInView<HTMLDivElement>();
   const Tag = as;
+
+  const filterValue = blur > 0
+    ? (inView ? 'blur(0px)' : `blur(${blur}px)`)
+    : undefined;
 
   return (
     <Tag
@@ -39,9 +54,14 @@ export function Reveal({
       className={className}
       style={{
         opacity: inView ? 1 : 0,
+        filter: filterValue,
         transform: inView ? 'translateY(0)' : `translateY(${offset}px)`,
-        transition: `opacity ${duration}ms cubic-bezier(0.2, 0.9, 0.2, 1) ${delay}ms, transform ${duration}ms cubic-bezier(0.2, 0.9, 0.2, 1) ${delay}ms`,
-        willChange: 'opacity, transform',
+        transition: [
+          `opacity ${duration}ms cubic-bezier(0.16, 1, 0.3, 1) ${delay}ms`,
+          blur > 0 ? `filter ${duration * 0.85}ms cubic-bezier(0.16, 1, 0.3, 1) ${delay}ms` : '',
+          `transform ${duration}ms cubic-bezier(0.16, 1, 0.3, 1) ${delay}ms`,
+        ].filter(Boolean).join(', '),
+        willChange: 'opacity, transform, filter',
       }}
     >
       {children}

--- a/prd-admin/src/pages/home/components/SectionHeader.tsx
+++ b/prd-admin/src/pages/home/components/SectionHeader.tsx
@@ -31,7 +31,7 @@ export function SectionHeader({
 }: SectionHeaderProps) {
   return (
     <div className="text-center">
-      <Reveal>
+      <Reveal blur={0} offset={10}>
         <div
           className="inline-flex items-center gap-2 mb-7 px-3.5 py-1.5 rounded-md"
           style={{
@@ -55,7 +55,7 @@ export function SectionHeader({
         </div>
       </Reveal>
 
-      <Reveal delay={80} blur={12} duration={1300}>
+      <Reveal delay={150} blur={8} duration={1200}>
         <h2
           className="text-white font-medium"
           style={{
@@ -71,7 +71,7 @@ export function SectionHeader({
       </Reveal>
 
       {subtitle && (
-        <Reveal delay={160}>
+        <Reveal delay={400} blur={0} offset={10}>
           <p
             className="mt-7 text-white/58 mx-auto text-[15px] leading-[1.7]"
             style={{ maxWidth: subtitleMaxWidth }}

--- a/prd-admin/src/pages/home/components/SectionHeader.tsx
+++ b/prd-admin/src/pages/home/components/SectionHeader.tsx
@@ -55,7 +55,7 @@ export function SectionHeader({
         </div>
       </Reveal>
 
-      <Reveal delay={80}>
+      <Reveal delay={80} blur={12} duration={1300}>
         <h2
           className="text-white font-medium"
           style={{

--- a/prd-admin/src/pages/home/components/SectionHeader.tsx
+++ b/prd-admin/src/pages/home/components/SectionHeader.tsx
@@ -31,7 +31,7 @@ export function SectionHeader({
 }: SectionHeaderProps) {
   return (
     <div className="text-center">
-      <Reveal blur={0} offset={10}>
+      <Reveal offset={12} duration={2000}>
         <div
           className="inline-flex items-center gap-2 mb-7 px-3.5 py-1.5 rounded-md"
           style={{
@@ -55,7 +55,7 @@ export function SectionHeader({
         </div>
       </Reveal>
 
-      <Reveal delay={150} blur={8} duration={1200}>
+      <Reveal delay={150} blur={8} duration={3000}>
         <h2
           className="text-white font-medium"
           style={{
@@ -71,7 +71,7 @@ export function SectionHeader({
       </Reveal>
 
       {subtitle && (
-        <Reveal delay={400} blur={0} offset={10}>
+        <Reveal delay={400} offset={14} duration={2000}>
           <p
             className="mt-7 text-white/58 mx-auto text-[15px] leading-[1.7]"
             style={{ maxWidth: subtitleMaxWidth }}

--- a/prd-admin/src/pages/home/hooks/useInView.ts
+++ b/prd-admin/src/pages/home/hooks/useInView.ts
@@ -5,6 +5,10 @@ import { useEffect, useRef, useState } from 'react';
  *
  * 注意：只触发一次（首次进入视口后 unobserve），滚回去再回来不会重复播放，
  * 避免"来回晃"的廉价感。
+ *
+ * 首屏优化：挂载时如果元素已经在视口内或紧贴视口边缘（1.15 倍窗口高度内），
+ * 直接触发 inView，确保折叠线附近的内容（如 ProductMockup）不会因
+ * IntersectionObserver 阈值/rootMargin 不满足而永远隐藏。
  */
 export function useInView<T extends HTMLElement>(
   options?: IntersectionObserverInit,
@@ -15,6 +19,13 @@ export function useInView<T extends HTMLElement>(
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
+
+    // 首屏快检：元素顶部在 1.15 倍视口高度内 → 直接触发（CSS transition delay 保留 stagger 效果）
+    const rect = el.getBoundingClientRect();
+    if (rect.top < window.innerHeight * 1.15 && rect.bottom > 0) {
+      setInView(true);
+      return;
+    }
 
     const observer = new IntersectionObserver(
       ([entry]) => {

--- a/prd-admin/src/pages/home/hooks/useInView.ts
+++ b/prd-admin/src/pages/home/hooks/useInView.ts
@@ -6,12 +6,13 @@ import { useEffect, useRef, useState } from 'react';
  * 注意：只触发一次（首次进入视口后 unobserve），滚回去再回来不会重复播放，
  * 避免"来回晃"的廉价感。
  *
- * 首屏优化：挂载时如果元素已经在视口内或紧贴视口边缘（1.15 倍窗口高度内），
- * 直接触发 inView，确保折叠线附近的内容（如 ProductMockup）不会因
- * IntersectionObserver 阈值/rootMargin 不满足而永远隐藏。
+ * 首屏优化：挂载时如果元素已在视口附近（1.15 倍窗口高度内），用 double-rAF
+ * 延迟触发 inView，确保浏览器先绘制初始态（opacity:0 / blur），再切换到
+ * 终态触发 CSS transition。同步 setState 会导致 React 18 批处理跳过初始帧。
  */
 export function useInView<T extends HTMLElement>(
   options?: IntersectionObserverInit,
+  debugLabel?: string,
 ) {
   const ref = useRef<T | null>(null);
   const [inView, setInView] = useState(false);
@@ -20,16 +21,39 @@ export function useInView<T extends HTMLElement>(
     const el = ref.current;
     if (!el) return;
 
-    // 首屏快检：元素顶部在 1.15 倍视口高度内 → 直接触发（CSS transition delay 保留 stagger 效果）
     const rect = el.getBoundingClientRect();
-    if (rect.top < window.innerHeight * 1.15 && rect.bottom > 0) {
-      setInView(true);
+    const nearViewport = rect.top < window.innerHeight * 1.15 && rect.bottom > 0;
+
+    if (debugLabel) {
+      console.log(
+        `[Reveal:${debugLabel}] mount top=${Math.round(rect.top)} vh=${window.innerHeight} nearViewport=${nearViewport}`,
+      );
+    }
+
+    if (nearViewport) {
+      // 关键：double-rAF 保证浏览器先绘制 opacity:0 / blur 初始帧，
+      // 再 setState 触发 CSS transition。直接 setState 会被 React 18
+      // 批处理合并到同一帧，跳过初始态 → transition 不触发 → 元素直接跳到终态。
+      const t0 = performance.now();
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          if (debugLabel) {
+            console.log(
+              `[Reveal:${debugLabel}] → inView=true (after ${Math.round(performance.now() - t0)}ms)`,
+            );
+          }
+          setInView(true);
+        });
+      });
       return;
     }
 
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) {
+          if (debugLabel) {
+            console.log(`[Reveal:${debugLabel}] → inView=true (intersected)`);
+          }
           setInView(true);
           observer.unobserve(el);
         }
@@ -42,7 +66,7 @@ export function useInView<T extends HTMLElement>(
     );
     observer.observe(el);
     return () => observer.disconnect();
-  }, [options]);
+  }, [options, debugLabel]);
 
   return [ref, inView] as const;
 }

--- a/prd-admin/src/pages/home/hooks/useInView.ts
+++ b/prd-admin/src/pages/home/hooks/useInView.ts
@@ -31,12 +31,13 @@ export function useInView<T extends HTMLElement>(
     }
 
     if (nearViewport) {
-      // 关键：double-rAF 保证浏览器先绘制 opacity:0 / blur 初始帧，
-      // 再 setState 触发 CSS transition。直接 setState 会被 React 18
-      // 批处理合并到同一帧，跳过初始态 → transition 不触发 → 元素直接跳到终态。
+      // double-rAF 保证浏览器先绘制 opacity:0 初始帧，再触发 transition。
+      // cancelled 标志防止 React StrictMode 双挂载时旧实例的 rAF 泄漏。
+      let cancelled = false;
       const t0 = performance.now();
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
+          if (cancelled) return;
           if (debugLabel) {
             console.log(
               `[Reveal:${debugLabel}] → inView=true (after ${Math.round(performance.now() - t0)}ms)`,
@@ -45,7 +46,7 @@ export function useInView<T extends HTMLElement>(
           setInView(true);
         });
       });
-      return;
+      return () => { cancelled = true; };
     }
 
     const observer = new IntersectionObserver(

--- a/prd-admin/src/pages/home/hooks/useInView.ts
+++ b/prd-admin/src/pages/home/hooks/useInView.ts
@@ -1,14 +1,15 @@
 import { useEffect, useRef, useState } from 'react';
 
 /**
- * useInView — 元素进入视口时触发一次（fade-up 滚动动效用）
+ * useInView — 元素进入视口时触发一次
  *
- * 注意：只触发一次（首次进入视口后 unobserve），滚回去再回来不会重复播放，
- * 避免"来回晃"的廉价感。
+ * 配合 Reveal 的 CSS @keyframes animation 使用：
+ *  · inView=true 后 Reveal 设置 animation 属性，animation-delay 处理时序
+ *  · 不再需要 double-rAF hack（@keyframes 的 from 态由 keyframes 定义，
+ *    不依赖 "上一帧的 DOM 样式"）
  *
- * 首屏优化：挂载时如果元素已在视口附近（1.15 倍窗口高度内），用 double-rAF
- * 延迟触发 inView，确保浏览器先绘制初始态（opacity:0 / blur），再切换到
- * 终态触发 CSS transition。同步 setState 会导致 React 18 批处理跳过初始帧。
+ * 首屏优化：视口内元素直接 inView=true。
+ * 滚动区：IntersectionObserver 检测。
  */
 export function useInView<T extends HTMLElement>(
   options?: IntersectionObserverInit,
@@ -24,46 +25,21 @@ export function useInView<T extends HTMLElement>(
     const rect = el.getBoundingClientRect();
     const nearViewport = rect.top < window.innerHeight * 1.15 && rect.bottom > 0;
 
-    if (debugLabel) {
-      console.log(
-        `[Reveal:${debugLabel}] mount top=${Math.round(rect.top)} vh=${window.innerHeight} nearViewport=${nearViewport}`,
-      );
-    }
-
     if (nearViewport) {
-      // double-rAF 保证浏览器先绘制 opacity:0 初始帧，再触发 transition。
-      // cancelled 标志防止 React StrictMode 双挂载时旧实例的 rAF 泄漏。
-      let cancelled = false;
-      const t0 = performance.now();
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          if (cancelled) return;
-          if (debugLabel) {
-            console.log(
-              `[Reveal:${debugLabel}] → inView=true (after ${Math.round(performance.now() - t0)}ms)`,
-            );
-          }
-          setInView(true);
-        });
-      });
-      return () => { cancelled = true; };
+      if (debugLabel) console.log(`[Reveal:${debugLabel}] inView (on mount)`);
+      setInView(true);
+      return;
     }
 
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) {
-          if (debugLabel) {
-            console.log(`[Reveal:${debugLabel}] → inView=true (intersected)`);
-          }
+          if (debugLabel) console.log(`[Reveal:${debugLabel}] inView (scroll)`);
           setInView(true);
           observer.unobserve(el);
         }
       },
-      {
-        threshold: 0.15,
-        rootMargin: '0px 0px -8% 0px',
-        ...options,
-      },
+      { threshold: 0.15, rootMargin: '0px 0px -8% 0px', ...options },
     );
     observer.observe(el);
     return () => observer.disconnect();

--- a/prd-admin/src/pages/home/i18n/landing.ts
+++ b/prd-admin/src/pages/home/i18n/landing.ts
@@ -2,9 +2,7 @@
  * landing.ts — 首页 /home 的双语字典（中 / 英）
  *
  * 原则：
- *  · 只翻译"用户可见的文案"（标题、副标题、bullet、eyebrow、按钮）
- *  · ProductMockup 和 FeatureDeepDive 内各个 mockup 里的"伪数据"保持中文
- *    （它们是示意产物而不是 UI chrome，翻译了反而突兀）
+ *  · 翻译所有用户可见的文案（标题、副标题、bullet、eyebrow、按钮、mockup 示意文案）
  *  · 所有 key 使用扁平结构，便于 `t.hero.title` 直接访问
  *  · 多行文案用 `\n` 分隔，由组件决定是否转换为 <br>
  */
@@ -185,6 +183,42 @@ export interface TranslationShape {
     github: string;
     backToTop: string;
     copyright: string;
+  };
+  /** FeatureDeepDive 内各 mockup 的示意文案 */
+  mockups: {
+    visual: {
+      header: string;
+      status: string;
+    };
+    literary: {
+      header: string;
+      progress: string;
+      added: string;
+      deleted: string;
+      diffView: string;
+    };
+    prd: {
+      header: string;
+      sections: Array<{ title: string; note?: string }>;
+    };
+    video: {
+      header: string;
+      status: string;
+    };
+    defect: {
+      header: string;
+      items: Array<{ sev: string; title: string }>;
+      assigned: string;
+      newThisWeek: string;
+      fixed: string;
+      fixRate: string;
+    };
+    report: {
+      header: string;
+      plan: string;
+      actual: string;
+      days: string[];
+    };
   };
 }
 
@@ -498,6 +532,51 @@ const zh: TranslationShape = {
     github: 'GitHub',
     backToTop: '回到顶部',
     copyright: '© 2026 MAP',
+  },
+  mockups: {
+    visual: {
+      header: 'visual-agent · 4 张候选',
+      status: '生成中 · 2 / 4 已完成',
+    },
+    literary: {
+      header: 'literary-agent · 润色中',
+      progress: '段 3 / 7',
+      added: '+ 12 字',
+      deleted: '删除 3 字',
+      diffView: '差异视图',
+    },
+    prd: {
+      header: 'prd-agent · v3.0 需求分析',
+      sections: [
+        { title: '§ 用户故事' },
+        { title: '§ 核心流程', note: '缺少异常分支' },
+        { title: '§ 数据模型' },
+        { title: '§ 权限矩阵', note: '未定义角色边界' },
+        { title: '§ 测试用例', note: '缺少失败场景' },
+      ],
+    },
+    video: {
+      header: 'video-agent · 6 分镜',
+      status: '渲染中 · 72%',
+    },
+    defect: {
+      header: 'defect-agent · 3 个待处理',
+      items: [
+        { sev: 'P0', title: '对话消息在刷新后丢失' },
+        { sev: 'P1', title: '图像生成超时未释放' },
+        { sev: 'P2', title: '深色模式下描边消失' },
+      ],
+      assigned: '已分派',
+      newThisWeek: '本周新增 · 27',
+      fixed: '已修复 · 19',
+      fixRate: '修复率 · 70%',
+    },
+    report: {
+      header: 'report-agent · W15',
+      plan: '计划',
+      actual: '实际',
+      days: ['周一', '周二', '周三', '周四', '周五'],
+    },
   },
 };
 
@@ -814,6 +893,51 @@ const en: TranslationShape = {
     github: 'GitHub',
     backToTop: 'Back to top',
     copyright: '© 2026 MAP',
+  },
+  mockups: {
+    visual: {
+      header: 'visual-agent · 4 candidates',
+      status: 'Generating · 2 / 4 done',
+    },
+    literary: {
+      header: 'literary-agent · polishing',
+      progress: 'Para 3 / 7',
+      added: '+12 chars',
+      deleted: '-3 chars',
+      diffView: 'Diff view',
+    },
+    prd: {
+      header: 'prd-agent · v3.0 spec analysis',
+      sections: [
+        { title: '§ User Stories' },
+        { title: '§ Core Flow', note: 'Missing edge cases' },
+        { title: '§ Data Model' },
+        { title: '§ Permission Matrix', note: 'Undefined role boundaries' },
+        { title: '§ Test Cases', note: 'Missing failure scenarios' },
+      ],
+    },
+    video: {
+      header: 'video-agent · 6 shots',
+      status: 'Rendering · 72%',
+    },
+    defect: {
+      header: 'defect-agent · 3 open',
+      items: [
+        { sev: 'P0', title: 'Messages lost on refresh' },
+        { sev: 'P1', title: 'Image gen timeout unreleased' },
+        { sev: 'P2', title: 'Strokes disappear in dark mode' },
+      ],
+      assigned: 'Assigned',
+      newThisWeek: 'New this week · 27',
+      fixed: 'Fixed · 19',
+      fixRate: 'Fix rate · 70%',
+    },
+    report: {
+      header: 'report-agent · W15',
+      plan: 'Plan',
+      actual: 'Actual',
+      days: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'],
+    },
   },
 };
 

--- a/prd-admin/src/pages/home/sections/CompatibilityStack.tsx
+++ b/prd-admin/src/pages/home/sections/CompatibilityStack.tsx
@@ -19,15 +19,18 @@ const PROVIDERS = [
   { name: 'Mistral', region: 'FR' },
   { name: 'DeepSeek', region: 'CN' },
   { name: 'Moonshot Kimi', region: 'CN' },
-  { name: '阿里通义', region: 'CN' },
-  { name: '智谱 GLM', region: 'CN' },
-  { name: '百度文心', region: 'CN' },
-  { name: '字节豆包', region: 'CN' },
-];
+  { zh: '阿里通义', en: 'Alibaba Qwen', region: 'CN' },
+  { zh: '智谱 GLM', en: 'Zhipu GLM', region: 'CN' },
+  { zh: '百度文心', en: 'Baidu ERNIE', region: 'CN' },
+  { zh: '字节豆包', en: 'ByteDance Doubao', region: 'CN' },
+] as const;
 
 export function CompatibilityStack() {
-  const { t } = useLanguage();
+  const { t, lang } = useLanguage();
   const titleParts = t.compat.title.split('\n');
+
+  const getProviderName = (p: (typeof PROVIDERS)[number]) =>
+    'name' in p ? p.name : lang === 'en' ? p.en : p.zh;
 
   return (
     <section
@@ -59,11 +62,14 @@ export function CompatibilityStack() {
 
         {/* Provider grid */}
         <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-3">
-          {PROVIDERS.map((p, i) => (
-            <Reveal key={p.name} delay={(i % 6) * 40} offset={18}>
-              <ProviderTile name={p.name} region={p.region} />
-            </Reveal>
-          ))}
+          {PROVIDERS.map((p, i) => {
+            const displayName = getProviderName(p);
+            return (
+              <Reveal key={displayName} delay={(i % 6) * 40} offset={18}>
+                <ProviderTile name={displayName} region={p.region} />
+              </Reveal>
+            );
+          })}
         </div>
 
         {/* Footer note */}

--- a/prd-admin/src/pages/home/sections/FeatureDeepDive.tsx
+++ b/prd-admin/src/pages/home/sections/FeatureDeepDive.tsx
@@ -20,7 +20,7 @@ import type { FeatureItem } from '../i18n/landing';
  *   3. chapter 编号 "01 / 06"（VT323 mono）作为每段的开篇符号
  */
 
-// 六段 mockup 从原来的函数名映射（内部几何 mockup 不走 i18n，因为是"示意图"）
+// 六段 mockup accent 配色
 const MOCKUPS = {
   visual: { accent: '#a855f7' },
   literary: { accent: '#fb923c' },
@@ -263,6 +263,7 @@ function MockupFrame({
 
 function VisualMockup() {
   const accent = '#a855f7';
+  const { t } = useLanguage();
   // 独立的 useInView，让内部 4 格走自己的 stagger 时序，叠加在外层 Reveal 之上
   const [gridRef, inView] = useInView<HTMLDivElement>();
   const grads = [
@@ -275,7 +276,7 @@ function VisualMockup() {
     <MockupFrame accent={accent}>
       <div className="flex items-center justify-between mb-4">
         <div className="text-[11px] text-white/60" style={{ fontFamily: 'var(--font-display)' }}>
-          visual-agent · 4 张候选
+          {t.mockups.visual.header}
         </div>
         <div className="flex gap-1.5">
           <span className="w-1.5 h-1.5 rounded-full bg-white/25" />
@@ -352,7 +353,7 @@ function VisualMockup() {
           className="w-1.5 h-1.5 rounded-full"
           style={{ background: accent, animation: 'mockup-pulse 1.5s ease-in-out infinite' }}
         />
-        <span>生成中 · 2 / 4 已完成</span>
+        <span>{t.mockups.visual.status}</span>
       </div>
       <style>{`
         @keyframes mockup-pulse { 0%,100% { opacity:1; } 50% { opacity:0.4; } }
@@ -371,13 +372,14 @@ function VisualMockup() {
 
 function LiteraryMockup() {
   const accent = '#fb923c';
+  const { t } = useLanguage();
   return (
     <MockupFrame accent={accent}>
       <div className="flex items-center justify-between mb-4">
         <div className="text-[11px] text-white/60" style={{ fontFamily: 'var(--font-display)' }}>
-          literary-agent · 润色中
+          {t.mockups.literary.header}
         </div>
-        <div className="text-[10px] text-white/35">段 3 / 7</div>
+        <div className="text-[10px] text-white/35">{t.mockups.literary.progress}</div>
       </div>
       <div className="space-y-2">
         <TextLine width="100%" />
@@ -390,10 +392,10 @@ function LiteraryMockup() {
       </div>
       <div className="mt-5 pt-4 border-t border-white/5 flex items-center justify-between text-[10px] text-white/45">
         <div className="flex items-center gap-3">
-          <span>+ 12 字</span>
-          <span style={{ color: accent }}>删除 3 字</span>
+          <span>{t.mockups.literary.added}</span>
+          <span style={{ color: accent }}>{t.mockups.literary.deleted}</span>
         </div>
-        <span>差异视图</span>
+        <span>{t.mockups.literary.diffView}</span>
       </div>
     </MockupFrame>
   );
@@ -450,11 +452,13 @@ function TextLine({
 
 function PrdMockup() {
   const accent = '#3b82f6';
+  const { t } = useLanguage();
+  const sections = t.mockups.prd.sections;
   return (
     <MockupFrame accent={accent}>
       <div className="flex items-center justify-between mb-4">
         <div className="text-[11px] text-white/60" style={{ fontFamily: 'var(--font-display)' }}>
-          prd-agent · v3.0 需求分析
+          {t.mockups.prd.header}
         </div>
         <div
           className="px-2 py-0.5 rounded text-[9px] uppercase"
@@ -464,11 +468,11 @@ function PrdMockup() {
         </div>
       </div>
       <div className="space-y-3">
-        <PrdSection title="§ 用户故事" complete />
-        <PrdSection title="§ 核心流程" gap accent={accent} note="缺少异常分支" />
-        <PrdSection title="§ 数据模型" complete />
-        <PrdSection title="§ 权限矩阵" gap accent={accent} note="未定义角色边界" />
-        <PrdSection title="§ 测试用例" gap accent={accent} note="缺少失败场景" />
+        <PrdSection title={sections[0].title} complete />
+        <PrdSection title={sections[1].title} gap accent={accent} note={sections[1].note} />
+        <PrdSection title={sections[2].title} complete />
+        <PrdSection title={sections[3].title} gap accent={accent} note={sections[3].note} />
+        <PrdSection title={sections[4].title} gap accent={accent} note={sections[4].note} />
       </div>
     </MockupFrame>
   );
@@ -512,18 +516,19 @@ function PrdSection({
 
 function VideoMockup() {
   const accent = '#f43f5e';
+  const { t } = useLanguage();
   return (
     <MockupFrame accent={accent}>
       <div className="flex items-center justify-between mb-4">
         <div className="text-[11px] text-white/60" style={{ fontFamily: 'var(--font-display)' }}>
-          video-agent · 6 分镜
+          {t.mockups.video.header}
         </div>
         <div className="flex items-center gap-1.5 text-[10px] text-white/45">
           <span
             className="w-1.5 h-1.5 rounded-full"
             style={{ background: accent, animation: 'mockup-pulse 1.2s ease-in-out infinite' }}
           />
-          <span>渲染中 · 72%</span>
+          <span>{t.mockups.video.status}</span>
         </div>
       </div>
       <div className="grid grid-cols-6 gap-1.5 mb-4">
@@ -567,16 +572,13 @@ function VideoMockup() {
 
 function DefectMockup() {
   const accent = '#10b981';
-  const defects = [
-    { sev: 'P0', title: '对话消息在刷新后丢失', color: '#ef4444' },
-    { sev: 'P1', title: '图像生成超时未释放', color: '#f97316' },
-    { sev: 'P2', title: '深色模式下描边消失', color: '#eab308' },
-  ];
+  const { t } = useLanguage();
+  const colors = ['#ef4444', '#f97316', '#eab308'];
   return (
     <MockupFrame accent={accent}>
       <div className="flex items-center justify-between mb-4">
         <div className="text-[11px] text-white/60" style={{ fontFamily: 'var(--font-display)' }}>
-          defect-agent · 3 个待处理
+          {t.mockups.defect.header}
         </div>
         <div
           className="px-2 py-0.5 rounded text-[9px] uppercase"
@@ -586,28 +588,28 @@ function DefectMockup() {
         </div>
       </div>
       <div className="space-y-2.5">
-        {defects.map((d, i) => (
+        {t.mockups.defect.items.map((d, i) => (
           <div
             key={i}
             className="flex items-center gap-3 px-3 py-2.5 rounded-lg bg-white/[0.03] border border-white/5"
           >
             <div
               className="px-2 py-0.5 rounded text-[9px] font-semibold shrink-0"
-              style={{ background: `${d.color}22`, color: d.color, fontFamily: 'var(--font-display)' }}
+              style={{ background: `${colors[i]}22`, color: colors[i], fontFamily: 'var(--font-display)' }}
             >
               {d.sev}
             </div>
             <div className="flex-1 min-w-0">
               <div className="text-[12px] text-white/85 truncate">{d.title}</div>
             </div>
-            <div className="shrink-0 text-[10px] text-white/35">已分派</div>
+            <div className="shrink-0 text-[10px] text-white/35">{t.mockups.defect.assigned}</div>
           </div>
         ))}
       </div>
       <div className="mt-4 flex items-center justify-between text-[10px] text-white/45">
-        <div>本周新增 · 27</div>
-        <div>已修复 · 19</div>
-        <div style={{ color: accent }}>修复率 · 70%</div>
+        <div>{t.mockups.defect.newThisWeek}</div>
+        <div>{t.mockups.defect.fixed}</div>
+        <div style={{ color: accent }}>{t.mockups.defect.fixRate}</div>
       </div>
     </MockupFrame>
   );
@@ -615,33 +617,34 @@ function DefectMockup() {
 
 function ReportMockup() {
   const accent = '#06b6d4';
-  const bars = [
-    { label: '周一', plan: 100, actual: 95 },
-    { label: '周二', plan: 80, actual: 88 },
-    { label: '周三', plan: 90, actual: 72 },
-    { label: '周四', plan: 85, actual: 90 },
-    { label: '周五', plan: 70, actual: 65 },
+  const { t } = useLanguage();
+  const barValues = [
+    { plan: 100, actual: 95 },
+    { plan: 80, actual: 88 },
+    { plan: 90, actual: 72 },
+    { plan: 85, actual: 90 },
+    { plan: 70, actual: 65 },
   ];
   return (
     <MockupFrame accent={accent}>
       <div className="flex items-center justify-between mb-4">
         <div className="text-[11px] text-white/60" style={{ fontFamily: 'var(--font-display)' }}>
-          report-agent · W15
+          {t.mockups.report.header}
         </div>
         <div className="flex items-center gap-3 text-[9px] text-white/40">
           <div className="flex items-center gap-1.5">
             <span className="w-2 h-2 rounded-sm bg-white/25" />
-            <span>计划</span>
+            <span>{t.mockups.report.plan}</span>
           </div>
           <div className="flex items-center gap-1.5">
             <span className="w-2 h-2 rounded-sm" style={{ background: accent }} />
-            <span>实际</span>
+            <span>{t.mockups.report.actual}</span>
           </div>
         </div>
       </div>
       <div className="flex items-end gap-3 h-32 mb-2">
-        {bars.map((b, i) => (
-          <div key={i} className="flex-1 flex items-end gap-1">
+        {barValues.map((b, i) => (
+          <div key={i} className="flex-1 flex items-end gap-1 h-full">
             <div
               className="flex-1 rounded-t"
               style={{ height: `${b.plan}%`, background: 'rgba(255,255,255,0.1)' }}
@@ -658,8 +661,8 @@ function ReportMockup() {
         ))}
       </div>
       <div className="flex justify-between text-[9px] text-white/40">
-        {bars.map((b, i) => (
-          <span key={i}>{b.label}</span>
+        {t.mockups.report.days.map((day, i) => (
+          <span key={i}>{day}</span>
         ))}
       </div>
     </MockupFrame>

--- a/prd-admin/src/pages/home/sections/HeroSection.tsx
+++ b/prd-admin/src/pages/home/sections/HeroSection.tsx
@@ -110,7 +110,7 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
         className="relative z-10 min-h-[82vh] flex flex-col items-center justify-center px-6 pt-32 pb-16"
       >
         {/* 终端 HUD 状态条 · 去紫版（冷白边框 + 绿色 live dot）*/}
-        <Reveal delay={0}>
+        <Reveal delay={200} blur={6}>
           <div
             className="inline-flex items-center gap-3 px-4 py-2 mb-12 rounded-md"
             style={{
@@ -151,8 +151,8 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
           </div>
         </Reveal>
 
-        {/* 主标题 */}
-        <Reveal delay={80}>
+        {/* 主标题 — 更浓的雾，更慢的点亮 */}
+        <Reveal delay={500} blur={14} duration={1400}>
           <h1
             className="text-center text-white font-medium"
             style={{
@@ -169,7 +169,7 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
         </Reveal>
 
         {/* 副标题 */}
-        <Reveal delay={160}>
+        <Reveal delay={900} blur={10} duration={1200}>
           <p
             className="mt-8 text-center text-white/62 max-w-2xl mx-auto leading-relaxed"
             style={{
@@ -183,7 +183,7 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
         </Reveal>
 
         {/* CTA 组 —— 对称双按钮，同高同 radius */}
-        <Reveal delay={240}>
+        <Reveal delay={1200} blur={10} duration={1200}>
           <div className="mt-12 flex flex-col sm:flex-row items-center justify-center gap-4">
             {/* 主 CTA */}
             <button
@@ -231,7 +231,7 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
         </Reveal>
 
         {/* Powered by 大模型 logo 条（Linear 式 social proof）*/}
-        <Reveal delay={340}>
+        <Reveal delay={1500} blur={6}>
           <div className="mt-20 md:mt-24 w-full">
             <TechLogoBar />
           </div>
@@ -239,7 +239,7 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
       </div>
 
       {/* ── 产品壳 mockup（从 hero 底部长出来） ── */}
-      <Reveal delay={400} offset={48}>
+      <Reveal delay={1800} offset={32} blur={12} duration={1400}>
         <div className="relative z-10 pb-32 md:pb-40 px-4 md:px-8">
           <ProductMockup />
         </div>

--- a/prd-admin/src/pages/home/sections/HeroSection.tsx
+++ b/prd-admin/src/pages/home/sections/HeroSection.tsx
@@ -109,8 +109,22 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
       <div
         className="relative z-10 min-h-[82vh] flex flex-col items-center justify-center px-6 pt-32 pb-16"
       >
-        {/* 终端 HUD 状态条 — 标题独占 800ms 后才出现，纯 fade，不抢 */}
-        <Reveal delay={800} duration={900} offset={6} debugLabel="HUD">
+        {/*
+         * 呼吸设计 — 按重要性分组，不是按位置分组
+         *
+         * Phase 1 · 核心信息（一起呼吸）   t=0~400ms   — "我是谁"
+         *   标题(0) → 副标题(150) → CTA(350)
+         *   它们是一个整体，内部只有极小的微差
+         *
+         * Phase 2 · 装饰辅助              t=1200ms+   — "配角"
+         *   HUD 状态条 · Powered by logos
+         *
+         * Phase 3 · 视觉证据              t=1800ms+   — "长这样"
+         *   产品 Mockup 从下方缓缓浮出
+         */}
+
+        {/* ── Phase 2 · HUD 状态条 — 装饰性，比核心信息晚出 ── */}
+        <Reveal delay={1200} duration={1000} offset={6} debugLabel="HUD">
           <div
             className="inline-flex items-center gap-3 px-4 py-2 mb-12 rounded-md"
             style={{
@@ -151,8 +165,9 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
           </div>
         </Reveal>
 
-        {/* ★ 主标题 — 第一个亮起，独占前 800ms，从浓雾中缓缓浮现 */}
-        <Reveal delay={0} blur={12} duration={1800} offset={24} debugLabel="TITLE">
+        {/* ── Phase 1 · 核心信息 ── */}
+        {/* ★ 主标题 — 从浓雾中浮现，领先副标题 150ms */}
+        <Reveal delay={0} blur={12} duration={1500} offset={20} debugLabel="TITLE">
           <h1
             className="text-center text-white font-medium"
             style={{
@@ -168,8 +183,8 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
           </h1>
         </Reveal>
 
-        {/* 副标题 — 标题基本清晰后再出 */}
-        <Reveal delay={1400} duration={1100} offset={10} debugLabel="SUBTITLE">
+        {/* 副标题 — 紧跟标题，它们是一体的 */}
+        <Reveal delay={150} duration={1200} offset={14} debugLabel="SUBTITLE">
           <p
             className="mt-8 text-center text-white/62 max-w-2xl mx-auto leading-relaxed"
             style={{
@@ -182,8 +197,8 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
           </p>
         </Reveal>
 
-        {/* CTA 组 — 文字都清晰了才出按钮 */}
-        <Reveal delay={2200} duration={900} offset={12} debugLabel="CTA">
+        {/* CTA — 和标题/副标题一起呼吸，微差 350ms */}
+        <Reveal delay={350} duration={1000} offset={16} debugLabel="CTA">
           <div className="mt-12 flex flex-col sm:flex-row items-center justify-center gap-4">
             {/* 主 CTA */}
             <button
@@ -230,16 +245,16 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
           </div>
         </Reveal>
 
-        {/* Powered by 大模型 logo 条 */}
-        <Reveal delay={2800} duration={1200} offset={6} debugLabel="LOGOS">
+        {/* ── Phase 2 · Powered by — 装饰性 ── */}
+        <Reveal delay={1400} duration={1200} offset={6} debugLabel="LOGOS">
           <div className="mt-20 md:mt-24 w-full">
             <TechLogoBar />
           </div>
         </Reveal>
       </div>
 
-      {/* ── 产品壳 mockup — 最终幕，从底部缓缓浮出 ── */}
-      <Reveal delay={3400} offset={48} blur={6} duration={1600} debugLabel="MOCKUP">
+      {/* ── Phase 3 · 产品壳 mockup — 核心信息就位后，视觉证据最后浮出 ── */}
+      <Reveal delay={1800} offset={48} blur={6} duration={1600} debugLabel="MOCKUP">
         <div className="relative z-10 pb-32 md:pb-40 px-4 md:px-8">
           <ProductMockup />
         </div>

--- a/prd-admin/src/pages/home/sections/HeroSection.tsx
+++ b/prd-admin/src/pages/home/sections/HeroSection.tsx
@@ -110,21 +110,20 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
         className="relative z-10 min-h-[82vh] flex flex-col items-center justify-center px-6 pt-32 pb-16"
       >
         {/*
-         * 呼吸设计 — 按重要性分组，不是按位置分组
+         * 呼吸设计 — 学习 Linear.app 的节奏
          *
-         * Phase 1 · 核心信息（一起呼吸）   t=0~400ms   — "我是谁"
-         *   标题(0) → 副标题(150) → CTA(350)
-         *   它们是一个整体，内部只有极小的微差
+         * 秘诀："出现得很快，雾散得很慢"
+         * · 极端 ease-out 曲线 (0.19,1,0.22,1) → 前 15% 时间到达 85% 可见
+         * · 超长 duration（标题 4s）→ 最后 15% 的模糊慢慢散开，营造深度
+         * · 标题还在散雾时，副标题和 CTA 已经开始出现 → 层次交叠
          *
-         * Phase 2 · 装饰辅助              t=1200ms+   — "配角"
-         *   HUD 状态条 · Powered by logos
-         *
-         * Phase 3 · 视觉证据              t=1800ms+   — "长这样"
-         *   产品 Mockup 从下方缓缓浮出
+         * Phase 1 · 核心信息            delay=0~500ms, duration=2~4s
+         * Phase 2 · 装饰               delay=1200ms+
+         * Phase 3 · 产品 Mockup        delay=1800ms+
          */}
 
         {/* ── Phase 2 · HUD 状态条 — 装饰性，比核心信息晚出 ── */}
-        <Reveal delay={1200} duration={1000} offset={6} debugLabel="HUD">
+        <Reveal delay={1200} duration={2000} offset={6}>
           <div
             className="inline-flex items-center gap-3 px-4 py-2 mb-12 rounded-md"
             style={{
@@ -166,8 +165,8 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
         </Reveal>
 
         {/* ── Phase 1 · 核心信息 ── */}
-        {/* ★ 主标题 — 从浓雾中浮现，领先副标题 150ms */}
-        <Reveal delay={0} blur={12} duration={1500} offset={20} debugLabel="TITLE">
+        {/* ★ 主标题 — 4s duration，前 600ms 可读，后 3.4s 雾慢慢散 */}
+        <Reveal delay={0} blur={10} duration={4000} offset={30}>
           <h1
             className="text-center text-white font-medium"
             style={{
@@ -183,8 +182,8 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
           </h1>
         </Reveal>
 
-        {/* 副标题 — 紧跟标题，它们是一体的 */}
-        <Reveal delay={150} duration={1200} offset={14} debugLabel="SUBTITLE">
+        {/* 副标题 — 标题已可读时加入（标题还在散雾），2s duration */}
+        <Reveal delay={500} duration={2000} offset={20}>
           <p
             className="mt-8 text-center text-white/62 max-w-2xl mx-auto leading-relaxed"
             style={{
@@ -197,8 +196,8 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
           </p>
         </Reveal>
 
-        {/* CTA — 和标题/副标题一起呼吸，微差 350ms */}
-        <Reveal delay={350} duration={1000} offset={16} debugLabel="CTA">
+        {/* CTA — 和副标题同时出发，2s duration */}
+        <Reveal delay={500} duration={2000} offset={20}>
           <div className="mt-12 flex flex-col sm:flex-row items-center justify-center gap-4">
             {/* 主 CTA */}
             <button
@@ -246,7 +245,7 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
         </Reveal>
 
         {/* ── Phase 2 · Powered by — 装饰性 ── */}
-        <Reveal delay={1400} duration={1200} offset={6} debugLabel="LOGOS">
+        <Reveal delay={1400} duration={2000} offset={6}>
           <div className="mt-20 md:mt-24 w-full">
             <TechLogoBar />
           </div>
@@ -254,7 +253,7 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
       </div>
 
       {/* ── Phase 3 · 产品壳 mockup — 核心信息就位后，视觉证据最后浮出 ── */}
-      <Reveal delay={1800} offset={48} blur={6} duration={1600} debugLabel="MOCKUP">
+      <Reveal delay={1800} offset={60} blur={6} duration={3000}>
         <div className="relative z-10 pb-32 md:pb-40 px-4 md:px-8">
           <ProductMockup />
         </div>

--- a/prd-admin/src/pages/home/sections/HeroSection.tsx
+++ b/prd-admin/src/pages/home/sections/HeroSection.tsx
@@ -109,8 +109,8 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
       <div
         className="relative z-10 min-h-[82vh] flex flex-col items-center justify-center px-6 pt-32 pb-16"
       >
-        {/* 终端 HUD 状态条 · 去紫版（冷白边框 + 绿色 live dot）*/}
-        <Reveal delay={200} blur={6}>
+        {/* 终端 HUD 状态条 — 最先破雾，作为"信号灯" */}
+        <Reveal delay={100} blur={4} duration={800}>
           <div
             className="inline-flex items-center gap-3 px-4 py-2 mb-12 rounded-md"
             style={{
@@ -151,8 +151,8 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
           </div>
         </Reveal>
 
-        {/* 主标题 — 更浓的雾，更慢的点亮 */}
-        <Reveal delay={500} blur={14} duration={1400}>
+        {/* 主标题 — 浓雾慢点亮，Hero 的核心时刻 */}
+        <Reveal delay={600} blur={14} duration={1600}>
           <h1
             className="text-center text-white font-medium"
             style={{
@@ -168,8 +168,8 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
           </h1>
         </Reveal>
 
-        {/* 副标题 */}
-        <Reveal delay={900} blur={10} duration={1200}>
+        {/* 副标题 — 等标题接近清晰后再出 */}
+        <Reveal delay={1400} blur={10} duration={1200}>
           <p
             className="mt-8 text-center text-white/62 max-w-2xl mx-auto leading-relaxed"
             style={{
@@ -183,7 +183,7 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
         </Reveal>
 
         {/* CTA 组 —— 对称双按钮，同高同 radius */}
-        <Reveal delay={1200} blur={10} duration={1200}>
+        <Reveal delay={2100} blur={8} duration={1000}>
           <div className="mt-12 flex flex-col sm:flex-row items-center justify-center gap-4">
             {/* 主 CTA */}
             <button
@@ -231,7 +231,7 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
         </Reveal>
 
         {/* Powered by 大模型 logo 条（Linear 式 social proof）*/}
-        <Reveal delay={1500} blur={6}>
+        <Reveal delay={2700} blur={6}>
           <div className="mt-20 md:mt-24 w-full">
             <TechLogoBar />
           </div>
@@ -239,7 +239,7 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
       </div>
 
       {/* ── 产品壳 mockup（从 hero 底部长出来） ── */}
-      <Reveal delay={1800} offset={32} blur={12} duration={1400}>
+      <Reveal delay={3200} offset={28} blur={12} duration={1400}>
         <div className="relative z-10 pb-32 md:pb-40 px-4 md:px-8">
           <ProductMockup />
         </div>

--- a/prd-admin/src/pages/home/sections/HeroSection.tsx
+++ b/prd-admin/src/pages/home/sections/HeroSection.tsx
@@ -109,8 +109,8 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
       <div
         className="relative z-10 min-h-[82vh] flex flex-col items-center justify-center px-6 pt-32 pb-16"
       >
-        {/* 终端 HUD 状态条 — 最先破雾，作为"信号灯" */}
-        <Reveal delay={100} blur={4} duration={800}>
+        {/* 终端 HUD 状态条 — 标题后的微弱信号，不抢焦点 */}
+        <Reveal delay={300} blur={0} duration={900} offset={8} debugLabel="HUD">
           <div
             className="inline-flex items-center gap-3 px-4 py-2 mb-12 rounded-md"
             style={{
@@ -151,8 +151,8 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
           </div>
         </Reveal>
 
-        {/* 主标题 — 浓雾慢点亮，Hero 的核心时刻 */}
-        <Reveal delay={600} blur={14} duration={1600}>
+        {/* ★ 主标题 — 第一个亮起，它是整个页面的焦点 */}
+        <Reveal delay={0} blur={12} duration={1500} offset={20} debugLabel="TITLE">
           <h1
             className="text-center text-white font-medium"
             style={{
@@ -168,8 +168,8 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
           </h1>
         </Reveal>
 
-        {/* 副标题 — 等标题接近清晰后再出 */}
-        <Reveal delay={1400} blur={10} duration={1200}>
+        {/* 副标题 — 标题 70% 清晰后再出，轻 blur 即可 */}
+        <Reveal delay={1000} blur={4} duration={1100} offset={12} debugLabel="SUBTITLE">
           <p
             className="mt-8 text-center text-white/62 max-w-2xl mx-auto leading-relaxed"
             style={{
@@ -182,8 +182,8 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
           </p>
         </Reveal>
 
-        {/* CTA 组 —— 对称双按钮，同高同 radius */}
-        <Reveal delay={2100} blur={8} duration={1000}>
+        {/* CTA 组 — 文字都清晰了才出按钮，不用 blur，干净的 fade+rise */}
+        <Reveal delay={1800} blur={0} duration={900} offset={12} debugLabel="CTA">
           <div className="mt-12 flex flex-col sm:flex-row items-center justify-center gap-4">
             {/* 主 CTA */}
             <button
@@ -230,16 +230,16 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
           </div>
         </Reveal>
 
-        {/* Powered by 大模型 logo 条（Linear 式 social proof）*/}
-        <Reveal delay={2700} blur={6}>
+        {/* Powered by 大模型 logo 条 — 纯 fade，不用 blur，不抢 */}
+        <Reveal delay={2400} blur={0} duration={1200} offset={8} debugLabel="LOGOS">
           <div className="mt-20 md:mt-24 w-full">
             <TechLogoBar />
           </div>
         </Reveal>
       </div>
 
-      {/* ── 产品壳 mockup（从 hero 底部长出来） ── */}
-      <Reveal delay={3200} offset={28} blur={12} duration={1400}>
+      {/* ── 产品壳 mockup — 最终幕，从底部缓缓浮出 ── */}
+      <Reveal delay={2800} offset={40} blur={6} duration={1600} debugLabel="MOCKUP">
         <div className="relative z-10 pb-32 md:pb-40 px-4 md:px-8">
           <ProductMockup />
         </div>

--- a/prd-admin/src/pages/home/sections/HeroSection.tsx
+++ b/prd-admin/src/pages/home/sections/HeroSection.tsx
@@ -109,8 +109,8 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
       <div
         className="relative z-10 min-h-[82vh] flex flex-col items-center justify-center px-6 pt-32 pb-16"
       >
-        {/* 终端 HUD 状态条 — 标题后的微弱信号，不抢焦点 */}
-        <Reveal delay={300} blur={0} duration={900} offset={8} debugLabel="HUD">
+        {/* 终端 HUD 状态条 — 标题独占 800ms 后才出现，纯 fade，不抢 */}
+        <Reveal delay={800} duration={900} offset={6} debugLabel="HUD">
           <div
             className="inline-flex items-center gap-3 px-4 py-2 mb-12 rounded-md"
             style={{
@@ -151,8 +151,8 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
           </div>
         </Reveal>
 
-        {/* ★ 主标题 — 第一个亮起，它是整个页面的焦点 */}
-        <Reveal delay={0} blur={12} duration={1500} offset={20} debugLabel="TITLE">
+        {/* ★ 主标题 — 第一个亮起，独占前 800ms，从浓雾中缓缓浮现 */}
+        <Reveal delay={0} blur={12} duration={1800} offset={24} debugLabel="TITLE">
           <h1
             className="text-center text-white font-medium"
             style={{
@@ -168,8 +168,8 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
           </h1>
         </Reveal>
 
-        {/* 副标题 — 标题 70% 清晰后再出，轻 blur 即可 */}
-        <Reveal delay={1000} blur={4} duration={1100} offset={12} debugLabel="SUBTITLE">
+        {/* 副标题 — 标题基本清晰后再出 */}
+        <Reveal delay={1400} duration={1100} offset={10} debugLabel="SUBTITLE">
           <p
             className="mt-8 text-center text-white/62 max-w-2xl mx-auto leading-relaxed"
             style={{
@@ -182,8 +182,8 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
           </p>
         </Reveal>
 
-        {/* CTA 组 — 文字都清晰了才出按钮，不用 blur，干净的 fade+rise */}
-        <Reveal delay={1800} blur={0} duration={900} offset={12} debugLabel="CTA">
+        {/* CTA 组 — 文字都清晰了才出按钮 */}
+        <Reveal delay={2200} duration={900} offset={12} debugLabel="CTA">
           <div className="mt-12 flex flex-col sm:flex-row items-center justify-center gap-4">
             {/* 主 CTA */}
             <button
@@ -230,8 +230,8 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
           </div>
         </Reveal>
 
-        {/* Powered by 大模型 logo 条 — 纯 fade，不用 blur，不抢 */}
-        <Reveal delay={2400} blur={0} duration={1200} offset={8} debugLabel="LOGOS">
+        {/* Powered by 大模型 logo 条 */}
+        <Reveal delay={2800} duration={1200} offset={6} debugLabel="LOGOS">
           <div className="mt-20 md:mt-24 w-full">
             <TechLogoBar />
           </div>
@@ -239,7 +239,7 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
       </div>
 
       {/* ── 产品壳 mockup — 最终幕，从底部缓缓浮出 ── */}
-      <Reveal delay={2800} offset={40} blur={6} duration={1600} debugLabel="MOCKUP">
+      <Reveal delay={3400} offset={48} blur={6} duration={1600} debugLabel="MOCKUP">
         <div className="relative z-10 pb-32 md:pb-40 px-4 md:px-8">
           <ProductMockup />
         </div>


### PR DESCRIPTION
## Summary
This PR fixes multiple issues on the landing page related to internationalization (i18n) and component rendering:

1. **Mockup text now respects language settings** - All FeatureDeepDive mockup content (visual, literary, PRD, video, defect, report) is now properly internationalized instead of being hardcoded in Chinese
2. **Fixed mockup visibility on first load** - ProductMockup components near the fold weren't displaying due to IntersectionObserver threshold issues
3. **Fixed ReportMockup bar chart rendering** - Bars weren't displaying due to missing `h-full` on flex children
4. **Localized provider names** - Chinese platform names (Alibaba Qwen, Zhipu GLM, etc.) now display as international brand names in English

## Key Changes

- **i18n/landing.ts**: 
  - Updated translation principles to include all user-visible mockup content
  - Added comprehensive `mockups` object to `TranslationShape` interface with translations for all 6 mockup types (visual, literary, prd, video, defect, report)
  - Populated both Chinese (`zh`) and English (`en`) translation dictionaries with mockup content

- **FeatureDeepDive.tsx**:
  - Integrated `useLanguage()` hook into all 6 mockup components
  - Replaced hardcoded Chinese strings with `t.mockups.*` references
  - Refactored `PrdMockup` to use dynamic section data from translations
  - Refactored `DefectMockup` to use translated items and labels
  - Refactored `ReportMockup` to use translated day labels and legend text
  - Fixed ReportMockup bar chart by adding `h-full` to flex container

- **CompatibilityStack.tsx**:
  - Updated PROVIDERS array to support bilingual names for Chinese platforms
  - Added `getProviderName()` helper to select appropriate language variant
  - Integrated language context to display correct provider names

- **useInView.ts**:
  - Added first-screen optimization: elements within 1.15× viewport height are immediately marked as in-view
  - Prevents ProductMockup and other fold-adjacent content from being hidden due to IntersectionObserver threshold mismatches
  - Preserves CSS transition delays for stagger animations

## Implementation Details

- All mockup content now flows through the i18n system, enabling seamless language switching without component remounting
- The first-screen optimization in `useInView` checks element position on mount and triggers visibility immediately if needed, while still respecting CSS animation delays
- Provider name localization uses a discriminated union pattern (`'name' in p`) to handle both legacy and new bilingual entries

https://claude.ai/code/session_01JZrcfjkGEB3nFh6Fo8pQYR