### PR TITLE
Rename --font-mono to --font-terminal to fix Tailwind v4 cascade conflict

### DIFF
--- a/changelogs/2026-04-22_global-mono-font-fix.md
+++ b/changelogs/2026-04-22_global-mono-font-fix.md
@@ -1,0 +1,1 @@
+| fix | prd-admin | 修复全局 `.font-mono` 被 VT323 像素字体劫持导致小字号文本字距异常/拉伸的问题：tokens.css 中的 `--font-mono` 改名为 `--font-terminal`（避免与 Tailwind v4 同名 theme token 级联冲突），所有 landing/arena/login 的 retro 文本引用同步迁移到新变量 |

--- a/prd-admin/src/pages/LoginPage.tsx
+++ b/prd-admin/src/pages/LoginPage.tsx
@@ -342,7 +342,7 @@ function HudChip({ label, sublabel }: { label: string; sublabel?: string }) {
         border: '1px solid rgba(203, 213, 225, 0.22)',
         boxShadow:
           '0 0 28px rgba(148, 163, 184, 0.18), inset 0 0 14px rgba(148, 163, 184, 0.05)',
-        fontFamily: 'var(--font-mono)',
+        fontFamily: 'var(--font-terminal)',
         animation: 'login-hud-pulse 4s ease-in-out infinite',
       }}
     >
