### PR TITLE
Rebrand MAP platform messaging and update hero section copy

### DIFF
--- a/changelogs/2026-04-14_homepage-map-rebrand.md
+++ b/changelogs/2026-04-14_homepage-map-rebrand.md
@@ -1,0 +1,1 @@
+| feat | prd-admin | 首页品牌更新：顶栏/底栏/Hero HUD 品牌名统一为「米多智能体生态平台」(Midoo Agentic Platform)，Hero 副标题替换为 MAP 官方定义，传递「企业级数字劳动力平台 · 碳硅共生」的核心定位 |

--- a/changelogs/2026-04-14_homepage-map-rebrand.md
+++ b/changelogs/2026-04-14_homepage-map-rebrand.md
@@ -1,1 +1,2 @@
 | feat | prd-admin | 首页品牌更新：顶栏/底栏/Hero HUD 品牌名统一为「米多智能体生态平台」(Midoo Agentic Platform)，Hero 副标题替换为 MAP 官方定义，传递「企业级数字劳动力平台 · 碳硅共生」的核心定位 |
+| fix | prd-admin | 首页 Hero 副标题排版收敛：容器 max-w-2xl → max-w-3xl、字号 clamp(0.95rem,1.2vw,1.125rem) → clamp(0.85rem,0.95vw,1rem)，解决长段定义换行产生尾行孤字、视觉权重压过 CTA 的问题 |

--- a/prd-admin/src/pages/home/i18n/landing.ts
+++ b/prd-admin/src/pages/home/i18n/landing.ts
@@ -236,10 +236,10 @@ const zh: TranslationShape = {
   },
   hero: {
     status: 'SYSTEM ONLINE',
-    brand: 'MAP · 米多 AGENT 平台',
+    brand: 'MAP · 米多智能体生态平台',
     title: '让创造，自由呼吸',
     subtitle:
-      '融合大模型与多模态能力的 AI 工作台 —— 视觉、文学、产品、视频、缺陷，十余个专业 Agent 在同一个空间协同。',
+      'MAP（Midoo Agentic Platform）· 米多智能体生态平台是企业级数字劳动力平台，致力于将 AI 从辅助工具升级为具备端到端作业能力的数字劳动力，强调碳硅共生的深度融合、人机共治、价值共创、共同进化，赋能企业进化为碳硅共生的智能型组织。',
     primaryCta: '进入 MAP',
     secondaryCta: '观看片花',
     techBarLabel: 'POWERED BY',
@@ -528,7 +528,7 @@ const zh: TranslationShape = {
     secondary: '联系我们',
   },
   footer: {
-    brand: '米多 Agent 平台',
+    brand: '米多智能体生态平台',
     github: 'GitHub',
     backToTop: '回到顶部',
     copyright: '© 2026 MAP',
@@ -594,10 +594,10 @@ const en: TranslationShape = {
   },
   hero: {
     status: 'SYSTEM ONLINE',
-    brand: 'MAP · MIDOR AGENT PLATFORM',
+    brand: 'MAP · MIDOO AGENTIC PLATFORM',
     title: 'Create, freely.',
     subtitle:
-      'A multimodal AI workbench where 15+ specialized Agents — visual, literary, product, video, QA — collaborate in one shared space.',
+      'MAP (Midoo Agentic Platform) is an enterprise-grade digital workforce platform — upgrading AI from an assistant into a workforce with end-to-end execution, built on deep carbon-silicon symbiosis, human-AI co-governance, shared value creation, and continuous co-evolution.',
     primaryCta: 'Enter MAP',
     secondaryCta: 'Watch Trailer',
     techBarLabel: 'POWERED BY',
@@ -889,7 +889,7 @@ const en: TranslationShape = {
     secondary: 'Contact us',
   },
   footer: {
-    brand: 'Midor Agent Platform',
+    brand: 'Midoo Agentic Platform',
     github: 'GitHub',
     backToTop: 'Back to top',
     copyright: '© 2026 MAP',

--- a/prd-admin/src/pages/home/sections/HeroSection.tsx
+++ b/prd-admin/src/pages/home/sections/HeroSection.tsx
@@ -183,12 +183,13 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
         </Reveal>
 
         {/* 副标题 — 标题已可读时加入（标题还在散雾），2s duration */}
+        {/* 容器放宽到 max-w-3xl、字号收到 clamp(13.6,0.95vw,16px)，承载 100 字中文定义 */}
         <Reveal delay={500} duration={2000} offset={20}>
           <p
-            className="mt-8 text-center text-white/62 max-w-2xl mx-auto leading-relaxed"
+            className="mt-8 text-center text-white/62 max-w-3xl mx-auto leading-relaxed"
             style={{
               fontFamily: 'var(--font-body)',
-              fontSize: 'clamp(0.95rem, 1.2vw, 1.125rem)',
+              fontSize: 'clamp(0.85rem, 0.95vw, 1rem)',
               letterSpacing: '0.005em',
             }}
           >


### PR DESCRIPTION
## Summary
Updated the homepage branding and messaging to reflect MAP's positioning as an enterprise-grade digital workforce platform. This includes rebranding the platform name across all sections and replacing the hero subtitle with a more comprehensive definition of MAP's core value proposition.

## Key Changes
- **Brand name updates**: Changed "米多 AGENT 平台" / "MIDOR AGENT PLATFORM" to "米多智能体生态平台" / "MIDOO AGENTIC PLATFORM" across header, footer, and hero sections
- **Hero subtitle replacement**: Updated the hero section subtitle in both Chinese and English to emphasize MAP as an enterprise-grade digital workforce platform with focus on:
  - End-to-end execution capabilities
  - Carbon-silicon symbiosis (碳硅共生)
  - Human-AI co-governance and shared value creation
  - Continuous co-evolution
- **Consistent terminology**: Aligned English branding from "Midor" to "Midoo" for consistency across all locales

## Implementation Details
- Changes applied to both Chinese (zh) and English (en) translation objects
- Updated 4 brand name references and 2 subtitle descriptions
- Added changelog entry documenting the rebrand initiative

https://claude.ai/code/session_015nkEhtXCWTFUHCWi9jb1TV