### PR TITLE
feat(llm-gateway): OpenRouter 应用归属 header + 流式观测黑洞修复

### DIFF
--- a/changelogs/2026-04-18_openrouter-app-attribution.md
+++ b/changelogs/2026-04-18_openrouter-app-attribution.md
@@ -1,2 +1,3 @@
 | feat | prd-api | LLM Gateway 对 OpenRouter 上游自动注入 `HTTP-Referer` + `X-Title` header，把 AppCallerCode 映射到 OpenRouter Dashboard 的应用归属维度；按 ApiUrl 域名隔离，不影响 DeepSeek / 通义 / Claude 等其他上游 |
 | fix | prd-api | LLM Gateway 流式请求的传输层异常（HttpClient 超时、连接失败、流中途断连）现在会落 llmrequestlogs 的 statusCode + error，不再被 Watchdog 5 分钟兜底成 `error="TIMEOUT" / dur=300000` 的观测黑洞 |
+| fix | prd-api | LLM Gateway 流式请求上游返回 401/4xx 时，先写日志再 yield Fail chunk；避免 caller 收到 Error chunk 立即 return 释放迭代器，导致 MarkError 被跳过、日志滞留 running 最终被 Watchdog 盖成 TIMEOUT |

--- a/changelogs/2026-04-18_openrouter-app-attribution.md
+++ b/changelogs/2026-04-18_openrouter-app-attribution.md
@@ -1,1 +1,2 @@
 | feat | prd-api | LLM Gateway 对 OpenRouter 上游自动注入 `HTTP-Referer` + `X-Title` header，把 AppCallerCode 映射到 OpenRouter Dashboard 的应用归属维度；按 ApiUrl 域名隔离，不影响 DeepSeek / 通义 / Claude 等其他上游 |
+| fix | prd-api | LLM Gateway 流式请求的传输层异常（HttpClient 超时、连接失败、流中途断连）现在会落 llmrequestlogs 的 statusCode + error，不再被 Watchdog 5 分钟兜底成 `error="TIMEOUT" / dur=300000` 的观测黑洞 |

--- a/changelogs/2026-04-18_openrouter-app-attribution.md
+++ b/changelogs/2026-04-18_openrouter-app-attribution.md
@@ -1,0 +1,1 @@
+| feat | prd-api | LLM Gateway 对 OpenRouter 上游自动注入 `HTTP-Referer` + `X-Title` header，把 AppCallerCode 映射到 OpenRouter Dashboard 的应用归属维度；按 ApiUrl 域名隔离，不影响 DeepSeek / 通义 / Claude 等其他上游 |

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/LlmGateway.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/LlmGateway.cs
@@ -180,12 +180,13 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "[LlmGateway] 请求失败");
+            var (msg, code) = ClassifyTransportException(ex, ct.IsCancellationRequested);
+            _logger.LogError(ex, "[LlmGateway] 请求失败 status={Code}", code);
             if (logId != null)
             {
-                _logWriter?.MarkError(logId, ex.Message);
+                _logWriter?.MarkError(logId, msg, code);
             }
-            return GatewayResponse.Fail("GATEWAY_ERROR", ex.Message);
+            return GatewayResponse.Fail("GATEWAY_ERROR", msg, code);
         }
     }
 
@@ -262,7 +263,39 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
                 resolution.ActualModel,
                 resolution.ActualPlatformName ?? resolution.ActualPlatformId);
 