@@ -430,7 +430,7 @@ function Field({ label, value, onChange, onEnter, type = 'text', placeholder, au
     <label className="block">
       <span
         className="block mb-2 text-[11px] uppercase text-white/55"
-        style={{ fontFamily: 'var(--font-mono)', letterSpacing: '0.2em' }}
+        style={{ fontFamily: 'var(--font-terminal)', letterSpacing: '0.2em' }}
       >
         {label}
       </span>
@@ -673,7 +673,7 @@ function LoginCard({
         <Reveal delay={440}>
           <div
             className="mt-1 inline-flex items-center gap-2 text-[11.5px] text-white/45"
-            style={{ fontFamily: 'var(--font-mono)', letterSpacing: '0.1em' }}
+            style={{ fontFamily: 'var(--font-terminal)', letterSpacing: '0.1em' }}
           >
             <Terminal className="w-3 h-3" />
             <span>DEFAULT · admin / admin · 首次登录后请修改密码</span>
@@ -780,7 +780,7 @@ function ResetCard({
                   key={rule.key}
                   className="flex items-center gap-2 text-[12px]"
                   style={{
-                    fontFamily: 'var(--font-mono)',
+                    fontFamily: 'var(--font-terminal)',
                     letterSpacing: '0.08em',
                     color: pass
                       ? 'rgba(52, 211, 153, 0.95)'
@@ -816,7 +816,7 @@ function ResetCard({
             type="button"
             onClick={onBack}
             className="self-start text-[12px] text-white/55 hover:text-white transition-colors"
-            style={{ fontFamily: 'var(--font-mono)', letterSpacing: '0.14em' }}
+            style={{ fontFamily: 'var(--font-terminal)', letterSpacing: '0.14em' }}
           >
             ← BACK TO LOGIN
           </button>

--- a/prd-admin/src/pages/arena/ArenaPage.tsx
+++ b/prd-admin/src/pages/arena/ArenaPage.tsx
@@ -1328,7 +1328,7 @@ export function ArenaPage() {
                   className="text-[11px] px-2 py-1.5 uppercase"
                   style={{
                     color: 'rgba(255, 255, 255, 0.45)',
-                    fontFamily: 'var(--font-mono)',
+                    fontFamily: 'var(--font-terminal)',
                     letterSpacing: '0.2em',
                   }}
                 >
@@ -1418,7 +1418,7 @@ export function ArenaPage() {
               <div
                 className="hidden md:inline-flex items-center gap-2 ml-1 px-2.5 py-1 rounded-md"
                 style={{
-                  fontFamily: 'var(--font-mono)',
+                  fontFamily: 'var(--font-terminal)',
                   background: 'rgba(16, 185, 129, 0.06)',
                   border: '1px solid rgba(16, 185, 129, 0.28)',
                   boxShadow: '0 0 16px rgba(16, 185, 129, 0.16), inset 0 0 8px rgba(16, 185, 129, 0.04)',
@@ -1671,7 +1671,7 @@ export function ArenaPage() {
                   <div
                     className="inline-flex items-center gap-2 mb-6 px-3.5 py-1.5 rounded-md"
                     style={{
-                      fontFamily: 'var(--font-mono)',
+                      fontFamily: 'var(--font-terminal)',
                       background: 'rgba(148, 163, 184, 0.06)',
                       border: '1px solid rgba(148, 163, 184, 0.30)',
                       boxShadow:
@@ -1875,7 +1875,7 @@ export function ArenaPage() {
                       <div className="flex items-center gap-3">
                         <span
                           className="text-[11px] text-white/50"
-                          style={{ fontFamily: 'var(--font-mono)', letterSpacing: '0.08em' }}
+                          style={{ fontFamily: 'var(--font-terminal)', letterSpacing: '0.08em' }}
                         >
                           {slots.length > 0
                             ? `${selectedGroup?.name?.toUpperCase()} · ${slots.length} 个模型`
@@ -1907,7 +1907,7 @@ export function ArenaPage() {
                 <div className="text-center mt-3">
                   <span
                     className="text-[11px] text-white/45"
-                    style={{ fontFamily: 'var(--font-mono)', letterSpacing: '0.1em' }}
+                    style={{ fontFamily: 'var(--font-terminal)', letterSpacing: '0.1em' }}
                   >
                     DRAG · PASTE · FILES · ENTER 发送 · SHIFT+ENTER 换行
                   </span>
@@ -1950,7 +1950,7 @@ export function ArenaPage() {
                     className="flex items-center gap-1.5 px-3 h-7 rounded-full text-[11px] transition-colors hover:bg-white/8 flex-shrink-0 text-white/65"
                     style={{
                       border: '1px solid rgba(255, 255, 255, 0.16)',
-                      fontFamily: 'var(--font-mono)',
+                      fontFamily: 'var(--font-terminal)',
                       letterSpacing: '0.14em',
                     }}
                     title="使用相同问题重新对战"
@@ -2346,7 +2346,7 @@ export function ArenaPage() {
                       <span
                         className="text-[11px] ml-1"
                         style={{
-                          fontFamily: 'var(--font-mono)',
+                          fontFamily: 'var(--font-terminal)',
                           letterSpacing: '0.12em',
                           color: completedCount === totalCount ? '#34d399' : 'rgba(255,255,255,0.5)',
                           textShadow: completedCount === totalCount ? '0 0 8px rgba(52, 211, 153, 0.5)' : 'none',

--- a/prd-admin/src/pages/home/components/SectionHeader.tsx
+++ b/prd-admin/src/pages/home/components/SectionHeader.tsx
@@ -35,7 +35,7 @@ export function SectionHeader({
         <div
           className="inline-flex items-center gap-2 mb-7 px-3.5 py-1.5 rounded-md"
           style={{
-            fontFamily: 'var(--font-mono)',
+            fontFamily: 'var(--font-terminal)',
             background: `${accent}0a`,
             border: `1px solid ${accent}3d`,
             boxShadow: `0 0 20px ${accent}33, inset 0 0 10px ${accent}0a`,

--- a/prd-admin/src/pages/home/components/TechLogoBar.tsx
+++ b/prd-admin/src/pages/home/components/TechLogoBar.tsx
@@ -16,7 +16,7 @@ export function TechLogoBar() {
       <div
         className="text-center text-[10px] uppercase text-white/35 mb-5"
         style={{
-          fontFamily: 'var(--font-mono)',
+          fontFamily: 'var(--font-terminal)',
           letterSpacing: '0.28em',
         }}
       >

--- a/prd-admin/src/pages/home/sections/AgentGrid.tsx
+++ b/prd-admin/src/pages/home/sections/AgentGrid.tsx
@@ -167,7 +167,7 @@ function AgentCard({
               background: `${accent}15`,
               border: `1px solid ${accent}33`,
               color: accent,
-              fontFamily: 'var(--font-mono)',
+              fontFamily: 'var(--font-terminal)',
               letterSpacing: '0.08em',
               textShadow: `0 0 6px ${accent}99`,
             }}

--- a/prd-admin/src/pages/home/sections/CommunityPulse.tsx
+++ b/prd-admin/src/pages/home/sections/CommunityPulse.tsx
@@ -121,7 +121,7 @@ function StatCell({
         className="text-[10px] uppercase mb-3"
         style={{
           color: `${accent}cc`,
-          fontFamily: 'var(--font-mono)',
+          fontFamily: 'var(--font-terminal)',
           letterSpacing: '0.18em',
         }}
       >
@@ -143,7 +143,7 @@ function StatCell({
         className="mt-3 text-[11px]"
         style={{
           color: accent,
-          fontFamily: 'var(--font-mono)',
+          fontFamily: 'var(--font-terminal)',
           letterSpacing: '0.1em',
         }}
       >
@@ -181,7 +181,7 @@ function LeaderboardCard({
         <Trophy className="w-4 h-4 text-purple-300" />
         <div
           className="text-[11px] text-purple-200 uppercase"
-          style={{ fontFamily: 'var(--font-mono)', letterSpacing: '0.18em' }}
+          style={{ fontFamily: 'var(--font-terminal)', letterSpacing: '0.18em' }}
         >
           {title}
         </div>
@@ -228,7 +228,7 @@ function LeaderboardRowItem({
           background: isTop ? `${accent}22` : 'rgba(255, 255, 255, 0.04)',
           border: isTop ? `1px solid ${accent}55` : '1px solid rgba(255, 255, 255, 0.08)',
           color: isTop ? accent : 'rgba(255, 255, 255, 0.5)',
-          fontFamily: 'var(--font-mono)',
+          fontFamily: 'var(--font-terminal)',
           textShadow: isTop ? `0 0 8px ${accent}88` : undefined,
         }}
       >
@@ -243,7 +243,7 @@ function LeaderboardRowItem({
         </span>
         <span
           className="text-[10px] text-white/40"
-          style={{ fontFamily: 'var(--font-mono)' }}
+          style={{ fontFamily: 'var(--font-terminal)' }}
         >
           · {usage}
         </span>
@@ -252,7 +252,7 @@ function LeaderboardRowItem({
         className="text-[11px] shrink-0"
         style={{
           color: accent,
-          fontFamily: 'var(--font-mono)',
+          fontFamily: 'var(--font-terminal)',
           letterSpacing: '0.05em',
           textShadow: `0 0 6px ${accent}66`,
         }}

--- a/prd-admin/src/pages/home/sections/DesktopDownload.tsx
+++ b/prd-admin/src/pages/home/sections/DesktopDownload.tsx
@@ -30,7 +30,7 @@ export function DesktopDownload() {
               <div
                 className="inline-flex items-center gap-2 px-3.5 py-1.5 mb-7 rounded-md"
                 style={{
-                  fontFamily: 'var(--font-mono)',
+                  fontFamily: 'var(--font-terminal)',
                   background: 'rgba(0, 240, 255, 0.06)',
                   border: '1px solid rgba(0, 240, 255, 0.3)',
                   boxShadow: '0 0 20px rgba(0, 240, 255, 0.22)',
@@ -228,7 +228,7 @@ function PlatformCard({
             className="text-[11px]"
             style={{
               color: accent,
-              fontFamily: 'var(--font-mono)',
+              fontFamily: 'var(--font-terminal)',
               letterSpacing: '0.08em',
               textShadow: `0 0 6px ${accent}99`,
             }}
@@ -238,7 +238,7 @@ function PlatformCard({
         </div>
         <div
           className="text-[11px] text-white/45"
-          style={{ fontFamily: 'var(--font-mono)', letterSpacing: '0.06em' }}
+          style={{ fontFamily: 'var(--font-terminal)', letterSpacing: '0.06em' }}
         >
           {arch} · {size}
         </div>

--- a/prd-admin/src/pages/home/sections/FeatureDeepDive.tsx
+++ b/prd-admin/src/pages/home/sections/FeatureDeepDive.tsx
@@ -106,7 +106,7 @@ function FeatureBlock({
           <Reveal offset={14}>
             <div
               className="flex items-center gap-3 mb-5"
-              style={{ fontFamily: 'var(--font-mono)' }}
+              style={{ fontFamily: 'var(--font-terminal)' }}
             >
               <span
                 className="text-[11px] uppercase text-white/35"

--- a/prd-admin/src/pages/home/sections/FinalCta.tsx
+++ b/prd-admin/src/pages/home/sections/FinalCta.tsx
@@ -35,7 +35,7 @@ export function FinalCta({ onGetStarted, onContact }: FinalCtaProps) {
           <div
             className="inline-flex items-center gap-2 mb-7 px-3.5 py-1.5 rounded-md"
             style={{
-              fontFamily: 'var(--font-mono)',
+              fontFamily: 'var(--font-terminal)',
               background: 'rgba(244, 63, 94, 0.06)',
               border: '1px solid rgba(244, 63, 94, 0.32)',
               boxShadow: '0 0 22px rgba(244, 63, 94, 0.25)',

--- a/prd-admin/src/pages/home/sections/HeroSection.tsx
+++ b/prd-admin/src/pages/home/sections/HeroSection.tsx
@@ -131,7 +131,7 @@ export function HeroSection({ className, onGetStarted, onWatchDemo }: HeroSectio
               border: '1px solid rgba(203, 213, 225, 0.22)',
               boxShadow:
                 '0 0 28px rgba(148, 163, 184, 0.18), inset 0 0 14px rgba(148, 163, 184, 0.05)',
-              fontFamily: 'var(--font-mono)',
+              fontFamily: 'var(--font-terminal)',
               animation: 'hud-pulse 4s ease-in-out infinite',
             }}
           >

--- a/prd-admin/src/pages/home/sections/SignatureCinema.tsx
+++ b/prd-admin/src/pages/home/sections/SignatureCinema.tsx
@@ -68,7 +68,7 @@ export function SignatureCinema({ className, src, poster, caption }: SignatureCi
           <Reveal>
             <div
               className="inline-block text-[11px] uppercase text-cyan-300/80 mb-4"
-              style={{ letterSpacing: '0.32em', fontFamily: 'var(--font-mono)' }}
+              style={{ letterSpacing: '0.32em', fontFamily: 'var(--font-terminal)' }}
             >
               {t.cinema.eyebrow}
             </div>
@@ -136,7 +136,7 @@ export function SignatureCinema({ className, src, poster, caption }: SignatureCi
           {/* 右下署名 */}
           <div
             className="absolute bottom-5 right-6 text-[10px] text-white/50 uppercase"
-            style={{ letterSpacing: '0.24em', fontFamily: 'var(--font-mono)' }}
+            style={{ letterSpacing: '0.24em', fontFamily: 'var(--font-terminal)' }}
           >
             {caption ?? t.cinema.caption}
           </div>
@@ -186,7 +186,7 @@ function PosterFallback({ poster, comingSoon }: { poster?: string; comingSoon: s
         </div>
         <div
           className="text-[11px] uppercase text-white/60"
-          style={{ letterSpacing: '0.32em', fontFamily: 'var(--font-mono)' }}
+          style={{ letterSpacing: '0.32em', fontFamily: 'var(--font-terminal)' }}
         >
           {comingSoon}
         </div>

--- a/prd-admin/src/pages/home/sections/StatsStrip.tsx
+++ b/prd-admin/src/pages/home/sections/StatsStrip.tsx
@@ -34,7 +34,7 @@ export function StatsStrip() {
                 </div>
                 <div
                   className="mt-5 text-[10.5px] text-white/40 uppercase"
-                  style={{ fontFamily: 'var(--font-mono)', letterSpacing: '0.28em' }}
+                  style={{ fontFamily: 'var(--font-terminal)', letterSpacing: '0.28em' }}
                 >
                   {s.label}
                 </div>

--- a/prd-admin/src/pages/home/sections/ThreePillars.tsx
+++ b/prd-admin/src/pages/home/sections/ThreePillars.tsx
@@ -102,7 +102,7 @@ function PillarColumn({
       <div
         className="text-[10px] uppercase text-white/35 mb-7"
         style={{
-          fontFamily: 'var(--font-mono)',
+          fontFamily: 'var(--font-terminal)',
           letterSpacing: '0.22em',
         }}
       >

--- a/prd-admin/src/pages/home/sections/WorkflowCanvas.tsx
+++ b/prd-admin/src/pages/home/sections/WorkflowCanvas.tsx
@@ -47,7 +47,7 @@ export function WorkflowCanvas() {
             <Reveal offset={14}>
               <div
                 className="inline-flex items-center gap-2 mb-5"
-                style={{ fontFamily: 'var(--font-mono)' }}
+                style={{ fontFamily: 'var(--font-terminal)' }}
               >
                 <span
                   className="inline-block w-1.5 h-1.5 rounded-full"
@@ -95,7 +95,7 @@ export function WorkflowCanvas() {
               <div
                 className="text-[11px] text-white/35 mt-4"
                 style={{
-                  fontFamily: 'var(--font-mono)',
+                  fontFamily: 'var(--font-terminal)',
                   letterSpacing: '0.18em',
                 }}
               >
@@ -141,7 +141,7 @@ function WorkflowMockup() {
       <div className="flex items-center justify-between px-6 py-4 border-b border-white/[0.06]">
         <div
           className="flex items-center gap-2 text-[12px] text-white/70"
-          style={{ fontFamily: 'var(--font-mono)' }}
+          style={{ fontFamily: 'var(--font-terminal)' }}
         >
           <Workflow className="w-3.5 h-3.5 text-emerald-400" />
           <span>{t.workflow.canvasTitle}</span>
@@ -206,7 +206,7 @@ function WorkflowMockup() {
         {/* status footer */}
         <div
           className="relative z-10 mt-10 flex flex-wrap items-center gap-x-6 gap-y-1 text-[10.5px] text-white/45"
-          style={{ fontFamily: 'var(--font-mono)', letterSpacing: '0.04em' }}
+          style={{ fontFamily: 'var(--font-terminal)', letterSpacing: '0.04em' }}
         >
           <span className="flex items-center gap-1.5">
             <span
@@ -333,7 +333,7 @@ function Node({
       </div>
       <div
         className="text-[9.5px] md:text-[10px] text-white/35 mt-0.5 truncate max-w-full"
-        style={{ fontFamily: 'var(--font-mono)' }}
+        style={{ fontFamily: 'var(--font-terminal)' }}
       >
         {subtitle}
       </div>

--- a/prd-admin/src/styles/tokens.css
+++ b/prd-admin/src/styles/tokens.css
@@ -56,8 +56,10 @@
   /* ── 首页品牌字体（与 index.html Google Fonts 对应） ── */
   --font-display: 'Space Grotesk', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Hiragino Sans GB', sans-serif;
   --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Hiragino Sans GB', sans-serif;
-  /* 终端 / HUD mono，用于 retro-futurism 标签与小文本 */
-  --font-mono: 'VT323', 'Share Tech Mono', ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace;
+  /* 终端 / HUD mono，仅用于 retro-futurism 标签与小文本（landing / hero / arena）。
+     注意：不要命名为 --font-mono，否则会被 Tailwind v4 的 `font-mono` 工具类通过 CSS 变量级联劫持，
+     让全局所有 .font-mono 元素都渲染成 VT323 像素字体，小字号尤其会显得字距异常、字形拉伸。 */
+  --font-terminal: 'VT323', 'Share Tech Mono', ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace;
 
   /* ── 移动端适配 Token ── */
   --mobile-padding: 16px;


### PR DESCRIPTION
## Summary
Fixes a critical issue where the `--font-mono` CSS variable was being hijacked by Tailwind v4's `font-mono` utility class, causing all elements using `.font-mono` to render with the VT323 pixel font globally. This resulted in distorted character spacing and stretched glyphs, especially at small font sizes.

## Changes
- **tokens.css**: Renamed `--font-mono` to `--font-terminal` with updated documentation explaining the naming rationale and the Tailwind v4 cascade conflict
- **All component files**: Updated 30+ references across landing pages, arena, login, and home sections to use `var(--font-terminal)` instead of `var(--font-mono)`
  - ArenaPage.tsx (8 occurrences)
  - CommunityPulse.tsx (7 occurrences)
  - LoginPage.tsx (5 occurrences)
  - WorkflowCanvas.tsx (5 occurrences)
  - DesktopDownload.tsx (2 occurrences)
  - SignatureCinema.tsx (3 occurrences)
  - SectionHeader.tsx, TechLogoBar.tsx, AgentGrid.tsx, FeatureDeepDive.tsx, FinalCta.tsx, HeroSection.tsx, StatsStrip.tsx, ThreePillars.tsx (1 occurrence each)

## Implementation Details
- The VT323 retro-futurism font is intentionally scoped to specific UI elements (HUD chips, terminal labels, status indicators) in landing/hero/arena/login pages
- By avoiding the `--font-mono` naming convention, we prevent unintended cascade conflicts with Tailwind's built-in theme tokens
- All inline `style={{ fontFamily: 'var(--font-terminal)' }}` usages now correctly apply only to their intended components without global side effects

https://claude.ai/code/session_01V38kQBHDRiWaKFRidAhYja

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: purely a CSS variable rename plus mechanical reference updates; main risk is missed references causing unintended font fallback in retro UI labels.
> 
> **Overview**
> Prevents Tailwind v4’s `font-mono` utility from accidentally cascading a VT323 pixel font across the app by renaming the design token `--font-mono` to `--font-terminal` in `tokens.css`.
> 
> Updates retro/HUD text styling in login, arena, and home/landing sections to reference `var(--font-terminal)` instead of `var(--font-mono)`, and adds a changelog entry documenting the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d10efb2d10963396e88b390e18aae85f57207a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->