### PR TITLE
Refactor Agent Switcher to unified command palette with search & pinning

### DIFF
--- a/changelogs/2026-04-18_cmdk-panel-user-space.md
+++ b/changelogs/2026-04-18_cmdk-panel-user-space.md
@@ -1,0 +1,5 @@
+| feat | prd-admin | Cmd/Ctrl+K 命令面板重构：从只能切 5 个 Agent 升级为统一命令面板，收录 Agent / 百宝箱 / 实用工具，支持搜索、分组（置顶/最近/Agent/百宝箱/实用工具）、键盘导航、点击星标置顶 |
+| feat | prd-admin | 新增「设置 → 我的空间」页：私人使用数据看板，展示置顶工具、最近使用、常用工具 Top 10（按启动次数排序），支持一键取消置顶 / 清空最近 / 重置统计 |
+| feat | prd-admin | 用户下拉菜单新增「我的空间」入口，快速跳转到 /settings?tab=user-space |
+| refactor | prd-admin | 新增 lib/launcherCatalog.ts 作为 Agent + 百宝箱 + 实用工具的统一目录（命令面板与我的空间共享），按权限自动过滤 |
+| refactor | prd-admin | agentSwitcherStore 扩展：recentVisits 新增 id/icon 字段 + 新增 usageCounts / pinnedIds，版本迁移至 v2 兼容老数据 |

--- a/changelogs/2026-04-18_cmdk-panel-user-space.md
+++ b/changelogs/2026-04-18_cmdk-panel-user-space.md
@@ -4,3 +4,4 @@
 | refactor | prd-admin | 新增 lib/launcherCatalog.ts 作为 Agent + 百宝箱 + 实用工具的统一目录（命令面板与我的空间共享），按权限自动过滤 |
 | refactor | prd-admin | agentSwitcherStore 扩展：recentVisits 新增 id/icon 字段 + 新增 usageCounts / pinnedIds，版本迁移至 v2 兼容老数据 |
 | refactor | prd-admin | 命令面板卡片改为紧凑方形（5 列网格，高度 96px，2 行描述），面板最大宽度 1080px，键盘上下移动按列数 5 对齐 |
+| fix | prd-admin | 命令面板卡片取消固定高度与截断：描述文字自然换行，卡片按内容增高；同行卡片通过 grid items-stretch 对齐 |

--- a/changelogs/2026-04-18_cmdk-panel-user-space.md
+++ b/changelogs/2026-04-18_cmdk-panel-user-space.md
@@ -3,3 +3,4 @@
 | feat | prd-admin | 用户下拉菜单新增「我的空间」入口，快速跳转到 /settings?tab=user-space |
 | refactor | prd-admin | 新增 lib/launcherCatalog.ts 作为 Agent + 百宝箱 + 实用工具的统一目录（命令面板与我的空间共享），按权限自动过滤 |
 | refactor | prd-admin | agentSwitcherStore 扩展：recentVisits 新增 id/icon 字段 + 新增 usageCounts / pinnedIds，版本迁移至 v2 兼容老数据 |
+| refactor | prd-admin | 命令面板卡片改为紧凑方形（5 列网格，高度 96px，2 行描述），面板最大宽度 1080px，键盘上下移动按列数 5 对齐 |

--- a/prd-admin/src/components/agent-switcher/AgentSwitcher.tsx
+++ b/prd-admin/src/components/agent-switcher/AgentSwitcher.tsx
@@ -1,816 +1,570 @@
 /**
- * Agent Switcher 浮层组件 v12.0
+ * Agent Switcher 浮层（命令面板）v13.0
  *
- * 改进：
- * - 真正的边缘发光（不是背光）
- * - 传送门穿越过渡效果（灵感来自可灵 AI 传送门）
- *   - Canvas 绘制的椭圆发光环从卡片中心展开
- *   - 环内显示 Agent 主题色渐变 + 光线效果
- *   - 白色核心光环 + 主题色外发光
- *   - 最终白光闪烁完成过渡
+ * 触发：全局快捷键 Cmd/Ctrl + K
+ * 内容：Agent / 百宝箱 / 实用工具 的统一命令面板，支持：
+ *   - 搜索（按名称 / 标签 / 描述）
+ *   - 键盘导航（↑↓ 行内、←→ 横向、Enter 进入、Esc 关闭）
+ *   - 置顶（Pin）、最近使用、使用次数自动排序
+ *   - 分组展示：置顶 → 最近 → Agent → 百宝箱 → 实用工具
+ *
+ * 存储：复用 agentSwitcherStore 的 pinnedIds / usageCounts / recentVisits（sessionStorage 持久化）
  */
 
