### PR TITLE
Add remark-breaks plugin to preserve line breaks in markdown

### DIFF
--- a/changelogs/2026-04-14_knowledge-hall-linebreaks.md
+++ b/changelogs/2026-04-14_knowledge-hall-linebreaks.md
@@ -1,1 +1,2 @@
-| fix | prd-admin | 智识殿堂文档阅读器补齐 remark-breaks 插件，保留单行换行符，避免纯文本/排版文档被 markdown 合并成一整段 |
+| fix | prd-admin | 智识殿堂文档阅读器（LibraryDocReader）补齐 remark-breaks 插件，保留单行换行符，避免纯文本/排版文档被 markdown 合并成一整段 |
+| fix | prd-admin | 文档空间 /document-store 的 DocBrowser 同步补齐 remark-breaks 插件，修复 ASCII 框图/步骤箭头被压成一段的问题 |

--- a/changelogs/2026-04-14_knowledge-hall-linebreaks.md
+++ b/changelogs/2026-04-14_knowledge-hall-linebreaks.md
@@ -1,0 +1,1 @@
+| fix | prd-admin | 智识殿堂文档阅读器补齐 remark-breaks 插件，保留单行换行符，避免纯文本/排版文档被 markdown 合并成一整段 |

--- a/changelogs/2026-04-14_knowledge-hall-linebreaks.md
+++ b/changelogs/2026-04-14_knowledge-hall-linebreaks.md
@@ -1,2 +1,3 @@
 | fix | prd-admin | 智识殿堂文档阅读器（LibraryDocReader）补齐 remark-breaks 插件，保留单行换行符，避免纯文本/排版文档被 markdown 合并成一整段 |
 | fix | prd-admin | 文档空间 /document-store 的 DocBrowser 同步补齐 remark-breaks 插件，修复 ASCII 框图/步骤箭头被压成一段的问题 |
+| fix | prd-admin | 修复 LibraryDocReader/DocBrowser 代码块判断逻辑：原代码用 `language-` 类名判断 inline，导致未指定语言的 fenced code block（架构图/树形结构等）被错当成 inline 渲染成一颗颗药丸。改为按"内容含换行"判断块级，未指定语言时降级为 text 高亮 |

--- a/changelogs/2026-04-14_knowledge-hall-linebreaks.md
+++ b/changelogs/2026-04-14_knowledge-hall-linebreaks.md
@@ -1,3 +1,4 @@
 | fix | prd-admin | 智识殿堂文档阅读器（LibraryDocReader）补齐 remark-breaks 插件，保留单行换行符，避免纯文本/排版文档被 markdown 合并成一整段 |
 | fix | prd-admin | 文档空间 /document-store 的 DocBrowser 同步补齐 remark-breaks 插件，修复 ASCII 框图/步骤箭头被压成一段的问题 |
-| fix | prd-admin | 修复 LibraryDocReader/DocBrowser 代码块判断逻辑：原代码用 `language-` 类名判断 inline，导致未指定语言的 fenced code block（架构图/树形结构等）被错当成 inline 渲染成一颗颗药丸。改为按"内容含换行"判断块级，未指定语言时降级为 text 高亮 |
+| fix | prd-admin | 修复 LibraryDocReader/DocBrowser 代码块判断逻辑：原代码用 `language-` 类名判断 inline，导致未指定语言的 fenced code block（架构图/树形结构等）被错当成 inline 渲染成一颗颗药丸。改为按"内容含换行"判断块级 |
+| fix | prd-admin | LibraryDocReader/DocBrowser 无语言 fenced 代码块跳过 Prism，改用纯 `<pre>` 渲染，消除 ASCII 框图上 Prism token 背景叠加导致的"多余背景色块"；同步 override `pre` 为 fragment 避免双重包裹 |

--- a/changelogs/2026-04-14_knowledge-hall-linebreaks.md
+++ b/changelogs/2026-04-14_knowledge-hall-linebreaks.md
@@ -2,3 +2,6 @@
 | fix | prd-admin | 文档空间 /document-store 的 DocBrowser 同步补齐 remark-breaks 插件，修复 ASCII 框图/步骤箭头被压成一段的问题 |
 | fix | prd-admin | 修复 LibraryDocReader/DocBrowser 代码块判断逻辑：原代码用 `language-` 类名判断 inline，导致未指定语言的 fenced code block（架构图/树形结构等）被错当成 inline 渲染成一颗颗药丸。改为按"内容含换行"判断块级 |
 | fix | prd-admin | LibraryDocReader/DocBrowser 无语言 fenced 代码块跳过 Prism，改用纯 `<pre>` 渲染，消除 ASCII 框图上 Prism token 背景叠加导致的"多余背景色块"；同步 override `pre` 为 fragment 避免双重包裹 |
