### PR TITLE
fix(deploy): exec_dep.sh activates standalone nginx config, fix 502 l…

### DIFF
--- a/changelogs/2026-04-14_fix-standalone-nginx-default-conf.md
+++ b/changelogs/2026-04-14_fix-standalone-nginx-default-conf.md
@@ -1,0 +1,2 @@
+| fix | deploy | exec_dep.sh 独立部署模式修复 nginx 502：新增 deploy/nginx/conf.d/branches/_standalone.conf (内容同 deploy/nginx/nginx.conf 的 /api → api:8080 反代)，exec_dep.sh 每次部署都幂等重建 default.conf → branches/_standalone.conf 的 symlink，修复纯净机器首次部署后所有 /api/* 都被仓库默认的 _disconnected.conf 拦成 {"error":"No active branch connected"} 的问题 |
+| docs | docker-compose.yml | gateway 服务注释补齐三种部署模式（standalone/cds/disconnected）下 default.conf symlink 的指向规则，避免下一位部署者再次踩坑 |

--- a/deploy/nginx/conf.d/branches/_standalone.conf
+++ b/deploy/nginx/conf.d/branches/_standalone.conf
@@ -1,0 +1,65 @@
+## exec_dep.sh 独立部署模式的 nginx 路由配置
+##
+## 激活方式：exec_dep.sh 把 default.conf symlink 重指到本文件
+##   ln -sfn branches/_standalone.conf deploy/nginx/conf.d/default.conf
+##
+## 与 CDS 多分支模式互斥：CDS 模式下 default.conf 由 cds 动态重指到
+## branches/<branch>.conf，exec_cds.sh 会先把本文件对应的 symlink 换掉。
+##
+## ⚠ 内容必须与 deploy/nginx/nginx.conf 保持一致（后者仅供 docker-compose.local.yml
+## 的 Dockerfile COPY 到镜像里用，这两条独立部署路径共享同一份 nginx 配置语义）。
+## 改动一处时请同步改另一处。
+server {
+    listen 80;
+    server_name _;
+    # 允许较大的 JSON 请求体（如 dataURL/base64 图片、图生图首帧等）
+    # 后端仍会按业务规则做尺寸限制并返回 DOCUMENT_TOO_LARGE
+    client_max_body_size 30m;
+
+    # 防止目录访问时使用绝对路径重定向（避免暴露内部 IP）
+    absolute_redirect off;
+    port_in_redirect off;
+
+    # 静态站点根目录（prd-admin build 产物，由 exec_dep.sh 从 GitHub Pages 下载并解压）
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # /api/* 反代到后端（后端路由为 /api/v1/...）
+    location ^~ /api/ {
+        proxy_pass http://api:8080;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_connect_timeout 3s;
+        proxy_send_timeout 60s;
+        # SSE/流式：避免缓存与缓冲导致"卡住"
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 3600s;
+    }
+
+    # /assets/ 目录下的所有文件（静态资源）
+    # 优先级高于 SPA fallback，避免前端路由冲突
+    location ^~ /assets/ {
+        try_files $uri =404;
+        expires 7d;
+        add_header Cache-Control "public, max-age=604800" always;
+    }
+
+    # 其他静态资源（根目录下的 favicon、manifest 等）
+    location ~* \.(?:js|css|map|png|jpg|jpeg|gif|webp|svg|ico|woff2?|json|txt)$ {
+        try_files $uri =404;
+        expires 7d;
+        add_header Cache-Control "public, max-age=604800" always;
+    }
+
+    # SPA fallback：其余路径都交给前端路由
+    # 移除 $uri/ 避免目录匹配导致 403，让前端路由接管
+    location / {
+        try_files $uri /index.html;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,10 @@ services:
     ports:
       - "5500:80"
     volumes:
-      # Per-branch nginx configs in conf.d/branches/, activated via symlink default.conf
+      # conf.d/default.conf 是 symlink，由部署模式决定指向哪个 branches/*.conf：
+      #   - 独立部署 (exec_dep.sh) → branches/_standalone.conf (真正的 /api → api:8080 反代)
+      #   - CDS 多分支模式 (exec_cds.sh) → branches/<branch>.conf (动态重指)
+      #   - 仓库默认状态 → branches/_disconnected.conf (CDS 未激活时的 502 兜底)
       - ./deploy/nginx/conf.d:/etc/nginx/conf.d:ro
       # 由 deploy.sh 从 GitHub Release 下载并解压到此目录
       - ./deploy/web/dist:/usr/share/nginx/html:ro

--- a/exec_dep.sh
+++ b/exec_dep.sh
@@ -135,6 +135,23 @@ unzip -q "$zip_path" -d deploy/web/dist
 
 echo ""
 echo "Static dist extracted to: deploy/web/dist"
+
+# 激活独立部署模式的 nginx 配置：
+# - 仓库里 default.conf 默认 symlink 到 branches/_disconnected.conf（CDS 未激活时的 502 兜底）
+# - 独立部署模式下必须重指到 branches/_standalone.conf（真正的 /api/ → api:8080 反代）
+# - 幂等：每次部署都重建 symlink，抗漂移、抗 git 副作用
+NGINX_CONF_D="deploy/nginx/conf.d"
+STANDALONE_CONF="$NGINX_CONF_D/branches/_standalone.conf"
+DEFAULT_CONF="$NGINX_CONF_D/default.conf"
+if [ ! -f "$STANDALONE_CONF" ]; then
+  echo "ERROR: 缺少独立部署 nginx 配置：$STANDALONE_CONF" >&2
+  echo "  这通常意味着仓库不完整，请确认已 git pull 到最新。" >&2
+  exit 1
+fi
+echo "Activating standalone nginx config (default.conf -> branches/_standalone.conf) ..."
+rm -f "$DEFAULT_CONF"
+ln -s "branches/_standalone.conf" "$DEFAULT_CONF"
+
 echo "Pulling latest api image..."
 $COMPOSE pull api
 


### PR DESCRIPTION
…ogin

根因：deploy/nginx/conf.d/default.conf 是 symlink → branches/_disconnected.conf （CDS 兜底，所有 /api/* 返 502 "No active branch connected"）。独立部署 docker-compose.yml 把 conf.d 目录只读挂进 gateway，nginx 读到的就是 disconnected 兜底，api 反代从未生效——纯净机器首次 exec_dep.sh 部署后 登录直接撞 502。

设计文档 doc/design.exec-bt-deployment.md 早就写了"独立部署模式下 default.conf 应该是普通文件指向 api:8080"，但代码层没人实现这一步。

修复：
- 新增 branches/_standalone.conf，内容对齐 deploy/nginx/nginx.conf （后者仅 docker-compose.local.yml 的 Dockerfile COPY 路径用）。
- exec_dep.sh 每次部署都幂等重建 default.conf symlink 指向 _standalone.conf， 抗 git 副作用、抗漂移。
- docker-compose.yml 补三种部署模式下 symlink 指向规则的注释。