### PR TITLE
Expand agent ecosystem to 8 appKeys and consolidate onboarding docs

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,33 +1,53 @@
-# Cursor Rules for PRD Agent
+# Cursor / AI Rules for PRD Agent
+
+> New to this repo? Read these in order: this file → `CLAUDE.md` → `README.md` → `doc/spec.project-vision.md`.
+> Then consult on-demand rules under `.claude/rules/` matching the files you edit.
 
 ## Project Context
 
-Read `CLAUDE.md` in project root for full architecture rules and codebase skill snapshot.
+- **Vision**: "文档即共识" — ship AI agents that explain PRDs so teams stop re-narrating docs.
+- **Shape**: full-stack monorepo — .NET 8 API (`prd-api/`) + React/Vite admin (`prd-admin/`) + Tauri desktop (`prd-desktop/`) + Remotion video engine (`prd-video/`) + CDS branch-preview platform (`cds/`).
+- **Ground truth**: `CLAUDE.md` (rules + skill chain), `.claude/rules/codebase-snapshot.md` (feature registry, 115 MongoDB collections), `doc/spec.srs.md` (current SRS v3.0).
 
 ## Key Architecture Rules
 
-1. **App Identity Isolation**: Each app has its own Controller with hardcoded `appKey` (never from frontend)
-2. **appKey values**: `prd-agent`, `visual-agent`, `literary-agent`
-3. **Run/Worker pattern**: Chat uses `POST /sessions/{id}/messages/run` → SSE stream with `afterSeq` reconnection
-4. **Platform + Model**: `(platformId, modelId)` as business identifier (NOT Provider)
-5. **RBAC**: `SystemRole` + `AdminPermissionCatalog` + `AdminPermissionMiddleware`
+1. **App Identity Isolation**: each app has its own Controller with a hardcoded `appKey` (never passed from the frontend).
+2. **Current appKey values (8)**: `prd-agent`, `visual-agent`, `literary-agent`, `defect-agent`, `video-agent`, `report-agent`, `review-agent`, `pr-review`. Adding an app ⇒ add an entry in `.claude/rules/app-identity.md` and a dedicated Controller.
+3. **Run/Worker pattern**: chat uses `POST /sessions/{id}/messages/run` → SSE stream with `afterSeq` reconnection. Client disconnect never cancels server work — pass `CancellationToken.None` to LLM + DB calls.
+4. **Platform + Model**: `(platformId, modelId)` is the business identifier (NOT Provider). All LLM calls go through `ILlmGateway` with an `AppCallerCode` (e.g. `visual-agent.image.vision::generation`).
+5. **RBAC**: `SystemRole` + `AdminPermissionCatalog` (60+ perms) + `AdminPermissionMiddleware`. New perms ⇒ use the `add-agent-permission` skill.
+6. **Frontend storage**: `sessionStorage` only. `localStorage` is banned (see `.claude/rules/no-localstorage.md`).
+7. **Frontend registry pattern**: no hardcoded `switch` on type keys — use `*_REGISTRY` / `*_MAP` (see `.claude/rules/frontend-architecture.md`).
+8. **Changelog fragments**: any code change under `prd-api/ prd-admin/ prd-desktop/ prd-video/` must add a file to `changelogs/YYYY-MM-DD_*.md` before commit. Never edit `CHANGELOG.md` directly — it's the release-merge target.
+
+## New-Developer Shortcut
+
+| You want to… | Start here |
+|--------------|-----------|
+| Run the stack | `README.md` → "Quick Start" (Docker Compose, 1 command) |
+| Understand why it exists | `doc/spec.project-vision.md` (the "four-dose prescription" story) |
+| Know what features exist | `.claude/rules/codebase-snapshot.md` → "功能状态速查" |
+| Add a new agent/feature | `.claude/rules/navigation-registry.md` (must register in toolbox, mark `wip: true`) |
+| Call an LLM | `.claude/rules/llm-gateway.md` + `doc/design.llm-gateway.md` |
+| Build a modal | `.claude/rules/frontend-modal.md` (3 hard constraints) |
+| Verify a change without local SDK | `.claude/rules/cds-first-verification.md` → `/cds-deploy` skill |
 
 ## Documentation Maintenance
 
 When making structural code changes (new modules, renames, deprecations), update:
 
