### PR TITLE
Fix DocumentSyncWorker host crash from unhandled exceptions

### DIFF
--- a/changelogs/2026-04-18_fix-document-sync-host-crash.md
+++ b/changelogs/2026-04-18_fix-document-sync-host-crash.md
@@ -1,0 +1,2 @@
+| fix | prd-api | 修复 DocumentSyncWorker 因 HttpClient 30s 超时抛 TaskCanceledException 被 catch filter 误判为"关机取消"漏掉，最终拖垮整个 Host 导致无法登录的问题 |
+| fix | prd-api | HostOptions.BackgroundServiceExceptionBehavior 显式设为 Ignore，避免任一 BackgroundService 未捕获异常时整个进程被停 |

--- a/prd-api/src/PrdAgent.Api/Program.cs
+++ b/prd-api/src/PrdAgent.Api/Program.cs
@@ -128,6 +128,14 @@ builder.Services.AddSingleton<IAdminControllerScanner, PrdAgent.Infrastructure.S
 builder.Services.AddSingleton<ILLMRequestContextAccessor, LLMRequestContextAccessor>();
 builder.Services.AddSingleton<LlmRequestLogBackground>();
 builder.Services.AddSingleton<ILlmRequestLogWriter, LlmRequestLogWriter>();
+// BackgroundService 未捕获异常时不要拖垮整个 Host。单个 Worker 崩溃已有
+// ILogger 记录，继续运行其它服务；默认 StopHost 会让 HttpClient 超时这类
+// 瞬时故障变成全站宕机（已在 DocumentSyncWorker 上踩过一次）。
+builder.Services.Configure<HostOptions>(options =>
+{
+    options.BackgroundServiceExceptionBehavior = BackgroundServiceExceptionBehavior.Ignore;
+});
+
 builder.Services.AddHostedService<LlmRequestLogWatchdog>();
 builder.Services.AddHostedService<PrdAgent.Api.Middleware.ApiRequestLogWatchdog>();
 builder.Services.AddHostedService<PrdAgent.Api.Middleware.AiScoreWatchdog>();

--- a/prd-api/src/PrdAgent.Api/Services/DocumentSyncWorker.cs
+++ b/prd-api/src/PrdAgent.Api/Services/DocumentSyncWorker.cs
@@ -51,7 +51,11 @@ public class DocumentSyncWorker : BackgroundService
             {
                 await SyncDueEntriesAsync(stoppingToken);
             }
-            catch (Exception ex) when (ex is not OperationCanceledException)
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
             {
                 _logger.LogError(ex, "[DocumentSyncWorker] Scan cycle failed");
             }
@@ -163,7 +167,11 @@ public class DocumentSyncWorker : BackgroundService
                 "[DocumentSyncWorker] GitHub directory sync completed for {EntryId} (changes={Changes})",
                 entry.Id, diff.HasChanges);
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
         {
             sw.Stop();
             _logger.LogWarning(ex, "[DocumentSyncWorker] GitHub directory sync failed for {EntryId}", entry.Id);
@@ -304,7 +312,11 @@ public class DocumentSyncWorker : BackgroundService
             _logger.LogInformation("[DocumentSyncWorker] Synced entry {EntryId} from {Url}, {Size} chars",
                 entry.Id, entry.SourceUrl, content.Length);
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
         {
             sw.Stop();
             _logger.LogWarning(ex, "[DocumentSyncWorker] Failed to sync entry {EntryId} from {Url}",


### PR DESCRIPTION
## Summary
This PR fixes a critical issue where unhandled exceptions in `DocumentSyncWorker` could crash the entire application host, making it inaccessible. The root cause was improper exception handling that conflated timeout exceptions with cancellation requests, combined with the default host behavior of stopping when background services throw unhandled exceptions.

## Key Changes

- **Improved exception handling in DocumentSyncWorker**: Updated three catch blocks to explicitly distinguish between `OperationCanceledException` (when cancellation is actually requested) and other exceptions. This prevents timeout exceptions (like `TaskCanceledException` from HttpClient 30s timeouts) from being incorrectly treated as graceful shutdowns.

- **Configure BackgroundServiceExceptionBehavior**: Explicitly set `HostOptions.BackgroundServiceExceptionBehavior` to `Ignore` in `Program.cs`. This prevents a single background service failure from stopping the entire host process. Individual worker crashes are still logged, but other services continue running.

## Implementation Details

The exception handling pattern was changed from:
```csharp
catch (Exception ex) when (ex is not OperationCanceledException)
```

To:
```csharp
catch (OperationCanceledException) when (ct.IsCancellationRequested)
{
    throw;
}
catch (Exception ex)
```

This ensures that only genuine cancellation requests are re-thrown, while transient failures (like HTTP timeouts) are properly logged and handled without crashing the host.

This change was applied consistently across three methods in `DocumentSyncWorker`:
- `ExecuteAsync`
- `SyncGitHubDirectoryAsync`
- `SyncEntryAsync`

https://claude.ai/code/session_01LF9dtn812cKqsi4czp9STi