### PR TITLE
Add image generation metrics & fix model health probe for generation models

### DIFF
--- a/changelogs/2026-04-16_fix-probe-add-image-stats.md
+++ b/changelogs/2026-04-16_fix-probe-add-image-stats.md
@@ -1,0 +1,3 @@
+| fix | prd-api | 修复模型探针对 generation 类型永远失败的设计缺陷，跳过图片生成池探活，默认间隔调整为 180s/600s |
+| feat | prd-api | 团队排行榜新增视觉生图、文学配图、上传参考图三个用量维度（image_gen_runs + upload_artifacts） |
+| feat | prd-admin | 排行榜前端新增 image-gen-visual / image-gen-literary / image-upload 三列维度展示 |

--- a/changelogs/2026-04-16_fix-probe-add-image-stats.md
+++ b/changelogs/2026-04-16_fix-probe-add-image-stats.md
@@ -1,3 +1,4 @@
 | fix | prd-api | 修复模型探针对 generation 类型永远失败的设计缺陷，跳过图片生成池探活，默认间隔调整为 180s/600s |
 | feat | prd-api | 团队排行榜新增视觉生图、文学配图、上传参考图三个用量维度（image_gen_runs + upload_artifacts） |
 | feat | prd-admin | 排行榜前端新增 image-gen-visual / image-gen-literary / image-upload 三列维度展示 |
+| fix | prd-api | 探针后台服务默认关闭；PoolHealthTracker 内建 Half-Open 熔断器（5分钟冷却后由真实用户请求自动探活，零后台线程）|

--- a/prd-admin/src/pages/ExecutiveDashboardPage.tsx
+++ b/prd-admin/src/pages/ExecutiveDashboardPage.tsx
@@ -383,11 +383,14 @@ const DIMENSION_META: Record<string, { icon: typeof Bot; color: string; barColor
   'ai-toolbox':       { icon: Zap,           color: D.primary,  barColor: hexAlpha(D.primary, 0.4),   short: '工具箱' },
   'report-agent':     { icon: FileText,      color: D.primary,  barColor: hexAlpha(D.primary, 0.4),   short: '周报' },
   'video-agent':      { icon: Activity,      color: D.primary,  barColor: hexAlpha(D.primary, 0.4),   short: '视频' },
-  'defects-created':  { icon: Bug,           color: D.danger,   barColor: hexAlpha(D.danger, 0.35),   short: '提缺陷' },
-  'defects-resolved': { icon: Bug,           color: D.success,  barColor: hexAlpha(D.success, 0.35),  short: '解缺陷' },
-  'images':           { icon: Image,         color: D.primary,  barColor: hexAlpha(D.primary, 0.4),   short: '图片' },
-  'workflows':        { icon: Zap,           color: D.primary,  barColor: hexAlpha(D.primary, 0.35),  short: '工作流' },
-  'arena':            { icon: Users,         color: D.primary,  barColor: hexAlpha(D.primary, 0.35),  short: '竞技场' },
+  'defects-created':    { icon: Bug,           color: D.danger,   barColor: hexAlpha(D.danger, 0.35),   short: '提缺陷' },
+  'defects-resolved':   { icon: Bug,           color: D.success,  barColor: hexAlpha(D.success, 0.35),  short: '解缺陷' },
+  'images':             { icon: Image,         color: D.primary,  barColor: hexAlpha(D.primary, 0.4),   short: '图片合计' },
+  'image-gen-visual':   { icon: Image,         color: D.primary,  barColor: hexAlpha(D.primary, 0.45),  short: '视觉生图' },
+  'image-gen-literary': { icon: Image,         color: D.primary,  barColor: hexAlpha(D.primary, 0.4),   short: '文学配图' },
+  'image-upload':       { icon: Image,         color: D.primary,  barColor: hexAlpha(D.primary, 0.35),  short: '上传参考图' },
+  'workflows':          { icon: Zap,           color: D.primary,  barColor: hexAlpha(D.primary, 0.35),  short: '工作流' },
+  'arena':              { icon: Users,         color: D.primary,  barColor: hexAlpha(D.primary, 0.35),  short: '竞技场' },
 };
 
 

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ExecutiveController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ExecutiveController.cs
@@ -522,7 +522,7 @@ public class ExecutiveController : ControllerBase
             .GroupBy(d => d.ResolvedById!)
             .ToDictionary(g => g.Key, g => g.Count());
 
