### PR TITLE
Add PRD document input mode to video storyboard generation

### DIFF
--- a/changelogs/2026-04-19_video-prd-storyboard.md
+++ b/changelogs/2026-04-19_video-prd-storyboard.md
@@ -1,0 +1,4 @@
+| feat | prd-api | 视频 Agent 分镜模式新增 PRD 输入源：CreateVideoGenRunRequest 扩展 inputSourceType + attachmentIds 字段，空 articleMarkdown 时自动从附件 ExtractedText 拼接 markdown |
+| feat | prd-api | VideoGenRunWorker Scripting 阶段针对 PRD 输入使用专用 prompt（痛点→方案→功能演示→收益 8-12 镜结构），与技术文章拆分镜模板区分 |
+| feat | prd-admin | 视频 Agent 分镜模式输入区新增双通道：Markdown 文章 / PRD 文档，PRD 模式支持 PDF/Word/Markdown 多文件上传，经 /api/v1/attachments 提取文本，附件 chip 展示与移除 |
+| feat | prd-admin | 视频 Agent 直出模式模型选择器重构为三档卡片（经济 Wan 2.6 / 平衡 Seedance 2.0 / 顶配 Veo 3.1）+ 折叠「高级」按钮展开 OpenRouter 全量 7 个模型，默认推荐自动档 |

--- a/changelogs/2026-04-19_video-unified-entry.md
+++ b/changelogs/2026-04-19_video-unified-entry.md
@@ -1,0 +1,6 @@
+| refactor | prd-admin | 视频 Agent 统一入口：撤掉「分镜模式 / 直出模式」两个 tab，合并为单一输入 Hero（UnifiedInputHero），根据用户输入（有附件 / 文本 > 200 字 → 拆分镜，短 prompt → 一镜直出）自动路由到对应管线 |
+| refactor | prd-admin | 视频 Agent 输入字段默认收起：视频标题 / 系统提示词 / 画面风格 / 路由偏好 / 直出模型档 / 时长 / 宽高 / 分辨率 等统一折叠到「高级设置 ▸」，首次进入只暴露输入框 + 示例 chip + 上传按钮 |
+| feat | prd-admin | 新增路由判定实时提示 chip（"即将：拆分镜 / 一镜直出"）+ 提交后 2.5 秒吐司显示判定原因，可在高级设置里强制"总是拆分镜 / 总是一镜直出" |
+| feat | prd-admin | 新增历史任务抽屉（HistoryDrawer，createPortal 右侧）取代原左下历史列表，顶部应用条暴露「📂 历史(N)」按钮一键打开，带状态徽章 + 相对时间 |
+| refactor | prd-admin | VideoGenDirectPanel 支持 `externalRunId` 纯输出模式：外层已创建的 videogen run 可直接传入，面板跳过内置输入区只做画布 + 进度 + 下载 |
+| feat | prd-admin | 输入 Hero 支持拖拽文件（PDF/Word/Markdown/TXT 皆可），小文本文件（.md/.txt < 128KB）走 FileReader 可视，其它走 /api/v1/attachments 后端提取 |

