### PR TITLE
feat: Add cover image & preview URL to marketplace skills

### DIFF
--- a/changelogs/2026-04-21_marketplace-skill-cover-and-preview.md
+++ b/changelogs/2026-04-21_marketplace-skill-cover-and-preview.md
@@ -1,0 +1,4 @@
+| feat | prd-api | 海鲜市场「技能」新增封面图 + 预览地址（external URL / hosted_site）字段、上传流程、删除清理 |
+| feat | prd-api | 技能详情自动兜底链升级：用户输入 → 规则提取 SKILL.md → LLM 30 字摘要 → 标题 |
+| feat | prd-admin | 重设计海鲜市场技能卡片（封面图为主视觉 + 预览地址快捷入口 + 收藏按钮行内化） |
+| feat | prd-admin | 技能上传弹窗新增封面图上传区 + 预览地址三 Tab（不设置 / 托管站点 / 外部 URL） |

--- a/prd-admin/src/lib/marketplaceTypes.tsx
+++ b/prd-admin/src/lib/marketplaceTypes.tsx
@@ -28,7 +28,7 @@ import React, { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
-import { FileText, Heart, Image as ImageIcon, Package, Sparkles, Tag as TagIcon, type LucideIcon } from 'lucide-react';
+import { ExternalLink, FileText, Globe, Heart, Image as ImageIcon, Package, Sparkles, Tag as TagIcon, type LucideIcon } from 'lucide-react';
 import { WatermarkDescriptionGrid } from '@/components/watermark/WatermarkDescriptionGrid';
 import {
   listLiteraryPromptsMarketplace,
@@ -270,8 +270,17 @@ const WatermarkPreviewRenderer: React.FC<{ item: MarketplaceWatermark }> = ({ it
 );
 
 /**
- * 技能预览：海报式大图，展示 emoji 图标 + 描述 + 标签 + 收藏按钮。
- * 文件大小 / 下载次数 / 作者名 由外层通用 MarketplaceCard 的底栏展示，这里不重复。
+ * 技能预览（重设计）：封面图为主视觉，支持预览地址快捷访问。
+ *
+ * 布局：
+ *   ┌──────────┬─────────────────────────┐
+ *   │ 封面     │ 描述                    │
+ *   │ 96×96    │ 标签…                   │
+ *   │ (emoji兜底)│ 预览 ↗ · 收藏 ♥        │
+ *   └──────────┴─────────────────────────┘
+ *
+ * - 有封面图 → 覆盖填充；无封面图 → 水波纹渐变 + 大 emoji
+ * - 预览地址存在时显示可点击的「预览 ↗」标签（在封面角标 + 右侧行内各一处）
  */
 const SkillPreviewRenderer: React.FC<{ item: MarketplaceSkill }> = ({ item }) => {
   const [favorited, setFavorited] = useState(item.isFavoritedByCurrentUser);
@@ -283,7 +292,6 @@ const SkillPreviewRenderer: React.FC<{ item: MarketplaceSkill }> = ({ item }) =>
     e.preventDefault();
     if (pending) return;
     setPending(true);
-    // 乐观更新
     const next = !favorited;
     setFavorited(next);
     setFavoriteCount((c) => (next ? c + 1 : Math.max(0, c - 1)));
@@ -292,7 +300,6 @@ const SkillPreviewRenderer: React.FC<{ item: MarketplaceSkill }> = ({ item }) =>
         ? await favoriteMarketplaceSkill({ id: item.id })
         : await unfavoriteMarketplaceSkill({ id: item.id });
       if (!res.success) {
-        // 回滚
         setFavorited(!next);
         setFavoriteCount((c) => (next ? Math.max(0, c - 1) : c + 1));
       }
@@ -305,93 +312,166 @@ const SkillPreviewRenderer: React.FC<{ item: MarketplaceSkill }> = ({ item }) =>
   };
 
   const tags = item.tags || [];
+  const hasCover = !!item.coverImageUrl;
+  const hasPreview = !!item.previewUrl;
+  const previewHostLabel = (() => {
+    if (!item.previewUrl) return '';
+    if (item.previewSource === 'hosted_site') return '托管站点';
+    try {
+      return new URL(item.previewUrl).hostname;
+    } catch {
+      return '预览';
+    }
+  })();
+
+  const stopAndOpen = (e: React.MouseEvent, url?: string | null) => {
+    e.stopPropagation();
+    e.preventDefault();
+    if (!url) return;
+    window.open(url, '_blank', 'noopener,noreferrer');
+  };
+
   return (
     <div
-      className="relative overflow-hidden rounded-[6px] flex flex-col"
+      className="relative overflow-hidden rounded-[6px] flex"
       style={{
         height: PREVIEW_HEIGHT,
-        background:
-          'linear-gradient(135deg, rgba(37, 99, 235, 0.22) 0%, rgba(14, 165, 233, 0.18) 40%, rgba(6, 182, 212, 0.15) 100%)',
-        border: '1px solid rgba(56, 189, 248, 0.28)',
+        background: 'rgba(255, 255, 255, 0.02)',
+        border: '1px solid rgba(56, 189, 248, 0.22)',
       }}
     >
-      {/* 背景水波纹装饰 */}
+      {/* 左：封面图 / 兜底 emoji */}
       <div
-        className="absolute inset-0 pointer-events-none opacity-30"
+        className="relative flex items-center justify-center overflow-hidden flex-shrink-0"
         style={{
-          backgroundImage:
-            'radial-gradient(circle at 85% 18%, rgba(125, 211, 252, 0.38), transparent 40%), radial-gradient(circle at 15% 85%, rgba(56, 189, 248, 0.28), transparent 45%)',
-        }}
-      />
-      {/* 内容 */}
-      <div className="relative flex gap-2 p-2 flex-1 min-h-0">
-        {/* 左侧：大 emoji 图标 */}
-        <div
-          className="flex-shrink-0 flex items-center justify-center rounded-[6px]"
-          style={{
-            width: 52,
-            height: 52,
-            fontSize: 32,
-            lineHeight: 1,
-            background: 'rgba(255, 255, 255, 0.08)',
-            border: '1px solid rgba(255, 255, 255, 0.12)',
-          }}
-        >
-          <span>{item.iconEmoji || '🧩'}</span>
-        </div>
-        {/* 右侧：描述 + 标签 */}
-        <div className="flex-1 min-w-0 flex flex-col gap-1">
-          <div
-            className="text-[11px] leading-[1.35] line-clamp-2"
-            style={{ color: 'rgba(241, 245, 249, 0.92)' }}
-            title={item.description}
-          >
-            {item.description || '（暂无详情）'}
-          </div>
-          {tags.length > 0 && (
-            <div className="flex items-center gap-1 flex-wrap overflow-hidden" style={{ maxHeight: 18 }}>
-              {tags.slice(0, 4).map((t) => (
-                <span
-                  key={t}
-                  className="inline-flex items-center gap-0.5 px-1.5 rounded-full text-[9px]"
-                  style={{
-                    background: 'rgba(255, 255, 255, 0.10)',
-                    border: '1px solid rgba(255, 255, 255, 0.15)',
-                    color: 'rgba(224, 242, 254, 0.92)',
-                    height: 16,
-                  }}
-                >
-                  <TagIcon size={8} />
-                  {t}
-                </span>
-              ))}
-              {tags.length > 4 && (
-                <span className="text-[9px]" style={{ color: 'rgba(224, 242, 254, 0.6)' }}>
-                  +{tags.length - 4}
-                </span>
-              )}
-            </div>
-          )}
-        </div>
-      </div>
-      {/* 右上角：收藏按钮 + 计数（计数单独显示，即使未点击也展示） */}
-      <button
-        type="button"
-        onClick={toggleFavorite}
-        disabled={pending}
-        title={favorited ? '取消收藏' : '收藏'}
-        className="absolute top-1 right-1 flex items-center gap-1 px-1.5 rounded-full text-[10px] transition-all"
-        style={{
-          height: 20,
-          background: favorited ? 'rgba(244, 63, 94, 0.22)' : 'rgba(15, 23, 42, 0.5)',
-          border: `1px solid ${favorited ? 'rgba(244, 63, 94, 0.6)' : 'rgba(255, 255, 255, 0.15)'}`,
-          color: favorited ? 'rgba(251, 113, 133, 0.98)' : 'rgba(226, 232, 240, 0.9)',
-          cursor: pending ? 'wait' : 'pointer',
+          width: 96,
+          height: '100%',
+          background: hasCover
+            ? `#0b1220 url(${item.coverImageUrl}) center/cover no-repeat`
+            : 'linear-gradient(135deg, rgba(37, 99, 235, 0.24) 0%, rgba(14, 165, 233, 0.18) 50%, rgba(6, 182, 212, 0.18) 100%)',
+          borderRight: '1px solid rgba(255, 255, 255, 0.06)',
         }}
       >
-        <Heart size={10} fill={favorited ? 'currentColor' : 'none'} />
-        <span>{favoriteCount}</span>
-      </button>
+        {!hasCover && (
+          <>
+            <div
+              className="absolute inset-0 pointer-events-none opacity-40"
+              style={{
+                backgroundImage:
+                  'radial-gradient(circle at 85% 18%, rgba(125, 211, 252, 0.42), transparent 45%), radial-gradient(circle at 15% 85%, rgba(56, 189, 248, 0.32), transparent 50%)',
+              }}
+            />
+            <span
+              className="relative"
+              style={{ fontSize: 40, lineHeight: 1, filter: 'drop-shadow(0 2px 4px rgba(0,0,0,0.3))' }}
+            >
+              {item.iconEmoji || '🧩'}
+            </span>
+          </>
+        )}
+        {/* 封面角标：预览地址存在时的快捷入口 */}
+        {hasPreview && (
+          <button
+            type="button"
+            onClick={(e) => stopAndOpen(e, item.previewUrl)}
+            title={`打开预览：${item.previewUrl}`}
+            className="absolute bottom-1 left-1 inline-flex items-center gap-0.5 px-1.5 rounded-full text-[9px] transition-all hover:scale-105"
+            style={{
+              height: 16,
+              background: 'rgba(15, 23, 42, 0.78)',
+              border: '1px solid rgba(125, 211, 252, 0.55)',
+              color: 'rgba(186, 230, 253, 0.98)',
+              backdropFilter: 'blur(4px)',
+            }}
+          >
+            {item.previewSource === 'hosted_site' ? <Globe size={8} /> : <ExternalLink size={8} />}
+            预览
+          </button>
+        )}
+      </div>
+
+      {/* 右：描述 + 标签 + 行内预览链 + 收藏计数 */}
+      <div className="relative flex-1 min-w-0 flex flex-col p-2 gap-1">
+        <div
+          className="text-[11px] leading-[1.35] line-clamp-2"
+          style={{ color: 'rgba(241, 245, 249, 0.94)' }}
+          title={item.description}
+        >
+          {item.description || '（暂无详情）'}
+        </div>
+
+        {tags.length > 0 && (
+          <div
+            className="flex items-center gap-1 flex-wrap overflow-hidden"
+            style={{ maxHeight: 18 }}
+          >
+            {tags.slice(0, 3).map((t) => (
+              <span
+                key={t}
+                className="inline-flex items-center gap-0.5 px-1.5 rounded-full text-[9px]"
+                style={{
+                  background: 'rgba(56, 189, 248, 0.12)',
+                  border: '1px solid rgba(56, 189, 248, 0.28)',
+                  color: 'rgba(186, 230, 253, 0.95)',
+                  height: 16,
+                }}
+              >
+                <TagIcon size={8} />
+                {t}
+              </span>
+            ))}
+            {tags.length > 3 && (
+              <span className="text-[9px]" style={{ color: 'rgba(186, 230, 253, 0.7)' }}>
+                +{tags.length - 3}
+              </span>
+            )}
+          </div>
+        )}
+
+        {/* 底部：预览地址 + 收藏 */}
+        <div className="mt-auto flex items-center justify-between gap-2">
+          {hasPreview ? (
+            <button
+              type="button"
+              onClick={(e) => stopAndOpen(e, item.previewUrl)}
+              title={item.previewUrl!}
+              className="inline-flex items-center gap-1 px-1.5 rounded-[4px] text-[10px] transition-colors hover:bg-white/5 min-w-0"
+              style={{
+                height: 18,
+                color: 'rgba(125, 211, 252, 0.92)',
+                maxWidth: '70%',
+              }}
+            >
+              {item.previewSource === 'hosted_site' ? (
+                <Globe size={9} className="flex-shrink-0" />
+              ) : (
+                <ExternalLink size={9} className="flex-shrink-0" />
+              )}
+              <span className="truncate">{previewHostLabel}</span>
+            </button>
+          ) : (
+            <span className="text-[10px]" style={{ color: 'var(--text-muted)' }} />
+          )}
+
+          <button
+            type="button"
+            onClick={toggleFavorite}
+            disabled={pending}
+            title={favorited ? '取消收藏' : '收藏'}
+            className="flex items-center gap-1 px-1.5 rounded-full text-[10px] transition-all flex-shrink-0"
+            style={{
+              height: 18,
+              background: favorited ? 'rgba(244, 63, 94, 0.22)' : 'rgba(255, 255, 255, 0.05)',
+              border: `1px solid ${favorited ? 'rgba(244, 63, 94, 0.5)' : 'rgba(255, 255, 255, 0.12)'}`,
+              color: favorited ? 'rgba(251, 113, 133, 0.98)' : 'rgba(226, 232, 240, 0.9)',
+              cursor: pending ? 'wait' : 'pointer',
+            }}
+          >
+            <Heart size={10} fill={favorited ? 'currentColor' : 'none'} />
+            <span>{favoriteCount}</span>
+          </button>
+        </div>
+      </div>
     </div>
   );
 };

--- a/prd-admin/src/pages/marketplace/SkillUploadDialog.tsx
+++ b/prd-admin/src/pages/marketplace/SkillUploadDialog.tsx
@@ -1,23 +1,43 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { FileArchive, Hash, Plus, UploadCloud, X } from 'lucide-react';
+import {
+  ExternalLink,
+  FileArchive,
+  Globe,
+  Hash,
+  ImageIcon,
+  Link as LinkIcon,
+  Plus,
+  Sparkles,
+  UploadCloud,
+  X,
+} from 'lucide-react';
 import { Button } from '@/components/design/Button';
 import { uploadMarketplaceSkill } from '@/services';
+import { listSites, type HostedSite } from '@/services/real/webPages';
 import { toast } from '@/lib/toast';
 
 /**
- * 海鲜市场「技能」上传弹窗。
+ * 海鲜市场「技能」上传弹窗（重设计版）。
  *
- * 遵循：
+ * 新增能力：
+ * - 封面图上传（替代 emoji 作为卡片主视觉；兜底仍可选 emoji）
+ * - 预览地址（external URL 或选自己的 hosted_sites）
+ *
+ * 仍然遵循：
  * - `.claude/rules/frontend-modal.md`: inline style 高度 + createPortal + min-h:0
- * - `.claude/rules/zero-friction-input.md`: 拖拽 + 点击双通道，标题/详情可空走兜底
+ * - `.claude/rules/zero-friction-input.md`: 双通道（上传/手输 + 下拉/URL）
  */
 interface Props {
   onClose: () => void;
   onUploaded: () => void;
 }
 
-const MAX_BYTES = 20 * 1024 * 1024;
+const MAX_ZIP_BYTES = 20 * 1024 * 1024;
+const MAX_COVER_BYTES = 5 * 1024 * 1024;
+const ALLOWED_COVER_MIME = ['image/png', 'image/jpeg', 'image/webp', 'image/gif'];
+
+type PreviewTab = 'none' | 'hosted' | 'external';
 
 export function SkillUploadDialog({ onClose, onUploaded }: Props) {
   const [file, setFile] = useState<File | null>(null);
@@ -30,7 +50,21 @@ export function SkillUploadDialog({ onClose, onUploaded }: Props) {
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState('');
 
+  // 封面图
+  const [coverFile, setCoverFile] = useState<File | null>(null);
+  const [coverPreview, setCoverPreview] = useState<string | null>(null);
+
+  // 预览地址
+  const [previewTab, setPreviewTab] = useState<PreviewTab>('none');
+  const [previewUrlInput, setPreviewUrlInput] = useState('');
+  const [selectedSiteId, setSelectedSiteId] = useState<string>('');
+
+  // hosted_sites 列表
+  const [sites, setSites] = useState<HostedSite[]>([]);
+  const [loadingSites, setLoadingSites] = useState(false);
+
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const coverInputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -40,8 +74,40 @@ export function SkillUploadDialog({ onClose, onUploaded }: Props) {
     return () => document.removeEventListener('keydown', onKey);
   }, [onClose]);
 
+  // 首次切到「选已有托管站点」时才拉列表
+  useEffect(() => {
+    if (previewTab !== 'hosted' || sites.length > 0 || loadingSites) return;
+    setLoadingSites(true);
+    listSites({ limit: 100, sort: 'updated_desc' })
+      .then((res) => {
+        if (res.success && res.data?.items) setSites(res.data.items);
+      })
+      .catch(() => {
+        /* 静默：用户可在 tab 下方看到空态提示 */
+      })
+      .finally(() => setLoadingSites(false));
+  }, [previewTab, sites.length, loadingSites]);
+
+  // 封面图本地预览 URL（blob）生命周期
+  useEffect(() => {
+    if (!coverFile) {
+      setCoverPreview(null);
+      return;
+    }
+    const url = URL.createObjectURL(coverFile);
+    setCoverPreview(url);
+    return () => URL.revokeObjectURL(url);
+  }, [coverFile]);
+
   const pickFile = () => {
     const el = fileInputRef.current;
+    if (!el) return;
+    el.value = '';
+    el.click();
+  };
+
+  const pickCover = () => {
+    const el = coverInputRef.current;
     if (!el) return;
     el.value = '';
     el.click();
@@ -55,11 +121,25 @@ export function SkillUploadDialog({ onClose, onUploaded }: Props) {
       setError('仅支持 .zip 格式的技能包');
       return;
     }
-    if (f.size > MAX_BYTES) {
-      setError(`文件大小不能超过 ${MAX_BYTES / 1024 / 1024}MB`);
+    if (f.size > MAX_ZIP_BYTES) {
+      setError(`文件大小不能超过 ${MAX_ZIP_BYTES / 1024 / 1024}MB`);
       return;
     }
     setFile(f);
+  };
+
+  const handleCover = (f: File | null) => {
+    if (!f) return;
+    setError('');
+    if (f.size > MAX_COVER_BYTES) {
+      setError(`封面图不能超过 ${MAX_COVER_BYTES / 1024 / 1024}MB`);
+      return;
+    }
+    if (f.type && !ALLOWED_COVER_MIME.includes(f.type)) {
+      setError('封面图仅支持 png / jpg / webp / gif');
+      return;
+    }
+    setCoverFile(f);
   };
 
   const addTag = () => {
@@ -85,8 +165,36 @@ export function SkillUploadDialog({ onClose, onUploaded }: Props) {
 
   const canSubmit = !!file && !uploading;
 
+  const selectedSite = useMemo(
+    () => sites.find((s) => s.id === selectedSiteId) ?? null,
+    [sites, selectedSiteId],
+  );
+
   const submit = async () => {
     if (!file) return;
+
+    // 预览地址校验
+    let previewSource: 'external' | 'hosted_site' | undefined;
+    let previewUrl: string | undefined;
+    let previewHostedSiteId: string | undefined;
+
+    if (previewTab === 'external') {
+      const raw = previewUrlInput.trim();
+      if (raw) {
+        if (!/^https?:\/\//i.test(raw)) {
+          setError('预览地址必须以 http:// 或 https:// 开头');
+          return;
+        }
+        previewSource = 'external';
+        previewUrl = raw;
+      }
+    } else if (previewTab === 'hosted') {
+      if (selectedSiteId) {
+        previewSource = 'hosted_site';
+        previewHostedSiteId = selectedSiteId;
+      }
+    }
+
     setUploading(true);
     setError('');
     try {
@@ -96,6 +204,10 @@ export function SkillUploadDialog({ onClose, onUploaded }: Props) {
         description: description.trim() || undefined,
         iconEmoji: iconEmoji.trim() || undefined,
         tags: tags.length > 0 ? tags : undefined,
+        coverImage: coverFile ?? undefined,
+        previewSource,
+        previewUrl,
+        previewHostedSiteId,
       });
       if (!res.success) {
         setError(res.error?.message || '上传失败');
@@ -121,9 +233,9 @@ export function SkillUploadDialog({ onClose, onUploaded }: Props) {
         onClick={(e) => e.stopPropagation()}
         className="flex flex-col rounded-[16px]"
         style={{
-          width: 'min(560px, calc(100vw - 32px))',
-          height: '82vh',
-          maxHeight: '82vh',
+          width: 'min(640px, calc(100vw - 32px))',
+          height: '88vh',
+          maxHeight: '88vh',
           background:
             'linear-gradient(180deg, rgba(15, 23, 42, 0.88) 0%, rgba(2, 6, 23, 0.92) 100%)',
           border: '1px solid rgba(56, 189, 248, 0.28)',
@@ -148,7 +260,7 @@ export function SkillUploadDialog({ onClose, onUploaded }: Props) {
               上传技能包到海鲜市场
             </h3>
             <p className="text-[11px] mt-0.5" style={{ color: 'var(--text-muted)' }}>
-              支持 .zip 压缩包（≤ 20MB），标题与详情可留空走兜底
+              .zip ≤ 20MB · 标题/详情留空自动兜底 · 可选封面图 + 预览地址
             </p>
           </div>
           <button
@@ -161,7 +273,7 @@ export function SkillUploadDialog({ onClose, onUploaded }: Props) {
           </button>
         </div>
 
-        {/* Body（滚动区：min-h:0 + overflow-y:auto） */}
+        {/* Body */}
         <div
           className="flex-1 px-5 py-4"
           style={{ minHeight: 0, overflowY: 'auto', overscrollBehavior: 'contain' }}
@@ -173,8 +285,15 @@ export function SkillUploadDialog({ onClose, onUploaded }: Props) {
             className="hidden"
             onChange={(e) => handleFile(e.target.files?.[0] ?? null)}
           />
+          <input
+            ref={coverInputRef}
+            type="file"
+            accept="image/png,image/jpeg,image/webp,image/gif"
+            className="hidden"
+            onChange={(e) => handleCover(e.target.files?.[0] ?? null)}
+          />
 
-          {/* 拖拽区 */}
+          {/* 1. zip 拖拽区 */}
           <div
             onClick={pickFile}
             onDragOver={(e) => {
@@ -190,9 +309,7 @@ export function SkillUploadDialog({ onClose, onUploaded }: Props) {
             className="flex flex-col items-center justify-center gap-2 rounded-[12px] cursor-pointer transition-all"
             style={{
               padding: file ? '16px' : '28px 16px',
-              background: dragOver
-                ? 'rgba(56, 189, 248, 0.12)'
-                : 'rgba(255, 255, 255, 0.03)',
+              background: dragOver ? 'rgba(56, 189, 248, 0.12)' : 'rgba(255, 255, 255, 0.03)',
               border: `1px dashed ${dragOver ? 'rgba(56, 189, 248, 0.6)' : 'rgba(255, 255, 255, 0.18)'}`,
             }}
           >
@@ -215,13 +332,77 @@ export function SkillUploadDialog({ onClose, onUploaded }: Props) {
                   拖拽 .zip 技能包到这里，或 <span style={{ color: 'rgba(125, 211, 252, 0.95)' }}>点击选择</span>
                 </div>
                 <div className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
-                  上限 20 MB · 压缩包内建议包含 SKILL.md（用于自动生成摘要）
+                  上限 20 MB · 含 SKILL.md 时自动提取摘要（先规则提取，失败兜底 LLM）
                 </div>
               </>
             )}
           </div>
 
-          {/* 标题 */}
+          {/* 2. 封面图 */}
+          <div className="mt-4">
+            <LabelRow
+              label="封面图"
+              hint="卡片主视觉；未上传则使用下方 emoji 兜底"
+            />
+            <div className="flex items-center gap-3">
+              <div
+                onClick={pickCover}
+                className="flex items-center justify-center rounded-[12px] cursor-pointer overflow-hidden transition-colors"
+                style={{
+                  width: 104,
+                  height: 104,
+                  flexShrink: 0,
+                  background: coverPreview
+                    ? `url(${coverPreview}) center/cover`
+                    : 'rgba(255, 255, 255, 0.03)',
+                  border: `1px dashed ${coverPreview ? 'rgba(56, 189, 248, 0.45)' : 'rgba(255, 255, 255, 0.18)'}`,
+                }}
+              >
+                {!coverPreview && (
+                  <div className="flex flex-col items-center gap-1.5">
+                    <ImageIcon size={22} style={{ color: 'rgba(125, 211, 252, 0.85)' }} />
+                    <span className="text-[10px]" style={{ color: 'var(--text-muted)' }}>
+                      点击上传
+                    </span>
+                  </div>
+                )}
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="text-[12px] leading-5" style={{ color: 'var(--text-secondary)' }}>
+                  支持 png / jpg / webp / gif，单张 ≤ 5MB
+                </div>
+                <div className="text-[11px] leading-5 mt-0.5" style={{ color: 'var(--text-muted)' }}>
+                  海鲜市场会用这张图作为瀑布流卡片的封面。
+                </div>
+                {coverFile && (
+                  <div className="flex items-center gap-2 mt-2">
+                    <span
+                      className="inline-flex items-center gap-1 px-2 py-1 rounded-full text-[11px]"
+                      style={{
+                        background: 'rgba(56, 189, 248, 0.14)',
+                        border: '1px solid rgba(56, 189, 248, 0.35)',
+                        color: 'rgba(186, 230, 253, 0.95)',
+                      }}
+                    >
+                      {coverFile.name.length > 22
+                        ? `${coverFile.name.slice(0, 20)}…`
+                        : coverFile.name}
+                      <button
+                        type="button"
+                        onClick={() => setCoverFile(null)}
+                        className="hover:opacity-70"
+                        aria-label="移除封面图"
+                      >
+                        <X size={10} />
+                      </button>
+                    </span>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* 3. 标题 */}
           <div className="mt-4">
             <LabelRow label="标题" hint="留空则使用文件名（去扩展名）" />
             <input
@@ -239,11 +420,11 @@ export function SkillUploadDialog({ onClose, onUploaded }: Props) {
             />
           </div>
 
-          {/* 详情 */}
+          {/* 4. 详情 */}
           <div className="mt-3">
             <LabelRow
               label="详情"
-              hint="留空将尝试从压缩包内的 SKILL.md 用 LLM 自动提取 30 字摘要"
+              hint="留空 → 规则提取 SKILL.md → 失败兜底 LLM 30 字摘要"
             />
             <textarea
               value={description}
@@ -260,9 +441,101 @@ export function SkillUploadDialog({ onClose, onUploaded }: Props) {
             />
           </div>
 
-          {/* Icon */}
+          {/* 5. 预览地址 */}
           <div className="mt-3">
-            <LabelRow label="图标（emoji）" hint="粘贴任意 emoji，默认 🧩" />
+            <LabelRow label="预览地址" hint="可选：让下载者先在网页上看看效果" />
+            <div className="flex items-center gap-1 mb-2">
+              <PreviewTabBtn
+                active={previewTab === 'none'}
+                onClick={() => setPreviewTab('none')}
+                icon={<Sparkles size={12} />}
+                label="不设置"
+              />
+              <PreviewTabBtn
+                active={previewTab === 'hosted'}
+                onClick={() => setPreviewTab('hosted')}
+                icon={<Globe size={12} />}
+                label="我的托管站点"
+              />
+              <PreviewTabBtn
+                active={previewTab === 'external'}
+                onClick={() => setPreviewTab('external')}
+                icon={<LinkIcon size={12} />}
+                label="外部 URL"
+              />
+            </div>
+
+            {previewTab === 'hosted' && (
+              <div>
+                {loadingSites ? (
+                  <div className="text-[12px] py-2" style={{ color: 'var(--text-muted)' }}>
+                    正在加载我的托管站点...
+                  </div>
+                ) : sites.length === 0 ? (
+                  <div
+                    className="px-3 py-2 rounded-[10px] text-[12px]"
+                    style={{
+                      background: 'rgba(255, 255, 255, 0.03)',
+                      border: '1px solid rgba(255, 255, 255, 0.08)',
+                      color: 'var(--text-muted)',
+                    }}
+                  >
+                    你还没有托管站点。先去「网页托管」上传一份即可在这里选中。
+                  </div>
+                ) : (
+                  <select
+                    value={selectedSiteId}
+                    onChange={(e) => setSelectedSiteId(e.target.value)}
+                    className="w-full h-9 px-3 rounded-[10px] text-[13px] focus:outline-none"
+                    style={{
+                      background: 'rgba(255, 255, 255, 0.04)',
+                      border: '1px solid rgba(255, 255, 255, 0.12)',
+                      color: 'var(--text-primary)',
+                    }}
+                  >
+                    <option value="">— 选择一个托管站点 —</option>
+                    {sites.map((s) => (
+                      <option key={s.id} value={s.id}>
+                        {s.title || '未命名'} ({s.visibility === 'public' ? '公开' : '私有'})
+                      </option>
+                    ))}
+                  </select>
+                )}
+                {selectedSite?.siteUrl && (
+                  <a
+                    href={selectedSite.siteUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 mt-1.5 text-[11px]"
+                    style={{ color: 'rgba(125, 211, 252, 0.95)' }}
+                  >
+                    <ExternalLink size={10} />
+                    {selectedSite.siteUrl}
+                  </a>
+                )}
+              </div>
+            )}
+
+            {previewTab === 'external' && (
+              <input
+                type="url"
+                value={previewUrlInput}
+                onChange={(e) => setPreviewUrlInput(e.target.value)}
+                placeholder="https://example.com/preview"
+                maxLength={512}
+                className="w-full h-9 px-3 rounded-[10px] text-[13px] focus:outline-none"
+                style={{
+                  background: 'rgba(255, 255, 255, 0.04)',
+                  border: '1px solid rgba(255, 255, 255, 0.12)',
+                  color: 'var(--text-primary)',
+                }}
+              />
+            )}
+          </div>
+
+          {/* 6. Emoji 兜底图标 */}
+          <div className="mt-3">
+            <LabelRow label="图标（emoji）" hint="未上传封面图时作为卡片兜底视觉" />
             <div className="flex items-center gap-2">
               <input
                 type="text"
@@ -295,7 +568,7 @@ export function SkillUploadDialog({ onClose, onUploaded }: Props) {
             </div>
           </div>
 
-          {/* Tags */}
+          {/* 7. 标签 */}
           <div className="mt-3">
             <LabelRow label="标签" hint="回车添加，最多 10 个（用于顶部筛选）" />
             <div className="flex items-center gap-2">
@@ -406,5 +679,33 @@ function LabelRow({ label, hint }: { label: string; hint?: string }) {
         </span>
       )}
     </div>
+  );
+}
+
+function PreviewTabBtn({
+  active,
+  onClick,
+  icon,
+  label,
+}: {
+  active: boolean;
+  onClick: () => void;
+  icon: React.ReactNode;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-[8px] text-[11px] transition-colors"
+      style={{
+        background: active ? 'rgba(56, 189, 248, 0.18)' : 'rgba(255, 255, 255, 0.04)',
+        border: `1px solid ${active ? 'rgba(56, 189, 248, 0.5)' : 'rgba(255, 255, 255, 0.1)'}`,
+        color: active ? 'rgba(186, 230, 253, 0.95)' : 'var(--text-secondary)',
+      }}
+    >
+      {icon}
+      {label}
+    </button>
   );
 }

--- a/prd-admin/src/services/contracts/marketplaceSkills.ts
+++ b/prd-admin/src/services/contracts/marketplaceSkills.ts
@@ -26,6 +26,14 @@ export interface MarketplaceSkillDto {
   title: string;
   description: string;
   iconEmoji: string;
+  /** 封面图 CDN URL，空则走 iconEmoji 兜底 */
+  coverImageUrl?: string | null;
+  /** 预览地址：作者设置的展示 URL（托管站点或外部 URL） */
+  previewUrl?: string | null;
+  /** 预览地址来源：external | hosted_site */
+  previewSource?: 'external' | 'hosted_site' | null;
+  /** 若 previewSource=hosted_site，对应的 HostedSite.id */
+  previewHostedSiteId?: string | null;
   tags: string[];
   zipUrl: string;
   zipSizeBytes: number;
@@ -62,10 +70,18 @@ export type UploadMarketplaceSkillContract = (input: {
   file: File;
   /** 为空则使用文件名（去扩展名）兜底 */
   title?: string;
-  /** 为空则尝试从 SKILL.md 用 LLM 提取 30 字摘要；都失败回退到标题 */
+  /** 为空则先规则提取 SKILL.md → 失败兜底 LLM 30 字摘要 → 回退到标题 */
   description?: string;
   iconEmoji?: string;
   tags?: string[];
+  /** 封面图（可选）— 上传后落对象存储，卡片展示用 */
+  coverImage?: File;
+  /** 预览地址 URL；external 时必填，hosted_site 时可传空由后端解析 */
+  previewUrl?: string;
+  /** 预览地址来源：external（自填 URL）/ hosted_site（选 HostedSite） */
+  previewSource?: 'external' | 'hosted_site';
+  /** previewSource === 'hosted_site' 时必填 */
+  previewHostedSiteId?: string;
 }) => Promise<ApiResponse<{ item: MarketplaceSkillDto }>>;
 
 export type ForkMarketplaceSkillContract = (input: {

--- a/prd-admin/src/services/real/marketplaceSkills.ts
+++ b/prd-admin/src/services/real/marketplaceSkills.ts
@@ -57,6 +57,10 @@ export const uploadMarketplaceSkillReal: UploadMarketplaceSkillContract = async 
   if (input.tags && input.tags.length > 0) {
     fd.append('tagsJson', JSON.stringify(input.tags));
   }
+  if (input.coverImage) fd.append('coverImage', input.coverImage);
+  if (input.previewSource) fd.append('previewSource', input.previewSource);
+  if (input.previewUrl) fd.append('previewUrl', input.previewUrl);
+  if (input.previewHostedSiteId) fd.append('previewHostedSiteId', input.previewHostedSiteId);
 
   const rawBase = ((import.meta.env.VITE_API_BASE_URL as string | undefined) ?? '').trim().replace(/\/+$/, '');
   const url = rawBase ? `${rawBase}${api.marketplaceSkills.upload()}` : api.marketplaceSkills.upload();

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/MarketplaceSkillsController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/MarketplaceSkillsController.cs
@@ -26,11 +26,18 @@ namespace PrdAgent.Api.Controllers.Api;
 public class MarketplaceSkillsController : ControllerBase
 {
     private const long MaxZipBytes = 20L * 1024 * 1024;
+    private const long MaxCoverBytes = 5L * 1024 * 1024;
     private const int SummaryMaxChars = 30;
     private const int DescriptionMaxChars = 200;
     private const int TitleMaxChars = 80;
     private const int MaxTagsPerItem = 10;
     private const int MaxTagLength = 20;
+    private const int PreviewUrlMaxLen = 512;
+
+    private static readonly HashSet<string> AllowedCoverExts = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".png", ".jpg", ".jpeg", ".webp", ".gif"
+    };
 
     private readonly MongoDbContext _db;
     private readonly ILlmGateway _gateway;
@@ -143,13 +150,17 @@ public class MarketplaceSkillsController : ControllerBase
     /// - 标签来自用户自定义（JSON 数组字符串），最多 10 个
     /// </summary>
     [HttpPost("upload")]
-    [RequestSizeLimit(MaxZipBytes)]
+    [RequestSizeLimit(MaxZipBytes + MaxCoverBytes + 1024 * 1024)]
     public async Task<IActionResult> Upload(
         [FromForm] IFormFile file,
         [FromForm] string? title,
         [FromForm] string? description,
         [FromForm] string? iconEmoji,
         [FromForm] string? tagsJson,
+        [FromForm] IFormFile? coverImage,
+        [FromForm] string? previewUrl,
+        [FromForm] string? previewSource,
+        [FromForm] string? previewHostedSiteId,
         CancellationToken ct)
     {
         var userId = this.GetRequiredUserId();
@@ -163,6 +174,25 @@ public class MarketplaceSkillsController : ControllerBase
         if (ext != ".zip")
             return BadRequest(ApiResponse<object>.Fail("INVALID_FILE", "仅支持 .zip 格式的技能包"));
 
+        // 校验封面图（可选）
+        if (coverImage != null && coverImage.Length > 0)
+        {
+            if (coverImage.Length > MaxCoverBytes)
+                return BadRequest(ApiResponse<object>.Fail("COVER_TOO_LARGE", $"封面图不能超过 {MaxCoverBytes / 1024 / 1024}MB"));
+            var coverExt = Path.GetExtension(coverImage.FileName).ToLowerInvariant();
+            if (!AllowedCoverExts.Contains(coverExt))
+                return BadRequest(ApiResponse<object>.Fail("INVALID_COVER", "封面图仅支持 png/jpg/jpeg/webp/gif"));
+            if (!string.IsNullOrWhiteSpace(coverImage.ContentType) &&
+                !coverImage.ContentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
+                return BadRequest(ApiResponse<object>.Fail("INVALID_COVER", "封面图必须是图片类型"));
+        }
+
+        // 校验预览地址（可选）
+        var (resolvedPreviewUrl, resolvedPreviewSource, resolvedPreviewHostedSiteId, previewError) =
+            await ResolvePreviewAsync(userId, previewUrl, previewSource, previewHostedSiteId, ct);
+        if (previewError != null)
+            return BadRequest(ApiResponse<object>.Fail("INVALID_PREVIEW", previewError));
+
         // 读 zip 到内存（上限 20MB 可接受）
         using var ms = new MemoryStream();
         await file.CopyToAsync(ms, ct);
@@ -173,7 +203,7 @@ public class MarketplaceSkillsController : ControllerBase
         if (!string.IsNullOrEmpty(meta.Error))
             return BadRequest(ApiResponse<object>.Fail("INVALID_FILE", $"压缩包解析失败: {meta.Error}"));
 
-        // 生成 ID、上传到 COS / R2
+        // 生成 ID、上传 zip 到 COS / R2
         var id = Guid.NewGuid().ToString("N");
         var safeName = SanitizeFileName(file.FileName);
         var key = $"marketplace-skills/{id}/{safeName}";
@@ -188,23 +218,54 @@ public class MarketplaceSkillsController : ControllerBase
         }
         var zipUrl = _assetStorage.BuildUrlForKey(key);
 
-        // 字段兜底
+        // 上传封面图（若有）
+        string? coverUrl = null;
+        string? coverKey = null;
+        if (coverImage != null && coverImage.Length > 0)
+        {
+            try
+            {
+                using var coverMs = new MemoryStream();
+                await coverImage.CopyToAsync(coverMs, ct);
+                var coverBytes = coverMs.ToArray();
+                var coverExt = Path.GetExtension(coverImage.FileName).ToLowerInvariant();
+                coverKey = $"marketplace-skills/{id}/cover{coverExt}";
+                var coverMime = string.IsNullOrWhiteSpace(coverImage.ContentType)
+                    ? GuessImageMime(coverExt)
+                    : coverImage.ContentType;
+                await _assetStorage.UploadToKeyAsync(coverKey, coverBytes, coverMime, ct);
+                coverUrl = _assetStorage.BuildUrlForKey(coverKey);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "MarketplaceSkill 封面图上传失败 userId={UserId} id={Id}", userId, id);
+                coverUrl = null;
+                coverKey = null;
+            }
+        }
+
+        // 字段兜底：标题
         var finalTitle = TrimChars(
             string.IsNullOrWhiteSpace(title) ? Path.GetFileNameWithoutExtension(file.FileName) : title.Trim(),
             TitleMaxChars);
         if (string.IsNullOrWhiteSpace(finalTitle))
             finalTitle = "未命名技能";
 
+        // 字段兜底：描述 — 先用户输入 → 规则提取 SKILL.md → LLM 摘要 → 标题
         var finalDescription = (description ?? "").Trim();
         if (string.IsNullOrEmpty(finalDescription) && meta.HasSkillMd && !string.IsNullOrWhiteSpace(meta.SkillMdContent))
         {
-            try
+            finalDescription = ExtractDescriptionByRule(meta.SkillMdContent!);
+            if (string.IsNullOrWhiteSpace(finalDescription))
             {
-                finalDescription = await GenerateSummaryAsync(userId, meta.SkillMdContent!, ct);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "MarketplaceSkill 自动摘要失败 userId={UserId} id={Id}", userId, id);
+                try
+                {
+                    finalDescription = await GenerateSummaryAsync(userId, meta.SkillMdContent!, ct);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "MarketplaceSkill 自动摘要失败 userId={UserId} id={Id}", userId, id);
+                }
             }
         }
         if (string.IsNullOrWhiteSpace(finalDescription))
@@ -226,6 +287,11 @@ public class MarketplaceSkillsController : ControllerBase
             Title = finalTitle,
             Description = finalDescription,
             IconEmoji = finalIcon,
+            CoverImageUrl = coverUrl,
+            CoverImageKey = coverKey,
+            PreviewUrl = resolvedPreviewUrl,
+            PreviewSource = resolvedPreviewSource,
+            PreviewHostedSiteId = resolvedPreviewHostedSiteId,
             Tags = tags,
             OwnerUserId = userId,
             AuthorName = authorName,
@@ -338,6 +404,18 @@ public class MarketplaceSkillsController : ControllerBase
             _logger.LogWarning(ex, "MarketplaceSkill 删除对象失败 key={Key}", skill.ZipKey);
         }
 
+        if (!string.IsNullOrWhiteSpace(skill.CoverImageKey))
+        {
+            try
+            {
+                await _assetStorage.DeleteByKeyAsync(skill.CoverImageKey!, ct);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "MarketplaceSkill 删除封面图失败 key={Key}", skill.CoverImageKey);
+            }
+        }
+
         await _db.MarketplaceSkills.DeleteOneAsync(x => x.Id == id, ct);
         return Ok(ApiResponse<object>.Ok(new { deleted = true }));
     }
@@ -401,6 +479,110 @@ public class MarketplaceSkillsController : ControllerBase
         return TrimChars(summary, SummaryMaxChars);
     }
 
+    /// <summary>
+    /// 校验并解析"预览地址"三元组。返回 (url, source, hostedSiteId, error)。
+    /// - external: 必须是 http/https，长度 ≤ 512
+    /// - hosted_site: 查 HostedSite 归属当前用户，实际落的 url 以 SiteUrl 为准
+    /// - 空 / null：四个字段全 null
+    /// </summary>
+    private async Task<(string? Url, string? Source, string? HostedSiteId, string? Error)> ResolvePreviewAsync(
+        string userId,
+        string? previewUrl,
+        string? previewSource,
+        string? previewHostedSiteId,
+        CancellationToken ct)
+    {
+        var source = (previewSource ?? "").Trim().ToLowerInvariant();
+        var urlInput = (previewUrl ?? "").Trim();
+        var siteIdInput = (previewHostedSiteId ?? "").Trim();
+
+        // 三者皆空 → 未提供
+        if (string.IsNullOrEmpty(source) && string.IsNullOrEmpty(urlInput) && string.IsNullOrEmpty(siteIdInput))
+            return (null, null, null, null);
+
+        if (source == "hosted_site")
+        {
+            if (string.IsNullOrEmpty(siteIdInput))
+                return (null, null, null, "选择托管页面时 previewHostedSiteId 不能为空");
+
+            var site = await _db.HostedSites
+                .Find(s => s.Id == siteIdInput && s.OwnerUserId == userId)
+                .FirstOrDefaultAsync(ct);
+            if (site == null)
+                return (null, null, null, "所选托管页面不存在或无权访问");
+            if (string.IsNullOrWhiteSpace(site.SiteUrl))
+                return (null, null, null, "所选托管页面尚未生成可访问 URL");
+
+            var resolved = TrimChars(site.SiteUrl, PreviewUrlMaxLen);
+            return (resolved, "hosted_site", site.Id, null);
+        }
+
+        if (source == "external" || (string.IsNullOrEmpty(source) && !string.IsNullOrEmpty(urlInput)))
+        {
+            if (string.IsNullOrEmpty(urlInput))
+                return (null, null, null, "预览地址不能为空");
+            if (urlInput.Length > PreviewUrlMaxLen)
+                return (null, null, null, $"预览地址过长（不超过 {PreviewUrlMaxLen} 字符）");
+            if (!Uri.TryCreate(urlInput, UriKind.Absolute, out var parsed) ||
+                (parsed.Scheme != Uri.UriSchemeHttp && parsed.Scheme != Uri.UriSchemeHttps))
+                return (null, null, null, "预览地址必须是 http:// 或 https:// 开头的完整 URL");
+
+            return (urlInput, "external", null, null);
+        }
+
+        return (null, null, null, $"未知的 previewSource: {previewSource}");
+    }
+
+    /// <summary>
+    /// 规则提取 SKILL.md 摘要：按 description frontmatter → 首段 → 返回。不涉及 LLM。
+    /// 提取不到时返回空串，交由上层走 LLM 兜底。
+    /// </summary>
+    private static string ExtractDescriptionByRule(string skillMd)
+    {
+        if (string.IsNullOrWhiteSpace(skillMd)) return string.Empty;
+
+        // 1. 尝试 YAML frontmatter 的 description 字段
+        var fmMatch = Regex.Match(skillMd, @"^---\s*\r?\n([\s\S]*?)\r?\n---", RegexOptions.Multiline);
+        if (fmMatch.Success)
+        {
+            var fm = fmMatch.Groups[1].Value;
+            var descMatch = Regex.Match(fm, @"^\s*description\s*:\s*[""']?([^""'\r\n]+)[""']?", RegexOptions.Multiline | RegexOptions.IgnoreCase);
+            if (descMatch.Success)
+            {
+                var d = descMatch.Groups[1].Value.Trim();
+                if (!string.IsNullOrWhiteSpace(d))
+                    return TrimChars(d, SummaryMaxChars);
+            }
+        }
+
+        // 2. 去掉 frontmatter，找首个非标题、非空行
+        var body = Regex.Replace(skillMd, @"^---\s*\r?\n[\s\S]*?\r?\n---\s*\r?\n?", "");
+        foreach (var rawLine in body.Split('\n'))
+        {
+            var line = rawLine.Trim();
+            if (string.IsNullOrEmpty(line)) continue;
+            if (line.StartsWith("#")) continue; // Markdown 标题跳过
+            if (line.StartsWith(">")) continue; // 引用跳过
+            if (line.StartsWith("```")) continue;
+            // 去掉 Markdown 链接、粗体、斜体等常见干扰符
+            var cleaned = Regex.Replace(line, @"\[([^\]]+)\]\([^)]+\)", "$1");
+            cleaned = Regex.Replace(cleaned, @"[*_`]+", "");
+            cleaned = cleaned.Trim();
+            if (cleaned.Length >= 6)
+                return TrimChars(cleaned, SummaryMaxChars);
+        }
+        return string.Empty;
+    }
+
+    private static string GuessImageMime(string ext) => ext switch
+    {
+        ".png" => "image/png",
+        ".jpg" or ".jpeg" => "image/jpeg",
+        ".webp" => "image/webp",
+        ".gif" => "image/gif",
+        _ => "application/octet-stream"
+    };
+
     private static List<string> ParseTags(string? tagsJson)
     {
         if (string.IsNullOrWhiteSpace(tagsJson))
@@ -445,6 +627,10 @@ public class MarketplaceSkillsController : ControllerBase
             s.Title,
             s.Description,
             iconEmoji = s.IconEmoji,
+            coverImageUrl = s.CoverImageUrl,
+            previewUrl = s.PreviewUrl,
+            previewSource = s.PreviewSource,
+            previewHostedSiteId = s.PreviewHostedSiteId,
             tags = s.Tags ?? new List<string>(),
             zipUrl = s.ZipUrl,
             zipSizeBytes = s.ZipSizeBytes,

--- a/prd-api/src/PrdAgent.Core/Models/MarketplaceSkill.cs
+++ b/prd-api/src/PrdAgent.Core/Models/MarketplaceSkill.cs
@@ -19,8 +19,23 @@ public class MarketplaceSkill : IMarketplaceItem
     /// <summary>技能详情（用户填写 或 SKILL.md 自动提取 30 字摘要）</summary>
     public string Description { get; set; } = string.Empty;
 
-    /// <summary>图标（emoji）</summary>
+    /// <summary>图标（emoji）— 无封面图时作为卡片兜底视觉</summary>
     public string IconEmoji { get; set; } = "🧩";
+
+    /// <summary>封面图 CDN URL（上传后落 COS 拿到），空则卡片 fallback 到 IconEmoji</summary>
+    public string? CoverImageUrl { get; set; }
+
+    /// <summary>封面图 COS key（便于删除技能时回收）</summary>
+    public string? CoverImageKey { get; set; }
+
+    /// <summary>预览地址 — 用户对外展示技能效果的网页 URL（可为托管站点或外部 URL）</summary>
+    public string? PreviewUrl { get; set; }
+
+    /// <summary>预览地址来源：external | hosted_site；null 表示未提供</summary>
+    public string? PreviewSource { get; set; }
+
+    /// <summary>若 PreviewSource == hosted_site，关联的 HostedSite.Id（留存便于以后同步）</summary>
+    public string? PreviewHostedSiteId { get; set; }
 
     /// <summary>用户自定义标签（任意字符串）</summary>
     public List<string> Tags { get; set; } = new();


### PR DESCRIPTION
## Summary
Redesigned the marketplace skill upload dialog and preview card to support cover images and preview URLs, enhancing the visual presentation and user experience for skill discovery.

## Key Changes

### Frontend (prd-admin)
- **Upload Dialog Redesign**
  - Added cover image upload (PNG/JPG/WebP/GIF, max 5MB) with local preview
  - Added preview URL configuration with dual input modes:
    - External URL (manual input with validation)
    - Hosted sites (dropdown selection from user's own hosted pages)
  - Expanded dialog dimensions (640px width, 88vh height) to accommodate new fields
  - Improved field organization with numbered sections and better hints
  - Added `useMemo` hook for selected site resolution and lazy-loading of hosted sites list

- **Skill Card Redesign**
  - Changed layout from vertical to horizontal (cover image on left, content on right)
  - Cover image (96×96) displays as primary visual; falls back to emoji with gradient background if not provided
  - Added preview URL quick-access button (corner badge on cover + inline link in footer)
  - Reorganized content: description, tags (max 3 shown), and favorite button
  - Updated icon imports to include `ExternalLink`, `Globe`, `ImageIcon`, `LinkIcon`, `Sparkles`

### Backend (prd-api)
- **Upload Endpoint Enhancement**
  - Added `coverImage` file parameter (max 5MB, validated MIME types)
  - Added preview URL parameters: `previewUrl`, `previewSource`, `previewHostedSiteId`
  - Implemented `ResolvePreviewAsync()` to validate and resolve preview addresses:
    - External URLs: must be http/https, max 512 chars
    - Hosted sites: validates ownership and retrieves actual site URL
  - Implemented `ExtractDescriptionByRule()` for rule-based SKILL.md extraction before LLM fallback
  - Cover image upload to object storage with proper cleanup on skill deletion
  - Increased request size limit to accommodate cover image

- **Data Model Updates**
  - Added `CoverImageUrl`, `CoverImageKey`, `PreviewUrl`, `PreviewSource`, `PreviewHostedSiteId` fields to `MarketplaceSkill`
  - Updated DTO to expose new fields to frontend

### Contracts & Services
- Updated `MarketplaceSkillDto` interface with new optional fields
- Updated `UploadMarketplaceSkillContract` to accept `coverImage`, `previewUrl`, `previewSource`, `previewHostedSiteId`
- Updated real service implementation to append new form fields

## Notable Implementation Details
- Cover image preview uses blob URLs with proper lifecycle management (creation/revocation)
- Hosted sites list is lazy-loaded only when user switches to that tab
- Description fallback chain: user input → rule extraction → LLM summary → title
- Preview URL validation handles both absolute URLs and hosted site references
- Skill deletion properly cleans up both zip and cover image from object storage
- Dialog maintains existing patterns: inline styles for height constraints, createPortal for modality, drag-drop support

https://claude.ai/code/session_01CjcFXqt3RF2nvZxwVBUiSn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the skill upload API and persistence model (new files, validation, storage upload/delete), so regressions could affect uploads or data integrity despite being scoped to the marketplace skills feature.
> 
> **Overview**
> Adds **cover images** and **preview URLs** to marketplace skills end-to-end.
> 
> On `prd-api`, the skill upload endpoint now accepts an optional `coverImage` (validated and uploaded to object storage with deletion cleanup) plus preview fields (`previewSource`, `previewUrl`, `previewHostedSiteId`) with server-side resolution/authorization for hosted sites; the description fallback chain is updated to try **rule-based `SKILL.md` extraction** before LLM summary.
> 
> On `prd-admin`, the skill upload dialog is redesigned to upload a cover image and configure preview via tabs (none / hosted site selection / external URL), the skill card preview is redesigned around the cover image with quick preview links, and the API contracts/client `FormData` wiring is extended to send/receive the new fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9519fd1d5b38d02ec8807971d7ff0002734701b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->