-        // --- 图片生成 ---
+        // --- 图片生成（合计，所有来源）---
         var imgItems = await _db.ImageAssets
             .Find(r => r.CreatedAt >= periodStart)
             .Project(r => new { r.OwnerUserId })
@@ -530,6 +530,40 @@ public class ExecutiveController : ControllerBase
         var imageByUser = imgItems
             .Where(r => !string.IsNullOrEmpty(r.OwnerUserId) && userIds.Contains(r.OwnerUserId))
             .GroupBy(r => r.OwnerUserId)
+            .ToDictionary(g => g.Key, g => g.Count());
+
+        // --- 视觉创作 AI 生图（image_gen_runs AppKey=visual-agent, Completed）---
+        var visualGenItems = await _db.ImageGenRuns
+            .Find(r => r.CreatedAt >= periodStart
+                    && r.AppKey == "visual-agent"
+                    && r.Status == ImageGenRunStatus.Completed)
+            .Project(r => new { r.OwnerAdminId })
+            .ToListAsync();
+        var visualGenByUser = visualGenItems
+            .Where(r => !string.IsNullOrEmpty(r.OwnerAdminId) && userIds.Contains(r.OwnerAdminId))
+            .GroupBy(r => r.OwnerAdminId)
+            .ToDictionary(g => g.Key, g => g.Count());
+
+        // --- 文学创作配图（image_gen_runs AppKey=literary-agent, Completed）---
+        var literaryGenItems = await _db.ImageGenRuns
+            .Find(r => r.CreatedAt >= periodStart
+                    && r.AppKey == "literary-agent"
+                    && r.Status == ImageGenRunStatus.Completed)
+            .Project(r => new { r.OwnerAdminId })
+            .ToListAsync();
+        var literaryGenByUser = literaryGenItems
+            .Where(r => !string.IsNullOrEmpty(r.OwnerAdminId) && userIds.Contains(r.OwnerAdminId))
+            .GroupBy(r => r.OwnerAdminId)
+            .ToDictionary(g => g.Key, g => g.Count());
+
+        // --- 上传参考图（upload_artifacts Kind=input_image）---
+        var uploadItems = await _db.UploadArtifacts
+            .Find(r => r.CreatedAt >= periodStart && r.Kind == "input_image")
+            .Project(r => new { r.CreatedByAdminId })
+            .ToListAsync();
+        var uploadByUser = uploadItems
+            .Where(r => !string.IsNullOrEmpty(r.CreatedByAdminId) && userIds.Contains(r.CreatedByAdminId))
+            .GroupBy(r => r.CreatedByAdminId)
             .ToDictionary(g => g.Key, g => g.Count());
 
         // --- 工作流执行 ---
@@ -579,7 +613,10 @@ public class ExecutiveController : ControllerBase
 
         dimensions.Add(new { key = "defects-created", name = "缺陷提交", category = "activity", values = defectsCreatedByUser });
         dimensions.Add(new { key = "defects-resolved", name = "缺陷解决", category = "activity", values = defectsResolvedByUser });
-        dimensions.Add(new { key = "images", name = "图片生成", category = "activity", values = imageByUser });
+        dimensions.Add(new { key = "images", name = "图片合计", category = "activity", values = imageByUser });
+        dimensions.Add(new { key = "image-gen-visual", name = "视觉生图", category = "image", values = visualGenByUser });
+        dimensions.Add(new { key = "image-gen-literary", name = "文学配图", category = "image", values = literaryGenByUser });
+        dimensions.Add(new { key = "image-upload", name = "上传参考图", category = "image", values = uploadByUser });
         dimensions.Add(new { key = "workflows", name = "工作流执行", category = "activity", values = workflowByUser });
         dimensions.Add(new { key = "arena", name = "竞技场对战", category = "activity", values = arenaByUser });
 

--- a/prd-api/src/PrdAgent.Infrastructure/ModelPool/ModelPoolHealthProbeService.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/ModelPool/ModelPoolHealthProbeService.cs
@@ -42,7 +42,14 @@ public sealed class ModelPoolHealthProbeService : BackgroundService
         _config = config;
     }
 
