### PR TITLE
Fix GitHub OAuth environment variables in docker-compose

### DIFF
--- a/changelogs/2026-04-14_fix-github-oauth-env-in-compose.md
+++ b/changelogs/2026-04-14_fix-github-oauth-env-in-compose.md
@@ -1,0 +1,2 @@
+| fix | prd-api | docker-compose.yml / docker-compose.dev.yml 的 api 服务补上 GitHubOAuth__ClientId / ClientSecret / Scopes 三个环境变量映射（docker compose 不会自动转发宿主机 env，必须显式声明），修复 PR Review Agent 提示 "尚未配置 GitHub OAuth App" 的问题 |
+| fix | prd-admin | GitHubConnectCard 未配置提示改写：补充 .env 文件写法 / .bashrc 改完需重开终端 / 需要重跑 exec_dep.sh 的操作指引 |

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -74,6 +74,11 @@ services:
       - R2_ENDPOINT=${R2_ENDPOINT:-}
       # Webhook 通知中「查看详情」链接的前端基地址
       - App__FrontendBaseUrl=${FRONTEND_BASE_URL:-http://localhost:5500}
+      # GitHub OAuth Device Flow（PR Review Agent 使用）
+      # 与生产 docker-compose.yml 保持一致：宿主机 export 或写入同目录 .env 即可。
+      - GitHubOAuth__ClientId=${GitHubOAuth__ClientId:-}
+      - GitHubOAuth__ClientSecret=${GitHubOAuth__ClientSecret:-}
+      - GitHubOAuth__Scopes=${GitHubOAuth__Scopes:-}
     # 重要：此 API 容器建议只读，避免任何本地落盘（你这种”可写层 1MB”环境必开）
     read_only: true
     # 允许少量临时写入到内存（tmpfs），避免 .NET/HTTP 栈因无 /tmp 可写而异常；不会落到磁盘

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,13 @@ services:
       - ROOT_ACCESS_PASSWORD=${ROOT_ACCESS_PASSWORD:-}
       # Webhook 通知中「查看详情」链接的前端基地址（如 https://example.com）
       - App__FrontendBaseUrl=${FRONTEND_BASE_URL:-}
+      # GitHub OAuth Device Flow（PR Review Agent 使用）
+      # 管理员需在 GitHub 创建 OAuth App 并勾选 "Enable Device Flow"，
+      # 然后在宿主机 export 这两个变量（或写进同目录 .env 文件）。Device Flow 无需 Callback URL。
+      # 变量名沿用 ASP.NET Configuration 约定（节点分隔符 "__"），后端通过 IConfiguration["GitHubOAuth:ClientId"] 读取。
+      - GitHubOAuth__ClientId=${GitHubOAuth__ClientId:-}
+      - GitHubOAuth__ClientSecret=${GitHubOAuth__ClientSecret:-}
+      - GitHubOAuth__Scopes=${GitHubOAuth__Scopes:-}
     # 重要：此 API 容器建议只读，避免任何本地落盘（你这种“可写层 1MB”环境必开）
     read_only: true
     # 允许少量临时写入到内存（tmpfs），避免 .NET/HTTP 栈因无 /tmp 可写而异常；不会落到磁盘

--- a/prd-admin/src/pages/pr-review/GitHubConnectCard.tsx
+++ b/prd-admin/src/pages/pr-review/GitHubConnectCard.tsx
@@ -47,10 +47,14 @@ export function GitHubConnectCard() {
           <div className="font-semibold mb-1">尚未配置 GitHub OAuth App</div>
           <div className="text-amber-200/80 leading-relaxed">
             管理员需要先在 GitHub 创建 OAuth App，勾选{' '}
-            <code className="px-1 rounded bg-black/40">Enable Device Flow</code>，并设置环境变量{' '}
+            <code className="px-1 rounded bg-black/40">Enable Device Flow</code>，然后在宿主机（运行
+            docker compose 的机器）设置环境变量{' '}
             <code className="px-1 rounded bg-black/40">GitHubOAuth__ClientId</code>
-            （和可选 <code className="px-1 rounded bg-black/40">GitHubOAuth__ClientSecret</code>）。
-            Device Flow 不需要 Callback URL，本地/CDS/生产共用一套配置。
+            （和可选 <code className="px-1 rounded bg-black/40">GitHubOAuth__ClientSecret</code>），
+            推荐写入项目根目录的 <code className="px-1 rounded bg-black/40">.env</code> 文件，
+            docker compose 会自动加载；或写入 <code className="px-1 rounded bg-black/40">.bashrc</code>
+            后重开终端，再执行 <code className="px-1 rounded bg-black/40">./exec_dep.sh</code>
+            重启 api 容器使之生效。Device Flow 不需要 Callback URL，本地/CDS/生产共用一套配置。
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
This PR fixes the GitHub OAuth configuration for the PR Review Agent by explicitly mapping environment variables in docker-compose files and improving the setup instructions in the UI.

## Key Changes

- **docker-compose.yml & docker-compose.dev.yml**: Added explicit environment variable mappings for GitHub OAuth Device Flow (`GitHubOAuth__ClientId`, `GitHubOAuth__ClientSecret`, `GitHubOAuth__Scopes`) to the api service. Docker Compose does not automatically forward host environment variables, so these must be explicitly declared.

- **GitHubConnectCard.tsx**: Enhanced the "GitHub OAuth not configured" warning message to provide clearer setup instructions:
  - Clarified that environment variables should be set on the host machine (where docker compose runs)
  - Added guidance on using `.env` file in the project root (automatically loaded by docker compose)
  - Added alternative instructions for setting variables in `.bashrc` and restarting the terminal
  - Documented the need to run `./exec_dep.sh` to restart the api container for changes to take effect

## Implementation Details

The root cause was that docker-compose does not automatically inherit environment variables from the host shell. The variables must be explicitly declared in the service configuration using the `${VAR_NAME:-default}` syntax to be passed through from the host environment or `.env` file.

The UI improvements guide users through both common setup methods (`.env` file and shell environment variables) with clear steps for each approach.

https://claude.ai/code/session_012Ss6vwtjbj9WZa7LHRcLsS