-            using var response = await httpClient.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead, ct);
+            // 5.1 SendAsync 异常捕获：HttpClient 超时 / 连接失败等传输层异常必须落日志，
+            //     否则日志会滞留 status=running，直到 LlmRequestLogWatchdog 5 分钟后强写
+            //     error="TIMEOUT"、dur=300000，真实错误信息和状态码被彻底吞掉。
+            HttpResponseMessage? rawResponse = null;
+            Exception? sendException = null;
+            try
+            {
+                rawResponse = await httpClient.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead, ct);
+            }
+            catch (Exception ex)
+            {
+                sendException = ex;
+            }
+
+            if (sendException != null)
+            {
+                var (sendMsg, sendCode) = ClassifyTransportException(sendException, ct.IsCancellationRequested);
+                _logger.LogWarning(sendException,
+                    "[LlmGateway] HttpClient.SendAsync 失败 status={Code} model={Model}",
+                    sendCode, resolution.ActualModel);
+                if (logId != null)
+                {
+                    _logWriter?.MarkError(logId, sendMsg, sendCode);
+                }
+                if (!string.IsNullOrWhiteSpace(resolution.ModelGroupId))
+                {
+                    await _modelResolver.RecordFailureAsync(resolution, ct);
+                }
+                yield return GatewayStreamChunk.Fail(sendMsg);
+                yield break;
+            }
+
+            using var response = rawResponse!;
 
             if (!response.IsSuccessStatusCode)
             {
@@ -300,8 +333,47 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
             // Intent 模型类型强制禁止思考输出，其他类型尊重请求方设置
             var effectiveIncludeThinking = IsThinkingEffective(request.IncludeThinking, request.ModelType);
 
-            await foreach (var data in sseReader.ReadEventsAsync(ct))
+            // 6.1 手工迭代 SSE 读取器，把 MoveNextAsync 的传输层异常（上游中途断连、读超时等）
+            //     转成日志 MarkError + Fail chunk；否则异常冒泡出 StreamAsync，日志保持 running，
+            //     Watchdog 5 分钟后兜底成 "TIMEOUT"，真实原因丢失。
+            await using var eventEnum = sseReader.ReadEventsAsync(ct).GetAsyncEnumerator(ct);
+            bool streamAborted = false;
+            string? streamAbortMsg = null;
+            int? streamAbortCode = null;
+
+            while (true)
             {
+                bool hasNext;
+                string data = string.Empty;
+                Exception? readException = null;
+                try
+                {
+                    hasNext = await eventEnum.MoveNextAsync();
+                    if (hasNext)
+                    {
+                        data = eventEnum.Current;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    readException = ex;
+                    hasNext = false;
+                }
+
+                if (readException != null)
+                {
+                    var (readMsg, readCode) = ClassifyTransportException(readException, ct.IsCancellationRequested);
+                    _logger.LogWarning(readException,
+                        "[LlmGateway] 流式读取中断 status={Code} model={Model} firstByteAt={FirstByteAt}",
+                        readCode, resolution.ActualModel, firstByteAt);
+                    streamAborted = true;
+                    streamAbortMsg = readMsg;
+                    streamAbortCode = readCode;
+                    break;
+                }
+
+                if (!hasNext) break;
+
                 // 标记首字节
                 if (firstByteAt == null)
                 {
@@ -394,6 +466,22 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
                 {
                     tokenUsage = chunk.TokenUsage;
                 }
+            }
+
+            // 6.2 流被迫中断时，把真实错误落进日志并推 Fail chunk 出去。
+            //     这条路径必须在 Watchdog 扫到之前写，否则 error 会被覆盖成 "TIMEOUT"。
+            if (streamAborted)
+            {
+                if (logId != null)
+                {
+                    _logWriter?.MarkError(logId, streamAbortMsg!, streamAbortCode);
+                }
+                if (!string.IsNullOrWhiteSpace(resolution.ModelGroupId))
+                {
+                    await _modelResolver.RecordFailureAsync(resolution, ct);
+                }
+                yield return GatewayStreamChunk.Fail(streamAbortMsg!);
+                yield break;
             }
 
             // 刷新 ThinkTagStripper 缓冲区
@@ -892,12 +980,13 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "[LlmGateway.SendRaw] 请求失败");
+            var (msg, code) = ClassifyTransportException(ex, ct.IsCancellationRequested);
+            _logger.LogError(ex, "[LlmGateway.SendRaw] 请求失败 status={Code}", code);
             if (logId != null)
             {
-                _logWriter?.MarkError(logId, ex.Message);
+                _logWriter?.MarkError(logId, msg, code);
             }
-            return GatewayRawResponse.Fail("GATEWAY_ERROR", ex.Message);
+            return GatewayRawResponse.Fail("GATEWAY_ERROR", msg, code);
         }
     }
 
@@ -975,6 +1064,30 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
         {
             httpRequest.Headers.TryAddWithoutValidation("X-Title", appCallerCode);
         }
+    }
+
+    /// <summary>
+    /// 把 HttpClient / 流式读取阶段抛出的异常分类为 (人类可读错误, HTTP 风格状态码)。
+    /// 目的：让 llmrequestlogs 里的 StatusCode + Error 能体现真实故障类型，
+    /// 避免被 Watchdog 5 分钟兜底成 "TIMEOUT"/status=null 的观测黑洞。
+    /// - TaskCanceled / OperationCanceled（非 caller 取消）→ 504（上游超时）
+    /// - HttpRequestException → 502（网络层失败）
+    /// - 其他 → 500
+    /// </summary>
+    private static (string Message, int StatusCode) ClassifyTransportException(Exception ex, bool callerCancelled)
+    {
+        if (callerCancelled)
+        {
+            return ("caller 已取消", 499);
+        }
+
+        return ex switch
+        {
+            TaskCanceledException => ("上游超时未响应（HttpClient timeout）", 504),
+            OperationCanceledException => ("上游超时未响应", 504),
+            HttpRequestException http => ($"网络请求失败：{http.Message}", 502),
+            _ => ($"传输层异常：{ex.Message}", 500)
+        };
     }
 
     /// <summary>

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/LlmGateway.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/LlmGateway.cs
@@ -105,6 +105,7 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
 
             var endpoint = adapter.BuildEndpoint(resolution.ApiUrl!, request.ModelType);
             var httpRequest = adapter.BuildHttpRequest(endpoint, resolution.ApiKey, requestBody, request.EnablePromptCache);
