### PR TITLE
GitHub webhook noise filtering and deploy dedup

### DIFF
--- a/cds/src/routes/github-webhook.ts
+++ b/cds/src/routes/github-webhook.ts
@@ -65,6 +65,61 @@ export interface GitHubWebhookRouterDeps {
  */
 type RawBodyRequest = Request & { rawBody?: Buffer };
 
+/**
+ * Events the dispatcher actively reacts to (creates/refreshes branches,
+ * posts comments, runs slash commands, etc.). Anything outside this set
+ * is routed through a cheap ack path that skips the dispatcher entirely
+ * — avoids running parse/validate work for events CDS can't action.
+ *
+ * Kept in sync with the switch in GitHubWebhookDispatcher.handle().
+ */
+const SUPPORTED_EVENTS: ReadonlySet<string> = new Set([
+  'ping',
+  'push',
+  'installation',
+  'installation_repositories',
+  'check_run',
+  'pull_request',
+  'issue_comment',
+  'delete',
+  'repository',
+  'release',
+]);
+
+/**
+ * Deploy dispatch dedup window. When a GitHub App is subscribed to
+ * many events (or GitHub retries a delivery because we returned a
+ * non-2xx), the SAME (branchId, commitSha) can arrive as a push AND
+ * as a check_run.rerequested within seconds. Without dedup the build
+ * fires twice back-to-back, tearing down containers the first build
+ * just started. We remember recent dispatches and skip duplicates
+ * within the window. Slash commands (`/cds redeploy`) bypass this
+ * because they go through a separate code path.
+ */
+const DEPLOY_DEDUP_WINDOW_MS = 30_000;
+const recentDeployDispatches = new Map<string, number>();
+
+function shouldSkipDuplicateDispatch(branchId: string, commitSha: string): boolean {
+  const key = `${branchId}:${commitSha}`;
+  const now = Date.now();
+  // Tidy stale entries so the map doesn't grow unbounded on a chatty
+  // install (one entry per push over the service's lifetime).
+  for (const [k, ts] of recentDeployDispatches) {
+    if (now - ts > DEPLOY_DEDUP_WINDOW_MS * 2) {
+      recentDeployDispatches.delete(k);
+    }
+  }
+  const prev = recentDeployDispatches.get(key);
+  if (prev && now - prev < DEPLOY_DEDUP_WINDOW_MS) return true;
+  recentDeployDispatches.set(key, now);
+  return false;
+}
+
+/** Test-only: reset dedup state between cases so they don't leak. */
+export function __resetWebhookDedupForTests(): void {
+  recentDeployDispatches.clear();
+}
+
 export function createGithubWebhookRouter(deps: GitHubWebhookRouterDeps): Router {
   const router = Router();
   const {
@@ -120,6 +175,32 @@ export function createGithubWebhookRouter(deps: GitHubWebhookRouterDeps): Router
       return;
     }
 
+    // Stash the event name on res.locals so the activity middleware can
+    // render a finer-grained label (e.g. "GitHub Webhook · push" vs
+    // "GitHub Webhook · check_run"). Must come before any early-return
+    // below so the label is set even on noise-filtered events.
+    (res.locals as { cdsGithubEvent?: string }).cdsGithubEvent = eventName;
+
+    // ── Noise filter ─────────────────────────────────────────────────
+    // If a user subscribes the GitHub App to "all events", a single
+    // push can flood CDS with check_suite / workflow_run / status /
+    // pull_request_review / ... deliveries. We don't act on any of
+    // those, so short-circuit before the dispatcher and tell the
+    // activity stream to skip the entry so the operator's monitor
+    // isn't drowned out. Signature verification runs first, so this
+    // path still requires a valid HMAC.
+    if (!SUPPORTED_EVENTS.has(eventName)) {
+      res.setHeader('X-CDS-Suppress-Activity', '1');
+      res.json({
+        ok: true,
+        event: eventName,
+        delivery: deliveryId,
+        action: 'ignored-unsubscribed',
+        message: `Event '${eventName}' not handled by CDS; acknowledged without dispatch.`,
+      });
+      return;
+    }
+
     let payload: unknown;
     try {
       payload = JSON.parse(rawBody.toString('utf-8'));
@@ -132,12 +213,21 @@ export function createGithubWebhookRouter(deps: GitHubWebhookRouterDeps): Router
     try {
       result = await dispatcher.handle(eventName, payload);
     } catch (err) {
+      // Return 200 on dispatcher failure so GitHub DOES NOT retry the
+      // delivery. A retry storm (5xx → GitHub re-POSTs every few
+      // minutes for up to 8 hours) was visibly rebuilding the user's
+      // app in a loop. The error is still recorded server-side so an
+      // operator can grep it. Also persist the error body as a 200 so
+      // the Dashboard activity entry surfaces the failure clearly.
       // eslint-disable-next-line no-console
       console.error(
         `[webhook] dispatch error event=${eventName} delivery=${deliveryId || '?'}:`,
         err,
       );
-      res.status(500).json({
+      res.status(200).json({
+        ok: false,
+        event: eventName,
+        delivery: deliveryId,
         error: 'dispatch_error',
         message: (err as Error).message,
       });
@@ -147,18 +237,36 @@ export function createGithubWebhookRouter(deps: GitHubWebhookRouterDeps): Router
     // Kick off the deploy asynchronously. The webhook response is sent
     // back to GitHub within the GitHub 10s timeout regardless of how
     // long the build takes.
+    //
+    // Dedup by (branchId, commitSha) within a short window: the same
+    // SHA can legitimately arrive twice — once as a `push`, once as a
+    // `check_run.rerequested` piggy-backed on our own check-run PATCH,
+    // plus any GitHub retries. Building twice tears down the first
+    // build's containers mid-flight and doubles the user's wait. The
+    // /cds redeploy slash command doesn't go through this branch (it
+    // posts directly from runSlashCommand), so explicit redeploys are
+    // unaffected.
+    let deployDedupSkipped = false;
     if (result.deployRequest) {
       const request = result.deployRequest;
-      // Use the injected dispatcher for tests; default to a localhost HTTP
-      // call to this same CDS instance.
-      const dispatcherFn = dispatchDeploy || defaultLocalhostDeploy(config);
-      dispatcherFn(request.branchId, request.commitSha).catch((err) => {
+      if (shouldSkipDuplicateDispatch(request.branchId, request.commitSha)) {
+        deployDedupSkipped = true;
         // eslint-disable-next-line no-console
-        console.error(
-          `[webhook] deploy dispatch failed for branch=${request.branchId}:`,
-          (err as Error).message,
+        console.log(
+          `[webhook] skip duplicate deploy dispatch branch=${request.branchId} sha=${request.commitSha.slice(0, 7)} (within ${DEPLOY_DEDUP_WINDOW_MS}ms)`,
         );
-      });
+      } else {
+        // Use the injected dispatcher for tests; default to a localhost HTTP
+        // call to this same CDS instance.
+        const dispatcherFn = dispatchDeploy || defaultLocalhostDeploy(config);
+        dispatcherFn(request.branchId, request.commitSha).catch((err) => {
+          // eslint-disable-next-line no-console
+          console.error(
+            `[webhook] deploy dispatch failed for branch=${request.branchId}:`,
+            (err as Error).message,
+          );
+        });
+      }
     }
 
     // PR opened/reopened → post (or refresh) the preview-URL bot comment.
@@ -213,6 +321,13 @@ export function createGithubWebhookRouter(deps: GitHubWebhookRouterDeps): Router
       });
     }
 
+    // Actions that are pure "received but nothing to do" — same UX as
+    // the noise filter above. Keeps the activity stream focused on
+    // events that actually moved state.
+    if (result.action === 'ignored-event' || result.action === 'ignored-ping') {
+      res.setHeader('X-CDS-Suppress-Activity', '1');
+    }
+
     res.json({
       ok: true,
       event: eventName,
@@ -220,7 +335,8 @@ export function createGithubWebhookRouter(deps: GitHubWebhookRouterDeps): Router
       action: result.action,
       message: result.message,
       branchId: result.branchId,
-      deployDispatched: Boolean(result.deployRequest),
+      deployDispatched: Boolean(result.deployRequest) && !deployDedupSkipped,
+      deployDedupSkipped: deployDedupSkipped || undefined,
       stopDispatched: Boolean(result.stopRequest),
       slashCommand: result.slashCommand?.command,
     });

--- a/cds/src/server.ts
+++ b/cds/src/server.ts
@@ -865,8 +865,31 @@ export function createServer(deps: ServerDeps): express.Express {
     const branchTags = branchId ? (deps.stateService.getBranch(branchId)?.tags ?? []) : [];
 
     (res as any).end = function (...args: any[]) {
+      // Routes can opt out of broadcasting to the activity stream by
+      // setting `X-CDS-Suppress-Activity: 1`. Used by the GitHub
+      // webhook receiver to skip noise events (check_suite,
+      // workflow_run, etc.) that fire per push when the App is
+      // subscribed to "all events" — otherwise the operator's
+      // monitor is drowned out by ignored deliveries.
+      if (res.getHeader('X-CDS-Suppress-Activity') === '1') {
+        // Strip the internal signalling header before sending to the
+        // client — it's a CDS internal, not something the GitHub webhook
+        // delivery log needs to show.
+        try { res.removeHeader('X-CDS-Suppress-Activity'); } catch { /* ignore */ }
+        return origEnd(...args);
+      }
       const duration = Date.now() - start;
       const fullPath = `/api${req.path}`;
+      // Refine the label for GitHub webhook deliveries so the operator
+      // can tell "push" from "check_run" / "issue_comment" / ... at a
+      // glance, instead of seeing a homogeneous stream of "GitHub 推送
+      // Webhook". The event name is stashed on res.locals by the
+      // webhook route after signature verification.
+      let label = resolveApiLabel(req.method, fullPath);
+      const ghEvent = (res.locals as { cdsGithubEvent?: string }).cdsGithubEvent;
+      if (ghEvent && fullPath.endsWith('/github/webhook')) {
+        label = `${label} · ${ghEvent}`;
+      }
       const event: ActivityEvent = {
         id: ++activitySeq,
         ts: new Date().toISOString(),
@@ -877,7 +900,7 @@ export function createServer(deps: ServerDeps): express.Express {
         type: 'cds',
         source: aiSession ? 'ai' : 'user',
         agent: aiSession?.agentName,
-        label: resolveApiLabel(req.method, fullPath),
+        label,
         body: reqBody,
         query: reqQuery,
         branchId,

--- a/cds/tests/routes/github-webhook.test.ts
+++ b/cds/tests/routes/github-webhook.test.ts
@@ -17,7 +17,10 @@ import { createHmac } from 'node:crypto';
 import { StateService } from '../../src/services/state.js';
 import { WorktreeService } from '../../src/services/worktree.js';
 import type { IShellExecutor, CdsConfig } from '../../src/types.js';
-import { createGithubWebhookRouter } from '../../src/routes/github-webhook.js';
+import {
+  createGithubWebhookRouter,
+  __resetWebhookDedupForTests,
+} from '../../src/routes/github-webhook.js';
 
 class MockShell implements IShellExecutor {
   async exec() {
@@ -35,7 +38,7 @@ async function request(
   urlPath: string,
   body: string,
   headers: Record<string, string> = {},
-): Promise<{ status: number; body: any }> {
+): Promise<{ status: number; body: any; headers: http.IncomingHttpHeaders }> {
   return new Promise((resolve, reject) => {
     const addr = server.address() as { port: number };
     const req = http.request(
@@ -55,9 +58,9 @@ async function request(
         res.on('data', (c: Buffer) => (raw += c.toString()));
         res.on('end', () => {
           try {
-            resolve({ status: res.statusCode!, body: raw ? JSON.parse(raw) : null });
+            resolve({ status: res.statusCode!, body: raw ? JSON.parse(raw) : null, headers: res.headers });
           } catch {
-            resolve({ status: res.statusCode!, body: raw });
+            resolve({ status: res.statusCode!, body: raw, headers: res.headers });
           }
         });
       },
@@ -128,6 +131,7 @@ describe('GitHub webhook route', () => {
     tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cds-webhook-'));
     stateService = new StateService(path.join(tmp, 'state.json'), tmp);
     stateService.load();
+    __resetWebhookDedupForTests();
   });
 
   afterEach(async () => {
@@ -227,6 +231,131 @@ describe('GitHub webhook route', () => {
     expect(res.body.deployDispatched).toBe(false);
     await new Promise((r) => setTimeout(r, 20));
     expect(deployCalls).toHaveLength(0);
+  });
+
+  it('ack-and-skip (200 + suppress-activity header) for unsubscribed noise events', async () => {
+    server = startServer();
+    // check_suite / workflow_run / pull_request_review / status are
+    // common culprits when the GitHub App is subscribed to "all events"
+    // — none actionable by CDS, should bypass the dispatcher entirely.
+    for (const noiseEvent of ['check_suite', 'workflow_run', 'pull_request_review', 'status', 'star']) {
+      const body = JSON.stringify({ repository: { full_name: 'octocat/repo' } });
+      const res = await request(server, 'POST', '/api/github/webhook', body, {
+        'X-GitHub-Event': noiseEvent,
+        'X-Hub-Signature-256': sign('whsec-test', body),
+      });
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.action).toBe('ignored-unsubscribed');
+      expect(res.body.event).toBe(noiseEvent);
+      expect(res.headers['x-cds-suppress-activity']).toBe('1');
+    }
+    await new Promise((r) => setTimeout(r, 20));
+    expect(deployCalls).toHaveLength(0);
+  });
+
+  it('returns 200 (ok:false) — NOT 500 — when the dispatcher throws', async () => {
+    // Wire a worktree mock that explodes so handlePush throws synchronously
+    // inside the dispatcher. Before the fix, the route surfaced this as a
+    // 500, which made GitHub retry the delivery — a real user hit this and
+    // the retry storm rebuilt the app in a loop.
+    stateService.addProject({
+      id: 'pY',
+      slug: 'boom',
+      name: 'Boom',
+      kind: 'git',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      githubRepoFullName: 'octocat/repo',
+      githubInstallationId: 42,
+    });
+
+    const app = express();
+    app.use(express.json({
+      verify: (req, _res, buf) => {
+        (req as { rawBody?: Buffer }).rawBody = buf;
+      },
+    }));
+    const shell = new MockShell();
+    class BoomWorktree extends WorktreeService {
+      override async create(): Promise<void> { throw new Error('simulated git worktree failure'); }
+    }
+    const worktree = new BoomWorktree(shell);
+    deployCalls = [];
+    app.use('/api', createGithubWebhookRouter({
+      stateService,
+      worktreeService: worktree,
+      shell,
+      config: buildConfig(),
+      githubApp: null,
+      dispatchDeploy: async (b, s) => { deployCalls.push({ branchId: b, commitSha: s }); },
+    }));
+    server = app.listen(0);
+
+    const payload = {
+      ref: 'refs/heads/unknown-branch',
+      after: 'feedface01234567890abcdef1234567890abcde',
+      repository: { full_name: 'octocat/repo' },
+      installation: { id: 42 },
+    };
+    const body = JSON.stringify(payload);
+    const res = await request(server, 'POST', '/api/github/webhook', body, {
+      'X-GitHub-Event': 'push',
+      'X-Hub-Signature-256': sign('whsec-test', body),
+    });
+    // Critical: 200 (not 500) so GitHub doesn't retry the delivery.
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe('dispatch_error');
+    expect(res.body.event).toBe('push');
+    expect(res.body.message).toContain('simulated git worktree failure');
+    // No deploy should have been dispatched.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(deployCalls).toHaveLength(0);
+  });
+
+  it('dedups repeated (branchId, sha) deploy dispatches within the window', async () => {
+    stateService.addProject({
+      id: 'pZ',
+      slug: 'sample',
+      name: 'Sample',
+      kind: 'git',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      githubRepoFullName: 'octocat/repo',
+      githubInstallationId: 42,
+    });
+    server = startServer();
+
+    const payload = {
+      ref: 'refs/heads/feature-dedup',
+      after: 'cafef00d1234567890abcdef1234567890abcdef',
+      repository: { full_name: 'octocat/repo' },
+      installation: { id: 42 },
+    };
+    const body = JSON.stringify(payload);
+    const headers = {
+      'X-GitHub-Event': 'push',
+      'X-Hub-Signature-256': sign('whsec-test', body),
+    };
+
+    // First delivery — dispatches.
+    const res1 = await request(server, 'POST', '/api/github/webhook', body, headers);
+    expect(res1.status).toBe(200);
+    expect(res1.body.deployDispatched).toBe(true);
+    expect(res1.body.deployDedupSkipped).toBeUndefined();
+
+    // Immediate second delivery (GitHub retry or check_run.rerequested)
+    // — same branch + same SHA — should be deduped, no extra dispatch.
+    const res2 = await request(server, 'POST', '/api/github/webhook', body, headers);
+    expect(res2.status).toBe(200);
+    expect(res2.body.deployDispatched).toBe(false);
+    expect(res2.body.deployDedupSkipped).toBe(true);
+
+    await new Promise((r) => setTimeout(r, 20));
+    // Only the first delivery reached the deploy dispatcher.
+    expect(deployCalls).toHaveLength(1);
+    expect(deployCalls[0].commitSha).toBe(payload.after);
   });
 });
 

--- a/changelogs/2026-04-19_cds-webhook-noise-filter.md
+++ b/changelogs/2026-04-19_cds-webhook-noise-filter.md
@@ -2,3 +2,4 @@
 | fix | cds | dispatcher 抛错时 webhook 返回 200 (ok:false) 而不是 500,阻止 GitHub 按 8 小时策略重投递触发反复构建;错误仍在服务端日志记录 |
 | fix | cds | 同一 (branchId, commitSha) 30 秒内重复 dispatch 自动去重,避免 push + check_run.rerequested + 延迟重投等多路径同 SHA 连续触发两次构建把第一次刚起的容器撕掉 |
 | feat | cds | Dashboard 活动流的 GitHub webhook 条目追加事件名标签(如 "GitHub 推送 Webhook · push" / "· check_run" / "· issue_comment"),一眼分辨不同事件类型 |
+| docs | doc | 新增 guide.cds-github-webhook-events.md:列出 CDS 必订的 7 个事件(push / pull_request / issue_comment / check_run / installation_repositories / delete / repository)、可选事件(ping / installation / release)、被静默过滤的噪声事件清单(check_suite / workflow_run / pull_request_review 等 20+ 种),以及 GitHub App 后台订阅配置步骤、self-test 验证方法、新增订阅 checklist |

--- a/changelogs/2026-04-19_cds-webhook-noise-filter.md
+++ b/changelogs/2026-04-19_cds-webhook-noise-filter.md
@@ -1,0 +1,4 @@
+| fix | cds | GitHub webhook 收到非订阅事件(check_suite / workflow_run / pull_request_review / status / star 等)时直接 200 确认并跳过 dispatcher,响应头 X-CDS-Suppress-Activity=1 让 Dashboard 活动流不再被噪声事件淹没 |
+| fix | cds | dispatcher 抛错时 webhook 返回 200 (ok:false) 而不是 500,阻止 GitHub 按 8 小时策略重投递触发反复构建;错误仍在服务端日志记录 |
+| fix | cds | 同一 (branchId, commitSha) 30 秒内重复 dispatch 自动去重,避免 push + check_run.rerequested + 延迟重投等多路径同 SHA 连续触发两次构建把第一次刚起的容器撕掉 |
+| feat | cds | Dashboard 活动流的 GitHub webhook 条目追加事件名标签(如 "GitHub 推送 Webhook · push" / "· check_run" / "· issue_comment"),一眼分辨不同事件类型 |

--- a/doc/guide.cds-github-webhook-events.md
+++ b/doc/guide.cds-github-webhook-events.md
@@ -1,0 +1,183 @@
+# CDS GitHub Webhook 订阅配置指南
+
+> **类型**：操作指南 (How-to) | **日期**：2026-04-19 | **版本**：v1.0 | **适用**：CDS GitHub App
+
+---
+
+## 1. 一句话结论
+
+在 GitHub App "Permissions & events → Subscribe to events" 页面,**只勾 7 个事件就够了**:
+
+- `Push`
+- `Pull request`
+- `Issue comment`
+- `Check run`
+- `Installation repository`
+- `Delete`
+- `Repository`
+
+其他全部留空。即使历史配置中勾了全部事件,CDS 从 2026-04-19 起也会在服务端自动静默过滤,不会导致重复构建或活动流刷屏,但**仍建议去 GitHub 后台取消勾选**,节省 GitHub 端投递成本。
+
+---
+
+## 2. 事件订阅总览表
+
+| 事件 (X-GitHub-Event) | 必要性 | CDS 的动作 | 说明 |
+|---|---|---|---|
+| `push` | ✅ **必订** | 建/刷新分支 worktree + 触发部署 + 更新 check run | 核心触发器。不订,push 即部署就废了 |
+| `pull_request` | ✅ **必订** | opened/reopened → 发预览评论;closed → 停预览容器 | 不订,PR 合并/关闭后容器不会自动回收 |
+| `issue_comment` | ✅ **必订** | 解析 `/cds <cmd>` 斜杠命令 (redeploy/stop/logs/help) | 不订,PR 评论里的 `/cds redeploy` 等命令全部失效 |
+| `check_run` | ✅ **必订** | `rerequested` → 按 check 重跑部署;其他动作仅记录 | 不订,PR Checks 面板的"Re-run" 按钮失效 |
+| `installation_repositories` | ✅ **必订** | 仓库从 installation 移除时自动解绑项目 | 不订,用户在 GitHub 后台取消授权后 CDS 仍会处理旧 push |
+| `delete` | ✅ **必订** | 远端分支删除 → 停对应 CDS 预览容器 | 不订,删分支不会回收容器,资源持续占用 |
+| `repository` | ✅ **必订** | renamed/transferred/deleted → 解绑项目避免错投 | 不订,仓库改名后 CDS 链接成脏数据 |
+| `ping` | 🟢 自动 | 响应 pong | GitHub 创建/更新 App 时自动发一次,不用单独订 |
+| `installation` | 🟡 可选 | 记录日志,不做任何状态变更 | 订了也无害,GitHub App 生命周期审计用 |
+| `release` | 🟡 预留 | 当前仅 ack,未来接生产标签发布 | 订不订都行,目前无功能影响 |
+
+---
+
+## 3. 被 CDS 静默过滤的噪声事件
+
+以下事件即使 GitHub App 订阅了、签名通过了,CDS 路由层也会**立刻 200 ack 并跳过 dispatcher**,不进 Dashboard 活动流,不触发任何动作。属于"订阅了也没后果,但徒增 GitHub 投递成本"。
+
+| 事件 | 为什么过滤 |
+|---|---|
+| `check_suite` | GitHub 对每个 commit 自动创建,且 CDS 只关心具体 `check_run`,suite 层不需要 |
+| `workflow_run` / `workflow_job` | GitHub Actions CI 的事件,CDS 不替用户跑 CI,只关心自己的 check_run |
+| `status` | 老式 commit status API,现已被 check_run 取代 |
+| `pull_request_review` / `pull_request_review_comment` / `pull_request_review_thread` | 代码 review 活动,CDS 预览只关心 PR 生命周期 (opened/closed) |
+| `commit_comment` | 提交页面上的独立评论,CDS 不处理 |
+| `star` / `watch` / `fork` / `public` | 社交/社区事件,与部署无关 |
+| `label` / `milestone` / `project` / `project_card` / `project_column` / `projects_v2*` | 项目管理类元数据 |
+| `discussion` / `discussion_comment` | Discussions 板块,不是代码 |
+| `member` / `membership` / `organization` / `org_block` / `team` / `team_add` | 权限/团队变更 |
+| `page_build` | GitHub Pages 构建 |
+| `deployment` / `deployment_status` | GitHub 原生 Deployments API,CDS 有自己的部署链路 |
+| `registry_package` / `package` | GitHub Packages |
+| `meta` | webhook 配置被删除时触发一次,CDS 不处理 |
+| `secret_scanning_alert*` / `code_scanning_alert` / `dependabot_alert` / `repository_advisory` | 安全告警,与部署无关 |
+| 其他未列举事件 | 统一走白名单外分支 |
+
+> **实现位置**:`cds/src/routes/github-webhook.ts` 顶部 `SUPPORTED_EVENTS` 白名单。不在集合内的事件一律走 `ignored-unsubscribed` 分支,响应体 `{ok:true, action:'ignored-unsubscribed'}`,同时设响应头 `X-CDS-Suppress-Activity: 1` 让活动中间件跳过广播。
+
+---
+
+## 4. 如何在 GitHub App 后台配置订阅
+
+### 4.1 打开订阅页
+
+1. 以 App 所有者身份登录 GitHub
+2. 打开 https://github.com/settings/apps
+3. 选中你的 CDS App → 左侧 **"Permissions & events"**
+4. 下拉到 **"Subscribe to events"** 区块
+
+### 4.2 只勾 §2 表中"✅ 必订"的 7 项
+
+页面上 GitHub 的命名和事件名有微小差异,按以下对照勾选:
+
+| 事件名 | GitHub 页面勾选项 |
+|---|---|
+| `push` | **Push** |
+| `pull_request` | **Pull request** |
+| `issue_comment` | **Issue comment** |
+| `check_run` | **Check run** |
+| `installation_repositories` | *(自动启用,不在可勾选列表里)* |
+| `delete` | *(自动启用,分支/tag 删除)* |
+| `repository` | **Repository** |
+
+`installation_repositories` 和 `delete` 默认就会送,不需要手动勾。
+
+### 4.3 保存
+
+页面底部 **Save changes**。GitHub 会立刻按新订阅集合推送事件,无需重启 CDS。
+
+---
+
+## 5. 如何验证 CDS 真的收到 / 过滤对了
+
+### 5.1 查 GitHub App 的 Recent Deliveries
+
+GitHub App 设置页 → **Advanced → Recent Deliveries** 列出最近 30 次投递。每条显示:
+
+- HTTP 状态码(CDS 侧现在**只会返 200**,即使 dispatcher 抛错也返 200 ok:false)
+- Request Headers / Body(GitHub 签名后的原始 payload)
+- Response Headers / Body(CDS 响应,里面有 `action` 字段表明走了哪条分支)
+
+若看到 `action: "ignored-unsubscribed"`,说明你 GitHub App 订阅了但 CDS 没处理(属于预期行为)。
+
+### 5.2 用 CDS 自带的自测端点
+
+CDS 提供一个 dry-run 自测端点,**不真的 deploy**,只告诉你某个事件会走哪条分支:
+
+```bash
+curl -sS -X POST "$CDS_URL/api/github/webhook/self-test" \
+  -H "X-AI-Access-Key: $AI_ACCESS_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "eventName": "push",
+    "payload": {
+      "ref": "refs/heads/feature-x",
+      "after": "deadbeef1234567890abcdef1234567890abcdef",
+      "repository": {"full_name": "inernoro/prd_agent"},
+      "installation": {"id": 12345}
+    }
+  }' | python3 -m json.tool
+```
+
+返回 `dispatcherResult.action`:
+- `"branch-created"` / `"branch-refreshed"` — 会真正触发部署(但在 self-test 里不会真跑)
+- `"ignored-no-project"` — repoFullName 没绑定任何项目
+- `"ignored-auto-deploy-off"` — 项目 `githubAutoDeploy=false`
+- `"ignored-event"` — push 目标不是分支(比如 tag)
+
+### 5.3 看 Dashboard 活动流
+
+推一次代码后,Dashboard 右上角 Activity 面板的条目现在追加了事件类型后缀:
+
+```
+POST  GitHub 推送 Webhook · push         200  120ms
+POST  GitHub 推送 Webhook · check_run    200   15ms
+```
+
+若 GitHub App 仍订阅了噪声事件,它们**不会**出现在这里 —— 被 `X-CDS-Suppress-Activity` 头过滤掉了。想看完整投递明细,去 §5.1 的 GitHub Recent Deliveries 面板。
+
+---
+
+## 6. 常见问题
+
+### Q1: 我只想让 CDS 部署某些分支,不想 push 到 main 就部署
+
+项目详情页 Settings → 把 **Auto-Deploy** 关掉(对应 `githubAutoDeploy=false`),然后在需要部署的分支上用 `/cds redeploy` PR 斜杠命令手动触发。
+
+### Q2: CDS 返 500 了会怎样? GitHub 会重试吗?
+
+2026-04-19 之后 **不会**。dispatcher 抛错统一返 200 `{ok:false, error, message}`,GitHub 收到 200 就不会按 8 小时退避策略重投递,彻底断开"500 → 重试 → 反复构建"的循环。错误细节仍在 CDS 服务端日志(`[webhook] dispatch error event=...`)和 Activity body 里。
+
+### Q3: 同一个 commit 被推两次会部署两次吗?
+
+**不会**。CDS 在路由层对 `(branchId, commitSha)` 做 30 秒去重:同一 SHA 在窗口内的第二次 dispatch 会被 skip 并记日志 `[webhook] skip duplicate deploy dispatch ...`。响应体 `deployDedupSkipped: true` 标记此情形。
+
+需要强制重跑可用 `/cds redeploy` 斜杠命令 —— 它走独立代码路径,不经过去重。
+
+### Q4: 我在 GitHub App 里已经勾了所有事件,懒得改,会不会出问题?
+
+不会。从 2026-04-19 起 CDS 路由层会静默 ack 掉所有非白名单事件,既不触发动作也不污染活动流,和"只订 7 个"的运行效果一致。唯一差别是 GitHub 那边会每次都发网络请求过来,白白消耗带宽。推荐仍按 §2 精简订阅。
+
+### Q5: 新增一种订阅事件需要改哪里?
+
+1. `cds/src/services/github-webhook-dispatcher.ts` 的 `handle()` switch 增加一个 case + `handleXxx()` 私有方法
+2. `cds/src/routes/github-webhook.ts` 顶部 `SUPPORTED_EVENTS` 集合加入事件名
+3. 本文档 §2 表补一行
+4. `cds/tests/services/github-webhook-dispatcher.test.ts` + `cds/tests/routes/github-webhook.test.ts` 加用例
+5. `changelogs/` 加一条 `feat | cds | 新增 xxx 事件订阅...` 碎片
+
+---
+
+## 7. 相关文件
+
+- `cds/src/routes/github-webhook.ts` — webhook 路由,白名单 + dedup + 500→200 逻辑
+- `cds/src/services/github-webhook-dispatcher.ts` — 事件分发核心
+- `cds/tests/routes/github-webhook.test.ts` — 单测(噪声过滤/去重/500→200)
+- `.claude/rules/cds-auto-deploy.md` — push 即部署原则
+- `doc/design.cds.md` — CDS 总体设计

--- a/doc/guide.list.directory.md
+++ b/doc/guide.list.directory.md
@@ -250,6 +250,9 @@
 - [CDS + 后端 API 双层认证诊断指南](guide.cds-ai-auth) `guide.cds-ai-auth`
   > CDS 与后端 API 双层认证的诊断与排查指南
 
+- [CDS GitHub Webhook 订阅配置指南](guide.cds-github-webhook-events) `guide.cds-github-webhook-events`
+  > 说明 CDS 消费哪些 GitHub webhook 事件、哪些被静默过滤,以及如何在 GitHub App 后台配置订阅
+
 - [AI 技能工作流指南](guide.skill-workflow) `guide.skill-workflow`
   > 从需求到上线的完整技能链工作流指南
 

--- a/doc/index.yml
+++ b/doc/index.yml
@@ -106,6 +106,7 @@ docs:
   guide.troubleshooting: 疑难杂症排查手册
   guide.prd-agent-operations: PRD Agent 全平台操作手册
   guide.cds-ai-auth: CDS + 后端 API 双层认证诊断指南
+  guide.cds-github-webhook-events: CDS GitHub Webhook 订阅配置指南
   guide.skill-workflow: AI 技能工作流指南
   guide.mongodb-indexes: MongoDB 索引手册
   guide.multi-image-compose-test: 多图组合功能测试备忘录


### PR DESCRIPTION
## Summary

Implement GitHub webhook event filtering and deploy request deduplication to prevent activity stream pollution and duplicate builds when the GitHub App is subscribed to unnecessary events.

## Key Changes

**Webhook Event Filtering**
- Add `SUPPORTED_EVENTS` whitelist in `github-webhook.ts` containing only 7 actionable events (push, pull_request, issue_comment, check_run, installation_repositories, delete, repository)
- Route unsupported events (check_suite, workflow_run, pull_request_review, status, star, etc.) through a cheap ack path that skips the dispatcher entirely
- Set `X-CDS-Suppress-Activity: 1` header on filtered events to prevent Dashboard activity stream pollution

**Error Handling**
- Change webhook dispatcher error responses from 500 to 200 with `ok:false` to prevent GitHub's 8-hour retry storm that was causing repeated builds
- Error details still logged server-side and included in response body for operator visibility

**Deploy Request Deduplication**
- Implement 30-second dedup window for `(branchId, commitSha)` pairs to prevent duplicate builds when the same commit arrives via multiple webhook paths (push + check_run.rerequested + GitHub retries)
- Slash commands (`/cds redeploy`) bypass dedup since they use a separate code path
- Add `__resetWebhookDedupForTests()` export for test isolation

**Activity Stream Enhancement**
- Refine GitHub webhook activity labels to show event type (e.g., "GitHub 推送 Webhook · push" vs "· check_run") for better operator visibility
- Stash event name on `res.locals.cdsGithubEvent` for activity middleware to consume

**Documentation**
- Add comprehensive guide (`guide.cds-github-webhook-events.md`) explaining which 7 events to subscribe to, why others are filtered, and how to verify configuration
- Include troubleshooting section with self-test endpoint and FAQ

## Testing

- Add test cases for noise event filtering with `X-CDS-Suppress-Activity` header verification
- Add test for dispatcher error returning 200 instead of 500
- Add test for deploy dedup within the 30-second window
- Update test utilities to capture response headers and reset dedup state between test cases

https://claude.ai/code/session_01RP61tHbZ2fQMjRCHNy6hzX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the GitHub webhook ingestion path and deploy triggering behavior; mistakes could cause missed deployments or hide operational signals, though changes are scoped and covered by new integration tests.
> 
> **Overview**
> Reduces GitHub webhook overhead by adding a `SUPPORTED_EVENTS` allowlist and immediately 200-acking everything else, marking these responses with `X-CDS-Suppress-Activity` so the Dashboard activity stream skips noise.
> 
> Changes webhook failure semantics to return `200 {ok:false}` on dispatcher exceptions (to stop GitHub retry storms), and adds a 30s `(branchId, commitSha)` dedup window to avoid back-to-back duplicate deploy dispatches.
> 
> Activity tracking is updated to honor the suppress header and to append the GitHub event name to the webhook activity label; tests and new docs/changelog entries cover noise filtering, 200-on-error, and deploy dedup behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 171be749d6ab6b299b77356ed909a1d1345f78e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->