--- a/prd-admin/src/pages/video-agent/HistoryDrawer.tsx
+++ b/prd-admin/src/pages/video-agent/HistoryDrawer.tsx
@@ -1,0 +1,202 @@
+/**
+ * 历史任务抽屉：右侧 drawer，createPortal 到 body
+ * 遵循 frontend-modal.md 的 3 条硬约束（inline style 高度 / createPortal / flex min-h:0）
+ */
+import React, { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { X, Clock, Video, AlertCircle, CheckCircle2, Wand2, FileType2 } from 'lucide-react';
+import { cn } from '@/lib/cn';
+import type { VideoGenRunListItem } from '@/services/contracts/videoAgent';
+
+export interface HistoryDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  runs: VideoGenRunListItem[];
+  selectedRunId: string | null;
+  onSelect: (runId: string) => void;
+}
+
+const STATUS_BADGES: Record<string, { label: string; bg: string; color: string; Icon: typeof CheckCircle2 }> = {
+  Queued: { label: '排队中', bg: 'rgba(148,163,184,0.12)', color: '#94a3b8', Icon: Clock },
+  Scripting: { label: '拆分镜', bg: 'rgba(59,130,246,0.14)', color: '#60a5fa', Icon: FileType2 },
+  Editing: { label: '编辑中', bg: 'rgba(236,72,153,0.14)', color: '#f472b6', Icon: FileType2 },
+  Rendering: { label: '渲染中', bg: 'rgba(167,139,250,0.14)', color: '#a78bfa', Icon: Video },
+  Completed: { label: '已完成', bg: 'rgba(34,197,94,0.14)', color: '#4ade80', Icon: CheckCircle2 },
+  Failed: { label: '失败', bg: 'rgba(239,68,68,0.14)', color: '#f87171', Icon: AlertCircle },
+  Cancelled: { label: '已取消', bg: 'rgba(148,163,184,0.12)', color: '#94a3b8', Icon: X },
+};
+
+function formatRelativeTime(iso?: string): string {
+  if (!iso) return '';
+  const t = new Date(iso).getTime();
+  if (!Number.isFinite(t)) return '';
+  const diff = Date.now() - t;
+  const min = Math.floor(diff / 60000);
+  if (min < 1) return '刚刚';
+  if (min < 60) return `${min} 分钟前`;
+  const h = Math.floor(min / 60);
+  if (h < 24) return `${h} 小时前`;
+  const d = Math.floor(h / 24);
+  if (d < 30) return `${d} 天前`;
+  return new Date(iso).toLocaleDateString('zh-CN');
+}
+
+export const HistoryDrawer: React.FC<HistoryDrawerProps> = ({
+  open,
+  onClose,
+  runs,
+  selectedRunId,
+  onSelect,
+}) => {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const node = (
+    <div className="fixed inset-0 z-[120]">
+      {/* 遮罩 */}
+      <div
+        className="absolute inset-0"
+        style={{ background: 'rgba(0,0,0,0.5)', backdropFilter: 'blur(4px)' }}
+        onClick={onClose}
+      />
+
+      {/* 抽屉面板 */}
+      <div
+        className="absolute top-0 right-0 flex flex-col"
+        style={{
+          width: 'min(420px, 92vw)',
+          height: '100vh',
+          background: 'var(--panel)',
+          borderLeft: '1px solid var(--border-default)',
+          boxShadow: '-10px 0 40px rgba(0,0,0,0.35)',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div
+          className="shrink-0 flex items-center justify-between px-4 py-3"
+          style={{ borderBottom: '1px solid var(--border-default)' }}
+        >
+          <div className="flex items-center gap-2">
+            <Clock size={14} style={{ color: 'var(--text-muted)' }} />
+            <span className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
+              历史任务
+            </span>
+            <span className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
+              {runs.length} 个
+            </span>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1 rounded hover:opacity-80 opacity-60"
+            title="关闭（Esc）"
+          >
+            <X size={14} style={{ color: 'var(--text-muted)' }} />
+          </button>
+        </div>
+
+        {/* List */}
+        <div
+          className="flex-1"
+          style={{ minHeight: 0, overflowY: 'auto', overscrollBehavior: 'contain' }}
+        >
+          {runs.length === 0 ? (
+            <div className="flex flex-col items-center justify-center h-full gap-2 px-6 text-center">
+              <Clock size={28} style={{ color: 'var(--text-muted)', opacity: 0.4 }} />
+              <div className="text-xs" style={{ color: 'var(--text-muted)' }}>
+                还没有历史任务
+              </div>
+              <div className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
+                提交一次生成后，会自动出现在这里
+              </div>
+            </div>
+          ) : (
+            <div className="py-2">
+              {runs.map((run) => {
+                const badge = STATUS_BADGES[run.status] ?? STATUS_BADGES.Queued;
+                const isSelected = selectedRunId === run.id;
+                const isVideogen = !!run.videoAssetUrl && run.scenesCount === 0;
+                const Icon = badge.Icon;
+                const modeIcon = isVideogen ? Wand2 : FileType2;
+                const ModeIcon = modeIcon;
+                return (
+                  <button
+                    key={run.id}
+                    onClick={() => onSelect(run.id)}
+                    className={cn('w-full text-left px-4 py-3 transition-colors flex flex-col gap-1')}
+                    style={{
+                      background: isSelected ? 'rgba(236,72,153,0.08)' : 'transparent',
+                      borderLeft: '2px solid ' + (isSelected ? '#f472b6' : 'transparent'),
+                    }}
+                  >
+                    <div className="flex items-center gap-2">
+                      <ModeIcon
+                        size={11}
+                        style={{ color: isVideogen ? '#a78bfa' : '#f472b6', flexShrink: 0 }}
+                      />
+                      <span
+                        className="text-xs font-medium truncate flex-1"
+                        style={{ color: 'var(--text-primary)' }}
+                        title={run.articleTitle || run.id}
+                      >
+                        {run.articleTitle || '（未命名）'}
+                      </span>
+                      <span
+                        className="shrink-0 inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded"
+                        style={{ background: badge.bg, color: badge.color }}
+                      >
+                        <Icon size={9} />
+                        {badge.label}
+                      </span>
+                    </div>
+                    <div
+                      className="flex items-center gap-2 text-[10px]"
+                      style={{ color: 'var(--text-muted)' }}
+                    >
+                      <span>{formatRelativeTime(run.createdAt)}</span>
+                      {run.scenesCount > 0 && (
+                        <>
+                          <span>·</span>
+                          <span>
+                            {run.scenesReady}/{run.scenesCount} 镜头
+                          </span>
+                        </>
+                      )}
+                      {run.totalDurationSeconds > 0 && (
+                        <>
+                          <span>·</span>
+                          <span>{run.totalDurationSeconds.toFixed(1)}s</span>
+                        </>
+                      )}
+                    </div>
+                    {run.errorMessage && (
+                      <div
+                        className="text-[10px] truncate"
+                        style={{ color: '#f87171' }}
+                        title={run.errorMessage}
+                      >
+                        {run.errorMessage}
+                      </div>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+
+  return createPortal(node, document.body);
+};
+
+export default HistoryDrawer;

--- a/prd-admin/src/pages/video-agent/UnifiedInputHero.tsx
+++ b/prd-admin/src/pages/video-agent/UnifiedInputHero.tsx
@@ -1,0 +1,492 @@
+/**
+ * 统一输入 Hero：视频 Agent 入口主视觉
+ *
+ * 设计目标：心智降到只剩一件事——描述或上传。
+ * - 拖拽 / 点击上传 文档（PDF / Word / Markdown）
+ * - 或粘贴 / 输入 文本描述
+ * - 底部示例 chip 一键填入
+ * - 所有参数（标题 / 系统提示词 / 风格 / 模型档 / 时长 / 宽高）默认折叠在「高级设置 ▸」
+ *
+ * 不做路由判定——路由由父组件 detectVideoMode 完成，Hero 只负责采集输入。
+ */
+import React, { useCallback, useRef, useState } from 'react';
+import {
+  Upload,
+  Paperclip,
+  X,
+  ChevronDown,
+  ChevronUp,
+  Sparkles,
+  FileType2,
+  Wand2,
+  Zap,
+  Scale,
+  Crown,
+  Clock,
+  Maximize2,
+} from 'lucide-react';
+import { cn } from '@/lib/cn';
+import { Button } from '@/components/design/Button';
+import { MapSpinner } from '@/components/ui/VideoLoader';
+import {
+  OPENROUTER_VIDEO_MODELS,
+  VIDEO_MODEL_TIERS,
+} from '@/services/contracts/videoAgent';
+import type { RoutePreference, VideoMode } from './videoModeDetect';
+import { detectVideoMode } from './videoModeDetect';
+
+const TIER_ICONS = { economy: Zap, balanced: Scale, premium: Crown } as const;
+
+export interface UnifiedInputState {
+  text: string;
+  attachments: Array<{ attachmentId: string; fileName: string }>;
+  // 高级设置
+  routePreference: RoutePreference;
+  title: string;
+  systemPrompt: string;
+  styleDescription: string;
+  model: string; // '' = auto
+  duration: number;
+  aspect: '16:9' | '9:16' | '1:1';
+  resolution: '480p' | '720p' | '1080p';
+}
+
+export interface UnifiedInputHeroProps {
+  value: UnifiedInputState;
+  onChange: (patch: Partial<UnifiedInputState>) => void;
+  onSubmit: () => void;
+  onFileSelect: (files: File[]) => Promise<void>;
+  onRemoveAttachment: (attachmentId: string) => void;
+  uploading: boolean;
+  submitting: boolean;
+}
+
+const EXAMPLES: Array<{ label: string; text: string; hintMode: VideoMode }> = [
+  {
+    label: '一只金毛在海滩奔跑',
+    text: '一只金毛犬在落日的海滩上奔跑追逐海浪，电影级光影，慢动作镜头',
+    hintMode: 'videogen',
+  },
+  {
+    label: '咖啡馆拉花特写',
+    text: '咖啡馆吧台，咖啡师正在拉花，奶泡形成精美的天鹅图案，柔和自然光',
+    hintMode: 'videogen',
+  },
+  {
+    label: '粘贴一段产品介绍',
+    text: '',
+    hintMode: 'remotion',
+  },
+];
+
+export const UnifiedInputHero: React.FC<UnifiedInputHeroProps> = ({
+  value,
+  onChange,
+  onSubmit,
+  onFileSelect,
+  onRemoveAttachment,
+  uploading,
+  submitting,
+}) => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [dragActive, setDragActive] = useState(false);
+
+  const decision = detectVideoMode({
+    text: value.text,
+    attachmentsCount: value.attachments.length,
+    preference: value.routePreference,
+  });
+
+  const canSubmit =
+    !submitting &&
+    !uploading &&
+    (value.text.trim().length > 0 || value.attachments.length > 0);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      setDragActive(false);
+      const files = Array.from(e.dataTransfer.files ?? []);
+      if (files.length > 0) {
+        void onFileSelect(files);
+      }
+    },
+    [onFileSelect],
+  );
+
+  const handleFilePick = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files ?? []);
+    e.target.value = '';
+    if (files.length > 0) void onFileSelect(files);
+  };
+
+  return (
+    <div className="w-full max-w-[880px] mx-auto flex flex-col gap-4 px-4 py-8">
+      {/* 标题 */}
+      <div className="text-center flex flex-col gap-1.5">
+        <h1 className="text-xl font-semibold tracking-wide" style={{ color: 'var(--text-primary)' }}>
+          想做什么视频？
+        </h1>
+        <p className="text-xs" style={{ color: 'var(--text-muted)' }}>
+          描述画面出短片，或上传文档拆分镜
+        </p>
+      </div>
+
+      {/* 主输入区 */}
+      <div
+        onDragOver={(e) => {
+          e.preventDefault();
+          setDragActive(true);
+        }}
+        onDragLeave={() => setDragActive(false)}
+        onDrop={handleDrop}
+        className={cn('relative rounded-[20px] p-4 flex flex-col gap-3 transition-colors')}
+        style={{
+          background: 'var(--panel)',
+          border: '1px solid ' + (dragActive ? 'rgba(236,72,153,0.6)' : 'var(--border-default)'),
+          boxShadow: dragActive
+            ? '0 0 0 3px rgba(236,72,153,0.15)'
+            : 'var(--shadow-card)',
+        }}
+      >
+        <textarea
+          value={value.text}
+          onChange={(e) => onChange({ text: e.target.value })}
+          placeholder="例：一只金毛在落日海滩上奔跑… 或 粘贴一段产品介绍文案、PRD 大纲…"
+          rows={4}
+          disabled={submitting}
+          className="w-full resize-none bg-transparent text-sm outline-none"
+          style={{ color: 'var(--text-primary)', minHeight: 88 }}
+        />
+
+        {/* 附件 chip 列表 */}
+        {value.attachments.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {value.attachments.map((att) => (
+              <span
+                key={att.attachmentId}
+                className="inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px]"
+                style={{
+                  background: 'rgba(236,72,153,0.08)',
+                  border: '1px solid rgba(236,72,153,0.25)',
+                  color: 'var(--text-primary)',
+                }}
+              >
+                <Paperclip size={10} />
+                <span className="max-w-[220px] truncate">{att.fileName}</span>
+                <button
+                  onClick={() => onRemoveAttachment(att.attachmentId)}
+                  className="ml-0.5 opacity-60 hover:opacity-100"
+                  title="移除"
+                >
+                  <X size={10} />
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* 底部工具栏 */}
+        <div className="flex items-center gap-2 flex-wrap">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={uploading || submitting}
+            title="PDF / Word / Markdown / TXT，多文件"
+          >
+            {uploading ? <MapSpinner size={12} /> : <Upload size={14} />}
+            上传文件
+          </Button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            accept=".pdf,.doc,.docx,.md,.markdown,.txt,.html,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,text/plain,text/markdown"
+            className="hidden"
+            onChange={handleFilePick}
+          />
+
+          {/* 自动路由提示（实时显示当前判定） */}
+          <div
+            className="inline-flex items-center gap-1 text-[11px] px-2 py-1 rounded-md"
+            style={{
+              color: decision.mode === 'remotion' ? '#f472b6' : '#a78bfa',
+              background: decision.mode === 'remotion' ? 'rgba(236,72,153,0.08)' : 'rgba(167,139,250,0.08)',
+              border: '1px solid ' + (decision.mode === 'remotion' ? 'rgba(236,72,153,0.2)' : 'rgba(167,139,250,0.2)'),
+            }}
+            title={decision.reason}
+          >
+            {decision.mode === 'remotion' ? (
+              <>
+                <FileType2 size={11} /> 即将：拆分镜
+              </>
+            ) : (
+              <>
+                <Wand2 size={11} /> 即将：一镜直出
+              </>
+            )}
+          </div>
+
+          <div className="flex-1" />
+
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={onSubmit}
+            disabled={!canSubmit}
+          >
+            {submitting ? (
+              <>
+                <MapSpinner size={12} /> 提交中…
+              </>
+            ) : (
+              <>
+                <Sparkles size={12} /> 立即生成
+              </>
+            )}
+          </Button>
+        </div>
+      </div>
+
+      {/* 示例 chip */}
+      <div className="flex items-center gap-1.5 flex-wrap justify-center">
+        <span className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
+          示例：
+        </span>
+        {EXAMPLES.filter((ex) => ex.text).map((ex) => (
+          <button
+            key={ex.label}
+            onClick={() => onChange({ text: ex.text })}
+            className="text-[11px] px-2 py-1 rounded-md hover:opacity-80 transition-opacity"
+            style={{
+              background: 'var(--bg-base)',
+              border: '1px solid var(--border-default)',
+              color: 'var(--text-secondary)',
+            }}
+          >
+            {ex.label}
+          </button>
+        ))}
+      </div>
+
+      {/* 高级设置折叠 */}
+      <div className="flex flex-col gap-2">
+        <button
+          onClick={() => setShowAdvanced((s) => !s)}
+          className="self-center inline-flex items-center gap-1 text-[11px]"
+          style={{ color: 'var(--text-muted)' }}
+        >
+          高级设置
+          {showAdvanced ? <ChevronUp size={11} /> : <ChevronDown size={11} />}
+        </button>
+
+        {showAdvanced && (
+          <div
+            className="rounded-[14px] p-4 flex flex-col gap-3"
+            style={{
+              background: 'var(--bg-base)',
+              border: '1px dashed var(--border-default)',
+            }}
+          >
+            {/* 路由偏好 */}
+            <div className="flex flex-col gap-1">
+              <label className="text-[11px] font-medium" style={{ color: 'var(--text-secondary)' }}>
+                生成方式
+              </label>
+              <div className="inline-flex rounded-lg overflow-hidden self-start" style={{ border: '1px solid var(--border-default)' }}>
+                {([
+                  { key: 'auto' as const, label: '自动（推荐）' },
+                  { key: 'remotion' as const, label: '总是拆分镜' },
+                  { key: 'videogen' as const, label: '总是一镜直出' },
+                ]).map((opt) => {
+                  const active = value.routePreference === opt.key;
+                  return (
+                    <button
+                      key={opt.key}
+                      onClick={() => onChange({ routePreference: opt.key })}
+                      className="px-3 py-1 text-[11px] transition-colors"
+                      style={{
+                        background: active ? 'rgba(236,72,153,0.14)' : 'transparent',
+                        color: active ? '#f472b6' : 'var(--text-muted)',
+                      }}
+                    >
+                      {opt.label}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            {/* 视频标题 */}
+            <div className="flex flex-col gap-1">
+              <label className="text-[11px] font-medium" style={{ color: 'var(--text-secondary)' }}>
+                视频标题（可选，留空自动提取）
+              </label>
+              <input
+                value={value.title}
+                onChange={(e) => onChange({ title: e.target.value })}
+                className="w-full rounded-md px-2 py-1.5 text-xs outline-none"
+                style={{
+                  background: 'var(--panel)',
+                  border: '1px solid var(--border-default)',
+                  color: 'var(--text-primary)',
+                }}
+              />
+            </div>
+
+            {/* 直出模式专属参数 */}
+            {(value.routePreference === 'auto' || value.routePreference === 'videogen') && (
+              <div
+                className="flex flex-col gap-2 rounded-lg p-3"
+                style={{ background: 'var(--panel)', border: '1px solid var(--border-subtle)' }}
+              >
+                <div className="text-[11px] font-medium inline-flex items-center gap-1" style={{ color: 'var(--text-secondary)' }}>
+                  <Wand2 size={11} /> 一镜直出参数（短描述时生效）
+                </div>
+
+                {/* 模型档 */}
+                <div className="flex items-center gap-2 flex-wrap">
+                  <button
+                    onClick={() => onChange({ model: '' })}
+                    className="text-[10px] px-2 py-1 rounded-md"
+                    style={{
+                      background: value.model === '' ? 'rgba(236,72,153,0.14)' : 'var(--bg-base)',
+                      border: '1px solid ' + (value.model === '' ? 'rgba(236,72,153,0.4)' : 'var(--border-default)'),
+                      color: value.model === '' ? '#f472b6' : 'var(--text-primary)',
+                    }}
+                  >
+                    <Sparkles size={9} className="inline" /> 自动
+                  </button>
+                  {VIDEO_MODEL_TIERS.map((t) => {
+                    const Icon = TIER_ICONS[t.tier];
+                    const active = value.model === t.modelId;
+                    return (
+                      <button
+                        key={t.tier}
+                        onClick={() => onChange({ model: t.modelId })}
+                        className="text-[10px] px-2 py-1 rounded-md"
+                        style={{
+                          background: active ? 'rgba(236,72,153,0.14)' : 'var(--bg-base)',
+                          border: '1px solid ' + (active ? 'rgba(236,72,153,0.4)' : 'var(--border-default)'),
+                          color: active ? '#f472b6' : 'var(--text-primary)',
+                        }}
+                        title={t.desc}
+                      >
+                        <Icon size={9} className="inline" /> {t.label}
+                      </button>
+                    );
+                  })}
+                  <select
+                    value={value.model}
+                    onChange={(e) => onChange({ model: e.target.value })}
+                    className="text-[10px] rounded-md px-2 py-1"
+                    style={{
+                      background: 'var(--bg-base)',
+                      border: '1px solid var(--border-default)',
+                      color: 'var(--text-primary)',
+                    }}
+                    title="全量 OpenRouter 视频模型"
+                  >
+                    <option value="">更多…</option>
+                    {OPENROUTER_VIDEO_MODELS.map((m) => (
+                      <option key={m.id} value={m.id}>{m.label}</option>
+                    ))}
+                  </select>
+                </div>
+
+                {/* 时长 / 宽高 / 分辨率 */}
+                <div className="flex items-center gap-2 flex-wrap">
+                  <div className="flex items-center gap-1 px-2 py-1 rounded-md text-[10px]" style={{ background: 'var(--bg-base)', border: '1px solid var(--border-default)' }}>
+                    <Clock size={10} style={{ color: 'var(--text-muted)' }} />
+                    <select
+                      value={value.duration}
+                      onChange={(e) => onChange({ duration: Number(e.target.value) })}
+                      className="bg-transparent outline-none"
+                      style={{ color: 'var(--text-primary)' }}
+                    >
+                      {[5, 8, 10, 12, 15].map((d) => (
+                        <option key={d} value={d}>{d}s</option>
+                      ))}
+                    </select>
+                  </div>
+                  <div className="flex rounded-md overflow-hidden" style={{ border: '1px solid var(--border-default)' }}>
+                    {(['16:9', '9:16', '1:1'] as const).map((a) => {
+                      const active = value.aspect === a;
+                      return (
+                        <button
+                          key={a}
+                          onClick={() => onChange({ aspect: a })}
+                          className="px-2 py-1 text-[10px]"
+                          style={{
+                            background: active ? 'rgba(236,72,153,0.18)' : 'var(--bg-base)',
+                            color: active ? '#f472b6' : 'var(--text-muted)',
+                          }}
+                        >
+                          {a}
+                        </button>
+                      );
+                    })}
+                  </div>
+                  <div className="flex items-center gap-1 px-2 py-1 rounded-md text-[10px]" style={{ background: 'var(--bg-base)', border: '1px solid var(--border-default)' }}>
+                    <Maximize2 size={10} style={{ color: 'var(--text-muted)' }} />
+                    <select
+                      value={value.resolution}
+                      onChange={(e) => onChange({ resolution: e.target.value as '480p' | '720p' | '1080p' })}
+                      className="bg-transparent outline-none"
+                      style={{ color: 'var(--text-primary)' }}
+                    >
+                      {(['480p', '720p', '1080p'] as const).map((r) => (
+                        <option key={r} value={r}>{r}</option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* 分镜模式专属参数 */}
+            {(value.routePreference === 'auto' || value.routePreference === 'remotion') && (
+              <div
+                className="flex flex-col gap-2 rounded-lg p-3"
+                style={{ background: 'var(--panel)', border: '1px solid var(--border-subtle)' }}
+              >
+                <div className="text-[11px] font-medium inline-flex items-center gap-1" style={{ color: 'var(--text-secondary)' }}>
+                  <FileType2 size={11} /> 拆分镜参数（长内容 / 附件时生效）
+                </div>
+                <div className="flex flex-col gap-1">
+                  <label className="text-[10px]" style={{ color: 'var(--text-muted)' }}>
+                    系统提示词（旁白语言风格）
+                  </label>
+                  <textarea
+                    value={value.systemPrompt}
+                    onChange={(e) => onChange({ systemPrompt: e.target.value })}
+                    rows={2}
+                    placeholder="旁白语言活泼轻松，面向初学者…"
+                    className="w-full rounded-md px-2 py-1.5 text-xs outline-none resize-none"
+                    style={{ background: 'var(--bg-base)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
+                  />
+                </div>
+                <div className="flex flex-col gap-1">
+                  <label className="text-[10px]" style={{ color: 'var(--text-muted)' }}>
+                    画面风格
+                  </label>
+                  <input
+                    value={value.styleDescription}
+                    onChange={(e) => onChange({ styleDescription: e.target.value })}
+                    placeholder="科技感、深色背景、霓虹色系…"
+                    className="w-full rounded-md px-2 py-1.5 text-xs outline-none"
+                    style={{ background: 'var(--bg-base)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default UnifiedInputHero;

--- a/prd-admin/src/pages/video-agent/VideoAgentPage.tsx
+++ b/prd-admin/src/pages/video-agent/VideoAgentPage.tsx
@@ -6,7 +6,6 @@ import { Button } from '@/components/design/Button';
 import { WorkflowProgressBar } from '@/components/ui/WorkflowProgressBar';
 import { cn } from '@/lib/cn';
 import {
-  Upload,
   Sparkles,
   Settings,
   FileText,
@@ -20,8 +19,6 @@ import {
   Pencil,
   Eye,
   Bug,
-  FileType2,
-  Paperclip,
 } from 'lucide-react';
 import { toast } from '@/lib/toast';
 import { MapSpinner } from '@/components/ui/VideoLoader';
@@ -38,14 +35,15 @@ import {
   getVideoGenStreamUrl,
   getVideoGenDownloadUrl,
 } from '@/services/real/videoAgent';
-import type { VideoGenRun, VideoGenRunListItem, VideoInputSourceType } from '@/services/contracts/videoAgent';
+import type { VideoGenRun, VideoGenRunListItem } from '@/services/contracts/videoAgent';
 import { uploadAttachment } from '@/services/real/aiToolbox';
+import { UnifiedInputHero } from './UnifiedInputHero';
+import { HistoryDrawer } from './HistoryDrawer';
+import { detectVideoMode, type RoutePreference } from './videoModeDetect';
 import { VideoGenDirectPanel } from './VideoGenDirectPanel';
 
-// 顶部模式切换：remotion（原分镜流程） | videogen（OpenRouter 直出）
-// 保留 Remotion 路径不变，新增直出能力
-type VideoPageMode = 'remotion' | 'videogen';
-const MODE_STORAGE_KEY = 'video-agent.mode';
+// 路由偏好持久化 key（auto / remotion / videogen 三档）
+const ROUTE_PREF_KEY = 'video-agent.routePref';
 
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -120,16 +118,19 @@ export const VideoAgentPage: React.FC = () => {
   const token = useAuthStore((s) => s.token);
   const { isMobile } = useBreakpoint();
 
-  // ─── Mode toggle (remotion | videogen) ───
-  const [mode, setMode] = useState<VideoPageMode>(() => {
+  // ─── 路由偏好（auto / remotion / videogen），持久化到 sessionStorage ───
+  const [routePreference, setRoutePreference] = useState<RoutePreference>(() => {
     try {
-      const raw = sessionStorage.getItem(MODE_STORAGE_KEY);
-      return raw === 'videogen' ? 'videogen' : 'remotion';
-    } catch { return 'remotion'; }
+      const raw = sessionStorage.getItem(ROUTE_PREF_KEY);
+      return (raw === 'remotion' || raw === 'videogen') ? raw : 'auto';
+    } catch { return 'auto'; }
   });
   useEffect(() => {
-    try { sessionStorage.setItem(MODE_STORAGE_KEY, mode); } catch { /* ignore */ }
-  }, [mode]);
+    try { sessionStorage.setItem(ROUTE_PREF_KEY, routePreference); } catch { /* ignore */ }
+  }, [routePreference]);
+
+  // ─── 历史抽屉开关 ───
+  const [historyOpen, setHistoryOpen] = useState(false);
 
   // ─── Workflow state ───
   const [phase, setPhase] = useState<WorkflowPhase>(0);
@@ -141,12 +142,16 @@ export const VideoAgentPage: React.FC = () => {
   const [uploadedFileName, setUploadedFileName] = useState<string | null>(null);
   const [isEditingArticle, setIsEditingArticle] = useState(false);
   const [showDebugModal, setShowDebugModal] = useState(false);
-  const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // ─── 输入来源类型（article 默认技术文章 / prd 产品需求文档） ───
-  const [inputSourceType, setInputSourceType] = useState<VideoInputSourceType>('article');
+  // ─── 附件（PRD / PDF / Word 等），走 /api/v1/attachments 上传 ───
   const [prdAttachments, setPrdAttachments] = useState<Array<{ attachmentId: string; fileName: string }>>([]);
   const [prdUploading, setPrdUploading] = useState(false);
+
+  // ─── 直出模式参数（当判定为 videogen 或 preference === videogen 时生效） ───
+  const [directModel, setDirectModel] = useState<string>(''); // '' = auto
+  const [directDuration, setDirectDuration] = useState<number>(5);
+  const [directAspect, setDirectAspect] = useState<'16:9' | '9:16' | '1:1'>('16:9');
+  const [directResolution, setDirectResolution] = useState<'480p' | '720p' | '1080p'>('720p');
 
   // ─── Config state ───
   const [systemPrompt, setSystemPrompt] = useState('');
@@ -358,16 +363,14 @@ export const VideoAgentPage: React.FC = () => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [runs.map((r) => `${r.id}:${r.status}`).join(',')]);
 
-  // ─── File upload handler ───
-  // 根据当前 inputSourceType 分流：
-  //   - article 模式：.md/.txt 走 FileReader 直接读成 string（旧逻辑保留）
-  //   - prd 模式：任意文档（PDF/Word/.md 等）走 /api/v1/attachments 上传，让后端提取文本
-  const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = Array.from(e.target.files ?? []);
-    e.target.value = ''; // 先清空，避免重复选择同一文件无事件
+  // ─── 文件上传：统一走附件 API，让后端 FileContentExtractor 提取文本 ───
+  // 支持拖拽或点选，PDF/Word/Markdown/TXT 皆可。
+  // 例外：纯 .md/.txt 短文本仍走 FileReader 塞进 textarea（方便用户看到和编辑）。
+  const handleFileSelect = async (files: File[]) => {
     if (files.length === 0) return;
 
-    if (inputSourceType === 'article') {
+    // 小文本文件（.md / .txt 且 < 128KB）走前端 FileReader，方便用户可视
+    if (files.length === 1 && files[0].size < 128 * 1024 && /\.(md|markdown|txt)$/i.test(files[0].name)) {
       const file = files[0];
       setUploadedFileName(file.name);
       const reader = new FileReader();
@@ -383,7 +386,7 @@ export const VideoAgentPage: React.FC = () => {
       return;
     }
 
-    // PRD 模式：批量上传附件，ExtractedText 由后端 Worker 使用
+    // 其它：上传到 /api/v1/attachments，让后端提取文本
     setPrdUploading(true);
     try {
       const uploaded: Array<{ attachmentId: string; fileName: string }> = [];
@@ -414,31 +417,60 @@ export const VideoAgentPage: React.FC = () => {
     setPrdAttachments((prev) => prev.filter((a) => a.attachmentId !== attachmentId));
   };
 
-  // ─── Create run ───
+  // ─── 统一创建任务：根据 detectVideoMode 自动路由到 videogen 或 remotion ───
   const handleCreate = async () => {
     const hasText = !!articleContent.trim();
-    const hasAttachments = inputSourceType === 'prd' && prdAttachments.length > 0;
+    const hasAttachments = prdAttachments.length > 0;
     if (!hasText && !hasAttachments) {
-      toast.warning(
-        '缺少输入内容',
-        inputSourceType === 'prd'
-          ? '请上传 PRD 文档，或粘贴文本'
-          : '请先上传或粘贴文章'
-      );
+      toast.warning('缺少输入', '请输入描述或上传文档');
       return;
     }
+
+    const decision = detectVideoMode({
+      text: articleContent,
+      attachmentsCount: prdAttachments.length,
+      preference: routePreference,
+    });
+
     setCreating(true);
     try {
-      const res = await createVideoGenRunReal({
-        articleMarkdown: hasText ? articleContent : undefined,
+      const commonFields = {
         articleTitle: articleTitle || undefined,
-        systemPrompt: systemPrompt || undefined,
-        styleDescription: styleDescription || undefined,
-        inputSourceType,
-        attachmentIds: hasAttachments ? prdAttachments.map((a) => a.attachmentId) : undefined,
-      });
+      };
+
+      let res;
+      if (decision.mode === 'videogen') {
+        // 一镜直出：短 prompt 走视频大模型
+        res = await createVideoGenRunReal({
+          ...commonFields,
+          renderMode: 'videogen',
+          directPrompt: articleContent.trim(),
+          directVideoModel: directModel || undefined,
+          directAspectRatio: directAspect,
+          directResolution: directResolution,
+          directDuration: directDuration,
+        });
+      } else {
+        // 拆分镜：文档或长描述
+        res = await createVideoGenRunReal({
+          ...commonFields,
+          articleMarkdown: hasText ? articleContent : undefined,
+          systemPrompt: systemPrompt || undefined,
+          styleDescription: styleDescription || undefined,
+          inputSourceType: hasAttachments ? 'prd' : 'article',
+          attachmentIds: hasAttachments ? prdAttachments.map((a) => a.attachmentId) : undefined,
+        });
+      }
+
       if (res.success) {
-        toast.success('已提交', '正在生成分镜脚本...');
+        // 1.5 秒可撤销的判定提示条
+        if (!decision.forced) {
+          toast.info(
+            decision.mode === 'videogen' ? '一镜直出模式' : '拆分镜模式',
+            decision.reason,
+            2500,
+          );
+        }
         setSelectedRunId(res.data.runId);
         await loadRuns();
       } else {
@@ -448,7 +480,9 @@ export const VideoAgentPage: React.FC = () => {
       const msg = err instanceof Error ? err.message : '网络请求失败';
       toast.error('请求异常', msg);
       console.error('[VideoAgent] createRun error:', err);
-    } finally { setCreating(false); }
+    } finally {
+      setCreating(false);
+    }
   };
 
   // ─── Cancel run ───
@@ -604,11 +638,8 @@ export const VideoAgentPage: React.FC = () => {
   // ─── Active button (depends on phase) ───
   const activeButton = (() => {
     if ((phase === 0 || phase === 1) && !selectedRun) {
-      const canSubmit =
-        articleContent.trim().length > 0 ||
-        (inputSourceType === 'prd' && prdAttachments.length > 0);
-      const label = inputSourceType === 'prd' ? '拆分镜（PRD 模式）' : '生成分镜标记';
-      return { label, icon: Sparkles, action: handleCreate, disabled: !canSubmit };
+      // 统一入口会自己渲染提交按钮，这里不再提供（避免重复 CTA）
+      return null;
     }
     if (isEditing) {
       return { label: exporting ? '渲染中...' : '导出视频', icon: Video, action: handleExport, disabled: exporting };
@@ -635,42 +666,52 @@ export const VideoAgentPage: React.FC = () => {
     >
       <style>{PRD_MD_STYLE}</style>
 
-      {/* ═══ 模式切换栏（顶部全宽） ═══ */}
+      {/* ═══ 顶部应用条（取代旧的分镜/直出 tab） ═══ */}
       <div
-        className="flex-shrink-0 flex items-center justify-center gap-2 px-4 py-2"
+        className="flex-shrink-0 flex items-center justify-between gap-2 px-4 py-2"
         style={{ borderBottom: '1px solid var(--border-default)', background: 'var(--panel)' }}
       >
-        <div className="inline-flex rounded-full overflow-hidden" style={{ border: '1px solid var(--border-default)' }}>
+        <div className="flex items-center gap-2">
+          <Video size={14} style={{ color: 'var(--text-muted)' }} />
+          <span className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
+            视频 Agent
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          {selectedRun && !isActive && (
+            <button
+              onClick={handleNewTask}
+              className="text-[11px] px-2.5 py-1 rounded-md hover:bg-white/10 transition-colors border flex items-center gap-1"
+              style={{ color: 'var(--text-muted)', borderColor: 'var(--border-subtle)' }}
+              title="回到输入区，开始一个新任务"
+            >
+              <Sparkles size={11} />
+              新任务
+            </button>
+          )}
           <button
-            onClick={() => setMode('remotion')}
-            className={cn('px-4 py-1.5 text-xs font-medium transition-colors')}
-            style={{
-              background: mode === 'remotion' ? 'rgba(236,72,153,0.18)' : 'transparent',
-              color: mode === 'remotion' ? '#f472b6' : 'var(--text-muted)',
-            }}
-            title="把文章转成多分镜视频，走 Remotion 本地合成"
+            onClick={() => setHistoryOpen(true)}
+            className="text-[11px] px-2.5 py-1 rounded-md hover:bg-white/10 transition-colors border flex items-center gap-1"
+            style={{ color: 'var(--text-muted)', borderColor: 'var(--border-subtle)' }}
+            title="查看历史任务"
           >
-            📝 分镜模式（Remotion）
-          </button>
-          <button
-            onClick={() => setMode('videogen')}
-            className={cn('px-4 py-1.5 text-xs font-medium transition-colors')}
-            style={{
-              background: mode === 'videogen' ? 'rgba(168,85,247,0.22)' : 'transparent',
-              color: mode === 'videogen' ? '#c084fc' : 'var(--text-muted)',
-            }}
-            title="直接把 prompt 交给 Sora / Veo / Seedance / Wan 等视频大模型"
-          >
-            🎬 直出模式（AI 视频大模型）
+            📂 历史（{runs.length}）
           </button>
         </div>
       </div>
 
-      {/* 直出模式：独立面板 */}
-      {mode === 'videogen' && <VideoGenDirectPanel />}
+      {/* 历史抽屉 */}
+      <HistoryDrawer
+        open={historyOpen}
+        onClose={() => setHistoryOpen(false)}
+        runs={runs}
+        selectedRunId={selectedRunId}
+        onSelect={(runId) => {
+          setSelectedRunId(runId);
+          setHistoryOpen(false);
+        }}
+      />
 
-      {/* 分镜模式：保留原有全部 UI */}
-      {mode === 'remotion' && (
       <>
       {/* Mobile tabs */}
       {isMobile && (
@@ -692,6 +733,46 @@ export const VideoAgentPage: React.FC = () => {
         </div>
       )}
 
+      {!selectedRun ? (
+        /* ═══ 空态：统一输入 Hero（代替原来的"上传文章"左侧面板 + 右侧 config） ═══ */
+        <div className="flex-1 min-h-0 overflow-auto">
+          <UnifiedInputHero
+            value={{
+              text: articleContent,
+              attachments: prdAttachments,
+              routePreference,
+              title: articleTitle,
+              systemPrompt,
+              styleDescription,
+              model: directModel,
+              duration: directDuration,
+              aspect: directAspect,
+              resolution: directResolution,
+            }}
+            onChange={(patch) => {
+              if (patch.text !== undefined) setArticleContent(patch.text);
+              if (patch.title !== undefined) setArticleTitle(patch.title);
+              if (patch.systemPrompt !== undefined) setSystemPrompt(patch.systemPrompt);
+              if (patch.styleDescription !== undefined) setStyleDescription(patch.styleDescription);
+              if (patch.routePreference !== undefined) setRoutePreference(patch.routePreference);
+              if (patch.model !== undefined) setDirectModel(patch.model);
+              if (patch.duration !== undefined) setDirectDuration(patch.duration);
+              if (patch.aspect !== undefined) setDirectAspect(patch.aspect);
+              if (patch.resolution !== undefined) setDirectResolution(patch.resolution);
+            }}
+            onSubmit={() => void handleCreate()}
+            onFileSelect={handleFileSelect}
+            onRemoveAttachment={handleRemovePrdAttachment}
+            uploading={prdUploading}
+            submitting={creating}
+          />
+        </div>
+      ) : selectedRun?.renderMode === 'videogen' ? (
+        /* ═══ videogen 产出：复用 VideoGenDirectPanel 纯输出模式 ═══ */
+        <div className="flex-1 min-h-0 overflow-auto">
+          <VideoGenDirectPanel externalRunId={selectedRunId ?? undefined} onReset={handleNewTask} />
+        </div>
+      ) : (
       <div className="flex-1 min-h-0 flex gap-4 p-4 overflow-hidden">
         {/* ═══ LEFT PANEL: Article Preview ═══ */}
         <div className={cn('flex-1 min-w-0 flex flex-col gap-4', isMobile && mobileTab !== 'article' && 'hidden')}>
@@ -752,115 +833,7 @@ export const VideoAgentPage: React.FC = () => {
 
             {/* Content area */}
             <div className="flex-1 min-h-0 overflow-auto">
-              {phase === 0 ? (
-                /* Upload / Input phase — 双通道：article(Markdown) / prd(PRD 文档) */
-                <div className="h-full flex flex-col gap-3 p-2">
-                  {/* 输入来源切换 */}
-                  <div
-                    className="inline-flex rounded-full overflow-hidden self-start"
-                    style={{ border: '1px solid var(--border-default)' }}
-                  >
-                    {([
-                      { key: 'article', label: 'Markdown 文章', icon: FileText },
-                      { key: 'prd', label: 'PRD 文档', icon: FileType2 },
-                    ] as const).map((opt) => {
-                      const Icon = opt.icon;
-                      const active = inputSourceType === opt.key;
-                      return (
-                        <button
-                          key={opt.key}
-                          onClick={() => setInputSourceType(opt.key)}
-                          className={cn('px-3 py-1 text-xs font-medium transition-colors inline-flex items-center gap-1.5')}
-                          style={{
-                            background: active ? 'rgba(236,72,153,0.18)' : 'transparent',
-                            color: active ? '#f472b6' : 'var(--text-muted)',
-                          }}
-                        >
-                          <Icon size={12} />
-                          {opt.label}
-                        </button>
-                      );
-                    })}
-                  </div>
-
-                  {/* 来源说明 */}
-                  <div className="text-[11px] leading-relaxed" style={{ color: 'var(--text-muted)' }}>
-                    {inputSourceType === 'prd'
-                      ? '上传 PRD 文档（PDF / Word / Markdown / TXT 等）→ AI 按"痛点→方案→功能演示→收益"拆成产品介绍视频分镜。'
-                      : '粘贴或上传技术文章 Markdown → AI 按"概念→步骤→演示→总结"拆成讲解视频分镜。'}
-                  </div>
-
-                  {/* 上传入口 */}
-                  <div className="flex items-center gap-3 flex-wrap">
-                    <Button
-                      variant="secondary"
-                      size="sm"
-                      onClick={() => fileInputRef.current?.click()}
-                      disabled={prdUploading}
-                    >
-                      {prdUploading ? <MapSpinner size={12} /> : <Upload size={14} />}
-                      {inputSourceType === 'prd' ? '上传 PRD 文档' : '选择 Markdown 文件'}
-                    </Button>
-                    {inputSourceType === 'article' && uploadedFileName && (
-                      <span className="text-xs truncate" style={{ color: 'var(--text-muted)' }}>
-                        {uploadedFileName}
-                      </span>
-                    )}
-                    <input
-                      ref={fileInputRef}
-                      type="file"
-                      multiple={inputSourceType === 'prd'}
-                      accept={
-                        inputSourceType === 'prd'
-                          ? '.pdf,.doc,.docx,.md,.markdown,.txt,.html,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,text/plain,text/markdown'
-                          : '.md,.txt,.markdown'
-                      }
-                      className="hidden"
-                      onChange={handleFileUpload}
-                    />
-                  </div>
-
-                  {/* PRD 附件列表 */}
-                  {inputSourceType === 'prd' && prdAttachments.length > 0 && (
-                    <div className="flex flex-wrap gap-1.5">
-                      {prdAttachments.map((att) => (
-                        <span
-                          key={att.attachmentId}
-                          className="inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px]"
-                          style={{
-                            background: 'rgba(236,72,153,0.08)',
-                            border: '1px solid rgba(236,72,153,0.25)',
-                            color: 'var(--text-primary)',
-                          }}
-                        >
-                          <Paperclip size={10} />
-                          <span className="max-w-[200px] truncate">{att.fileName}</span>
-                          <button
-                            onClick={() => handleRemovePrdAttachment(att.attachmentId)}
-                            className="ml-0.5 opacity-60 hover:opacity-100"
-                            title="移除"
-                          >
-                            <X size={10} />
-                          </button>
-                        </span>
-                      ))}
-                    </div>
-                  )}
-
-                  {/* 文本输入（PRD 模式下为可选，用于补充说明） */}
-                  <textarea
-                    placeholder={
-                      inputSourceType === 'prd'
-                        ? '（可选）额外补充说明，例如：视频风格偏活泼 / 目标用户是 XX / 重点突出 XX 功能……'
-                        : '粘贴 Markdown 文章内容，或点击上方按钮选择文件…'
-                    }
-                    value={articleContent}
-                    onChange={(e) => setArticleContent(e.target.value)}
-                    className="flex-1 w-full rounded-[14px] px-3 py-2.5 text-sm outline-none resize-none prd-field"
-                    style={{ minHeight: 160 }}
-                  />
-                </div>
-              ) : selectedRun && (selectedRun.status === 'Scripting' || selectedRun.status === 'Queued') ? (
+              {selectedRun && (selectedRun.status === 'Scripting' || selectedRun.status === 'Queued') ? (
                 /* Streaming display — 实时显示思考过程和 LLM 输出 */
                 <div className="h-full flex flex-col">
                   {/* Header bar */}
@@ -938,44 +911,6 @@ export const VideoAgentPage: React.FC = () => {
               )}
             </div>
 
-            {/* History list at bottom */}
-            {runs.length > 0 && (
-              <div className="flex-shrink-0 mt-3 pt-3 border-t" style={{ borderColor: 'var(--border-subtle)' }}>
-                <div className="flex items-center justify-between mb-2">
-                  <span className="text-xs font-semibold" style={{ color: 'var(--text-muted)' }}>历史任务</span>
-                  <span className="text-[10px]" style={{ color: 'var(--text-muted)' }}>{runs.length} 个</span>
-                </div>
-                <div className="max-h-[120px] overflow-auto space-y-1">
-                  {runs.map((run) => (
-                    <button
-                      key={run.id}
-                      onClick={() => setSelectedRunId(run.id)}
-                      className="w-full rounded-lg p-2 text-left text-xs transition-colors"
-                      style={{
-                        background: selectedRunId === run.id ? 'rgba(236, 72, 153, 0.08)' : 'transparent',
-                        border: selectedRunId === run.id ? '1px solid rgba(236, 72, 153, 0.2)' : '1px solid transparent',
-                      }}
-                    >
-                      <div className="flex items-center justify-between gap-2">
-                        <div className="flex items-center gap-1.5 min-w-0">
-                          {ACTIVE_STATUSES.includes(run.status) && (
-                            <MapSpinner size={12} color="rgba(236, 72, 153, 0.7)" className="flex-shrink-0" />
-                          )}
-                          <span className="font-medium truncate" style={{ color: 'var(--text-primary)' }}>
-                            {run.articleTitle || `任务 ${run.id.slice(0, 8)}`}
-                          </span>
-                        </div>
-                        <RunStatusBadge status={run.status} />
-                      </div>
-                      <div className="mt-0.5 flex items-center gap-2" style={{ color: 'var(--text-muted)' }}>
-                        <span>{new Date(run.createdAt).toLocaleString('zh-CN')}</span>
-                        {run.scenesCount > 0 && <span>{run.scenesReady}/{run.scenesCount} 镜头</span>}
-                      </div>
-                    </button>
-                  ))}
-                </div>
-              </div>
-            )}
           </GlassCard>
         </div>
 
@@ -1059,41 +994,7 @@ export const VideoAgentPage: React.FC = () => {
               </button>
             </div>
 
-            {/* Inline config inputs (simple version before config dialog is implemented) */}
-            {!selectedRun && (
-              <div className="mt-3 space-y-2">
-                <div>
-                  <label className="text-[11px] font-medium mb-1 block" style={{ color: 'var(--text-muted)' }}>视频标题</label>
-                  <input
-                    type="text"
-                    value={articleTitle}
-                    onChange={(e) => setArticleTitle(e.target.value)}
-                    placeholder="可选，自动从文章提取"
-                    className="w-full rounded-[10px] px-2.5 py-1.5 text-[12px] outline-none prd-field"
-                  />
-                </div>
-                <div>
-                  <label className="text-[11px] font-medium mb-1 block" style={{ color: 'var(--text-muted)' }}>系统提示词</label>
-                  <textarea
-                    value={systemPrompt}
-                    onChange={(e) => setSystemPrompt(e.target.value)}
-                    placeholder="旁白语言活泼轻松，面向初学者..."
-                    rows={2}
-                    className="w-full rounded-[10px] px-2.5 py-1.5 text-[12px] outline-none resize-none prd-field"
-                  />
-                </div>
-                <div>
-                  <label className="text-[11px] font-medium mb-1 block" style={{ color: 'var(--text-muted)' }}>风格描述</label>
-                  <textarea
-                    value={styleDescription}
-                    onChange={(e) => setStyleDescription(e.target.value)}
-                    placeholder="科技感、深色背景、霓虹色系..."
-                    rows={2}
-                    className="w-full rounded-[10px] px-2.5 py-1.5 text-[12px] outline-none resize-none prd-field"
-                  />
-                </div>
-              </div>
-            )}
+            {/* 注：标题 / 系统提示词 / 风格描述等配置已移到 UnifiedInputHero 的「高级设置 ▸」 */}
           </PanelCard>
 
           {/* Scene list (visible when scenes exist — including during streaming) */}
@@ -1449,6 +1350,7 @@ export const VideoAgentPage: React.FC = () => {
           )}
         </div>
       </div>
+      )}
       {/* ═══ Debug Modal ═══ */}
       {showDebugModal && selectedRun && (
         <div
@@ -1586,33 +1488,12 @@ export const VideoAgentPage: React.FC = () => {
         </div>
       )}
       </>
-      )}
     </div>
   );
 };
 
 // ─── Sub-components ───
 
-const RunStatusBadge: React.FC<{ status: string }> = ({ status }) => {
-  const config: Record<string, { label: string; bg: string; border: string; color: string }> = {
-    Queued: { label: '排队', bg: 'var(--bg-input-hover)', border: 'var(--border-default)', color: 'var(--text-secondary)' },
-    Scripting: { label: '生成中', bg: 'rgba(250, 204, 21, 0.12)', border: 'rgba(250, 204, 21, 0.24)', color: 'rgba(250, 204, 21, 0.95)' },
-    Editing: { label: '编辑中', bg: 'rgba(236, 72, 153, 0.12)', border: 'rgba(236, 72, 153, 0.24)', color: 'rgba(236, 72, 153, 0.95)' },
-    Rendering: { label: '渲染中', bg: 'rgba(251, 146, 60, 0.12)', border: 'rgba(251, 146, 60, 0.24)', color: 'rgba(251, 146, 60, 0.95)' },
-    Completed: { label: '完成', bg: 'rgba(34, 197, 94, 0.12)', border: 'rgba(34, 197, 94, 0.28)', color: 'rgba(34, 197, 94, 0.95)' },
-    Failed: { label: '失败', bg: 'rgba(239, 68, 68, 0.12)', border: 'rgba(239, 68, 68, 0.28)', color: 'rgba(239, 68, 68, 0.95)' },
-    Cancelled: { label: '取消', bg: 'var(--bg-input-hover)', border: 'var(--border-default)', color: 'var(--text-secondary)' },
-  };
-  const c = config[status] ?? { label: status, bg: 'var(--bg-input-hover)', border: 'var(--border-default)', color: 'var(--text-secondary)' };
-  return (
-    <span
-      className="text-[11px] px-2 py-0.5 rounded-full font-semibold"
-      style={{ background: c.bg, border: `1px solid ${c.border}`, color: c.color }}
-    >
-      {c.label}
-    </span>
-  );
-};
 
 const DownloadButton: React.FC<{ runId: string; type: 'srt' | 'narration' | 'script'; label: string }> = ({ runId, type, label }) => {
   const token = useAuthStore((s) => s.token);

--- a/prd-admin/src/pages/video-agent/VideoAgentPage.tsx
+++ b/prd-admin/src/pages/video-agent/VideoAgentPage.tsx
@@ -20,6 +20,8 @@ import {
   Pencil,
   Eye,
   Bug,
+  FileType2,
+  Paperclip,
 } from 'lucide-react';
 import { toast } from '@/lib/toast';
 import { MapSpinner } from '@/components/ui/VideoLoader';
@@ -36,7 +38,8 @@ import {
   getVideoGenStreamUrl,
   getVideoGenDownloadUrl,
 } from '@/services/real/videoAgent';
-import type { VideoGenRun, VideoGenRunListItem } from '@/services/contracts/videoAgent';
+import type { VideoGenRun, VideoGenRunListItem, VideoInputSourceType } from '@/services/contracts/videoAgent';
+import { uploadAttachment } from '@/services/real/aiToolbox';
 import { VideoGenDirectPanel } from './VideoGenDirectPanel';
 
 // 顶部模式切换：remotion（原分镜流程） | videogen（OpenRouter 直出）
@@ -139,6 +142,11 @@ export const VideoAgentPage: React.FC = () => {
   const [isEditingArticle, setIsEditingArticle] = useState(false);
   const [showDebugModal, setShowDebugModal] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // ─── 输入来源类型（article 默认技术文章 / prd 产品需求文档） ───
+  const [inputSourceType, setInputSourceType] = useState<VideoInputSourceType>('article');
+  const [prdAttachments, setPrdAttachments] = useState<Array<{ attachmentId: string; fileName: string }>>([]);
+  const [prdUploading, setPrdUploading] = useState(false);
 
   // ─── Config state ───
   const [systemPrompt, setSystemPrompt] = useState('');
@@ -351,37 +359,83 @@ export const VideoAgentPage: React.FC = () => {
   }, [runs.map((r) => `${r.id}:${r.status}`).join(',')]);
 
   // ─── File upload handler ───
-  const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    setUploadedFileName(file.name);
-    const reader = new FileReader();
-    reader.onload = () => {
-      const text = reader.result as string;
-      setArticleContent(text);
-      if (!articleTitle) {
-        // Auto-extract title from first heading
-        const match = text.match(/^#\s+(.+)/m);
-        if (match) setArticleTitle(match[1]);
+  // 根据当前 inputSourceType 分流：
+  //   - article 模式：.md/.txt 走 FileReader 直接读成 string（旧逻辑保留）
+  //   - prd 模式：任意文档（PDF/Word/.md 等）走 /api/v1/attachments 上传，让后端提取文本
+  const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files ?? []);
+    e.target.value = ''; // 先清空，避免重复选择同一文件无事件
+    if (files.length === 0) return;
+
+    if (inputSourceType === 'article') {
+      const file = files[0];
+      setUploadedFileName(file.name);
+      const reader = new FileReader();
+      reader.onload = () => {
+        const text = reader.result as string;
+        setArticleContent(text);
+        if (!articleTitle) {
+          const match = text.match(/^#\s+(.+)/m);
+          if (match) setArticleTitle(match[1]);
+        }
+      };
+      reader.readAsText(file);
+      return;
+    }
+
+    // PRD 模式：批量上传附件，ExtractedText 由后端 Worker 使用
+    setPrdUploading(true);
+    try {
+      const uploaded: Array<{ attachmentId: string; fileName: string }> = [];
+      for (const file of files) {
+        const res = await uploadAttachment(file);
+        if (res.success && res.data) {
+          uploaded.push({ attachmentId: res.data.attachmentId, fileName: res.data.fileName });
+        } else {
+          toast.error('上传失败', res.error?.message || file.name);
+        }
       }
-    };
-    reader.readAsText(file);
-    e.target.value = ''; // Reset
+      if (uploaded.length > 0) {
+        setPrdAttachments((prev) => [...prev, ...uploaded]);
+        if (!articleTitle) {
+          const first = uploaded[0].fileName;
+          const dot = first.lastIndexOf('.');
+          setArticleTitle(dot > 0 ? first.slice(0, dot) : first);
+        }
+      }
+    } catch (err) {
+      toast.error('上传失败', err instanceof Error ? err.message : '未知错误');
+    } finally {
+      setPrdUploading(false);
+    }
+  };
+
+  const handleRemovePrdAttachment = (attachmentId: string) => {
+    setPrdAttachments((prev) => prev.filter((a) => a.attachmentId !== attachmentId));
   };
 
   // ─── Create run ───
   const handleCreate = async () => {
-    if (!articleContent.trim()) {
-      toast.warning('缺少文章内容', '请先上传或粘贴文章');
+    const hasText = !!articleContent.trim();
+    const hasAttachments = inputSourceType === 'prd' && prdAttachments.length > 0;
+    if (!hasText && !hasAttachments) {
+      toast.warning(
+        '缺少输入内容',
+        inputSourceType === 'prd'
+          ? '请上传 PRD 文档，或粘贴文本'
+          : '请先上传或粘贴文章'
+      );
       return;
     }
     setCreating(true);
     try {
       const res = await createVideoGenRunReal({
-        articleMarkdown: articleContent,
+        articleMarkdown: hasText ? articleContent : undefined,
         articleTitle: articleTitle || undefined,
         systemPrompt: systemPrompt || undefined,
         styleDescription: styleDescription || undefined,
+        inputSourceType,
+        attachmentIds: hasAttachments ? prdAttachments.map((a) => a.attachmentId) : undefined,
       });
       if (res.success) {
         toast.success('已提交', '正在生成分镜脚本...');
@@ -550,7 +604,11 @@ export const VideoAgentPage: React.FC = () => {
   // ─── Active button (depends on phase) ───
   const activeButton = (() => {
     if ((phase === 0 || phase === 1) && !selectedRun) {
-      return { label: '生成分镜标记', icon: Sparkles, action: handleCreate, disabled: !articleContent.trim() };
+      const canSubmit =
+        articleContent.trim().length > 0 ||
+        (inputSourceType === 'prd' && prdAttachments.length > 0);
+      const label = inputSourceType === 'prd' ? '拆分镜（PRD 模式）' : '生成分镜标记';
+      return { label, icon: Sparkles, action: handleCreate, disabled: !canSubmit };
     }
     if (isEditing) {
       return { label: exporting ? '渲染中...' : '导出视频', icon: Video, action: handleExport, disabled: exporting };
@@ -565,6 +623,7 @@ export const VideoAgentPage: React.FC = () => {
     setArticleContent('');
     setArticleTitle('');
     setUploadedFileName(null);
+    setPrdAttachments([]);
     setIsEditingArticle(false);
     setPhase(0);
   };
@@ -694,15 +753,55 @@ export const VideoAgentPage: React.FC = () => {
             {/* Content area */}
             <div className="flex-1 min-h-0 overflow-auto">
               {phase === 0 ? (
-                /* Upload / Input phase — textarea always visible */
-                <div className="h-full flex flex-col gap-4 p-2">
-                  {/* File upload button */}
-                  <div className="flex items-center gap-3">
-                    <Button variant="secondary" size="sm" onClick={() => fileInputRef.current?.click()}>
-                      <Upload size={14} />
-                      选择文件
+                /* Upload / Input phase — 双通道：article(Markdown) / prd(PRD 文档) */
+                <div className="h-full flex flex-col gap-3 p-2">
+                  {/* 输入来源切换 */}
+                  <div
+                    className="inline-flex rounded-full overflow-hidden self-start"
+                    style={{ border: '1px solid var(--border-default)' }}
+                  >
+                    {([
+                      { key: 'article', label: 'Markdown 文章', icon: FileText },
+                      { key: 'prd', label: 'PRD 文档', icon: FileType2 },
+                    ] as const).map((opt) => {
+                      const Icon = opt.icon;
+                      const active = inputSourceType === opt.key;
+                      return (
+                        <button
+                          key={opt.key}
+                          onClick={() => setInputSourceType(opt.key)}
+                          className={cn('px-3 py-1 text-xs font-medium transition-colors inline-flex items-center gap-1.5')}
+                          style={{
+                            background: active ? 'rgba(236,72,153,0.18)' : 'transparent',
+                            color: active ? '#f472b6' : 'var(--text-muted)',
+                          }}
+                        >
+                          <Icon size={12} />
+                          {opt.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+
+                  {/* 来源说明 */}
+                  <div className="text-[11px] leading-relaxed" style={{ color: 'var(--text-muted)' }}>
+                    {inputSourceType === 'prd'
+                      ? '上传 PRD 文档（PDF / Word / Markdown / TXT 等）→ AI 按"痛点→方案→功能演示→收益"拆成产品介绍视频分镜。'
+                      : '粘贴或上传技术文章 Markdown → AI 按"概念→步骤→演示→总结"拆成讲解视频分镜。'}
+                  </div>
+
+                  {/* 上传入口 */}
+                  <div className="flex items-center gap-3 flex-wrap">
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => fileInputRef.current?.click()}
+                      disabled={prdUploading}
+                    >
+                      {prdUploading ? <MapSpinner size={12} /> : <Upload size={14} />}
+                      {inputSourceType === 'prd' ? '上传 PRD 文档' : '选择 Markdown 文件'}
                     </Button>
-                    {uploadedFileName && (
+                    {inputSourceType === 'article' && uploadedFileName && (
                       <span className="text-xs truncate" style={{ color: 'var(--text-muted)' }}>
                         {uploadedFileName}
                       </span>
@@ -710,18 +809,55 @@ export const VideoAgentPage: React.FC = () => {
                     <input
                       ref={fileInputRef}
                       type="file"
-                      accept=".md,.txt,.markdown"
+                      multiple={inputSourceType === 'prd'}
+                      accept={
+                        inputSourceType === 'prd'
+                          ? '.pdf,.doc,.docx,.md,.markdown,.txt,.html,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,text/plain,text/markdown'
+                          : '.md,.txt,.markdown'
+                      }
                       className="hidden"
                       onChange={handleFileUpload}
                     />
                   </div>
-                  {/* Article content textarea — always visible, won't unmount */}
+
+                  {/* PRD 附件列表 */}
+                  {inputSourceType === 'prd' && prdAttachments.length > 0 && (
+                    <div className="flex flex-wrap gap-1.5">
+                      {prdAttachments.map((att) => (
+                        <span
+                          key={att.attachmentId}
+                          className="inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px]"
+                          style={{
+                            background: 'rgba(236,72,153,0.08)',
+                            border: '1px solid rgba(236,72,153,0.25)',
+                            color: 'var(--text-primary)',
+                          }}
+                        >
+                          <Paperclip size={10} />
+                          <span className="max-w-[200px] truncate">{att.fileName}</span>
+                          <button
+                            onClick={() => handleRemovePrdAttachment(att.attachmentId)}
+                            className="ml-0.5 opacity-60 hover:opacity-100"
+                            title="移除"
+                          >
+                            <X size={10} />
+                          </button>
+                        </span>
+                      ))}
+                    </div>
+                  )}
+
+                  {/* 文本输入（PRD 模式下为可选，用于补充说明） */}
                   <textarea
-                    placeholder="粘贴 Markdown 文章内容，或点击上方按钮选择文件..."
+                    placeholder={
+                      inputSourceType === 'prd'
+                        ? '（可选）额外补充说明，例如：视频风格偏活泼 / 目标用户是 XX / 重点突出 XX 功能……'
+                        : '粘贴 Markdown 文章内容，或点击上方按钮选择文件…'
+                    }
                     value={articleContent}
                     onChange={(e) => setArticleContent(e.target.value)}
                     className="flex-1 w-full rounded-[14px] px-3 py-2.5 text-sm outline-none resize-none prd-field"
-                    style={{ minHeight: 200 }}
+                    style={{ minHeight: 160 }}
                   />
                 </div>
               ) : selectedRun && (selectedRun.status === 'Scripting' || selectedRun.status === 'Queued') ? (

--- a/prd-admin/src/pages/video-agent/VideoGenDirectPanel.tsx
+++ b/prd-admin/src/pages/video-agent/VideoGenDirectPanel.tsx
@@ -9,7 +9,7 @@
  *   4. status === 'Completed' 时 videoAssetUrl 就位，内嵌播放器直接播放
  */
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Sparkles, Play, Download, RefreshCw, Wand2, Clock, Maximize2, AlertCircle } from 'lucide-react';
+import { Sparkles, Play, Download, RefreshCw, Wand2, Clock, Maximize2, AlertCircle, ChevronDown, ChevronUp, Zap, Scale, Crown } from 'lucide-react';
 import { cn } from '@/lib/cn';
 import { Button } from '@/components/design/Button';
 import { MapSpinner } from '@/components/ui/VideoLoader';
@@ -20,8 +20,11 @@ import {
 } from '@/services/real/videoAgent';
 import {
   OPENROUTER_VIDEO_MODELS,
+  VIDEO_MODEL_TIERS,
   type VideoGenRun,
 } from '@/services/contracts/videoAgent';
+
+const TIER_ICONS = { economy: Zap, balanced: Scale, premium: Crown } as const;
 
 type AspectRatio = '16:9' | '9:16' | '1:1';
 type Resolution = '480p' | '720p' | '1080p';
@@ -39,6 +42,7 @@ const AUTO_MODEL = ''; // 空字符串 = 交由后端模型池自动选择
 export const VideoGenDirectPanel: React.FC = () => {
   const [prompt, setPrompt] = useState('');
   const [model, setModel] = useState<string>(AUTO_MODEL);
+  const [showAdvanced, setShowAdvanced] = useState(false);
   const [duration, setDuration] = useState<number>(5);
   const [aspect, setAspect] = useState<AspectRatio>('16:9');
   const [resolution, setResolution] = useState<Resolution>('720p');
@@ -226,23 +230,99 @@ export const VideoGenDirectPanel: React.FC = () => {
             }}
           />
 
+          {/* ─── 模型档位（3 张卡片，默认推荐；展开"高级"才露出全量 7 个 OpenRouter 模型） ─── */}
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center gap-2 flex-wrap">
+              {/* 自动档 */}
+              <button
+                onClick={() => setModel(AUTO_MODEL)}
+                disabled={isActive || isSubmitting}
+                className={cn(
+                  'flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs transition-colors',
+                  model === AUTO_MODEL && 'ring-1'
+                )}
+                style={{
+                  background: model === AUTO_MODEL ? 'rgba(236,72,153,0.14)' : 'var(--bg-base)',
+                  border: '1px solid ' + (model === AUTO_MODEL ? 'rgba(236,72,153,0.4)' : 'var(--border-default)'),
+                  color: model === AUTO_MODEL ? '#f472b6' : 'var(--text-primary)',
+                }}
+                title="由后端模型池按负载 / 健康度自动选择"
+              >
+                <Sparkles size={11} /> 自动
+              </button>
+
+              {/* 三档推荐 */}
+              {VIDEO_MODEL_TIERS.map((t) => {
+                const Icon = TIER_ICONS[t.tier];
+                const active = model === t.modelId;
+                return (
+                  <button
+                    key={t.tier}
+                    onClick={() => setModel(t.modelId)}
+                    disabled={isActive || isSubmitting}
+                    className={cn(
+                      'flex flex-col items-start gap-0.5 px-3 py-1.5 rounded-lg text-left transition-colors min-w-[120px]',
+                      active && 'ring-1'
+                    )}
+                    style={{
+                      background: active ? 'rgba(236,72,153,0.14)' : 'var(--bg-base)',
+                      border: '1px solid ' + (active ? 'rgba(236,72,153,0.4)' : 'var(--border-default)'),
+                      color: active ? '#f472b6' : 'var(--text-primary)',
+                    }}
+                    title={t.desc}
+                  >
+                    <span className="inline-flex items-center gap-1 text-xs font-medium">
+                      <Icon size={11} />
+                      {t.label}
+                      <span className="ml-1 text-[10px]" style={{ color: 'var(--text-muted)' }}>
+                        {t.tagline}
+                      </span>
+                    </span>
+                    <span className="text-[10px] leading-tight" style={{ color: 'var(--text-muted)' }}>
+                      {t.desc}
+                    </span>
+                  </button>
+                );
+              })}
+
+              {/* 高级展开 */}
+              <button
+                onClick={() => setShowAdvanced((s) => !s)}
+                disabled={isActive || isSubmitting}
+                className="inline-flex items-center gap-1 px-2 py-1.5 rounded-lg text-[11px]"
+                style={{ background: 'transparent', color: 'var(--text-muted)', border: '1px solid var(--border-default)' }}
+                title="展开 OpenRouter 全量视频模型（含 Wan 2.7 / Seedance / Sora）"
+              >
+                高级 {showAdvanced ? <ChevronUp size={11} /> : <ChevronDown size={11} />}
+              </button>
+            </div>
+
+            {showAdvanced && (
+              <div
+                className="flex flex-col gap-1 rounded-lg p-2"
+                style={{ background: 'var(--bg-base)', border: '1px dashed var(--border-default)' }}
+              >
+                <div className="text-[10px]" style={{ color: 'var(--text-muted)' }}>
+                  不知道选什么？保持"自动"即可；需要指定型号时从下面挑选：
+                </div>
+                <select
+                  value={model}
+                  onChange={(e) => setModel(e.target.value)}
+                  disabled={isActive || isSubmitting}
+                  className="text-xs rounded-md px-2 py-1.5"
+                  style={{ background: 'var(--panel)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
+                >
+                  <option value={AUTO_MODEL}>自动（由模型池决定）</option>
+                  {OPENROUTER_VIDEO_MODELS.map((m) => (
+                    <option key={m.id} value={m.id}>{m.label}</option>
+                  ))}
+                </select>
+              </div>
+            )}
+          </div>
+
           {/* 参数栏 */}
           <div className="flex flex-wrap items-center gap-2">
-            {/* 模型（可选：空 = 由模型池自动选择最优） */}
-            <select
-              value={model}
-              onChange={(e) => setModel(e.target.value)}
-              disabled={isActive || isSubmitting}
-              className="text-xs rounded-lg px-2 py-1.5 max-w-[280px] truncate"
-              style={{ background: 'var(--bg-base)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
-              title="留空让模型池自动选择，或指定偏好模型"
-            >
-              <option value={AUTO_MODEL}>自动（由模型池决定）</option>
-              {OPENROUTER_VIDEO_MODELS.map((m) => (
-                <option key={m.id} value={m.id}>{m.label}</option>
-              ))}
-            </select>
-
             {/* 时长 */}
             <div className="flex items-center gap-1 px-2 py-1 rounded-lg text-xs" style={{ background: 'var(--bg-base)', border: '1px solid var(--border-default)' }}>
               <Clock size={11} style={{ color: 'var(--text-muted)' }} />

--- a/prd-admin/src/pages/video-agent/VideoGenDirectPanel.tsx
+++ b/prd-admin/src/pages/video-agent/VideoGenDirectPanel.tsx
@@ -1,12 +1,14 @@
 /**
- * 直出模式面板：跳过分镜，直接把 prompt 交给 OpenRouter 视频大模型
- * 设计风格参考：Sora / Pika —— 黑色沉浸、单焦点画布、prompt 前置
+ * 直出模式面板（双模式）
  *
- * 交互流程：
- *   1. 用户输入 prompt + 选模型 + 选时长/比例
- *   2. 点"生成"→ 后端 VideoGenRun (renderMode=videogen) 异步跑
- *   3. 前端每 3 秒轮询 getVideoGenRun，展示 phase.progress
- *   4. status === 'Completed' 时 videoAssetUrl 就位，内嵌播放器直接播放
+ * 模式 A（输入模式）：走 props.externalRunId === undefined
+ *   用户输入 prompt + 选参数 → 提交 → 内嵌轮询。独立使用时可直接挂在页面里。
+ *
+ * 模式 B（纯输出模式）：走 props.externalRunId !== undefined
+ *   由外层（如统一入口页）已经创建好 run，panel 只负责展示 canvas + 进度 +
+ *   完成后的 videoAssetUrl。输入区隐藏。
+ *
+ * 设计风格参考：Sora / Pika —— 黑色沉浸、单焦点画布、prompt 前置
  */
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Sparkles, Play, Download, RefreshCw, Wand2, Clock, Maximize2, AlertCircle, ChevronDown, ChevronUp, Zap, Scale, Crown } from 'lucide-react';
@@ -39,7 +41,16 @@ const RESOLUTION_OPTIONS: Resolution[] = ['480p', '720p', '1080p'];
 
 const AUTO_MODEL = ''; // 空字符串 = 交由后端模型池自动选择
 
-export const VideoGenDirectPanel: React.FC = () => {
+export interface VideoGenDirectPanelProps {
+  /** 外部已创建的 runId（纯输出模式），不传则启用完整输入模式 */
+  externalRunId?: string;
+  /** 外部传入后，点"再来一条"回调，通常外层用来回到输入 Hero */
+  onReset?: () => void;
+}
+
+export const VideoGenDirectPanel: React.FC<VideoGenDirectPanelProps> = ({ externalRunId, onReset }) => {
+  const isOutputOnly = !!externalRunId;
+
   const [prompt, setPrompt] = useState('');
   const [model, setModel] = useState<string>(AUTO_MODEL);
   const [showAdvanced, setShowAdvanced] = useState(false);
@@ -80,6 +91,28 @@ export const VideoGenDirectPanel: React.FC = () => {
       }
     }, 3000);
   }, []);
+
+  // 纯输出模式：外部传入 runId 后立即拉一次 + 开启轮询
+  useEffect(() => {
+    if (!externalRunId) return;
+    let cancelled = false;
+    (async () => {
+      const res = await getVideoGenRunReal(externalRunId);
+      if (!cancelled && res.success && res.data) {
+        setCurrentRun(res.data);
+        if (!['Completed', 'Failed', 'Cancelled'].includes(res.data.status)) {
+          startPolling(externalRunId);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+    };
+  }, [externalRunId, startPolling]);
 
   const handleGenerate = useCallback(async () => {
     const trimmed = prompt.trim();
@@ -126,7 +159,11 @@ export const VideoGenDirectPanel: React.FC = () => {
       pollRef.current = null;
     }
     setCurrentRun(null);
-  }, []);
+    // 纯输出模式下交给外层回调（通常是"回到输入 Hero"）
+    if (isOutputOnly && onReset) {
+      onReset();
+    }
+  }, [isOutputOnly, onReset]);
 
   const progressText = (() => {
     if (!currentRun) return '';
@@ -207,7 +244,8 @@ export const VideoGenDirectPanel: React.FC = () => {
           </div>
         </div>
 
-        {/* ═══ Prompt 输入 ═══ */}
+        {/* ═══ Prompt 输入（纯输出模式下整个隐藏） ═══ */}
+        {!isOutputOnly && (
         <div
           className="rounded-[16px] p-4 flex flex-col gap-3"
           style={{
@@ -415,6 +453,39 @@ export const VideoGenDirectPanel: React.FC = () => {
             )}
           </div>
         </div>
+        )}
+
+        {/* 纯输出模式的紧凑信息栏（没有输入区时，把关键信息展示在画布下方） */}
+        {isOutputOnly && (
+          <div
+            className="rounded-[14px] p-3 flex items-center gap-3 flex-wrap text-xs"
+            style={{ background: 'var(--panel)', border: '1px solid var(--border-default)' }}
+          >
+            <span style={{ color: 'var(--text-muted)' }}>{progressText || '—'}</span>
+            <div className="flex-1" />
+            {currentRun?.directVideoCost != null && (
+              <span style={{ color: 'var(--text-muted)' }}>
+                费用 ${currentRun.directVideoCost.toFixed(3)}
+              </span>
+            )}
+            {(isCompleted || isFailed) && (
+              <Button size="sm" variant="ghost" onClick={handleReset}>
+                <RefreshCw size={12} /> 新任务
+              </Button>
+            )}
+            {isCompleted && currentRun?.videoAssetUrl && (
+              <a
+                href={currentRun.videoAssetUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="text-xs inline-flex items-center gap-1 px-3 py-1.5 rounded-lg"
+                style={{ background: 'rgba(34,197,94,0.14)', color: '#4ade80', border: '1px solid rgba(34,197,94,0.3)' }}
+              >
+                <Download size={12} /> 下载 MP4
+              </a>
+            )}
+          </div>
+        )}
 
         {/* 完成后的播放器信息 */}
         {isCompleted && currentRun?.videoAssetUrl && (

--- a/prd-admin/src/pages/video-agent/videoModeDetect.ts
+++ b/prd-admin/src/pages/video-agent/videoModeDetect.ts
@@ -1,0 +1,64 @@
+/**
+ * 视频生成自动路由：根据用户输入自动判定走 videogen（一镜直出）或 remotion（拆分镜）
+ *
+ * 路由原则（MVP v1）：
+ *   1. 任何附件（PRD / Word / PDF 等） → remotion 分镜（长内容必拆分镜）
+ *   2. 纯文本 > 200 字 → remotion（长描述 = 有叙事，走分镜）
+ *   3. 其余（短 prompt） → videogen（一镜直出 5s 短片）
+ *
+ * 用户可在"高级设置"里强制指定，override 此判定。
+ */
+
+export type VideoMode = 'videogen' | 'remotion';
+
+export type RoutePreference = 'auto' | 'videogen' | 'remotion';
+
+export const AUTO_ROUTE_TEXT_THRESHOLD = 200;
+
+export interface RouteInput {
+  text: string;
+  attachmentsCount: number;
+  preference?: RoutePreference;
+}
+
+export interface RouteDecision {
+  mode: VideoMode;
+  /** 判定原因，给用户可见的提示条用 */
+  reason: string;
+  /** 是否来自用户强制偏好（true = 不显示"判断为…"toast） */
+  forced: boolean;
+}
+
+export function detectVideoMode(input: RouteInput): RouteDecision {
+  const { text, attachmentsCount, preference = 'auto' } = input;
+
+  if (preference === 'videogen') {
+    return { mode: 'videogen', reason: '你已设置「总是一镜直出」', forced: true };
+  }
+  if (preference === 'remotion') {
+    return { mode: 'remotion', reason: '你已设置「总是拆分镜」', forced: true };
+  }
+
+  if (attachmentsCount > 0) {
+    return {
+      mode: 'remotion',
+      reason: `检测到 ${attachmentsCount} 个附件，将拆分镜生成讲解视频`,
+      forced: false,
+    };
+  }
+
+  const trimmedLen = text.trim().length;
+  if (trimmedLen > AUTO_ROUTE_TEXT_THRESHOLD) {
+    return {
+      mode: 'remotion',
+      reason: `描述较长（${trimmedLen} 字），将拆分镜生成多镜头视频`,
+      forced: false,
+    };
+  }
+
+  return {
+    mode: 'videogen',
+    reason: '短描述，将一镜到底直出 5 秒短片',
+    forced: false,
+  };
+}

--- a/prd-admin/src/services/contracts/videoAgent.ts
+++ b/prd-admin/src/services/contracts/videoAgent.ts
@@ -14,6 +14,39 @@ export const OPENROUTER_VIDEO_MODELS = [
   { id: 'openai/sora-2-pro', label: 'Sora 2 Pro（OpenAI，~$0.30/秒，最贵最强）', defaultDuration: 5 },
 ] as const;
 
+/**
+ * 三档推荐模型（MVP：默认展示这三张卡片，用户不懂型号也能做决定）
+ * 对应的 modelId 会直接作为 directVideoModel 传给后端；空串 = auto
+ */
+export const VIDEO_MODEL_TIERS = [
+  {
+    tier: 'economy',
+    label: '经济',
+    modelId: 'alibaba/wan-2.6',
+    tagline: '日常使用',
+    desc: '阿里 Wan 2.6，1080p/24fps，约 $0.04/秒',
+  },
+  {
+    tier: 'balanced',
+    label: '平衡',
+    modelId: 'bytedance/seedance-2.0',
+    tagline: '性价比推荐',
+    desc: '字节 Seedance 2.0 精品版，含音频',
+  },
+  {
+    tier: 'premium',
+    label: '顶配',
+    modelId: 'google/veo-3.1',
+    tagline: '大片质感',
+    desc: 'Google Veo 3.1，1080p/4K，电影级光影',
+  },
+] as const;
+
+export type VideoModelTier = typeof VIDEO_MODEL_TIERS[number]['tier'];
+
+/** 分镜模式的输入来源：article（技术文章）/ prd（产品需求文档） */
+export type VideoInputSourceType = 'article' | 'prd';
+
 /** 分镜状态 */
 export type SceneItemStatus = 'Draft' | 'Generating' | 'Done' | 'Error';
 
@@ -73,6 +106,9 @@ export interface VideoGenRun {
   directDuration?: number;
   directVideoJobId?: string;
   directVideoCost?: number;
+  // ─── 分镜输入来源（PRD 模式专用） ───
+  inputSourceType?: VideoInputSourceType;
+  attachmentIds?: string[];
 }
 
 /** 任务列表项（精简版） */
@@ -104,6 +140,9 @@ export type CreateVideoGenRunContract = (input: {
   directAspectRatio?: '16:9' | '9:16' | '1:1' | '4:3' | '3:4' | '21:9' | '9:21';
   directResolution?: '480p' | '720p' | '1080p';
   directDuration?: number;
+  // ─── 分镜模式输入来源（PRD 模式专用） ───
+  inputSourceType?: VideoInputSourceType;
+  attachmentIds?: string[];
 }) => Promise<ApiResponse<{ runId: string }>>;
 
 export type ListVideoGenRunsContract = (input?: {

--- a/prd-api/src/PrdAgent.Api/Services/VideoGenRunWorker.cs
+++ b/prd-api/src/PrdAgent.Api/Services/VideoGenRunWorker.cs
@@ -708,8 +708,11 @@ public class VideoGenRunWorker : BackgroundService
         var gateway = scope.ServiceProvider.GetRequiredService<ILlmGateway>();
 
         // 构建系统提示词（可能包含用户自定义系统提示词和风格描述）
-        var systemPrompt = BuildScriptSystemPrompt(run.SystemPrompt, run.StyleDescription);
-        var userPrompt = $"请将以下技术文章转化为视频脚本：\n\n{run.ArticleMarkdown}";
+        var systemPrompt = BuildScriptSystemPrompt(run.SystemPrompt, run.StyleDescription, run.InputSourceType);
+        var userPromptHeader = run.InputSourceType == VideoInputSourceType.Prd
+            ? "请将以下产品需求文档（PRD）转化为产品介绍视频脚本："
+            : "请将以下技术文章转化为视频脚本：";
+        var userPrompt = $"{userPromptHeader}\n\n{run.ArticleMarkdown}";
 
         var request = new GatewayRequest
         {
@@ -1271,45 +1274,98 @@ public class VideoGenRunWorker : BackgroundService
         }
     }
 
-    private static string BuildScriptSystemPrompt(string? userSystemPrompt, string? styleDescription)
+    private static string BuildScriptSystemPrompt(string? userSystemPrompt, string? styleDescription, string? inputSourceType = null)
     {
         var sb = new StringBuilder();
-        sb.AppendLine("""
-            你是一个专业的技术视频脚本编写者。你的任务是将技术文章转化为8-10个视频镜头的脚本。
 
-            请严格按照以下 JSON 格式输出，不要包含任何其他文字：
+        // PRD 专用拆分镜 prompt — 强调产品价值 → 用户痛点 → 功能演示 → 体验收尾
+        if (inputSourceType == VideoInputSourceType.Prd)
+        {
+            sb.AppendLine("""
+                你是一个资深的产品视频导演。你的任务是将产品需求文档（PRD）转化为 8-12 个镜头的产品介绍视频脚本。
 
-            ```json
-            [
-              {
-                "index": 0,
-                "topic": "镜头主题（一句话概括）",
-                "narration": "旁白文本（朗读的台词）",
-                "visualDescription": "画面描述（该镜头展示的视觉元素）",
-                "sceneType": "intro"
-              }
-            ]
-            ```
+                请严格按照以下 JSON 格式输出，不要包含任何其他文字：
 
-            sceneType 可选值：
-            - intro: 开场介绍
-            - concept: 概念解释
-            - steps: 步骤演示
-            - code: 代码展示
-            - comparison: 对比说明
-            - diagram: 图表/架构
-            - summary: 总结回顾
-            - outro: 结尾
+                ```json
+                [
+                  {
+                    "index": 0,
+                    "topic": "镜头主题（一句话概括）",
+                    "narration": "旁白文本（朗读的台词）",
+                    "visualDescription": "画面描述（该镜头展示的视觉元素）",
+                    "sceneType": "intro"
+                  }
+                ]
+                ```
 
-            规则：
-            1. 第一个镜头必须是 intro 类型，最后一个必须是 outro 类型
-            2. 旁白文本要口语化、自然，适合朗读
-            3. 每个镜头的旁白控制在 20-60 字之间
-            4. 画面描述要具体，包含可视化的元素（标题、卡片、代码块、流程图等）
-            5. 确保所有关键信息都被覆盖，不遗漏重要内容
-            6. 只输出 JSON 数组，不要包含 markdown 代码块标记
-            7. **所有输出必须使用中文**，包括 topic、narration 和 visualDescription，即使原文是英文也要翻译为中文
-            """);
+                sceneType 可选值：
+                - intro: 开场介绍（点题 + 引发共鸣）
+                - concept: 产品定位 / 核心价值说明
+                - steps: 功能操作步骤演示
+                - code: （PRD 场景少用）技术亮点/架构说明
+                - comparison: 新旧对比 / 竞品对比
+                - diagram: 流程图 / 架构图 / 数据图
+                - summary: 收益总结
+                - outro: 行动号召 / 结尾
+
+                PRD 拆分镜结构建议（按顺序）：
+                1. 开场（intro）：产品名 + 一句话价值主张
+                2. 痛点（concept）：用户遇到的问题是什么
+                3. 解决方案（concept）：产品如何解决
+                4-6. 核心功能演示（steps / diagram 交替）：挑 3 个最有差异化的功能，每个单独一镜
+                7. 对比（comparison）：和现有方案/竞品的差异（若 PRD 中有相关内容）
+                8. 收益（summary）：量化指标 / 用户收益
+                9. 结尾（outro）：Call to Action（如"立即体验"/"访问官网"）
+
+                规则：
+                1. 第一个镜头必须是 intro 类型，最后一个必须是 outro 类型
+                2. 旁白文本要口语化、有画面感，避免 PRD 里"用户可以"这种干瘪句式
+                3. 每个镜头的旁白控制在 20-60 字之间
+                4. 画面描述要具体：标题文案、UI 截图描述、图表类型、数据高亮等
+                5. 忽略 PRD 中的技术实现细节（如 API 字段、数据库表结构），聚焦用户可见的价值
+                6. 只输出 JSON 数组，不要包含 markdown 代码块标记
+                7. **所有输出必须使用中文**，即使原文是英文也要翻译为中文
+                """);
+        }
+        else
+        {
+            sb.AppendLine("""
+                你是一个专业的技术视频脚本编写者。你的任务是将技术文章转化为8-10个视频镜头的脚本。
+
+                请严格按照以下 JSON 格式输出，不要包含任何其他文字：
+
+                ```json
+                [
+                  {
+                    "index": 0,
+                    "topic": "镜头主题（一句话概括）",
+                    "narration": "旁白文本（朗读的台词）",
+                    "visualDescription": "画面描述（该镜头展示的视觉元素）",
+                    "sceneType": "intro"
+                  }
+                ]
+                ```
+
+                sceneType 可选值：
+                - intro: 开场介绍
+                - concept: 概念解释
+                - steps: 步骤演示
+                - code: 代码展示
+                - comparison: 对比说明
+                - diagram: 图表/架构
+                - summary: 总结回顾
+                - outro: 结尾
+
+                规则：
+                1. 第一个镜头必须是 intro 类型，最后一个必须是 outro 类型
+                2. 旁白文本要口语化、自然，适合朗读
+                3. 每个镜头的旁白控制在 20-60 字之间
+                4. 画面描述要具体，包含可视化的元素（标题、卡片、代码块、流程图等）
+                5. 确保所有关键信息都被覆盖，不遗漏重要内容
+                6. 只输出 JSON 数组，不要包含 markdown 代码块标记
+                7. **所有输出必须使用中文**，包括 topic、narration 和 visualDescription，即使原文是英文也要翻译为中文
+                """);
+        }
 
         if (!string.IsNullOrWhiteSpace(userSystemPrompt))
         {

--- a/prd-api/src/PrdAgent.Core/Models/VideoGenModels.cs
+++ b/prd-api/src/PrdAgent.Core/Models/VideoGenModels.cs
@@ -129,6 +129,26 @@ public class VideoGenRun
 
     /// <summary>videogen 任务生成成本（美元）</summary>
     public double? DirectVideoCost { get; set; }
+
+    // ─── 分镜输入来源（2026-04 新增：支持 PRD 文档上传） ───
+
+    /// <summary>输入来源类型：article（默认，技术文章）/ prd（PRD 文档，使用专用拆分镜 prompt）</summary>
+    public string InputSourceType { get; set; } = VideoInputSourceType.Article;
+
+    /// <summary>关联的附件 id 列表（PRD 模式下由附件 ExtractedText 拼接成 ArticleMarkdown）</summary>
+    public List<string> AttachmentIds { get; set; } = new();
+}
+
+/// <summary>
+/// 分镜输入来源类型
+/// </summary>
+public static class VideoInputSourceType
+{
+    /// <summary>技术文章 Markdown（默认，通用拆分镜 prompt）</summary>
+    public const string Article = "article";
+
+    /// <summary>PRD 文档（使用 PRD 专用拆分镜 prompt，强调产品价值 → 功能演示 → 用户体验）</summary>
+    public const string Prd = "prd";
 }
 
 /// <summary>
@@ -229,6 +249,14 @@ public class CreateVideoGenRunRequest
 
     /// <summary>videogen 模式专用：分辨率（720p/1080p，默认 720p）</summary>
     public string? DirectResolution { get; set; }
+
+    // ─── 分镜输入来源（2026-04 新增：支持 PRD 文档上传） ───
+
+    /// <summary>输入来源类型：article（默认）/ prd；prd 时允许仅传 attachmentIds，后端自动拼接 ExtractedText</summary>
+    public string? InputSourceType { get; set; }
+
+    /// <summary>关联的附件 id 列表（PRD 模式使用；PDF/Word/Markdown 等上传后 ExtractedText 已落库）</summary>
+    public List<string>? AttachmentIds { get; set; }
 }
 
 /// <summary>

--- a/prd-api/src/PrdAgent.Infrastructure/Services/VideoGenService.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/VideoGenService.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 using PrdAgent.Core.Interfaces;
@@ -80,12 +81,41 @@ public class VideoGenService : IVideoGenService
         }
 
         // ─── 默认分支：remotion（原流程） ───
+        var inputSourceType = (request?.InputSourceType ?? VideoInputSourceType.Article).Trim().ToLowerInvariant();
+        if (inputSourceType is not (VideoInputSourceType.Article or VideoInputSourceType.Prd))
+            inputSourceType = VideoInputSourceType.Article;
+
+        var attachmentIds = (request?.AttachmentIds ?? new List<string>())
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Select(x => x.Trim())
+            .Distinct()
+            .ToList();
+
         var markdown = (request?.ArticleMarkdown ?? string.Empty).Trim();
+
+        // PRD 模式：允许 markdown 为空，从附件提取
+        if (string.IsNullOrWhiteSpace(markdown) && attachmentIds.Count > 0)
+        {
+            var extracted = await BuildMarkdownFromAttachmentsAsync(attachmentIds, ownerAdminId, ct);
+            markdown = extracted.Markdown;
+            if (string.IsNullOrWhiteSpace(markdown))
+                throw new ArgumentException("所选附件未能提取到可用文本，请换一份文档或粘贴文本");
+            // 若用户没指定标题，用首个附件名兜底
+            if (string.IsNullOrWhiteSpace(request?.ArticleTitle) && !string.IsNullOrWhiteSpace(extracted.Title))
+            {
+                request!.ArticleTitle = extracted.Title;
+            }
+        }
+
         if (string.IsNullOrWhiteSpace(markdown))
             throw new ArgumentException("文章内容不能为空");
 
         if (markdown.Length > 100_000)
-            throw new ArgumentException("文章内容超过 10 万字限制");
+        {
+            // PRD/长文档截断而不是报错，避免用户上传大文档直接失败
+            markdown = markdown[..100_000];
+            _logger.LogWarning("VideoGen 输入超过 10 万字，已截断: appKey={AppKey}", appKey);
+        }
 
         var title = (request?.ArticleTitle ?? string.Empty).Trim();
         if (string.IsNullOrWhiteSpace(title)) title = null;
@@ -104,6 +134,8 @@ public class VideoGenService : IVideoGenService
             EnableTts = request?.EnableTts ?? false,
             VoiceId = request?.VoiceId?.Trim(),
             RenderMode = VideoRenderMode.Remotion,
+            InputSourceType = inputSourceType,
+            AttachmentIds = attachmentIds,
             CreatedAt = DateTime.UtcNow
         };
 
@@ -345,6 +377,47 @@ public class VideoGenService : IVideoGenService
         }
 
         await PublishEventAsync(runId, "audio.all.queued", new { sceneCount = updates.Count });
+    }
+
+    private async Task<(string Markdown, string? Title)> BuildMarkdownFromAttachmentsAsync(
+        List<string> attachmentIds, string ownerAdminId, CancellationToken ct)
+    {
+        if (attachmentIds.Count == 0) return (string.Empty, null);
+
+        var fb = Builders<Attachment>.Filter;
+        var filter = fb.In(a => a.AttachmentId, attachmentIds) & fb.Eq(a => a.UploaderId, ownerAdminId);
+        var atts = await _db.Attachments.Find(filter).ToListAsync(ct);
+
+        if (atts.Count == 0)
+            throw new ArgumentException("附件不存在或无权访问");
+
+        // 按请求顺序排序
+        var ordered = attachmentIds
+            .Select(id => atts.FirstOrDefault(a => a.AttachmentId == id))
+            .Where(a => a != null)
+            .ToList();
+
+        var sb = new StringBuilder();
+        string? firstTitle = null;
+        foreach (var att in ordered)
+        {
+            var text = (att!.ExtractedText ?? string.Empty).Trim();
+            if (string.IsNullOrWhiteSpace(text)) continue;
+
+            if (sb.Length > 0) sb.AppendLine().AppendLine("---").AppendLine();
+            sb.AppendLine($"# {att.FileName}");
+            sb.AppendLine();
+            sb.AppendLine(text);
+
+            if (firstTitle == null)
+            {
+                // 去掉扩展名作为兜底标题
+                var dot = att.FileName.LastIndexOf('.');
+                firstTitle = dot > 0 ? att.FileName[..dot] : att.FileName;
+            }
+        }
+
+        return (sb.ToString(), firstTitle);
     }
 
     private async Task PublishEventAsync(string runId, string eventName, object payload)


### PR DESCRIPTION
## Summary

Extends the video storyboard generation feature to support PRD (Product Requirements Document) input in addition to technical articles. Users can now upload PDF, Word, Markdown, or text documents, which are automatically processed and converted into product-focused video scripts with a specialized narrative structure.

## Key Changes

**Frontend (prd-admin)**
- Added input source type toggle: "Markdown Article" vs "PRD Document" modes
- Implemented dual-channel file upload:
  - Article mode: Direct FileReader for `.md`/`.txt` files (existing behavior)
  - PRD mode: Multi-file upload via `/api/v1/attachments` endpoint with visual attachment chips
- Updated button labels and placeholder text to reflect selected mode
- Enhanced model selection UI with three recommended tiers (Economy/Balanced/Premium) and collapsible advanced options
- Added `inputSourceType` and `attachmentIds` to video generation request payload

**Backend (prd-api)**
- Extended `VideoGenRun` and `CreateVideoGenRunRequest` models with:
  - `InputSourceType` field (article/prd)
  - `AttachmentIds` list for PRD mode
- Implemented `BuildMarkdownFromAttachmentsAsync()` to extract and concatenate text from uploaded attachments
- Added PRD-specific system prompt in `BuildScriptSystemPrompt()`:
  - Tailored narrative structure: intro → pain point → solution → feature demos → benefits → CTA
  - 8-12 scene target (vs 8-10 for articles)
  - Optimized for product value communication
- Updated `ProcessScriptingAsync()` to use appropriate prompt based on input source type
- Added input validation: allows empty `ArticleMarkdown` if `AttachmentIds` provided; truncates oversized inputs gracefully

**Data Models**
- Added `VideoInputSourceType` constants (Article/Prd)
- Added `VIDEO_MODEL_TIERS` export for UI tier selection
- Updated type definitions to include new input source fields

## Implementation Details

- PRD mode supports batch file uploads (multiple documents concatenated with separators)
- Attachment filenames are used as fallback titles if user doesn't specify one
- Backend automatically extracts text from attachments (assumes `ExtractedText` field is pre-populated by attachment service)
- Maintains backward compatibility: existing article-mode workflows unchanged
- Input size limit (100k chars) applies to both modes; PRD mode truncates rather than fails

https://claude.ai/code/session_01UmsiExGjkMe2T6Ksx4zGnz

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches both frontend workflow and backend run creation/scripting: new PRD attachment ingestion, new request fields, and automatic routing between `remotion` and `videogen` could change how runs are created and prompted. Risk is moderated but includes new input validation/truncation paths and UI refactor of the entry flow.
> 
> **Overview**
> Adds a **PRD document input path** for storyboard generation: `CreateVideoGenRunRequest`/`VideoGenRun` now accept `inputSourceType` and `attachmentIds`, and the backend can build `articleMarkdown` from uploaded attachment `ExtractedText` (with title fallback and oversized-input truncation).
> 
> Refactors `prd-admin` to a **single unified Video Agent entry** (`UnifiedInputHero`) with drag/drop + multi-file upload via `/api/v1/attachments`, automatic mode routing (`detectVideoMode`) with user-overridable preference, and a new `HistoryDrawer` replacing the inline history list.
> 
> Upgrades direct video generation UI to support **recommended model tiers** (`VIDEO_MODEL_TIERS`) and makes `VideoGenDirectPanel` reusable in an output-only mode via `externalRunId`, enabling seamless handoff when the unified entry routes to `videogen`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b0ced5814e3c51e9f3b55c28135623bf6e2631c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->