### PR TITLE
fix(cds): 修复 Bugbot 第二轮提出的

### DIFF
--- a/cds/src/routes/comment-template.ts
+++ b/cds/src/routes/comment-template.ts
@@ -29,6 +29,7 @@ import {
   DEFAULT_TEMPLATE_BODY,
   VARIABLE_DEFS,
   buildDashboardUrl,
+  buildPreviewUrl,
   buildTemplateVariables,
   renderTemplate,
 } from '../services/comment-template.js';
@@ -64,13 +65,12 @@ export function createCommentTemplateRouter(deps: CommentTemplateRouterDeps): Ro
   const { stateService, config } = deps;
 
   /**
-   * Compute the `{{previewUrl}}` the webhook would use for a given
-   * branch id. Mirrors the inline logic in github-webhook.ts so the
-   * preview mode and the real path stay consistent.
+   * Resolve the configured preview host the same way the webhook
+   * does. Extracted once so the two callers (preview branch + live
+   * webhook) pass identical inputs into `buildPreviewUrl`.
    */
-  function previewUrlFor(branchId: string): string {
-    const host = config.previewDomain || config.rootDomains?.[0];
-    return host ? `https://${branchId}.${host}` : '';
+  function previewHost(): string | undefined {
+    return config.previewDomain || config.rootDomains?.[0];
   }
 
   // GET /api/comment-template
@@ -81,11 +81,19 @@ export function createCommentTemplateRouter(deps: CommentTemplateRouterDeps): Ro
   // the list on the frontend.
   router.get('/comment-template', (_req, res) => {
     const current = stateService.getCommentTemplate();
+    // isDefault reflects what the user is ACTUALLY seeing in the
+    // rendered GitHub comment, not whether a state record exists.
+    // After PUT with empty body (documented as "reset to default"),
+    // `current` is non-null but `current.body` is '', so we fall
+    // through to DEFAULT_TEMPLATE_BODY — in that case `isDefault`
+    // must still be true, otherwise the UI would show a "最近保存"
+    // timestamp next to a body that's actually the built-in default.
+    const effectivelyDefault = !current || !current.body;
     res.json({
       ok: true,
       body: current?.body || DEFAULT_TEMPLATE_BODY,
       updatedAt: current?.updatedAt || null,
-      isDefault: !current,
+      isDefault: effectivelyDefault,
       defaultBody: DEFAULT_TEMPLATE_BODY,
       variables: VARIABLE_DEFS,
     });
@@ -140,7 +148,7 @@ export function createCommentTemplateRouter(deps: CommentTemplateRouterDeps): Ro
     const vars = buildTemplateVariables({
       branch: PREVIEW_SAMPLE.branch,
       commitSha: PREVIEW_SAMPLE.commitSha,
-      previewUrl: previewUrlFor(effectiveBranchId),
+      previewUrl: buildPreviewUrl(previewHost(), effectiveBranchId),
       dashboardUrl: buildDashboardUrl(config.publicBaseUrl, effectiveBranchId),
       repoFullName: PREVIEW_SAMPLE.repoFullName,
       prNumber: PREVIEW_SAMPLE.prNumber,

--- a/cds/src/routes/github-webhook.ts
+++ b/cds/src/routes/github-webhook.ts
@@ -44,6 +44,7 @@ import {
 import {
   DEFAULT_TEMPLATE_BODY,
   buildDashboardUrl,
+  buildPreviewUrl,
   buildTemplateVariables,
   renderTemplate,
 } from '../services/comment-template.js';
@@ -644,7 +645,7 @@ async function postOrUpdatePrComment(
   // PR review deeplink) go through buildTemplateVariables so the
   // settings-panel preview and the live render stay in lock-step.
   const host = config.previewDomain || config.rootDomains?.[0];
-  const previewUrl = host ? `https://${branchId}.${host}` : '';
+  const previewUrl = buildPreviewUrl(host, branchId);
   const dashboardUrl = buildDashboardUrl(config.publicBaseUrl, branchId);
   const settings = stateService.getCommentTemplate();
   const templateBody = settings?.body && settings.body.length > 0 ? settings.body : DEFAULT_TEMPLATE_BODY;

--- a/cds/src/services/comment-template.ts
+++ b/cds/src/services/comment-template.ts
@@ -142,6 +142,27 @@ export function buildDashboardUrl(
 }
 
 /**
+ * Assemble the branch's preview URL.
+ *
+ * Shared between webhook (routes/github-webhook.ts) and the settings
+ * preview handler so `{{previewUrl}}` renders identically in both.
+ * Returns '' when no host is configured — the default template still
+ * produces a harmless empty link rather than `https://${branchId}.`.
+ *
+ * The caller is responsible for picking `config.previewDomain ||
+ * config.rootDomains?.[0]` as the `host` argument; keeping that
+ * decision at the call site avoids importing the full CdsConfig type
+ * into this service.
+ */
+export function buildPreviewUrl(
+  host: string | undefined | null,
+  branchId: string,
+): string {
+  if (!host || !branchId) return '';
+  return `https://${branchId}.${host}`;
+}
+
+/**
  * Assemble the PR-review Agent deeplink from the current branch's
  * preview URL.
  *

--- a/cds/tests/routes/comment-template.test.ts
+++ b/cds/tests/routes/comment-template.test.ts
@@ -153,6 +153,17 @@ describe('comment-template router', () => {
       expect(res.body.body).toBe('');
     });
 
+    it('GET after saving empty body reports isDefault=true (reset-to-default contract)', async () => {
+      // Regression: the PUT endpoint documents empty body as
+      // "reset to default". GET must surface that via isDefault:true
+      // so the UI doesn't show a "最近保存 <timestamp>" label next to
+      // a rendered body that's actually DEFAULT_TEMPLATE_BODY.
+      await request(app, 'PUT', '/api/comment-template', { body: '' });
+      const getRes = await request(app, 'GET', '/api/comment-template');
+      expect(getRes.body.body).toBe(DEFAULT_TEMPLATE_BODY);
+      expect(getRes.body.isDefault).toBe(true);
+    });
+
     it('rejects non-string body', async () => {
       const res = await request(app, 'PUT', '/api/comment-template', { body: 42 });
       expect(res.status).toBe(400);

--- a/cds/tests/services/comment-template.test.ts
+++ b/cds/tests/services/comment-template.test.ts
@@ -4,6 +4,7 @@ import {
   VARIABLE_DEFS,
   buildDashboardUrl,
   buildPrReviewDeeplink,
+  buildPreviewUrl,
   buildTemplateVariables,
   renderTemplate,
 } from '../../src/services/comment-template.js';
@@ -47,6 +48,20 @@ describe('renderTemplate', () => {
   it('treats undefined values as "do not substitute"', () => {
     expect(renderTemplate('{{prUrl}}', {} as unknown as Parameters<typeof renderTemplate>[1]))
       .toBe('{{prUrl}}');
+  });
+});
+
+describe('buildPreviewUrl', () => {
+  it('returns empty string when host or branchId missing', () => {
+    expect(buildPreviewUrl(undefined, 'feat')).toBe('');
+    expect(buildPreviewUrl('', 'feat')).toBe('');
+    expect(buildPreviewUrl(null, 'feat')).toBe('');
+    expect(buildPreviewUrl('example.com', '')).toBe('');
+  });
+
+  it('produces the subdomain form used by CDS preview routing', () => {
+    expect(buildPreviewUrl('example.com', 'feature-a'))
+      .toBe('https://feature-a.example.com');
   });
 });
 


### PR DESCRIPTION
## 1. (medium) GET /api/comment-template 的 isDefault 标志错位

PUT 文档将"空 body"定义为"重置为默认模板"，但 GET 的
`isDefault: !current` 只检查有没有持久化记录。用户一旦 PUT 了空
body，`current` 非 null，GET 返回 `isDefault=false`；而 `body` 却因 `current?.body || DEFAULT_TEMPLATE_BODY` 回落到默认模板。UI 表现为 显示"最近保存: <时间戳>"的同时贴着默认模板正文，与「空 = 重置」
契约完全矛盾。

修复：`isDefault` 改为反映"实际渲染出的 body 是否默认"：
`!current || !current.body`。新增路由测试验证 PUT 空 body 后 GET 返回 `isDefault=true` + DEFAULT_TEMPLATE_BODY。

## 2. (low) previewUrl 构造逻辑两处重复

上个 commit 抽了 `buildDashboardUrl` 共享，但 preview URL 的 ``host ? `https://${branchId}.${host}` : ''`` 在 webhook 和 route 依然各贴一份，Bugbot 点出同样理由应统一。

抽 `buildPreviewUrl(host, branchId)` 到 comment-template service， webhook 和 route 都改用它。路由里把「选择 host」的逻辑单独封装成
`previewHost()`，保持两调用方传入 helper 的参数一致。新增 2 个单测
（空 host / 空 branchId / 正常拼接）。

## 测试
- cds pnpm tsc --noEmit 通过
- pnpm vitest run tests/services|routes/comment-template.test.ts tests/routes/github-webhook.test.ts 全绿 (39/39, +3)

## 说明

原 PR #466 已合并，本次提交是 Bugbot 在合并后新发现的两个问题的补丁。
如需进 main 需要另外创建 follow-up PR。

https://claude.ai/code/session_01UMGbNEybcMHdEunncTGVAb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, well-tested fixes to template settings metadata and URL construction; changes affect only how PR comment/template preview URLs and UI flags are computed.
> 
> **Overview**
> Fixes `GET /api/comment-template` so `isDefault` reflects the *effective* rendered body (treating a saved empty body as “reset to default”), preventing the UI from showing a “recently saved” timestamp next to the built-in default template.
> 
> Deduplicates preview URL construction by introducing `buildPreviewUrl(host, branchId)` in `services/comment-template.ts` and switching both the settings preview route and the live GitHub webhook comment renderer to use it, with new unit/regression tests covering both behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0563121104bace930ce494280b3da1f743dee903. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->