-import { useCallback, useEffect, useLayoutEffect, useState, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { createPortal } from 'react-dom';
-import {
-  useAgentSwitcherStore,
-  AGENT_DEFINITIONS,
-  type AgentDefinition,
-} from '@/stores/agentSwitcherStore';
+import * as LucideIcons from 'lucide-react';
+import { Search, Pin, PinOff, Clock, Star, Hammer, Sparkles, X } from 'lucide-react';
+import { useAgentSwitcherStore } from '@/stores/agentSwitcherStore';
 import { useAuthStore } from '@/stores/authStore';
+import {
+  getLauncherCatalog,
+  findLauncherItem,
+  type LauncherItem,
+  type LauncherGroup,
+} from '@/lib/launcherCatalog';
 
-/** 图标相对路径映射（CDN 前缀从 authStore.cdnBaseUrl 获取） */
-const ICON_PATHS: Record<string, string> = {
-  'prd-agent': 'icon/backups/agent/prd-agent.png',
-  'visual-agent': 'icon/backups/agent/visual-agent.png',
-  'literary-agent': 'icon/backups/agent/literary-agent.png',
-  'defect-agent': 'icon/backups/agent/defect-agent.png',
-  'video-agent': 'icon/backups/agent/video-agent.png',
-  'report-agent': 'icon/backups/agent/report-agent.png',
-  'arena': 'icon/backups/agent/arena.png',
-  'shortcuts-agent': 'icon/backups/agent/shortcuts-agent.png',
-  'workflow-agent': 'icon/backups/agent/workflow-agent.png',
-};
-
-function getAgentIconUrl(appKey: string): string {
-  const path = ICON_PATHS[appKey];
-  if (!path) return '';
-  const base = (useAuthStore.getState().cdnBaseUrl ?? '').replace(/\/+$/, '');
-  return base ? `${base}/${path}` : `/${path}`;
+interface Section {
+  key: 'pinned' | 'recent' | 'agent' | 'toolbox' | 'utility';
+  title: string;
+  subtitle?: string;
+  icon: React.ReactNode;
+  items: LauncherItem[];
 }
 
-/** Agent 功能描述 */
-const AGENT_DESCRIPTIONS: Record<string, string> = {
-  'prd-agent': '智能解读PRD文档，快速提取需求要点',
-  'visual-agent': 'AI驱动的视觉创作，一键生成精美图像',
-  'literary-agent': '文学创作助手，为文章配图赋予灵魂',
-  'defect-agent': '缺陷管理专家，高效追踪问题闭环',
-  'video-agent': '文章转视频教程，AI驱动分镜创作',
-};
+function getIcon(name: string, size = 18) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const Icon = (LucideIcons as any)[name] ?? LucideIcons.Circle;
+  return <Icon size={size} />;
+}
 
-/** 入场方向配置 */
-const ENTRY_DIRECTIONS = [
-  { x: -80, y: -40, rotate: -5 },
-  { x: -40, y: -40, rotate: -3 },
-  { x: 0, y: -40, rotate: 0 },
-  { x: 40, y: -40, rotate: 3 },
-  { x: 80, y: -40, rotate: 5 },
-];
-
-/** Agent 卡片组件 */
-function AgentCard({
-  agent,
-  index,
+/** 单张卡片 */
+function LauncherCard({
+  item,
   isSelected,
-  isTransitioning,
+  isPinned,
   onClick,
   onMouseEnter,
-  isClosing,
-  cardRef,
-  convergeOffset,
+  onTogglePin,
+  badge,
 }: {
-  agent: AgentDefinition;
-  index: number;
+  item: LauncherItem;
   isSelected: boolean;
-  isTransitioning: boolean;
+  isPinned: boolean;
   onClick: () => void;
   onMouseEnter: () => void;
-  isClosing: boolean;
-  cardRef?: React.Ref<HTMLButtonElement>;
-  convergeOffset?: { x: number; y: number };
+  onTogglePin: (e: React.MouseEvent) => void;
+  badge?: string;
 }) {
-  const iconUrl = getAgentIconUrl(agent.key);
-  const [iconFailed, setIconFailed] = useState(false);
-  const description = AGENT_DESCRIPTIONS[agent.key];
-  const direction = ENTRY_DIRECTIONS[index];
-
+  const accent = item.accentColor ?? '#818CF8';
   return (
     <button
-      ref={cardRef}
       type="button"
       onClick={onClick}
       onMouseEnter={onMouseEnter}
-      className="group relative outline-none focus:outline-none"
+      className="group relative text-left outline-none focus:outline-none"
       style={{
-        animation: isClosing && !isTransitioning
-          ? `cardExit 0.25s cubic-bezier(0.55, 0, 1, 0.45) ${index * 30}ms both`
-          : isTransitioning
-          ? 'none'
-          : `cardEnter 0.45s cubic-bezier(0.22, 1, 0.36, 1) ${80 + index * 60}ms both`,
-        ['--entry-x' as string]: `${direction.x}px`,
-        ['--entry-y' as string]: `${direction.y}px`,
-        ['--entry-rotate' as string]: `${direction.rotate}deg`,
-        // 穿越动画时: 4张卡片向选中卡片中心汇聚
-        transform: isTransitioning && convergeOffset
-          ? `translate(${convergeOffset.x}px, ${convergeOffset.y}px) scale(0.15)`
-          : undefined,
-        opacity: isTransitioning ? 0 : undefined,
-        transition: isTransitioning
-          ? 'transform 0.28s cubic-bezier(0.4, 0, 1, 1), opacity 0.22s ease-out 0.06s'
-          : undefined,
+        width: '100%',
       }}
     >
-      {/* 主卡片 — 图片铺满 + 底部文字叠加 */}
       <div
-        className="relative w-[200px] h-[260px] rounded-[28px] overflow-hidden transition-all duration-400 ease-out cursor-pointer"
+        className="relative h-[92px] p-3 rounded-[14px] flex items-start gap-3 transition-all duration-200 cursor-pointer overflow-hidden"
         style={{
-          // 真正的边缘发光：多层 box-shadow
+          background: isSelected
+            ? `linear-gradient(135deg, ${accent}22 0%, rgba(255,255,255,0.03) 100%)`
+            : 'rgba(255, 255, 255, 0.025)',
+          border: `1px solid ${isSelected ? `${accent}55` : 'rgba(255,255,255,0.06)'}`,
           boxShadow: isSelected
-            ? `
-              inset 0 0 0 1.5px ${agent.color.text}60,
-              0 0 0 1px ${agent.color.text}30,
-              0 0 15px 0 ${agent.color.text}40,
-              0 0 30px -5px ${agent.color.text}30,
-              0 25px 50px -12px rgba(0, 0, 0, 0.7)
-            `
-            : '0 20px 40px -12px rgba(0, 0, 0, 0.5)',
-          transform: isSelected
-            ? 'translateY(-8px) scale(1.02)'
-            : 'translateY(0) scale(1)',
+            ? `0 0 0 1px ${accent}40 inset, 0 8px 24px -8px ${accent}55`
+            : '0 2px 8px rgba(0,0,0,0.25)',
+          transform: isSelected ? 'translateY(-1px)' : 'translateY(0)',
         }}
       >
-        {/* 图片铺满整个卡片，加载失败时降级为渐变背景 */}
-        {iconUrl && !iconFailed ? (
-          <img
-            src={iconUrl}
-            alt={agent.name}
-            className="absolute inset-0 w-full h-full object-cover transition-transform duration-500 ease-out"
-            style={{
-              transform: isSelected ? 'scale(1.06)' : 'scale(1)',
-            }}
-            draggable={false}
-            onError={() => setIconFailed(true)}
-          />
-        ) : (
-          <div
-            className="absolute inset-0 transition-transform duration-500 ease-out"
-            style={{
-              transform: isSelected ? 'scale(1.06)' : 'scale(1)',
-              background: `
-                radial-gradient(ellipse at 30% 20%, ${agent.color.text}35 0%, transparent 60%),
-                radial-gradient(ellipse at 70% 80%, ${agent.color.text}20 0%, transparent 50%),
-                linear-gradient(145deg, rgba(20, 22, 35, 0.98) 0%, rgba(12, 14, 22, 0.99) 100%)
-              `,
-            }}
-          >
-            <div className="absolute inset-0 flex items-center justify-center" style={{ paddingBottom: '30%' }}>
-              <div
-                className="absolute rounded-full blur-3xl"
-                style={{
-                  width: 80,
-                  height: 80,
-                  background: `radial-gradient(circle, ${agent.color.text}50 0%, ${agent.color.text}15 60%, transparent 100%)`,
-                }}
-              />
-              <div
-                className="relative text-[42px] font-bold"
-                style={{
-                  color: agent.color.text,
-                  opacity: 0.85,
-                  textShadow: `0 0 30px ${agent.color.text}60`,
-                }}
-              >
-                {agent.name[0]}
-              </div>
-            </div>
-          </div>
-        )}
-
-        {/* 底部渐变遮罩 — 保证文字可读 */}
+        {/* 图标 */}
         <div
-          className="absolute inset-0 pointer-events-none"
+          className="shrink-0 w-10 h-10 rounded-[10px] flex items-center justify-center"
           style={{
-            background: isSelected
-              ? `linear-gradient(0deg, rgba(0,0,0,0.85) 0%, rgba(0,0,0,0.4) 45%, transparent 70%), linear-gradient(0deg, ${agent.color.text}18 0%, transparent 40%)`
-              : 'linear-gradient(0deg, rgba(0,0,0,0.8) 0%, rgba(0,0,0,0.3) 45%, transparent 70%)',
-          }}
-        />
-
-        {/* 边缘光晕层 - 内边框发光 */}
-        <div
-          className="absolute inset-0 rounded-[28px] pointer-events-none transition-opacity duration-300"
-          style={{
-            opacity: isSelected ? 1 : 0,
-            background: `
-              linear-gradient(135deg, ${agent.color.text}15 0%, transparent 50%),
-              linear-gradient(315deg, ${agent.color.text}10 0%, transparent 50%)
-            `,
-          }}
-        />
-
-        {/* 顶部高光边缘 */}
-        <div
-          className="absolute top-0 left-4 right-4 h-[1px] pointer-events-none transition-opacity duration-300"
-          style={{
-            opacity: isSelected ? 1 : 0.3,
-            background: isSelected
-              ? `linear-gradient(90deg, transparent, ${agent.color.text}80, transparent)`
-              : 'linear-gradient(90deg, transparent, rgba(255,255,255,0.2), transparent)',
-          }}
-        />
-
-        {/* 文字区域 — 定位在底部 */}
-        <div className="absolute bottom-0 left-0 right-0 px-5 pb-5">
-          <h3
-            className="text-[18px] font-semibold text-center mb-1.5 transition-all duration-300"
-            style={{
-              color: isSelected ? '#fff' : 'rgba(255,255,255,0.92)',
-              textShadow: '0 1px 4px rgba(0,0,0,0.5)',
-            }}
-          >
-            {agent.name}
-          </h3>
-          <p
-            className="text-[12px] text-center leading-relaxed transition-all duration-300"
-            style={{
-              color: isSelected ? 'rgba(255,255,255,0.8)' : 'rgba(255,255,255,0.55)',
-              textShadow: '0 1px 3px rgba(0,0,0,0.5)',
-            }}
-          >
-            {description}
-          </p>
-        </div>
-
-        {/* 快捷键 */}
-        <div
-          className="absolute top-4 right-4 w-8 h-8 rounded-xl flex items-center justify-center text-[13px] font-bold transition-all duration-300 backdrop-blur-sm"
-          style={{
-            background: isSelected ? `${agent.color.text}45` : 'rgba(0, 0, 0, 0.35)',
-            color: isSelected ? '#fff' : 'rgba(255,255,255,0.7)',
-            boxShadow: isSelected ? `0 0 12px ${agent.color.text}30` : 'none',
+            background: isSelected ? `${accent}20` : 'rgba(255,255,255,0.04)',
+            color: isSelected ? accent : 'rgba(255,255,255,0.72)',
+            border: `1px solid ${isSelected ? `${accent}40` : 'rgba(255,255,255,0.06)'}`,
           }}
         >
-          {index + 1}
+          {getIcon(item.icon, 18)}
         </div>
+
+        {/* 文字 */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <span
+              className="text-[13px] font-semibold truncate"
+              style={{ color: isSelected ? '#fff' : 'rgba(255,255,255,0.92)' }}
+            >
+              {item.name}
+            </span>
+            {item.wip && (
+              <span
+                className="shrink-0 text-[9px] font-bold px-1.5 py-0.5 rounded"
+                style={{ background: 'rgba(251, 146, 60, 0.2)', color: '#fb923c' }}
+              >
+                施工中
+              </span>
+            )}
+            {badge && (
+              <span
+                className="shrink-0 text-[9px] font-bold px-1.5 py-0.5 rounded"
+                style={{ background: 'rgba(99,102,241,0.2)', color: '#a5b4fc' }}
+              >
+                {badge}
+              </span>
+            )}
+          </div>
+          <div
+            className="mt-1 text-[11px] leading-relaxed line-clamp-2"
+            style={{ color: isSelected ? 'rgba(255,255,255,0.72)' : 'rgba(255,255,255,0.48)' }}
+          >
+            {item.description}
+          </div>
+        </div>
+
+        {/* 置顶按钮（hover 或已置顶时显示） */}
+        <button
+          type="button"
+          onClick={onTogglePin}
+          className="absolute top-2 right-2 w-6 h-6 rounded-md flex items-center justify-center transition-opacity"
+          style={{
+            opacity: isPinned || isSelected ? 1 : 0,
+            background: isPinned ? `${accent}30` : 'rgba(255,255,255,0.05)',
+            color: isPinned ? accent : 'rgba(255,255,255,0.55)',
+            border: `1px solid ${isPinned ? `${accent}60` : 'rgba(255,255,255,0.08)'}`,
+          }}
+          title={isPinned ? '取消置顶' : '置顶到前台'}
+          aria-label={isPinned ? '取消置顶' : '置顶'}
+        >
+          {isPinned ? <Pin size={11} /> : <PinOff size={11} />}
+        </button>
       </div>
     </button>
   );
 }
 
-/**
- * 传送门穿越过渡层 — 山洞/缝隙穿越效果
- *
- * 核心原理：
- * - canvas 作为透明遮罩层，用 evenodd 镂空一个不规则洞口
- * - 洞口区域完全透明，露出下方已导航的目标页面
- * - 洞口从极小的裂缝缓缓扩张至全屏
- * - 洞口边缘有主题色发光，营造传送门感
- * - onNavigate 在动画早期触发，页面在洞口扩张前已加载
- * - onComplete 在动画结束时触发，关闭 modal
- */
-function PortalTransition({
-  agent,
-  startRect,
-  onNavigate,
-  onComplete,
-}: {
-  agent: AgentDefinition;
-  startRect: DOMRect;
-  onNavigate: () => void;
-  onComplete: () => void;
-}) {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
-  const cbRef = useRef({ onNavigate, onComplete });
-  cbRef.current = { onNavigate, onComplete };
-  const navigatedRef = useRef(false);
-
-  const cx = startRect.left + startRect.width / 2;
-  const cy = startRect.top + startRect.height / 2;
-
-  useLayoutEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-
-    const dpr = window.devicePixelRatio || 1;
-    const vw = window.innerWidth;
-    const vh = window.innerHeight;
-    canvas.width = vw * dpr;
-    canvas.height = vh * dpr;
-    const ctx = canvas.getContext('2d')!;
-    ctx.scale(dpr, dpr);
-
-    // 洞口需要扩到足以覆盖全屏
-    const maxR = Math.hypot(
-      Math.max(cx, vw - cx),
-      Math.max(cy, vh - cy)
-    ) * 1.5;
-
-    const color = agent.color.text;
-    const cr = parseInt(color.slice(1, 3), 16);
-    const cg = parseInt(color.slice(3, 5), 16);
-    const cb = parseInt(color.slice(5, 7), 16);
-
-    // 不规则洞口噪声 — 模拟山洞/缝隙的粗糙边缘
-    const N = 64;
-    let noiseArr = Array.from({ length: N }, () => (Math.random() - 0.5) * 0.4);
-    // 平滑3次，让边缘看起来自然
-    for (let s = 0; s < 3; s++) {
-      noiseArr = noiseArr.map((_, i) => {
-        const p = noiseArr[(i - 1 + N) % N];
-        const c = noiseArr[i];
-        const n = noiseArr[(i + 1) % N];
-        return p * 0.25 + c * 0.5 + n * 0.25;
-      });
-    }
-
-    const duration = 700;
-    const startTime = performance.now();
-    let frame: number;
-
-    // 首帧：全黑遮罩
-    ctx.fillStyle = '#080810';
-    ctx.fillRect(0, 0, vw, vh);
-
-    /** 在当前路径上追加不规则椭圆洞口 */
-    function traceHole(radius: number, nScale: number) {
-      const pts: [number, number][] = [];
-      for (let i = 0; i < N; i++) {
-        const angle = (i / N) * Math.PI * 2;
-        const r = radius * (1 + noiseArr[i] * nScale);
-        pts.push([
-          cx + r * Math.cos(angle) * 1.15,
-          cy + r * Math.sin(angle) * 0.85,
-        ]);
-      }
-      const last = pts[pts.length - 1];
-      ctx.moveTo((last[0] + pts[0][0]) / 2, (last[1] + pts[0][1]) / 2);
-      for (let i = 0; i < pts.length; i++) {
-        const next = pts[(i + 1) % pts.length];
-        ctx.quadraticCurveTo(
-          pts[i][0], pts[i][1],
-          (pts[i][0] + next[0]) / 2, (pts[i][1] + next[1]) / 2
-        );
-      }
-      ctx.closePath();
-    }
-
-    function draw(now: number) {
-      const elapsed = now - startTime;
-      const t = Math.min(elapsed / duration, 1);
-
-      // 缓缓打开：前期稍慢营造裂缝感，后期加速展开
-      const ease = t < 0.2
-        ? Math.pow(t / 0.2, 1.5) * 0.15
-        : 0.15 + 0.85 * (1 - Math.pow(1 - (t - 0.2) / 0.8, 2));
-
-      // 提前导航
-      if (t >= 0.12 && !navigatedRef.current) {
-        navigatedRef.current = true;
-        cbRef.current.onNavigate();
-      }
-
-      const radius = 30 + (maxR - 30) * ease;
-      // 洞口越大越规则（小 = 山洞粗糙感，大 = 平滑圆形收尾）
-      const nScale = Math.max(0, 1 - ease * 1.5);
-
-      // 清除为全透明
-      ctx.clearRect(0, 0, vw, vh);
-
-      // ═══ 暗色遮罩 + evenodd 镂空 ═══
-      const overlayAlpha = t > 0.88 ? Math.max(0, 1 - (t - 0.88) / 0.12) : 1;
-      ctx.beginPath();
-      ctx.rect(0, 0, vw, vh);
-      traceHole(radius, nScale);
-      ctx.fillStyle = `rgba(8, 8, 15, ${overlayAlpha})`;
-      ctx.fill('evenodd');
-
-      // ═══ 洞口边缘发光 ═══
-      const glowAlpha = t < 0.08 ? t / 0.08 : t > 0.7 ? Math.max(0, 1 - (t - 0.7) / 0.3) : 1;
-      if (glowAlpha > 0.01) {
-        // 主题色外发光
-        ctx.save();
-        ctx.beginPath();
-        traceHole(radius, nScale);
-        ctx.strokeStyle = `rgba(${cr},${cg},${cb},${glowAlpha * 0.7})`;
-        ctx.lineWidth = 4;
-        ctx.shadowColor = color;
-        ctx.shadowBlur = 40;
-        ctx.stroke();
-        ctx.restore();
-
-        // 白色内发光
-        ctx.save();
-        ctx.beginPath();
-        traceHole(radius, nScale);
-        ctx.strokeStyle = `rgba(255,255,255,${glowAlpha * 0.5})`;
-        ctx.lineWidth = 1.5;
-        ctx.shadowColor = `rgba(${cr},${cg},${cb},0.8)`;
-        ctx.shadowBlur = 15;
-        ctx.stroke();
-        ctx.restore();
-      }
-
-      if (t < 1) {
-        frame = requestAnimationFrame(draw);
-      } else {
-        ctx.clearRect(0, 0, vw, vh);
-        cbRef.current.onComplete();
-      }
-    }
-
-    frame = requestAnimationFrame(draw);
-    return () => cancelAnimationFrame(frame);
-  }, [cx, cy, agent]);
-
-  return (
-    <div className="fixed inset-0 z-[300] pointer-events-none">
-      <canvas
-        ref={canvasRef}
-        style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }}
-      />
-    </div>
-  );
-}
-
-/** 主浮层组件 */
 export function AgentSwitcher() {
   const navigate = useNavigate();
-  const [isClosing, setIsClosing] = useState(false);
-  const [transitionAgent, setTransitionAgent] = useState<AgentDefinition | null>(null);
-  const [transitionRect, setTransitionRect] = useState<DOMRect | null>(null);
-  const [convergeOffsets, setConvergeOffsets] = useState<Record<number, { x: number; y: number }>>({});
-  const cardRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const permissions = useAuthStore((s) => s.permissions ?? []);
+  const isRoot = useAuthStore((s) => s.isRoot ?? false);
 
   const {
     isOpen,
-    selectedIndex,
+    selectedId,
+    searchQuery,
+    recentVisits,
+    usageCounts,
+    pinnedIds,
     close,
-    setSelectedIndex,
-    moveSelection,
+    setSelectedId,
+    setSearchQuery,
     addRecentVisit,
+    togglePin,
   } = useAgentSwitcherStore();
 
-  const navigateToAgent = useCallback(
-    (agent: AgentDefinition, index: number) => {
-      addRecentVisit({
-        agentKey: agent.key,
-        agentName: agent.name,
-        title: '首页',
-        path: agent.route,
-      });
-
-      // 获取点击卡片位置
-      const clickedEl = cardRefs.current[index];
-      if (!clickedEl) return;
-
-      const clickedRect = clickedEl.getBoundingClientRect();
-      const targetCx = clickedRect.left + clickedRect.width / 2;
-      const targetCy = clickedRect.top + clickedRect.height / 2;
-
-      // 计算所有卡片向选中卡片中心汇聚的偏移量
-      const offsets: Record<number, { x: number; y: number }> = {};
-      cardRefs.current.forEach((el, i) => {
-        if (el) {
-          const r = el.getBoundingClientRect();
-          const cardCx = r.left + r.width / 2;
-          const cardCy = r.top + r.height / 2;
-          offsets[i] = { x: targetCx - cardCx, y: targetCy - cardCy };
-        }
-      });
-
-      setConvergeOffsets(offsets);
-      setTransitionRect(clickedRect);
-      setTransitionAgent(agent);
-    },
-    [addRecentVisit]
+  // 目录（按权限过滤）
+  const catalog = useMemo(
+    () => getLauncherCatalog({ permissions, isRoot }),
+    [permissions, isRoot]
   );
 
-  // 动画早期触发：提前导航，页面开始加载
-  const handleNavigate = useCallback(() => {
-    if (transitionAgent) {
-      navigate(transitionAgent.route);
+  // 过滤 + 分组
+  const sections = useMemo<Section[]>(() => {
+    const query = searchQuery.trim().toLowerCase();
+    const match = (it: LauncherItem) => {
+      if (!query) return true;
+      const haystack = [it.name, it.description, ...(it.tags ?? [])].join(' ').toLowerCase();
+      return haystack.includes(query);
+    };
+
+    const filtered = catalog.filter(match);
+
+    // 置顶
+    const pinnedSet = new Set(pinnedIds);
+    const pinned = pinnedIds
+      .map((id) => findLauncherItem(filtered, id))
+      .filter((x): x is LauncherItem => !!x);
+
+    // 最近（去掉已置顶的）
+    const recentIds = recentVisits.map((v) => v.id).filter((id) => !pinnedSet.has(id));
+    const recent = recentIds
+      .map((id) => findLauncherItem(filtered, id))
+      .filter((x): x is LauncherItem => !!x)
+      .slice(0, 6);
+
+    // 按 group 拆分（去掉已置顶的）
+    const rest = filtered.filter((it) => !pinnedSet.has(it.id));
+    const byGroup = (g: LauncherGroup) => {
+      const arr = rest.filter((it) => it.group === g);
+      // 有搜索时：按"匹配名称优先 + 使用次数"简易排序
+      arr.sort((a, b) => {
+        if (query) {
+          const aName = a.name.toLowerCase().includes(query) ? 0 : 1;
+          const bName = b.name.toLowerCase().includes(query) ? 0 : 1;
+          if (aName !== bName) return aName - bName;
+        }
+        return (usageCounts[b.id] ?? 0) - (usageCounts[a.id] ?? 0);
+      });
+      return arr;
+    };
+
+    const agents = byGroup('agent');
+    const toolbox = byGroup('toolbox');
+    const utility = byGroup('utility');
+
+    const out: Section[] = [];
+    if (pinned.length)
+      out.push({
+        key: 'pinned',
+        title: '置顶',
+        subtitle: '你固定在前台的入口',
+        icon: <Pin size={12} />,
+        items: pinned,
+      });
+    if (!query && recent.length)
+      out.push({
+        key: 'recent',
+        title: '最近使用',
+        subtitle: '近期从这里打开的工具',
+        icon: <Clock size={12} />,
+        items: recent,
+      });
+    if (agents.length)
+      out.push({
+        key: 'agent',
+        title: 'Agent',
+        subtitle: '专属场景助手',
+        icon: <Star size={12} />,
+        items: agents,
+      });
+    if (toolbox.length)
+      out.push({
+        key: 'toolbox',
+        title: '百宝箱',
+        subtitle: '内置工具与定制 Agent',
+        icon: <Hammer size={12} />,
+        items: toolbox,
+      });
+    if (utility.length)
+      out.push({
+        key: 'utility',
+        title: '实用工具',
+        subtitle: '日常高频入口',
+        icon: <Sparkles size={12} />,
+        items: utility,
+      });
+
+    return out;
+  }, [catalog, pinnedIds, recentVisits, usageCounts, searchQuery]);
+
+  // 扁平化列表用于键盘导航
+  const flatList = useMemo(() => sections.flatMap((s) => s.items), [sections]);
+
+  // 打开时自动选中第一项
+  useEffect(() => {
+    if (!isOpen) return;
+    if (flatList.length === 0) {
+      if (selectedId !== null) setSelectedId(null);
+      return;
     }
-  }, [transitionAgent, navigate]);
+    if (!selectedId || !flatList.some((it) => it.id === selectedId)) {
+      setSelectedId(flatList[0].id);
+    }
+  }, [isOpen, flatList, selectedId, setSelectedId]);
 
-  // 动画结束触发：关闭 modal、清理状态
-  const handleTransitionComplete = useCallback(() => {
-    close();
-    setTransitionAgent(null);
-    setTransitionRect(null);
-    setConvergeOffsets({});
-  }, [close]);
+  // 输入框聚焦
+  useEffect(() => {
+    if (isOpen) {
+      const t = setTimeout(() => inputRef.current?.focus(), 60);
+      return () => clearTimeout(t);
+    }
+  }, [isOpen]);
 
-  const handleClose = useCallback(() => {
-    setIsClosing(true);
-    setTimeout(() => {
+  const launchItem = useCallback(
+    (item: LauncherItem) => {
+      addRecentVisit({
+        id: item.id,
+        agentKey: item.agentKey ?? '',
+        agentName: item.name,
+        title: item.name,
+        path: item.route,
+        icon: item.icon,
+      });
       close();
-      setIsClosing(false);
-    }, 280);
-  }, [close]);
+      navigate(item.route);
+    },
+    [addRecentVisit, close, navigate]
+  );
 
+  // 键盘导航
   useEffect(() => {
     if (!isOpen) return;
 
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (['ArrowLeft', 'ArrowRight', 'Enter', 'Escape'].includes(e.key)) {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
         e.preventDefault();
+        close();
+        return;
       }
 
+      if (flatList.length === 0) return;
+      const curIdx = Math.max(
+        0,
+        flatList.findIndex((it) => it.id === selectedId)
+      );
+
+      const move = (delta: number) => {
+        e.preventDefault();
+        const next = (curIdx + delta + flatList.length) % flatList.length;
+        setSelectedId(flatList[next].id);
+      };
+
       switch (e.key) {
-        case 'Escape':
-          if (!transitionAgent) handleClose();
+        case 'ArrowDown':
+          move(2);
           break;
-        case 'ArrowLeft':
-          if (!transitionAgent) moveSelection('left');
+        case 'ArrowUp':
+          move(-2);
           break;
         case 'ArrowRight':
-          if (!transitionAgent) moveSelection('right');
+          move(1);
+          break;
+        case 'ArrowLeft':
+          move(-1);
           break;
         case 'Enter': {
-          if (!transitionAgent) {
-            const agent = AGENT_DEFINITIONS[selectedIndex];
-            if (agent) navigateToAgent(agent, selectedIndex);
-          }
-          break;
-        }
-        case '1':
-        case '2':
-        case '3':
-        case '4':
-        case '5': {
-          if (!transitionAgent) {
-            const idx = parseInt(e.key, 10) - 1;
-            const agent = AGENT_DEFINITIONS[idx];
-            if (agent) navigateToAgent(agent, idx);
-          }
+          e.preventDefault();
+          const item = flatList[curIdx];
+          if (item) launchItem(item);
           break;
         }
       }
     };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [isOpen, flatList, selectedId, setSelectedId, launchItem, close]);
 
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [isOpen, selectedIndex, handleClose, moveSelection, navigateToAgent, transitionAgent]);
-
-  const handleBackdropClick = useCallback(
+  const handleBackdrop = useCallback(
     (e: React.MouseEvent) => {
-      if (e.target === e.currentTarget && !transitionAgent) handleClose();
+      if (e.target === e.currentTarget) close();
     },
-    [handleClose, transitionAgent]
+    [close]
   );
 
   if (!isOpen) return null;
 
-  const isTransitioning = !!transitionAgent;
-
   return createPortal(
-    <>
+    <div
+      className="fixed inset-0 z-[200] flex items-start justify-center"
+      onClick={handleBackdrop}
+      style={{
+        animation: 'switcherBgIn 0.18s ease-out both',
+        paddingTop: '8vh',
+      }}
+    >
+      {/* 背景 */}
       <div
-        className="fixed inset-0 z-[200] flex items-center justify-center"
-        onClick={handleBackdropClick}
+        className="absolute inset-0"
         style={{
-          // 穿越动画时：立即隐藏背景，让目标页面透过洞口可见
-          // 必须用 animation:none 清除 bgFadeIn 的 fill:both，否则其 opacity:1 会覆盖 inline style
-          animation: isTransitioning
-            ? 'none'
-            : isClosing
-            ? 'bgFadeOut 0.25s cubic-bezier(0.55, 0, 1, 0.45) both'
-            : 'bgFadeIn 0.35s cubic-bezier(0.22, 1, 0.36, 1) both',
-          visibility: isTransitioning ? 'hidden' : undefined,
+          background: 'rgba(8, 9, 15, 0.72)',
+          backdropFilter: 'blur(14px)',
+          WebkitBackdropFilter: 'blur(14px)',
         }}
+      />
+
+      {/* 面板 */}
+      <div
+        className="relative w-[92vw] max-w-[960px]"
+        style={{
+          height: '80vh',
+          maxHeight: '80vh',
+          animation: 'switcherPanelIn 0.22s cubic-bezier(0.22, 1, 0.36, 1) both',
+        }}
+        role="dialog"
+        aria-modal="true"
+        aria-label="命令面板"
       >
-        {/* 深黑背景 */}
         <div
-          className="absolute inset-0"
+          className="h-full flex flex-col rounded-[20px] overflow-hidden"
           style={{
-            background: 'linear-gradient(180deg, #0a0a0f 0%, #0f0f18 50%, #0a0a12 100%)',
+            background: 'linear-gradient(180deg, rgba(22, 23, 32, 0.96) 0%, rgba(16, 17, 25, 0.96) 100%)',
+            border: '1px solid rgba(255,255,255,0.08)',
+            boxShadow:
+              '0 30px 80px -20px rgba(0,0,0,0.6), 0 0 0 1px rgba(255,255,255,0.02) inset',
           }}
-        />
-
-        {/* 网格背景 */}
-        <div
-          className="absolute inset-0 opacity-[0.015]"
-          style={{
-            backgroundImage: `
-              linear-gradient(rgba(255,255,255,0.1) 1px, transparent 1px),
-              linear-gradient(90deg, rgba(255,255,255,0.1) 1px, transparent 1px)
-            `,
-            backgroundSize: '60px 60px',
-          }}
-        />
-
-        {/* 中央光晕 */}
-        <div
-          className="absolute pointer-events-none"
-          style={{
-            width: '900px',
-            height: '700px',
-            top: '50%',
-            left: '50%',
-            transform: 'translate(-50%, -50%)',
-            background: 'radial-gradient(ellipse at center, rgba(100, 120, 255, 0.05) 0%, transparent 55%)',
-          }}
-        />
-
-        {/* 内容区域 */}
-        <div
-          className="relative"
-          style={{
-            animation: isClosing
-              ? 'contentFadeOut 0.2s cubic-bezier(0.55, 0, 1, 0.45) both'
-              : 'contentFadeIn 0.4s cubic-bezier(0.22, 1, 0.36, 1) both',
-          }}
-          role="dialog"
-          aria-modal="true"
         >
-          {/* 标题 */}
+          {/* 搜索栏 */}
           <div
-            className="text-center mb-12"
-            style={{
-              animation: isClosing ? 'none' : 'titleSlideIn 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.05s both',
-              opacity: isTransitioning ? 0 : undefined,
-              transition: isTransitioning ? 'opacity 0.2s ease-out' : undefined,
-            }}
+            className="shrink-0 flex items-center gap-3 px-5 h-[60px]"
+            style={{ borderBottom: '1px solid rgba(255,255,255,0.06)' }}
           >
-            <h2
-              className="text-[36px] font-bold tracking-tight"
+            <Search size={18} style={{ color: 'rgba(255,255,255,0.4)' }} />
+            <input
+              ref={inputRef}
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="搜索 Agent、工具或页面..."
+              className="flex-1 bg-transparent outline-none text-[15px]"
+              style={{ color: '#fff' }}
+            />
+            {searchQuery && (
+              <button
+                type="button"
+                onClick={() => setSearchQuery('')}
+                className="w-6 h-6 rounded-md flex items-center justify-center"
+                style={{ background: 'rgba(255,255,255,0.06)', color: 'rgba(255,255,255,0.6)' }}
+                aria-label="清空搜索"
+              >
+                <X size={12} />
+              </button>
+            )}
+            <div
+              className="text-[11px] px-2 py-1 rounded"
               style={{
-                color: '#fff',
-                background: 'linear-gradient(180deg, #fff 0%, rgba(255,255,255,0.7) 100%)',
-                WebkitBackgroundClip: 'text',
-                WebkitTextFillColor: 'transparent',
+                background: 'rgba(255,255,255,0.04)',
+                color: 'rgba(255,255,255,0.4)',
+                border: '1px solid rgba(255,255,255,0.06)',
               }}
             >
-              选择你的 Agent
-            </h2>
-            <p
-              className="mt-4 text-[15px]"
-              style={{ color: 'rgba(255, 255, 255, 0.4)' }}
-            >
-              每个 Agent 都是为特定场景打造的智能助手
-            </p>
+              Esc 关闭
+            </div>
           </div>
 
-          {/* Agent 卡片网格 */}
-          <div className="flex gap-6 justify-center">
-            {AGENT_DEFINITIONS.map((agent, index) => (
-              <AgentCard
-                key={agent.key}
-                agent={agent}
-                index={index}
-                isSelected={selectedIndex === index}
-                isTransitioning={isTransitioning}
-                onClick={() => navigateToAgent(agent, index)}
-                onMouseEnter={() => !isTransitioning && setSelectedIndex(index)}
-                isClosing={isClosing}
-                cardRef={el => { cardRefs.current[index] = el; }}
-                convergeOffset={convergeOffsets[index]}
-              />
-            ))}
+          {/* 内容区 */}
+          <div
+            className="flex-1"
+            style={{ minHeight: 0, overflowY: 'auto', overscrollBehavior: 'contain' }}
+          >
+            {sections.length === 0 ? (
+              <div
+                className="h-full flex flex-col items-center justify-center gap-2"
+                style={{ color: 'rgba(255,255,255,0.4)' }}
+              >
+                <Search size={24} style={{ opacity: 0.4 }} />
+                <div className="text-[13px]">没有匹配的条目</div>
+                <div className="text-[11px]" style={{ color: 'rgba(255,255,255,0.3)' }}>
+                  试试其他关键词，或按 Esc 关闭
+                </div>
+              </div>
+            ) : (
+              <div className="px-5 py-4 space-y-5">
+                {sections.map((section) => (
+                  <div key={section.key}>
+                    <div className="flex items-center gap-2 mb-2.5">
+                      <span style={{ color: 'rgba(255,255,255,0.45)' }}>{section.icon}</span>
+                      <span
+                        className="text-[11px] font-bold uppercase tracking-wider"
+                        style={{ color: 'rgba(255,255,255,0.55)' }}
+                      >
+                        {section.title}
+                      </span>
+                      {section.subtitle && (
+                        <span className="text-[11px]" style={{ color: 'rgba(255,255,255,0.28)' }}>
+                          · {section.subtitle}
+                        </span>
+                      )}
+                      <span
+                        className="ml-auto text-[10px]"
+                        style={{ color: 'rgba(255,255,255,0.3)' }}
+                      >
+                        {section.items.length}
+                      </span>
+                    </div>
+                    <div className="grid grid-cols-2 gap-2.5">
+                      {section.items.map((item) => (
+                        <LauncherCard
+                          key={`${section.key}:${item.id}`}
+                          item={item}
+                          isSelected={selectedId === item.id}
+                          isPinned={pinnedIds.includes(item.id)}
+                          onClick={() => launchItem(item)}
+                          onMouseEnter={() => setSelectedId(item.id)}
+                          onTogglePin={(e) => {
+                            e.stopPropagation();
+                            togglePin(item.id);
+                          }}
+                          badge={
+                            section.key === 'recent'
+                              ? undefined
+                              : section.key === 'pinned'
+                              ? undefined
+                              : (usageCounts[item.id] ?? 0) > 0
+                              ? `${usageCounts[item.id]}`
+                              : undefined
+                          }
+                        />
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
 
           {/* 底部提示 */}
           <div
-            className="mt-12 flex justify-center gap-8"
+            className="shrink-0 flex items-center justify-between px-5 h-[38px] text-[11px]"
             style={{
-              animation: isClosing ? 'none' : 'hintFadeIn 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.35s both',
-              opacity: isTransitioning ? 0 : undefined,
-              transition: isTransitioning ? 'opacity 0.2s ease-out' : undefined,
+              borderTop: '1px solid rgba(255,255,255,0.06)',
+              color: 'rgba(255,255,255,0.4)',
+              background: 'rgba(255,255,255,0.015)',
             }}
           >
-            <div
-              className="flex items-center gap-3 text-[13px]"
-              style={{ color: 'rgba(255, 255, 255, 0.35)' }}
-            >
-              <div className="flex gap-1">
-                <span
-                  className="px-2 py-1 rounded-lg"
-                  style={{
-                    background: 'rgba(255, 255, 255, 0.06)',
-                    border: '1px solid rgba(255, 255, 255, 0.08)',
-                  }}
+            <div className="flex items-center gap-4">
+              <span className="flex items-center gap-1.5">
+                <kbd
+                  className="px-1.5 py-0.5 rounded font-mono"
+                  style={{ background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.08)' }}
                 >
-                  ←
-                </span>
-                <span
-                  className="px-2 py-1 rounded-lg"
-                  style={{
-                    background: 'rgba(255, 255, 255, 0.06)',
-                    border: '1px solid rgba(255, 255, 255, 0.08)',
-                  }}
+                  ↑↓←→
+                </kbd>
+                <span>导航</span>
+              </span>
+              <span className="flex items-center gap-1.5">
+                <kbd
+                  className="px-1.5 py-0.5 rounded font-mono"
+                  style={{ background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.08)' }}
                 >
-                  →
-                </span>
-              </div>
-              <span>切换选择</span>
-            </div>
-            <div
-              className="flex items-center gap-3 text-[13px]"
-              style={{ color: 'rgba(255, 255, 255, 0.35)' }}
-            >
-              <span
-                className="px-3 py-1 rounded-lg"
-                style={{
-                  background: 'rgba(255, 255, 255, 0.06)',
-                  border: '1px solid rgba(255, 255, 255, 0.08)',
-                }}
-              >
-                Enter
+                  Enter
+                </kbd>
+                <span>进入</span>
               </span>
-              <span>确认进入</span>
-            </div>
-            <div
-              className="flex items-center gap-3 text-[13px]"
-              style={{ color: 'rgba(255, 255, 255, 0.35)' }}
-            >
-              <span
-                className="px-3 py-1 rounded-lg"
-                style={{
-                  background: 'rgba(255, 255, 255, 0.06)',
-                  border: '1px solid rgba(255, 255, 255, 0.08)',
-                }}
-              >
-                Esc
+              <span className="flex items-center gap-1.5">
+                <Pin size={11} />
+                <span>点击星标置顶</span>
               </span>
-              <span>关闭</span>
+            </div>
+            <div style={{ color: 'rgba(255,255,255,0.3)' }}>
+              {flatList.length} 个入口 · 在「设置 → 我的空间」管理
             </div>
           </div>
         </div>
-
-        {/* 动画样式 */}
-        <style>{`
-          @keyframes bgFadeIn {
-            from { opacity: 0; }
-            to { opacity: 1; }
-          }
-          @keyframes bgFadeOut {
-            from { opacity: 1; }
-            to { opacity: 0; }
-          }
-          @keyframes contentFadeIn {
-            from {
-              opacity: 0;
-              transform: scale(0.98);
-            }
-            to {
-              opacity: 1;
-              transform: scale(1);
-            }
-          }
-          @keyframes contentFadeOut {
-            from {
-              opacity: 1;
-              transform: scale(1);
-            }
-            to {
-              opacity: 0;
-              transform: scale(0.98);
-            }
-          }
-          @keyframes titleSlideIn {
-            from {
-              opacity: 0;
-              transform: translateY(-15px);
-            }
-            to {
-              opacity: 1;
-              transform: translateY(0);
-            }
-          }
-          @keyframes hintFadeIn {
-            from {
-              opacity: 0;
-              transform: translateY(8px);
-            }
-            to {
-              opacity: 1;
-              transform: translateY(0);
-            }
-          }
-          @keyframes cardEnter {
-            0% {
-              opacity: 0;
-              transform: translate(var(--entry-x), var(--entry-y)) rotate(var(--entry-rotate)) scale(0.85);
-            }
-            100% {
-              opacity: 1;
-              transform: translate(0, 0) rotate(0deg) scale(1);
-            }
-          }
-          @keyframes cardExit {
-            from {
-              opacity: 1;
-              transform: translate(0, 0) rotate(0deg) scale(1);
-            }
-            to {
-              opacity: 0;
-              transform: translate(calc(var(--entry-x) * 0.5), calc(var(--entry-y) * 0.5)) rotate(calc(var(--entry-rotate) * 0.5)) scale(0.9);
-            }
-          }
-        `}</style>
       </div>
 
-      {/* 传送门穿越过渡层 — 点击后立即展示 */}
-      {transitionAgent && transitionRect && (
-        <PortalTransition
-          agent={transitionAgent}
-          startRect={transitionRect}
-          onNavigate={handleNavigate}
-          onComplete={handleTransitionComplete}
-        />
-      )}
-    </>,
+      <style>{`
+        @keyframes switcherBgIn {
+          from { opacity: 0; }
+          to { opacity: 1; }
+        }
+        @keyframes switcherPanelIn {
+          from {
+            opacity: 0;
+            transform: translateY(-12px) scale(0.985);
+          }
+          to {
+            opacity: 1;
+            transform: translateY(0) scale(1);
+          }
+        }
+      `}</style>
+    </div>,
     document.body
   );
 }

--- a/prd-admin/src/components/agent-switcher/AgentSwitcher.tsx
+++ b/prd-admin/src/components/agent-switcher/AgentSwitcher.tsx
@@ -39,7 +39,7 @@ function getIcon(name: string, size = 18) {
   return <Icon size={size} />;
 }
 
-/** 单张卡片 */
+/** 单张卡片（紧凑方形，可放 5 列） */
 function LauncherCard({
   item,
   isSelected,
@@ -64,84 +64,91 @@ function LauncherCard({
       onClick={onClick}
       onMouseEnter={onMouseEnter}
       className="group relative text-left outline-none focus:outline-none"
-      style={{
-        width: '100%',
-      }}
+      style={{ width: '100%' }}
+      title={item.description}
     >
       <div
-        className="relative h-[92px] p-3 rounded-[14px] flex items-start gap-3 transition-all duration-200 cursor-pointer overflow-hidden"
+        className="relative rounded-[12px] p-2.5 flex flex-col items-start gap-1.5 transition-all duration-200 cursor-pointer overflow-hidden"
         style={{
+          height: 96,
           background: isSelected
             ? `linear-gradient(135deg, ${accent}22 0%, rgba(255,255,255,0.03) 100%)`
             : 'rgba(255, 255, 255, 0.025)',
           border: `1px solid ${isSelected ? `${accent}55` : 'rgba(255,255,255,0.06)'}`,
           boxShadow: isSelected
-            ? `0 0 0 1px ${accent}40 inset, 0 8px 24px -8px ${accent}55`
-            : '0 2px 8px rgba(0,0,0,0.25)',
+            ? `0 0 0 1px ${accent}40 inset, 0 6px 20px -8px ${accent}55`
+            : '0 1px 4px rgba(0,0,0,0.2)',
           transform: isSelected ? 'translateY(-1px)' : 'translateY(0)',
         }}
       >
-        {/* 图标 */}
-        <div
-          className="shrink-0 w-10 h-10 rounded-[10px] flex items-center justify-center"
-          style={{
-            background: isSelected ? `${accent}20` : 'rgba(255,255,255,0.04)',
-            color: isSelected ? accent : 'rgba(255,255,255,0.72)',
-            border: `1px solid ${isSelected ? `${accent}40` : 'rgba(255,255,255,0.06)'}`,
-          }}
-        >
-          {getIcon(item.icon, 18)}
-        </div>
-
-        {/* 文字 */}
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2">
-            <span
-              className="text-[13px] font-semibold truncate"
-              style={{ color: isSelected ? '#fff' : 'rgba(255,255,255,0.92)' }}
-            >
-              {item.name}
-            </span>
+        {/* 顶部：图标 + 徽标 */}
+        <div className="flex items-center justify-between w-full">
+          <div
+            className="shrink-0 w-8 h-8 rounded-[8px] flex items-center justify-center"
+            style={{
+              background: isSelected ? `${accent}20` : 'rgba(255,255,255,0.04)',
+              color: isSelected ? accent : 'rgba(255,255,255,0.75)',
+              border: `1px solid ${isSelected ? `${accent}40` : 'rgba(255,255,255,0.06)'}`,
+            }}
+          >
+            {getIcon(item.icon, 15)}
+          </div>
+          <div className="flex items-center gap-1">
             {item.wip && (
               <span
-                className="shrink-0 text-[9px] font-bold px-1.5 py-0.5 rounded"
+                className="shrink-0 text-[9px] font-bold px-1 py-0.5 rounded leading-none"
                 style={{ background: 'rgba(251, 146, 60, 0.2)', color: '#fb923c' }}
               >
-                施工中
+                WIP
               </span>
             )}
             {badge && (
               <span
-                className="shrink-0 text-[9px] font-bold px-1.5 py-0.5 rounded"
+                className="shrink-0 text-[9px] font-bold px-1 py-0.5 rounded leading-none"
                 style={{ background: 'rgba(99,102,241,0.2)', color: '#a5b4fc' }}
               >
                 {badge}
               </span>
             )}
           </div>
-          <div
-            className="mt-1 text-[11px] leading-relaxed line-clamp-2"
-            style={{ color: isSelected ? 'rgba(255,255,255,0.72)' : 'rgba(255,255,255,0.48)' }}
-          >
-            {item.description}
-          </div>
+        </div>
+
+        {/* 名称 */}
+        <div
+          className="text-[12.5px] font-semibold leading-tight w-full truncate"
+          style={{ color: isSelected ? '#fff' : 'rgba(255,255,255,0.92)' }}
+        >
+          {item.name}
+        </div>
+
+        {/* 描述（两行省略） */}
+        <div
+          className="text-[10.5px] leading-snug w-full overflow-hidden"
+          style={{
+            color: isSelected ? 'rgba(255,255,255,0.72)' : 'rgba(255,255,255,0.44)',
+            display: '-webkit-box',
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: 'vertical',
+          }}
+        >
+          {item.description}
         </div>
 
         {/* 置顶按钮（hover 或已置顶时显示） */}
         <button
           type="button"
           onClick={onTogglePin}
-          className="absolute top-2 right-2 w-6 h-6 rounded-md flex items-center justify-center transition-opacity"
+          className="absolute top-1.5 right-1.5 w-5 h-5 rounded-[5px] flex items-center justify-center transition-opacity"
           style={{
-            opacity: isPinned || isSelected ? 1 : 0,
+            opacity: isPinned ? 1 : isSelected ? 0.85 : 0,
             background: isPinned ? `${accent}30` : 'rgba(255,255,255,0.05)',
-            color: isPinned ? accent : 'rgba(255,255,255,0.55)',
+            color: isPinned ? accent : 'rgba(255,255,255,0.6)',
             border: `1px solid ${isPinned ? `${accent}60` : 'rgba(255,255,255,0.08)'}`,
           }}
           title={isPinned ? '取消置顶' : '置顶到前台'}
           aria-label={isPinned ? '取消置顶' : '置顶'}
         >
-          {isPinned ? <Pin size={11} /> : <PinOff size={11} />}
+          {isPinned ? <Pin size={10} /> : <PinOff size={10} />}
         </button>
       </div>
     </button>
@@ -328,10 +335,10 @@ export function AgentSwitcher() {
 
       switch (e.key) {
         case 'ArrowDown':
-          move(2);
+          move(5);
           break;
         case 'ArrowUp':
-          move(-2);
+          move(-5);
           break;
         case 'ArrowRight':
           move(1);
@@ -381,7 +388,7 @@ export function AgentSwitcher() {
 
       {/* 面板 */}
       <div
-        className="relative w-[92vw] max-w-[960px]"
+        className="relative w-[92vw] max-w-[1080px]"
         style={{
           height: '80vh',
           maxHeight: '80vh',
@@ -477,7 +484,7 @@ export function AgentSwitcher() {
                         {section.items.length}
                       </span>
                     </div>
-                    <div className="grid grid-cols-2 gap-2.5">
+                    <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-2">
                       {section.items.map((item) => (
                         <LauncherCard
                           key={`${section.key}:${item.id}`}

--- a/prd-admin/src/components/agent-switcher/AgentSwitcher.tsx
+++ b/prd-admin/src/components/agent-switcher/AgentSwitcher.tsx
@@ -63,14 +63,14 @@ function LauncherCard({
       type="button"
       onClick={onClick}
       onMouseEnter={onMouseEnter}
-      className="group relative text-left outline-none focus:outline-none"
+      className="group relative text-left outline-none focus:outline-none flex"
       style={{ width: '100%' }}
       title={item.description}
     >
       <div
-        className="relative rounded-[12px] p-2.5 flex flex-col items-start gap-1.5 transition-all duration-200 cursor-pointer overflow-hidden"
+        className="relative w-full rounded-[12px] p-2.5 flex flex-col items-start gap-1.5 transition-all duration-200 cursor-pointer"
         style={{
-          height: 96,
+          minHeight: 96,
           background: isSelected
             ? `linear-gradient(135deg, ${accent}22 0%, rgba(255,255,255,0.03) 100%)`
             : 'rgba(255, 255, 255, 0.025)',
@@ -113,22 +113,19 @@ function LauncherCard({
           </div>
         </div>
 
-        {/* 名称 */}
+        {/* 名称（长名也换行显示，不截断） */}
         <div
-          className="text-[12.5px] font-semibold leading-tight w-full truncate"
+          className="text-[12.5px] font-semibold leading-tight w-full break-words"
           style={{ color: isSelected ? '#fff' : 'rgba(255,255,255,0.92)' }}
         >
           {item.name}
         </div>
 
-        {/* 描述（两行省略） */}
+        {/* 描述（自然换行、不截断；卡片高度随内容增长） */}
         <div
-          className="text-[10.5px] leading-snug w-full overflow-hidden"
+          className="text-[10.5px] leading-snug w-full break-words"
           style={{
             color: isSelected ? 'rgba(255,255,255,0.72)' : 'rgba(255,255,255,0.44)',
-            display: '-webkit-box',
-            WebkitLineClamp: 2,
-            WebkitBoxOrient: 'vertical',
           }}
         >
           {item.description}
@@ -484,7 +481,7 @@ export function AgentSwitcher() {
                         {section.items.length}
                       </span>
                     </div>
-                    <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-2">
+                    <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-2 items-stretch">
                       {section.items.map((item) => (
                         <LauncherCard
                           key={`${section.key}:${item.id}`}

--- a/prd-admin/src/layouts/AppShell.tsx
+++ b/prd-admin/src/layouts/AppShell.tsx
@@ -1052,11 +1052,27 @@ export default function AppShell() {
                   <span className="text-[13px]">数据分享</span>
                 </DropdownMenu.Item>
 
+                <DropdownMenu.Item
+                  className="flex items-center gap-3 px-3 py-2.5 rounded-[10px] cursor-pointer outline-none transition-colors hover:bg-white/6"
+                  style={{ color: 'var(--text-secondary)' }}
+                  onSelect={() => navigate('/settings?tab=user-space')}
+                >
+                  <Sparkles size={16} className="shrink-0" />
+                  <span className="text-[13px]">我的空间</span>
+                  <span
+                    className="ml-auto text-[10px]"
+                    style={{ color: 'var(--text-muted)' }}
+                  >
+                    常用 / 最近 / 置顶
+                  </span>
+                </DropdownMenu.Item>
+
                 {/* 注意：工具类菜单项（网页托管/知识库/涌现/提示词/实验室/自动化/快捷指令/PR 审查/请求日志 等）
                     已从用户菜单移除。它们的入口现在是：
                     - 首页「实用工具」区（AgentLauncherPage staticUtilities）
                     - 百宝箱 BUILTIN_TOOLS
-                    原则：用户菜单只保留「账户 + 系统 + 退出」三类，不承载工具导航。 */}
+                    - Cmd/Ctrl + K 命令面板（Agent / 工具 / 实用工具 统一搜索）
+                    原则：用户菜单只保留「账户 + 系统 + 我的空间 + 退出」四类，不承载工具导航。 */}
 
                 <DropdownMenu.Item
                   className="flex items-center gap-3 px-3 py-2.5 rounded-[10px] cursor-pointer outline-none transition-colors hover:bg-white/6"

--- a/prd-admin/src/lib/launcherCatalog.ts
+++ b/prd-admin/src/lib/launcherCatalog.ts
@@ -1,0 +1,212 @@
+/**
+ * Launcher Catalog — Agent / 工具 / 实用工具 的统一目录
+ *
+ * Agent Switcher 浮层和「我的空间」设置页共享同一份目录，避免各自维护拷贝。
+ */
+
+import { AGENT_DEFINITIONS } from '@/stores/agentSwitcherStore';
+import { BUILTIN_TOOLS } from '@/stores/toolboxStore';
+
+export type LauncherGroup = 'agent' | 'toolbox' | 'utility';
+
+export interface LauncherItem {
+  /** 稳定 id，用作置顶 / 使用次数 / 最近访问的 key */
+  id: string;
+  name: string;
+  description: string;
+  /** Lucide 图标名 */
+  icon: string;
+  group: LauncherGroup;
+  route: string;
+  tags: string[];
+  /** Agent 卡片的主题色（hex） */
+  accentColor?: string;
+  /** Agent 卡片的 appKey（用于首屏封面图） */
+  agentKey?: string;
+  /** 权限键，缺失则无门控 */
+  permission?: string | string[];
+  /** 标记为施工中（WIP） */
+  wip?: boolean;
+}
+
+/** Agent 的图标/描述兜底 */
+const AGENT_DESCRIPTIONS: Record<string, string> = {
+  'prd-agent': '智能解读 PRD 文档，快速提取需求要点',
+  'visual-agent': 'AI 驱动的视觉创作，一键生成精美图像',
+  'literary-agent': '文学创作助手，为文章配图赋予灵魂',
+  'defect-agent': '缺陷管理专家，高效追踪问题闭环',
+  'video-agent': '文章转视频教程，AI 驱动分镜创作',
+};
+
+/** Agent 条目（来自 AGENT_DEFINITIONS） */
+function buildAgentItems(): LauncherItem[] {
+  return AGENT_DEFINITIONS.map((a) => ({
+    id: `agent:${a.key}`,
+    name: a.name,
+    description: AGENT_DESCRIPTIONS[a.key] ?? `${a.name} - 智能助手`,
+    icon: a.icon,
+    group: 'agent' as const,
+    route: a.route,
+    tags: [a.name, 'Agent', a.appKey],
+    accentColor: a.color.text,
+    agentKey: a.appKey,
+  }));
+}
+
+/** 百宝箱内置工具（来自 toolboxStore.BUILTIN_TOOLS） */
+function buildToolboxItems(): LauncherItem[] {
+  return BUILTIN_TOOLS.filter((t) => !!t.routePath).map((t) => ({
+    id: `toolbox:${t.id}`,
+    name: t.name,
+    description: t.description ?? '',
+    icon: t.icon ?? 'Bot',
+    group: 'toolbox' as const,
+    route: t.routePath!,
+    tags: [t.name, ...(t.tags ?? [])],
+    agentKey: t.agentKey,
+    wip: t.wip,
+  }));
+}
+
+/**
+ * 实用工具（与 AgentLauncherPage 的 staticUtilities 保持同步）
+ * 每项可以带 permission 来做门控。
+ */
+function buildUtilityItems(): LauncherItem[] {
+  return [
+    {
+      id: 'utility:document-store',
+      name: '知识库',
+      description: '文档存储与知识管理，支持文件夹、GitHub 同步',
+      icon: 'Library',
+      group: 'utility',
+      route: '/document-store',
+      tags: ['文档', '知识', '知识库', 'docs'],
+    },
+    {
+      id: 'utility:emergence',
+      name: '涌现探索',
+      description: '从文档出发，AI 辅助发现功能创意与交叉价值',
+      icon: 'Sparkle',
+      group: 'utility',
+      route: '/emergence',
+      tags: ['涌现', '探索', 'AI', '创意'],
+    },
+    {
+      id: 'utility:web-pages',
+      name: '网页托管',
+      description: '上传 HTML 或 ZIP，托管并分享你的网页',
+      icon: 'Globe',
+      group: 'utility',
+      route: '/web-pages',
+      tags: ['托管', '网页', 'hosting'],
+    },
+    {
+      id: 'utility:skill-agent',
+      name: '技能创建助手',
+      description: 'AI 引导你逐步创建可复用的技能模板',
+      icon: 'Wand2',
+      group: 'utility',
+      route: '/skill-agent',
+      tags: ['技能', 'skill', 'AI', '创建', '模板'],
+    },
+    {
+      id: 'utility:prompts',
+      name: '提示词管理',
+      description: '管理系统与技能提示词',
+      icon: 'FileText',
+      group: 'utility',
+      route: '/prompts',
+      tags: ['提示词', 'prompts', '管理'],
+      permission: ['prompts.read', 'prompts.write'],
+    },
+    {
+      id: 'utility:lab',
+      name: '实验室',
+      description: 'Model Lab / 桌面实验 / 工具箱',
+      icon: 'FlaskConical',
+      group: 'utility',
+      route: '/lab',
+      tags: ['实验室', 'lab', 'beta'],
+      permission: ['lab.read', 'lab.write'],
+    },
+    {
+      id: 'utility:automations',
+      name: '自动化规则',
+      description: '创建和管理跨系统的自动化任务',
+      icon: 'Zap',
+      group: 'utility',
+      route: '/automations',
+      tags: ['自动化', 'automation', '规则'],
+      permission: 'automations.manage',
+    },
+    {
+      id: 'utility:logs',
+      name: '请求日志',
+      description: 'LLM 调用与 API 请求日志审计',
+      icon: 'ScrollText',
+      group: 'utility',
+      route: '/logs',
+      tags: ['日志', 'logs', '审计'],
+      permission: 'logs.read',
+    },
+    {
+      id: 'utility:settings',
+      name: '设置',
+      description: '皮肤、导航、数据管理等系统设置',
+      icon: 'Settings',
+      group: 'utility',
+      route: '/settings',
+      tags: ['设置', 'settings', '偏好'],
+    },
+  ];
+}
+
+/**
+ * 按当前用户权限与 isRoot 过滤出完整目录。
+ * - isRoot = true：绕过所有权限校验
+ * - permission 为字符串：必须拥有该权限
+ * - permission 为数组：任一命中即可
+ */
+export function getLauncherCatalog(opts: {
+  permissions: string[];
+  isRoot: boolean;
+}): LauncherItem[] {
+  const { permissions, isRoot } = opts;
+  const perms = new Set(permissions);
+  const hasPerm = (p: string) => isRoot || perms.has(p) || perms.has('super');
+
+  const match = (item: LauncherItem) => {
+    if (!item.permission) return true;
+    if (Array.isArray(item.permission)) return item.permission.some(hasPerm);
+    return hasPerm(item.permission);
+  };
+
+  const all = [...buildAgentItems(), ...buildToolboxItems(), ...buildUtilityItems()];
+
+  // 根据 id 去重（toolbox 中的 Agent 已在 agent: 前缀下独立呈现）
+  const seen = new Set<string>();
+  const dedup: LauncherItem[] = [];
+  for (const it of all) {
+    if (seen.has(it.id)) continue;
+    seen.add(it.id);
+    dedup.push(it);
+  }
+
+  return dedup.filter(match);
+}
+
+/** 按 id 查找 LauncherItem */
+export function findLauncherItem(
+  catalog: LauncherItem[],
+  id: string
+): LauncherItem | undefined {
+  return catalog.find((it) => it.id === id);
+}
+
+/** Group 中文标签 */
+export const LAUNCHER_GROUP_LABELS: Record<LauncherGroup, string> = {
+  agent: 'Agent',
+  toolbox: '百宝箱',
+  utility: '实用工具',
+};

--- a/prd-admin/src/pages/SettingsPage.tsx
+++ b/prd-admin/src/pages/SettingsPage.tsx
@@ -6,7 +6,7 @@ import type { TabBarItem } from '@/components/design/TabBar';
 import { Button } from '@/components/design/Button';
 import { useNavOrderStore } from '@/stores/navOrderStore';
 import { useAuthStore } from '@/stores/authStore';
-import { GripVertical, Palette, RefreshCw, RotateCcw, Image, UserCog, Database, ListOrdered, Zap } from 'lucide-react';
+import { GripVertical, Palette, RefreshCw, RotateCcw, Image, UserCog, Database, ListOrdered, Zap, Sparkles } from 'lucide-react';
 import { MapSpinner } from '@/components/ui/VideoLoader';
 import * as LucideIcons from 'lucide-react';
 import { ThemeSkinEditor } from '@/pages/settings/ThemeSkinEditor';
@@ -14,6 +14,7 @@ import AssetsManagePage from '@/pages/AssetsManagePage';
 import AuthzPage from '@/pages/AuthzPage';
 import DataManagePage from '@/pages/DataManagePage';
 import { UpdateAccelerationSettings } from '@/pages/settings/UpdateAccelerationSettings';
+import { UserSpaceSettings } from '@/pages/settings/UserSpaceSettings';
 
 interface NavItem {
   key: string;
@@ -259,6 +260,7 @@ export default function SettingsPage() {
   // 根据权限构建可见 tab 列表
   const tabs = useMemo(() => {
     const list: TabBarItem[] = [
+      { key: 'user-space', label: '我的空间', icon: <Sparkles size={14} /> },
       { key: 'skin', label: '皮肤设置', icon: <Palette size={14} /> },
       { key: 'nav-order', label: '导航顺序', icon: <ListOrdered size={14} /> },
     ];
@@ -270,7 +272,7 @@ export default function SettingsPage() {
     return list;
   }, [perms, isRoot]);
 
-  const tabFromUrl = searchParams.get('tab') || 'skin';
+  const tabFromUrl = searchParams.get('tab') || 'user-space';
   const [activeTab, setActiveTab] = useState(tabFromUrl);
 
   // 同步 URL 参数
@@ -295,6 +297,7 @@ export default function SettingsPage() {
       />
 
       <div className="flex-1 min-h-0">
+        {activeTab === 'user-space' && <UserSpaceSettings />}
         {activeTab === 'skin' && <SkinSettings />}
         {activeTab === 'nav-order' && <NavOrderSettings />}
         {activeTab === 'assets' && <AssetsManagePage />}

--- a/prd-admin/src/pages/settings/UserSpaceSettings.tsx
+++ b/prd-admin/src/pages/settings/UserSpaceSettings.tsx
@@ -1,0 +1,473 @@
+/**
+ * 「我的空间」设置页
+ *
+ * 展示并管理当前用户的私人使用数据：
+ *  - 常用工具：按使用次数自动排序
+ *  - 最近使用：按最近访问时间倒序
+ *  - 已置顶：用户固定的快捷入口
+ *
+ * 数据源：useAgentSwitcherStore（sessionStorage 持久化，登出即清空）
+ * 与命令面板（Cmd/Ctrl + K）共享同一份存储，两边看到的是同一份数据。
+ */
+
+import { useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import * as LucideIcons from 'lucide-react';
+import {
+  Pin,
+  Clock,
+  TrendingUp,
+  Trash2,
+  ExternalLink,
+  Keyboard,
+  Sparkles,
+} from 'lucide-react';
+import { GlassCard } from '@/components/design/GlassCard';
+import { Button } from '@/components/design/Button';
+import {
+  useAgentSwitcherStore,
+  getRelativeTime,
+} from '@/stores/agentSwitcherStore';
+import { useAuthStore } from '@/stores/authStore';
+import { getLauncherCatalog, type LauncherItem } from '@/lib/launcherCatalog';
+
+function getIcon(name: string, size = 16) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const Icon = (LucideIcons as any)[name] ?? LucideIcons.Circle;
+  return <Icon size={size} />;
+}
+
+/** 一行工具条目 */
+function ToolRow({
+  item,
+  rightSlot,
+  onClick,
+  onRemove,
+  removeLabel,
+}: {
+  item: LauncherItem;
+  rightSlot?: React.ReactNode;
+  onClick?: () => void;
+  onRemove?: () => void;
+  removeLabel?: string;
+}) {
+  const accent = item.accentColor ?? '#818CF8';
+  return (
+    <div
+      className="flex items-center gap-3 px-3 py-2.5 rounded-[10px] transition-colors cursor-pointer group"
+      style={{
+        background: 'var(--nested-block-bg, rgba(255,255,255,0.025))',
+        border: '1px solid var(--nested-block-border, rgba(255,255,255,0.06))',
+      }}
+      onClick={onClick}
+    >
+      <div
+        className="shrink-0 w-8 h-8 rounded-[8px] flex items-center justify-center"
+        style={{
+          background: `${accent}18`,
+          border: `1px solid ${accent}30`,
+          color: accent,
+        }}
+      >
+        {getIcon(item.icon, 14)}
+      </div>
+      <div className="flex-1 min-w-0">
+        <div
+          className="text-[13px] font-medium truncate"
+          style={{ color: 'var(--text-primary)' }}
+        >
+          {item.name}
+        </div>
+        <div
+          className="text-[11px] truncate"
+          style={{ color: 'var(--text-muted)' }}
+        >
+          {item.route}
+        </div>
+      </div>
+      {rightSlot}
+      {onRemove && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove();
+          }}
+          className="shrink-0 w-7 h-7 rounded-md flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
+          style={{
+            background: 'rgba(239, 68, 68, 0.08)',
+            color: 'rgba(239, 68, 68, 0.85)',
+            border: '1px solid rgba(239, 68, 68, 0.2)',
+          }}
+          title={removeLabel ?? '移除'}
+          aria-label={removeLabel ?? '移除'}
+        >
+          <Trash2 size={11} />
+        </button>
+      )}
+      <ExternalLink
+        size={12}
+        className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
+        style={{ color: 'var(--text-muted)' }}
+      />
+    </div>
+  );
+}
+
+/** 区块头 */
+function SectionHeader({
+  icon,
+  title,
+  subtitle,
+  count,
+  action,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  subtitle: string;
+  count: number;
+  action?: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 mb-3 shrink-0">
+      <div className="flex items-center gap-2.5 min-w-0">
+        <div
+          className="shrink-0 w-7 h-7 rounded-[8px] flex items-center justify-center"
+          style={{
+            background: 'rgba(99, 102, 241, 0.12)',
+            color: '#a5b4fc',
+            border: '1px solid rgba(99, 102, 241, 0.24)',
+          }}
+        >
+          {icon}
+        </div>
+        <div className="min-w-0">
+          <div
+            className="text-[13px] font-bold flex items-center gap-2"
+            style={{ color: 'var(--text-primary)' }}
+          >
+            {title}
+            <span
+              className="text-[10px] font-mono px-1.5 py-0.5 rounded"
+              style={{
+                background: 'var(--bg-input, rgba(255,255,255,0.04))',
+                color: 'var(--text-muted)',
+              }}
+            >
+              {count}
+            </span>
+          </div>
+          <div
+            className="text-[11px] mt-0.5 truncate"
+            style={{ color: 'var(--text-muted)' }}
+          >
+            {subtitle}
+          </div>
+        </div>
+      </div>
+      {action && <div className="shrink-0">{action}</div>}
+    </div>
+  );
+}
+
+export function UserSpaceSettings() {
+  const navigate = useNavigate();
+  const permissions = useAuthStore((s) => s.permissions ?? []);
+  const isRoot = useAuthStore((s) => s.isRoot ?? false);
+  const user = useAuthStore((s) => s.user);
+
+  const {
+    pinnedIds,
+    recentVisits,
+    usageCounts,
+    togglePin,
+    clearPins,
+    clearRecentVisits,
+    resetUsage,
+    open: openSwitcher,
+  } = useAgentSwitcherStore();
+
+  const catalog = useMemo(
+    () => getLauncherCatalog({ permissions, isRoot }),
+    [permissions, isRoot]
+  );
+
+  const catalogById = useMemo(() => {
+    const m = new Map<string, LauncherItem>();
+    for (const it of catalog) m.set(it.id, it);
+    return m;
+  }, [catalog]);
+
+  const pinnedItems = useMemo(
+    () =>
+      pinnedIds
+        .map((id) => catalogById.get(id))
+        .filter((x): x is LauncherItem => !!x),
+    [pinnedIds, catalogById]
+  );
+
+  const recentItems = useMemo(
+    () =>
+      recentVisits
+        .map((v) => ({ item: catalogById.get(v.id), visit: v }))
+        .filter(
+          (x): x is { item: LauncherItem; visit: typeof recentVisits[number] } =>
+            !!x.item
+        )
+        .slice(0, 10),
+    [recentVisits, catalogById]
+  );
+
+  const frequentItems = useMemo(() => {
+    const entries = Object.entries(usageCounts)
+      .filter(([, count]) => count > 0)
+      .sort((a, b) => b[1] - a[1]);
+    return entries
+      .map(([id, count]) => {
+        const item = catalogById.get(id);
+        return item ? { item, count } : null;
+      })
+      .filter((x): x is { item: LauncherItem; count: number } => !!x)
+      .slice(0, 10);
+  }, [usageCounts, catalogById]);
+
+  const totalLaunches = useMemo(
+    () => Object.values(usageCounts).reduce((sum, n) => sum + n, 0),
+    [usageCounts]
+  );
+
+  return (
+    <div className="h-full min-h-0 overflow-y-auto pr-1">
+      {/* 顶部引导卡 */}
+      <GlassCard animated glow accentHue={250} className="mb-5">
+        <div className="flex items-start gap-4">
+          <div
+            className="shrink-0 w-12 h-12 rounded-[12px] flex items-center justify-center"
+            style={{
+              background: 'linear-gradient(135deg, rgba(99,102,241,0.2) 0%, rgba(139,92,246,0.2) 100%)',
+              border: '1px solid rgba(139, 92, 246, 0.3)',
+              color: '#c4b5fd',
+            }}
+          >
+            <Sparkles size={20} />
+          </div>
+          <div className="flex-1 min-w-0">
+            <div
+              className="text-[14px] font-bold"
+              style={{ color: 'var(--text-primary)' }}
+            >
+              {user?.displayName ?? '你'}的私人空间
+            </div>
+            <div
+              className="text-[12px] mt-1"
+              style={{ color: 'var(--text-muted)' }}
+            >
+              这里记录你常用的 Agent 与工具。数据仅存储在当前浏览器会话中（登出即清空），不会被其他用户看到。
+            </div>
+            <div className="flex items-center gap-4 mt-3 flex-wrap">
+              <div
+                className="flex items-center gap-1.5 text-[11px]"
+                style={{ color: 'var(--text-secondary)' }}
+              >
+                <Pin size={12} />
+                <span>已置顶</span>
+                <span className="font-bold" style={{ color: '#a5b4fc' }}>
+                  {pinnedItems.length}
+                </span>
+              </div>
+              <div
+                className="flex items-center gap-1.5 text-[11px]"
+                style={{ color: 'var(--text-secondary)' }}
+              >
+                <Clock size={12} />
+                <span>近期使用</span>
+                <span className="font-bold" style={{ color: '#a5b4fc' }}>
+                  {recentItems.length}
+                </span>
+              </div>
+              <div
+                className="flex items-center gap-1.5 text-[11px]"
+                style={{ color: 'var(--text-secondary)' }}
+              >
+                <TrendingUp size={12} />
+                <span>总启动次数</span>
+                <span className="font-bold" style={{ color: '#a5b4fc' }}>
+                  {totalLaunches}
+                </span>
+              </div>
+            </div>
+          </div>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => openSwitcher()}
+            className="shrink-0"
+          >
+            <Keyboard size={14} />
+            打开命令面板
+          </Button>
+        </div>
+      </GlassCard>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
+        {/* 置顶 */}
+        <GlassCard animated accentHue={230} className="flex flex-col">
+          <SectionHeader
+            icon={<Pin size={14} />}
+            title="置顶工具"
+            subtitle="在命令面板点击星标加入"
+            count={pinnedItems.length}
+            action={
+              pinnedItems.length > 0 ? (
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  onClick={() => {
+                    if (confirm('确认清空所有置顶？此操作不可撤销。')) clearPins();
+                  }}
+                >
+                  <Trash2 size={12} />
+                  清空
+                </Button>
+              ) : null
+            }
+          />
+          {pinnedItems.length === 0 ? (
+            <EmptyHint
+              title="还没有置顶工具"
+              hint="按 Cmd/Ctrl + K 打开命令面板，把你最常用的 Agent 或工具点击星标置顶到这里"
+            />
+          ) : (
+            <div className="flex flex-col gap-2">
+              {pinnedItems.map((item) => (
+                <ToolRow
+                  key={item.id}
+                  item={item}
+                  onClick={() => navigate(item.route)}
+                  onRemove={() => togglePin(item.id)}
+                  removeLabel="取消置顶"
+                />
+              ))}
+            </div>
+          )}
+        </GlassCard>
+
+        {/* 最近使用 */}
+        <GlassCard animated accentHue={180} className="flex flex-col">
+          <SectionHeader
+            icon={<Clock size={14} />}
+            title="最近使用"
+            subtitle="最近从命令面板进入的工具"
+            count={recentItems.length}
+            action={
+              recentItems.length > 0 ? (
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  onClick={() => {
+                    if (confirm('确认清空最近使用记录？')) clearRecentVisits();
+                  }}
+                >
+                  <Trash2 size={12} />
+                  清空
+                </Button>
+              ) : null
+            }
+          />
+          {recentItems.length === 0 ? (
+            <EmptyHint
+              title="还没有使用记录"
+              hint="通过命令面板打开任意工具，这里就会出现最近访问列表"
+            />
+          ) : (
+            <div className="flex flex-col gap-2">
+              {recentItems.map(({ item, visit }) => (
+                <ToolRow
+                  key={`${item.id}-${visit.timestamp}`}
+                  item={item}
+                  onClick={() => navigate(item.route)}
+                  rightSlot={
+                    <span
+                      className="shrink-0 text-[10px] font-mono px-1.5 py-0.5 rounded"
+                      style={{
+                        background: 'var(--bg-input, rgba(255,255,255,0.04))',
+                        color: 'var(--text-muted)',
+                      }}
+                    >
+                      {getRelativeTime(visit.timestamp)}
+                    </span>
+                  }
+                />
+              ))}
+            </div>
+          )}
+        </GlassCard>
+
+        {/* 常用工具 */}
+        <GlassCard animated accentHue={290} className="flex flex-col lg:col-span-2">
+          <SectionHeader
+            icon={<TrendingUp size={14} />}
+            title="常用工具"
+            subtitle="按累计启动次数自动排序"
+            count={frequentItems.length}
+            action={
+              frequentItems.length > 0 ? (
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  onClick={() => {
+                    if (confirm('确认重置使用统计？「常用工具」将清空。')) resetUsage();
+                  }}
+                >
+                  <Trash2 size={12} />
+                  重置统计
+                </Button>
+              ) : null
+            }
+          />
+          {frequentItems.length === 0 ? (
+            <EmptyHint
+              title="还没有统计数据"
+              hint="每次通过命令面板打开工具时都会计数，积累几次之后这里会展示你的使用 Top 10"
+            />
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+              {frequentItems.map(({ item, count }) => (
+                <ToolRow
+                  key={item.id}
+                  item={item}
+                  onClick={() => navigate(item.route)}
+                  rightSlot={
+                    <span
+                      className="shrink-0 text-[10px] font-mono px-2 py-0.5 rounded"
+                      style={{
+                        background: 'rgba(99, 102, 241, 0.15)',
+                        color: '#a5b4fc',
+                      }}
+                    >
+                      × {count}
+                    </span>
+                  }
+                />
+              ))}
+            </div>
+          )}
+        </GlassCard>
+      </div>
+    </div>
+  );
+}
+
+function EmptyHint({ title, hint }: { title: string; hint: string }) {
+  return (
+    <div
+      className="flex flex-col items-center justify-center gap-1.5 py-8 text-center"
+      style={{ color: 'var(--text-muted)' }}
+    >
+      <div className="text-[13px] font-medium">{title}</div>
+      <div className="text-[11px] max-w-[280px] leading-relaxed">{hint}</div>
+    </div>
+  );
+}
+
+export default UserSpaceSettings;

--- a/prd-admin/src/stores/agentSwitcherStore.ts
+++ b/prd-admin/src/stores/agentSwitcherStore.ts
@@ -1,9 +1,10 @@
 /**
  * Agent Switcher Store
  *
- * 管理 Agent 快捷切换浮层的状态和最近访问记录
+ * 管理 Agent 快捷切换浮层（命令面板）的状态：
  * - 全局快捷键 Cmd/Ctrl + K 触发
- * - 最近访问记录本地持久化
+ * - 最近访问 / 使用次数 / 置顶 全部本地持久化（sessionStorage）
+ * - 支持 Agent / 工具 / 实用工具 统一收录
  */
 
 import { create } from 'zustand';
@@ -27,10 +28,19 @@ export interface AgentDefinition {
 
 /** 最近访问记录 */
 export interface RecentVisit {
+  /** Launcher 条目的稳定 id（Agent key / toolbox id / utility id） */
+  id: string;
+  /** 兼容旧字段：Agent key，非 Agent 条目为空字符串 */
   agentKey: string;
+  /** 条目名 */
   agentName: string;
+  /** 副标题，历史上记录页面名，现在默认为条目类型 */
   title: string;
+  /** 跳转路径 */
   path: string;
+  /** Lucide 图标名（可选，Agent 条目为空时走 appKey 图标） */
+  icon?: string;
+  /** 访问时间戳 */
   timestamp: number;
 }
 
@@ -112,36 +122,47 @@ export const AGENT_DEFINITIONS: AgentDefinition[] = [
 interface AgentSwitcherState {
   // 浮层状态
   isOpen: boolean;
-  selectedIndex: number;
+  /** 当前选中项的 id（命令面板语义，替代原 selectedIndex） */
+  selectedId: string | null;
   searchQuery: string;
 
-  // 最近访问
+  // 最近访问 / 使用统计 / 置顶（均持久化）
   recentVisits: RecentVisit[];
+  usageCounts: Record<string, number>;
+  pinnedIds: string[];
 
   // Actions
   open: () => void;
   close: () => void;
   toggle: () => void;
-  setSelectedIndex: (index: number) => void;
+  setSelectedId: (id: string | null) => void;
   setSearchQuery: (query: string) => void;
-  moveSelection: (direction: 'up' | 'down' | 'left' | 'right') => void;
-  addRecentVisit: (visit: Omit<RecentVisit, 'timestamp'>) => void;
+
+  addRecentVisit: (visit: Omit<RecentVisit, 'timestamp'> & Partial<Pick<RecentVisit, 'id'>>) => void;
   clearRecentVisits: () => void;
+
+  togglePin: (id: string) => void;
+  isPinned: (id: string) => boolean;
+  clearPins: () => void;
+
+  resetUsage: () => void;
 }
 
-const MAX_RECENT_VISITS = 10;
+const MAX_RECENT_VISITS = 20;
 
 export const useAgentSwitcherStore = create<AgentSwitcherState>()(
   persist(
     (set, get) => ({
       // Initial state
       isOpen: false,
-      selectedIndex: 0,
+      selectedId: null,
       searchQuery: '',
       recentVisits: [],
+      usageCounts: {},
+      pinnedIds: [],
 
       // Actions
-      open: () => set({ isOpen: true, selectedIndex: 0, searchQuery: '' }),
+      open: () => set({ isOpen: true, selectedId: null, searchQuery: '' }),
 
       close: () => set({ isOpen: false, searchQuery: '' }),
 
@@ -150,66 +171,80 @@ export const useAgentSwitcherStore = create<AgentSwitcherState>()(
         if (isOpen) {
           set({ isOpen: false, searchQuery: '' });
         } else {
-          set({ isOpen: true, selectedIndex: 0, searchQuery: '' });
+          set({ isOpen: true, selectedId: null, searchQuery: '' });
         }
       },
 
-      setSelectedIndex: (index) => set({ selectedIndex: index }),
+      setSelectedId: (id) => set({ selectedId: id }),
 
       setSearchQuery: (query) => set({ searchQuery: query }),
 
-      moveSelection: (direction) => {
-        const { selectedIndex } = get();
-        const totalItems = AGENT_DEFINITIONS.length;
-        const cols = 4; // 网格列数
-
-        let newIndex = selectedIndex;
-
-        switch (direction) {
-          case 'up':
-            newIndex = selectedIndex - cols;
-            if (newIndex < 0) newIndex = selectedIndex;
-            break;
-          case 'down':
-            newIndex = selectedIndex + cols;
-            if (newIndex >= totalItems) newIndex = selectedIndex;
-            break;
-          case 'left':
-            newIndex = selectedIndex - 1;
-            if (newIndex < 0) newIndex = totalItems - 1;
-            break;
-          case 'right':
-            newIndex = selectedIndex + 1;
-            if (newIndex >= totalItems) newIndex = 0;
-            break;
-        }
-
-        set({ selectedIndex: newIndex });
-      },
-
       addRecentVisit: (visit) => {
-        const { recentVisits } = get();
+        const id = visit.id ?? visit.agentKey ?? visit.path;
+        const { recentVisits, usageCounts } = get();
         const newVisit: RecentVisit = {
-          ...visit,
+          id,
+          agentKey: visit.agentKey,
+          agentName: visit.agentName,
+          title: visit.title,
+          path: visit.path,
+          icon: visit.icon,
           timestamp: Date.now(),
         };
 
-        // 移除相同路径的旧记录
-        const filtered = recentVisits.filter((v) => v.path !== visit.path);
-
-        // 添加到开头，限制最大数量
+        // 移除相同 id 的旧记录
+        const filtered = recentVisits.filter((v) => v.id !== id);
         const updated = [newVisit, ...filtered].slice(0, MAX_RECENT_VISITS);
 
-        set({ recentVisits: updated });
+        set({
+          recentVisits: updated,
+          usageCounts: { ...usageCounts, [id]: (usageCounts[id] ?? 0) + 1 },
+        });
       },
 
       clearRecentVisits: () => set({ recentVisits: [] }),
+
+      togglePin: (id: string) => {
+        const { pinnedIds } = get();
+        if (pinnedIds.includes(id)) {
+          set({ pinnedIds: pinnedIds.filter((p) => p !== id) });
+        } else {
+          set({ pinnedIds: [id, ...pinnedIds].slice(0, 20) });
+        }
+      },
+
+      isPinned: (id: string) => get().pinnedIds.includes(id),
+
+      clearPins: () => set({ pinnedIds: [] }),
+
+      resetUsage: () => set({ usageCounts: {} }),
     }),
     {
       name: 'prd-admin-agent-switcher',
+      version: 2,
       storage: createJSONStorage(() => sessionStorage),
-      // 只持久化最近访问记录
-      partialize: (state) => ({ recentVisits: state.recentVisits }),
+      partialize: (state) => ({
+        recentVisits: state.recentVisits,
+        usageCounts: state.usageCounts,
+        pinnedIds: state.pinnedIds,
+      }),
+      // v1 → v2 迁移：补齐 id 字段，兼容老数据结构
+      migrate: (persisted: unknown, version: number) => {
+        const state = (persisted ?? {}) as Partial<AgentSwitcherState>;
+        if (version < 2) {
+          const visits = (state.recentVisits ?? []).map((v: RecentVisit) => ({
+            ...v,
+            id: v.id ?? v.agentKey ?? v.path,
+          }));
+          return {
+            ...state,
+            recentVisits: visits,
+            usageCounts: state.usageCounts ?? {},
+            pinnedIds: state.pinnedIds ?? [],
+          } as AgentSwitcherState;
+        }
+        return state as AgentSwitcherState;
+      },
     }
   )
 );


### PR DESCRIPTION
## Summary

Completely redesigned the Agent Switcher from a 5-card grid UI into a modern command palette (Cmd/Ctrl + K) that unifies Agent, Toolbox, and Utility tools discovery. Added persistent user preferences (pinning, recent visits, usage tracking) and a new "My Space" settings page to visualize personal usage data.

## Key Changes

### Agent Switcher Component (`AgentSwitcher.tsx`)
- **Removed**: Portal transition animation (canvas-based tunnel effect), 5-card grid layout, agent-specific styling
- **Added**: 
  - Unified command palette UI with search input
  - Keyboard navigation (↑↓ for 5-column grid, ←→ for linear, Enter to launch, Esc to close)
  - Dynamic section grouping: Pinned → Recent → Agent → Toolbox → Utility
  - Pin/unpin buttons on each item card
  - Real-time search across name, description, and tags
  - Compact card layout (5 columns) with accent colors and WIP badges

### New Launcher Catalog (`launcherCatalog.ts`)
- Centralized directory of all launchable items (Agent, Toolbox, Utility)
- Unified `LauncherItem` interface with stable IDs for persistence
- Permission-based filtering (supports string or array permissions)
- Deduplication logic to prevent duplicate entries

### Enhanced Store (`agentSwitcherStore.ts`)
- Replaced `selectedIndex` with `selectedId` (string-based selection)
- Added `usageCounts` (tracks launch frequency per item)
- Added `pinnedIds` (user-pinned items)
- Extended `RecentVisit` with `id` field for non-Agent items
- New actions: `togglePin()`, `isPinned()`, `clearPins()`, `resetUsage()`
- All data persisted to sessionStorage

### New "My Space" Settings Page (`UserSpaceSettings.tsx`)
- Dashboard showing user's personal usage data
- Three sections: Pinned Tools, Recent Visits, Frequent Tools (Top 10)
- Quick actions to clear pins, recent visits, or reset usage stats
- Integrated with same store as command palette (shared data source)

### UI Updates
- Added "My Space" menu item in AppShell settings dropdown
- New SettingsPage tab for "My Space"
- Consistent glass-morphism design with accent colors

## Implementation Details

- **Search**: Case-insensitive substring matching across item name, description, and tags
- **Sorting**: Recent items by timestamp (desc), frequent items by usage count (desc), others by usage count when searching
- **Keyboard UX**: 5-column grid navigation (↑↓ moves 5 items), ←→ for adjacent items, Enter launches, Esc closes
- **Persistence**: sessionStorage (clears on logout), survives page refresh within session
- **Icons**: Lucide React icons with dynamic lookup by name string
- **Permissions**: Items filtered based on user's permission set; root users bypass all checks

https://claude.ai/code/session_01TokaNU1SLPng83eK6xghMK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it rewires the launcher UX and its persisted state (selection, recents, pinning, usage counts) across multiple entry points; issues could break navigation or corrupt session-persisted preferences.
> 
> **Overview**
> **Replaces the old 5-agent switcher overlay with a unified Cmd/Ctrl+K command palette** that lists *Agents + 百宝箱工具 + 实用工具* in one searchable, keyboard-navigable UI, with grouping (置顶/最近/各类分组) and per-item pin/unpin.
> 
> **Introduces a shared `launcherCatalog`** to generate a permission-filtered, de-duplicated list of launchable items for both the command palette and settings.
> 
> **Extends `agentSwitcherStore` persistence to v2**: switches selection from `selectedIndex` to `selectedId`, adds `pinnedIds` and `usageCounts`, expands `recentVisits` with stable `id`/`icon`, and adds actions to toggle/clear pins and reset usage (with migration for old data).
> 
> **Adds a new Settings → `我的空间` page and entry points** (Settings default tab + user dropdown link) to view/manage pinned items, recent launches, and top-used tools, sharing the same session-scoped data as the command palette.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5fc156df41d1270f867d93566acb3075bfd4ad0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->