### PR TITLE
fix(更新中心): AI 总结走 ILlmGateway（appCallerCode）

### DIFF
--- a/cds-compose.yml
+++ b/cds-compose.yml
@@ -70,6 +70,7 @@ services:
     working_dir: /app
     volumes:
       - ./prd-api:/app
+      - .:/repo:ro
       - api-nuget-cache:/root/.nuget/packages
     ports:
       - "5000"
@@ -83,6 +84,7 @@ services:
     environment:
       # 仅服务特有变量，全局变量已由 x-cds-env 注入
       ASPNETCORE_ENVIRONMENT: Development
+      Changelog__RootPath: /repo
       MongoDB__ConnectionString: "mongodb://${CDS_HOST}:${CDS_MONGODB_PORT}"
       MongoDB__DatabaseName: prdagent
       Redis__ConnectionString: "${CDS_HOST}:${CDS_REDIS_PORT}"

--- a/cds/cds-compose.yaml
+++ b/cds/cds-compose.yaml
@@ -28,6 +28,7 @@ services:
     working_dir: /app
     volumes:
       - ./prd-api:/app
+      - .:/repo:ro
     ports:
       - "5000"
     command: >-
@@ -39,6 +40,7 @@ services:
       redis: { condition: service_healthy }
     environment:
       ASPNETCORE_ENVIRONMENT: Development
+      Changelog__RootPath: /repo
       MongoDB__ConnectionString: "mongodb://${CDS_HOST}:${CDS_MONGODB_PORT}"
       MongoDB__DatabaseName: prdagent
       Redis__ConnectionString: "${CDS_HOST}:${CDS_REDIS_PORT}"

--- a/changelogs/2026-04-21_changelog-ai-summary-llm-gateway.md
+++ b/changelogs/2026-04-21_changelog-ai-summary-llm-gateway.md
@@ -1,0 +1,2 @@
+| feat | prd-api | 更新中心 POST `/api/changelog/ai-summary`：经 `ILlmGateway` + `prd-admin.changelog.aiSummary::chat` 生成摘要，`LlmRequestContext` 含 UserId |
+| feat | prd-admin | 更新中心「AI 总结」改为调用上述接口，移除本地规则拼装与假延迟 |

--- a/changelogs/2026-04-21_changelog-bugbot-refresh-gitpipe.md
+++ b/changelogs/2026-04-21_changelog-bugbot-refresh-gitpipe.md
@@ -1,0 +1,2 @@
+| fix | prd-admin | handleRefresh 拉 GitHub 日志补 `.catch()`，避免未处理 Promise 拒绝（Bugbot） |
+| fix | prd-api | TryReadGitLogsAsync 并行读完 stdout/stderr，避免重定向管道死锁（Bugbot） |

--- a/changelogs/2026-04-21_changelog-github-logs-prefetch-race.md
+++ b/changelogs/2026-04-21_changelog-github-logs-prefetch-race.md
@@ -1,0 +1,1 @@
+| fix | prd-admin | GitHub 日志主拉取 effect 恢复依赖 `loadingGitHubLogs`，修复预取进行中切 tab 后预取失败不触发正式拉取的卡死（Bugbot PR#468） |

--- a/changelogs/2026-04-21_changelog-pr468-bugbot-fixes.md
+++ b/changelogs/2026-04-21_changelog-pr468-bugbot-fixes.md
@@ -1,0 +1,2 @@
+| fix | prd-admin | 更新中心：GitHub 日志拉取失败不再无限重试；后台预取仅调度一次；AI 总结按子 tab 独立 runId 避免永久 loading |
+| fix | prd-api | ChangelogReader 本地 git log 时间由 %aI 改为 %cI，与 GitHub API committer.date 对齐 |

--- a/prd-admin/src/pages/changelog/ChangelogPage.tsx
+++ b/prd-admin/src/pages/changelog/ChangelogPage.tsx
@@ -235,9 +235,9 @@ export default function ChangelogPage() {
     }).finally(() => {
       setLoadingGitHubLogs(false);
     });