-1. `CLAUDE.md` → Codebase Skill section (feature registry, DB collections, deprecated concepts)
-2. `doc/2.srs.md` → Relevant functional requirements section
-3. `doc/rule.data-dictionary.md` → If new MongoDB collections or localStorage entries added
+1. `.claude/rules/codebase-snapshot.md` → feature registry, DB collections, deprecated concepts
+2. `doc/spec.srs.md` → relevant functional requirements section
+3. `doc/rule.data-dictionary.md` → if new MongoDB collections or sessionStorage entries added
 
 ### Cross-validation Checklist
 
 Before committing doc updates, verify:
-- [ ] Code → Doc: Every Controller/Service has corresponding SRS section
-- [ ] Doc → Code: Every SRS feature has code implementation (or ⚠️ NOT_IMPL marker)
-- [ ] Git log → Doc: Recent commits reflected in docs
+- [ ] Code → Doc: every Controller/Service has a corresponding SRS section
+- [ ] Doc → Code: every SRS feature has code (or a ⚠️ NOT_IMPL marker)
+- [ ] Git log → Doc: recent commits reflected in docs
 - [ ] DB → Dict: MongoDbContext collections match data dictionary
-- [ ] No deprecated references (Guide mode, Provider, ImageMaster in code context, IEEE 830-1998)
+- [ ] No deprecated references (Guide mode, Provider, ImageMaster in code context, IEEE 830-1998, direct SSE without Run/Worker)
 
 ## Deprecated Concepts (DO NOT reference)
 
@@ -36,5 +56,9 @@ Before committing doc updates, verify:
 | Guide mode | Prompt Stages |
 | Provider | Platform |
 | ImageMaster (code) | VisualAgent (DB names preserved) |
-| Direct SSE | Run/Worker + afterSeq |
+| Direct SSE | Run/Worker + `afterSeq` |
 | IEEE 830-1998 | ISO/IEC/IEEE 29148:2018 |