+| fix | prd-admin | 举一反三：MarkdownContent（共享组件，周报/技能页等 5 处消费）和 ai-toolbox ToolDetail 的 AssistantMarkdown 存在同构 Bug A+B，同步修复（含 `pre` fragment override） |
+| fix | prd-admin | 补齐 `remark-breaks` 插件：ArticleIllustrationEditorPage（7 处）、ConfigManagementDialog、VideoAgentPage、SubmissionDetailModal、RichTextMarkdownContent、GroupsPage、DefectDetailPanel、AiChatPage、ArenaPage、LlmRequestDetailDialog、LlmLogsPage、marketplaceTypes，统一单行换行行为 |
+| fix | prd-desktop | KnowledgeBasePage 补齐 `remark-breaks` 插件，与管理端统一 |

--- a/prd-admin/src/components/doc-browser/DocBrowser.tsx
+++ b/prd-admin/src/components/doc-browser/DocBrowser.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import 'katex/dist/katex.min.css';
@@ -507,7 +508,7 @@ function MarkdownViewer({ content }: { content: string }) {
   return (
     <div className="prose-invert max-w-none text-[13px] leading-relaxed">
       <ReactMarkdown
-        remarkPlugins={[remarkGfm, remarkMath]}
+        remarkPlugins={[remarkGfm, remarkBreaks, remarkMath]}
         rehypePlugins={[rehypeKatex]}
         components={{
           h1: mkHeading('h1'),

--- a/prd-admin/src/components/doc-browser/DocBrowser.tsx
+++ b/prd-admin/src/components/doc-browser/DocBrowser.tsx
@@ -560,21 +560,23 @@ function MarkdownViewer({ content }: { content: string }) {
           td: ({ children }) => <td className="px-3 py-1.5" style={{ borderBottom: '1px solid rgba(255,255,255,0.03)', color: 'var(--text-secondary)' }}>{children}</td>,
           code: ({ className, children, ...props }) => {
             const match = /language-(\w+)/.exec(className || '');
-            const inline = !match;
-            if (inline) {
+            const text = String(children ?? '');
+            // 块级判断：有 language- 类名 或 内容包含换行（兼容未指定语言的 fenced code block）
+            const isBlock = !!match || text.includes('\n');
+            if (!isBlock) {
               return <code className="px-1.5 py-0.5 rounded text-[12px]" style={{ background: 'rgba(255,255,255,0.06)', color: 'rgba(248,113,113,0.9)' }} {...props}>{children}</code>;
             }
             return (
               <SyntaxHighlighter
                 style={oneDark}
-                language={match[1]}
+                language={match?.[1] ?? 'text'}
                 PreTag="div"
                 customStyle={{
                   margin: '12px 0', borderRadius: '10px', fontSize: '12px',
                   background: 'rgba(0,0,0,0.3)', border: '1px solid rgba(255,255,255,0.04)',
                 }}
               >
-                {String(children).replace(/\n$/, '')}
+                {text.replace(/\n$/, '')}
               </SyntaxHighlighter>
             );
           },

--- a/prd-admin/src/components/doc-browser/DocBrowser.tsx
+++ b/prd-admin/src/components/doc-browser/DocBrowser.tsx
@@ -560,26 +560,50 @@ function MarkdownViewer({ content }: { content: string }) {
           td: ({ children }) => <td className="px-3 py-1.5" style={{ borderBottom: '1px solid rgba(255,255,255,0.03)', color: 'var(--text-secondary)' }}>{children}</td>,
           code: ({ className, children, ...props }) => {
             const match = /language-(\w+)/.exec(className || '');
-            const text = String(children ?? '');
+            const text = String(children ?? '').replace(/\n$/, '');
             // 块级判断：有 language- 类名 或 内容包含换行（兼容未指定语言的 fenced code block）
             const isBlock = !!match || text.includes('\n');
             if (!isBlock) {
               return <code className="px-1.5 py-0.5 rounded text-[12px]" style={{ background: 'rgba(255,255,255,0.06)', color: 'rgba(248,113,113,0.9)' }} {...props}>{children}</code>;
             }
+            // 块级且指定了语言 → Prism 高亮
+            if (match) {
+              return (
+                <SyntaxHighlighter
+                  style={oneDark}
+                  language={match[1]}
+                  PreTag="div"
+                  customStyle={{
+                    margin: '12px 0', borderRadius: '10px', fontSize: '12px',
+                    background: 'rgba(0,0,0,0.3)', border: '1px solid rgba(255,255,255,0.04)',
+                  }}
+                >
+                  {text}
+                </SyntaxHighlighter>
+              );
+            }
+            // 块级但无语言 → 纯 <pre>，避免 Prism token 背景污染 ASCII 框图
             return (
-              <SyntaxHighlighter
-                style={oneDark}
-                language={match?.[1] ?? 'text'}
-                PreTag="div"
-                customStyle={{
-                  margin: '12px 0', borderRadius: '10px', fontSize: '12px',
-                  background: 'rgba(0,0,0,0.3)', border: '1px solid rgba(255,255,255,0.04)',
+              <pre
+                style={{
+                  margin: '12px 0',
+                  padding: '12px 14px',
+                  borderRadius: '10px',
+                  fontSize: '12px',
+                  lineHeight: 1.6,
+                  background: 'rgba(0,0,0,0.3)',
+                  border: '1px solid rgba(255,255,255,0.04)',
+                  color: 'rgba(255,255,255,0.85)',
+                  fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+                  whiteSpace: 'pre',
+                  overflowX: 'auto',
                 }}
               >
-                {text.replace(/\n$/, '')}
-              </SyntaxHighlighter>
+                {text}
+              </pre>
             );
           },
+          pre: ({ children }) => <>{children}</>,
           hr: () => <hr className="my-4" style={{ borderColor: 'rgba(255,255,255,0.06)' }} />,
           img: ({ src, alt }) => (
             <img src={src} alt={alt || ''} className="max-w-full rounded-lg my-3" style={{ maxHeight: '400px', border: '1px solid rgba(255,255,255,0.06)' }} />

--- a/prd-admin/src/components/llm/LlmRequestDetailDialog.tsx
+++ b/prd-admin/src/components/llm/LlmRequestDetailDialog.tsx
@@ -5,6 +5,7 @@ import type { LlmRequestLog } from '@/types/admin';
 import { Copy, ExternalLink } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
 import rehypeRaw from 'rehype-raw';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
@@ -275,7 +276,7 @@ export function LlmRequestDetailDialog({
                 >
                   <div className="prd-md">
                     <ReactMarkdown
-                      remarkPlugins={[remarkGfm]}
+                      remarkPlugins={[remarkGfm, remarkBreaks]}
                       rehypePlugins={[rehypeRaw]}
                       components={{
                         a: ({ href, children, ...props }) => (

--- a/prd-admin/src/components/showcase/SubmissionDetailModal.tsx
+++ b/prd-admin/src/components/showcase/SubmissionDetailModal.tsx
@@ -20,6 +20,7 @@ import type { MarketplaceCardContext } from '@/components/config-management/Conf
 import ReactMarkdown from 'react-markdown';
 import { MapSectionLoader } from '@/components/ui/VideoLoader';
 import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
 
 interface SubmissionDetailModalProps {
   submissionId: string | null;
@@ -318,7 +319,7 @@ export function SubmissionDetailModal({ submissionId, onClose, onLikeChanged }: 
                   {/* ── 正文 Tab（仅文学创作） ── */}
                   {rightTab === 'article' && isLiterary && (
                     <div className="text-sm leading-relaxed arena-markdown" style={{ color: 'var(--text-secondary, rgba(255,255,255,0.7))' }}>
-                      <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                      <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>
                         {detail.articleContent || '暂无文章内容'}
                       </ReactMarkdown>
                     </div>

--- a/prd-admin/src/components/ui/MarkdownContent.tsx
+++ b/prd-admin/src/components/ui/MarkdownContent.tsx
@@ -1,6 +1,7 @@
 import { memo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { Copy } from 'lucide-react';
@@ -19,11 +20,21 @@ export const MarkdownContent = memo(function MarkdownContent({ content, classNam
   return (
     <div className={className ?? 'text-[13px] leading-relaxed'} style={{ color: 'var(--text-primary)' }}>
       <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
+        remarkPlugins={[remarkGfm, remarkBreaks]}
         components={{
           code({ className: cn, children, ...props }) {
             const match = /language-(\w+)/.exec(cn || '');
-            const codeStr = String(children).replace(/\n$/, '');
+            const codeStr = String(children ?? '').replace(/\n$/, '');
+            // 块级判断：有 language- 类名 或 内容含换行（兼容未指定语言的 fenced block）
+            const isBlock = !!match || codeStr.includes('\n');
+            if (!isBlock) {
+              return (
+                <code className="px-1 py-0.5 rounded text-xs" style={{ background: 'rgba(255,255,255,0.1)' }} {...props}>
+                  {children}
+                </code>
+              );
+            }
+            // 块级且指定语言 → Prism 高亮
             if (match) {
               return (
                 <div className="relative group/code my-2">
@@ -53,10 +64,23 @@ export const MarkdownContent = memo(function MarkdownContent({ content, classNam
                 </div>
               );
             }
+            // 块级但无语言 → 纯 <pre>，避免 Prism token 背景污染 ASCII 框图
             return (
-              <code className="px-1 py-0.5 rounded text-xs" style={{ background: 'rgba(255,255,255,0.1)' }} {...props}>
-                {children}
-              </code>
+              <pre
+                className="my-2 rounded-lg overflow-x-auto"
+                style={{
+                  margin: '0.5rem 0',
+                  padding: '12px 14px',
+                  fontSize: '0.75rem',
+                  lineHeight: 1.6,
+                  background: 'rgba(0,0,0,0.3)',
+                  color: 'var(--text-primary)',
+                  fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+                  whiteSpace: 'pre',
+                }}
+              >
+                {codeStr}
+              </pre>
             );
           },
           pre({ children }) { return <>{children}</>; },

--- a/prd-admin/src/lib/marketplaceTypes.tsx
+++ b/prd-admin/src/lib/marketplaceTypes.tsx
@@ -27,6 +27,7 @@
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
 import { FileText, Image as ImageIcon, Sparkles, type LucideIcon } from 'lucide-react';
 import { WatermarkDescriptionGrid } from '@/components/watermark/WatermarkDescriptionGrid';
 import {
@@ -171,7 +172,7 @@ const PromptPreviewRenderer: React.FC<{ item: MarketplacePrompt }> = ({ item }) 
     `}</style>
     <div className="marketplace-prompt-md">
       {item.content ? (
-        <ReactMarkdown remarkPlugins={[remarkGfm]}>
+        <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>
           {item.content}
         </ReactMarkdown>
       ) : (

--- a/prd-admin/src/pages/AiChatPage.tsx
+++ b/prd-admin/src/pages/AiChatPage.tsx
@@ -14,6 +14,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
 import rehypeRaw from 'rehype-raw';
 import type { AiChatStreamEvent } from '@/services/contracts/aiChat';
 import { SuggestedQuestions } from './ai-chat/components/SuggestedQuestions';
@@ -106,7 +107,7 @@ function unwrapMarkdownFences(text: string): string {
 
 const AssistantMarkdown = memo(function AssistantMarkdown({ content }: { content: string }) {
   return (
-    <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]}>
+    <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]} rehypePlugins={[rehypeRaw]}>
       {content}
     </ReactMarkdown>
   );

--- a/prd-admin/src/pages/GroupsPage.tsx
+++ b/prd-admin/src/pages/GroupsPage.tsx
@@ -25,6 +25,7 @@ import { systemDialog } from '@/lib/systemDialog';
 import { toast } from '@/lib/toast';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
 import rehypeRaw from 'rehype-raw';
 import { LlmRequestDetailDialog } from '@/components/llm/LlmRequestDetailDialog';
 
@@ -111,7 +112,7 @@ function MessageMarkdown({ content }: { content: string }) {
   return (
     <div className="prd-md">
       <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
+        remarkPlugins={[remarkGfm, remarkBreaks]}
         rehypePlugins={[rehypeRaw]}
         components={{
           a: ({ href, children, ...props }) => (

--- a/prd-admin/src/pages/LlmLogsPage.tsx
+++ b/prd-admin/src/pages/LlmLogsPage.tsx
@@ -20,6 +20,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useBreakpoint } from '@/hooks/useBreakpoint';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
 import rehypeRaw from 'rehype-raw';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { useSearchParams } from 'react-router-dom';
@@ -2427,7 +2428,7 @@ export function LlmLogsPanel({ embedded, defaultAppKey, customApis }: {
                         `}</style>
                         <div className="prd-md">
                           <ReactMarkdown
-                            remarkPlugins={[remarkGfm]}
+                            remarkPlugins={[remarkGfm, remarkBreaks]}
                             rehypePlugins={[rehypeRaw]}
                             components={{
                               a: ({ href, children, ...props }) => (

--- a/prd-admin/src/pages/ai-toolbox/components/ToolDetail.tsx
+++ b/prd-admin/src/pages/ai-toolbox/components/ToolDetail.tsx
@@ -36,6 +36,7 @@ import {
 import type { LucideIcon } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
 import { MapSpinner } from '@/components/ui/VideoLoader';
 import remarkMath from 'remark-math';
 import rehypeRaw from 'rehype-raw';
@@ -1150,12 +1151,20 @@ const sanitizeSchema = {
 const AssistantMarkdown = memo(function AssistantMarkdown({ content }: { content: string }) {
   return (
     <ReactMarkdown
-      remarkPlugins={[remarkGfm, remarkMath]}
+      remarkPlugins={[remarkGfm, remarkBreaks, remarkMath]}
       rehypePlugins={[rehypeRaw, [rehypeSanitize, sanitizeSchema], rehypeKatex]}
       components={{
         code({ className, children, ...props }) {
           const match = /language-(\w+)/.exec(className || '');
-          const codeStr = String(children).replace(/\n$/, '');
+          const codeStr = String(children ?? '').replace(/\n$/, '');
+          // 块级判断：有 language- 类名 或 内容含换行（兼容未指定语言的 fenced block）
+          const isBlock = !!match || codeStr.includes('\n');
+          if (!isBlock) {
+            return (
+              <code className="px-1 py-0.5 rounded text-xs" style={{ background: 'rgba(255, 255, 255, 0.1)' }} {...props}>{children}</code>
+            );
+          }
+          // 块级且指定语言 → Prism 高亮
           if (match) {
             return (
               <div className="relative group/code my-2">
@@ -1179,8 +1188,23 @@ const AssistantMarkdown = memo(function AssistantMarkdown({ content }: { content
               </div>
             );
           }
+          // 块级但无语言 → 纯 <pre>，避免 Prism token 背景污染 ASCII 框图
           return (
-            <code className="px-1 py-0.5 rounded text-xs" style={{ background: 'rgba(255, 255, 255, 0.1)' }} {...props}>{children}</code>
+            <pre
+              className="my-2 rounded-lg overflow-x-auto"
+              style={{
+                margin: '0.5rem 0',
+                padding: '12px 14px',
+                fontSize: '0.75rem',
+                lineHeight: 1.6,
+                background: 'rgba(0,0,0,0.3)',
+                color: 'var(--text-primary)',
+                fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+                whiteSpace: 'pre',
+              }}
+            >
+              {codeStr}
+            </pre>
           );
         },
         pre({ children }) { return <>{children}</>; },

--- a/prd-admin/src/pages/arena/ArenaPage.tsx
+++ b/prd-admin/src/pages/arena/ArenaPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
 import { Button } from '@/components/design/Button';
 import { PlatformLabel } from '@/components/design/PlatformLabel';
 import { toast } from '@/lib/toast';
@@ -2125,7 +2126,7 @@ export function ArenaPage() {
                             )}
                             {/* Main content */}
                             <div className="arena-markdown text-[14px] leading-[1.75] break-words" style={{ color: 'var(--text-primary)' }}>
-                              <ReactMarkdown remarkPlugins={[remarkGfm]}>{panel.text}</ReactMarkdown>
+                              <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>{panel.text}</ReactMarkdown>
                               {panel.status === 'streaming' && (
                                 <span
                                   className="inline-block w-[2px] h-[14px] ml-0.5 animate-pulse"

--- a/prd-admin/src/pages/defect-agent/components/DefectDetailPanel.tsx
+++ b/prd-admin/src/pages/defect-agent/components/DefectDetailPanel.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
 import { Button } from '@/components/design/Button';
 import { glassPanel } from '@/lib/glassStyles';
 import { useDefectStore } from '@/stores/defectStore';
@@ -672,7 +673,7 @@ export function DefectDetailPanel() {
                   contentSegments.map((seg, idx) =>
                     seg.type === 'text' ? (
                       <div key={idx} className="defect-md">
-                        <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                        <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>
                           {seg.content}
                         </ReactMarkdown>
                       </div>
@@ -1140,7 +1141,7 @@ export function DefectDetailPanel() {
                           {msgSegments.map((seg, idx) =>
                             seg.type === 'text' ? (
                               <div key={idx} className="defect-md text-[12px]">
-                                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                                <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>
                                   {seg.content}
                                 </ReactMarkdown>
                               </div>

--- a/prd-admin/src/pages/library/LibraryDocReader.tsx
+++ b/prd-admin/src/pages/library/LibraryDocReader.tsx
@@ -13,6 +13,7 @@ import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import 'katex/dist/katex.min.css';
@@ -935,7 +936,7 @@ function ClayMarkdown({
       style={{ color: '#1E1B4B', fontFamily: "'Nunito', system-ui, sans-serif" }}
     >
       <ReactMarkdown
-        remarkPlugins={[remarkGfm, remarkMath]}
+        remarkPlugins={[remarkGfm, remarkBreaks, remarkMath]}
         rehypePlugins={[rehypeKatex]}
         components={{
           ...headingComponents,

--- a/prd-admin/src/pages/library/LibraryDocReader.tsx
+++ b/prd-admin/src/pages/library/LibraryDocReader.tsx
@@ -1108,8 +1108,10 @@ function ClayMarkdown({
           ),
           code: ({ className, children, ...props }) => {
             const match = /language-(\w+)/.exec(className || '');
-            const inline = !match;
-            if (inline) {
+            const text = String(children ?? '');
+            // 块级判断：有 language- 类名 或 内容包含换行（兼容未指定语言的 fenced code block）
+            const isBlock = !!match || text.includes('\n');
+            if (!isBlock) {
               return (
                 <code
                   className="px-2 py-0.5 rounded-lg text-[13px] font-mono font-semibold"
@@ -1135,7 +1137,7 @@ function ClayMarkdown({
               >
                 <SyntaxHighlighter
                   style={oneLight}
-                  language={match[1]}
+                  language={match?.[1] ?? 'text'}
                   PreTag="div"
                   customStyle={{
                     margin: 0,
@@ -1145,7 +1147,7 @@ function ClayMarkdown({
                     border: 'none',
                   }}
                 >
-                  {String(children).replace(/\n$/, '')}
+                  {text.replace(/\n$/, '')}
                 </SyntaxHighlighter>
               </div>
             );

--- a/prd-admin/src/pages/library/LibraryDocReader.tsx
+++ b/prd-admin/src/pages/library/LibraryDocReader.tsx
@@ -1108,7 +1108,7 @@ function ClayMarkdown({
           ),
           code: ({ className, children, ...props }) => {
             const match = /language-(\w+)/.exec(className || '');
-            const text = String(children ?? '');
+            const text = String(children ?? '').replace(/\n$/, '');
             // 块级判断：有 language- 类名 或 内容包含换行（兼容未指定语言的 fenced code block）
             const isBlock = !!match || text.includes('\n');
             if (!isBlock) {
@@ -1126,32 +1126,62 @@ function ClayMarkdown({
                 </code>
               );
             }
+            // 块级且指定了语言 → 走 Prism 高亮
+            if (match) {
+              return (
+                <div
+                  className="my-4 rounded-2xl overflow-hidden"
+                  style={{
+                    background: '#FFFFFF',
+                    border: '3px solid #1E1B4B',
+                    boxShadow: '4px 4px 0 #1E1B4B',
+                  }}
+                >
+                  <SyntaxHighlighter
+                    style={oneLight}
+                    language={match[1]}
+                    PreTag="div"
+                    customStyle={{
+                      margin: 0,
+                      padding: '16px',
+                      fontSize: '13px',
+                      background: 'transparent',
+                      border: 'none',
+                    }}
+                  >
+                    {text}
+                  </SyntaxHighlighter>
+                </div>
+              );
+            }
+            // 块级但无语言 → 纯 <pre><code>，避免 Prism 对 ASCII 框图加 token 背景
             return (
               <div
-                className="my-4 rounded-2xl overflow-hidden"
+                className="my-4 rounded-2xl overflow-x-auto"
                 style={{
                   background: '#FFFFFF',
                   border: '3px solid #1E1B4B',
                   boxShadow: '4px 4px 0 #1E1B4B',
                 }}
               >
-                <SyntaxHighlighter
-                  style={oneLight}
-                  language={match?.[1] ?? 'text'}
-                  PreTag="div"
-                  customStyle={{
+                <pre
+                  style={{
                     margin: 0,
                     padding: '16px',
                     fontSize: '13px',
+                    lineHeight: 1.6,
+                    color: '#1E1B4B',
+                    fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
                     background: 'transparent',
-                    border: 'none',
+                    whiteSpace: 'pre',
                   }}
                 >
-                  {text.replace(/\n$/, '')}
-                </SyntaxHighlighter>
+                  {text}
+                </pre>
               </div>
             );
           },
+          pre: ({ children }) => <>{children}</>,
           hr: () => (
             <hr
               className="my-6"

--- a/prd-admin/src/pages/literary-agent/ArticleIllustrationEditorPage.tsx
+++ b/prd-admin/src/pages/literary-agent/ArticleIllustrationEditorPage.tsx
@@ -64,6 +64,7 @@ import { useNavigate } from 'react-router-dom';
 
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
 import rehypeRaw from 'rehype-raw';
 import { extractMarkers, type ArticleMarker } from '@/lib/articleMarkerExtractor';
 import { useDebounce } from '@/hooks/useDebounce';
@@ -2529,7 +2530,7 @@ export default function ArticleIllustrationEditorPage({ workspaceId }: { workspa
               <div className="p-4 relative">
                 <div className="prd-md">
                   <ReactMarkdown
-                    remarkPlugins={[remarkGfm]}
+                    remarkPlugins={[remarkGfm, remarkBreaks]}
                     rehypePlugins={[rehypeRaw]}
                     components={{
                       p: ({ node: _node, children, ...props }) => <p {...props}>{highlightChildren(children)}</p>,
@@ -2578,7 +2579,7 @@ export default function ArticleIllustrationEditorPage({ workspaceId }: { workspa
                         color: 'rgba(255, 255, 255, 0.7)',
                       }}
                     >
-                      <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                      <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>
                         {thinkingContent}
                       </ReactMarkdown>
                     </div>
@@ -2686,7 +2687,7 @@ export default function ArticleIllustrationEditorPage({ workspaceId }: { workspa
                         borderTop: '1px solid rgba(168, 85, 247, 0.1)',
                       }}
                     >
-                      <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                      <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>
                         {thinkingContent}
                       </ReactMarkdown>
                     </div>
@@ -2696,7 +2697,7 @@ export default function ArticleIllustrationEditorPage({ workspaceId }: { workspa
                 <div className="prd-md">
                   <ReactMarkdown
                     key="article-preview-main"
-                    remarkPlugins={[remarkGfm]}
+                    remarkPlugins={[remarkGfm, remarkBreaks]}
                     rehypePlugins={[rehypeRaw]}
                     components={{
                       p: ({ node: _node, children, ...props }) => <p {...props}>{highlightChildren(children)}</p>,
@@ -3427,7 +3428,7 @@ export default function ArticleIllustrationEditorPage({ workspaceId }: { workspa
                       `}</style>
                       <div className="create-prompt-md">
                         {creatingPrompt.content ? (
-                          <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                          <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>
                             {creatingPrompt.content}
                           </ReactMarkdown>
                         ) : (
@@ -3544,7 +3545,7 @@ export default function ArticleIllustrationEditorPage({ workspaceId }: { workspa
                       `}</style>
                       <div className="edit-prompt-md">
                         {editingPrompt.content ? (
-                          <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                          <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>
                             {editingPrompt.content}
                           </ReactMarkdown>
                         ) : (
@@ -3708,7 +3709,7 @@ export default function ArticleIllustrationEditorPage({ workspaceId }: { workspa
                               `}</style>
                               <div className="modal-prompt-md">
                                 {prompt.content ? (
-                                  <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                                  <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>
                                     {prompt.content}
                                   </ReactMarkdown>
                                 ) : (

--- a/prd-admin/src/pages/literary-agent/ConfigManagementDialog.tsx
+++ b/prd-admin/src/pages/literary-agent/ConfigManagementDialog.tsx
@@ -2,6 +2,7 @@ import { MapSectionLoader } from '@/components/ui/VideoLoader';
 import { useState, useRef, useCallback, forwardRef, useImperativeHandle } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
 import { GlassCard } from '@/components/design/GlassCard';
 import { Button } from '@/components/design/Button';
 import { Dialog } from '@/components/ui/Dialog';
@@ -458,7 +459,7 @@ export const ConfigManagementDialog = forwardRef<ConfigManagementDialogHandle, C
                           `}</style>
                           <div className="modal-prompt-md">
                             {prompt.content ? (
-                              <ReactMarkdown remarkPlugins={[remarkGfm]}>{prompt.content}</ReactMarkdown>
+                              <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>{prompt.content}</ReactMarkdown>
                             ) : (
                               <div style={{ color: 'var(--text-muted)' }}>（内容为空）</div>
                             )}

--- a/prd-admin/src/pages/report-agent/components/RichTextMarkdownContent.tsx
+++ b/prd-admin/src/pages/report-agent/components/RichTextMarkdownContent.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
 import { ImagePreviewDialog } from '@/components/ui/ImagePreviewDialog';
 
 interface RichTextMarkdownContentProps {
@@ -52,7 +53,7 @@ export function RichTextMarkdownContent({
         )}
         <div className="text-[12px] leading-relaxed text-left">
           <ReactMarkdown
-            remarkPlugins={[remarkGfm]}
+            remarkPlugins={[remarkGfm, remarkBreaks]}
             components={{
               p: ({ children }) => (
                 <p className="my-1 whitespace-pre-wrap break-words">{children}</p>

--- a/prd-admin/src/pages/video-agent/VideoAgentPage.tsx
+++ b/prd-admin/src/pages/video-agent/VideoAgentPage.tsx
@@ -40,6 +40,7 @@ import type { VideoGenRun, VideoGenRunListItem } from '@/services/contracts/vide
 
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
 
 // ─── Types ───
 
@@ -740,7 +741,7 @@ export const VideoAgentPage: React.FC = () => {
               ) : (
                 /* Article preview (markdown render) */
                 <div className="prd-md p-2">
-                  <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                  <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>
                     {articleContent}
                   </ReactMarkdown>
                 </div>

--- a/prd-desktop/src/components/KnowledgeBase/KnowledgeBasePage.tsx
+++ b/prd-desktop/src/components/KnowledgeBase/KnowledgeBasePage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState, useRef } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
 import { invoke } from '@tauri-apps/api/core';
 import { open } from '@tauri-apps/plugin-dialog';
 import { useGroupListStore } from '../../stores/groupListStore';
@@ -395,7 +396,7 @@ export default function KnowledgeBasePage() {
           <div className="p-5 ui-glass-panel">
             <div className="text-lg font-semibold mb-2">说明</div>
             <div className="prose prose-sm dark:prose-invert max-w-none">
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>
+              <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>
                 {`- **主文档**：对话的焦点，AI 回答围绕主文档展开，默认为产品文档类型。\n- **文档类型**：可为每个文档设置类型（产品文档、技术文档、设计文档、参考资料），AI 会根据类型调整引用权重。\n- **多文档支持**：追加的资料文件会作为 AI 对话时的参考上下文，与主文档一同被引用。支持一次选择多个文件。\n- **支持格式**：支持所有文本格式（代码、配置、文档等）和 PDF / Word / Excel / PPT。系统自动识别文件类型并提取文本内容。\n- **未绑定 PRD 的群组**：不允许进行任何基于 PRD 的问答/讲解。`}
               </ReactMarkdown>
             </div>


### PR DESCRIPTION
## Summary
Added the `remark-breaks` plugin to the markdown renderer in the Library Document Reader to preserve single line breaks in markdown content, preventing plain text and formatted documents from being collapsed into a single paragraph.

## Changes
- Imported `remark-breaks` plugin from the remark ecosystem
- Added `remarkBreaks` to the `remarkPlugins` array in the `ClayMarkdown` component's `ReactMarkdown` configuration

## Details
The `remark-breaks` plugin enables markdown to treat single line breaks as hard breaks (equivalent to `<br>` tags in HTML), rather than treating them as soft breaks that get collapsed into spaces. This is particularly important for documents that rely on line breaks for formatting and readability, such as plain text documents or content where line breaks are semantically meaningful.

The plugin is positioned between `remarkGfm` and `remarkMath` in the plugin chain to ensure proper processing order.

https://claude.ai/code/session_011dYgCYgNG8HC4MoE48kWjk