### PR TITLE
Style/mobile home text glassmorphism

### DIFF
--- a/prd-admin/src/pages/AgentLauncherPage.tsx
+++ b/prd-admin/src/pages/AgentLauncherPage.tsx
@@ -272,9 +272,9 @@ function FeaturedCard({ item, onClick }: { item: ToolboxItem; onClick: () => voi
 
       {/* Strong dark fade at the bottom for text readability */}
       <div
-        className="absolute inset-x-0 bottom-0 pointer-events-none z-[2] h-1/2"
+        className="absolute inset-x-0 bottom-0 pointer-events-none z-[2] h-[65%]"
         style={{
-          background: 'linear-gradient(180deg, transparent 0%, rgba(0,0,0,0.6) 50%, rgba(0,0,0,0.95) 100%)',
+          background: 'linear-gradient(180deg, transparent 0%, rgba(0,0,0,0.4) 30%, rgba(0,0,0,0.85) 65%, rgba(0,0,0,0.98) 100%)',
         }}
       />
 
@@ -306,13 +306,13 @@ function FeaturedCard({ item, onClick }: { item: ToolboxItem; onClick: () => voi
       <div className="absolute bottom-0 left-0 right-0 p-5 z-[10]">
         <h3
           className="text-[17px] font-semibold truncate transition-all duration-300 group-hover:translate-y-[-2px]"
-          style={{ color: '#fff', textShadow: '0 2px 8px rgba(0,0,0,0.8), 0 1px 3px rgba(0,0,0,0.6)' }}
+          style={{ color: '#ffffff', textShadow: '0 1px 2px rgba(0,0,0,1), 0 2px 8px rgba(0,0,0,0.9), 0 4px 16px rgba(0,0,0,0.5)' }}
         >
           {item.name}
         </h3>
         <p
           className="text-[13px] leading-relaxed mt-1.5 line-clamp-2 transition-all duration-300 group-hover:translate-y-[-2px] group-hover:opacity-100 opacity-80"
-          style={{ color: 'rgba(255,255,255,0.9)', textShadow: '0 1px 4px rgba(0,0,0,0.8)' }}
+          style={{ color: 'rgba(255,255,255,0.95)', textShadow: '0 1px 2px rgba(0,0,0,1), 0 2px 6px rgba(0,0,0,0.8)' }}
         >
           {item.description}
         </p>
@@ -874,13 +874,13 @@ export default function AgentLauncherPage() {
 
                       <div
                         className={`mt-3 font-semibold tracking-tight ${isMobile ? 'text-[14px]' : 'text-[15px]'}`}
-                        style={{ color: 'var(--text-primary, #fff)', textShadow: '0 2px 4px rgba(0,0,0,0.5)' }}
+                        style={{ color: 'var(--text-primary, #ffffff)', textShadow: '0 1px 2px rgba(0,0,0,1), 0 2px 6px rgba(0,0,0,0.6)' }}
                       >
                         {link.label}
                       </div>
                       <div
                         className="text-[11px] mt-1 leading-relaxed line-clamp-2"
-                        style={{ color: 'var(--text-muted, rgba(255,255,255,0.8))', textShadow: '0 1px 3px rgba(0,0,0,0.4)' }}
+                        style={{ color: 'var(--text-muted, rgba(255,255,255,0.85))', textShadow: '0 1px 2px rgba(0,0,0,0.9), 0 2px 4px rgba(0,0,0,0.6)' }}
                       >
                         {link.desc}
                       </div>

--- a/prd-admin/src/pages/AgentLauncherPage.tsx
+++ b/prd-admin/src/pages/AgentLauncherPage.tsx
@@ -270,28 +270,37 @@ function FeaturedCard({ item, onClick }: { item: ToolboxItem; onClick: () => voi
         />
       )}
 
-      {/* Bottom gradient overlay */}
+      {/* Subtle fade to blend image with glass panel */}
       <div
-        className="absolute inset-0 pointer-events-none"
+        className="absolute inset-0 pointer-events-none z-[2]"
         style={{
-          background: 'linear-gradient(180deg, rgba(0,0,0,0) 30%, rgba(0,0,0,0.7) 70%, rgba(0,0,0,0.9) 100%)',
+          background: 'linear-gradient(180deg, rgba(0,0,0,0) 40%, rgba(0,0,0,0.7) 100%)',
         }}
       />
 
       {/* Hover border glow */}
       <div
-        className="absolute inset-0 rounded-2xl opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none"
+        className="absolute inset-0 rounded-2xl opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none flex z-[20]"
         style={{ boxShadow: `inset 0 0 0 1px ${accent.from}40, 0 0 20px ${accent.from}10` }}
       />
 
-      {/* Content */}
-      <div className="absolute bottom-0 left-0 right-0 p-5 z-10">
+      {/* Content — Unified Glassmorphism Panel */}
+      <div 
+        className="absolute bottom-0 left-0 right-0 p-5 z-[10] transition-all duration-300 border-t"
+        style={{ 
+          borderColor: 'rgba(255,255,255,0.06)',
+          background: 'var(--card-glass-bg, rgba(16,16,24,0.45))',
+          backdropFilter: 'blur(16px)',
+          WebkitBackdropFilter: 'blur(16px)'
+        }}
+      >
         <div className="flex items-start gap-3">
           <div
-            className="shrink-0 w-10 h-10 rounded-xl flex items-center justify-center"
+            className="shrink-0 w-10 h-10 rounded-xl flex items-center justify-center transition-transform duration-300 group-hover:scale-105"
             style={{
-              background: `linear-gradient(135deg, ${accent.from}30, ${accent.from}10)`,
-              border: `1px solid ${accent.from}30`,
+              background: `linear-gradient(135deg, ${accent.from}40, ${accent.from}15)`,
+              border: `1px solid ${accent.from}40`,
+              boxShadow: `0 8px 24px -10px ${accent.from}60`
             }}
           >
             <Icon size={20} style={{ color: accent.to }} />
@@ -299,8 +308,8 @@ function FeaturedCard({ item, onClick }: { item: ToolboxItem; onClick: () => voi
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2">
               <h3
-                className="text-[15px] font-semibold truncate px-2 py-0.5 rounded-md bg-black/20 backdrop-blur-md shadow-sm w-fit"
-                style={{ color: '#fff', textShadow: '0 1px 4px rgba(0,0,0,0.5)', border: '1px solid rgba(255,255,255,0.05)' }}
+                className="text-[15px] font-semibold truncate transition-colors"
+                style={{ color: '#fff', textShadow: '0 2px 4px rgba(0,0,0,0.4)' }}
               >
                 {item.name}
               </h3>
@@ -311,8 +320,8 @@ function FeaturedCard({ item, onClick }: { item: ToolboxItem; onClick: () => voi
               />
             </div>
             <p
-              className="text-[12px] leading-relaxed mt-1 line-clamp-2 px-2 py-1 rounded-md bg-black/20 backdrop-blur-md shadow-sm w-fit max-w-full"
-              style={{ color: 'var(--text-muted, rgba(255,255,255,0.85))', border: '1px solid rgba(255,255,255,0.05)' }}
+              className="text-[12px] leading-relaxed mt-1 line-clamp-2"
+              style={{ color: 'rgba(255,255,255,0.7)', textShadow: '0 1px 2px rgba(0,0,0,0.3)' }}
             >
               {item.description}
             </p>
@@ -321,11 +330,11 @@ function FeaturedCard({ item, onClick }: { item: ToolboxItem; onClick: () => voi
                 {item.tags.slice(0, 3).map((t) => (
                   <span
                     key={t}
-                    className="text-[10px] px-2 py-0.5 rounded-[5px] backdrop-blur-md shadow-sm"
+                    className="text-[10px] px-2 py-0.5 rounded-[5px]"
                     style={{
-                      background: 'rgba(0,0,0,0.3)',
+                      background: 'rgba(255,255,255,0.08)',
                       color: 'rgba(255,255,255,0.7)',
-                      border: '1px solid rgba(255,255,255,0.08)',
+                      border: '1px solid rgba(255,255,255,0.05)',
                     }}
                   >
                     {t}
@@ -830,10 +839,11 @@ export default function AgentLauncherPage() {
                             backgroundPosition: 'center',
                           }}
                         />
+                        {/* Stronger unified gradient for text readability over bright images */}
                         <div
                           className="absolute inset-0 pointer-events-none"
                           style={{
-                            background: 'linear-gradient(180deg, rgba(0,0,0,0.15) 0%, rgba(0,0,0,0.55) 70%, rgba(0,0,0,0.8) 100%)',
+                            background: 'linear-gradient(180deg, rgba(0,0,0,0.4) 0%, rgba(0,0,0,0.7) 50%, rgba(0,0,0,0.9) 100%)',
                           }}
                         />
                       </>
@@ -891,14 +901,14 @@ export default function AgentLauncherPage() {
                       </div>
 
                       <div
-                        className={`mt-3 font-semibold tracking-tight px-2.5 py-0.5 rounded-md bg-black/20 backdrop-blur-md shadow-sm w-fit ${isMobile ? 'text-[14px]' : 'text-[15px]'}`}
-                        style={{ color: 'var(--text-primary, #fff)', border: '1px solid rgba(255,255,255,0.05)' }}
+                        className={`mt-3 font-semibold tracking-tight ${isMobile ? 'text-[14px]' : 'text-[15px]'}`}
+                        style={{ color: 'var(--text-primary, #fff)', textShadow: '0 2px 4px rgba(0,0,0,0.5)' }}
                       >
                         {link.label}
                       </div>
                       <div
-                        className="text-[11px] mt-1.5 leading-relaxed line-clamp-2 px-2 py-1 rounded-md bg-black/20 backdrop-blur-md shadow-sm w-fit max-w-full"
-                        style={{ color: 'var(--text-muted, rgba(255,255,255,0.85))', border: '1px solid rgba(255,255,255,0.05)' }}
+                        className="text-[11px] mt-1 leading-relaxed line-clamp-2"
+                        style={{ color: 'var(--text-muted, rgba(255,255,255,0.8))', textShadow: '0 1px 3px rgba(0,0,0,0.4)' }}
                       >
                         {link.desc}
                       </div>

--- a/prd-admin/src/pages/AgentLauncherPage.tsx
+++ b/prd-admin/src/pages/AgentLauncherPage.tsx
@@ -270,11 +270,11 @@ function FeaturedCard({ item, onClick }: { item: ToolboxItem; onClick: () => voi
         />
       )}
 
-      {/* Subtle fade to blend image with glass panel */}
+      {/* Strong dark fade at the bottom for text readability */}
       <div
-        className="absolute inset-0 pointer-events-none z-[2]"
+        className="absolute inset-x-0 bottom-0 pointer-events-none z-[2] h-1/2"
         style={{
-          background: 'linear-gradient(180deg, rgba(0,0,0,0) 40%, rgba(0,0,0,0.7) 100%)',
+          background: 'linear-gradient(180deg, transparent 0%, rgba(0,0,0,0.6) 50%, rgba(0,0,0,0.95) 100%)',
         }}
       />
 
@@ -284,66 +284,38 @@ function FeaturedCard({ item, onClick }: { item: ToolboxItem; onClick: () => voi
         style={{ boxShadow: `inset 0 0 0 1px ${accent.from}40, 0 0 20px ${accent.from}10` }}
       />
 
-      {/* Content — Unified Glassmorphism Panel */}
+      {/* Top Floating App Icon */}
       <div 
-        className="absolute bottom-0 left-0 right-0 p-5 z-[10] transition-all duration-300 border-t"
-        style={{ 
-          borderColor: 'rgba(255,255,255,0.06)',
-          background: 'var(--card-glass-bg, rgba(16,16,24,0.45))',
-          backdropFilter: 'blur(16px)',
-          WebkitBackdropFilter: 'blur(16px)'
+        className="absolute top-4 left-4 z-[10] shrink-0 w-11 h-11 rounded-2xl flex items-center justify-center transition-transform duration-300 group-hover:scale-110"
+        style={{
+          background: `linear-gradient(135deg, ${accent.from}50, ${accent.from}15)`,
+          border: `1px solid ${accent.from}60`,
+          boxShadow: `0 8px 24px -8px ${accent.from}90, inset 0 1px 0 rgba(255,255,255,0.25)`,
+          backdropFilter: 'blur(8px)'
         }}
       >
-        <div className="flex items-start gap-3">
-          <div
-            className="shrink-0 w-10 h-10 rounded-xl flex items-center justify-center transition-transform duration-300 group-hover:scale-105"
-            style={{
-              background: `linear-gradient(135deg, ${accent.from}40, ${accent.from}15)`,
-              border: `1px solid ${accent.from}40`,
-              boxShadow: `0 8px 24px -10px ${accent.from}60`
-            }}
-          >
-            <Icon size={20} style={{ color: accent.to }} />
-          </div>
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2">
-              <h3
-                className="text-[15px] font-semibold truncate transition-colors"
-                style={{ color: '#fff', textShadow: '0 2px 4px rgba(0,0,0,0.4)' }}
-              >
-                {item.name}
-              </h3>
-              <ArrowRight
-                size={14}
-                className="shrink-0 opacity-0 group-hover:opacity-80 transition-all duration-200 group-hover:translate-x-0.5"
-                style={{ color: accent.to }}
-              />
-            </div>
-            <p
-              className="text-[12px] leading-relaxed mt-1 line-clamp-2"
-              style={{ color: 'rgba(255,255,255,0.7)', textShadow: '0 1px 2px rgba(0,0,0,0.3)' }}
-            >
-              {item.description}
-            </p>
-            {item.tags.length > 0 && (
-              <div className="flex gap-1.5 mt-2.5">
-                {item.tags.slice(0, 3).map((t) => (
-                  <span
-                    key={t}
-                    className="text-[10px] px-2 py-0.5 rounded-[5px]"
-                    style={{
-                      background: 'rgba(255,255,255,0.08)',
-                      color: 'rgba(255,255,255,0.7)',
-                      border: '1px solid rgba(255,255,255,0.05)',
-                    }}
-                  >
-                    {t}
-                  </span>
-                ))}
-              </div>
-            )}
-          </div>
-        </div>
+        <Icon size={22} style={{ color: accent.to, filter: `drop-shadow(0 2px 4px ${accent.from}80)` }} />
+      </div>
+
+      {/* Top-Right Arrow Indicator */}
+      <div className="absolute top-5 right-5 z-[10] shrink-0 opacity-0 -translate-x-3 group-hover:opacity-100 group-hover:translate-x-0 transition-all duration-300">
+        <ArrowRight size={18} style={{ color: accent.to, filter: `drop-shadow(0 2px 4px ${accent.from}80)` }} />
+      </div>
+
+      {/* Content — Clean Bottom Aligned */}
+      <div className="absolute bottom-0 left-0 right-0 p-5 z-[10]">
+        <h3
+          className="text-[17px] font-semibold truncate transition-all duration-300 group-hover:translate-y-[-2px]"
+          style={{ color: '#fff', textShadow: '0 2px 8px rgba(0,0,0,0.8), 0 1px 3px rgba(0,0,0,0.6)' }}
+        >
+          {item.name}
+        </h3>
+        <p
+          className="text-[13px] leading-relaxed mt-1.5 line-clamp-2 transition-all duration-300 group-hover:translate-y-[-2px] group-hover:opacity-100 opacity-80"
+          style={{ color: 'rgba(255,255,255,0.9)', textShadow: '0 1px 4px rgba(0,0,0,0.8)' }}
+        >
+          {item.description}
+        </p>
       </div>
     </button>
   );

--- a/prd-admin/src/pages/AgentLauncherPage.tsx
+++ b/prd-admin/src/pages/AgentLauncherPage.tsx
@@ -299,8 +299,8 @@ function FeaturedCard({ item, onClick }: { item: ToolboxItem; onClick: () => voi
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2">
               <h3
-                className="text-[15px] font-semibold truncate"
-                style={{ color: '#fff', textShadow: '0 1px 4px rgba(0,0,0,0.5)' }}
+                className="text-[15px] font-semibold truncate px-2 py-0.5 rounded-md bg-black/20 backdrop-blur-md shadow-sm w-fit"
+                style={{ color: '#fff', textShadow: '0 1px 4px rgba(0,0,0,0.5)', border: '1px solid rgba(255,255,255,0.05)' }}
               >
                 {item.name}
               </h3>
@@ -311,8 +311,8 @@ function FeaturedCard({ item, onClick }: { item: ToolboxItem; onClick: () => voi
               />
             </div>
             <p
-              className="text-[12px] leading-relaxed mt-1 line-clamp-2"
-              style={{ color: 'rgba(255,255,255,0.55)' }}
+              className="text-[12px] leading-relaxed mt-1 line-clamp-2 px-2 py-1 rounded-md bg-black/20 backdrop-blur-md shadow-sm w-fit max-w-full"
+              style={{ color: 'var(--text-muted, rgba(255,255,255,0.85))', border: '1px solid rgba(255,255,255,0.05)' }}
             >
               {item.description}
             </p>
@@ -321,11 +321,11 @@ function FeaturedCard({ item, onClick }: { item: ToolboxItem; onClick: () => voi
                 {item.tags.slice(0, 3).map((t) => (
                   <span
                     key={t}
-                    className="text-[10px] px-2 py-0.5 rounded-md"
+                    className="text-[10px] px-2 py-0.5 rounded-[5px] backdrop-blur-md shadow-sm"
                     style={{
-                      background: 'rgba(255,255,255,0.06)',
-                      color: 'rgba(255,255,255,0.5)',
-                      border: '1px solid rgba(255,255,255,0.04)',
+                      background: 'rgba(0,0,0,0.3)',
+                      color: 'rgba(255,255,255,0.7)',
+                      border: '1px solid rgba(255,255,255,0.08)',
                     }}
                   >
                     {t}
@@ -891,14 +891,14 @@ export default function AgentLauncherPage() {
                       </div>
 
                       <div
-                        className={`mt-3 font-semibold tracking-tight ${isMobile ? 'text-[14px]' : 'text-[15px]'}`}
-                        style={{ color: 'var(--text-primary, #fff)' }}
+                        className={`mt-3 font-semibold tracking-tight px-2.5 py-0.5 rounded-md bg-black/20 backdrop-blur-md shadow-sm w-fit ${isMobile ? 'text-[14px]' : 'text-[15px]'}`}
+                        style={{ color: 'var(--text-primary, #fff)', border: '1px solid rgba(255,255,255,0.05)' }}
                       >
                         {link.label}
                       </div>
                       <div
-                        className="text-[11px] mt-1 leading-relaxed line-clamp-2"
-                        style={{ color: 'var(--text-muted, rgba(255,255,255,0.5))' }}
+                        className="text-[11px] mt-1.5 leading-relaxed line-clamp-2 px-2 py-1 rounded-md bg-black/20 backdrop-blur-md shadow-sm w-fit max-w-full"
+                        style={{ color: 'var(--text-muted, rgba(255,255,255,0.85))', border: '1px solid rgba(255,255,255,0.05)' }}
                       >
                         {link.desc}
                       </div>

--- a/prd-admin/src/pages/MobileHomePage.tsx
+++ b/prd-admin/src/pages/MobileHomePage.tsx
@@ -132,11 +132,17 @@ export default function MobileHomePage() {
               {(user?.displayName || user?.username || '?')[0]}
             </div>
           )}
-          <div>
-            <div className="text-lg font-semibold" style={{ color: 'var(--text-primary)' }}>
+          <div className="flex flex-col items-start">
+            <div
+              className="text-lg font-semibold px-2.5 py-0.5 rounded-lg bg-black/20 backdrop-blur-md shadow-sm border border-white/5"
+              style={{ color: 'var(--text-primary)', textShadow: '0 1px 3px rgba(0,0,0,0.5)' }}
+            >
               {greeting}，{user?.displayName || user?.username}
             </div>
-            <div className="text-xs" style={{ color: 'var(--text-muted)' }}>
+            <div
+              className="text-xs mt-1.5 px-2 py-0.5 rounded-md bg-black/20 backdrop-blur-md shadow-sm border border-white/5"
+              style={{ color: 'var(--text-muted)' }}
+            >
               看看今天能帮你做什么
             </div>
           </div>
@@ -144,7 +150,10 @@ export default function MobileHomePage() {
 
         {/* ── 快捷 Agent 入口 ── */}
         <div className="mb-5">
-          <div className="text-xs font-medium mb-3" style={{ color: 'var(--text-muted)' }}>
+          <div
+            className="text-xs font-medium mb-3 px-2.5 py-1 rounded-md inline-block bg-black/20 backdrop-blur-md shadow-sm border border-white/5"
+            style={{ color: 'var(--text-primary)' }}
+          >
             快捷入口
           </div>
           <div className={`grid gap-3 ${quickAgents.length > 4 ? 'grid-cols-5' : 'grid-cols-4'}`}>
@@ -163,8 +172,8 @@ export default function MobileHomePage() {
                     <AgentIcon size={20} style={{ color: agent.color }} />
                   </div>
                   <span
-                    className="text-[10px] font-medium text-center leading-tight px-0.5 line-clamp-2"
-                    style={{ color: 'var(--text-secondary)' }}
+                    className="text-[10px] font-medium text-center leading-tight px-1.5 py-0.5 mt-0.5 rounded bg-black/20 backdrop-blur-md shadow-sm border border-white/5 line-clamp-2"
+                    style={{ color: 'var(--text-primary)' }}
                   >
                     {agent.label}
                   </span>
@@ -177,7 +186,10 @@ export default function MobileHomePage() {
         {/* ── 统计卡片 (近 7 日) ── */}
         {stats && (
           <div className="mb-5">
-            <div className="text-xs font-medium mb-3" style={{ color: 'var(--text-muted)' }}>
+            <div
+              className="text-xs font-medium mb-3 px-2.5 py-1 rounded-md inline-block bg-black/20 backdrop-blur-md shadow-sm border border-white/5"
+              style={{ color: 'var(--text-primary)' }}
+            >
               近 7 日统计
             </div>
             <div className="grid grid-cols-4 gap-2">
@@ -190,11 +202,17 @@ export default function MobileHomePage() {
                     key={card.key}
                     className="surface-inset flex flex-col items-center gap-1.5 py-3 rounded-xl"
                   >
-                    <CardIcon size={16} style={{ color: card.color }} />
-                    <div className="text-base font-bold" style={{ color: 'var(--text-primary)' }}>
+                    <CardIcon size={16} className="mb-0.5" style={{ color: card.color }} />
+                    <div
+                      className="text-base font-bold px-2 py-0.5 rounded-md bg-black/20 backdrop-blur-md shadow-sm border border-white/5"
+                      style={{ color: 'var(--text-primary)', textShadow: '0 1px 2px rgba(0,0,0,0.5)' }}
+                    >
                       {display}
                     </div>
-                    <div className="text-[10px]" style={{ color: 'var(--text-muted)' }}>
+                    <div
+                      className="text-[10px] px-1.5 py-0.5 rounded bg-black/20 backdrop-blur-md shadow-sm border border-white/5"
+                      style={{ color: 'var(--text-muted)' }}
+                    >
                       {card.label}
                     </div>
                   </div>
@@ -208,10 +226,16 @@ export default function MobileHomePage() {
         {notifications.length > 0 && (
           <div className="mb-5">
             <div className="flex items-center justify-between mb-3">
-              <div className="text-xs font-medium" style={{ color: 'var(--text-muted)' }}>
+              <div
+                className="text-xs font-medium px-2.5 py-1 rounded-md inline-block bg-black/20 backdrop-blur-md shadow-sm border border-white/5"
+                style={{ color: 'var(--text-primary)' }}
+              >
                 通知
               </div>
-              <div className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
+              <div
+                className="text-[11px] px-2 py-0.5 rounded-md bg-black/20 backdrop-blur-md shadow-sm border border-white/5"
+                style={{ color: 'var(--text-muted)' }}
+              >
                 {notifications.length} 条未读
               </div>
             </div>
@@ -223,11 +247,17 @@ export default function MobileHomePage() {
                 >
                   <Bell size={16} className="mt-0.5 shrink-0" style={{ color: 'var(--text-muted)' }} />
                   <div className="flex-1 min-w-0">
-                    <div className="text-sm font-medium truncate" style={{ color: 'var(--text-primary)' }}>
+                    <div
+                      className="text-sm font-medium truncate px-1.5 py-0.5 rounded bg-black/20 w-fit max-w-full backdrop-blur-md shadow-sm border border-white/5"
+                      style={{ color: 'var(--text-primary)' }}
+                    >
                       {n.title}
                     </div>
                     {n.message && (
-                      <div className="text-xs mt-0.5 line-clamp-2" style={{ color: 'var(--text-muted)' }}>
+                      <div
+                        className="text-xs mt-1 line-clamp-2 px-1.5 py-0.5 rounded bg-black/20 w-fit backdrop-blur-md shadow-sm border border-white/5"
+                        style={{ color: 'var(--text-muted)' }}
+                      >
                         {n.message}
                       </div>
                     )}
@@ -264,7 +294,10 @@ export default function MobileHomePage() {
         {/* ── Feed 流 (最近活动) ── */}
         {feed.length > 0 && (
           <div>
-            <div className="text-xs font-medium mb-3" style={{ color: 'var(--text-muted)' }}>
+            <div
+              className="text-xs font-medium mb-3 px-2.5 py-1 rounded-md inline-block bg-black/20 backdrop-blur-md shadow-sm border border-white/5"
+              style={{ color: 'var(--text-primary)' }}
+            >
               最近活动
             </div>
             <div className="space-y-2">
@@ -284,10 +317,16 @@ export default function MobileHomePage() {
                       <FeedIcon size={18} style={{ color: meta.color }} />
                     </div>
                     <div className="flex-1 min-w-0">
-                      <div className="text-sm font-medium truncate" style={{ color: 'var(--text-primary)' }}>
+                      <div
+                        className="text-sm font-medium truncate px-1.5 py-0.5 rounded bg-black/20 w-fit max-w-full backdrop-blur-md shadow-sm border border-white/5"
+                        style={{ color: 'var(--text-primary)' }}
+                      >
                         {item.title}
                       </div>
-                      <div className="text-[11px] truncate" style={{ color: 'var(--text-muted)' }}>
+                      <div
+                        className="text-[11px] truncate mt-1 px-1.5 py-0.5 rounded bg-black/20 w-fit max-w-full backdrop-blur-md shadow-sm border border-white/5"
+                        style={{ color: 'var(--text-muted)' }}
+                      >
                         {item.subtitle}
                       </div>
                     </div>


### PR DESCRIPTION
## 优化说明 / Features
重构了 Desktop 与 Mobile 端首页关键卡片的文字清晰度及排版布局，彻底告别文字与杂乱/过亮背景图融为一体的问题，升级为类似 Apple Arcade 的现代高级悬浮感界面。

- **Desktop 重构 (`AgentLauncherPage.tsx`)**:
  - **采用 Floating Layout 分级**：将 Icon 提取悬浮至左上角，箭头交互悬浮至右上角。将核心 Title 和 Desc 完全沉底摆放。
  - **极致减负**：移除了挤在卡片底部冗余的 `Tags`，大幅提升首屏呼吸感。
  - **重构暗格遮罩**：去除了呆板僵硬的全尺寸边框/实心毛玻璃控制台。变更为仅存在于卡片 `65%` 以下高度的极强纯黑色沉底羽化渐变（`transparent` -> `0.98` 黑）。
  - **三重文本立体阴影**：为白色字体添加由极高密度 `rgba(0,0,0,1)` 起步的紧凑发丝级边缘阴影包裹，完美防御任何极光发光体污染。
- **Mobile 端打底 (`MobileHomePage.tsx`)**:
  - 给因紧贴动态极光背景而导致不可读的散落文字容器，附加独立的 `bg-black/20` 及 `backdrop-blur-md` 属性。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure UI/styling changes to homepage cards and text treatments; no logic, data flow, or permission behavior changes.
> 
> **Overview**
> **Desktop (`AgentLauncherPage`)** refactors the featured agent card visual hierarchy: moves the app icon to a floating top-left chip, adds a top-right hover arrow, drops the bottom tag row, and strengthens the bottom fade + text shadows to keep title/description readable over bright imagery.
> 
> **Quick link cards** also get a stronger unified dark gradient and text shadows for labels/descriptions when a background image is present.
> 
> **Mobile (`MobileHomePage`)** applies consistent *glassmorphism* containers (`bg-black/20` + `backdrop-blur-md`) to greeting, section headers, quick agent labels, stat values/labels, notifications, and feed items to prevent text blending into the aurora background.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11c8181e9c0af0e861bb7def11df1566df857657. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->