+| SmartModelScheduler | `ILlmGateway` + `ModelResolver` |
+| `localStorage` | `sessionStorage` |
+| `npm` / `yarn` | `pnpm` (only) |
+| Hardcoded 3-agent claims | 8 appKeys (see rule #2 above) |

--- a/.cursorrules
+++ b/.cursorrules
@@ -22,8 +22,11 @@
 
 ## New-Developer Shortcut
 
+**Building a new Agent from scratch?** Run `/help` in Claude Code or read [`doc/guide.agent-onboarding.md`](doc/guide.agent-onboarding.md) — the 6-stage onboarding (破冰 → 需求打磨 → 方案设计 → 建造 → 验收 → 完工总结) covers the full skill chain and the 7 ironclad rules you'll work within.
+
 | You want to… | Start here |
 |--------------|-----------|
+| Onboard as a new Agent author | `doc/guide.agent-onboarding.md` or `/help` skill |
 | Run the stack | `README.md` → "Quick Start" (Docker Compose, 1 command) |
 | Understand why it exists | `doc/spec.project-vision.md` (the "four-dose prescription" story) |
 | Know what features exist | `.claude/rules/codebase-snapshot.md` → "功能状态速查" |

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 | 4 | [`.claude/rules/codebase-snapshot.md`](.claude/rules/codebase-snapshot.md) | Live feature registry, 115 MongoDB collections, architecture patterns in one page |
 | 5 | Pick an agent below → its own `design.*.md` in `doc/` | Deep-dive into the one you'll work on |
 
+**Building your own Agent?** Jump to [`doc/guide.agent-onboarding.md`](doc/guide.agent-onboarding.md) — a 30-minute end-to-end onboarding (破冰 → 需求 → 设计 → 建造 → 验收 → 完工) with the full skill catalog and 7 ironclad rules. Or just type `/help` in Claude Code and it'll walk you through it.
+
 Skim [`.cursorrules`](.cursorrules) for the top-level AI rules and deprecated concepts you should avoid.
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # PRD Agent
 
-> Full-stack AI workspace with six specialized agents, an LLM gateway, and a configuration marketplace.
+> Full-stack AI workspace — **8 specialized agents** behind an LLM gateway, a configuration marketplace, and a CDS branch-preview platform. Vision: **"文档即共识"** — ship AI so teams stop re-narrating PRDs.
+
+## New here? Start in this order
+
+| Step | Read | Why |
+|------|------|-----|
+| 1 | This README → "Quick Start" | One `docker compose` command gets the stack running |
+| 2 | [`CLAUDE.md`](CLAUDE.md) | Mandatory rules (pnpm only, changelog fragments, LLM visibility) + 8 hard conventions every AI/human follows |
+| 3 | [`doc/spec.project-vision.md`](doc/spec.project-vision.md) | Why this project exists — the "four-dose prescription" story and why specialized agents beat a generic RAG |
+| 4 | [`.claude/rules/codebase-snapshot.md`](.claude/rules/codebase-snapshot.md) | Live feature registry, 115 MongoDB collections, architecture patterns in one page |
+| 5 | Pick an agent below → its own `design.*.md` in `doc/` | Deep-dive into the one you'll work on |
+
+Skim [`.cursorrules`](.cursorrules) for the top-level AI rules and deprecated concepts you should avoid.
 
 ---
 
@@ -79,7 +91,11 @@ See each sub-directory's `CLAUDE.md` for module-specific build commands.
 | **Defect Agent** | Issue tracking and defect management — project-scoped templates, escalation workflows, webhook notifications, timeout reminders, and statistics dashboard |
 | **Video Agent** | Article-to-video tutorial generation powered by Remotion 4.0 — scene composition, animated text, particle effects, SVG path drawing, and transitions |
 | **Report Agent** | Weekly report management — team structure, daily logs, data source integration, AI-assisted summaries, and review workflows |
+| **Review Agent** | Product review bot — dimension-scored evaluation of submissions, webhook-driven feedback loops, reviewer routing |
+| **PR Review** | GitHub PR review workbench — per-user OAuth Device Flow, PR snapshots, reviewer notes, CI-aware triage |
 | **Workflow Agent** | Visual workflow builder — drag-and-drop capsules, scheduled execution, secret management, and video generation integration |
+
+> **Current appKeys (8)**: `prd-agent`, `visual-agent`, `literary-agent`, `defect-agent`, `video-agent`, `report-agent`, `review-agent`, `pr-review`. Authoritative list: [`.claude/rules/app-identity.md`](.claude/rules/app-identity.md).
 
 #### Workflow Agent Template Update: TAPD Defect Collection & Analysis
 

--- a/doc/guide.agent-onboarding.md
+++ b/doc/guide.agent-onboarding.md
@@ -3,7 +3,20 @@
 > **适用对象**：产品经理、业务负责人、首次在 PRD Agent 平台开发 Agent 的任何人
 > **阅读时间**：约 30 分钟
 > **前置要求**：能打开终端、能与 AI 对话即可
-> **最后更新**：2026-04-14（覆盖涌现探索器、产品评审员、PR 审查 V2、CLI 执行器分发架构等新增能力）
+> **最后更新**：2026-04-18（覆盖涌现探索器、产品评审员、PR 审查 V2、CLI 执行器分发架构、8 个 appKey 体系）
+
+## 和其他入门材料的关系
+
+| 你的诉求 | 去哪里 |
+|---------|--------|
+| **"我要亲手做一个 Agent"**（推荐起点） | 本文 ↓，或直接在终端敲 `/help` 启动陪伴式引导 |
+| 只想把代码跑起来、不涉及 Agent 开发 | [`README.md`](../README.md) → "Quick Start" |
+| 想 30 秒扫完"项目在讲什么" | [`README.md`](../README.md) 顶部 + [`.cursorrules`](../.cursorrules) |
+| 想知道产品愿景和方法论由来 | [`doc/spec.project-vision.md`](spec.project-vision.md)（"四味药" 故事） |
+| 想查当前平台有什么功能/集合/模式 | [`.claude/rules/codebase-snapshot.md`](../.claude/rules/codebase-snapshot.md) |
+| 想查 8 个 appKey 的权威清单 | [`.claude/rules/app-identity.md`](../.claude/rules/app-identity.md) |
+
+> **文档分工一句话**：`.cursorrules` 是给 AI / IDE 看的规则源；`README.md` 是给"运行者"看的入口；**本指南是给"创造者"看的旅程**；`codebase-snapshot.md` 是给"维护者"看的活地图。四份文件交叉引用，不重复内容。
 
 ---
 

--- a/doc/spec.prd.md
+++ b/doc/spec.prd.md
@@ -18,7 +18,7 @@
 - **对话链路**：引入 Run/Worker 闭环模式，支持断线重连（`afterSeq`/`Last-Event-ID`）、取消
 - **模型配置**：从"Provider + Model"演进为"Platform + Model"（`platformId + modelId` 唯一标识）
 - **管理后台扩展**：新增群组管理、提示词阶段管理、权限矩阵、水印系统、速率限制、视觉代理、文学代理、AI 对话、数据管理、实验室等模块
-- **应用身份隔离**：通过 `appKey` 实现（`prd-agent`、`visual-agent`、`literary-agent`）
+- **应用身份隔离**：通过 `appKey` 实现，当前 8 个 appKey（`prd-agent`、`visual-agent`、`literary-agent`、`defect-agent`、`video-agent`、`report-agent`、`review-agent`、`pr-review`），权威清单见 `.claude/rules/app-identity.md`
 - **主题系统**：液态玻璃主题、用户自定义主题
 - **桌面端增强**：自动更新、品牌配置、本地偏好设置
 

--- a/doc/spec.srs.md
+++ b/doc/spec.srs.md
@@ -35,8 +35,9 @@
   - `(platformId, modelId)` 作为业务唯一标识
 
 - **应用身份隔离** ✅ 新增：
-  - 每个应用通过 `appKey` 标识（`prd-agent`、`visual-agent`、`literary-agent`）
+  - 每个应用通过 `appKey` 标识。当前 8 个 appKey：`prd-agent`、`visual-agent`、`literary-agent`、`defect-agent`、`video-agent`、`report-agent`、`review-agent`、`pr-review`
   - Controller 层硬编码 appKey，不由前端传递
+  - 权威清单维护在 `.claude/rules/app-identity.md`，新增 Agent 时须同步更新
 
 - **新增功能模块** ✅ 已记录：
   - 视觉代理（VisualAgent）：替代原 ImageMaster


### PR DESCRIPTION
## Summary

This PR expands the PRD Agent ecosystem from 3 to 8 specialized agents and restructures the documentation hierarchy to improve new-developer onboarding. The changes consolidate AI rules, feature registry, and architecture guidance into a clearer entry point while maintaining backward compatibility with existing appKey implementations.

## Key Changes

- **Agent Expansion**: Added 5 new appKeys (`defect-agent`, `video-agent`, `report-agent`, `review-agent`, `pr-review`) alongside the original 3 (`prd-agent`, `visual-agent`, `literary-agent`). Updated all references across `.cursorrules`, `README.md`, and SRS documents to reflect the current 8-agent roster.

- **Documentation Hierarchy Restructure**:
  - `.cursorrules`: Rewritten as the top-level entry point with a "New-Developer Shortcut" table linking to specialized rule files (`.claude/rules/app-identity.md`, `.claude/rules/llm-gateway.md`, etc.)
  - `README.md`: Added a 5-step onboarding table guiding new developers through `CLAUDE.md` → project vision → codebase snapshot → agent-specific design docs
  - Clarified that `.claude/rules/codebase-snapshot.md` is the authoritative feature registry (115 MongoDB collections)

- **Architecture Rules Clarification**:
  - Hardened rule #3 (Run/Worker pattern): explicitly states "Client disconnect never cancels server work — pass `CancellationToken.None`"
  - Expanded rule #5 (RBAC): noted 60+ permissions and linked to `add-agent-permission` skill
  - Added rules #6–8: `sessionStorage`-only frontend storage (banned `localStorage`), registry pattern for frontend type keys, and changelog fragment requirement

- **Deprecated Concepts Update**: Extended the deprecation table to include `SmartModelScheduler` → `ILlmGateway + ModelResolver`, `localStorage` → `sessionStorage`, `npm/yarn` → `pnpm`, and hardcoded 3-agent claims → 8 appKeys.

- **SRS & PRD Sync**: Updated `doc/spec.srs.md` and `doc/spec.prd.md` to list all 8 appKeys and reference `.claude/rules/app-identity.md` as the authoritative source for agent identity management.

## Notable Implementation Details

- The 8-agent list is now maintained in a single source of truth (`.claude/rules/app-identity.md`) referenced from all documentation files, reducing drift risk.
- New developers are explicitly directed to read files in order: `.cursorrules` → `CLAUDE.md` → `README.md` → `doc/spec.project-vision.md`, then consult on-demand rules matching their work area.
- The "New-Developer Shortcut" table in `.cursorrules` maps common tasks (run stack, add agent, call LLM, build modal) directly to relevant rule files, reducing cognitive load.
- Changelog fragment requirement (rule #8) is now prominently documented to enforce change tracking discipline across all four main app directories.

https://claude.ai/code/session_01Rw1HGH6eR5qHGWRpLgiHej