+            ApplyOpenRouterAttribution(httpRequest, resolution.ApiUrl, request.AppCallerCode);
 
             // 4. 写入日志（开始）
             var gatewayResolution = resolution.ToGatewayResolution();
@@ -241,6 +242,7 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
 
             var endpoint = adapter.BuildEndpoint(resolution.ApiUrl!, request.ModelType);
             var httpRequest = adapter.BuildHttpRequest(endpoint, resolution.ApiKey, requestBody, request.EnablePromptCache);
+            ApplyOpenRouterAttribution(httpRequest, resolution.ApiUrl, request.AppCallerCode);
 
             // 4. 写入日志（开始）
             logId = await StartLogAsync(request, gatewayResolution, endpoint, requestBody, startedAt, ct);
@@ -655,6 +657,8 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
                 }
             }
 
+            ApplyOpenRouterAttribution(httpRequest, resolution.ApiUrl, request.AppCallerCode);
+
             // 5. 写入日志（开始）
             logId = await StartRawLogAsync(request, gatewayResolution, endpoint, requestBodyForLog, startedAt, ct);
 
@@ -951,6 +955,26 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
         // Uri.EscapeDataString 保证 model 名里的特殊字符（极少但有可能）不破坏 URL
         var encoded = Uri.EscapeDataString(actualModel);
         return urlTemplate.Replace("{model}", encoded, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// OpenRouter 应用归属：通过 HTTP-Referer + X-Title header 告诉 OpenRouter 本次调用来自哪个 AppCaller。
+    /// 仅在 ApiUrl 指向 openrouter.ai 时注入，避免污染其他严格校验 header/body 的上游（DeepSeek、通义、
+    /// Claude 原生、各类中转站等）。body 不动，彻底规避未知字段导致 400 的风险。
+    /// </summary>
+    private static void ApplyOpenRouterAttribution(
+        HttpRequestMessage httpRequest,
+        string? apiUrl,
+        string appCallerCode)
+    {
+        if (string.IsNullOrWhiteSpace(apiUrl)) return;
+        if (apiUrl.IndexOf("openrouter.ai", StringComparison.OrdinalIgnoreCase) < 0) return;
+
+        httpRequest.Headers.TryAddWithoutValidation("HTTP-Referer", "https://prd-agent.miduo.org");
+        if (!string.IsNullOrWhiteSpace(appCallerCode))
+        {
+            httpRequest.Headers.TryAddWithoutValidation("X-Title", appCallerCode);
+        }
     }
 
     /// <summary>

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/LlmGateway.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/LlmGateway.cs
@@ -301,9 +301,11 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
             {
                 var errorBody = await response.Content.ReadAsStringAsync(ct);
                 var errorMsg = TryExtractErrorMessage(errorBody) ?? $"HTTP {(int)response.StatusCode}";
-                yield return GatewayStreamChunk.Fail(errorMsg);
 
-                // 更新日志状态为失败
+                // 先落日志再 yield：caller 收到 Error chunk 后可能立刻 return 释放迭代器，
+                // 导致 yield 之后的代码永不执行。这样 MarkError 就会被跳过，日志滞留 running
+                // 直到 Watchdog 5 分钟后盖成 "TIMEOUT"——这正是"禁用 key 秒级返回但日志仍
+                // 显示 TIMEOUT"的罪魁祸首。
                 if (logId != null)
                 {
                     _logWriter?.MarkError(logId, errorMsg, (int)response.StatusCode);
@@ -313,6 +315,8 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
                 {
                     await _modelResolver.RecordFailureAsync(resolution, ct);
                 }
+
+                yield return GatewayStreamChunk.Fail(errorMsg);
                 yield break;
             }
 


### PR DESCRIPTION
## Summary

一个 feature + 它在验收过程中暴露出的既有 bug 两连发。

### 1. `feat`: OpenRouter 应用归属 header（9d84d1e）

LLM Gateway 在请求上游为 OpenRouter 时自动注入：

- `HTTP-Referer: https://prd-agent.miduo.org`
- `X-Title: {AppCallerCode}`（如 `ai-toolbox.orchestration::chat`）

OpenRouter Dashboard 据此按 AppCaller 维度聚合统计（文学创作 / PR 审查 / 视觉创作 等各自独立）。

**按 `ApiUrl.Contains("openrouter.ai")` 域名隔离**，不污染 DeepSeek / 通义 / Claude 原生 / 各类中转站等其他上游的请求——body 一个字节不动，彻底规避未知字段导致 400 的风险。

涉及 `SendAsync` / `StreamAsync` / `SendRawAsync` 三个入口。

### 2. `fix`: 流式传输层异常落日志（f019e3d）

`StreamAsync` 的外层 try 此前没有 catch。HttpClient 超时 / 连接拒绝 / 流中途断连等传输层异常直接冒泡，`llmrequestlogs` 滞留 `status=running`，5 分钟后被 `LlmRequestLogWatchdog` 强写 `error="TIMEOUT" / dur=300000 / statusCode=null`，真实错误被吞。

修复：

- 引入 `ClassifyTransportException` 归一异常为 `(message, statusCode)`：`TaskCanceledException=504`、`HttpRequestException=502`、caller 取消=499
- 用"变量捕获 + 块外 yield"规避迭代器"no yield in catch"限制：SendAsync 和 MoveNextAsync 分别包 try/catch
- 手工迭代 `sseReader` 替代 `await foreach`，配合 `await using var` 确保 enumerator 正确释放
- `SendAsync` / `SendRawAsync` 外层 catch 同步走 classifier，日志 statusCode 从 null 变真实码

### 3. `fix`: 401/4xx 先落日志再 yield（de37a59）

真正的观测黑洞。`StreamAsync` 上游 4xx 原本：

```csharp
yield return GatewayStreamChunk.Fail(errorMsg);  // caller 收到 Error chunk 立即 return
_logWriter?.MarkError(logId, errorMsg, 401);     // ← 永不执行，迭代器已被 dispose
```

DirectChat 这类 caller 收到 Error chunk 立刻 `return;` 释放迭代器，yield 之后的代码永远不跑。真实 `401 + "User not found."` 消息被丢弃，日志最终被 Watchdog 盖成 `TIMEOUT`。

修复：先 MarkError/RecordFailure 再 yield。落日志不依赖 caller 继续拉取。

## Test plan

三条线全部实测通过（CDS 灰度环境 `claude-openrouter-app-field-support-bzazq.miduo.org`）：

- [x] **feat 验证**：`/api/ai-toolbox/direct-chat` 调用走通，LLM 日志 `apiBase=https://openrouter.ai`，容器内 `grep ApplyOpenRouterAttribution` 命中 4 处（1 定义 + 3 调用点）
- [x] **fix #1 验证**：临时把 `platform1` 的 ApiUrl 指到死端口 `http://127.0.0.1:61234/` → 2 秒内日志写入 `statusCode=502, error="网络请求失败：Connection refused (127.0.0.1:61234)"`，**非** Watchdog 的 `TIMEOUT` stub
- [x] **fix #2 验证**：禁用 OpenRouter key → 3 秒内日志写入 `statusCode=401, error="User not found."`（OpenRouter 真实响应），**非** Watchdog 的 `TIMEOUT` stub
- [x] **回归**：有效 key → `status=succeeded, statusCode=200, durationMs=6984, inputTokens=62, outputTokens=1013`，流式文本正常生成

## 已知遗留（不阻塞）

- `MarkError` 接口不写 `durationMs`，失败路径的 `durationMs` 字段为 `null`（有 `startedAt`/`endedAt` 可反算）。后续如有需要可扩展 `MarkError(logId, error, statusCode, durationMs?)`

## 人工验收建议

打开 https://openrouter.ai/activity ，登录到 platform1 绑定的 OpenRouter 账户，查看最近几条 `anthropic/claude-opus-4.6-fast` 调用记录的 **App/Title** 列，应出现 `ai-toolbox.orchestration::chat` 等 AppCallerCode 值。

https://claude.ai/code/session_01H9TBzx4Kk1ddA6q5YCxs79

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core LLM gateway request/streaming paths and changes exception/iterator control flow; mistakes could alter failure semantics or log accuracy, but changes are scoped and mostly additive.
> 
> **Overview**
> Adds OpenRouter-specific attribution by injecting `HTTP-Referer` and `X-Title` (from `AppCallerCode`) headers for requests whose `ApiUrl` targets `openrouter.ai`, applied across `SendAsync`, `StreamAsync`, and `SendRawAsync`.
> 
> Fixes streaming observability gaps by classifying transport/read exceptions into a message + status code, ensuring `llmrequestlogs` gets `MarkError` with a meaningful `statusCode` for `SendAsync`/`SendRawAsync` failures and for streaming `SendAsync`/SSE read aborts.
> 
> Reorders streaming 4xx/401 handling to write logs (`MarkError`/`RecordFailureAsync`) before yielding an error chunk, preventing iterator early-disposal from skipping log finalization, and documents the changes in a new changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de37a59c228f947ff5f07123826f5b55a2aaf1a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->