-    // 不依赖 loadingGitHubLogs：避免失败后 false 再次触发 effect 形成请求风暴；失败由 gitHubLogsError 挡住直至离开子 tab 或刷新
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeTab, historySubtab, githubLogs, gitHubLogsError]);
+    // 依赖 loadingGitHubLogs：后台预取进行中用户切到「GitHub 日志」时先被 guard 挡住，预取结束 loading→false 后需再跑一次以发起正式拉取。
+    // 失败风暴仍由 gitHubLogsError 挡住（成功则 githubLogs 有值），不会与仅因 loading 翻转形成死循环。
+  }, [activeTab, historySubtab, githubLogs, gitHubLogsError, loadingGitHubLogs]);
 
   useEffect(() => {
     if (activeTab !== 'update_center' || historySubtab === 'github_logs' || loadingGitHubLogs || githubLogs) {

--- a/prd-admin/src/pages/changelog/ChangelogPage.tsx
+++ b/prd-admin/src/pages/changelog/ChangelogPage.tsx
@@ -3,11 +3,13 @@ import type { LucideIcon } from 'lucide-react';
 import {
   Sparkles, Calendar, Tag, RefreshCw, Filter, X, FileText,
   Wrench, Zap, Gauge, Shuffle, Shield, Package, FlaskConical, UploadCloud, Cog,
+  Github, GitCommit, ExternalLink,
 } from 'lucide-react';
 import { useChangelogStore } from '@/stores/changelogStore';
 import { MapSectionLoader, MapSpinner } from '@/components/ui/VideoLoader';
 import { glassPanel } from '@/lib/glassStyles';
-import type { ChangelogEntry } from '@/services';
+import { getChangelogGitHubLogs } from '@/services';
+import type { ChangelogEntry, GitHubLogEntry, GitHubLogsView } from '@/services';
 import { TabBar } from '@/components/design/TabBar';
 import {
   WeeklyReportsTab,
@@ -48,21 +50,47 @@ interface FlatEntry extends ChangelogEntry {
   date: string;
   /** ISO 8601 秒级时间（仅 github 源可用） */
   commitTimeUtc?: string | null;
-  source: 'release';
+  source: 'release' | 'fragment';
   releaseVersion?: string;
 }
 
-/** 格式化右侧展示时间：有秒级则 "YYYY-MM-DD HH:mm:ss"，否则 "YYYY-MM-DD" */
-function formatEntryTime(date: string, commitTimeUtc?: string | null): string {
-  if (!commitTimeUtc) return date;
-  try {
-    const d = new Date(commitTimeUtc);
-    if (Number.isNaN(d.getTime())) return date;
-    const pad = (n: number) => n.toString().padStart(2, '0');
-    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
-  } catch {
-    return date;
+type HistorySubtab = 'releases' | 'fragments' | 'github_logs';
+
+function formatLocalDateValue(d: Date): string {
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+function formatLocalDateTimeValue(d: Date): string {
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  return `${formatLocalDateValue(d)} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}
+
+function parseIsoDate(iso?: string | null): Date | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+function formatDisplayDate(date: string, commitTimeUtc?: string | null): string {
+  const d = parseIsoDate(commitTimeUtc);
+  return d ? formatLocalDateValue(d) : date;
+}
+
+function formatCommitDateTime(commitTimeUtc?: string | null): string | null {
+  const d = parseIsoDate(commitTimeUtc);
+  return d ? formatLocalDateTimeValue(d) : null;
+}
+
+function getReleaseDisplayDate(releaseDate: string | null, days: Array<{ date: string; commitTimeUtc?: string | null }>): string | null {
+  const latestCommitDay = days
+    .map((d) => parseIsoDate(d.commitTimeUtc))
+    .filter((d): d is Date => d instanceof Date)
+    .sort((a, b) => b.getTime() - a.getTime())[0];
+  if (latestCommitDay) {
+    return formatLocalDateValue(latestCommitDay);
   }
+  return releaseDate;
 }
 
 export default function ChangelogPage() {
@@ -76,6 +104,10 @@ export default function ChangelogPage() {
 
   const [typeFilter, setTypeFilter] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<string>('update_center');
+  const [historySubtab, setHistorySubtab] = useState<HistorySubtab>('releases');
+  const [githubLogs, setGitHubLogs] = useState<GitHubLogsView | null>(null);
+  const [loadingGitHubLogs, setLoadingGitHubLogs] = useState(false);
+  const [gitHubLogsError, setGitHubLogsError] = useState<string | null>(null);
 
   /**
    * NEW 徽章 cutoff：用户上次打开更新中心那天的 23:59:59.999。
@@ -101,9 +133,38 @@ export default function ChangelogPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  useEffect(() => {
+    if (activeTab !== 'update_center' || historySubtab !== 'github_logs' || loadingGitHubLogs || githubLogs) return;
+    let alive = true;
+    setLoadingGitHubLogs(true);
+    setGitHubLogsError(null);
+    void getChangelogGitHubLogs(40).then((res) => {
+      if (!alive) return;
+      if (res.success) {
+        setGitHubLogs(res.data);
+      } else {
+        setGitHubLogsError(res.error?.message || '加载 GitHub 日志失败');
+      }
+    }).finally(() => {
+      if (alive) setLoadingGitHubLogs(false);
+    });
+    return () => { alive = false; };
+  }, [activeTab, historySubtab, loadingGitHubLogs, githubLogs]);
+
   const handleRefresh = () => {
     void loadCurrentWeek(true);
     void loadReleases(20, true);
+    if (historySubtab === 'github_logs' || githubLogs) {
+      setLoadingGitHubLogs(true);
+      setGitHubLogsError(null);
+      void getChangelogGitHubLogs(40, true).then((res) => {
+        if (res.success) {
+          setGitHubLogs(res.data);
+        } else {
+          setGitHubLogsError(res.error?.message || '加载 GitHub 日志失败');
+        }
+      }).finally(() => setLoadingGitHubLogs(false));
+    }
   };
 
   // 收集 release 中出现过的 type 用于筛选 chip
@@ -118,8 +179,15 @@ export default function ChangelogPage() {
         }
       }
     }
+    if (currentWeek) {
+      for (const fragment of currentWeek.fragments) {
+        for (const entry of fragment.entries) {
+          if (entry.type) types.add(entry.type.toLowerCase());
+        }
+      }
+    }
     return { availableTypes: Array.from(types).sort() };
-  }, [releases]);
+  }, [currentWeek, releases]);
 
   const matchFilter = (e: ChangelogEntry): boolean => {
     if (typeFilter && e.type.toLowerCase() !== typeFilter) return false;
@@ -310,137 +378,310 @@ export default function ChangelogPage() {
         </div>
       )}
 
-      {/* ── 历史发布 ───────────────────────────────────── */}
+      {/* ── 历史区：CHANGELOG / 碎片 / GitHub 日志 ───────────────────── */}
       <section style={glassPanel} className="rounded-2xl p-5">
-        <div className="flex items-baseline justify-between gap-3 mb-4">
-          <h2 className="text-base font-semibold" style={{ color: 'var(--text-primary)' }}>
-            历史发布
-          </h2>
-          <span className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
-            来自 CHANGELOG.md
-          </span>
-        </div>
-
-        {loadingReleases && !releases && <MapSectionLoader text="正在加载历史发布…" />}
-
-        {!loadingReleases && releases && releases.releases.length === 0 && (
-          <div
-            className="rounded-xl px-4 py-6 text-center text-[12px]"
-            style={{
-              background: 'rgba(255, 255, 255, 0.02)',
-              border: '1px dashed rgba(255, 255, 255, 0.08)',
-              color: 'var(--text-muted)',
-            }}
-          >
-            暂无历史发布
-          </div>
-        )}
-
-        {releases && releases.releases.length > 0 && (
-          <div className="flex flex-col gap-6">
-            {releases.releases.map((release) => {
-              const visibleDays = release.days
-                .map((d) => ({
-                  ...d,
-                  entries: d.entries.filter(matchFilter),
-                }))
-                .filter((d) => d.entries.length > 0);
-              const totalCount = visibleDays.reduce((s, d) => s + d.entries.length, 0);
-              if (totalCount === 0 && release.highlights.length === 0) {
-                return null;
-              }
-
-              const isUnreleased = release.version === '未发布';
-
+        <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+          <div className="flex items-center gap-4 flex-wrap">
+            <h2 className="text-[18px] font-semibold tracking-wide" style={{ color: 'var(--text-primary)' }}>
+              历史发布
+            </h2>
+            {([
+              { key: 'releases', label: 'CHANGELOG', icon: <Calendar size={13} /> },
+              { key: 'fragments', label: '碎片补充', icon: <FileText size={13} /> },
+              { key: 'github_logs', label: 'GitHub 日志', icon: <Github size={13} /> },
+            ] as const).map((tab) => {
+              const active = historySubtab === tab.key;
               return (
-                <div key={`${release.version}-${release.releaseDate ?? ''}`}>
-                  <div className="flex items-center gap-2 mb-3">
-                    <div
-                      className="px-2.5 py-0.5 rounded-md text-[12px] font-semibold font-mono"
-                      style={{
-                        background: isUnreleased
-                          ? 'rgba(251, 191, 36, 0.10)'
-                          : 'rgba(99, 102, 241, 0.12)',
-                        border: `1px solid ${isUnreleased ? 'rgba(251, 191, 36, 0.32)' : 'rgba(99, 102, 241, 0.32)'}`,
-                        color: isUnreleased ? '#fbbf24' : '#a5b4fc',
-                      }}
-                    >
-                      {isUnreleased ? '未发布' : `v${release.version}`}
-                    </div>
-                    {release.releaseDate && (
-                      <span className="text-[11px] font-mono" style={{ color: 'var(--text-muted)' }}>
-                        {release.releaseDate}
-                      </span>
-                    )}
-                    <span className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
-                      · {totalCount} 条
-                    </span>
-                  </div>
-
-                  {release.highlights.length > 0 && (
-                    <div
-                      className="mb-3 rounded-lg px-3 py-2.5 text-[12px]"
-                      style={{
-                        background: 'rgba(99, 102, 241, 0.06)',
-                        border: '1px solid rgba(99, 102, 241, 0.18)',
-                      }}
-                    >
-                      <div
-                        className="text-[10px] font-semibold mb-1 tracking-wider"
-                        style={{ color: '#a5b4fc' }}
-                      >
-                        🚀 用户更新项
-                      </div>
-                      <ul className="flex flex-col gap-0.5" style={{ color: 'var(--text-secondary)' }}>
-                        {release.highlights.map((h, i) => (
-                          <li key={i}>• {h}</li>
-                        ))}
-                      </ul>
-                    </div>
-                  )}
-
-                  {visibleDays.length > 0 && (
-                    <div className="flex flex-col gap-3">
-                      {visibleDays.map((day, dayIdx) => (
-                        <div key={`${day.date}-${dayIdx}`}>
-                          <div
-                            className="inline-flex items-center gap-2 mb-2.5 px-2.5 py-1 rounded-md"
-                            style={{
-                              background: 'rgba(255, 255, 255, 0.04)',
-                              border: '1px solid rgba(255, 255, 255, 0.08)',
-                              color: 'var(--text-secondary)',
-                              fontSize: '13px',
-                              fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
-                              fontWeight: 600,
-                              letterSpacing: '0.02em',
-                            }}
-                          >
-                            <Calendar size={13} />
-                            {day.date}
-                          </div>
-                          <div className="flex flex-col gap-1.5">
-                            {day.entries.map((e, idx) => (
-                              <EntryRow
-                                key={`${day.date}-${idx}`}
-                                entry={{
-                                  ...e,
-                                  date: day.date,
-                                  commitTimeUtc: day.commitTimeUtc ?? null,
-                                  source: 'release',
-                                  releaseVersion: release.version,
-                                }}
-                                newCutoff={newBadgeCutoff}
-                              />
-                            ))}
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
+                <button
+                  key={tab.key}
+                  type="button"
+                  onClick={() => setHistorySubtab(tab.key)}
+                  className="h-8 px-3 rounded-lg inline-flex items-center gap-1.5 text-[12px] font-medium transition-all"
+                  style={{
+                    background: active ? 'rgba(99, 102, 241, 0.14)' : 'rgba(255, 255, 255, 0.04)',
+                    border: `1px solid ${active ? 'rgba(99, 102, 241, 0.32)' : 'rgba(255, 255, 255, 0.08)'}`,
+                    color: active ? '#c7d2fe' : 'var(--text-muted)',
+                    cursor: 'pointer',
+                  }}
+                >
+                  {tab.icon}
+                  {tab.label}
+                </button>
               );
             })}
           </div>
+          <span className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
+            {historySubtab === 'releases' && '来自 CHANGELOG.md'}
+            {historySubtab === 'fragments' && '来自 changelogs/*.md（当前周碎片）'}
+            {historySubtab === 'github_logs' && (
+              githubLogs?.source === 'local' ? '来自本地 git log' : '来自 GitHub commits API'
+            )}
+          </span>
+        </div>
+
+        {historySubtab === 'releases' && (
+          <>
+            {loadingReleases && !releases && <MapSectionLoader text="正在加载历史发布…" />}
+
+            {!loadingReleases && releases && releases.releases.length === 0 && (
+              <div
+                className="rounded-xl px-4 py-6 text-center text-[12px]"
+                style={{
+                  background: 'rgba(255, 255, 255, 0.02)',
+                  border: '1px dashed rgba(255, 255, 255, 0.08)',
+                  color: 'var(--text-muted)',
+                }}
+              >
+                暂无历史发布
+              </div>
+            )}
+
+            {releases && releases.releases.length > 0 && (
+              <div className="flex flex-col gap-6">
+                {releases.releases.map((release) => {
+                  const visibleDays = release.days
+                    .map((d) => ({
+                      ...d,
+                      entries: d.entries.filter(matchFilter),
+                    }))
+                    .filter((d) => d.entries.length > 0);
+                  const totalCount = visibleDays.reduce((s, d) => s + d.entries.length, 0);
+                  if (totalCount === 0 && release.highlights.length === 0) {
+                    return null;
+                  }
+
+                  const isUnreleased = release.version === '未发布';
+                  const releaseDisplayDate = getReleaseDisplayDate(release.releaseDate, visibleDays);
+                  const releaseDateTitle = release.releaseDate && releaseDisplayDate && releaseDisplayDate !== release.releaseDate
+                    ? `CHANGELOG 标注日期：${release.releaseDate}\nGitHub 本地日期：${releaseDisplayDate}`
+                    : undefined;
+
+                  return (
+                    <div key={`${release.version}-${release.releaseDate ?? ''}`}>
+                      <div className="flex items-center gap-2 mb-3">
+                        <div
+                          className="px-2.5 py-0.5 rounded-md text-[12px] font-semibold font-mono"
+                          style={{
+                            background: isUnreleased
+                              ? 'rgba(251, 191, 36, 0.10)'
+                              : 'rgba(99, 102, 241, 0.12)',
+                            border: `1px solid ${isUnreleased ? 'rgba(251, 191, 36, 0.32)' : 'rgba(99, 102, 241, 0.32)'}`,
+                            color: isUnreleased ? '#fbbf24' : '#a5b4fc',
+                          }}
+                        >
+                          {isUnreleased ? '未发布' : `v${release.version}`}
+                        </div>
+                        {releaseDisplayDate && (
+                          <span className="text-[11px] font-mono" style={{ color: 'var(--text-muted)' }} title={releaseDateTitle}>
+                            {releaseDisplayDate}
+                          </span>
+                        )}
+                        <span className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
+                          · {totalCount} 条
+                        </span>
+                      </div>
+
+                      {release.highlights.length > 0 && (
+                        <div
+                          className="mb-3 rounded-lg px-3 py-2.5 text-[12px]"
+                          style={{
+                            background: 'rgba(99, 102, 241, 0.06)',
+                            border: '1px solid rgba(99, 102, 241, 0.18)',
+                          }}
+                        >
+                          <div
+                            className="text-[10px] font-semibold mb-1 tracking-wider"
+                            style={{ color: '#a5b4fc' }}
+                          >
+                            🚀 用户更新项
+                          </div>
+                          <ul className="flex flex-col gap-0.5" style={{ color: 'var(--text-secondary)' }}>
+                            {release.highlights.map((h, i) => (
+                              <li key={i}>• {h}</li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
+
+                      {visibleDays.length > 0 && (
+                        <div className="flex flex-col gap-3">
+                          {visibleDays.map((day, dayIdx) => {
+                            const dayDisplayDate = formatDisplayDate(day.date, day.commitTimeUtc);
+                            const dayTitle = day.commitTimeUtc && dayDisplayDate !== day.date
+                              ? `CHANGELOG 日期：${day.date}\nGitHub 本地日期：${dayDisplayDate}`
+                              : undefined;
+                            return (
+                              <div key={`${day.date}-${dayIdx}`}>
+                                <div
+                                  className="inline-flex items-center gap-2 mb-2.5 px-2.5 py-1 rounded-md"
+                                  style={{
+                                    background: 'rgba(255, 255, 255, 0.04)',
+                                    border: '1px solid rgba(255, 255, 255, 0.08)',
+                                    color: 'var(--text-secondary)',
+                                    fontSize: '13px',
+                                    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+                                    fontWeight: 600,
+                                    letterSpacing: '0.02em',
+                                  }}
+                                  title={dayTitle}
+                                >
+                                  <Calendar size={13} />
+                                  {dayDisplayDate}
+                                </div>
+                                <div className="flex flex-col gap-1.5">
+                                  {day.entries.map((e, idx) => (
+                                    <EntryRow
+                                      key={`${day.date}-${idx}`}
+                                      entry={{
+                                        ...e,
+                                        date: day.date,
+                                        commitTimeUtc: day.commitTimeUtc ?? null,
+                                        source: 'release',
+                                        releaseVersion: release.version,
+                                      }}
+                                      newCutoff={newBadgeCutoff}
+                                    />
+                                  ))}
+                                </div>
+                              </div>
+                            );
+                          })}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </>
+        )}
+
+        {historySubtab === 'fragments' && (
+          <>
+            {!currentWeek && <MapSectionLoader text="正在加载碎片补充…" />}
+
+            {currentWeek && currentWeek.fragments.length === 0 && (
+              <div
+                className="rounded-xl px-4 py-6 text-center text-[12px]"
+                style={{
+                  background: 'rgba(255, 255, 255, 0.02)',
+                  border: '1px dashed rgba(255, 255, 255, 0.08)',
+                  color: 'var(--text-muted)',
+                }}
+              >
+                当前周暂无碎片日志
+              </div>
+            )}
+
+            {currentWeek && currentWeek.fragments.length > 0 && currentWeek.fragments.filter((f) => f.entries.some(matchFilter)).length === 0 && (
+              <div
+                className="rounded-xl px-4 py-6 text-center text-[12px]"
+                style={{
+                  background: 'rgba(255, 255, 255, 0.02)',
+                  border: '1px dashed rgba(255, 255, 255, 0.08)',
+                  color: 'var(--text-muted)',
+                }}
+              >
+                当前筛选条件下暂无碎片条目
+              </div>
+            )}
+
+            {currentWeek && currentWeek.fragments.filter((f) => f.entries.some(matchFilter)).length > 0 && (
+              <div className="flex flex-col gap-4">
+                {currentWeek.fragments.map((fragment) => {
+                  const visibleEntries = fragment.entries.filter(matchFilter);
+                  if (visibleEntries.length === 0) return null;
+                  return (
+                    <div
+                      key={fragment.fileName}
+                      className="rounded-xl px-4 py-3"
+                      style={{
+                        background: 'rgba(255, 255, 255, 0.025)',
+                        border: '1px solid rgba(255, 255, 255, 0.06)',
+                      }}
+                    >
+                      <div className="flex items-center gap-2 mb-3 flex-wrap">
+                        <div
+                          className="inline-flex items-center gap-2 px-2.5 py-1 rounded-md"
+                          style={{
+                            background: 'rgba(255, 255, 255, 0.04)',
+                            border: '1px solid rgba(255, 255, 255, 0.08)',
+                            color: 'var(--text-secondary)',
+                            fontSize: '13px',
+                            fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+                            fontWeight: 600,
+                          }}
+                        >
+                          <Calendar size={13} />
+                          {fragment.date}
+                        </div>
+                        <span className="text-[12px]" style={{ color: 'var(--text-muted)' }}>
+                          {fragment.fileName}
+                        </span>
+                        <span className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
+                          · {visibleEntries.length} 条
+                        </span>
+                      </div>
+                      <div className="flex flex-col gap-1.5">
+                        {visibleEntries.map((entry, idx) => (
+                          <EntryRow
+                            key={`${fragment.fileName}-${idx}`}
+                            entry={{
+                              ...entry,
+                              date: fragment.date,
+                              commitTimeUtc: null,
+                              source: 'fragment',
+                            }}
+                            newCutoff={newBadgeCutoff}
+                          />
+                        ))}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </>
+        )}
+
+        {historySubtab === 'github_logs' && (
+          <>
+            {loadingGitHubLogs && !githubLogs && <MapSectionLoader text="正在加载 GitHub 日志…" />}
+
+            {gitHubLogsError && (
+              <div
+                className="rounded-xl px-4 py-3 text-[12px]"
+                style={{
+                  background: 'rgba(248, 113, 113, 0.08)',
+                  border: '1px solid rgba(248, 113, 113, 0.32)',
+                  color: '#fca5a5',
+                }}
+              >
+                ⚠ {gitHubLogsError}
+              </div>
+            )}
+
+            {!loadingGitHubLogs && githubLogs && githubLogs.logs.length === 0 && (
+              <div
+                className="rounded-xl px-4 py-6 text-center text-[12px]"
+                style={{
+                  background: 'rgba(255, 255, 255, 0.02)',
+                  border: '1px dashed rgba(255, 255, 255, 0.08)',
+                  color: 'var(--text-muted)',
+                }}
+              >
+                暂无 GitHub 日志
+              </div>
+            )}
+
+            {githubLogs && githubLogs.logs.length > 0 && (
+              <div className="flex flex-col gap-2">
+                {githubLogs.logs.map((log) => (
+                  <GitHubLogRow key={log.sha} log={log} />
+                ))}
+              </div>
+            )}
+          </>
         )}
       </section>
       </div>
@@ -461,10 +702,11 @@ export default function ChangelogPage() {
 function EntryRow({ entry, newCutoff }: { entry: FlatEntry; newCutoff: number | null }) {
   const meta = getTypeBadge(entry.type);
   const Icon = meta.icon;
-  const timeText = formatEntryTime(entry.date, entry.commitTimeUtc);
-  const timeTitle = entry.commitTimeUtc
-    ? `GitHub commit 时间：${timeText}`
-    : `提交日期：${entry.date}（无秒级 commit 时间）`;
+  const timeText = formatDisplayDate(entry.date, entry.commitTimeUtc);
+  const commitDateTime = formatCommitDateTime(entry.commitTimeUtc);
+  const timeTitle = commitDateTime
+    ? `GitHub commit 时间：${commitDateTime}\n原始日期：${entry.date}`
+    : `${entry.source === 'fragment' ? '碎片日期' : 'CHANGELOG 日期'}：${entry.date}`;
   const isFresh = (() => {
     if (newCutoff === null) return false;
     if (!entry.commitTimeUtc) return false;
@@ -538,5 +780,62 @@ function EntryRow({ entry, newCutoff }: { entry: FlatEntry; newCutoff: number | 
         {timeText}
       </div>
     </div>
+  );
+}
+
+function GitHubLogRow({ log }: { log: GitHubLogEntry }) {
+  const commitDate = formatDisplayDate('', log.commitTimeUtc);
+  const commitDateTime = formatCommitDateTime(log.commitTimeUtc) ?? log.commitTimeUtc;
+  return (
+    <a
+      href={log.htmlUrl}
+      target="_blank"
+      rel="noreferrer"
+      className="rounded-lg px-3.5 py-3 flex items-center gap-3 transition-colors hover:bg-white/5"
+      style={{
+        background: 'rgba(255, 255, 255, 0.025)',
+        border: '1px solid rgba(255, 255, 255, 0.06)',
+        textDecoration: 'none',
+      }}
+      title={commitDateTime}
+    >
+      <div
+        className="shrink-0 inline-flex items-center gap-1 px-2 h-[24px] rounded-md text-[12px] font-semibold"
+        style={{
+          background: 'rgba(99, 102, 241, 0.12)',
+          color: '#c7d2fe',
+          border: '1px solid rgba(99, 102, 241, 0.24)',
+          fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+        }}
+      >
+        <GitCommit size={11} />
+        {log.shortSha}
+      </div>
+      <div
+        className="shrink-0 inline-flex items-center gap-1 h-[24px] px-2 rounded-md text-[12px]"
+        style={{
+          color: 'var(--text-secondary)',
+          background: 'rgba(255, 255, 255, 0.04)',
+          border: '1px solid rgba(255, 255, 255, 0.08)',
+        }}
+      >
+        <Github size={11} />
+        {log.authorName}
+      </div>
+      <div className="text-[13px] leading-relaxed flex-1 truncate" style={{ color: 'var(--text-secondary)', minWidth: 0 }}>
+        {log.message}
+      </div>
+      <div
+        className="shrink-0 text-[12px]"
+        style={{
+          color: 'var(--text-muted)',
+          fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+          fontVariantNumeric: 'tabular-nums',
+        }}
+      >
+        {commitDate}
+      </div>
+      <ExternalLink size={13} style={{ color: 'var(--text-muted)', opacity: 0.65, flexShrink: 0 }} />
+    </a>
   );
 }

--- a/prd-admin/src/pages/changelog/ChangelogPage.tsx
+++ b/prd-admin/src/pages/changelog/ChangelogPage.tsx
@@ -10,8 +10,8 @@ import { MapSectionLoader, MapSpinner } from '@/components/ui/VideoLoader';
 import { SparkleButton } from '@/components/effects/SparkleButton';
 import { SseTypingBlock } from '@/components/sse/SseTypingBlock';
 import { glassPanel } from '@/lib/glassStyles';
-import { getChangelogGitHubLogs } from '@/services';
-import type { ChangelogEntry, CurrentWeekView, GitHubLogEntry, GitHubLogsView, ReleasesView } from '@/services';
+import { getChangelogGitHubLogs, postChangelogAiSummary } from '@/services';
+import type { ChangelogEntry, GitHubLogEntry, GitHubLogsView } from '@/services';
 import { TabBar } from '@/components/design/TabBar';
 import {
   WeeklyReportsTab,
@@ -78,28 +78,6 @@ interface HistorySummaryResult {
   generatedAt: number;
 }
 
-const HISTORY_SUMMARY_STEPS: Record<HistorySubtab, string[]> = {
-  releases: [
-    '读取版本时间线、用户更新项和最近可见条目',
-    '统计变更类型、模块热点与发布密度',
-    '压缩成适合顶部快速阅读的发布摘要',
-  ],
-  fragments: [
-    '聚合待发布功能并按日期合并重复上下文',
-    '识别模块热点和最值得优先发布的条目',
-    '整理成当前周的待发布功能摘要',
-  ],
-  github_logs: [
-    '扫描最近提交、作者分布与提交主题',
-    '识别重复推进方向和本轮研发热点',
-    '整理成仓库节奏与趋势摘要',
-  ],
-};
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => window.setTimeout(resolve, ms));
-}
-
 function formatLocalDateValue(d: Date): string {
   const pad = (n: number) => n.toString().padStart(2, '0');
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
@@ -162,160 +140,6 @@ function writeGitHubLogsCache(data: GitHubLogsView) {
   } catch {
     // ignore cache write failures
   }
-}
-
-function topCounts(values: string[], limit = 3): Array<{ label: string; count: number }> {
-  const counts = new Map<string, number>();
-  for (const raw of values) {
-    const label = raw.trim();
-    if (!label) continue;
-    counts.set(label, (counts.get(label) ?? 0) + 1);
-  }
-  return Array.from(counts.entries())
-    .map(([label, count]) => ({ label, count }))
-    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label))
-    .slice(0, limit);
-}
-
-function formatCountLabels(items: Array<{ label: string; count: number }>): string {
-  return items.map((item) => `${item.label} (${item.count})`).join('、');
-}
-
-function shorten(text: string, max = 42): string {
-  return text.length > max ? `${text.slice(0, max - 1)}…` : text;
-}
-
-function extractLogTopic(message: string): string {
-  const moduleMatch = message.match(/^[a-z]+(?:\(([^)]+)\))?/i);
-  if (moduleMatch?.[1]) return moduleMatch[1];
-  if (moduleMatch?.[0]) return moduleMatch[0].replace(/\(.+$/, '');
-  const head = message.split(/[:：]/)[0]?.trim();
-  return shorten(head || message, 18);
-}
-
-function buildReleaseSummary(releases: ReleasesView, typeFilter: string | null): HistorySummaryResult {
-  const visibleReleases = releases.releases
-    .map((release) => ({
-      ...release,
-      days: release.days
-        .map((day) => ({
-          ...day,
-          entries: day.entries.filter((entry) => !typeFilter || entry.type.toLowerCase() === typeFilter),
-        }))
-        .filter((day) => day.entries.length > 0),
-    }))
-    .filter((release) => release.days.length > 0 || release.highlights.length > 0);
-
-  const entries = visibleReleases.flatMap((release) => release.days.flatMap((day) => day.entries));
-  if (visibleReleases.length === 0 || entries.length === 0) {
-    throw new Error('当前筛选条件下没有可总结的历史发布');
-  }
-
-  const latest = visibleReleases[0];
-  const topTypes = topCounts(entries.map((entry) => getTypeBadge(entry.type).label));
-  const topModules = topCounts(entries.map((entry) => entry.module));
-  const latestHighlight = latest.highlights[0];
-
-  return {
-    title: 'CHANGELOG 发布摘要',
-    headline: `当前最值得先看的版本是 ${latest.version === '未发布' ? '未发布' : `v${latest.version}`}，共整理 ${entries.length} 条可见更新。`,
-    bullets: [
-      latestHighlight
-        ? `面向用户最值得先讲的是：${shorten(latestHighlight, 56)}`
-        : `最近版本主要围绕 ${topModules.length ? formatCountLabels(topModules) : '多模块并行推进'} 展开。`,
-      topTypes.length
-        ? `变更类型以 ${formatCountLabels(topTypes)} 为主。`
-        : '当前筛选下没有形成明显的类型集中趋势。',
-      topModules.length
-        ? `模块热点集中在 ${formatCountLabels(topModules)}。`
-        : '模块分布较分散，适合按用户更新项来讲。',
-    ],
-    stats: [
-      `${visibleReleases.length} 个版本`,
-      `${entries.length} 条更新`,
-      `${new Set(entries.map((entry) => entry.module)).size} 个模块`,
-    ],
-    insight: typeFilter
-      ? `当前摘要已按「${getTypeBadge(typeFilter).label}」筛选，适合只看这一类变更。`
-      : '适合先讲版本价值，再下钻到模块条目。',
-    thinkingTrace: '',
-    generatedAt: Date.now(),
-  };
-}
-
-function buildFragmentSummary(currentWeek: CurrentWeekView, typeFilter: string | null): HistorySummaryResult {
-  const rows = currentWeek.fragments.flatMap((fragment) =>
-    fragment.entries
-      .filter((entry) => !typeFilter || entry.type.toLowerCase() === typeFilter)
-      .map((entry) => ({ ...entry, date: fragment.date, fileName: fragment.fileName })),
-  );
-  if (rows.length === 0) {
-    throw new Error('当前筛选条件下没有可总结的待发布功能');
-  }
-
-  const topTypes = topCounts(rows.map((entry) => getTypeBadge(entry.type).label));
-  const topModules = topCounts(rows.map((entry) => entry.module));
-  const groupedDates = topCounts(rows.map((entry) => entry.date), 2);
-  const samples = rows.slice(0, 3).map((entry) => shorten(entry.description, 48));
-
-  return {
-    title: '待发布功能摘要',
-    headline: `当前待发布池里共有 ${rows.length} 条条目，覆盖 ${new Set(rows.map((row) => row.date)).size} 个日期批次。`,
-    bullets: [
-      topModules.length
-        ? `模块热度最高的是 ${formatCountLabels(topModules)}。`
-        : '目前没有明显的模块集中趋势。',
-      topTypes.length
-        ? `条目类型主要是 ${formatCountLabels(topTypes)}。`
-        : '条目类型较分散，适合按日期逐组发布。',
-      samples.length > 0
-        ? `最值得优先讲的功能点包括：${samples.join('；')}`
-        : '当前待发布功能仍需要进一步整理成发布话术。',
-    ],
-    stats: [
-      `${rows.length} 条待发布`,
-      `${new Set(rows.map((row) => row.module)).size} 个模块`,
-      groupedDates.length ? `高频日期 ${formatCountLabels(groupedDates)}` : '日期分布较散',
-    ],
-    insight: '更适合当作“下一版准备发布什么”的预告区，而不是当历史记录看。',
-    thinkingTrace: '',
-    generatedAt: Date.now(),
-  };
-}
-
-function buildGitHubLogSummary(logsView: GitHubLogsView): HistorySummaryResult {
-  const logs = logsView.logs.slice(0, GITHUB_LOGS_FETCH_LIMIT);
-  if (logs.length === 0) {
-    throw new Error('当前没有可总结的 GitHub 日志');
-  }
-
-  const topAuthors = topCounts(logs.map((log) => log.authorName));
-  const topTopics = topCounts(logs.map((log) => extractLogTopic(log.message)));
-  const latestMessages = logs.slice(0, 3).map((log) => shorten(log.message, 46));
-
-  return {
-    title: 'GitHub 日志摘要',
-    headline: `最近 ${logs.length} 条提交主要由 ${topAuthors.length ? formatCountLabels(topAuthors) : '多人协同'} 推进。`,
-    bullets: [
-      topTopics.length
-        ? `提交主题集中在 ${formatCountLabels(topTopics)}。`
-        : '当前提交主题较分散，没有形成单一热点。',
-      latestMessages.length > 0
-        ? `最近几条动作包括：${latestMessages.join('；')}`
-        : '最近没有足够的提交内容可用于提炼。',
-      logsView.source === 'local'
-        ? '当前日志来自本地 git log，响应会更快，也更适合看实时推进节奏。'
-        : '当前日志来自 GitHub commits API，适合看远端主线的最新推进。',
-    ],
-    stats: [
-      `${logs.length} 条提交`,
-      `${new Set(logs.map((log) => log.authorName)).size} 位作者`,
-      `${logsView.source === 'local' ? '本地仓库' : 'GitHub API'} 源`,
-    ],
-    insight: '适合用来判断这轮开发是在收尾修补，还是在推进新的主线功能。',
-    thinkingTrace: '',
-    generatedAt: Date.now(),
-  };
 }
 
 export default function ChangelogPage() {
@@ -442,52 +266,34 @@ export default function ChangelogPage() {
   const summarizeCurrentTab = async () => {
     const tab = historySubtab;
     const runId = ++summaryRunRef.current;
-    const startedAt = Date.now();
     setSummaryError((prev) => ({ ...prev, [tab]: null }));
     setSummaryStatus((prev) => ({ ...prev, [tab]: 'loading' }));
-    setSummaryThinking((prev) => ({ ...prev, [tab]: '' }));
+    setSummaryThinking((prev) => ({
+      ...prev,
+      [tab]: '正在请求服务端：ILlmGateway · prd-admin.changelog.aiSummary::chat …',
+    }));
 
-    let thinkingTrace = '';
     try {
-      for (const [index, step] of HISTORY_SUMMARY_STEPS[tab].entries()) {
-        thinkingTrace = `${thinkingTrace}${thinkingTrace ? '\n' : ''}${index + 1}. ${step}`;
-        if (summaryRunRef.current !== runId) return;
-        setSummaryThinking((prev) => ({ ...prev, [tab]: thinkingTrace }));
-        await delay(420);
-      }
-
-      let summary: HistorySummaryResult;
-      if (tab === 'releases') {
-        if (!releases) throw new Error('历史发布还没加载完成');
-        summary = buildReleaseSummary(releases, typeFilter);
-      } else if (tab === 'fragments') {
-        if (!currentWeek) throw new Error('待发布功能还没加载完成');
-        summary = buildFragmentSummary(currentWeek, typeFilter);
-      } else {
-        let logs = githubLogs;
-        if (!logs) {
-          const res = await getChangelogGitHubLogs(GITHUB_LOGS_FETCH_LIMIT);
-          if (!res.success) throw new Error(res.error?.message || '加载 GitHub 日志失败');
-          logs = res.data;
-          setGitHubLogs(res.data);
-          writeGitHubLogsCache(res.data);
-        }
-        summary = buildGitHubLogSummary(logs);
-      }
-
-      const elapsed = Date.now() - startedAt;
-      if (elapsed < 2000) {
-        await delay(2000 - elapsed);
-      }
+      const res = await postChangelogAiSummary({
+        subtab: tab,
+        typeFilter: typeFilter ?? undefined,
+      });
       if (summaryRunRef.current !== runId) return;
-
-      const completed = {
-        ...summary,
-        thinkingTrace,
-        generatedAt: Date.now(),
+      if (!res.success || !res.data) {
+        throw new Error(res.error?.message || 'AI 总结失败');
+      }
+      const data = res.data;
+      const completed: HistorySummaryResult = {
+        title: data.title,
+        headline: data.headline,
+        bullets: data.bullets,
+        stats: data.stats,
+        insight: data.insight,
+        thinkingTrace: data.thinkingTrace,
+        generatedAt: data.generatedAt,
       };
       setSummaryCache((prev) => ({ ...prev, [tab]: completed }));
-      setSummaryThinking((prev) => ({ ...prev, [tab]: thinkingTrace }));
+      setSummaryThinking((prev) => ({ ...prev, [tab]: data.thinkingTrace || '' }));
       setSummaryStatus((prev) => ({ ...prev, [tab]: 'ready' }));
     } catch (error) {
       if (summaryRunRef.current !== runId) return;
@@ -496,7 +302,7 @@ export default function ChangelogPage() {
         ...prev,
         [tab]: error instanceof Error ? error.message : '总结失败',
       }));
-      setSummaryThinking((prev) => ({ ...prev, [tab]: thinkingTrace }));
+      setSummaryThinking((prev) => ({ ...prev, [tab]: '' }));
     }
   };
 
@@ -803,7 +609,7 @@ export default function ChangelogPage() {
                 </div>
                 <div className="text-[13px] mt-1 leading-relaxed" style={{ color: 'var(--text-secondary)' }}>
                   {activeSummaryStatus === 'loading'
-                    ? '先在 2 秒内给出结构和方向，再补完整摘要。'
+                    ? '正在通过网关生成摘要（非本地规则拼装）。'
                     : activeSummary?.headline}
                 </div>
               </div>

--- a/prd-admin/src/pages/changelog/ChangelogPage.tsx
+++ b/prd-admin/src/pages/changelog/ChangelogPage.tsx
@@ -91,15 +91,15 @@ function formatCommitDateTime(commitTimeUtc?: string | null): string | null {
   return d ? formatLocalDateTimeValue(d) : null;
 }
 
-function getReleaseDisplayDate(releaseDate: string | null, days: Array<{ date: string; commitTimeUtc?: string | null }>): string | null {
+function getLatestCommitDateTime(days: Array<{ commitTimeUtc?: string | null }>): string | null {
   const latestCommitDay = days
     .map((d) => parseIsoDate(d.commitTimeUtc))
     .filter((d): d is Date => d instanceof Date)
     .sort((a, b) => b.getTime() - a.getTime())[0];
   if (latestCommitDay) {
-    return formatLocalDateValue(latestCommitDay);
+    return formatLocalDateTimeValue(latestCommitDay);
   }
-  return releaseDate;
+  return null;
 }
 
 function readGitHubLogsCache(): GitHubLogsView | null {
@@ -520,9 +520,10 @@ export default function ChangelogPage() {
                   }
 
                   const isUnreleased = release.version === '未发布';
-                  const releaseDisplayDate = getReleaseDisplayDate(release.releaseDate, visibleDays);
-                  const releaseDateTitle = release.releaseDate && releaseDisplayDate && releaseDisplayDate !== release.releaseDate
-                    ? `CHANGELOG 标注日期：${release.releaseDate}\nGitHub 本地日期：${releaseDisplayDate}`
+                  const releaseDisplayDate = release.releaseDate;
+                  const releaseCommitDateTime = getLatestCommitDateTime(visibleDays);
+                  const releaseDateTitle = releaseCommitDateTime
+                    ? `CHANGELOG 版本日期：${release.releaseDate ?? '未发布'}\n最近一次 CHANGELOG 合并提交：${releaseCommitDateTime}`
                     : undefined;
 
                   return (
@@ -575,38 +576,27 @@ export default function ChangelogPage() {
                       {visibleDays.length > 0 && (
                         <div className="flex flex-col gap-3">
                           {visibleDays.map((day, dayIdx) => {
-                            const dayCommitDisplayDate = formatDisplayDate(day.date, day.commitTimeUtc);
-                            const dayTitle = day.commitTimeUtc && dayCommitDisplayDate !== day.date
-                              ? `CHANGELOG 日期：${day.date}\nGitHub commit 本地日期：${dayCommitDisplayDate}`
+                            const dayCommitDateTime = formatCommitDateTime(day.commitTimeUtc);
+                            const dayTitle = dayCommitDateTime
+                              ? `CHANGELOG 日期：${day.date}\n最近一次 CHANGELOG 合并提交：${dayCommitDateTime}`
                               : undefined;
                             return (
                               <div key={`${day.date}-${dayIdx}`}>
-                                <div className="flex items-center gap-2 mb-2.5 flex-wrap">
-                                  <div
-                                    className="inline-flex items-center gap-2 px-2.5 py-1 rounded-md"
-                                    style={{
-                                      background: 'rgba(255, 255, 255, 0.04)',
-                                      border: '1px solid rgba(255, 255, 255, 0.08)',
-                                      color: 'var(--text-secondary)',
-                                      fontSize: '13px',
-                                      fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
-                                      fontWeight: 600,
-                                      letterSpacing: '0.02em',
-                                    }}
-                                    title={dayTitle}
-                                  >
-                                    <Calendar size={13} />
-                                    {day.date}
-                                  </div>
-                                  {day.commitTimeUtc && dayCommitDisplayDate !== day.date && (
-                                    <span
-                                      className="text-[11px] font-mono"
-                                      style={{ color: 'var(--text-muted)' }}
-                                      title={`GitHub commit 本地日期：${dayCommitDisplayDate}`}
-                                    >
-                                      提交落地 {dayCommitDisplayDate}
-                                    </span>
-                                  )}
+                                <div
+                                  className="inline-flex items-center gap-2 mb-2.5 px-2.5 py-1 rounded-md"
+                                  style={{
+                                    background: 'rgba(255, 255, 255, 0.04)',
+                                    border: '1px solid rgba(255, 255, 255, 0.08)',
+                                    color: 'var(--text-secondary)',
+                                    fontSize: '13px',
+                                    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+                                    fontWeight: 600,
+                                    letterSpacing: '0.02em',
+                                  }}
+                                  title={dayTitle}
+                                >
+                                  <Calendar size={13} />
+                                  {day.date}
                                 </div>
                                 <div className="flex flex-col gap-1.5">
                                   {day.entries.map((e, idx) => (
@@ -782,11 +772,6 @@ export default function ChangelogPage() {
 function EntryRow({ entry, newCutoff }: { entry: FlatEntry; newCutoff: number | null }) {
   const meta = getTypeBadge(entry.type);
   const Icon = meta.icon;
-  const timeText = formatDisplayDate(entry.date, entry.commitTimeUtc);
-  const commitDateTime = formatCommitDateTime(entry.commitTimeUtc);
-  const timeTitle = commitDateTime
-    ? `GitHub commit 时间：${commitDateTime}\n原始日期：${entry.date}`
-    : `${entry.source === 'fragment' ? '碎片日期' : 'CHANGELOG 日期'}：${entry.date}`;
   const isFresh = (() => {
     if (newCutoff === null) return false;
     if (!entry.commitTimeUtc) return false;
@@ -847,17 +832,6 @@ function EntryRow({ entry, newCutoff }: { entry: FlatEntry; newCutoff: number | 
         title={entry.description}
       >
         {entry.description}
-      </div>
-      <div
-        className="shrink-0 text-[12px]"
-        style={{
-          color: 'var(--text-muted)',
-          fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
-          fontVariantNumeric: 'tabular-nums',
-        }}
-        title={timeTitle}
-      >
-        {timeText}
       </div>
     </div>
   );

--- a/prd-admin/src/pages/changelog/ChangelogPage.tsx
+++ b/prd-admin/src/pages/changelog/ChangelogPage.tsx
@@ -1,15 +1,17 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { LucideIcon } from 'lucide-react';
 import {
   Sparkles, Calendar, Tag, RefreshCw, Filter, X, FileText,
   Wrench, Zap, Gauge, Shuffle, Shield, Package, FlaskConical, UploadCloud, Cog,
-  Github, GitCommit, ExternalLink,
+  Github, GitCommit, ExternalLink, Brain, Wand2,
 } from 'lucide-react';
 import { useChangelogStore } from '@/stores/changelogStore';
 import { MapSectionLoader, MapSpinner } from '@/components/ui/VideoLoader';
+import { SparkleButton } from '@/components/effects/SparkleButton';
+import { SseTypingBlock } from '@/components/sse/SseTypingBlock';
 import { glassPanel } from '@/lib/glassStyles';
 import { getChangelogGitHubLogs } from '@/services';
-import type { ChangelogEntry, GitHubLogEntry, GitHubLogsView } from '@/services';
+import type { ChangelogEntry, CurrentWeekView, GitHubLogEntry, GitHubLogsView, ReleasesView } from '@/services';
 import { TabBar } from '@/components/design/TabBar';
 import {
   WeeklyReportsTab,
@@ -55,6 +57,7 @@ interface FlatEntry extends ChangelogEntry {
 }
 
 type HistorySubtab = 'releases' | 'fragments' | 'github_logs';
+type HistorySummaryStatus = 'idle' | 'loading' | 'ready' | 'error';
 
 const GITHUB_LOGS_CACHE_KEY = 'changelog:github-logs:v1';
 const GITHUB_LOGS_CACHE_TTL_MS = 5 * 60 * 1000;
@@ -63,6 +66,38 @@ const GITHUB_LOGS_FETCH_LIMIT = 30;
 interface GitHubLogsCachePayload {
   cachedAt: number;
   data: GitHubLogsView;
+}
+
+interface HistorySummaryResult {
+  title: string;
+  headline: string;
+  bullets: string[];
+  stats: string[];
+  insight: string;
+  thinkingTrace: string;
+  generatedAt: number;
+}
+
+const HISTORY_SUMMARY_STEPS: Record<HistorySubtab, string[]> = {
+  releases: [
+    '读取版本时间线、用户更新项和最近可见条目',
+    '统计变更类型、模块热点与发布密度',
+    '压缩成适合顶部快速阅读的发布摘要',
+  ],
+  fragments: [
+    '聚合待发布功能并按日期合并重复上下文',
+    '识别模块热点和最值得优先发布的条目',
+    '整理成当前周的待发布功能摘要',
+  ],
+  github_logs: [
+    '扫描最近提交、作者分布与提交主题',
+    '识别重复推进方向和本轮研发热点',
+    '整理成仓库节奏与趋势摘要',
+  ],
+};
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
 }
 
 function formatLocalDateValue(d: Date): string {
@@ -129,6 +164,160 @@ function writeGitHubLogsCache(data: GitHubLogsView) {
   }
 }
 
+function topCounts(values: string[], limit = 3): Array<{ label: string; count: number }> {
+  const counts = new Map<string, number>();
+  for (const raw of values) {
+    const label = raw.trim();
+    if (!label) continue;
+    counts.set(label, (counts.get(label) ?? 0) + 1);
+  }
+  return Array.from(counts.entries())
+    .map(([label, count]) => ({ label, count }))
+    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label))
+    .slice(0, limit);
+}
+
+function formatCountLabels(items: Array<{ label: string; count: number }>): string {
+  return items.map((item) => `${item.label} (${item.count})`).join('、');
+}
+
+function shorten(text: string, max = 42): string {
+  return text.length > max ? `${text.slice(0, max - 1)}…` : text;
+}
+
+function extractLogTopic(message: string): string {
+  const moduleMatch = message.match(/^[a-z]+(?:\(([^)]+)\))?/i);
+  if (moduleMatch?.[1]) return moduleMatch[1];
+  if (moduleMatch?.[0]) return moduleMatch[0].replace(/\(.+$/, '');
+  const head = message.split(/[:：]/)[0]?.trim();
+  return shorten(head || message, 18);
+}
+
+function buildReleaseSummary(releases: ReleasesView, typeFilter: string | null): HistorySummaryResult {
+  const visibleReleases = releases.releases
+    .map((release) => ({
+      ...release,
+      days: release.days
+        .map((day) => ({
+          ...day,
+          entries: day.entries.filter((entry) => !typeFilter || entry.type.toLowerCase() === typeFilter),
+        }))
+        .filter((day) => day.entries.length > 0),
+    }))
+    .filter((release) => release.days.length > 0 || release.highlights.length > 0);
+
+  const entries = visibleReleases.flatMap((release) => release.days.flatMap((day) => day.entries));
+  if (visibleReleases.length === 0 || entries.length === 0) {
+    throw new Error('当前筛选条件下没有可总结的历史发布');
+  }
+
+  const latest = visibleReleases[0];
+  const topTypes = topCounts(entries.map((entry) => getTypeBadge(entry.type).label));
+  const topModules = topCounts(entries.map((entry) => entry.module));
+  const latestHighlight = latest.highlights[0];
+
+  return {
+    title: 'CHANGELOG 发布摘要',
+    headline: `当前最值得先看的版本是 ${latest.version === '未发布' ? '未发布' : `v${latest.version}`}，共整理 ${entries.length} 条可见更新。`,
+    bullets: [
+      latestHighlight
+        ? `面向用户最值得先讲的是：${shorten(latestHighlight, 56)}`
+        : `最近版本主要围绕 ${topModules.length ? formatCountLabels(topModules) : '多模块并行推进'} 展开。`,
+      topTypes.length
+        ? `变更类型以 ${formatCountLabels(topTypes)} 为主。`
+        : '当前筛选下没有形成明显的类型集中趋势。',
+      topModules.length
+        ? `模块热点集中在 ${formatCountLabels(topModules)}。`
+        : '模块分布较分散，适合按用户更新项来讲。',
+    ],
+    stats: [
+      `${visibleReleases.length} 个版本`,
+      `${entries.length} 条更新`,
+      `${new Set(entries.map((entry) => entry.module)).size} 个模块`,
+    ],
+    insight: typeFilter
+      ? `当前摘要已按「${getTypeBadge(typeFilter).label}」筛选，适合只看这一类变更。`
+      : '适合先讲版本价值，再下钻到模块条目。',
+    thinkingTrace: '',
+    generatedAt: Date.now(),
+  };
+}
+
+function buildFragmentSummary(currentWeek: CurrentWeekView, typeFilter: string | null): HistorySummaryResult {
+  const rows = currentWeek.fragments.flatMap((fragment) =>
+    fragment.entries
+      .filter((entry) => !typeFilter || entry.type.toLowerCase() === typeFilter)
+      .map((entry) => ({ ...entry, date: fragment.date, fileName: fragment.fileName })),
+  );
+  if (rows.length === 0) {
+    throw new Error('当前筛选条件下没有可总结的待发布功能');
+  }
+
+  const topTypes = topCounts(rows.map((entry) => getTypeBadge(entry.type).label));
+  const topModules = topCounts(rows.map((entry) => entry.module));
+  const groupedDates = topCounts(rows.map((entry) => entry.date), 2);
+  const samples = rows.slice(0, 3).map((entry) => shorten(entry.description, 48));
+
+  return {
+    title: '待发布功能摘要',
+    headline: `当前待发布池里共有 ${rows.length} 条条目，覆盖 ${new Set(rows.map((row) => row.date)).size} 个日期批次。`,
+    bullets: [
+      topModules.length
+        ? `模块热度最高的是 ${formatCountLabels(topModules)}。`
+        : '目前没有明显的模块集中趋势。',
+      topTypes.length
+        ? `条目类型主要是 ${formatCountLabels(topTypes)}。`
+        : '条目类型较分散，适合按日期逐组发布。',
+      samples.length > 0
+        ? `最值得优先讲的功能点包括：${samples.join('；')}`
+        : '当前待发布功能仍需要进一步整理成发布话术。',
+    ],
+    stats: [
+      `${rows.length} 条待发布`,
+      `${new Set(rows.map((row) => row.module)).size} 个模块`,
+      groupedDates.length ? `高频日期 ${formatCountLabels(groupedDates)}` : '日期分布较散',
+    ],
+    insight: '更适合当作“下一版准备发布什么”的预告区，而不是当历史记录看。',
+    thinkingTrace: '',
+    generatedAt: Date.now(),
+  };
+}
+
+function buildGitHubLogSummary(logsView: GitHubLogsView): HistorySummaryResult {
+  const logs = logsView.logs.slice(0, GITHUB_LOGS_FETCH_LIMIT);
+  if (logs.length === 0) {
+    throw new Error('当前没有可总结的 GitHub 日志');
+  }
+
+  const topAuthors = topCounts(logs.map((log) => log.authorName));
+  const topTopics = topCounts(logs.map((log) => extractLogTopic(log.message)));
+  const latestMessages = logs.slice(0, 3).map((log) => shorten(log.message, 46));
+
+  return {
+    title: 'GitHub 日志摘要',
+    headline: `最近 ${logs.length} 条提交主要由 ${topAuthors.length ? formatCountLabels(topAuthors) : '多人协同'} 推进。`,
+    bullets: [
+      topTopics.length
+        ? `提交主题集中在 ${formatCountLabels(topTopics)}。`
+        : '当前提交主题较分散，没有形成单一热点。',
+      latestMessages.length > 0
+        ? `最近几条动作包括：${latestMessages.join('；')}`
+        : '最近没有足够的提交内容可用于提炼。',
+      logsView.source === 'local'
+        ? '当前日志来自本地 git log，响应会更快，也更适合看实时推进节奏。'
+        : '当前日志来自 GitHub commits API，适合看远端主线的最新推进。',
+    ],
+    stats: [
+      `${logs.length} 条提交`,
+      `${new Set(logs.map((log) => log.authorName)).size} 位作者`,
+      `${logsView.source === 'local' ? '本地仓库' : 'GitHub API'} 源`,
+    ],
+    insight: '适合用来判断这轮开发是在收尾修补，还是在推进新的主线功能。',
+    thinkingTrace: '',
+    generatedAt: Date.now(),
+  };
+}
+
 export default function ChangelogPage() {
   const currentWeek = useChangelogStore((s) => s.currentWeek);
   const releases = useChangelogStore((s) => s.releases);
@@ -144,6 +333,27 @@ export default function ChangelogPage() {
   const [githubLogs, setGitHubLogs] = useState<GitHubLogsView | null>(() => readGitHubLogsCache());
   const [loadingGitHubLogs, setLoadingGitHubLogs] = useState(false);
   const [gitHubLogsError, setGitHubLogsError] = useState<string | null>(null);
+  const [summaryCache, setSummaryCache] = useState<Record<HistorySubtab, HistorySummaryResult | null>>({
+    releases: null,
+    fragments: null,
+    github_logs: null,
+  });
+  const [summaryStatus, setSummaryStatus] = useState<Record<HistorySubtab, HistorySummaryStatus>>({
+    releases: 'idle',
+    fragments: 'idle',
+    github_logs: 'idle',
+  });
+  const [summaryThinking, setSummaryThinking] = useState<Record<HistorySubtab, string>>({
+    releases: '',
+    fragments: '',
+    github_logs: '',
+  });
+  const [summaryError, setSummaryError] = useState<Record<HistorySubtab, string | null>>({
+    releases: null,
+    fragments: null,
+    github_logs: null,
+  });
+  const summaryRunRef = useRef(0);
 
   /**
    * NEW 徽章 cutoff：用户上次打开更新中心那天的 23:59:59.999。
@@ -208,8 +418,8 @@ export default function ChangelogPage() {
       return () => window.cancelIdleCallback(idleId);
     }
 
-    const timer = window.setTimeout(run, 800);
-    return () => window.clearTimeout(timer);
+    const timer = globalThis.setTimeout(run, 800);
+    return () => globalThis.clearTimeout(timer);
   }, [activeTab, historySubtab, loadingGitHubLogs, githubLogs]);
 
   const handleRefresh = () => {
@@ -226,6 +436,67 @@ export default function ChangelogPage() {
           setGitHubLogsError(res.error?.message || '加载 GitHub 日志失败');
         }
       }).finally(() => setLoadingGitHubLogs(false));
+    }
+  };
+
+  const summarizeCurrentTab = async () => {
+    const tab = historySubtab;
+    const runId = ++summaryRunRef.current;
+    const startedAt = Date.now();
+    setSummaryError((prev) => ({ ...prev, [tab]: null }));
+    setSummaryStatus((prev) => ({ ...prev, [tab]: 'loading' }));
+    setSummaryThinking((prev) => ({ ...prev, [tab]: '' }));
+
+    let thinkingTrace = '';
+    try {
+      for (const [index, step] of HISTORY_SUMMARY_STEPS[tab].entries()) {
+        thinkingTrace = `${thinkingTrace}${thinkingTrace ? '\n' : ''}${index + 1}. ${step}`;
+        if (summaryRunRef.current !== runId) return;
+        setSummaryThinking((prev) => ({ ...prev, [tab]: thinkingTrace }));
+        await delay(420);
+      }
+
+      let summary: HistorySummaryResult;
+      if (tab === 'releases') {
+        if (!releases) throw new Error('历史发布还没加载完成');
+        summary = buildReleaseSummary(releases, typeFilter);
+      } else if (tab === 'fragments') {
+        if (!currentWeek) throw new Error('待发布功能还没加载完成');
+        summary = buildFragmentSummary(currentWeek, typeFilter);
+      } else {
+        let logs = githubLogs;
+        if (!logs) {
+          const res = await getChangelogGitHubLogs(GITHUB_LOGS_FETCH_LIMIT);
+          if (!res.success) throw new Error(res.error?.message || '加载 GitHub 日志失败');
+          logs = res.data;
+          setGitHubLogs(res.data);
+          writeGitHubLogsCache(res.data);
+        }
+        summary = buildGitHubLogSummary(logs);
+      }
+
+      const elapsed = Date.now() - startedAt;
+      if (elapsed < 2000) {
+        await delay(2000 - elapsed);
+      }
+      if (summaryRunRef.current !== runId) return;
+
+      const completed = {
+        ...summary,
+        thinkingTrace,
+        generatedAt: Date.now(),
+      };
+      setSummaryCache((prev) => ({ ...prev, [tab]: completed }));
+      setSummaryThinking((prev) => ({ ...prev, [tab]: thinkingTrace }));
+      setSummaryStatus((prev) => ({ ...prev, [tab]: 'ready' }));
+    } catch (error) {
+      if (summaryRunRef.current !== runId) return;
+      setSummaryStatus((prev) => ({ ...prev, [tab]: 'error' }));
+      setSummaryError((prev) => ({
+        ...prev,
+        [tab]: error instanceof Error ? error.message : '总结失败',
+      }));
+      setSummaryThinking((prev) => ({ ...prev, [tab]: thinkingTrace }));
     }
   };
 
@@ -279,6 +550,15 @@ export default function ChangelogPage() {
       return '';
     }
   })();
+  const activeSummary = summaryCache[historySubtab];
+  const activeSummaryStatus = summaryStatus[historySubtab];
+  const activeSummaryThinking = summaryThinking[historySubtab];
+  const activeSummaryError = summaryError[historySubtab];
+  const activeSummaryLabel = historySubtab === 'releases'
+    ? 'CHANGELOG'
+    : historySubtab === 'fragments'
+      ? '待发布功能'
+      : 'GitHub 日志';
 
   return (
     <WeeklyReportSourcesProvider>
@@ -472,14 +752,149 @@ export default function ChangelogPage() {
               );
             })}
           </div>
-          <span className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
-            {historySubtab === 'releases' && '来自 CHANGELOG.md'}
-            {historySubtab === 'fragments' && '来自 changelogs/*.md（待合入 CHANGELOG）'}
-            {historySubtab === 'github_logs' && (
-              githubLogs?.source === 'local' ? '来自本地 git log' : '来自 GitHub commits API'
-            )}
-          </span>
+          <div className="flex items-center gap-3 flex-wrap justify-end">
+            <span className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
+              {historySubtab === 'releases' && '来自 CHANGELOG.md'}
+              {historySubtab === 'fragments' && '来自 changelogs/*.md（待合入 CHANGELOG）'}
+              {historySubtab === 'github_logs' && (
+                githubLogs?.source === 'local' ? '来自本地 git log' : '来自 GitHub commits API'
+              )}
+            </span>
+            <div
+              style={{
+                transform: 'scale(0.82)',
+                transformOrigin: 'right center',
+                opacity: activeSummaryStatus === 'loading' ? 0.76 : 1,
+                pointerEvents: activeSummaryStatus === 'loading' ? 'none' : 'auto',
+              }}
+            >
+              <SparkleButton
+                text={activeSummaryStatus === 'loading' ? '总结中...' : 'AI 总结'}
+                onClick={() => { void summarizeCurrentTab(); }}
+              />
+            </div>
+          </div>
         </div>
+
+        {(activeSummaryStatus !== 'idle' || activeSummary) && (
+          <div
+            className="mb-4 rounded-2xl px-4 py-4"
+            style={{
+              background: 'linear-gradient(135deg, rgba(99, 102, 241, 0.10), rgba(14, 165, 233, 0.06))',
+              border: '1px solid rgba(99, 102, 241, 0.18)',
+              boxShadow: '0 18px 48px rgba(15, 23, 42, 0.22)',
+            }}
+          >
+            <div className="flex items-start justify-between gap-4 flex-wrap">
+              <div>
+                <div
+                  className="inline-flex items-center gap-2 px-2.5 py-1 rounded-full text-[11px] font-semibold mb-2"
+                  style={{
+                    background: 'rgba(255, 255, 255, 0.06)',
+                    border: '1px solid rgba(255, 255, 255, 0.08)',
+                    color: '#c7d2fe',
+                  }}
+                >
+                  <Wand2 size={12} />
+                  AI 总结 · {activeSummaryLabel}
+                </div>
+                <div className="text-[18px] font-semibold" style={{ color: 'var(--text-primary)' }}>
+                  {activeSummary?.title ?? `正在总结 ${activeSummaryLabel}`}
+                </div>
+                <div className="text-[13px] mt-1 leading-relaxed" style={{ color: 'var(--text-secondary)' }}>
+                  {activeSummaryStatus === 'loading'
+                    ? '先在 2 秒内给出结构和方向，再补完整摘要。'
+                    : activeSummary?.headline}
+                </div>
+              </div>
+              <div
+                className="inline-flex items-center gap-2 text-[12px]"
+                style={{ color: 'var(--text-muted)' }}
+              >
+                <Brain size={13} />
+                {activeSummaryStatus === 'loading' && (
+                  <>
+                    <MapSpinner size={12} />
+                    <span>思考中…</span>
+                  </>
+                )}
+                {activeSummaryStatus === 'ready' && activeSummary && (
+                  <span>{new Date(activeSummary.generatedAt).toLocaleTimeString()}</span>
+                )}
+              </div>
+            </div>
+
+            {activeSummaryThinking && (
+              <div className="mt-3">
+                <SseTypingBlock
+                  label={activeSummaryStatus === 'loading' ? '思考过程' : '分析轨迹'}
+                  text={activeSummaryThinking}
+                  tailChars={800}
+                  maxHeight={140}
+                  showCursor={activeSummaryStatus === 'loading'}
+                />
+              </div>
+            )}
+
+            {activeSummaryStatus === 'error' && activeSummaryError && (
+              <div
+                className="mt-3 rounded-xl px-3 py-2 text-[12px]"
+                style={{
+                  background: 'rgba(248, 113, 113, 0.08)',
+                  border: '1px solid rgba(248, 113, 113, 0.22)',
+                  color: '#fca5a5',
+                }}
+              >
+                ⚠ {activeSummaryError}
+              </div>
+            )}
+
+            {activeSummaryStatus === 'ready' && activeSummary && (
+              <div className="mt-3 flex flex-col gap-3">
+                <div className="flex flex-wrap gap-2">
+                  {activeSummary.stats.map((stat) => (
+                    <span
+                      key={stat}
+                      className="px-2.5 py-1 rounded-full text-[11px] font-medium"
+                      style={{
+                        background: 'rgba(255, 255, 255, 0.05)',
+                        border: '1px solid rgba(255, 255, 255, 0.08)',
+                        color: 'var(--text-secondary)',
+                      }}
+                    >
+                      {stat}
+                    </span>
+                  ))}
+                </div>
+                <div className="grid gap-2">
+                  {activeSummary.bullets.map((bullet, index) => (
+                    <div
+                      key={`${activeSummary.title}-${index}`}
+                      className="rounded-xl px-3 py-2 text-[13px] leading-relaxed"
+                      style={{
+                        background: 'rgba(255, 255, 255, 0.03)',
+                        border: '1px solid rgba(255, 255, 255, 0.06)',
+                        color: 'var(--text-secondary)',
+                      }}
+                    >
+                      {bullet}
+                    </div>
+                  ))}
+                </div>
+                <div
+                  className="rounded-xl px-3 py-2 text-[12px] leading-relaxed"
+                  style={{
+                    background: 'rgba(99, 102, 241, 0.08)',
+                    border: '1px solid rgba(99, 102, 241, 0.14)',
+                    color: '#dbeafe',
+                  }}
+                >
+                  {activeSummary.insight}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
 
         {historySubtab === 'releases' && (
           <>

--- a/prd-admin/src/pages/changelog/ChangelogPage.tsx
+++ b/prd-admin/src/pages/changelog/ChangelogPage.tsx
@@ -56,6 +56,15 @@ interface FlatEntry extends ChangelogEntry {
 
 type HistorySubtab = 'releases' | 'fragments' | 'github_logs';
 
+const GITHUB_LOGS_CACHE_KEY = 'changelog:github-logs:v1';
+const GITHUB_LOGS_CACHE_TTL_MS = 5 * 60 * 1000;
+const GITHUB_LOGS_FETCH_LIMIT = 30;
+
+interface GitHubLogsCachePayload {
+  cachedAt: number;
+  data: GitHubLogsView;
+}
+
 function formatLocalDateValue(d: Date): string {
   const pad = (n: number) => n.toString().padStart(2, '0');
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
@@ -93,6 +102,33 @@ function getReleaseDisplayDate(releaseDate: string | null, days: Array<{ date: s
   return releaseDate;
 }
 
+function readGitHubLogsCache(): GitHubLogsView | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = sessionStorage.getItem(GITHUB_LOGS_CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as GitHubLogsCachePayload;
+    if (!parsed || typeof parsed.cachedAt !== 'number' || !parsed.data) return null;
+    if (Date.now() - parsed.cachedAt > GITHUB_LOGS_CACHE_TTL_MS) {
+      sessionStorage.removeItem(GITHUB_LOGS_CACHE_KEY);
+      return null;
+    }
+    return parsed.data;
+  } catch {
+    return null;
+  }
+}
+
+function writeGitHubLogsCache(data: GitHubLogsView) {
+  if (typeof window === 'undefined') return;
+  try {
+    const payload: GitHubLogsCachePayload = { cachedAt: Date.now(), data };
+    sessionStorage.setItem(GITHUB_LOGS_CACHE_KEY, JSON.stringify(payload));
+  } catch {
+    // ignore cache write failures
+  }
+}
+
 export default function ChangelogPage() {
   const currentWeek = useChangelogStore((s) => s.currentWeek);
   const releases = useChangelogStore((s) => s.releases);
@@ -105,7 +141,7 @@ export default function ChangelogPage() {
   const [typeFilter, setTypeFilter] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<string>('update_center');
   const [historySubtab, setHistorySubtab] = useState<HistorySubtab>('releases');
-  const [githubLogs, setGitHubLogs] = useState<GitHubLogsView | null>(null);
+  const [githubLogs, setGitHubLogs] = useState<GitHubLogsView | null>(() => readGitHubLogsCache());
   const [loadingGitHubLogs, setLoadingGitHubLogs] = useState(false);
   const [gitHubLogsError, setGitHubLogsError] = useState<string | null>(null);
 
@@ -138,10 +174,11 @@ export default function ChangelogPage() {
     let alive = true;
     setLoadingGitHubLogs(true);
     setGitHubLogsError(null);
-    void getChangelogGitHubLogs(40).then((res) => {
+    void getChangelogGitHubLogs(GITHUB_LOGS_FETCH_LIMIT).then((res) => {
       if (!alive) return;
       if (res.success) {
         setGitHubLogs(res.data);
+        writeGitHubLogsCache(res.data);
       } else {
         setGitHubLogsError(res.error?.message || '加载 GitHub 日志失败');
       }
@@ -151,15 +188,47 @@ export default function ChangelogPage() {
     return () => { alive = false; };
   }, [activeTab, historySubtab, loadingGitHubLogs, githubLogs]);
 
+  useEffect(() => {
+    if (activeTab !== 'update_center' || historySubtab === 'github_logs' || loadingGitHubLogs || githubLogs) return;
+    let alive = true;
+    const run = () => {
+      setLoadingGitHubLogs(true);
+      void getChangelogGitHubLogs(GITHUB_LOGS_FETCH_LIMIT).then((res) => {
+        if (!alive) return;
+        if (res.success) {
+          setGitHubLogs(res.data);
+          writeGitHubLogsCache(res.data);
+        }
+      }).finally(() => {
+        if (alive) setLoadingGitHubLogs(false);
+      });
+    };
+
+    if ('requestIdleCallback' in window) {
+      const idleId = window.requestIdleCallback(run, { timeout: 1500 });
+      return () => {
+        alive = false;
+        window.cancelIdleCallback(idleId);
+      };
+    }
+
+    const timer = window.setTimeout(run, 800);
+    return () => {
+      alive = false;
+      window.clearTimeout(timer);
+    };
+  }, [activeTab, historySubtab, loadingGitHubLogs, githubLogs]);
+
   const handleRefresh = () => {
     void loadCurrentWeek(true);
     void loadReleases(20, true);
     if (historySubtab === 'github_logs' || githubLogs) {
       setLoadingGitHubLogs(true);
       setGitHubLogsError(null);
-      void getChangelogGitHubLogs(40, true).then((res) => {
+      void getChangelogGitHubLogs(GITHUB_LOGS_FETCH_LIMIT, true).then((res) => {
         if (res.success) {
           setGitHubLogs(res.data);
+          writeGitHubLogsCache(res.data);
         } else {
           setGitHubLogsError(res.error?.message || '加载 GitHub 日志失败');
         }
@@ -458,7 +527,7 @@ export default function ChangelogPage() {
 
                   return (
                     <div key={`${release.version}-${release.releaseDate ?? ''}`}>
-                      <div className="flex items-center gap-2 mb-3">
+                        <div className="flex items-center gap-2 mb-3">
                         <div
                           className="px-2.5 py-0.5 rounded-md text-[12px] font-semibold font-mono"
                           style={{
@@ -506,27 +575,38 @@ export default function ChangelogPage() {
                       {visibleDays.length > 0 && (
                         <div className="flex flex-col gap-3">
                           {visibleDays.map((day, dayIdx) => {
-                            const dayDisplayDate = formatDisplayDate(day.date, day.commitTimeUtc);
-                            const dayTitle = day.commitTimeUtc && dayDisplayDate !== day.date
-                              ? `CHANGELOG 日期：${day.date}\nGitHub 本地日期：${dayDisplayDate}`
+                            const dayCommitDisplayDate = formatDisplayDate(day.date, day.commitTimeUtc);
+                            const dayTitle = day.commitTimeUtc && dayCommitDisplayDate !== day.date
+                              ? `CHANGELOG 日期：${day.date}\nGitHub commit 本地日期：${dayCommitDisplayDate}`
                               : undefined;
                             return (
                               <div key={`${day.date}-${dayIdx}`}>
-                                <div
-                                  className="inline-flex items-center gap-2 mb-2.5 px-2.5 py-1 rounded-md"
-                                  style={{
-                                    background: 'rgba(255, 255, 255, 0.04)',
-                                    border: '1px solid rgba(255, 255, 255, 0.08)',
-                                    color: 'var(--text-secondary)',
-                                    fontSize: '13px',
-                                    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
-                                    fontWeight: 600,
-                                    letterSpacing: '0.02em',
-                                  }}
-                                  title={dayTitle}
-                                >
-                                  <Calendar size={13} />
-                                  {dayDisplayDate}
+                                <div className="flex items-center gap-2 mb-2.5 flex-wrap">
+                                  <div
+                                    className="inline-flex items-center gap-2 px-2.5 py-1 rounded-md"
+                                    style={{
+                                      background: 'rgba(255, 255, 255, 0.04)',
+                                      border: '1px solid rgba(255, 255, 255, 0.08)',
+                                      color: 'var(--text-secondary)',
+                                      fontSize: '13px',
+                                      fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+                                      fontWeight: 600,
+                                      letterSpacing: '0.02em',
+                                    }}
+                                    title={dayTitle}
+                                  >
+                                    <Calendar size={13} />
+                                    {day.date}
+                                  </div>
+                                  {day.commitTimeUtc && dayCommitDisplayDate !== day.date && (
+                                    <span
+                                      className="text-[11px] font-mono"
+                                      style={{ color: 'var(--text-muted)' }}
+                                      title={`GitHub commit 本地日期：${dayCommitDisplayDate}`}
+                                    >
+                                      提交落地 {dayCommitDisplayDate}
+                                    </span>
+                                  )}
                                 </div>
                                 <div className="flex flex-col gap-1.5">
                                   {day.entries.map((e, idx) => (

--- a/prd-admin/src/pages/changelog/ChangelogPage.tsx
+++ b/prd-admin/src/pages/changelog/ChangelogPage.tsx
@@ -285,7 +285,11 @@ export default function ChangelogPage() {
         } else {
           setGitHubLogsError(res.error?.message || '加载 GitHub 日志失败');
         }
-      }).finally(() => setLoadingGitHubLogs(false));
+      }).catch((error: unknown) => {
+        setGitHubLogsError(error instanceof Error ? error.message : '加载 GitHub 日志失败');
+      }).finally(() => {
+        setLoadingGitHubLogs(false);
+      });
     }
   };
 

--- a/prd-admin/src/pages/changelog/ChangelogPage.tsx
+++ b/prd-admin/src/pages/changelog/ChangelogPage.tsx
@@ -177,7 +177,14 @@ export default function ChangelogPage() {
     fragments: null,
     github_logs: null,
   });
-  const summaryRunRef = useRef(0);
+  /** 各子 tab 独立世代，避免切 tab 后先发起的请求被后一次全局 runId 误判为过期而永久卡在 loading */
+  const summaryRunByTab = useRef<Record<HistorySubtab, number>>({
+    releases: 0,
+    fragments: 0,
+    github_logs: 0,
+  });
+  /** 后台预取 GitHub 日志只调度一次，避免失败时 idle/timeout 反复触发 */
+  const githubLogsPrefetchScheduledRef = useRef(false);
 
   /**
    * NEW 徽章 cutoff：用户上次打开更新中心那天的 23:59:59.999。
@@ -203,8 +210,17 @@ export default function ChangelogPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // 离开 GitHub 日志子 tab 或离开更新中心主 tab 时清错误，返回时可重新拉取
   useEffect(() => {
-    if (activeTab !== 'update_center' || historySubtab !== 'github_logs' || loadingGitHubLogs || githubLogs) return;
+    if (activeTab !== 'update_center' || historySubtab !== 'github_logs') {
+      setGitHubLogsError(null);
+    }
+  }, [activeTab, historySubtab]);
+
+  useEffect(() => {
+    if (activeTab !== 'update_center' || historySubtab !== 'github_logs' || loadingGitHubLogs || githubLogs || gitHubLogsError) {
+      return;
+    }
     setLoadingGitHubLogs(true);
     setGitHubLogsError(null);
     void getChangelogGitHubLogs(GITHUB_LOGS_FETCH_LIMIT).then((res) => {
@@ -219,10 +235,19 @@ export default function ChangelogPage() {
     }).finally(() => {
       setLoadingGitHubLogs(false);
     });
-  }, [activeTab, historySubtab, loadingGitHubLogs, githubLogs]);
+    // 不依赖 loadingGitHubLogs：避免失败后 false 再次触发 effect 形成请求风暴；失败由 gitHubLogsError 挡住直至离开子 tab 或刷新
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeTab, historySubtab, githubLogs, gitHubLogsError]);
 
   useEffect(() => {
-    if (activeTab !== 'update_center' || historySubtab === 'github_logs' || loadingGitHubLogs || githubLogs) return;
+    if (activeTab !== 'update_center' || historySubtab === 'github_logs' || loadingGitHubLogs || githubLogs) {
+      return;
+    }
+    if (githubLogsPrefetchScheduledRef.current) {
+      return;
+    }
+    githubLogsPrefetchScheduledRef.current = true;
+
     const run = () => {
       setLoadingGitHubLogs(true);
       void getChangelogGitHubLogs(GITHUB_LOGS_FETCH_LIMIT).then((res) => {
@@ -244,7 +269,8 @@ export default function ChangelogPage() {
 
     const timer = globalThis.setTimeout(run, 800);
     return () => globalThis.clearTimeout(timer);
-  }, [activeTab, historySubtab, loadingGitHubLogs, githubLogs]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeTab, historySubtab, githubLogs]);
 
   const handleRefresh = () => {
     void loadCurrentWeek(true);
@@ -265,7 +291,8 @@ export default function ChangelogPage() {
 
   const summarizeCurrentTab = async () => {
     const tab = historySubtab;
-    const runId = ++summaryRunRef.current;
+    summaryRunByTab.current[tab] += 1;
+    const runId = summaryRunByTab.current[tab];
     setSummaryError((prev) => ({ ...prev, [tab]: null }));
     setSummaryStatus((prev) => ({ ...prev, [tab]: 'loading' }));
     setSummaryThinking((prev) => ({
@@ -278,7 +305,7 @@ export default function ChangelogPage() {
         subtab: tab,
         typeFilter: typeFilter ?? undefined,
       });
-      if (summaryRunRef.current !== runId) return;
+      if (summaryRunByTab.current[tab] !== runId) return;
       if (!res.success || !res.data) {
         throw new Error(res.error?.message || 'AI 总结失败');
       }
@@ -296,7 +323,7 @@ export default function ChangelogPage() {
       setSummaryThinking((prev) => ({ ...prev, [tab]: data.thinkingTrace || '' }));
       setSummaryStatus((prev) => ({ ...prev, [tab]: 'ready' }));
     } catch (error) {
-      if (summaryRunRef.current !== runId) return;
+      if (summaryRunByTab.current[tab] !== runId) return;
       setSummaryStatus((prev) => ({ ...prev, [tab]: 'error' }));
       setSummaryError((prev) => ({
         ...prev,

--- a/prd-admin/src/pages/changelog/ChangelogPage.tsx
+++ b/prd-admin/src/pages/changelog/ChangelogPage.tsx
@@ -449,7 +449,7 @@ export default function ChangelogPage() {
             </h2>
             {([
               { key: 'releases', label: 'CHANGELOG', icon: <Calendar size={13} /> },
-              { key: 'fragments', label: '碎片补充', icon: <FileText size={13} /> },
+              { key: 'fragments', label: '待发布功能', icon: <FileText size={13} /> },
               { key: 'github_logs', label: 'GitHub 日志', icon: <Github size={13} /> },
             ] as const).map((tab) => {
               const active = historySubtab === tab.key;
@@ -474,7 +474,7 @@ export default function ChangelogPage() {
           </div>
           <span className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
             {historySubtab === 'releases' && '来自 CHANGELOG.md'}
-            {historySubtab === 'fragments' && '来自 changelogs/*.md（当前周碎片）'}
+            {historySubtab === 'fragments' && '来自 changelogs/*.md（待合入 CHANGELOG）'}
             {historySubtab === 'github_logs' && (
               githubLogs?.source === 'local' ? '来自本地 git log' : '来自 GitHub commits API'
             )}
@@ -621,7 +621,7 @@ export default function ChangelogPage() {
 
         {historySubtab === 'fragments' && (
           <>
-            {!currentWeek && <MapSectionLoader text="正在加载碎片补充…" />}
+            {!currentWeek && <MapSectionLoader text="正在加载待发布功能…" />}
 
             {currentWeek && currentWeek.fragments.length === 0 && (
               <div
@@ -632,7 +632,7 @@ export default function ChangelogPage() {
                   color: 'var(--text-muted)',
                 }}
               >
-                当前周暂无碎片日志
+                当前周暂无待发布功能
               </div>
             )}
 
@@ -645,18 +645,35 @@ export default function ChangelogPage() {
                   color: 'var(--text-muted)',
                 }}
               >
-                当前筛选条件下暂无碎片条目
+                当前筛选条件下暂无待发布条目
               </div>
             )}
 
             {currentWeek && currentWeek.fragments.filter((f) => f.entries.some(matchFilter)).length > 0 && (
               <div className="flex flex-col gap-4">
-                {currentWeek.fragments.map((fragment) => {
-                  const visibleEntries = fragment.entries.filter(matchFilter);
-                  if (visibleEntries.length === 0) return null;
-                  return (
+                {(() => {
+                  const grouped = currentWeek.fragments.reduce<Array<{
+                    date: string;
+                    rows: Array<FlatEntry & { fileName: string }>;
+                  }>>((acc, fragment) => {
+                    const visibleEntries = fragment.entries.filter(matchFilter);
+                    if (visibleEntries.length === 0) return acc;
+                    const bucket = acc.find((item) => item.date === fragment.date);
+                    const rows = visibleEntries.map((entry) => ({
+                      ...entry,
+                      date: fragment.date,
+                      commitTimeUtc: null,
+                      source: 'fragment' as const,
+                      fileName: fragment.fileName,
+                    }));
+                    if (bucket) bucket.rows.push(...rows);
+                    else acc.push({ date: fragment.date, rows });
+                    return acc;
+                  }, []);
+
+                  return grouped.map((group) => (
                     <div
-                      key={fragment.fileName}
+                      key={group.date}
                       className="rounded-xl px-4 py-3"
                       style={{
                         background: 'rgba(255, 255, 255, 0.025)',
@@ -676,32 +693,24 @@ export default function ChangelogPage() {
                           }}
                         >
                           <Calendar size={13} />
-                          {fragment.date}
+                          {group.date}
                         </div>
-                        <span className="text-[12px]" style={{ color: 'var(--text-muted)' }}>
-                          {fragment.fileName}
-                        </span>
                         <span className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
-                          · {visibleEntries.length} 条
+                          · {group.rows.length} 条
                         </span>
                       </div>
                       <div className="flex flex-col gap-1.5">
-                        {visibleEntries.map((entry, idx) => (
+                        {group.rows.map((entry, idx) => (
                           <EntryRow
-                            key={`${fragment.fileName}-${idx}`}
-                            entry={{
-                              ...entry,
-                              date: fragment.date,
-                              commitTimeUtc: null,
-                              source: 'fragment',
-                            }}
+                            key={`${group.date}-${entry.fileName}-${idx}`}
+                            entry={entry}
                             newCutoff={newBadgeCutoff}
                           />
                         ))}
                       </div>
                     </div>
-                  );
-                })}
+                  ));
+                })()}
               </div>
             )}
           </>

--- a/prd-admin/src/pages/changelog/ChangelogPage.tsx
+++ b/prd-admin/src/pages/changelog/ChangelogPage.tsx
@@ -171,52 +171,45 @@ export default function ChangelogPage() {
 
   useEffect(() => {
     if (activeTab !== 'update_center' || historySubtab !== 'github_logs' || loadingGitHubLogs || githubLogs) return;
-    let alive = true;
     setLoadingGitHubLogs(true);
     setGitHubLogsError(null);
     void getChangelogGitHubLogs(GITHUB_LOGS_FETCH_LIMIT).then((res) => {
-      if (!alive) return;
       if (res.success) {
         setGitHubLogs(res.data);
         writeGitHubLogsCache(res.data);
       } else {
         setGitHubLogsError(res.error?.message || '加载 GitHub 日志失败');
       }
+    }).catch((error: unknown) => {
+      setGitHubLogsError(error instanceof Error ? error.message : '加载 GitHub 日志失败');
     }).finally(() => {
-      if (alive) setLoadingGitHubLogs(false);
+      setLoadingGitHubLogs(false);
     });
-    return () => { alive = false; };
   }, [activeTab, historySubtab, loadingGitHubLogs, githubLogs]);
 
   useEffect(() => {
     if (activeTab !== 'update_center' || historySubtab === 'github_logs' || loadingGitHubLogs || githubLogs) return;
-    let alive = true;
     const run = () => {
       setLoadingGitHubLogs(true);
       void getChangelogGitHubLogs(GITHUB_LOGS_FETCH_LIMIT).then((res) => {
-        if (!alive) return;
         if (res.success) {
           setGitHubLogs(res.data);
           writeGitHubLogsCache(res.data);
         }
+      }).catch(() => {
+        // 预取失败不打断当前页，用户切到 GitHub 日志时会显式重试
       }).finally(() => {
-        if (alive) setLoadingGitHubLogs(false);
+        setLoadingGitHubLogs(false);
       });
     };
 
     if ('requestIdleCallback' in window) {
       const idleId = window.requestIdleCallback(run, { timeout: 1500 });
-      return () => {
-        alive = false;
-        window.cancelIdleCallback(idleId);
-      };
+      return () => window.cancelIdleCallback(idleId);
     }
 
     const timer = window.setTimeout(run, 800);
-    return () => {
-      alive = false;
-      window.clearTimeout(timer);
-    };
+    return () => window.clearTimeout(timer);
   }, [activeTab, historySubtab, loadingGitHubLogs, githubLogs]);
 
   const handleRefresh = () => {

--- a/prd-admin/src/pages/changelog/components/WeeklyReportsTab.tsx
+++ b/prd-admin/src/pages/changelog/components/WeeklyReportsTab.tsx
@@ -21,7 +21,6 @@ import type {
 } from '@/services/real/changelog';
 import { MarkdownContent } from '@/components/ui/MarkdownContent';
 import { MapSectionLoader, MapSpinner } from '@/components/ui/VideoLoader';
-import { glassPanel } from '@/lib/glassStyles';
 import { toast } from '@/lib/toast';
 import { useChangelogStore } from '@/stores/changelogStore';
 import { useWeeklyReportSources } from './weeklyReportSourcesContext';
@@ -234,37 +233,30 @@ export function WeeklyReportsTab() {
     <div className="flex flex-col flex-1 min-h-0" style={{ minHeight: '560px' }}>
       {/* ── 主体：左右独立滚动 ── */}
       <div
-        className="flex gap-3 rounded-2xl"
+        className="surface-raised text-crisp relative flex gap-3 rounded-2xl overflow-hidden"
         style={{
-          ...glassPanel,
           flex: 1,
           minHeight: 0,
           padding: '12px',
-          overflow: 'hidden',
         }}
       >
         {/* 左：文件列表 */}
         <aside
-          className="flex flex-col rounded-xl"
+          className="surface-reading text-crisp flex flex-col rounded-xl"
           style={{
-            width: '300px',
+            width: '308px',
             flexShrink: 0,
             minHeight: 0,
-            background: 'rgba(255,255,255,0.05)',
-            border: '1px solid rgba(255,255,255,0.10)',
             overflow: 'hidden',
           }}
         >
           <div
-            className="px-3 py-2 flex items-center justify-between gap-2"
-            style={{
-              borderBottom: '1px solid rgba(255,255,255,0.04)',
-              flexShrink: 0,
-            }}
+            className="surface-reading-header px-4 py-3 flex items-center justify-between gap-2"
+            style={{ flexShrink: 0 }}
           >
             <div className="flex items-center gap-2 min-w-0">
               <span
-                className="text-[11px] font-semibold uppercase tracking-wider truncate"
+                className="text-[12px] font-semibold truncate"
                 style={{ color: 'var(--text-muted)' }}
                 title={currentStore ? `知识库：${currentStore.name}${activeSource?.prefix ? ' · 关键词：' + activeSource.prefix : ''}` : undefined}
               >
@@ -272,7 +264,7 @@ export function WeeklyReportsTab() {
               </span>
             </div>
             <span
-              className="text-[10.5px] px-1.5 py-0.5 rounded shrink-0"
+              className="text-[11px] px-2 py-0.5 rounded-md shrink-0"
               style={{
                 background: 'rgba(168,85,247,0.14)',
                 color: '#d8b4fe',
@@ -302,7 +294,7 @@ export function WeeklyReportsTab() {
                     : '暂无文件'}
               </div>
             ) : (
-              <ul className="py-1">
+              <ul className="py-2">
                 {filtered.map(e => {
                   const active = selectedId === e.id;
                   const time = getEntryTime(e);
@@ -310,28 +302,27 @@ export function WeeklyReportsTab() {
                   const isGit = !!e.metadata?.github_last_commit_at;
                   const fresh = isAfterCutoff(time, cutoff);
                   return (
-                    <li key={e.id}>
+                    <li key={e.id} className="px-2 py-0.5">
                       <button
                         onClick={() => setSelectedId(e.id)}
-                        className="w-full text-left px-3 py-2 transition-colors"
+                        className="surface-row w-full rounded-[12px] text-left px-3.5 py-3 transition-colors"
+                        data-active={active ? 'true' : 'false'}
                         style={{
-                          background: active ? 'rgba(168,85,247,0.12)' : 'transparent',
-                          color: active ? '#e9d5ff' : 'var(--text-secondary)',
-                          borderLeft: `2px solid ${active ? 'rgba(168,85,247,0.6)' : 'transparent'}`,
+                          color: active ? '#f3e8ff' : 'var(--text-secondary)',
                           cursor: 'pointer',
                         }}
                       >
                         <div className="flex items-center gap-2 min-w-0">
-                          <FileText size={12} style={{ flexShrink: 0, opacity: 0.7 }} />
+                          <FileText size={13} style={{ flexShrink: 0, opacity: 0.72 }} />
                           <span
-                            className="text-[12px] truncate flex-1"
+                            className="text-[13px] font-medium truncate flex-1"
                             title={`${e.title}${titlePreviews[e.id] ? '\n\n' + titlePreviews[e.id] : ''}`}
                           >
                             {titlePreviews[e.id] || e.title}
                           </span>
                           {fresh && (
                             <span
-                              className="text-[9px] font-bold tracking-wider px-1.5 py-[1px] rounded"
+                              className="text-[9.5px] font-bold tracking-wider px-1.5 py-[1px] rounded"
                               style={{
                                 background: 'rgba(34, 197, 94, 0.18)',
                                 color: '#86efac',
@@ -347,8 +338,8 @@ export function WeeklyReportsTab() {
                         </div>
                         {date && (
                           <div
-                            className="text-[10px] mt-0.5 flex items-center gap-1"
-                            style={{ paddingLeft: 20, color: 'var(--text-muted)' }}
+                            className="text-[11px] mt-1 flex items-center gap-1.5"
+                            style={{ paddingLeft: 21, color: 'var(--text-muted)' }}
                             title={isGit ? '最近 git 提交时间' : '同步入库时间'}
                           >
                             <span>{date}</span>
@@ -370,23 +361,17 @@ export function WeeklyReportsTab() {
 
         {/* 右：内容 */}
         <section
-          className="flex flex-col rounded-xl"
+          className="surface-reading text-crisp flex flex-col rounded-xl"
           style={{
             flex: 1,
             minWidth: 0,
             minHeight: 0,
-            background: 'rgba(255,255,255,0.05)',
-            border: '1px solid rgba(255,255,255,0.10)',
             overflow: 'hidden',
           }}
         >
           <div
-            className="px-4 py-2.5 text-[13px] font-semibold truncate"
-            style={{
-              borderBottom: '1px solid rgba(255,255,255,0.04)',
-              color: 'var(--text-primary)',
-              flexShrink: 0,
-            }}
+            className="surface-reading-header px-5 py-3.5 text-[15px] font-semibold truncate"
+            style={{ color: 'var(--text-primary)', flexShrink: 0 }}
           >
             {filtered.find(e => e.id === selectedId)?.title || '（未选中文件）'}
           </div>
@@ -396,7 +381,7 @@ export function WeeklyReportsTab() {
               minHeight: 0,
               overflowY: 'auto',
               overscrollBehavior: 'contain',
-              padding: '20px 28px',
+              padding: '24px 32px',
             }}
           >
             {loadingContent ? (
@@ -406,7 +391,7 @@ export function WeeklyReportsTab() {
                 左侧点击一篇周报查看内容
               </div>
             ) : (
-              <MarkdownContent content={content} />
+              <MarkdownContent content={content} className="text-crisp text-[14px] leading-[1.8]" />
             )}
           </div>
         </section>

--- a/prd-admin/src/services/api.ts
+++ b/prd-admin/src/services/api.ts
@@ -1082,6 +1082,12 @@ export const api = {
       if (force) params.push('force=true');
       return `/api/changelog/releases${params.length ? `?${params.join('&')}` : ''}`;
     },
+    githubLogs: (limit?: number, force?: boolean) => {
+      const params: string[] = [];
+      if (limit) params.push(`limit=${limit}`);
+      if (force) params.push('force=true');
+      return `/api/changelog/github-logs${params.length ? `?${params.join('&')}` : ''}`;
+    },
     sources: {
       list: () => '/api/changelog/sources',
       create: () => '/api/changelog/sources',

--- a/prd-admin/src/services/api.ts
+++ b/prd-admin/src/services/api.ts
@@ -1088,6 +1088,8 @@ export const api = {
       if (force) params.push('force=true');
       return `/api/changelog/github-logs${params.length ? `?${params.join('&')}` : ''}`;
     },
+    /** AI 总结（走 ILlmGateway + prd-admin.changelog.aiSummary::chat） */
+    aiSummary: () => '/api/changelog/ai-summary',
     sources: {
       list: () => '/api/changelog/sources',
       create: () => '/api/changelog/sources',

--- a/prd-admin/src/services/index.ts
+++ b/prd-admin/src/services/index.ts
@@ -1350,6 +1350,7 @@ export {
   getCurrentWeekChangelog,
   getChangelogReleases,
   getChangelogGitHubLogs,
+  postChangelogAiSummary,
   listChangelogReportSources,
   createChangelogReportSource,
   updateChangelogReportSource,
@@ -1365,6 +1366,8 @@ export type {
   ReleasesView,
   GitHubLogEntry,
   GitHubLogsView,
+  ChangelogAiSummarySubtab,
+  ChangelogAiSummaryDto,
   ChangelogReportSource,
   ChangelogReportSourceUpsert,
 } from '@/services/real/changelog';

--- a/prd-admin/src/services/index.ts
+++ b/prd-admin/src/services/index.ts
@@ -1349,6 +1349,7 @@ export const channelService: IChannelService = new ChannelService();
 export {
   getCurrentWeekChangelog,
   getChangelogReleases,
+  getChangelogGitHubLogs,
   listChangelogReportSources,
   createChangelogReportSource,
   updateChangelogReportSource,
@@ -1362,6 +1363,8 @@ export type {
   ChangelogDay,
   ChangelogRelease,
   ReleasesView,
+  GitHubLogEntry,
+  GitHubLogsView,
   ChangelogReportSource,
   ChangelogReportSourceUpsert,
 } from '@/services/real/changelog';

--- a/prd-admin/src/services/real/changelog.ts
+++ b/prd-admin/src/services/real/changelog.ts
@@ -99,6 +99,35 @@ export async function getChangelogGitHubLogs(limit = 30, force = false): Promise
   return await apiRequest<GitHubLogsView>(api.changelog.githubLogs(limit, force), { method: 'GET' });
 }
 
+export type ChangelogAiSummarySubtab = 'releases' | 'fragments' | 'github_logs';
+
+export interface ChangelogAiSummaryDto {
+  title: string;
+  headline: string;
+  bullets: string[];
+  stats: string[];
+  insight: string;
+  /** 网关溯源（AppCallerCode） */
+  thinkingTrace: string;
+  generatedAt: number;
+}
+
+/**
+ * 更新中心「AI 总结」：服务端经 ILlmGateway 调用，AppCallerCode 为 prd-admin.changelog.aiSummary::chat
+ */
+export async function postChangelogAiSummary(body: {
+  subtab: ChangelogAiSummarySubtab;
+  typeFilter?: string | null;
+}): Promise<ApiResponse<ChangelogAiSummaryDto>> {
+  return await apiRequest<ChangelogAiSummaryDto>(api.changelog.aiSummary(), {
+    method: 'POST',
+    body: {
+      subtab: body.subtab,
+      typeFilter: body.typeFilter ?? null,
+    },
+  });
+}
+
 // ============ Report Sources（周报来源配置，全员共享） ============
 
 export interface ChangelogReportSource {

--- a/prd-admin/src/services/real/changelog.ts
+++ b/prd-admin/src/services/real/changelog.ts
@@ -57,6 +57,22 @@ export interface ReleasesView {
   releases: ChangelogRelease[];
 }
 
+export interface GitHubLogEntry {
+  sha: string;
+  shortSha: string;
+  message: string;
+  authorName: string;
+  commitTimeUtc: string;
+  htmlUrl: string;
+}
+
+export interface GitHubLogsView {
+  dataSourceAvailable: boolean;
+  source: 'local' | 'github' | 'none';
+  fetchedAt: string;
+  logs: GitHubLogEntry[];
+}
+
 // ============ API Calls ============
 
 /**
@@ -73,6 +89,14 @@ export async function getCurrentWeekChangelog(force = false): Promise<ApiRespons
  */
 export async function getChangelogReleases(limit = 20, force = false): Promise<ApiResponse<ReleasesView>> {
   return await apiRequest<ReleasesView>(api.changelog.releases(limit, force), { method: 'GET' });
+}
+
+/**
+ * 获取 GitHub 日志（优先本地 git log，失败时回退 GitHub commits API）
+ * @param force 绕过服务端缓存
+ */
+export async function getChangelogGitHubLogs(limit = 30, force = false): Promise<ApiResponse<GitHubLogsView>> {
+  return await apiRequest<GitHubLogsView>(api.changelog.githubLogs(limit, force), { method: 'GET' });
 }
 
 // ============ Report Sources（周报来源配置，全员共享） ============

--- a/prd-admin/src/styles/globals.css
+++ b/prd-admin/src/styles/globals.css
@@ -1352,6 +1352,31 @@ select optgroup {
   box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.12);
 }
 
+/*
+ * ── .surface-reading / .text-crisp — 高密度阅读区 ──
+ *
+ * 深色玻璃面板里如果 blur 太强、背景太透，正文会出现“发软 / 毛边”的观感。
+ * 阅读区改用更实的暗色表面，文字单独做字体平滑，避免正文直接压在大面积 blur 上。
+ */
+.surface-reading {
+  background: linear-gradient(180deg, rgba(24, 24, 30, 0.84) 0%, rgba(18, 18, 24, 0.92) 100%);
+  border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.08));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 12px 28px rgba(0, 0, 0, 0.18);
+}
+
+.surface-reading-header {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.035) 0%, rgba(255, 255, 255, 0.015) 100%);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.text-crisp {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
 /* ── .surface-row — 列表/表格行悬停 ── */
 .surface-row {
   transition: background 0.2s ease,

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ChangelogController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ChangelogController.cs
@@ -49,6 +49,17 @@ public class ChangelogController : ControllerBase
         return Ok(ApiResponse<ReleasesDto>.Ok(MapReleases(view)));
     }
 
+    /// <summary>
+    /// GitHub 日志（优先本地 git log，失败时回退 GitHub commits API）
+    /// </summary>
+    [HttpGet("github-logs")]
+    public async Task<IActionResult> GetGitHubLogs([FromQuery] int limit = 30, [FromQuery] bool force = false)
+    {
+        if (limit <= 0 || limit > 100) limit = 30;
+        var view = await _reader.GetGitHubLogsAsync(limit, force).ConfigureAwait(false);
+        return Ok(ApiResponse<GitHubLogsDto>.Ok(MapGitHubLogs(view)));
+    }
+
     // ── DTO 映射 ──────────────────────────────────────────────────────
 
     private static CurrentWeekDto MapCurrentWeek(CurrentWeekView view) => new()
@@ -82,6 +93,22 @@ public class ChangelogController : ControllerBase
                 CommitTimeUtc = d.CommitTimeUtc?.ToString("o"),
                 Entries = d.Entries.ConvertAll(MapEntry),
             }),
+        }),
+    };
+
+    private static GitHubLogsDto MapGitHubLogs(GitHubLogsView view) => new()
+    {
+        DataSourceAvailable = view.DataSourceAvailable,
+        Source = view.Source,
+        FetchedAt = view.FetchedAt.ToString("o"),
+        Logs = view.Logs.ConvertAll(l => new GitHubLogEntryDto
+        {
+            Sha = l.Sha,
+            ShortSha = l.ShortSha,
+            Message = l.Message,
+            AuthorName = l.AuthorName,
+            CommitTimeUtc = l.CommitTimeUtc.ToString("o"),
+            HtmlUrl = l.HtmlUrl,
         }),
     };
 
@@ -142,5 +169,23 @@ public class ChangelogController : ControllerBase
         public string Source { get; set; } = "none";
         public string FetchedAt { get; set; } = string.Empty;
         public List<ChangelogReleaseDto> Releases { get; set; } = new();
+    }
+
+    public sealed class GitHubLogEntryDto
+    {
+        public string Sha { get; set; } = string.Empty;
+        public string ShortSha { get; set; } = string.Empty;
+        public string Message { get; set; } = string.Empty;
+        public string AuthorName { get; set; } = string.Empty;
+        public string CommitTimeUtc { get; set; } = string.Empty;
+        public string HtmlUrl { get; set; } = string.Empty;
+    }
+
+    public sealed class GitHubLogsDto
+    {
+        public bool DataSourceAvailable { get; set; }
+        public string Source { get; set; } = "none";
+        public string FetchedAt { get; set; } = string.Empty;
+        public List<GitHubLogEntryDto> Logs { get; set; } = new();
     }
 }

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ChangelogController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ChangelogController.cs
@@ -1,7 +1,14 @@
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using PrdAgent.Api.Extensions;
+using PrdAgent.Core.Interfaces;
 using PrdAgent.Core.Models;
 using PrdAgent.Core.Security;
+using PrdAgent.Infrastructure.LlmGateway;
 using PrdAgent.Infrastructure.Services.Changelog;
 
 namespace PrdAgent.Api.Controllers.Api;
@@ -18,11 +25,26 @@ namespace PrdAgent.Api.Controllers.Api;
 [AdminController("changelog", AdminPermissionCatalog.Access)]
 public class ChangelogController : ControllerBase
 {
-    private readonly IChangelogReader _reader;
+    private const string ChangelogAiSummaryAppCallerCode = "prd-admin.changelog.aiSummary::chat";
 
-    public ChangelogController(IChangelogReader reader)
+    private static readonly JsonSerializerOptions AiSummaryPayloadJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private readonly IChangelogReader _reader;
+    private readonly ILlmGateway _gateway;
+    private readonly ILLMRequestContextAccessor _llmRequestContext;
+
+    public ChangelogController(
+        IChangelogReader reader,
+        ILlmGateway gateway,
+        ILLMRequestContextAccessor llmRequestContext)
     {
         _reader = reader;
+        _gateway = gateway;
+        _llmRequestContext = llmRequestContext;
     }
 
     /// <summary>
@@ -58,6 +80,142 @@ public class ChangelogController : ControllerBase
         if (limit <= 0 || limit > 100) limit = 30;
         var view = await _reader.GetGitHubLogsAsync(limit, force).ConfigureAwait(false);
         return Ok(ApiResponse<GitHubLogsDto>.Ok(MapGitHubLogs(view)));
+    }
+
+    /// <summary>
+    /// AI 总结：走 ILlmGateway + AppCallerCode（prd-admin.changelog.aiSummary::chat），禁止前端本地假摘要。
+    /// </summary>
+    [HttpPost("ai-summary")]
+    public async Task<IActionResult> AiSummary([FromBody] ChangelogAiSummaryRequest? request, CancellationToken ct)
+    {
+        if (request is null || string.IsNullOrWhiteSpace(request.Subtab))
+        {
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "subtab 必填，取值 releases / fragments / github_logs"));
+        }
+
+        var subtab = request.Subtab.Trim().ToLowerInvariant();
+        var typeFilter = string.IsNullOrWhiteSpace(request.TypeFilter) ? null : request.TypeFilter.Trim();
+
+        const int releasesLimit = 20;
+        const int githubLogsLimit = 30;
+
+        object payload = null!;
+        string sceneLabel;
+
+        switch (subtab)
+        {
+            case "releases":
+            {
+                var rv = await _reader.GetReleasesAsync(releasesLimit, false).ConfigureAwait(false);
+                var filtered = FilterReleasesForSummary(rv, typeFilter);
+                if (!HasAnyReleaseDayEntry(filtered))
+                {
+                    return BadRequest(ApiResponse<object>.Fail(ErrorCodes.CONTENT_EMPTY, "当前筛选条件下没有可总结的历史发布"));
+                }
+
+                payload = new { subtab = "releases", data = filtered };
+                sceneLabel = "历史发布（CHANGELOG）";
+                break;
+            }
+            case "fragments":
+            {
+                var cw = await _reader.GetCurrentWeekAsync(false).ConfigureAwait(false);
+                var filtered = FilterFragmentsForSummary(cw, typeFilter);
+                if (!HasAnyFragmentEntry(filtered))
+                {
+                    return BadRequest(ApiResponse<object>.Fail(ErrorCodes.CONTENT_EMPTY, "当前筛选条件下没有可总结的待发布功能"));
+                }
+
+                payload = new { subtab = "fragments", data = filtered };
+                sceneLabel = "待发布功能";
+                break;
+            }
+            case "github_logs":
+            {
+                var gv = await _reader.GetGitHubLogsAsync(githubLogsLimit, false).ConfigureAwait(false);
+                if (gv.Logs.Count == 0)
+                {
+                    return BadRequest(ApiResponse<object>.Fail(ErrorCodes.CONTENT_EMPTY, "当前没有可总结的 GitHub 日志"));
+                }
+
+                payload = new { subtab = "github_logs", data = gv };
+                sceneLabel = "GitHub 日志";
+                break;
+            }
+            default:
+                return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "subtab 无效"));
+        }
+
+        var userJson = JsonSerializer.Serialize(payload, AiSummaryPayloadJsonOptions);
+        if (userJson.Length > 14_000)
+        {
+            userJson = string.Concat(userJson.AsSpan(0, 14_000), "\n…(内容过长已截断)");
+        }
+
+        var userId = this.GetRequiredUserId();
+        using var _ = _llmRequestContext.BeginScope(new LlmRequestContext(
+            RequestId: Guid.NewGuid().ToString("N"),
+            GroupId: null,
+            SessionId: null,
+            UserId: userId,
+            ViewRole: null,
+            DocumentChars: userJson.Length,
+            DocumentHash: null,
+            SystemPromptRedacted: "changelog-ai-summary",
+            RequestType: "chat",
+            AppCallerCode: ChangelogAiSummaryAppCallerCode));
+
+        var systemPrompt =
+            $"你是 PrdAgent 更新中心助手。下面是仓库变更数据（JSON），场景：{sceneLabel}。\n" +
+            "你必须只输出**一个** JSON 对象，UTF-8，不要 markdown 代码围栏，不要解释。\n" +
+            "字段要求：\n" +
+            "- \"title\" string：简短中文标题（≤24字）\n" +
+            "- \"headline\" string：一句话总览\n" +
+            "- \"bullets\" string[]：3~5 条要点\n" +
+            "- \"stats\" string[]：恰好 3 条简短统计标签（如 \"12 条提交\"）\n" +
+            "- \"insight\" string：一句给读者的观察或建议";
+
+        var gatewayBody = new JsonObject
+        {
+            ["messages"] = new JsonArray
+            {
+                new JsonObject { ["role"] = "system", ["content"] = systemPrompt },
+                new JsonObject { ["role"] = "user", ["content"] = userJson },
+            },
+            ["temperature"] = 0.35,
+            ["max_tokens"] = 1200,
+        };
+
+        var gwResponse = await _gateway.SendAsync(new GatewayRequest
+        {
+            AppCallerCode = ChangelogAiSummaryAppCallerCode,
+            ModelType = "chat",
+            RequestBody = gatewayBody,
+        }, ct).ConfigureAwait(false);
+
+        if (!gwResponse.Success || string.IsNullOrWhiteSpace(gwResponse.Content))
+        {
+            return StatusCode(502, ApiResponse<object>.Fail("LLM_ERROR", gwResponse.ErrorMessage ?? "模型未返回有效内容"));
+        }
+
+        ChangelogAiSummaryDto? dto;
+        try
+        {
+            dto = ParseChangelogAiSummaryJson(gwResponse.Content);
+        }
+        catch
+        {
+            return StatusCode(502, ApiResponse<object>.Fail("LLM_PARSE_ERROR", "模型输出无法解析为 JSON"));
+        }
+
+        if (dto is null)
+        {
+            return StatusCode(502, ApiResponse<object>.Fail("LLM_PARSE_ERROR", "模型输出结构不完整"));
+        }
+
+        dto.ThinkingTrace = $"已通过 ILlmGateway 调用（AppCallerCode={ChangelogAiSummaryAppCallerCode}）。";
+        dto.GeneratedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        return Ok(ApiResponse<ChangelogAiSummaryDto>.Ok(dto));
     }
 
     // ── DTO 映射 ──────────────────────────────────────────────────────
@@ -119,7 +277,159 @@ public class ChangelogController : ControllerBase
         Description = e.Description,
     };
 
+    private static ReleasesView FilterReleasesForSummary(ReleasesView v, string? typeFilter)
+    {
+        if (string.IsNullOrWhiteSpace(typeFilter))
+            return v;
+
+        var tf = typeFilter.Trim().ToLowerInvariant();
+        var releases = new List<ChangelogRelease>();
+        foreach (var r in v.Releases)
+        {
+            var days = new List<ChangelogDay>();
+            foreach (var d in r.Days)
+            {
+                var entries = d.Entries.Where(e => e.Type.ToLowerInvariant() == tf).ToList();
+                if (entries.Count == 0)
+                    continue;
+                days.Add(new ChangelogDay
+                {
+                    Date = d.Date,
+                    CommitTimeUtc = d.CommitTimeUtc,
+                    Entries = entries,
+                });
+            }
+
+            if (days.Count == 0)
+                continue;
+
+            releases.Add(new ChangelogRelease
+            {
+                Version = r.Version,
+                ReleaseDate = r.ReleaseDate,
+                Highlights = r.Highlights,
+                Days = days,
+            });
+        }
+
+        return new ReleasesView
+        {
+            DataSourceAvailable = v.DataSourceAvailable,
+            Source = v.Source,
+            FetchedAt = v.FetchedAt,
+            Releases = releases,
+        };
+    }
+
+    private static CurrentWeekView FilterFragmentsForSummary(CurrentWeekView v, string? typeFilter)
+    {
+        if (string.IsNullOrWhiteSpace(typeFilter))
+            return v;
+
+        var tf = typeFilter.Trim().ToLowerInvariant();
+        var fragments = new List<ChangelogFragment>();
+        foreach (var f in v.Fragments)
+        {
+            var entries = f.Entries.Where(e => e.Type.ToLowerInvariant() == tf).ToList();
+            if (entries.Count == 0)
+                continue;
+            fragments.Add(new ChangelogFragment
+            {
+                FileName = f.FileName,
+                Date = f.Date,
+                Entries = entries,
+            });
+        }
+
+        return new CurrentWeekView
+        {
+            WeekStart = v.WeekStart,
+            WeekEnd = v.WeekEnd,
+            DataSourceAvailable = v.DataSourceAvailable,
+            Source = v.Source,
+            FetchedAt = v.FetchedAt,
+            Fragments = fragments,
+        };
+    }
+
+    private static bool HasAnyReleaseDayEntry(ReleasesView v) =>
+        v.Releases.Exists(r => r.Days.Exists(d => d.Entries.Count > 0));
+
+    private static bool HasAnyFragmentEntry(CurrentWeekView v) =>
+        v.Fragments.Exists(f => f.Entries.Count > 0);
+
+    private static readonly JsonSerializerOptions AiSummaryParseJsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+    };
+
+    private static string StripJsonFence(string raw)
+    {
+        var s = raw.Trim();
+        if (s.StartsWith("```", StringComparison.Ordinal))
+        {
+            var firstNl = s.IndexOf('\n', StringComparison.Ordinal);
+            if (firstNl >= 0)
+                s = s[(firstNl + 1)..];
+            var end = s.LastIndexOf("```", StringComparison.Ordinal);
+            if (end > 0)
+                s = s[..end];
+        }
+
+        return s.Trim();
+    }
+
+    private sealed class LlmSummaryJsonShape
+    {
+        public string? Title { get; set; }
+        public string? Headline { get; set; }
+        public List<string>? Bullets { get; set; }
+        public List<string>? Stats { get; set; }
+        public string? Insight { get; set; }
+    }
+
+    private static ChangelogAiSummaryDto? ParseChangelogAiSummaryJson(string raw)
+    {
+        var s = StripJsonFence(raw);
+        var shape = JsonSerializer.Deserialize<LlmSummaryJsonShape>(s, AiSummaryParseJsonOptions);
+        if (shape is null || string.IsNullOrWhiteSpace(shape.Title) || string.IsNullOrWhiteSpace(shape.Headline))
+            return null;
+
+        var bullets = (shape.Bullets ?? new List<string>()).Where(t => !string.IsNullOrWhiteSpace(t)).Take(8).ToList();
+        var stats = (shape.Stats ?? new List<string>()).Where(t => !string.IsNullOrWhiteSpace(t)).Take(6).ToList();
+        if (bullets.Count == 0)
+            return null;
+
+        return new ChangelogAiSummaryDto
+        {
+            Title = shape.Title.Trim(),
+            Headline = shape.Headline.Trim(),
+            Bullets = bullets.Select(x => x.Trim()).ToList(),
+            Stats = stats.Select(x => x.Trim()).ToList(),
+            Insight = (shape.Insight ?? string.Empty).Trim(),
+        };
+    }
+
     // ── DTO 定义（前端契约） ──────────────────────────────────────────
+
+    public sealed class ChangelogAiSummaryRequest
+    {
+        /// <summary>releases / fragments / github_logs</summary>
+        public string Subtab { get; set; } = "";
+        public string? TypeFilter { get; set; }
+    }
+
+    public sealed class ChangelogAiSummaryDto
+    {
+        public string Title { get; set; } = "";
+        public string Headline { get; set; } = "";
+        public List<string> Bullets { get; set; } = new();
+        public List<string> Stats { get; set; } = new();
+        public string Insight { get; set; } = "";
+        public string ThinkingTrace { get; set; } = "";
+        public long GeneratedAt { get; set; }
+    }
 
     public sealed class ChangelogEntryDto
     {

--- a/prd-api/src/PrdAgent.Infrastructure/Services/Changelog/ChangelogReader.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/Changelog/ChangelogReader.cs
@@ -591,8 +591,12 @@ public sealed class ChangelogReader : IChangelogReader
                 return null;
             }
 
-            var stdout = await process.StandardOutput.ReadToEndAsync().ConfigureAwait(false);
-            var stderr = await process.StandardError.ReadToEndAsync().ConfigureAwait(false);
+            // 并行读 stdout/stderr，避免单管道先读满导致子进程阻塞死锁（见 Process 重定向说明）
+            var stdoutTask = process.StandardOutput.ReadToEndAsync();
+            var stderrTask = process.StandardError.ReadToEndAsync();
+            await Task.WhenAll(stdoutTask, stderrTask).ConfigureAwait(false);
+            var stdout = stdoutTask.Result;
+            var stderr = stderrTask.Result;
             await process.WaitForExitAsync().ConfigureAwait(false);
             if (process.ExitCode != 0)
             {

--- a/prd-api/src/PrdAgent.Infrastructure/Services/Changelog/ChangelogReader.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/Changelog/ChangelogReader.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Net.Http;
+using System.Diagnostics;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Caching.Memory;
@@ -85,6 +86,30 @@ public sealed class ReleasesView
 }
 
 /// <summary>
+/// GitHub 日志单条记录（本地 git log 或 GitHub commits API）
+/// </summary>
+public sealed class GitHubLogEntry
+{
+    public string Sha { get; set; } = string.Empty;
+    public string ShortSha { get; set; } = string.Empty;
+    public string Message { get; set; } = string.Empty;
+    public string AuthorName { get; set; } = string.Empty;
+    public DateTime CommitTimeUtc { get; set; }
+    public string HtmlUrl { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// GitHub 日志视图
+/// </summary>
+public sealed class GitHubLogsView
+{
+    public List<GitHubLogEntry> Logs { get; set; } = new();
+    public bool DataSourceAvailable { get; set; }
+    public string Source { get; set; } = "none";
+    public DateTime FetchedAt { get; set; }
+}
+
+/// <summary>
 /// 从仓库的 changelogs/ 目录和 CHANGELOG.md 文件读取并解析更新记录。
 ///
 /// 数据源策略（按优先级）：
@@ -109,6 +134,7 @@ public interface IChangelogReader
 {
     Task<CurrentWeekView> GetCurrentWeekAsync(bool force = false);
     Task<ReleasesView> GetReleasesAsync(int limit, bool force = false);
+    Task<GitHubLogsView> GetGitHubLogsAsync(int limit, bool force = false);
 }
 
 public sealed class ChangelogReader : IChangelogReader
@@ -121,6 +147,7 @@ public sealed class ChangelogReader : IChangelogReader
 
     private const string CacheKeyCurrentWeek = "changelog:current-week";
     private const string CacheKeyReleases = "changelog:releases";
+    private const string CacheKeyGitHubLogs = "changelog:github-logs";
     private static readonly TimeSpan LocalCacheTtl = TimeSpan.FromMinutes(5);
 
     // 文件名格式：YYYY-MM-DD_<short>.md
@@ -233,6 +260,44 @@ public sealed class ChangelogReader : IChangelogReader
         }
 
         return new ReleasesView
+        {
+            DataSourceAvailable = false,
+            Source = "none",
+            FetchedAt = DateTime.UtcNow,
+        };
+    }
+
+    public async Task<GitHubLogsView> GetGitHubLogsAsync(int limit, bool force = false)
+    {
+        if (limit <= 0 || limit > 100) limit = 30;
+        var cacheKey = $"{CacheKeyGitHubLogs}:{limit}";
+        if (!force && _cache.TryGetValue(cacheKey, out GitHubLogsView? cached) && cached != null)
+        {
+            return cached;
+        }
+
+        var localView = await BuildGitHubLogsViewFromLocalAsync(limit).ConfigureAwait(false);
+        if (localView.DataSourceAvailable)
+        {
+            _cache.Set(cacheKey, localView, LocalCacheTtl);
+            return localView;
+        }
+
+        try
+        {
+            var githubView = await BuildGitHubLogsViewFromGitHubAsync(limit).ConfigureAwait(false);
+            if (githubView.DataSourceAvailable)
+            {
+                _cache.Set(cacheKey, githubView, GetGitHubCacheTtl());
+                return githubView;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[Changelog] GitHub 日志拉取失败");
+        }
+
+        return new GitHubLogsView
         {
             DataSourceAvailable = false,
             Source = "none",
@@ -383,6 +448,37 @@ public sealed class ChangelogReader : IChangelogReader
         return view;
     }
 
+    private async Task<GitHubLogsView> BuildGitHubLogsViewFromLocalAsync(int limit)
+    {
+        var view = new GitHubLogsView
+        {
+            Source = "local",
+            FetchedAt = DateTime.UtcNow,
+        };
+
+        var root = ResolveLocalRoot();
+        var gitPath = root == null ? null : Path.Combine(root, ".git");
+        if (root == null || gitPath == null || (!Directory.Exists(gitPath) && !File.Exists(gitPath)))
+        {
+            view.DataSourceAvailable = false;
+            return view;
+        }
+
+        var logs = await TryReadGitLogsAsync(root, GetGitHubBranch(), limit).ConfigureAwait(false)
+            ?? await TryReadGitLogsAsync(root, null, limit).ConfigureAwait(false)
+            ?? new List<GitHubLogEntry>();
+
+        if (logs.Count == 0)
+        {
+            view.DataSourceAvailable = false;
+            return view;
+        }
+
+        view.DataSourceAvailable = true;
+        view.Logs = logs;
+        return view;
+    }
+
     // ── GitHub 源 ─────────────────────────────────────────────────────
 
     private string GetGitHubOwner() => _config["Changelog:GitHubOwner"] ?? "inernoro";
@@ -397,6 +493,13 @@ public sealed class ChangelogReader : IChangelogReader
         var hours = _config.GetValue<int?>("Changelog:CacheTtlHours") ?? 24;
         if (hours <= 0) hours = 24;
         return TimeSpan.FromHours(hours);
+    }
+
+    private string BuildCommitHtmlUrl(string sha)
+    {
+        var owner = GetGitHubOwner();
+        var repo = GetGitHubRepo();
+        return $"https://github.com/{owner}/{repo}/commit/{sha}";
     }
 
     /// <summary>
@@ -454,6 +557,81 @@ public sealed class ChangelogReader : IChangelogReader
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "[Changelog] GitHub raw 拉取异常 {Url}", url);
+            return null;
+        }
+    }
+
+    private async Task<List<GitHubLogEntry>?> TryReadGitLogsAsync(string root, string? branch, int limit)
+    {
+        try
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "git",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            startInfo.ArgumentList.Add("-C");
+            startInfo.ArgumentList.Add(root);
+            startInfo.ArgumentList.Add("log");
+            if (!string.IsNullOrWhiteSpace(branch))
+            {
+                startInfo.ArgumentList.Add(branch!);
+            }
+            startInfo.ArgumentList.Add($"-n{limit}");
+            startInfo.ArgumentList.Add("--date=iso-strict");
+            startInfo.ArgumentList.Add("--pretty=format:%H%x1f%aI%x1f%an%x1f%s%x1e");
+
+            using var process = new Process { StartInfo = startInfo };
+            if (!process.Start())
+            {
+                return null;
+            }
+
+            var stdout = await process.StandardOutput.ReadToEndAsync().ConfigureAwait(false);
+            var stderr = await process.StandardError.ReadToEndAsync().ConfigureAwait(false);
+            await process.WaitForExitAsync().ConfigureAwait(false);
+            if (process.ExitCode != 0)
+            {
+                _logger.LogWarning("[Changelog] 本地 git log 失败 branch={Branch} stderr={Stderr}", branch ?? "HEAD", stderr);
+                return null;
+            }
+
+            var result = new List<GitHubLogEntry>();
+            foreach (var rawRecord in stdout.Split('\u001e', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                var parts = rawRecord.Split('\u001f');
+                if (parts.Length < 4) continue;
+                var sha = parts[0].Trim();
+                var committedAtIso = parts[1].Trim();
+                var authorName = parts[2].Trim();
+                var message = parts[3].Trim();
+                if (string.IsNullOrWhiteSpace(sha) || string.IsNullOrWhiteSpace(committedAtIso)) continue;
+                if (!DateTime.TryParse(
+                        committedAtIso,
+                        CultureInfo.InvariantCulture,
+                        DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                        out var committedAtUtc))
+                {
+                    continue;
+                }
+                result.Add(new GitHubLogEntry
+                {
+                    Sha = sha,
+                    ShortSha = sha.Length > 7 ? sha[..7] : sha,
+                    Message = message,
+                    AuthorName = string.IsNullOrWhiteSpace(authorName) ? "unknown" : authorName,
+                    CommitTimeUtc = committedAtUtc,
+                    HtmlUrl = BuildCommitHtmlUrl(sha),
+                });
+            }
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "[Changelog] 读取本地 git log 异常 branch={Branch}", branch ?? "HEAD");
             return null;
         }
     }
@@ -617,6 +795,96 @@ public sealed class ChangelogReader : IChangelogReader
             _logger.LogWarning(ex, "[Changelog] 拉取 CHANGELOG.md commit 历史失败（降级为纯日期展示）");
         }
 
+        return view;
+    }
+
+    private async Task<GitHubLogsView> BuildGitHubLogsViewFromGitHubAsync(int limit)
+    {
+        var view = new GitHubLogsView
+        {
+            Source = "github",
+            FetchedAt = DateTime.UtcNow,
+        };
+
+        var client = CreateGitHubClient();
+        var owner = GetGitHubOwner();
+        var repo = GetGitHubRepo();
+        var branch = GetGitHubBranch();
+        var apiBase = GetGitHubApiBase();
+        var url = $"{apiBase}/repos/{owner}/{repo}/commits?sha={branch}&per_page={limit}";
+
+        using var req = CreateGitHubApiRequest(HttpMethod.Get, url);
+        using var resp = await client.SendAsync(req).ConfigureAwait(false);
+        if (!resp.IsSuccessStatusCode)
+        {
+            _logger.LogWarning("[Changelog] GitHub Commits API 失败 {Url} status={Status}", url, (int)resp.StatusCode);
+            view.DataSourceAvailable = false;
+            return view;
+        }
+
+        var json = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+        using var doc = JsonDocument.Parse(json);
+        if (doc.RootElement.ValueKind != JsonValueKind.Array)
+        {
+            view.DataSourceAvailable = false;
+            return view;
+        }
+
+        foreach (var item in doc.RootElement.EnumerateArray())
+        {
+            var sha = item.TryGetProperty("sha", out var shaProp) ? shaProp.GetString() : null;
+            var htmlUrl = item.TryGetProperty("html_url", out var htmlUrlProp) ? htmlUrlProp.GetString() : null;
+            if (!item.TryGetProperty("commit", out var commitEl)) continue;
+            var message = commitEl.TryGetProperty("message", out var messageProp) ? messageProp.GetString() : null;
+            string? authorName = null;
+            JsonElement authorEl = default;
+            var hasAuthor = commitEl.TryGetProperty("author", out authorEl);
+            if (hasAuthor)
+            {
+                authorName = authorEl.TryGetProperty("name", out var nameProp) ? nameProp.GetString() : null;
+            }
+            authorName ??= commitEl.TryGetProperty("committer", out var committerEl) &&
+                           committerEl.TryGetProperty("name", out var committerNameProp)
+                ? committerNameProp.GetString()
+                : null;
+            string? committedAtIso = null;
+            if (commitEl.TryGetProperty("committer", out var commitCommitterEl) &&
+                commitCommitterEl.TryGetProperty("date", out var dateProp))
+            {
+                committedAtIso = dateProp.GetString();
+            }
+            committedAtIso ??= hasAuthor && authorEl.TryGetProperty("date", out var authorDateProp)
+                ? authorDateProp.GetString()
+                : null;
+
+            if (string.IsNullOrWhiteSpace(sha) || string.IsNullOrWhiteSpace(committedAtIso))
+            {
+                continue;
+            }
+            if (!DateTime.TryParse(
+                    committedAtIso,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                    out var committedAtUtc))
+            {
+                continue;
+            }
+
+            var firstLine = (message ?? string.Empty)
+                .Split('\n', 2, StringSplitOptions.TrimEntries)[0]
+                .Trim();
+            view.Logs.Add(new GitHubLogEntry
+            {
+                Sha = sha,
+                ShortSha = sha.Length > 7 ? sha[..7] : sha,
+                Message = string.IsNullOrWhiteSpace(firstLine) ? "(no message)" : firstLine,
+                AuthorName = string.IsNullOrWhiteSpace(authorName) ? "unknown" : authorName,
+                CommitTimeUtc = committedAtUtc,
+                HtmlUrl = string.IsNullOrWhiteSpace(htmlUrl) ? BuildCommitHtmlUrl(sha) : htmlUrl!,
+            });
+        }
+
+        view.DataSourceAvailable = true;
         return view;
     }
 

--- a/prd-api/src/PrdAgent.Infrastructure/Services/Changelog/ChangelogReader.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/Changelog/ChangelogReader.cs
@@ -582,7 +582,8 @@ public sealed class ChangelogReader : IChangelogReader
             }
             startInfo.ArgumentList.Add($"-n{limit}");
             startInfo.ArgumentList.Add("--date=iso-strict");
-            startInfo.ArgumentList.Add("--pretty=format:%H%x1f%aI%x1f%an%x1f%s%x1e");
+            // %cI：提交者时间，与 GitHub commits API 的 committer.date 对齐（%aI 为作者时间，rebase 后易不一致）
+            startInfo.ArgumentList.Add("--pretty=format:%H%x1f%cI%x1f%an%x1f%s%x1e");
 
             using var process = new Process { StartInfo = startInfo };
             if (!process.Start())


### PR DESCRIPTION
## 改动说明

更新中心的「AI 总结」此前在浏览器内用规则拼装与固定延迟，没有调用大模型网关。

### 后端
- 新增 POST /api/changelog/ai-summary，请求体 { subtab, typeFilter? }。
- 使用 ILlmGateway.SendAsync，AppCallerCode 固定为 prd-admin.changelog.aiSummary::chat。
- 调用前 LlmRequestContext.BeginScope，UserId 来自当前登录管理员。

### 前端
- ChangelogPage 的「AI 总结」改为调用上述接口，展示服务端返回的 thinkingTrace（含 AppCallerCode 溯源）。

### 附带
- changelogs/2026-04-21_changelog-ai-summary-llm-gateway.md 碎片记录。

## 验收建议
1. 管理员登录后打开更新中心，分别在 CHANGELOG / 待发布 / GitHub 日志 子 tab 点击「AI 总结」。
2. 在 LLM 请求日志中筛选 AppCallerCode 包含 prd-admin.changelog.aiSummary，确认有记录且 UserId 非空。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new backend endpoints that execute `git` and call the LLM gateway; failures or mis-parsing could impact changelog UX and gateway usage/cost, though scope is isolated to the changelog area.
> 
> **Overview**
> Updates the 更新中心 so **AI summaries are generated server-side** via new `POST /api/changelog/ai-summary`, calling `ILlmGateway` with fixed `AppCallerCode` (`prd-admin.changelog.aiSummary::chat`) and attaching per-request `LlmRequestContext` (incl. `UserId`), plus parsing/validating the model’s JSON output.
> 
> Adds a new `GET /api/changelog/github-logs` API and corresponding admin UI subtab that fetches recent commit logs (prefer local `git log`, fallback to GitHub Commits API), with sessionStorage caching/prefetch, improved refresh/error handling, and several Bugbot fixes (promise rejection handling, avoiding git process pipe deadlocks, aligning local commit timestamps). Also tweaks admin “reading” surfaces/typography CSS and sets `Changelog__RootPath`/repo volume mounts in CDS compose for local changelog access.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f374fa339044614f74bfee983f85d677e8a532d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->