-    private bool Enabled => _config.GetValue("ModelPool:HealthProbe:Enabled", true);
+    /// <summary>
+    /// 后台探针默认关闭。
+    /// 恢复机制已由 PoolHealthTracker 的 Half-Open 逻辑内建：
+    /// Unavailable 端点在冷却时间（HalfOpenCooldownSeconds，默认5分钟）到达后，
+    /// 下一个真实用户请求会自动充当探针，无需后台线程。
+    /// 仅当需要主动感知恢复（用户量极低、恢复时效要求高）时才开启此服务。
+    /// </summary>
+    private bool Enabled => _config.GetValue("ModelPool:HealthProbe:Enabled", false);
     private int IntervalSeconds => _config.GetValue("ModelPool:HealthProbe:IntervalSeconds", 180);
     private int CooldownSeconds => _config.GetValue("ModelPool:HealthProbe:CooldownSeconds", 600);
     private int ProbeTimeoutSeconds => _config.GetValue("ModelPool:HealthProbe:ProbeTimeoutSeconds", 15);

--- a/prd-api/src/PrdAgent.Infrastructure/ModelPool/ModelPoolHealthProbeService.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/ModelPool/ModelPoolHealthProbeService.cs
@@ -43,10 +43,26 @@ public sealed class ModelPoolHealthProbeService : BackgroundService
     }
 
     private bool Enabled => _config.GetValue("ModelPool:HealthProbe:Enabled", true);
-    private int IntervalSeconds => _config.GetValue("ModelPool:HealthProbe:IntervalSeconds", 60);
-    private int CooldownSeconds => _config.GetValue("ModelPool:HealthProbe:CooldownSeconds", 120);
+    private int IntervalSeconds => _config.GetValue("ModelPool:HealthProbe:IntervalSeconds", 180);
+    private int CooldownSeconds => _config.GetValue("ModelPool:HealthProbe:CooldownSeconds", 600);
     private int ProbeTimeoutSeconds => _config.GetValue("ModelPool:HealthProbe:ProbeTimeoutSeconds", 15);
     private int MaxConcurrentProbes => _config.GetValue("ModelPool:HealthProbe:MaxConcurrentProbes", 5);
+
+    /// <summary>
+    /// 跳过探活的模型类型列表（逗号分隔）。
+    /// 默认跳过 generation（图片生成）：图片生成 API 使用 /v1/images/generations 端点，
+    /// 无法通过 chat completions 格式探活，否则探针永远失败 → 模型永远 Unhealthy → 无限重试。
+    /// </summary>
+    private HashSet<string> SkipModelTypes
+    {
+        get
+        {
+            var raw = _config.GetValue("ModelPool:HealthProbe:SkipModelTypes", "generation");
+            return raw.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                      .Select(s => s.ToLowerInvariant())
+                      .ToHashSet();
+        }
+    }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -56,9 +72,10 @@ public sealed class ModelPoolHealthProbeService : BackgroundService
             return;
         }
 
+        var skipTypes = SkipModelTypes;
         _logger.LogInformation(
-            "[HealthProbe] 探活服务已启动: Interval={Interval}s, Cooldown={Cooldown}s, MaxConcurrent={Max}",
-            IntervalSeconds, CooldownSeconds, MaxConcurrentProbes);
+            "[HealthProbe] 探活服务已启动: Interval={Interval}s, Cooldown={Cooldown}s, MaxConcurrent={Max}, SkipTypes=[{Skip}]",
+            IntervalSeconds, CooldownSeconds, MaxConcurrentProbes, string.Join(",", skipTypes));
 
         // 启动后延迟 30s 再开始，避免启动风暴
         await Task.Delay(TimeSpan.FromSeconds(30), stoppingToken);
@@ -93,10 +110,13 @@ public sealed class ModelPoolHealthProbeService : BackgroundService
         // 查找所有包含不健康模型的模型组
         var allGroups = await db.ModelGroups.Find(_ => true).ToListAsync(ct);
 
+        var skipTypes = SkipModelTypes;
+
         var unhealthyGroups = allGroups
             .Where(g => g.Models?.Any(m =>
                 m.HealthStatus == ModelHealthStatus.Degraded ||
                 m.HealthStatus == ModelHealthStatus.Unavailable) == true)
+            .Where(g => !skipTypes.Contains(g.ModelType?.ToLowerInvariant() ?? ""))
             .ToList();
 
         if (unhealthyGroups.Count == 0)

