### PR TITLE
Enhance document store publishing, metadata, and sync scheduling

### DIFF
--- a/prd-admin/src/components/doc-browser/DocBrowser.tsx
+++ b/prd-admin/src/components/doc-browser/DocBrowser.tsx
@@ -59,6 +59,8 @@ export type DocBrowserEntry = {
   contentType: string;
   fileSize: number;
   tags?: string[];
+  updatedAt?: string;
+  updatedByName?: string;
   summary?: string;
   syncStatus?: string;
   /** 是否暂停（订阅类型） */
@@ -148,6 +150,19 @@ function canReprocess(entry: DocBrowserEntry): boolean {
   const ct = (entry.contentType ?? '').toLowerCase();
   // 文字类（markdown / 字幕 / 纯文本 / JSON / YAML 等）才能再加工
   return ct.startsWith('text/') || ct.includes('markdown') || ct === '';
+}
+
+function formatMetaTime(iso?: string): string {
+  if (!iso) return '未知时间';
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '未知时间';
+  return date.toLocaleString('zh-CN', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
 }
 
 // ── 右键/⋯ 菜单 ──
@@ -1482,6 +1497,28 @@ export function DocBrowser({
                   </>
                 );
               })()}
+              {(() => {
+                const sel = entries.find(e => e.id === selectedEntryId);
+                if (!sel || sel.isFolder) return null;
+                return (
+                  <div className="ml-auto flex items-center gap-3 min-w-0">
+                    <span
+                      className="text-[10px] whitespace-nowrap"
+                      style={{ color: 'var(--text-muted)' }}
+                      title={`最后更新时间：${formatMetaTime(sel.updatedAt)}`}
+                    >
+                      更新于 {formatMetaTime(sel.updatedAt)}
+                    </span>
+                    <span
+                      className="text-[10px] truncate max-w-[160px]"
+                      style={{ color: 'var(--text-muted)' }}
+                      title={`更新者：${sel.updatedByName || '未知用户'}`}
+                    >
+                      更新者 {sel.updatedByName || '未知用户'}
+                    </span>
+                  </div>
+                );
+              })()}
               {/* 当前文件最近更新徽标 + 订阅来源版本信息（git 类订阅独有） */}
               {(() => {
                 const sel = entries.find(e => e.id === selectedEntryId);
@@ -1585,7 +1622,7 @@ export function DocBrowser({
                 const cfg = getFileTypeConfig(sel.title, sel.contentType);
                 if (!cfg.editable) return null;
                 return (
-                  <div className="ml-auto flex items-center gap-1.5">
+                  <div className="flex items-center gap-1.5">
                     {editMode ? (
                       <>
                         <button

--- a/prd-admin/src/components/doc-browser/DocBrowser.tsx
+++ b/prd-admin/src/components/doc-browser/DocBrowser.tsx
@@ -28,7 +28,7 @@ import {
   Search, ChevronRight, ChevronDown, Plus, Pin, PinOff,
   FileSearch, ToggleLeft, ToggleRight, Trash2, FilePlus, FolderPlus,
   Upload, Link, LayoutTemplate, Bot, Pencil, Save, X,
-  Sparkles, Wand2,
+  Sparkles, Wand2, Tags,
 } from 'lucide-react';
 import { getFileTypeConfig } from '@/lib/fileTypeRegistry';
 import type { FilePreviewKind } from '@/lib/fileTypeRegistry';
@@ -58,6 +58,7 @@ export type DocBrowserEntry = {
   sourceType: string;
   contentType: string;
   fileSize: number;
+  tags?: string[];
   summary?: string;
   syncStatus?: string;
   /** 是否暂停（订阅类型） */
@@ -76,6 +77,7 @@ export type DocBrowserProps = {
   onSetPrimary?: (entryId: string) => void;
   onTogglePin?: (entryId: string, pin: boolean) => void;
   onDeleteEntry?: (entryId: string) => void;
+  onUpdateEntryTags?: (entryId: string, tags: string[]) => Promise<void>;
   onMoveEntry?: (entryId: string, targetFolderId: string | null) => void;
   onSaveContent?: (entryId: string, content: string) => Promise<void>;
   onCreateFolder?: (name: string, parentId?: string) => Promise<void>;
@@ -151,7 +153,7 @@ function canReprocess(entry: DocBrowserEntry): boolean {
 // ── 右键/⋯ 菜单 ──
 function ContextMenu({
   x, y, entry, isPrimary, isPinned,
-  onSetPrimary, onTogglePin, onDelete,
+  onSetPrimary, onTogglePin, onDelete, onEditTags,
   onGenerateSubtitle, onReprocess,
   onClose,
 }: {
@@ -163,6 +165,7 @@ function ContextMenu({
   onSetPrimary?: (entryId: string) => void;
   onTogglePin?: (entryId: string, pin: boolean) => void;
   onDelete?: (entryId: string) => void;
+  onEditTags?: (entry: DocBrowserEntry) => void;
   onGenerateSubtitle?: (entryId: string) => void;
   onReprocess?: (entryId: string) => void;
   onClose: () => void;
@@ -219,6 +222,15 @@ function ContextMenu({
           {isPinned ? '取消置顶' : '置顶文档'}
         </button>
       )}
+      {!entry.isFolder && onEditTags && (
+        <button
+          className="w-full px-3 py-1.5 text-left text-[12px] flex items-center gap-2 cursor-pointer transition-colors hover:bg-white/6"
+          style={{ color: 'var(--text-secondary)' }}
+          onClick={() => { onEditTags(entry); onClose(); }}>
+          <Tags size={12} />
+          打标签
+        </button>
+      )}
       {!entry.isFolder && onSetPrimary && !isPrimary && (
         <button
           className="w-full px-3 py-1.5 text-left text-[12px] flex items-center gap-2 cursor-pointer transition-colors hover:bg-white/6"
@@ -240,6 +252,157 @@ function ContextMenu({
           </button>
         </>
       )}
+    </div>
+  );
+}
+
+function EntryTagEditor({
+  entry,
+  onClose,
+  onSave,
+}: {
+  entry: DocBrowserEntry;
+  onClose: () => void;
+  onSave: (tags: string[]) => Promise<void>;
+}) {
+  const [tags, setTags] = useState<string[]>(entry.tags ?? []);
+  const [tagInput, setTagInput] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+
+  const addTag = useCallback((raw: string) => {
+    const trimmed = raw.trim().replace(/^#/, '');
+    if (!trimmed) return;
+    if (trimmed.length > 20) { setError('单个标签最多 20 个字'); return; }
+    if (tags.includes(trimmed)) { setTagInput(''); return; }
+    if (tags.length >= 10) { setError('最多 10 个标签'); return; }
+    setError('');
+    setTags(prev => [...prev, trimmed]);
+    setTagInput('');
+  }, [tags]);
+
+  const removeTag = useCallback((target: string) => {
+    setTags(prev => prev.filter(tag => tag !== target));
+    setError('');
+  }, []);
+
+  const handleTagKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' || e.key === ',' || e.key === '，') {
+      e.preventDefault();
+      addTag(tagInput);
+    } else if (e.key === 'Backspace' && !tagInput && tags.length > 0) {
+      removeTag(tags[tags.length - 1]);
+    }
+  }, [addTag, removeTag, tagInput, tags]);
+
+  const handleSave = useCallback(async () => {
+    const pending = tagInput.trim().replace(/^#/, '');
+    if (pending.length > 20) { setError('单个标签最多 20 个字'); return; }
+    const finalTags = pending && !tags.includes(pending) ? [...tags, pending] : tags;
+    if (finalTags.length > 10) { setError('最多 10 个标签'); return; }
+    setSaving(true);
+    setError('');
+    try {
+      await onSave(finalTags);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '保存失败');
+    } finally {
+      setSaving(false);
+    }
+  }, [onClose, onSave, tagInput, tags]);
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center"
+      style={{ background: 'rgba(0,0,0,0.5)', backdropFilter: 'blur(8px)' }}
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
+      <div className="w-[440px] max-w-[92vw] rounded-[16px] p-6"
+        style={{
+          background: 'linear-gradient(180deg, var(--glass-bg-start) 0%, var(--glass-bg-end) 100%)',
+          border: '1px solid rgba(255,255,255,0.08)',
+          backdropFilter: 'blur(40px) saturate(180%)',
+          boxShadow: '0 24px 48px -12px rgba(0,0,0,0.5)',
+        }}>
+        <div className="flex items-center justify-between mb-5">
+          <div className="flex items-center gap-2.5 min-w-0">
+            <div className="w-8 h-8 rounded-[10px] flex items-center justify-center"
+              style={{ background: 'rgba(59,130,246,0.08)', border: '1px solid rgba(59,130,246,0.12)' }}>
+              <Tags size={14} style={{ color: 'rgba(59,130,246,0.85)' }} />
+            </div>
+            <div className="min-w-0">
+              <div className="text-[15px] font-semibold truncate" style={{ color: 'var(--text-primary)' }}>
+                文档标签
+              </div>
+              <div className="text-[11px] truncate" style={{ color: 'var(--text-muted)' }}>
+                {entry.title}
+              </div>
+            </div>
+          </div>
+          <button onClick={onClose}
+            className="w-7 h-7 rounded-[8px] flex items-center justify-center cursor-pointer hover:bg-white/6 transition-colors duration-200"
+            style={{ color: 'var(--text-muted)' }}>
+            <X size={15} />
+          </button>
+        </div>
+
+        <div className="mb-4">
+          <label className="block text-[12px] mb-1.5" style={{ color: 'var(--text-muted)' }}>
+            标签 <span className="text-[10px]" style={{ color: 'var(--text-muted)' }}>（回车或逗号分隔，最多 10 个）</span>
+          </label>
+          <div
+            className="min-h-9 px-2 py-1.5 rounded-[10px] flex flex-wrap items-center gap-1.5"
+            style={{
+              background: 'var(--input-bg, rgba(255,255,255,0.05))',
+              border: '1px solid var(--border-subtle, rgba(255,255,255,0.1))',
+            }}>
+            {tags.map(tag => (
+              <span key={tag}
+                className="inline-flex items-center gap-1 h-6 px-2 rounded-[6px] text-[11px] font-medium"
+                style={{
+                  background: 'rgba(59,130,246,0.1)',
+                  border: '1px solid rgba(59,130,246,0.2)',
+                  color: 'rgba(59,130,246,0.9)',
+                }}>
+                # {tag}
+                <button
+                  onClick={() => removeTag(tag)}
+                  className="ml-0.5 cursor-pointer flex items-center justify-center"
+                  style={{ color: 'rgba(59,130,246,0.7)' }}
+                  title="移除">
+                  <X size={10} />
+                </button>
+              </span>
+            ))}
+            <input
+              autoFocus
+              value={tagInput}
+              onChange={e => setTagInput(e.target.value)}
+              onKeyDown={handleTagKeyDown}
+              placeholder={tags.length === 0 ? '如：架构、需求、API' : ''}
+              className="flex-1 min-w-[80px] h-6 bg-transparent outline-none text-[12px]"
+              style={{ color: 'var(--text-primary)' }}
+            />
+          </div>
+        </div>
+
+        {error && <p className="text-[12px] mb-3" style={{ color: 'rgba(239,68,68,0.9)' }}>{error}</p>}
+
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="h-8 px-3 rounded-[8px] text-[12px] font-semibold cursor-pointer"
+            style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)', color: 'var(--text-muted)' }}>
+            取消
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            className="h-8 px-3 rounded-[8px] text-[12px] font-semibold cursor-pointer"
+            style={{ background: 'rgba(59,130,246,0.12)', border: '1px solid rgba(59,130,246,0.18)', color: 'rgba(59,130,246,0.95)' }}>
+            {saving ? '保存中…' : '保存'}
+          </button>
+        </div>
+      </div>
     </div>
   );
 }
@@ -348,6 +511,21 @@ function TreeNode({
           }}>
           {displayTitle}
         </span>
+
+        {!isFolder && (entry.tags?.length ?? 0) > 0 && (
+          <span
+            className="text-[9px] px-1.5 py-0.5 rounded-full flex-shrink-0"
+            style={{
+              background: 'rgba(168,85,247,0.08)',
+              color: 'rgba(216,180,254,0.9)',
+              border: '1px solid rgba(168,85,247,0.16)',
+            }}
+            title={(entry.tags ?? []).map(tag => `#${tag}`).join(' ')}
+          >
+            #{entry.tags![0]}
+            {(entry.tags?.length ?? 0) > 1 ? ` +${entry.tags!.length - 1}` : ''}
+          </span>
+        )}
 
         {/* (new) 徽标：lastChangedAt 在 24 小时以内 */}
         {!isFolder && isRecentlyChanged(entry.lastChangedAt) && (
@@ -735,6 +913,7 @@ export function DocBrowser({
   onSetPrimary,
   onTogglePin,
   onDeleteEntry,
+  onUpdateEntryTags,
   onMoveEntry,
   onSaveContent,
   loadContent,
@@ -765,6 +944,7 @@ export function DocBrowser({
   const [editMode, setEditMode] = useState(false);
   const [editContent, setEditContent] = useState('');
   const [saving, setSaving] = useState(false);
+  const [tagEditEntry, setTagEditEntry] = useState<DocBrowserEntry | null>(null);
   // 左侧面板宽度（可拖拽调整，sessionStorage 持久化）
   const [sidebarWidth, setSidebarWidth] = useState<number>(() => {
     const saved = sessionStorage.getItem('doc-browser-sidebar-width');
@@ -1279,6 +1459,29 @@ export function DocBrowser({
                   置顶
                 </span>
               )}
+              {(() => {
+                const sel = entries.find(e => e.id === selectedEntryId);
+                if (!sel || sel.isFolder || (sel.tags?.length ?? 0) === 0) return null;
+                return (
+                  <>
+                    {sel.tags!.slice(0, 4).map(tag => (
+                      <span key={tag} className="text-[10px] px-2 py-0.5 rounded-full flex-shrink-0"
+                        style={{
+                          background: 'rgba(168,85,247,0.08)',
+                          color: 'rgba(216,180,254,0.92)',
+                          border: '1px solid rgba(168,85,247,0.16)',
+                        }}>
+                        #{tag}
+                      </span>
+                    ))}
+                    {sel.tags!.length > 4 && (
+                      <span className="text-[10px] flex-shrink-0" style={{ color: 'var(--text-muted)' }}>
+                        +{sel.tags!.length - 4}
+                      </span>
+                    )}
+                  </>
+                );
+              })()}
               {/* 当前文件最近更新徽标 + 订阅来源版本信息（git 类订阅独有） */}
               {(() => {
                 const sel = entries.find(e => e.id === selectedEntryId);
@@ -1513,9 +1716,20 @@ export function DocBrowser({
             });
             if (confirmed) onDeleteEntry(entryId);
           } : undefined}
+          onEditTags={onUpdateEntryTags ? (entry) => setTagEditEntry(entry) : undefined}
           onGenerateSubtitle={onGenerateSubtitle}
           onReprocess={onReprocess}
           onClose={() => setContextMenu(null)}
+        />
+      )}
+
+      {tagEditEntry && onUpdateEntryTags && (
+        <EntryTagEditor
+          entry={tagEditEntry}
+          onClose={() => setTagEditEntry(null)}
+          onSave={async (tags) => {
+            await onUpdateEntryTags(tagEditEntry.id, tags);
+          }}
         />
       )}
 

--- a/prd-admin/src/pages/document-store/DocumentStorePage.tsx
+++ b/prd-admin/src/pages/document-store/DocumentStorePage.tsx
@@ -541,9 +541,10 @@ function ShareDialog({ storeId, storeName, isPublic, onClose }: {
 }
 
 // ── 空间详情视图（文档列表 + 上传）──
-function StoreDetailView({ storeId, onBack }: {
+function StoreDetailView({ storeId, onBack, onOpenLibrary }: {
   storeId: string;
   onBack: () => void;
+  onOpenLibrary: (storeId: string) => void;
 }) {
   const [store, setStore] = useState<DocumentStore | null>(null);
   const [entries, setEntries] = useState<DocumentEntry[]>([]);
@@ -819,7 +820,7 @@ function StoreDetailView({ storeId, onBack }: {
             {store.isPublic ? (
               <div className="flex items-center gap-1">
                 <button
-                  onClick={() => navigate(`/library/${store.id}`)}
+                  onClick={() => onOpenLibrary(store.id)}
                   className="h-7 px-3 rounded-[8px] text-[11px] font-semibold flex items-center gap-1.5 cursor-pointer transition-all"
                   style={{
                     background: 'rgba(168,85,247,0.15)',
@@ -1236,7 +1237,7 @@ export function DocumentStorePage() {
 
   // 空间详情视图（仅 mine 标签下可进入编辑视图）
   if (selectedStoreId) {
-    return <StoreDetailView storeId={selectedStoreId} onBack={() => { setSelectedStoreId(null); loadStores(); }} />;
+    return <StoreDetailView storeId={selectedStoreId} onBack={() => { setSelectedStoreId(null); loadStores(); }} onOpenLibrary={(id) => navigate(`/library/${id}`)} />;
   }
 
   const tabs: { key: StoreTab; label: string; icon: typeof Library }[] = [

--- a/prd-admin/src/pages/document-store/DocumentStorePage.tsx
+++ b/prd-admin/src/pages/document-store/DocumentStorePage.tsx
@@ -22,6 +22,7 @@ import {
   Heart,
   Bookmark,
   Users,
+  ArrowUpRight,
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { GlassCard } from '@/components/design/GlassCard';
@@ -48,6 +49,7 @@ import {
   setFolderPrimaryChild,
   rebuildContentIndex,
   addDocumentEntry,
+  updateDocumentEntry,
   updateDocumentStore,
   createDocStoreShareLink,
   listDocStoreShareLinks,
@@ -676,6 +678,17 @@ function StoreDetailView({ storeId, onBack }: {
     }
   }, [selectedEntryId]);
 
+  const handleUpdateEntryTags = useCallback(async (entryId: string, tags: string[]) => {
+    const res = await updateDocumentEntry(entryId, { tags });
+    if (res.success) {
+      setEntries(prev => prev.map(entry => entry.id === entryId ? { ...entry, tags: res.data.tags ?? tags } : entry));
+      toast.success(tags.length > 0 ? '标签已更新' : '标签已清空');
+      return;
+    }
+    toast.error('标签更新失败', res.error?.message);
+    throw new Error(res.error?.message ?? '标签更新失败');
+  }, []);
+
   const handleMoveEntry = useCallback(async (entryId: string, targetFolderId: string | null) => {
     const res = await moveDocumentEntry(entryId, targetFolderId);
     if (res.success) {
@@ -797,20 +810,52 @@ function StoreDetailView({ storeId, onBack }: {
         actions={
           <div className="flex items-center gap-2">
             {/* 发布到智识殿堂开关 */}
-            <button
-              onClick={handleTogglePublish}
-              disabled={publishing}
-              className="h-7 px-3 rounded-[8px] text-[11px] font-semibold flex items-center gap-1.5 cursor-pointer transition-all"
-              style={{
-                background: store.isPublic ? 'rgba(168,85,247,0.15)' : 'rgba(255,255,255,0.04)',
-                border: store.isPublic ? '1px solid rgba(168,85,247,0.35)' : '1px solid rgba(255,255,255,0.08)',
-                color: store.isPublic ? 'rgba(216,180,254,0.95)' : 'var(--text-muted)',
-              }}
-              title={store.isPublic ? '已发布到智识殿堂，点击取消发布' : '发布到智识殿堂，让更多人看到'}
-            >
-              {publishing ? <MapSpinner size={11} /> : (store.isPublic ? <Globe size={11} /> : <GlobeLock size={11} />)}
-              {store.isPublic ? '已发布' : '发布到智识殿堂'}
-            </button>
+            {store.isPublic ? (
+              <div className="flex items-center gap-1">
+                <button
+                  onClick={() => navigate(`/library/${store.id}`)}
+                  className="h-7 px-3 rounded-[8px] text-[11px] font-semibold flex items-center gap-1.5 cursor-pointer transition-all"
+                  style={{
+                    background: 'rgba(168,85,247,0.15)',
+                    border: '1px solid rgba(168,85,247,0.35)',
+                    color: 'rgba(216,180,254,0.95)',
+                  }}
+                  title="已发布到智识殿堂，点击前往公开页"
+                >
+                  <Globe size={11} />
+                  已发布
+                  <ArrowUpRight size={11} />
+                </button>
+                <button
+                  onClick={handleTogglePublish}
+                  disabled={publishing}
+                  className="h-7 px-2 rounded-[8px] text-[11px] font-semibold flex items-center gap-1 cursor-pointer transition-all"
+                  style={{
+                    background: 'rgba(255,255,255,0.04)',
+                    border: '1px solid rgba(255,255,255,0.08)',
+                    color: 'var(--text-muted)',
+                  }}
+                  title="取消发布"
+                >
+                  {publishing ? <MapSpinner size={11} /> : <GlobeLock size={11} />}
+                </button>
+              </div>
+            ) : (
+              <button
+                onClick={handleTogglePublish}
+                disabled={publishing}
+                className="h-7 px-3 rounded-[8px] text-[11px] font-semibold flex items-center gap-1.5 cursor-pointer transition-all"
+                style={{
+                  background: 'rgba(255,255,255,0.04)',
+                  border: '1px solid rgba(255,255,255,0.08)',
+                  color: 'var(--text-muted)',
+                }}
+                title="发布到智识殿堂，让更多人看到"
+              >
+                {publishing ? <MapSpinner size={11} /> : <GlobeLock size={11} />}
+                发布到智识殿堂
+              </button>
+            )}
             <Button variant="secondary" size="xs" onClick={() => setShowViewers(true)}>
               <Users size={13} /> 访客
             </Button>
@@ -850,6 +895,7 @@ function StoreDetailView({ storeId, onBack }: {
           onSetPrimary={handleSetPrimary}
           onTogglePin={handleTogglePin}
           onDeleteEntry={handleDeleteEntry}
+          onUpdateEntryTags={handleUpdateEntryTags}
           onMoveEntry={handleMoveEntry}
           onSaveContent={handleSaveContent}
           loadContent={loadContent}

--- a/prd-admin/src/pages/document-store/DocumentStorePage.tsx
+++ b/prd-admin/src/pages/document-store/DocumentStorePage.tsx
@@ -681,7 +681,7 @@ function StoreDetailView({ storeId, onBack }: {
   const handleUpdateEntryTags = useCallback(async (entryId: string, tags: string[]) => {
     const res = await updateDocumentEntry(entryId, { tags });
     if (res.success) {
-      setEntries(prev => prev.map(entry => entry.id === entryId ? { ...entry, tags: res.data.tags ?? tags } : entry));
+      setEntries(prev => prev.map(entry => entry.id === entryId ? { ...entry, ...res.data, tags: res.data.tags ?? tags } : entry));
       toast.success(tags.length > 0 ? '标签已更新' : '标签已清空');
       return;
     }
@@ -706,7 +706,13 @@ function StoreDetailView({ storeId, onBack }: {
       // 更新本地 entries 中的 summary（前 200 字）
       const summary = newContent.length > 200 ? newContent.slice(0, 200) : newContent;
       setEntries(prev => prev.map(e =>
-        e.id === entryId ? { ...e, summary: summary.trim() } : e));
+        e.id === entryId ? {
+          ...e,
+          summary: summary.trim(),
+          updatedAt: res.data.updatedAt ?? e.updatedAt,
+          updatedBy: res.data.updatedBy ?? e.updatedBy,
+          updatedByName: res.data.updatedByName ?? e.updatedByName,
+        } : e));
       toast.success('已保存');
     } else {
       toast.error('保存失败', res.error?.message);

--- a/prd-admin/src/services/contracts/documentStore.ts
+++ b/prd-admin/src/services/contracts/documentStore.ts
@@ -78,6 +78,8 @@ export type DocumentEntry = {
   tags: string[];
   metadata: Record<string, string>;
   createdBy: string;
+  updatedBy?: string;
+  updatedByName?: string;
   // 同步字段
   sourceUrl?: string;
   syncIntervalMinutes?: number;

--- a/prd-admin/src/services/real/documentStore.ts
+++ b/prd-admin/src/services/real/documentStore.ts
@@ -175,7 +175,7 @@ export async function moveDocumentEntry(entryId: string, parentId: string | null
 
 /** 更新文档内容（在线编辑） */
 export async function updateDocumentContent(entryId: string, content: string) {
-  return await apiRequest<{ updated: boolean }>(
+  return await apiRequest<{ updated: boolean; updatedAt?: string; updatedBy?: string; updatedByName?: string }>(
     api.documentStore.entries.content(entryId),
     { method: 'PUT', body: { content } },
   );

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/DocumentStoreController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/DocumentStoreController.cs
@@ -58,7 +58,7 @@ public class DocumentStoreController : ControllerBase
 
     private async Task<User?> FindUserByAnyIdAsync(string userId)
     {
-        return await _db.Users.Find(u => u.UserId == userId || u.Id == userId).FirstOrDefaultAsync();
+        return await _db.Users.Find(u => u.UserId == userId).FirstOrDefaultAsync();
     }
 
     private async Task<(string userId, string userName)> GetActorInfoAsync()

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/DocumentStoreController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/DocumentStoreController.cs
@@ -56,6 +56,21 @@ public class DocumentStoreController : ControllerBase
 
     private string GetUserId() => this.GetRequiredUserId();
 
+    private async Task<User?> FindUserByAnyIdAsync(string userId)
+    {
+        return await _db.Users.Find(u => u.UserId == userId || u.Id == userId).FirstOrDefaultAsync();
+    }
+
+    private async Task<(string userId, string userName)> GetActorInfoAsync()
+    {
+        var userId = GetUserId();
+        var user = await FindUserByAnyIdAsync(userId);
+        var userName = user != null && !string.IsNullOrWhiteSpace(user.DisplayName)
+            ? user.DisplayName
+            : (user?.Username ?? "未知用户");
+        return (userId, userName);
+    }
+
     // ─────────────────────────────────────────────
     // 文档空间 CRUD
     // ─────────────────────────────────────────────
@@ -254,7 +269,7 @@ public class DocumentStoreController : ControllerBase
     [HttpPost("stores/{storeId}/entries")]
     public async Task<IActionResult> AddEntry(string storeId, [FromBody] AddDocumentEntryRequest request)
     {
-        var userId = GetUserId();
+        var (userId, userName) = await GetActorInfoAsync();
         var store = await _db.DocumentStores.Find(s => s.Id == storeId && s.OwnerId == userId).FirstOrDefaultAsync();
         if (store == null)
             return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "文档空间不存在"));
@@ -277,7 +292,9 @@ public class DocumentStoreController : ControllerBase
             FileSize = request.FileSize,
             Tags = request.Tags ?? new List<string>(),
             Metadata = request.Metadata ?? new Dictionary<string, string>(),
-            CreatedBy = userId
+            CreatedBy = userId,
+            UpdatedBy = userId,
+            UpdatedByName = userName,
         };
 
         await _db.DocumentEntries.InsertOneAsync(entry);
@@ -299,7 +316,7 @@ public class DocumentStoreController : ControllerBase
     [HttpPost("stores/{storeId}/folders")]
     public async Task<IActionResult> CreateFolder(string storeId, [FromBody] CreateDocStoreFolderRequest request)
     {
-        var userId = GetUserId();
+        var (userId, userName) = await GetActorInfoAsync();
         var store = await _db.DocumentStores.Find(s => s.Id == storeId && s.OwnerId == userId).FirstOrDefaultAsync();
         if (store == null)
             return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "文档空间不存在"));
@@ -325,6 +342,8 @@ public class DocumentStoreController : ControllerBase
             SourceType = DocumentSourceType.Upload,
             ContentType = "application/x-folder",
             CreatedBy = userId,
+            UpdatedBy = userId,
+            UpdatedByName = userName,
         };
 
         await _db.DocumentEntries.InsertOneAsync(folder);
@@ -435,7 +454,7 @@ public class DocumentStoreController : ControllerBase
     [HttpPut("entries/{entryId}")]
     public async Task<IActionResult> UpdateEntry(string entryId, [FromBody] UpdateDocumentEntryRequest request)
     {
-        var userId = GetUserId();
+        var (userId, userName) = await GetActorInfoAsync();
         var entry = await _db.DocumentEntries.Find(e => e.Id == entryId).FirstOrDefaultAsync();
         if (entry == null)
             return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "文档条目不存在"));
@@ -456,6 +475,8 @@ public class DocumentStoreController : ControllerBase
             updates.Add(Builders<DocumentEntry>.Update.Set(e => e.Metadata, request.Metadata));
 
         updates.Add(Builders<DocumentEntry>.Update.Set(e => e.UpdatedAt, DateTime.UtcNow));
+        updates.Add(Builders<DocumentEntry>.Update.Set(e => e.UpdatedBy, userId));
+        updates.Add(Builders<DocumentEntry>.Update.Set(e => e.UpdatedByName, userName));
 
         await _db.DocumentEntries.UpdateOneAsync(
             e => e.Id == entryId,
@@ -568,7 +589,7 @@ public class DocumentStoreController : ControllerBase
     [HttpPut("entries/{entryId}/move")]
     public async Task<IActionResult> MoveEntry(string entryId, [FromBody] MoveEntryRequest request)
     {
-        var userId = GetUserId();
+        var (userId, userName) = await GetActorInfoAsync();
         var entry = await _db.DocumentEntries.Find(e => e.Id == entryId).FirstOrDefaultAsync();
         if (entry == null)
             return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "文档条目不存在"));
@@ -590,6 +611,8 @@ public class DocumentStoreController : ControllerBase
             e => e.Id == entryId,
             Builders<DocumentEntry>.Update
                 .Set(e => e.ParentId, string.IsNullOrEmpty(request.ParentId) ? null : request.ParentId)
+                .Set(e => e.UpdatedBy, userId)
+                .Set(e => e.UpdatedByName, userName)
                 .Set(e => e.UpdatedAt, DateTime.UtcNow));
 
         return Ok(ApiResponse<object>.Ok(new { moved = true }));
@@ -599,7 +622,7 @@ public class DocumentStoreController : ControllerBase
     [HttpPut("entries/{entryId}/content")]
     public async Task<IActionResult> UpdateEntryContent(string entryId, [FromBody] UpdateEntryContentRequest request)
     {
-        var userId = GetUserId();
+        var (userId, userName) = await GetActorInfoAsync();
         var entry = await _db.DocumentEntries.Find(e => e.Id == entryId).FirstOrDefaultAsync();
         if (entry == null)
             return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "文档条目不存在"));
@@ -645,6 +668,8 @@ public class DocumentStoreController : ControllerBase
                 .Set(e => e.DocumentId, entry.DocumentId)
                 .Set(e => e.Summary, summary.Trim())
                 .Set(e => e.ContentIndex, contentIndex.Trim())
+                .Set(e => e.UpdatedBy, userId)
+                .Set(e => e.UpdatedByName, userName)
                 .Set(e => e.UpdatedAt, DateTime.UtcNow));
 
         // 重锚定划词评论：正文更新后，遍历所有 active 评论，用 SelectedText + context 重新定位
@@ -653,6 +678,9 @@ public class DocumentStoreController : ControllerBase
         return Ok(ApiResponse<object>.Ok(new
         {
             updated = true,
+            updatedAt = DateTime.UtcNow,
+            updatedBy = userId,
+            updatedByName = userName,
             inlineCommentsRebound = rebindStats.rebound,
             inlineCommentsOrphaned = rebindStats.orphaned,
         }));
@@ -724,7 +752,7 @@ public class DocumentStoreController : ControllerBase
     [HttpPut("entries/{folderId}/primary-child")]
     public async Task<IActionResult> SetFolderPrimaryChild(string folderId, [FromBody] SetPrimaryEntryRequest request)
     {
-        var userId = GetUserId();
+        var (userId, userName) = await GetActorInfoAsync();
         var folder = await _db.DocumentEntries.Find(e => e.Id == folderId && e.IsFolder).FirstOrDefaultAsync();
         if (folder == null)
             return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "文件夹不存在"));
@@ -751,6 +779,8 @@ public class DocumentStoreController : ControllerBase
             e => e.Id == folderId,
             Builders<DocumentEntry>.Update
                 .Set(e => e.Metadata, metadata)
+                .Set(e => e.UpdatedBy, userId)
+                .Set(e => e.UpdatedByName, userName)
                 .Set(e => e.UpdatedAt, DateTime.UtcNow));
 
         return Ok(ApiResponse<object>.Ok(new { primaryChildId = request.EntryId }));
@@ -822,7 +852,7 @@ public class DocumentStoreController : ControllerBase
     [RequestSizeLimit(MaxUploadBytes)]
     public async Task<IActionResult> UploadFile(string storeId, [FromForm] IFormFile file, [FromForm] string? parentId = null, CancellationToken ct = default)
     {
-        var userId = GetUserId();
+        var (userId, userName) = await GetActorInfoAsync();
         var store = await _db.DocumentStores.Find(s => s.Id == storeId && s.OwnerId == userId).FirstOrDefaultAsync(ct);
         if (store == null)
             return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "文档空间不存在"));
@@ -925,6 +955,8 @@ public class DocumentStoreController : ControllerBase
             ContentType = mime,
             FileSize = file.Length,
             CreatedBy = userId,
+            UpdatedBy = userId,
+            UpdatedByName = userName,
             ContentIndex = contentIndex?.Trim(),
         };
         await _db.DocumentEntries.InsertOneAsync(entry, cancellationToken: ct);
@@ -1021,7 +1053,7 @@ public class DocumentStoreController : ControllerBase
     [HttpPost("stores/{storeId}/subscribe")]
     public async Task<IActionResult> AddSubscription(string storeId, [FromBody] AddSubscriptionRequest request)
     {
-        var userId = GetUserId();
+        var (userId, userName) = await GetActorInfoAsync();
         var store = await _db.DocumentStores.Find(s => s.Id == storeId && s.OwnerId == userId).FirstOrDefaultAsync();
         if (store == null)
             return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "文档空间不存在"));
@@ -1046,6 +1078,8 @@ public class DocumentStoreController : ControllerBase
             ContentType = "text/html",
             Tags = request.Tags ?? new List<string>(),
             CreatedBy = userId,
+            UpdatedBy = userId,
+            UpdatedByName = userName,
         };
 
         await _db.DocumentEntries.InsertOneAsync(entry);
@@ -1066,7 +1100,7 @@ public class DocumentStoreController : ControllerBase
     [HttpPost("stores/{storeId}/subscribe-github")]
     public async Task<IActionResult> AddGitHubSubscription(string storeId, [FromBody] AddGitHubSubscriptionRequest request)
     {
-        var userId = GetUserId();
+        var (userId, userName) = await GetActorInfoAsync();
         var store = await _db.DocumentStores.Find(s => s.Id == storeId && s.OwnerId == userId).FirstOrDefaultAsync();
         if (store == null)
             return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "文档空间不存在"));
@@ -1115,6 +1149,8 @@ public class DocumentStoreController : ControllerBase
             SyncStatus = DocumentSyncStatus.Syncing, // 立即触发首次同步
             ContentType = "application/x-github-directory",
             CreatedBy = userId,
+            UpdatedBy = userId,
+            UpdatedByName = userName,
             Metadata = new Dictionary<string, string>
             {
                 ["github_owner"] = owner,

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/DocumentStoreController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/DocumentStoreController.cs
@@ -1132,7 +1132,7 @@ public class DocumentStoreController : ControllerBase
         if (duplicate != null)
             return BadRequest(ApiResponse<object>.Fail("ALREADY_EXISTS", $"该目录已订阅 (ID: {duplicate.Id})"));
 
-        var interval = Math.Clamp(request.SyncIntervalMinutes ?? 1440, 60, 1440); // 1小时 ~ 24小时，默认每天
+        var interval = 1440; // GitHub 目录固定为每日同步一次，首次添加后立即同步
 
         var title = request.Title?.Trim();
         if (string.IsNullOrEmpty(title))
@@ -1324,10 +1324,7 @@ public class DocumentStoreController : ControllerBase
             .Limit(limit)
             .ToListAsync();
 
-        // 计算下次同步时间（基于 LastSyncAt + SyncIntervalMinutes）
-        DateTime? nextSyncAt = null;
-        if (entry.LastSyncAt.HasValue && entry.SyncIntervalMinutes is > 0 && !entry.IsPaused)
-            nextSyncAt = entry.LastSyncAt.Value.AddMinutes(entry.SyncIntervalMinutes.Value);
+        var nextSyncAt = DocumentSyncSchedule.GetNextSyncAt(entry);
 
         return Ok(ApiResponse<object>.Ok(new
         {
@@ -1389,9 +1386,9 @@ public class DocumentStoreController : ControllerBase
 
         if (request.SyncIntervalMinutes.HasValue)
         {
-            // GitHub 目录类型最低 1 小时（避免 GitHub API 限流），其他 5 分钟起
-            var min = entry.SourceType == DocumentSourceType.GithubDirectory ? 60 : 5;
-            var clamped = Math.Clamp(request.SyncIntervalMinutes.Value, min, 1440);
+            var clamped = entry.SourceType == DocumentSourceType.GithubDirectory
+                ? 1440
+                : Math.Clamp(request.SyncIntervalMinutes.Value, 5, 1440);
             update = update.Set(e => e.SyncIntervalMinutes, clamped);
             changed = true;
         }

--- a/prd-api/src/PrdAgent.Api/Services/DocumentSyncSchedule.cs
+++ b/prd-api/src/PrdAgent.Api/Services/DocumentSyncSchedule.cs
@@ -1,0 +1,76 @@
+using PrdAgent.Core.Models;
+
+namespace PrdAgent.Api.Services;
+
+public static class DocumentSyncSchedule
+{
+    private static readonly TimeZoneInfo SyncTimeZone = ResolveTimeZone();
+
+    public static bool IsDue(DocumentEntry entry, DateTime utcNow)
+    {
+        if (entry.IsPaused)
+            return false;
+
+        if (entry.SyncStatus == DocumentSyncStatus.Syncing)
+            return true;
+
+        if (entry.LastSyncAt == null)
+            return true;
+
+        if (entry.SourceType == DocumentSourceType.GithubDirectory)
+        {
+            var lastLocalDate = TimeZoneInfo.ConvertTimeFromUtc(
+                DateTime.SpecifyKind(entry.LastSyncAt.Value, DateTimeKind.Utc),
+                SyncTimeZone).Date;
+            var nowLocalDate = TimeZoneInfo.ConvertTimeFromUtc(
+                DateTime.SpecifyKind(utcNow, DateTimeKind.Utc),
+                SyncTimeZone).Date;
+            return lastLocalDate < nowLocalDate;
+        }
+
+        return entry.SyncIntervalMinutes > 0 &&
+               entry.LastSyncAt.Value.AddMinutes(entry.SyncIntervalMinutes.Value) <= utcNow;
+    }
+
+    public static DateTime? GetNextSyncAt(DocumentEntry entry)
+    {
+        if (entry.IsPaused)
+            return null;
+
+        if (entry.SourceType == DocumentSourceType.GithubDirectory)
+        {
+            if (!entry.LastSyncAt.HasValue)
+                return entry.CreatedAt;
+
+            var lastLocal = TimeZoneInfo.ConvertTimeFromUtc(
+                DateTime.SpecifyKind(entry.LastSyncAt.Value, DateTimeKind.Utc),
+                SyncTimeZone);
+            var nextLocalMidnight = lastLocal.Date.AddDays(1);
+            return TimeZoneInfo.ConvertTimeToUtc(nextLocalMidnight, SyncTimeZone);
+        }
+
+        if (entry.LastSyncAt.HasValue && entry.SyncIntervalMinutes is > 0)
+            return entry.LastSyncAt.Value.AddMinutes(entry.SyncIntervalMinutes.Value);
+
+        return null;
+    }
+
+    private static TimeZoneInfo ResolveTimeZone()
+    {
+        foreach (var id in new[] { "Asia/Shanghai", "China Standard Time" })
+        {
+            try
+            {
+                return TimeZoneInfo.FindSystemTimeZoneById(id);
+            }
+            catch (TimeZoneNotFoundException)
+            {
+            }
+            catch (InvalidTimeZoneException)
+            {
+            }
+        }
+
+        return TimeZoneInfo.Utc;
+    }
+}

--- a/prd-api/src/PrdAgent.Api/Services/DocumentSyncWorker.cs
+++ b/prd-api/src/PrdAgent.Api/Services/DocumentSyncWorker.cs
@@ -20,9 +20,11 @@ namespace PrdAgent.Api.Services;
 /// </summary>
 public class DocumentSyncWorker : BackgroundService
 {
+    private static readonly TimeSpan SyncLeaseDuration = TimeSpan.FromMinutes(10);
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<DocumentSyncWorker> _logger;
     private readonly IHttpClientFactory _httpClientFactory;
+    private readonly string _instanceId = $"{Environment.MachineName}:{Environment.ProcessId}:{Guid.NewGuid():N}";
 
     /// <summary>每 2 分钟扫描一次待同步条目</summary>
     private static readonly TimeSpan ScanInterval = TimeSpan.FromMinutes(2);
@@ -64,38 +66,31 @@ public class DocumentSyncWorker : BackgroundService
 
         var now = DateTime.UtcNow;
 
-        // 查找需要同步的条目：
-        // 1. 有 SourceUrl 或 SourceType == github_directory
-        // 2. 有 SyncIntervalMinutes > 0
-        // 3. 未被暂停
-        // 4. SyncStatus == Syncing (手动触发) 或 距上次同步已超过间隔
-        var filter = Builders<DocumentEntry>.Filter.And(
-            Builders<DocumentEntry>.Filter.Or(
+        var regularCandidates = await db.DocumentEntries.Find(Builders<DocumentEntry>.Filter.And(
+                Builders<DocumentEntry>.Filter.Ne(e => e.SourceType, DocumentSourceType.GithubDirectory),
                 Builders<DocumentEntry>.Filter.Ne(e => e.SourceUrl, null),
-                Builders<DocumentEntry>.Filter.Eq(e => e.SourceType, DocumentSourceType.GithubDirectory)
-            ),
-            Builders<DocumentEntry>.Filter.Gt(e => e.SyncIntervalMinutes, 0),
-            Builders<DocumentEntry>.Filter.Ne(e => e.IsPaused, true),
-            Builders<DocumentEntry>.Filter.Or(
-                // 手动触发
-                Builders<DocumentEntry>.Filter.Eq(e => e.SyncStatus, DocumentSyncStatus.Syncing),
-                // 从未同步过
-                Builders<DocumentEntry>.Filter.Eq(e => e.LastSyncAt, null),
-                // 已过同步间隔（用 Builders 无法做动态计算，取所有有 SourceUrl 的条目在代码里过滤）
-                Builders<DocumentEntry>.Filter.Lt(e => e.LastSyncAt, now.AddHours(-24))
-            )
-        );
-
-        var candidates = await db.DocumentEntries.Find(filter)
-            .Limit(20) // 每轮最多处理 20 个
+                Builders<DocumentEntry>.Filter.Gt(e => e.SyncIntervalMinutes, 0),
+                Builders<DocumentEntry>.Filter.Ne(e => e.IsPaused, true),
+                Builders<DocumentEntry>.Filter.Or(
+                    Builders<DocumentEntry>.Filter.Eq(e => e.SyncStatus, DocumentSyncStatus.Syncing),
+                    Builders<DocumentEntry>.Filter.Eq(e => e.LastSyncAt, null),
+                    Builders<DocumentEntry>.Filter.Lt(e => e.LastSyncAt, now.AddHours(-24))
+                )))
+            .Limit(50)
             .ToListAsync(ct);
 
-        // 在代码里精确过滤到期的条目
-        var dueEntries = candidates.Where(e =>
-            e.SyncStatus == DocumentSyncStatus.Syncing || // 手动触发
-            e.LastSyncAt == null || // 从未同步
-            (e.SyncIntervalMinutes > 0 && e.LastSyncAt.Value.AddMinutes(e.SyncIntervalMinutes.Value) <= now)
-        ).ToList();
+        var githubCandidates = await db.DocumentEntries.Find(Builders<DocumentEntry>.Filter.And(
+                Builders<DocumentEntry>.Filter.Eq(e => e.SourceType, DocumentSourceType.GithubDirectory),
+                Builders<DocumentEntry>.Filter.Gt(e => e.SyncIntervalMinutes, 0),
+                Builders<DocumentEntry>.Filter.Ne(e => e.IsPaused, true)))
+            .ToListAsync(ct);
+
+        var dueEntries = regularCandidates
+            .Concat(githubCandidates)
+            .Where(e => DocumentSyncSchedule.IsDue(e, now))
+            .DistinctBy(e => e.Id)
+            .Take(20)
+            .ToList();
 
         if (dueEntries.Count == 0) return;
 
@@ -120,12 +115,8 @@ public class DocumentSyncWorker : BackgroundService
         var sw = System.Diagnostics.Stopwatch.StartNew();
         try
         {
-            // 标记为同步中
-            await db.DocumentEntries.UpdateOneAsync(
-                e => e.Id == entry.Id,
-                Builders<DocumentEntry>.Update
-                    .Set(e => e.SyncStatus, DocumentSyncStatus.Syncing),
-                cancellationToken: CancellationToken.None);
+            if (!await TryAcquireSyncLeaseAsync(db, entry, ct))
+                return;
 
             var githubSyncService = new GitHubDirectorySyncService(
                 _scopeFactory.CreateScope().ServiceProvider
@@ -138,7 +129,9 @@ public class DocumentSyncWorker : BackgroundService
                 .Set(e => e.SyncStatus, DocumentSyncStatus.Idle)
                 .Set(e => e.SyncError, null)
                 .Set(e => e.LastSyncAt, DateTime.UtcNow)
-                .Set(e => e.UpdatedAt, DateTime.UtcNow);
+                .Set(e => e.UpdatedAt, DateTime.UtcNow)
+                .Unset(e => e.SyncLeaseOwner)
+                .Unset(e => e.SyncLeaseExpiresAt);
 
             // 只在真的有文件变化时才更新 LastChangedAt
             if (diff.HasChanges)
@@ -188,12 +181,8 @@ public class DocumentSyncWorker : BackgroundService
         var sw = System.Diagnostics.Stopwatch.StartNew();
         try
         {
-            // 标记为同步中
-            await db.DocumentEntries.UpdateOneAsync(
-                e => e.Id == entry.Id,
-                Builders<DocumentEntry>.Update
-                    .Set(e => e.SyncStatus, DocumentSyncStatus.Syncing),
-                cancellationToken: CancellationToken.None);
+            if (!await TryAcquireSyncLeaseAsync(db, entry, ct))
+                return;
 
             // 拉取内容（带条件请求头，避免重复拉取被封控）
             var client = _httpClientFactory.CreateClient("DocumentSync");
@@ -223,7 +212,9 @@ public class DocumentSyncWorker : BackgroundService
                         .Set(e => e.SyncStatus, DocumentSyncStatus.Idle)
                         .Set(e => e.SyncError, null)
                         .Set(e => e.LastSyncAt, DateTime.UtcNow)
-                        .Set(e => e.UpdatedAt, DateTime.UtcNow),
+                        .Set(e => e.UpdatedAt, DateTime.UtcNow)
+                        .Unset(e => e.SyncLeaseOwner)
+                        .Unset(e => e.SyncLeaseExpiresAt),
                     cancellationToken: CancellationToken.None);
                 _logger.LogDebug("[DocumentSyncWorker] {EntryId} returned 304, skipped", entry.Id);
                 return;
@@ -257,7 +248,9 @@ public class DocumentSyncWorker : BackgroundService
                         .Set(e => e.LastSyncAt, DateTime.UtcNow)
                         .Set(e => e.UpdatedAt, DateTime.UtcNow)
                         .Set(e => e.LastETag, newETag)
-                        .Set(e => e.LastModifiedHeader, newLastModified),
+                        .Set(e => e.LastModifiedHeader, newLastModified)
+                        .Unset(e => e.SyncLeaseOwner)
+                        .Unset(e => e.SyncLeaseExpiresAt),
                     cancellationToken: CancellationToken.None);
                 _logger.LogDebug("[DocumentSyncWorker] {EntryId} content hash unchanged, skipped", entry.Id);
                 return;
@@ -287,7 +280,9 @@ public class DocumentSyncWorker : BackgroundService
                     .Set(e => e.UpdatedAt, DateTime.UtcNow)
                     .Set(e => e.ContentHash, newHash)
                     .Set(e => e.LastETag, newETag)
-                    .Set(e => e.LastModifiedHeader, newLastModified),
+                    .Set(e => e.LastModifiedHeader, newLastModified)
+                    .Unset(e => e.SyncLeaseOwner)
+                    .Unset(e => e.SyncLeaseExpiresAt),
                 cancellationToken: CancellationToken.None);
 
             sw.Stop();
@@ -352,7 +347,9 @@ public class DocumentSyncWorker : BackgroundService
                 .Set(e => e.SyncStatus, DocumentSyncStatus.Error)
                 .Set(e => e.SyncError, truncated)
                 .Set(e => e.LastSyncAt, DateTime.UtcNow)
-                .Set(e => e.UpdatedAt, DateTime.UtcNow),
+                .Set(e => e.UpdatedAt, DateTime.UtcNow)
+                .Unset(e => e.SyncLeaseOwner)
+                .Unset(e => e.SyncLeaseExpiresAt),
             cancellationToken: CancellationToken.None);
 
         await db.DocumentSyncLogs.InsertOneAsync(new DocumentSyncLog
@@ -364,5 +361,37 @@ public class DocumentSyncWorker : BackgroundService
             ErrorMessage = truncated,
             DurationMs = durationMs,
         }, cancellationToken: CancellationToken.None);
+    }
+
+    private async Task<bool> TryAcquireSyncLeaseAsync(
+        MongoDbContext db,
+        DocumentEntry entry,
+        CancellationToken ct)
+    {
+        var now = DateTime.UtcNow;
+        var leaseExpiresAt = now.Add(SyncLeaseDuration);
+
+        var filter = Builders<DocumentEntry>.Filter.And(
+            Builders<DocumentEntry>.Filter.Eq(e => e.Id, entry.Id),
+            Builders<DocumentEntry>.Filter.Ne(e => e.IsPaused, true),
+            Builders<DocumentEntry>.Filter.Or(
+                Builders<DocumentEntry>.Filter.Eq(e => e.SyncLeaseOwner, null),
+                Builders<DocumentEntry>.Filter.Lt(e => e.SyncLeaseExpiresAt, now),
+                Builders<DocumentEntry>.Filter.Eq(e => e.SyncLeaseOwner, _instanceId)
+            ));
+
+        var update = Builders<DocumentEntry>.Update
+            .Set(e => e.SyncStatus, DocumentSyncStatus.Syncing)
+            .Set(e => e.SyncLeaseOwner, _instanceId)
+            .Set(e => e.SyncLeaseExpiresAt, leaseExpiresAt);
+
+        var result = await db.DocumentEntries.UpdateOneAsync(filter, update, cancellationToken: ct);
+        if (result.ModifiedCount == 0)
+        {
+            _logger.LogDebug("[DocumentSyncWorker] Lease busy for {EntryId}, skipped on {InstanceId}", entry.Id, _instanceId);
+            return false;
+        }
+
+        return true;
     }
 }

--- a/prd-api/src/PrdAgent.Core/Models/DocumentEntry.cs
+++ b/prd-api/src/PrdAgent.Core/Models/DocumentEntry.cs
@@ -47,6 +47,12 @@ public class DocumentEntry
     /// <summary>上传/创建者 UserId</summary>
     public string CreatedBy { get; set; } = string.Empty;
 
+    /// <summary>最近一次更新者 UserId（为空时表示尚未有单独更新记录）</summary>
+    public string? UpdatedBy { get; set; }
+
+    /// <summary>最近一次更新者显示名（冗余，便于前端直接展示）</summary>
+    public string? UpdatedByName { get; set; }
+
     /// <summary>文档正文的文本索引（用于内容搜索，截取前 2000 字符存入 MongoDB）</summary>
     public string? ContentIndex { get; set; }
 

--- a/prd-api/src/PrdAgent.Core/Models/DocumentEntry.cs
+++ b/prd-api/src/PrdAgent.Core/Models/DocumentEntry.cs
@@ -76,6 +76,12 @@ public class DocumentEntry
     /// <summary>是否已暂停订阅（true 时 Worker 跳过该条目）</summary>
     public bool IsPaused { get; set; }
 
+    /// <summary>当前同步租约持有者（用于多实例互斥）</summary>
+    public string? SyncLeaseOwner { get; set; }
+
+    /// <summary>当前同步租约过期时间（UTC）</summary>
+    public DateTime? SyncLeaseExpiresAt { get; set; }
+
     /// <summary>正文内容 SHA256（hex），用于跨次同步对比是否变化，避免无意义写库</summary>
     public string? ContentHash { get; set; }
 


### PR DESCRIPTION
## Summary
- add document tags editing and tag display in the document store UI
- make the published action jump to the public library page and keep unpublish as a separate action
- show document update time and updater in the preview header
- persist `updatedBy` and `updatedByName` in document entry updates
- change GitHub directory sync to `first sync immediately, then once after local midnight`
- add per-entry sync lease fields so only one CDS instance syncs a subscription at a time
- align subscription `nextSyncAt` with the new daily GitHub sync schedule

## Validation
- `pnpm eslint src/components/doc-browser/DocBrowser.tsx src/pages/document-store/DocumentStorePage.tsx`
- CDS preview deploy on `codex-document-store-published-link`
- preview URL responded `HTTP 200`
- authenticated smoke passed:
  - `GET /api/users?pageSize=3`
  - `GET /api/document-store/stores?page=1&pageSize=2`

## Notes
- local `dotnet build` did not produce a usable result in the current environment because restore/build stalled, so runtime verification was done through CDS deploy + smoke instead.