--- a/prd-api/src/PrdAgent.Infrastructure/ModelPool/PoolHealthTracker.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/ModelPool/PoolHealthTracker.cs
@@ -6,6 +6,13 @@ namespace PrdAgent.Infrastructure.ModelPool;
 /// <summary>
 /// 内存健康追踪器实现
 /// 线程安全，支持并发读写
+///
+/// Half-Open 熔断器设计（无后台探针）：
+/// 当端点进入 Unavailable 状态后，不依赖后台探活任务恢复。
+/// 而是在 IsAvailable() 中：若距上次失败已超过 HalfOpenCooldownSeconds，
+/// 则放行下一个真实用户请求作为探针。请求成功 → RecordSuccess → 恢复 Healthy；
+/// 请求失败 → RecordFailure → 重置冷却计时，再等一轮。
+/// 优点：多实例安全（各实例独立尝试）、零后台线程、不消耗额外配额。
 /// </summary>
 public class PoolHealthTracker : IPoolHealthTracker
 {
@@ -19,6 +26,13 @@ public class PoolHealthTracker : IPoolHealthTracker
 
     /// <summary>延迟滑动窗口大小</summary>
     public int LatencyWindowSize { get; init; } = 20;
+
+    /// <summary>
+    /// Half-Open 冷却时间（秒）。
+    /// Unavailable 端点在距上次失败超过此时间后，允许下一个真实请求通过以探测恢复。
+    /// 默认 300 秒（5 分钟）。设为 0 则禁用 Half-Open（端点一旦 Unavailable 需手动重置）。
+    /// </summary>
+    public int HalfOpenCooldownSeconds { get; init; } = 300;
 
     public void RecordSuccess(string endpointId, long latencyMs)
     {
@@ -146,9 +160,29 @@ public class PoolHealthTracker : IPoolHealthTracker
         }
     }
 
+    /// <summary>
+    /// 判断端点是否可接受请求。
+    /// Healthy / Degraded → 始终可用。
+    /// Unavailable → 正常拒绝；但若距上次失败已超过 HalfOpenCooldownSeconds，
+    ///               放行本次请求（Half-Open 探针），由真实结果决定是否恢复。
+    /// </summary>
     public bool IsAvailable(string endpointId)
     {
-        return GetStatus(endpointId) != EndpointHealthStatus.Unavailable;
+        if (!_health.TryGetValue(endpointId, out var health))
+            return true; // 未知端点默认健康
+
+        if (health.Status != EndpointHealthStatus.Unavailable)
+            return true;
+
+        // Half-Open：冷却时间到则放行一次真实请求作为探针
+        if (HalfOpenCooldownSeconds > 0
+            && health.LastFailedAt.HasValue
+            && (DateTime.UtcNow - health.LastFailedAt.Value).TotalSeconds >= HalfOpenCooldownSeconds)
+        {
+            return true;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/prd-api/src/PrdAgent.Infrastructure/ModelPool/PoolHealthTracker.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/ModelPool/PoolHealthTracker.cs
@@ -43,6 +43,7 @@ public class PoolHealthTracker : IPoolHealthTracker
             health.ConsecutiveFailures = 0;
             health.Status = EndpointHealthStatus.Healthy;
             health.LastSuccessAt = DateTime.UtcNow;
+            health.IsHalfOpenProbing = false;
             health.AddLatency(latencyMs, LatencyWindowSize);
         }
     }
@@ -55,6 +56,7 @@ public class PoolHealthTracker : IPoolHealthTracker
             health.ConsecutiveFailures++;
             health.ConsecutiveSuccesses = 0;
             health.LastFailedAt = DateTime.UtcNow;
+            health.IsHalfOpenProbing = false;
 
             health.Status = health.ConsecutiveFailures >= UnavailableThreshold
                 ? EndpointHealthStatus.Unavailable
@@ -164,7 +166,10 @@ public class PoolHealthTracker : IPoolHealthTracker
     /// 判断端点是否可接受请求。
     /// Healthy / Degraded → 始终可用。
     /// Unavailable → 正常拒绝；但若距上次失败已超过 HalfOpenCooldownSeconds，
-    ///               放行本次请求（Half-Open 探针），由真实结果决定是否恢复。
+    ///               且当前没有其他请求正在探针中（IsHalfOpenProbing），
+    ///               则放行本次请求（Half-Open 探针），由真实结果决定是否恢复。
+    /// 防雪崩：同一时刻只放行一个探针，其他并发请求继续被拒绝，
+    ///         直到探针结果（RecordSuccess/RecordFailure）重置标记。
     /// </summary>
     public bool IsAvailable(string endpointId)
     {
@@ -174,12 +179,20 @@ public class PoolHealthTracker : IPoolHealthTracker
         if (health.Status != EndpointHealthStatus.Unavailable)
             return true;
 
-        // Half-Open：冷却时间到则放行一次真实请求作为探针
+        // Half-Open：冷却时间到且当前无探针在途，放行一次真实请求
         if (HalfOpenCooldownSeconds > 0
             && health.LastFailedAt.HasValue
             && (DateTime.UtcNow - health.LastFailedAt.Value).TotalSeconds >= HalfOpenCooldownSeconds)
         {
-            return true;
+            lock (health)
+            {
+                // 二次检查：若已有探针在途，拒绝本次（防雷群效应）
+                if (!health.IsHalfOpenProbing)
+                {
+                    health.IsHalfOpenProbing = true;
+                    return true;
+                }
+            }
         }
 
         return false;
@@ -195,6 +208,14 @@ public class PoolHealthTracker : IPoolHealthTracker
         public int ConsecutiveSuccesses;
         public DateTime? LastSuccessAt;
         public DateTime? LastFailedAt;
+
+        /// <summary>
+        /// Half-Open 探针锁：true 表示当前已有一个请求被放行作为探针，
+        /// 后续并发请求在探针结果出来前应继续被拒绝，避免雷群效应。
+        /// 由 RecordSuccess / RecordFailure 重置为 false。
+        /// </summary>
+        public bool IsHalfOpenProbing;
+
         public readonly Queue<long> LatencyWindow = new();
 
         public void AddLatency(long latencyMs, int windowSize)

--- a/prd-api/tests/PrdAgent.Tests/PoolHealthTrackerTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/PoolHealthTrackerTests.cs
@@ -1,0 +1,294 @@
+using PrdAgent.Infrastructure.ModelPool;
+using PrdAgent.Infrastructure.ModelPool.Models;
+using Xunit;
+
+namespace PrdAgent.Tests;
+
+/// <summary>
+/// PoolHealthTracker 单元测试（CI 可运行）
+/// 重点验证 Half-Open 熔断器逻辑：
+/// 1. Unavailable 端点在冷却期内应被拒绝
+/// 2. 冷却期到期后第一个请求被放行（Half-Open 探针）
+/// 3. 探针放行后，后续并发请求应被拒绝（防雷群效应）
+/// 4. RecordSuccess / RecordFailure 均会重置探针标志
+/// </summary>
+public class PoolHealthTrackerTests
+{
+    private const string EndpointId = "platform-1:model-gpt4";
+
+    // ─── 基础状态测试 ─────────────────────────────────────────────
+
+    [Fact]
+    public void UnknownEndpoint_IsAvailable_ReturnsTrue()
+    {
+        var tracker = new PoolHealthTracker();
+        Assert.True(tracker.IsAvailable("does-not-exist"));
+    }
+
+    [Fact]
+    public void HealthyEndpoint_IsAvailable_ReturnsTrue()
+    {
+        var tracker = new PoolHealthTracker();
+        tracker.RecordSuccess(EndpointId, 100);
+        Assert.True(tracker.IsAvailable(EndpointId));
+    }
+
+    [Fact]
+    public void DegradedEndpoint_IsAvailable_ReturnsTrue()
+    {
+        var tracker = new PoolHealthTracker { DegradeThreshold = 2, UnavailableThreshold = 5 };
+        tracker.RecordFailure(EndpointId);
+        tracker.RecordFailure(EndpointId);
+        tracker.RecordFailure(EndpointId);
+        Assert.Equal(EndpointHealthStatus.Degraded, tracker.GetStatus(EndpointId));
+        Assert.True(tracker.IsAvailable(EndpointId));
+    }
+
+    [Fact]
+    public void UnavailableEndpoint_IsAvailable_ReturnsFalse()
+    {
+        var tracker = new PoolHealthTracker { UnavailableThreshold = 3, HalfOpenCooldownSeconds = 300 };
+        tracker.RecordFailure(EndpointId);
+        tracker.RecordFailure(EndpointId);
+        tracker.RecordFailure(EndpointId);
+        Assert.Equal(EndpointHealthStatus.Unavailable, tracker.GetStatus(EndpointId));
+        Assert.False(tracker.IsAvailable(EndpointId));
+    }
+
+    // ─── Half-Open 核心逻辑 ───────────────────────────────────────
+
+    [Fact]
+    public void HalfOpen_Disabled_UnavailableAlwaysRejected()
+    {
+        // HalfOpenCooldownSeconds = 0 → 禁用 Half-Open，端点一旦 Unavailable 就不再自动恢复
+        var tracker = new PoolHealthTracker { UnavailableThreshold = 1, HalfOpenCooldownSeconds = 0 };
+        tracker.RecordFailure(EndpointId);
+        Assert.Equal(EndpointHealthStatus.Unavailable, tracker.GetStatus(EndpointId));
+
+        // 即使等很久也不应放行
+        Assert.False(tracker.IsAvailable(EndpointId));
+    }
+
+    [Fact]
+    public void HalfOpen_CooldownNotExpired_StillRejected()
+    {
+        // 使用很长的冷却期，模拟"尚未到期"
+        var tracker = new PoolHealthTracker { UnavailableThreshold = 1, HalfOpenCooldownSeconds = 3600 };
+        tracker.RecordFailure(EndpointId);
+        Assert.False(tracker.IsAvailable(EndpointId));
+    }
+
+    [Fact]
+    public void HalfOpen_CooldownExpired_FirstRequestAllowed()
+    {
+        // 冷却期设为 0 秒（已过期），应放行第一个请求
+        var tracker = new PoolHealthTracker { UnavailableThreshold = 1, HalfOpenCooldownSeconds = 1 };
+        tracker.RecordFailure(EndpointId);
+
+        // 手动把 LastFailedAt 设为很久以前（模拟冷却期到期）
+        SimulateExpiredCooldown(tracker, EndpointId);
+
+        Assert.True(tracker.IsAvailable(EndpointId));
+    }
+
+    [Fact]
+    public void HalfOpen_OnlyOneProbeAllowed_SubsequentRequestsRejected()
+    {
+        // 关键测试：防雷群效应
+        // 冷却期到期后，第一个请求放行，后续并发请求应被拒绝
+        var tracker = new PoolHealthTracker { UnavailableThreshold = 1, HalfOpenCooldownSeconds = 1 };
+        tracker.RecordFailure(EndpointId);
+        SimulateExpiredCooldown(tracker, EndpointId);
+
+        // 第一个请求：放行（Half-Open 探针）
+        bool first = tracker.IsAvailable(EndpointId);
+        // 第二个请求（并发）：应被拒绝
+        bool second = tracker.IsAvailable(EndpointId);
+        // 第三个请求（并发）：应被拒绝
+        bool third = tracker.IsAvailable(EndpointId);
+
+        Assert.True(first, "第一个请求应被放行作为 Half-Open 探针");
+        Assert.False(second, "探针在途时第二个请求应被拒绝（防雷群）");
+        Assert.False(third, "探针在途时第三个请求应被拒绝（防雷群）");
+    }
+
+    [Fact]
+    public void HalfOpen_AfterProbeSuccess_NewProbeAllowed()
+    {
+        // 探针成功（RecordSuccess）后重置标志，下次冷却到期可再放行
+        var tracker = new PoolHealthTracker { UnavailableThreshold = 1, HalfOpenCooldownSeconds = 1 };
+        tracker.RecordFailure(EndpointId);
+        SimulateExpiredCooldown(tracker, EndpointId);
+
+        // 第一轮探针放行
+        bool probe1 = tracker.IsAvailable(EndpointId);
+        Assert.True(probe1);
+
+        // 探针成功 → 端点恢复 Healthy，重置 IsHalfOpenProbing
+        tracker.RecordSuccess(EndpointId, 50);
+        Assert.Equal(EndpointHealthStatus.Healthy, tracker.GetStatus(EndpointId));
+
+        // 现在端点是 Healthy，应可用
+        Assert.True(tracker.IsAvailable(EndpointId));
+    }
+
+    [Fact]
+    public void HalfOpen_AfterProbeFailure_ProbeResetAllowsNextRound()
+    {
+        // 探针失败（RecordFailure）后重置标志，等下次冷却再到期
+        var tracker = new PoolHealthTracker { UnavailableThreshold = 1, HalfOpenCooldownSeconds = 1 };
+        tracker.RecordFailure(EndpointId);
+        SimulateExpiredCooldown(tracker, EndpointId);
+
+        // 第一轮探针放行
+        bool probe1 = tracker.IsAvailable(EndpointId);
+        Assert.True(probe1);
+
+        // 此时还有探针在途（IsHalfOpenProbing=true），应被拒绝
+        Assert.False(tracker.IsAvailable(EndpointId));
+
+        // 探针失败（端点仍然 Unavailable）
+        tracker.RecordFailure(EndpointId);
+        Assert.Equal(EndpointHealthStatus.Unavailable, tracker.GetStatus(EndpointId));
+
+        // 探针标志已重置，但 LastFailedAt 更新为刚才——冷却期重启，此时应再次被拒绝
+        Assert.False(tracker.IsAvailable(EndpointId));
+
+        // 再次模拟冷却期到期，应该能放行新一轮探针
+        SimulateExpiredCooldown(tracker, EndpointId);
+        Assert.True(tracker.IsAvailable(EndpointId), "新一轮冷却期到期后应放行新探针");
+    }
+
+    // ─── 并发场景（多线程同时检查）──────────────────────────────────
+
+    [Fact]
+    public void HalfOpen_ConcurrentRequests_ExactlyOneProbePasses()
+    {
+        // 模拟 100 个并发请求同时到达，只有 1 个应被放行
+        var tracker = new PoolHealthTracker { UnavailableThreshold = 1, HalfOpenCooldownSeconds = 1 };
+        tracker.RecordFailure(EndpointId);
+        SimulateExpiredCooldown(tracker, EndpointId);
+
+        const int concurrentCount = 100;
+        var results = new bool[concurrentCount];
+
+        Parallel.For(0, concurrentCount, i =>
+        {
+            results[i] = tracker.IsAvailable(EndpointId);
+        });
+
+        int allowedCount = results.Count(r => r);
+        Assert.Equal(1, allowedCount);
+    }
+
+    // ─── 状态指标测试 ─────────────────────────────────────────────
+
+    [Fact]
+    public void RecordSuccess_ResetsConsecutiveFailures()
+    {
+        var tracker = new PoolHealthTracker { DegradeThreshold = 2, UnavailableThreshold = 5 };
+        tracker.RecordFailure(EndpointId);
+        tracker.RecordFailure(EndpointId);
+        tracker.RecordSuccess(EndpointId, 100);
+
+        Assert.Equal(0, tracker.GetConsecutiveFailures(EndpointId));
+        Assert.Equal(EndpointHealthStatus.Healthy, tracker.GetStatus(EndpointId));
+    }
+
+    [Fact]
+    public void GetHealthScore_Healthy_Returns100()
+    {
+        var tracker = new PoolHealthTracker();
+        tracker.RecordSuccess(EndpointId, 100);
+        Assert.Equal(100, tracker.GetHealthScore(EndpointId));
+    }
+
+    [Fact]
+    public void GetHealthScore_Unavailable_Returns0()
+    {
+        var tracker = new PoolHealthTracker { UnavailableThreshold = 1 };
+        tracker.RecordFailure(EndpointId);
+        Assert.Equal(0, tracker.GetHealthScore(EndpointId));
+    }
+
+    [Fact]
+    public void ResetHealth_MakesEndpointHealthy()
+    {
+        var tracker = new PoolHealthTracker { UnavailableThreshold = 1 };
+        tracker.RecordFailure(EndpointId);
+        Assert.Equal(EndpointHealthStatus.Unavailable, tracker.GetStatus(EndpointId));
+
+        tracker.ResetHealth(EndpointId);
+        Assert.Equal(EndpointHealthStatus.Healthy, tracker.GetStatus(EndpointId));
+        Assert.True(tracker.IsAvailable(EndpointId));
+    }
+
+    [Fact]
+    public void ResetAll_MakesAllEndpointsHealthy()
+    {
+        var tracker = new PoolHealthTracker { UnavailableThreshold = 1 };
+        tracker.RecordFailure("ep-1");
+        tracker.RecordFailure("ep-2");
+        tracker.RecordFailure("ep-3");
+
+        tracker.ResetAll();
+
+        Assert.Equal(EndpointHealthStatus.Healthy, tracker.GetStatus("ep-1"));
+        Assert.Equal(EndpointHealthStatus.Healthy, tracker.GetStatus("ep-2"));
+        Assert.Equal(EndpointHealthStatus.Healthy, tracker.GetStatus("ep-3"));
+    }
+
+    [Fact]
+    public void GetAverageLatency_ReturnsCorrectAverage()
+    {
+        var tracker = new PoolHealthTracker { LatencyWindowSize = 5 };
+        tracker.RecordSuccess(EndpointId, 100);
+        tracker.RecordSuccess(EndpointId, 200);
+        tracker.RecordSuccess(EndpointId, 300);
+
+        var avg = tracker.GetAverageLatencyMs(EndpointId);
+        Assert.Equal(200.0, avg, precision: 1);
+    }
+
+    [Fact]
+    public void LatencyWindow_ExceedsCapacity_OldestDropped()
+    {
+        var tracker = new PoolHealthTracker { LatencyWindowSize = 3 };
+        tracker.RecordSuccess(EndpointId, 1000); // 会被淘汰
+        tracker.RecordSuccess(EndpointId, 100);
+        tracker.RecordSuccess(EndpointId, 200);
+        tracker.RecordSuccess(EndpointId, 300); // 此时窗口 = [100, 200, 300]
+
+        var avg = tracker.GetAverageLatencyMs(EndpointId);
+        Assert.Equal(200.0, avg, precision: 1);
+    }
+
+    // ─── 辅助方法 ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// 通过反射将端点的 LastFailedAt 设置为足够早的时间，模拟冷却期已到期。
+    /// 必须在 RecordFailure 之后调用（确保字典中已有该端点的条目）。
+    /// </summary>
+    private static void SimulateExpiredCooldown(PoolHealthTracker tracker, string endpointId)
+    {
+        // 1. 获取私有字段 _health（ConcurrentDictionary<string, EndpointHealth>）
+        var healthField = typeof(PoolHealthTracker)
+            .GetField("_health", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+
+        var dict = healthField.GetValue(tracker)!; // object，实际是 ConcurrentDictionary<string, EndpointHealth>
+
+        // 2. 通过反射调用 TryGetValue（避免因内部类型不可见无法直接强转）
+        var tryGetValue = dict.GetType().GetMethod("TryGetValue")!;
+        var args = new object?[] { endpointId, null };
+        bool found = (bool)tryGetValue.Invoke(dict, args)!;
+        if (!found) return;
+
+        var healthObj = args[1]!; // EndpointHealth 实例
+
+        // 3. 设置 LastFailedAt 为 1 小时前，确保任何冷却期都已到期
+        var lastFailedAtField = healthObj.GetType()
+            .GetField("LastFailedAt", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance)!;
+
+        lastFailedAtField.SetValue(healthObj, (DateTime?)DateTime.UtcNow.AddHours(-1));
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds granular image generation metrics to the executive leaderboard and fixes a design flaw in the model health probe service that causes generation-type models to be permanently marked as unhealthy.

## Key Changes

### Backend (prd-api)
- **Model Health Probe Fix**: Added `SkipModelTypes` configuration to skip health probing for generation models, which cannot be tested via chat completions endpoints. Defaults to skipping "generation" type models to prevent infinite retry loops.
- **Health Probe Tuning**: Increased default probe interval from 60s to 180s and cooldown from 120s to 600s to reduce unnecessary probing overhead.
- **Leaderboard Metrics**: Added three new image-related dimensions to the executive leaderboard:
  - `image-gen-visual`: Visual creation AI image generation (ImageGenRuns with AppKey="visual-agent")
  - `image-gen-literary`: Literary creation image generation (ImageGenRuns with AppKey="literary-agent")
  - `image-upload`: Reference image uploads (UploadArtifacts with Kind="input_image")
- Renamed existing "图片生成" metric to "图片合计" to clarify it represents all image sources combined.

### Frontend (prd-admin)
- Updated `DIMENSION_META` to include metadata for the three new image metrics with appropriate icons and colors.
- Updated the existing "images" dimension label from "图片" to "图片合计".

## Implementation Details
- All new metrics filter by `CreatedAt >= periodStart` and only include records from tracked users.
- Visual and literary generation metrics use `OwnerAdminId` field; upload metrics use `CreatedByAdminId`.
- New metrics are categorized under "image" category while existing metrics remain in "activity" category.
- Health probe skip list is configurable via `ModelPool:HealthProbe:SkipModelTypes` config setting.

https://claude.ai/code/session_01GhH9E3KmGYorg2x6TrNKLe