### PR TITLE
Add mobile error boundary & audit tool for blackscreen detection

### DIFF
--- a/changelogs/2026-04-22_mobile-apple-carousel-video.md
+++ b/changelogs/2026-04-22_mobile-apple-carousel-video.md
@@ -1,0 +1,1 @@
+| feat | prd-admin | 移动端首页第二轮苹果 Today 复刻对标：Hero 只保留"今日"单词（扔问候/姓名/日期/副标）；头像挪回 AppShell 右上角 header；Featured 改 3:4 海报级全屏轮播（5 张 snap-x）；视频背景（AGENT_VIDEO_DEFAULTS） + poster 图兜底 + mesh 渐变三级 fallback；只激活张自动播放省带宽；底部小点 page indicator；卡片副标限 1 行，Section caption 全部删除 |

--- a/changelogs/2026-04-22_mobile-apple-today-redesign.md
+++ b/changelogs/2026-04-22_mobile-apple-today-redesign.md
@@ -1,0 +1,3 @@
+| feat | prd-admin | 移动端首页页面级复刻苹果 App Store Today：新增 appStoreTokens 设计体系（字号 9 档 + 间距阶梯 + iOS Dark Mode 系统色 + SF Pro 字体栈），新增 mobile/appStore 组件集（Hero / Featured / Shelf / RankedList / SectionHeader / Pill / AppIcon / Section） |
+| feat | prd-admin | MobileHomePage 重写：Hero 大标题（日期 eyebrow + 34px 粗体问候 + 头像带通知红点）、Featured 大卡（今日推荐 Agent，复用 AGENT_COVER_DEFAULTS 封面图）、智能体横滑卡片（iOS Dark Mode 系统色 Accent 搭配每个 Agent）、工具 Top 榜单（编号 + 细分隔线）、极简 4 卡近 7 日统计、通知 / Feed 榜单风 |
+| refactor | prd-admin | AppShell 移动端首页 header 透明化：隐藏中间标题与右侧铃铛（已由 Hero 头像红点承担），避免和页面内 Hero 标题视觉冲突 |

--- a/changelogs/2026-04-22_mobile-blackscreen-fix.md
+++ b/changelogs/2026-04-22_mobile-blackscreen-fix.md
@@ -1,0 +1,4 @@
+| fix | prd-admin | 修复移动端登录后黑屏：新增 MobileSafeBoundary 错误边界（渲染异常不再静默卸载整棵树），MobileHomePage 改用 Promise.allSettled 避免单个 API 失败导致整页空白 |
+| fix | prd-admin | AppShell 根容器补 min-height:100dvh，修 iOS Safari 地址栏收缩引发的高度抖动/黑带 |
+| feat | prd-admin | 全局 window.error / unhandledrejection 自动捕获到 sessionStorage 环形缓冲，/_dev/mobile-audit 新增诊断视图（自动扫所有路由黑屏/JS 报错，客户端错误面板实时刷新） |
+| feat | prd-admin | 新增 mobileCompatibility 注册表 + MobileCompatGate：limited 页顶部黄色 banner 提示受限，pc-only 页中央门槛卡（继续/复制链接），full 页无感知 |

--- a/changelogs/2026-04-22_mobile-blackscreen-fix.md
+++ b/changelogs/2026-04-22_mobile-blackscreen-fix.md
@@ -3,3 +3,6 @@
 | fix | prd-admin | 修复 ChangelogBell 窄屏下无限 re-render + 请求风暴：selectRecentEntries 每次返回新数组触发 useSyncExternalStore 循环，改为组件侧 useMemo 派生 |
 | feat | prd-admin | 全局 window.error / unhandledrejection 自动捕获到 sessionStorage 环形缓冲，/_dev/mobile-audit 新增诊断视图（自动扫所有路由黑屏/JS 报错，客户端错误面板实时刷新） |
 | feat | prd-admin | 新增 mobileCompatibility 注册表 + MobileCompatGate：limited 页顶部黄色 banner 提示受限，pc-only 页中央门槛卡（继续/复制链接），full 页无感知 |
+| fix | prd-admin | 修复系统通知弹窗按钮被挤成竖排单字：卡片窄屏改竖排，按钮列 shrink-0，按钮文字 whitespace-nowrap |
+| fix | prd-admin | 移动端隐藏 AppShell 右下通知浮球（顶栏已有 Bell，避免与 MobileTabBar "+" 重叠） |
+| feat | prd-admin | MobileHomePage 重构首页：快捷入口 → 智能体 + 工具两个横滑卡片区（苹果 App Store 风），数据来自 BUILTIN_TOOLS；卡片右上角自动标记 pc-only/limited 徽章，首页即可触达所有内置 Agent |

--- a/changelogs/2026-04-22_mobile-blackscreen-fix.md
+++ b/changelogs/2026-04-22_mobile-blackscreen-fix.md
@@ -1,4 +1,5 @@
 | fix | prd-admin | 修复移动端登录后黑屏：新增 MobileSafeBoundary 错误边界（渲染异常不再静默卸载整棵树），MobileHomePage 改用 Promise.allSettled 避免单个 API 失败导致整页空白 |
 | fix | prd-admin | AppShell 根容器补 min-height:100dvh，修 iOS Safari 地址栏收缩引发的高度抖动/黑带 |
+| fix | prd-admin | 修复 ChangelogBell 窄屏下无限 re-render + 请求风暴：selectRecentEntries 每次返回新数组触发 useSyncExternalStore 循环，改为组件侧 useMemo 派生 |
 | feat | prd-admin | 全局 window.error / unhandledrejection 自动捕获到 sessionStorage 环形缓冲，/_dev/mobile-audit 新增诊断视图（自动扫所有路由黑屏/JS 报错，客户端错误面板实时刷新） |
 | feat | prd-admin | 新增 mobileCompatibility 注册表 + MobileCompatGate：limited 页顶部黄色 banner 提示受限，pc-only 页中央门槛卡（继续/复制链接），full 页无感知 |

--- a/changelogs/2026-04-22_mobile-icon-ripple.md
+++ b/changelogs/2026-04-22_mobile-icon-ripple.md
@@ -1,0 +1,2 @@
+| feat | prd-admin | 移动端首页：静态封面图作为 iOS app icon（AGENT_COVER_DEFAULTS），Featured 底部 glass bar + 智能体 Shelf 卡片全部改走封面图，无图 agent fallback Lucide + 渐变底 |
+| feat | prd-admin | 移动端 Featured Carousel 切换水波纹动效：点击底部小点触发 View Transition API，clip-path circle 从点击坐标扩散（520ms），复用系统皮肤切换同款技术栈；手指滑动保持原生 snap 手感；Safari < 18.2 降级为 scroll-behavior smooth |

--- a/prd-admin/src/components/MobileCompatGate.tsx
+++ b/prd-admin/src/components/MobileCompatGate.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useMemo, useState } from 'react';
+import { AlertTriangle, Copy, X, Monitor } from 'lucide-react';
+import { resolveMobileCompat, type MobileCompatLevel } from '@/lib/mobileCompatibility';
+
+interface Props {
+  pathname: string;
+}
+
+const DISMISS_KEY = 'map.mobile-compat-dismissed.v1';
+
+function readDismissed(): Set<string> {
+  try {
+    const raw = sessionStorage.getItem(DISMISS_KEY);
+    if (!raw) return new Set();
+    return new Set(JSON.parse(raw) as string[]);
+  } catch {
+    return new Set();
+  }
+}
+
+function writeDismissed(set: Set<string>) {
+  try {
+    sessionStorage.setItem(DISMISS_KEY, JSON.stringify([...set]));
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * 移动端兼容性门槛 —— 只在 isMobile 视口下由 AppShell 渲染。
+ *
+ *  - `full` 或无注册：不渲染
+ *  - `limited`：顶部黄色细 banner（非阻断）
+ *  - `pc-only`：中央半透明提示卡 + 继续 / 复制链接；已关闭过的路由本会话内不再提示
+ */
+export function MobileCompatGate({ pathname }: Props) {
+  const entry = useMemo(() => resolveMobileCompat(pathname), [pathname]);
+  const level: MobileCompatLevel | null = entry?.level ?? null;
+  const [dismissed, setDismissed] = useState<Set<string>>(() => readDismissed());
+  const [bannerClosed, setBannerClosed] = useState(false);
+
+  // 路由切换时清掉 banner 关闭状态（每个新路由都重新显示）
+  useEffect(() => {
+    setBannerClosed(false);
+  }, [pathname]);
+
+  const dismissPcOnly = () => {
+    const next = new Set(dismissed);
+    next.add(pathname);
+    setDismissed(next);
+    writeDismissed(next);
+  };
+
+  const copyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+    } catch {
+      // fallback
+      const ta = document.createElement('textarea');
+      ta.value = window.location.href;
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand('copy');
+      document.body.removeChild(ta);
+    }
+  };
+
+  if (!level) {
+    // 未注册：给一条非常轻的提示条，仅出现一次
+    return null;
+  }
+
+  if (level === 'full') return null;
+
+  if (level === 'limited') {
+    if (bannerClosed) return null;
+    return (
+      <div
+        className="mb-3 flex items-start gap-2 px-3 py-2 rounded-xl"
+        style={{
+          background: 'rgba(251, 191, 36, 0.10)',
+          border: '1px solid rgba(251, 191, 36, 0.25)',
+          color: 'rgba(255, 236, 179, 0.95)',
+          fontSize: 12,
+          lineHeight: 1.5,
+        }}
+      >
+        <AlertTriangle size={14} style={{ color: '#FBBF24', marginTop: 2, flexShrink: 0 }} />
+        <div className="flex-1">
+          <span>移动端部分功能受限。</span>
+          {entry?.note && <span style={{ opacity: 0.85 }}> {entry.note}</span>}
+        </div>
+        <button
+          type="button"
+          aria-label="关闭提示"
+          onClick={() => setBannerClosed(true)}
+          className="shrink-0 p-1 rounded hover:bg-white/10"
+          style={{ color: 'rgba(255, 236, 179, 0.7)' }}
+        >
+          <X size={12} />
+        </button>
+      </div>
+    );
+  }
+
+  // pc-only：全屏门槛
+  if (dismissed.has(pathname)) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[150] flex items-center justify-center px-5"
+      style={{ background: 'rgba(8, 8, 12, 0.82)', backdropFilter: 'blur(8px)' }}
+    >
+      <div
+        className="w-full max-w-md rounded-2xl p-5"
+        style={{
+          background: 'rgba(22, 22, 28, 0.95)',
+          border: '1px solid rgba(255, 255, 255, 0.08)',
+          color: 'var(--text-primary, #f7f7fb)',
+          boxShadow: '0 20px 40px rgba(0,0,0,0.5)',
+        }}
+      >
+        <div className="flex items-start gap-3 mb-3">
+          <div
+            className="h-10 w-10 rounded-xl flex items-center justify-center shrink-0"
+            style={{ background: 'rgba(248, 113, 113, 0.18)' }}
+          >
+            <Monitor size={20} style={{ color: '#f87171' }} />
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="text-base font-semibold mb-1">此页面建议在 PC 上使用</div>
+            <div className="text-[13px] opacity-75 leading-relaxed">
+              {entry?.note || '该功能依赖大屏幕 / 鼠标拖拽，移动端体验不佳。'}
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2 mt-4">
+          <button
+            type="button"
+            onClick={dismissPcOnly}
+            className="flex-1 px-4 py-2.5 rounded-xl text-[13px] font-medium transition-all active:scale-95"
+            style={{ background: 'rgba(129, 140, 248, 0.22)', color: '#c7d2fe' }}
+          >
+            继续浏览
+          </button>
+          <button
+            type="button"
+            onClick={copyLink}
+            className="inline-flex items-center gap-1.5 px-4 py-2.5 rounded-xl text-[13px] transition-all active:scale-95"
+            style={{ background: 'rgba(255, 255, 255, 0.08)', color: 'var(--text-primary)' }}
+          >
+            <Copy size={13} /> 复制链接
+          </button>
+        </div>
+        <div className="mt-3 text-center text-[11px]" style={{ color: 'var(--text-muted, rgba(255,255,255,0.45))' }}>
+          复制链接后在 PC 浏览器打开即可
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/prd-admin/src/components/MobileSafeBoundary.tsx
+++ b/prd-admin/src/components/MobileSafeBoundary.tsx
@@ -1,0 +1,173 @@
+import React from 'react';
+import { RefreshCw, Home, Copy, ChevronDown, ChevronUp } from 'lucide-react';
+import { recordClientError } from '@/lib/clientErrorReporter';
+
+interface Props {
+  children: React.ReactNode;
+  /** 触发 resetKey 变化时自动清掉错误状态（路由切换后重新渲染） */
+  resetKey?: string | number;
+}
+
+interface State {
+  error: Error | null;
+  errorInfo: React.ErrorInfo | null;
+  expanded: boolean;
+}
+
+/**
+ * 全局错误边界 —— 专门防止「某个页面渲染抛错 → 整个 App 卸载 → 黑屏」。
+ *
+ * 触发时展示：错误标题 + 一键重试 / 回首页 / 展开技术细节 / 复制堆栈。
+ * 同时把错误转发给 clientErrorReporter，进入 sessionStorage 环形缓冲（供 /_dev/mobile-audit 读取）。
+ */
+export class MobileSafeBoundary extends React.Component<Props, State> {
+  state: State = { error: null, errorInfo: null, expanded: false };
+
+  static getDerivedStateFromError(error: Error): Partial<State> {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    this.setState({ errorInfo });
+    recordClientError({
+      kind: 'render',
+      message: error.message,
+      stack: error.stack,
+      componentStack: errorInfo.componentStack ?? undefined,
+      url: window.location.href,
+      userAgent: navigator.userAgent,
+      viewport: `${window.innerWidth}x${window.innerHeight}`,
+    });
+  }
+
+  componentDidUpdate(prevProps: Props): void {
+    if (prevProps.resetKey !== this.props.resetKey && this.state.error) {
+      this.setState({ error: null, errorInfo: null, expanded: false });
+    }
+  }
+
+  reset = () => {
+    this.setState({ error: null, errorInfo: null, expanded: false });
+  };
+
+  goHome = () => {
+    this.reset();
+    window.location.hash = '';
+    window.location.pathname = '/';
+  };
+
+  copyStack = async () => {
+    const { error, errorInfo } = this.state;
+    const text = [
+      `URL: ${window.location.href}`,
+      `UA: ${navigator.userAgent}`,
+      `Viewport: ${window.innerWidth}x${window.innerHeight}`,
+      `Error: ${error?.message}`,
+      '',
+      'Stack:',
+      error?.stack ?? '(无)',
+      '',
+      'Component Stack:',
+      errorInfo?.componentStack ?? '(无)',
+    ].join('\n');
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      // fallback: 选中文本区供手动复制
+      const ta = document.createElement('textarea');
+      ta.value = text;
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand('copy');
+      document.body.removeChild(ta);
+    }
+  };
+
+  render() {
+    if (!this.state.error) return this.props.children;
+
+    const { error, errorInfo, expanded } = this.state;
+    return (
+      <div
+        className="h-full w-full flex items-center justify-center overflow-auto"
+        style={{ background: 'var(--bg-base, #141418)', padding: 16 }}
+      >
+        <div
+          className="w-full max-w-lg rounded-2xl p-5"
+          style={{
+            background: 'rgba(24, 24, 30, 0.9)',
+            border: '1px solid rgba(255, 80, 80, 0.25)',
+            color: 'var(--text-primary, #f7f7fb)',
+          }}
+        >
+          <div className="flex items-start gap-3 mb-3">
+            <div
+              className="h-10 w-10 rounded-xl flex items-center justify-center shrink-0"
+              style={{ background: 'rgba(248, 113, 113, 0.18)' }}
+            >
+              <span style={{ color: '#f87171', fontSize: 20 }}>!</span>
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="text-base font-semibold mb-1">页面渲染出错</div>
+              <div className="text-[13px] opacity-70 break-all">
+                {error.message || '未知错误'}
+              </div>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-2 mb-3">
+            <button
+              type="button"
+              onClick={this.reset}
+              className="inline-flex items-center gap-1.5 px-3 py-2 rounded-xl text-[13px] transition-all active:scale-95"
+              style={{ background: 'rgba(129, 140, 248, 0.18)', color: '#c7d2fe' }}
+            >
+              <RefreshCw size={14} /> 重试
+            </button>
+            <button
+              type="button"
+              onClick={this.goHome}
+              className="inline-flex items-center gap-1.5 px-3 py-2 rounded-xl text-[13px] transition-all active:scale-95"
+              style={{ background: 'rgba(255, 255, 255, 0.08)', color: 'var(--text-primary)' }}
+            >
+              <Home size={14} /> 回首页
+            </button>
+            <button
+              type="button"
+              onClick={this.copyStack}
+              className="inline-flex items-center gap-1.5 px-3 py-2 rounded-xl text-[13px] transition-all active:scale-95"
+              style={{ background: 'rgba(255, 255, 255, 0.06)', color: 'var(--text-secondary, #cfd0d7)' }}
+            >
+              <Copy size={14} /> 复制错误
+            </button>
+            <button
+              type="button"
+              onClick={() => this.setState({ expanded: !expanded })}
+              className="inline-flex items-center gap-1.5 px-3 py-2 rounded-xl text-[13px] transition-all active:scale-95"
+              style={{ background: 'rgba(255, 255, 255, 0.04)', color: 'var(--text-muted, #8c8d99)' }}
+            >
+              {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+              {expanded ? '收起细节' : '展开细节'}
+            </button>
+          </div>
+
+          {expanded && (
+            <pre
+              className="text-[11px] leading-[1.5] rounded-lg p-3 overflow-auto"
+              style={{
+                background: 'rgba(0, 0, 0, 0.35)',
+                maxHeight: 280,
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word',
+                color: 'var(--text-muted, #8c8d99)',
+              }}
+            >
+              {error.stack ?? '(无 stack)'}
+              {errorInfo?.componentStack ? `\n\n-- Component stack --${errorInfo.componentStack}` : ''}
+            </pre>
+          )}
+        </div>
+      </div>
+    );
+  }
+}

--- a/prd-admin/src/components/changelog/ChangelogBell.tsx
+++ b/prd-admin/src/components/changelog/ChangelogBell.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Sparkles, ArrowRight, Calendar } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
@@ -50,11 +50,20 @@ export function ChangelogBell({ size = 18, compact = false }: ChangelogBellProps
   const [popoverPos, setPopoverPos] = useState<{ top: number; left: number } | null>(null);
 
   const currentWeek = useChangelogStore((s) => s.currentWeek);
+  const lastSeenAt = useChangelogStore((s) => s.lastSeenAt);
   const loadingCurrent = useChangelogStore((s) => s.loadingCurrent);
   const loadCurrentWeek = useChangelogStore((s) => s.loadCurrentWeek);
   const markAsSeen = useChangelogStore((s) => s.markAsSeen);
-  const unread = useChangelogStore(selectUnreadCount);
-  const recent = useChangelogStore((s) => selectRecentEntries(s, 5));
+  // 通过 useMemo 在组件侧派生，避免 selector 每次返回新数组
+  // 触发 zustand useSyncExternalStore 的无限 re-render（getSnapshot should be cached）
+  const unread = useMemo(
+    () => selectUnreadCount({ currentWeek, lastSeenAt } as Parameters<typeof selectUnreadCount>[0]),
+    [currentWeek, lastSeenAt],
+  );
+  const recent = useMemo(
+    () => selectRecentEntries({ currentWeek } as Parameters<typeof selectRecentEntries>[0], 5),
+    [currentWeek],
+  );
 
   // 首次挂载：拉取本周更新（让红点提前出现）
   useEffect(() => {

--- a/prd-admin/src/components/mobile/appStore.tsx
+++ b/prd-admin/src/components/mobile/appStore.tsx
@@ -128,14 +128,60 @@ export function AppStorePill({ label, onClick, caption, variant = 'default' }: P
 
 interface AppIconProps {
   Icon: LucideIcon;
-  /** 渐变主题色（from / to），用于图标底色 */
+  /** 渐变主题色（from / to），Lucide fallback 时的图标底色 */
   accent: { from: string; to: string };
+  /** 静态封面图（优先使用，iOS app icon 级质感） */
+  imageUrl?: string | null;
   size?: number;
-  /** 叠在图片上时的特殊模式（白磨砂底） */
+  /** 叠在图片上时的特殊模式（白磨砂底，仅 Lucide fallback 用） */
   onImage?: boolean;
 }
 
-export function AppStoreAppIcon({ Icon, accent, size = AS_SIZE.appIconSize, onImage = false }: AppIconProps) {
+export function AppStoreAppIcon({
+  Icon,
+  accent,
+  imageUrl,
+  size = AS_SIZE.appIconSize,
+  onImage = false,
+}: AppIconProps) {
+  // 有封面图 —— 直接铺图（iOS app icon 的"品牌级"视觉）
+  if (imageUrl) {
+    return (
+      <div
+        className="shrink-0 overflow-hidden relative"
+        style={{
+          width: size,
+          height: size,
+          borderRadius: AS_SPACE.iconRadius,
+          background: '#1c1c1e',
+          boxShadow: onImage
+            ? '0 1px 3px rgba(0, 0, 0, 0.12)'
+            : '0 2px 6px rgba(0, 0, 0, 0.35)',
+        }}
+      >
+        <img
+          src={imageUrl}
+          alt=""
+          aria-hidden
+          className="w-full h-full object-cover"
+          onError={(e) => {
+            // img 加载失败 → 隐藏 img，露出下面的渐变兜底
+            e.currentTarget.style.display = 'none';
+          }}
+        />
+        {/* 图片之下的渐变兜底层（img 失败后可见） */}
+        <div
+          aria-hidden
+          className="absolute inset-0 -z-10 flex items-center justify-center"
+          style={{ background: `linear-gradient(135deg, ${accent.from}, ${accent.to})` }}
+        >
+          <Icon size={Math.round(size * 0.55)} strokeWidth={2} style={{ color: '#fff' }} />
+        </div>
+      </div>
+    );
+  }
+
+  // 无封面图 —— Lucide + 渐变底（原方案）
   const background = onImage
     ? 'rgba(255, 255, 255, 0.95)'
     : `linear-gradient(135deg, ${accent.from}, ${accent.to})`;
@@ -179,6 +225,8 @@ export interface FeaturedItem {
   /** 底部玻璃条的 app 信息 */
   footer: {
     Icon: LucideIcon;
+    /** 静态封面图 URL（iOS app icon 式），没有才 fallback 到 Icon */
+    iconImageUrl?: string | null;
     name: string;
     tagline: string;
   };
@@ -207,6 +255,7 @@ export function AppStoreFeatured(props: Omit<FeaturedItem, 'key'>) {
  */
 export function AppStoreFeaturedCarousel({ items }: { items: FeaturedItem[] }) {
   const scrollerRef = useRef<HTMLDivElement | null>(null);
+  const surfaceRef = useRef<HTMLDivElement | null>(null);
   const [activeIdx, setActiveIdx] = useState(0);
 
   useEffect(() => {
@@ -232,6 +281,47 @@ export function AppStoreFeaturedCarousel({ items }: { items: FeaturedItem[] }) {
     };
   }, [items.length]);
 
+  /**
+   * 点击小点切换 —— 走 View Transition API 的 clip-path 水波纹扩散。
+   * 手指滑动 carousel 走原生 snap（不拦截，保留跟手手感）。
+   * 不支持 View Transition 的浏览器降级为 scroll smooth。
+   */
+  const switchTo = (target: number, origin: { clientX: number; clientY: number }) => {
+    if (target === activeIdx) return;
+    const scroller = scrollerRef.current;
+    const surface = surfaceRef.current;
+    if (!scroller) return;
+
+    const slideWidth = scroller.firstElementChild?.getBoundingClientRect().width ?? 0;
+    const gap = AS_SIZE.shelfGap;
+    const targetLeft = target * (slideWidth + gap);
+
+    // 水波纹起点：相对 surface 容器的坐标（百分比更稳，避免受滚动影响）
+    if (surface) {
+      const rect = surface.getBoundingClientRect();
+      const xPct = Math.max(0, Math.min(100, ((origin.clientX - rect.left) / rect.width) * 100));
+      const yPct = Math.max(0, Math.min(100, ((origin.clientY - rect.top) / rect.height) * 100));
+      surface.style.setProperty('--as-ripple-x', `${xPct.toFixed(2)}%`);
+      surface.style.setProperty('--as-ripple-y', `${yPct.toFixed(2)}%`);
+    }
+
+    const doc = document as Document & {
+      startViewTransition?: (cb: () => void) => { finished: Promise<void> };
+    };
+
+    const apply = () => {
+      scroller.scrollTo({ left: targetLeft, behavior: 'instant' as ScrollBehavior });
+      setActiveIdx(target);
+    };
+
+    if (typeof doc.startViewTransition === 'function') {
+      doc.startViewTransition(apply);
+    } else {
+      scroller.scrollTo({ left: targetLeft, behavior: 'smooth' });
+      setActiveIdx(target);
+    }
+  };
+
   if (items.length === 0) return null;
   if (items.length === 1) {
     return (
@@ -242,7 +332,7 @@ export function AppStoreFeaturedCarousel({ items }: { items: FeaturedItem[] }) {
   }
 
   return (
-    <div>
+    <div ref={surfaceRef} data-ripple-transition>
       <div
         ref={scrollerRef}
         className="flex overflow-x-auto snap-x snap-mandatory"
@@ -259,20 +349,37 @@ export function AppStoreFeaturedCarousel({ items }: { items: FeaturedItem[] }) {
           <FeaturedSlide key={item.key} item={item} isActive={i === activeIdx} />
         ))}
       </div>
-      {/* 页指示小点 */}
-      <div className="flex items-center justify-center" style={{ gap: 6, marginTop: 14 }}>
-        {items.map((_, i) => (
-          <span
-            key={i}
-            style={{
-              width: i === activeIdx ? 16 : 6,
-              height: 6,
-              borderRadius: 999,
-              background: i === activeIdx ? AS_COLOR.label : AS_COLOR.labelTertiary,
-              transition: 'all 220ms ease',
-            }}
-          />
-        ))}
+
+      {/* 页指示小点 —— 可点击，触发水波纹切换 */}
+      <div
+        className="flex items-center justify-center"
+        style={{ gap: 8, marginTop: 14 }}
+        role="tablist"
+        aria-label="推荐内容"
+      >
+        {items.map((_, i) => {
+          const active = i === activeIdx;
+          return (
+            <button
+              key={i}
+              type="button"
+              role="tab"
+              aria-selected={active}
+              aria-label={`第 ${i + 1} 个推荐`}
+              onClick={(e) => switchTo(i, { clientX: e.clientX, clientY: e.clientY })}
+              className="transition-all"
+              style={{
+                width: active ? 22 : 7,
+                height: 7,
+                borderRadius: 999,
+                background: active ? AS_COLOR.label : AS_COLOR.labelTertiary,
+                border: 'none',
+                padding: 0,
+                cursor: 'pointer',
+              }}
+            />
+          );
+        })}
       </div>
     </div>
   );
@@ -402,7 +509,13 @@ function FeaturedSlide({ item, isActive }: { item: FeaturedItem; isActive: boole
         className="absolute left-0 right-0 bottom-0 flex items-center gap-3"
         style={{ padding: 16 }}
       >
-        <AppStoreAppIcon Icon={item.footer.Icon} accent={item.accent} size={48} onImage />
+        <AppStoreAppIcon
+          Icon={item.footer.Icon}
+          accent={item.accent}
+          imageUrl={item.footer.iconImageUrl}
+          size={52}
+          onImage
+        />
         <div className="min-w-0 flex-1">
           <div
             className="truncate"
@@ -432,6 +545,8 @@ function FeaturedSlide({ item, isActive }: { item: FeaturedItem; isActive: boole
 interface ShelfItem {
   key: string;
   Icon: LucideIcon;
+  /** 静态封面图（Agent 有，Tool 通常没有）—— 有图时用 iOS app icon 式封面 */
+  iconImageUrl?: string | null;
   accent: { from: string; to: string };
   title: string;
   subtitle: string;
@@ -483,7 +598,7 @@ function ShelfCard({ item }: { item: ShelfItem }) {
         border: `1px solid ${AS_COLOR.hairline}`,
       }}
     >
-      <AppStoreAppIcon Icon={item.Icon} accent={item.accent} size={56} />
+      <AppStoreAppIcon Icon={item.Icon} accent={item.accent} imageUrl={item.iconImageUrl} size={56} />
       <div className="min-w-0 flex-1">
         <div
           className="truncate"

--- a/prd-admin/src/components/mobile/appStore.tsx
+++ b/prd-admin/src/components/mobile/appStore.tsx
@@ -1,0 +1,565 @@
+import { ChevronRight } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import type { CSSProperties, ReactNode } from 'react';
+import { AS_COLOR, AS_TYPE, AS_SPACE, AS_SIZE, AS_FONT_FAMILY } from '@/lib/appStoreTokens';
+
+/**
+ * App Store Today tab（暗色）页面级复刻的基础组件集。
+ *
+ * 使用纪律：
+ *  - 每种排版只允许用 `AS_TYPE` 里的某一档，不允许自己写 fontSize
+ *  - 所有间距对齐 `AS_SPACE`，不自己造
+ *  - 暗色下永远用 `AS_COLOR.bg`（纯黑），不要 --bg-base 的灰黑
+ *  - 所有卡片圆角只能是 `featuredRadius (22)` / `shelfCardRadius (18)` / `iconRadius (12)` 三档
+ */
+
+/* ─────────────────────── Hero：页面主标题 ─────────────────────── */
+
+interface HeroProps {
+  /** 上眉日期/分组标签：`星期二 · 4 月 22 日` */
+  eyebrow?: string;
+  /** 大标题：`下午好，蒋云峰` */
+  title: string;
+  /** 副标：`看看今天能帮你做什么` */
+  subtitle?: string;
+  /** 右上头像区 */
+  trailing?: ReactNode;
+}
+
+export function AppStoreHero({ eyebrow, title, subtitle, trailing }: HeroProps) {
+  return (
+    <div
+      className="flex items-start justify-between gap-4"
+      style={{
+        fontFamily: AS_FONT_FAMILY,
+        padding: `${AS_SPACE.sectionGap}px ${AS_SPACE.gutter}px 0 ${AS_SPACE.gutter}px`,
+      }}
+    >
+      <div className="min-w-0 flex-1">
+        {eyebrow && (
+          <div
+            style={{
+              ...AS_TYPE.eyebrow,
+              color: AS_COLOR.labelSecondary,
+              marginBottom: 6,
+            }}
+          >
+            {eyebrow}
+          </div>
+        )}
+        <h1
+          style={{
+            ...AS_TYPE.heroTitle,
+            color: AS_COLOR.label,
+            margin: 0,
+            wordBreak: 'break-word',
+          }}
+        >
+          {title}
+        </h1>
+        {subtitle && (
+          <div
+            style={{
+              ...AS_TYPE.heroSubtitle,
+              color: AS_COLOR.labelSecondary,
+              marginTop: 6,
+            }}
+          >
+            {subtitle}
+          </div>
+        )}
+      </div>
+      {trailing && <div className="shrink-0">{trailing}</div>}
+    </div>
+  );
+}
+
+/* ─────────────────────── SectionHeader：区块标题 + See All ─────────────────────── */
+
+interface SectionHeaderProps {
+  title: string;
+  /** 右侧可点的"全部"/"See All"行动点 */
+  onShowAll?: () => void;
+  /** 标题下方的说明文字（可选） */
+  caption?: string;
+}
+
+export function AppStoreSectionHeader({ title, onShowAll, caption }: SectionHeaderProps) {
+  return (
+    <div style={{ padding: `0 ${AS_SPACE.gutter}px`, marginBottom: AS_SPACE.titleGap, fontFamily: AS_FONT_FAMILY }}>
+      <div className="flex items-end justify-between gap-3">
+        <h2 style={{ ...AS_TYPE.sectionTitle, color: AS_COLOR.label, margin: 0 }}>{title}</h2>
+        {onShowAll && (
+          <button
+            type="button"
+            onClick={onShowAll}
+            className="inline-flex items-center gap-0.5 active:opacity-60 transition-opacity"
+            style={{ ...AS_TYPE.sectionAction, color: AS_COLOR.blue }}
+          >
+            全部
+            <ChevronRight size={18} strokeWidth={2.2} />
+          </button>
+        )}
+      </div>
+      {caption && (
+        <div style={{ ...AS_TYPE.itemSubtitle, color: AS_COLOR.labelSecondary, marginTop: 4 }}>
+          {caption}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ─────────────────────── Pill Button：Get/Open 药丸按钮 ─────────────────────── */
+
+interface PillButtonProps {
+  label: string;
+  onClick?: (e: React.MouseEvent) => void;
+  /** 附加说明（如 "In-App Purchases"） */
+  caption?: string;
+  /** 反色（在深色图片上使用，用半透明白底 + 黑字） */
+  variant?: 'default' | 'onImage';
+}
+
+export function AppStorePill({ label, onClick, caption, variant = 'default' }: PillButtonProps) {
+  const bg = variant === 'onImage' ? 'rgba(255, 255, 255, 0.20)' : AS_COLOR.pillBg;
+  const fg = variant === 'onImage' ? AS_COLOR.label : AS_COLOR.blue;
+  return (
+    <div className="flex flex-col items-center gap-0.5 shrink-0" style={{ fontFamily: AS_FONT_FAMILY }}>
+      <button
+        type="button"
+        onClick={onClick}
+        className="inline-flex items-center justify-center transition-opacity active:opacity-60"
+        style={{
+          height: AS_SIZE.pillHeight,
+          minWidth: 78,
+          padding: '0 18px',
+          borderRadius: AS_SPACE.pillRadius,
+          background: bg,
+          color: fg,
+          backdropFilter: variant === 'onImage' ? 'blur(20px) saturate(180%)' : undefined,
+          WebkitBackdropFilter: variant === 'onImage' ? 'blur(20px) saturate(180%)' : undefined,
+          ...AS_TYPE.pill,
+          border: 'none',
+        }}
+      >
+        {label}
+      </button>
+      {caption && (
+        <div style={{ ...AS_TYPE.caption, color: AS_COLOR.labelTertiary }}>{caption}</div>
+      )}
+    </div>
+  );
+}
+
+/* ─────────────────────── AppIcon：圆角 52×52 图标格 ─────────────────────── */
+
+interface AppIconProps {
+  Icon: LucideIcon;
+  /** 渐变主题色（from / to），用于图标底色 */
+  accent: { from: string; to: string };
+  size?: number;
+  /** 叠在图片上时的特殊模式（白磨砂底） */
+  onImage?: boolean;
+}
+
+export function AppStoreAppIcon({ Icon, accent, size = AS_SIZE.appIconSize, onImage = false }: AppIconProps) {
+  const background = onImage
+    ? 'rgba(255, 255, 255, 0.95)'
+    : `linear-gradient(135deg, ${accent.from}, ${accent.to})`;
+  const iconColor = onImage ? accent.from : '#FFFFFF';
+  return (
+    <div
+      className="shrink-0 flex items-center justify-center"
+      style={{
+        width: size,
+        height: size,
+        borderRadius: AS_SPACE.iconRadius,
+        background,
+        boxShadow: onImage
+          ? '0 1px 3px rgba(0, 0, 0, 0.12)'
+          : `0 2px 8px ${accent.from}40`,
+      }}
+    >
+      <Icon size={Math.round(size * 0.55)} strokeWidth={2} style={{ color: iconColor }} />
+    </div>
+  );
+}
+
+/* ─────────────────────── Featured：Today 大卡 ─────────────────────── */
+
+interface FeaturedProps {
+  /** 上眉小标签：NOW AVAILABLE / MEET THE AGENT 等 */
+  eyebrow: string;
+  /** 上眉颜色（iOS System Color） */
+  eyebrowColor?: string;
+  /** 主标 */
+  title: string;
+  /** 副标（一两行） */
+  subtitle?: string;
+  /** 背景图 URL；不提供则用 accent 渐变兜底 */
+  imageUrl?: string | null;
+  /** 渐变 fallback + mesh 的主题色 */
+  accent: { from: string; to: string };
+  /** 底部玻璃条的 app 信息 */
+  footer: {
+    Icon: LucideIcon;
+    name: string;
+    tagline: string;
+  };
+  onClick: () => void;
+  /** 底部按钮文字，默认"打开" */
+  pillLabel?: string;
+  /** 底部按钮下方说明 */
+  pillCaption?: string;
+}
+
+export function AppStoreFeatured({
+  eyebrow,
+  eyebrowColor,
+  title,
+  subtitle,
+  imageUrl,
+  accent,
+  footer,
+  onClick,
+  pillLabel = '打开',
+  pillCaption,
+}: FeaturedProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="relative overflow-hidden block w-full text-left transition-transform active:scale-[0.985]"
+      style={{
+        margin: `0 ${AS_SPACE.gutter}px`,
+        width: `calc(100% - ${AS_SPACE.gutter * 2}px)`,
+        aspectRatio: AS_SIZE.featuredAspect,
+        borderRadius: AS_SPACE.featuredRadius,
+        background: imageUrl ? '#000' : buildMeshGradient(accent),
+        fontFamily: AS_FONT_FAMILY,
+        border: `1px solid ${AS_COLOR.hairline}`,
+      }}
+    >
+      {/* 背景图层 */}
+      {imageUrl && (
+        <img
+          src={imageUrl}
+          alt=""
+          aria-hidden
+          className="absolute inset-0 w-full h-full object-cover"
+          onError={(e) => {
+            (e.currentTarget.style.display = 'none');
+          }}
+        />
+      )}
+
+      {/* 底部渐变蒙版，保证文字可读（苹果的标配） */}
+      <div
+        aria-hidden
+        className="absolute inset-x-0 bottom-0"
+        style={{
+          top: '40%',
+          background: 'linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.55) 55%, rgba(0,0,0,0.85) 100%)',
+        }}
+      />
+
+      {/* 顶部 eyebrow + 标题 + 副标 */}
+      <div
+        className="absolute left-0 right-0 top-0 flex flex-col"
+        style={{ padding: 20, gap: 6 }}
+      >
+        <div
+          style={{
+            ...AS_TYPE.eyebrow,
+            color: eyebrowColor ?? AS_COLOR.blue,
+            textShadow: '0 1px 2px rgba(0,0,0,0.4)',
+          }}
+        >
+          {eyebrow}
+        </div>
+        <div
+          style={{
+            ...AS_TYPE.featuredTitle,
+            color: AS_COLOR.label,
+            textShadow: '0 2px 8px rgba(0,0,0,0.4)',
+            maxWidth: '90%',
+          }}
+        >
+          {title}
+        </div>
+        {subtitle && (
+          <div
+            style={{
+              ...AS_TYPE.featuredSubtitle,
+              color: 'rgba(255,255,255,0.85)',
+              textShadow: '0 1px 4px rgba(0,0,0,0.4)',
+              maxWidth: '90%',
+            }}
+          >
+            {subtitle}
+          </div>
+        )}
+      </div>
+
+      {/* 底部玻璃条：icon + 名字 + 一句话 + Pill */}
+      <div
+        className="absolute left-0 right-0 bottom-0 flex items-center gap-3"
+        style={{ padding: 14 }}
+      >
+        <AppStoreAppIcon Icon={footer.Icon} accent={accent} size={48} onImage />
+        <div className="min-w-0 flex-1">
+          <div
+            className="truncate"
+            style={{ ...AS_TYPE.itemTitle, color: AS_COLOR.label }}
+          >
+            {footer.name}
+          </div>
+          <div
+            className="truncate"
+            style={{ ...AS_TYPE.itemSubtitle, color: 'rgba(255,255,255,0.75)' }}
+          >
+            {footer.tagline}
+          </div>
+        </div>
+        <AppStorePill label={pillLabel} caption={pillCaption} variant="onImage" />
+      </div>
+    </button>
+  );
+}
+
+/* ─────────────────────── Shelf：横滑横幅卡片列表 ─────────────────────── */
+
+interface ShelfItem {
+  key: string;
+  Icon: LucideIcon;
+  accent: { from: string; to: string };
+  title: string;
+  subtitle: string;
+  /** 右上角角标（如 "PC" / "WIP"） */
+  tag?: { label: string; color: string; bg: string };
+  pillLabel?: string;
+  onClick: () => void;
+}
+
+interface ShelfProps {
+  items: ShelfItem[];
+}
+
+export function AppStoreShelf({ items }: ShelfProps) {
+  if (items.length === 0) return null;
+  return (
+    <div
+      className="flex overflow-x-auto snap-x snap-mandatory"
+      style={{
+        gap: AS_SIZE.shelfGap,
+        paddingLeft: AS_SPACE.gutter,
+        paddingRight: AS_SPACE.gutter,
+        paddingBottom: 2,
+        scrollbarWidth: 'none',
+        WebkitOverflowScrolling: 'touch',
+        overscrollBehaviorX: 'contain',
+        fontFamily: AS_FONT_FAMILY,
+      }}
+    >
+      {items.map((item) => (
+        <ShelfCard key={item.key} item={item} />
+      ))}
+    </div>
+  );
+}
+
+function ShelfCard({ item }: { item: ShelfItem }) {
+  return (
+    <button
+      type="button"
+      onClick={item.onClick}
+      className="relative snap-start shrink-0 flex items-center gap-3 text-left transition-transform active:scale-[0.98]"
+      style={{
+        width: AS_SIZE.shelfCardWidth,
+        height: AS_SIZE.shelfCardHeight,
+        padding: '0 14px 0 14px',
+        borderRadius: AS_SPACE.shelfCardRadius,
+        background: AS_COLOR.surface,
+        border: `1px solid ${AS_COLOR.hairline}`,
+      }}
+    >
+      <AppStoreAppIcon Icon={item.Icon} accent={item.accent} size={56} />
+      <div className="min-w-0 flex-1">
+        <div
+          className="truncate"
+          style={{ ...AS_TYPE.itemTitle, color: AS_COLOR.label }}
+        >
+          {item.title}
+        </div>
+        <div
+          className="line-clamp-2"
+          style={{
+            ...AS_TYPE.itemSubtitle,
+            color: AS_COLOR.labelSecondary,
+            display: '-webkit-box',
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+          }}
+        >
+          {item.subtitle}
+        </div>
+      </div>
+      {item.pillLabel && (
+        <AppStorePill label={item.pillLabel} onClick={(e) => { e.stopPropagation(); item.onClick(); }} />
+      )}
+      {item.tag && (
+        <span
+          className="absolute top-2 right-2 inline-flex items-center"
+          style={{
+            padding: '2px 7px',
+            borderRadius: 6,
+            background: item.tag.bg,
+            color: item.tag.color,
+            fontSize: 10,
+            fontWeight: 700,
+            letterSpacing: '0.04em',
+          }}
+        >
+          {item.tag.label}
+        </span>
+      )}
+    </button>
+  );
+}
+
+/* ─────────────────────── RankedList：Top 榜单式列表 ─────────────────────── */
+
+interface RankedItem {
+  key: string;
+  Icon: LucideIcon;
+  accent: { from: string; to: string };
+  title: string;
+  subtitle: string;
+  /** 右侧按钮文字，默认"打开" */
+  pillLabel?: string;
+  /** Pill 下方附加说明，如 "PC 推荐使用" */
+  pillCaption?: string;
+  onClick: () => void;
+}
+
+interface RankedListProps {
+  items: RankedItem[];
+  /** 是否显示左侧数字编号（App Store Top 榜风格） */
+  numbered?: boolean;
+}
+
+export function AppStoreRankedList({ items, numbered = true }: RankedListProps) {
+  if (items.length === 0) return null;
+  return (
+    <div
+      style={{
+        padding: `0 ${AS_SPACE.gutter}px`,
+        fontFamily: AS_FONT_FAMILY,
+      }}
+    >
+      <div>
+        {items.map((item, idx) => (
+          <RankedRow
+            key={item.key}
+            item={item}
+            rank={numbered ? idx + 1 : null}
+            isLast={idx === items.length - 1}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function RankedRow({ item, rank, isLast }: { item: RankedItem; rank: number | null; isLast: boolean }) {
+  return (
+    <button
+      type="button"
+      onClick={item.onClick}
+      className="w-full text-left flex items-center gap-3 transition-opacity active:opacity-60"
+      style={{
+        padding: `${AS_SPACE.listItemPaddingY}px 0`,
+        position: 'relative',
+      }}
+    >
+      {rank !== null && (
+        <div
+          className="shrink-0 text-center"
+          style={{
+            width: 22,
+            ...AS_TYPE.itemTitle,
+            color: AS_COLOR.labelSecondary,
+            fontWeight: 400,
+          }}
+        >
+          {rank}
+        </div>
+      )}
+      <AppStoreAppIcon Icon={item.Icon} accent={item.accent} size={AS_SIZE.appIconSize} />
+      <div className="min-w-0 flex-1">
+        <div
+          className="truncate"
+          style={{ ...AS_TYPE.itemTitle, color: AS_COLOR.label }}
+        >
+          {item.title}
+        </div>
+        <div
+          className="truncate"
+          style={{ ...AS_TYPE.itemSubtitle, color: AS_COLOR.labelSecondary, marginTop: 2 }}
+        >
+          {item.subtitle}
+        </div>
+      </div>
+      <AppStorePill
+        label={item.pillLabel ?? '打开'}
+        caption={item.pillCaption}
+        onClick={(e) => { e.stopPropagation(); item.onClick(); }}
+      />
+      {/* iOS 分隔线 —— 从 icon 右侧开始 */}
+      {!isLast && (
+        <div
+          className="absolute left-0 right-0 bottom-0"
+          style={{
+            height: 0.5,
+            background: AS_COLOR.separator,
+            marginLeft: rank !== null ? AS_SPACE.listDividerInset + 22 + 12 : AS_SPACE.listDividerInset,
+          }}
+          aria-hidden
+        />
+      )}
+    </button>
+  );
+}
+
+/* ─────────────────────── 程序化 mesh 渐变（无封面图时的兜底） ─────────────────────── */
+
+function buildMeshGradient(accent: { from: string; to: string }): string {
+  // 叠三层径向渐变，模拟苹果 Today 那种有质感的背景
+  return [
+    `radial-gradient(120% 90% at 10% 0%, ${accent.from}cc, transparent 60%)`,
+    `radial-gradient(100% 80% at 90% 20%, ${accent.to}aa, transparent 55%)`,
+    `radial-gradient(110% 100% at 50% 100%, ${accent.from}66, transparent 60%)`,
+    `linear-gradient(180deg, #1c1c1e, #000000)`,
+  ].join(', ');
+}
+
+/* ─────────────────────── Section：统一包一层 Section 做区块间距 ─────────────────────── */
+
+interface SectionProps {
+  title?: string;
+  caption?: string;
+  onShowAll?: () => void;
+  children: ReactNode;
+  style?: CSSProperties;
+}
+
+export function AppStoreSection({ title, caption, onShowAll, children, style }: SectionProps) {
+  return (
+    <section style={{ marginTop: AS_SPACE.sectionGap, ...style }}>
+      {title && <AppStoreSectionHeader title={title} caption={caption} onShowAll={onShowAll} />}
+      {children}
+    </section>
+  );
+}

--- a/prd-admin/src/components/mobile/appStore.tsx
+++ b/prd-admin/src/components/mobile/appStore.tsx
@@ -1,6 +1,7 @@
 import { ChevronRight } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import type { CSSProperties, ReactNode } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { AS_COLOR, AS_TYPE, AS_SPACE, AS_SIZE, AS_FONT_FAMILY } from '@/lib/appStoreTokens';
 
 /**
@@ -16,60 +17,31 @@ import { AS_COLOR, AS_TYPE, AS_SPACE, AS_SIZE, AS_FONT_FAMILY } from '@/lib/appS
 /* ─────────────────────── Hero：页面主标题 ─────────────────────── */
 
 interface HeroProps {
-  /** 上眉日期/分组标签：`星期二 · 4 月 22 日` */
-  eyebrow?: string;
-  /** 大标题：`下午好，蒋云峰` */
+  /** 单词大标题（"今日" / "游戏" / "App"），苹果 Today 范式 */
   title: string;
-  /** 副标：`看看今天能帮你做什么` */
-  subtitle?: string;
-  /** 右上头像区 */
-  trailing?: ReactNode;
 }
 
-export function AppStoreHero({ eyebrow, title, subtitle, trailing }: HeroProps) {
+/**
+ * Apple Today 的页面大标题 —— **只有一个词**。
+ * 右上角头像由 AppShell header 承担，不放在这里。
+ */
+export function AppStoreHero({ title }: HeroProps) {
   return (
     <div
-      className="flex items-start justify-between gap-4"
       style={{
         fontFamily: AS_FONT_FAMILY,
-        padding: `${AS_SPACE.sectionGap}px ${AS_SPACE.gutter}px 0 ${AS_SPACE.gutter}px`,
+        padding: `8px ${AS_SPACE.gutter}px 0 ${AS_SPACE.gutter}px`,
       }}
     >
-      <div className="min-w-0 flex-1">
-        {eyebrow && (
-          <div
-            style={{
-              ...AS_TYPE.eyebrow,
-              color: AS_COLOR.labelSecondary,
-              marginBottom: 6,
-            }}
-          >
-            {eyebrow}
-          </div>
-        )}
-        <h1
-          style={{
-            ...AS_TYPE.heroTitle,
-            color: AS_COLOR.label,
-            margin: 0,
-            wordBreak: 'break-word',
-          }}
-        >
-          {title}
-        </h1>
-        {subtitle && (
-          <div
-            style={{
-              ...AS_TYPE.heroSubtitle,
-              color: AS_COLOR.labelSecondary,
-              marginTop: 6,
-            }}
-          >
-            {subtitle}
-          </div>
-        )}
-      </div>
-      {trailing && <div className="shrink-0">{trailing}</div>}
+      <h1
+        style={{
+          ...AS_TYPE.heroTitle,
+          color: AS_COLOR.label,
+          margin: 0,
+        }}
+      >
+        {title}
+      </h1>
     </div>
   );
 }
@@ -186,18 +158,21 @@ export function AppStoreAppIcon({ Icon, accent, size = AS_SIZE.appIconSize, onIm
   );
 }
 
-/* ─────────────────────── Featured：Today 大卡 ─────────────────────── */
+/* ─────────────────────── Featured：Today 海报级大卡（单张） ─────────────────────── */
 
-interface FeaturedProps {
+export interface FeaturedItem {
+  key: string;
   /** 上眉小标签：NOW AVAILABLE / MEET THE AGENT 等 */
   eyebrow: string;
   /** 上眉颜色（iOS System Color） */
   eyebrowColor?: string;
-  /** 主标 */
+  /** 主标（超大） */
   title: string;
-  /** 副标（一两行） */
+  /** 副标（可选，一行内） */
   subtitle?: string;
-  /** 背景图 URL；不提供则用 accent 渐变兜底 */
+  /** 视频 URL（优先，自动播放） */
+  videoUrl?: string | null;
+  /** 封面图 URL（fallback 或 video poster） */
   imageUrl?: string | null;
   /** 渐变 fallback + mesh 的主题色 */
   accent: { from: string; to: string };
@@ -210,119 +185,243 @@ interface FeaturedProps {
   onClick: () => void;
   /** 底部按钮文字，默认"打开" */
   pillLabel?: string;
-  /** 底部按钮下方说明 */
-  pillCaption?: string;
 }
 
-export function AppStoreFeatured({
-  eyebrow,
-  eyebrowColor,
-  title,
-  subtitle,
-  imageUrl,
-  accent,
-  footer,
-  onClick,
-  pillLabel = '打开',
-  pillCaption,
-}: FeaturedProps) {
+/**
+ * 单张海报级 Featured 大卡 —— 3:4 纵向占屏，视频/图片/渐变三级 fallback。
+ * Apple Today 的单张大海报范式。
+ */
+export function AppStoreFeatured(props: Omit<FeaturedItem, 'key'>) {
+  return <FeaturedSlide item={{ ...props, key: 'single' }} isActive />;
+}
+
+/**
+ * Featured 轮播 —— 横滑多张海报级大卡（Apple Today 风的推荐位）。
+ *
+ * 特点：
+ *  - 每张卡宽 calc(100vw - gutter*2)，3:4 纵向海报
+ *  - snap-x snap-mandatory，片片 snap-start
+ *  - 第二张从右侧探出 ~16px 提示可滑（通过负 padding + gutter 实现）
+ *  - 底部 dot indicator（苹果小点）
+ *  - 只有"视觉中的活跃张"播放视频，节省带宽
+ */
+export function AppStoreFeaturedCarousel({ items }: { items: FeaturedItem[] }) {
+  const scrollerRef = useRef<HTMLDivElement | null>(null);
+  const [activeIdx, setActiveIdx] = useState(0);
+
+  useEffect(() => {
+    const el = scrollerRef.current;
+    if (!el) return;
+    let rafId = 0;
+    const update = () => {
+      if (!el) return;
+      const slideWidth = el.firstElementChild?.getBoundingClientRect().width ?? 0;
+      const gap = AS_SIZE.shelfGap;
+      const idx = Math.round(el.scrollLeft / (slideWidth + gap));
+      setActiveIdx(Math.max(0, Math.min(items.length - 1, idx)));
+    };
+    const onScroll = () => {
+      cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(update);
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    update();
+    return () => {
+      el.removeEventListener('scroll', onScroll);
+      cancelAnimationFrame(rafId);
+    };
+  }, [items.length]);
+
+  if (items.length === 0) return null;
+  if (items.length === 1) {
+    return (
+      <div style={{ padding: `0 ${AS_SPACE.gutter}px` }}>
+        <FeaturedSlide item={items[0]} isActive />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div
+        ref={scrollerRef}
+        className="flex overflow-x-auto snap-x snap-mandatory"
+        style={{
+          gap: AS_SIZE.shelfGap,
+          paddingLeft: AS_SPACE.gutter,
+          paddingRight: AS_SPACE.gutter,
+          scrollbarWidth: 'none',
+          WebkitOverflowScrolling: 'touch',
+          overscrollBehaviorX: 'contain',
+        }}
+      >
+        {items.map((item, i) => (
+          <FeaturedSlide key={item.key} item={item} isActive={i === activeIdx} />
+        ))}
+      </div>
+      {/* 页指示小点 */}
+      <div className="flex items-center justify-center" style={{ gap: 6, marginTop: 14 }}>
+        {items.map((_, i) => (
+          <span
+            key={i}
+            style={{
+              width: i === activeIdx ? 16 : 6,
+              height: 6,
+              borderRadius: 999,
+              background: i === activeIdx ? AS_COLOR.label : AS_COLOR.labelTertiary,
+              transition: 'all 220ms ease',
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function FeaturedSlide({ item, isActive }: { item: FeaturedItem; isActive: boolean }) {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const [videoFailed, setVideoFailed] = useState(false);
+
+  // 只在 active 时播放，切走时暂停，节省带宽与性能
+  useEffect(() => {
+    const v = videoRef.current;
+    if (!v) return;
+    if (isActive) {
+      v.play().catch(() => {/* iOS 低电量/省流可能拒绝 —— 静默兜底到 poster */});
+    } else {
+      v.pause();
+    }
+  }, [isActive]);
+
+  const hasMedia = (item.videoUrl && !videoFailed) || item.imageUrl;
+
   return (
     <button
       type="button"
-      onClick={onClick}
-      className="relative overflow-hidden block w-full text-left transition-transform active:scale-[0.985]"
+      onClick={item.onClick}
+      className="relative snap-start shrink-0 overflow-hidden text-left transition-transform active:scale-[0.985]"
       style={{
-        margin: `0 ${AS_SPACE.gutter}px`,
-        width: `calc(100% - ${AS_SPACE.gutter * 2}px)`,
-        aspectRatio: AS_SIZE.featuredAspect,
+        width: `calc(100vw - ${AS_SPACE.gutter * 2}px)`,
+        aspectRatio: '3 / 4',
         borderRadius: AS_SPACE.featuredRadius,
-        background: imageUrl ? '#000' : buildMeshGradient(accent),
+        background: hasMedia ? '#000' : buildMeshGradient(item.accent),
         fontFamily: AS_FONT_FAMILY,
         border: `1px solid ${AS_COLOR.hairline}`,
       }}
     >
-      {/* 背景图层 */}
-      {imageUrl && (
-        <img
-          src={imageUrl}
-          alt=""
-          aria-hidden
+      {/* 视频优先 */}
+      {item.videoUrl && !videoFailed && (
+        <video
+          ref={videoRef}
+          src={item.videoUrl}
+          poster={item.imageUrl ?? undefined}
+          muted
+          loop
+          playsInline
+          preload="metadata"
+          autoPlay={isActive}
           className="absolute inset-0 w-full h-full object-cover"
-          onError={(e) => {
-            (e.currentTarget.style.display = 'none');
-          }}
+          onError={() => setVideoFailed(true)}
         />
       )}
 
-      {/* 底部渐变蒙版，保证文字可读（苹果的标配） */}
+      {/* 图片 fallback */}
+      {(!item.videoUrl || videoFailed) && item.imageUrl && (
+        <img
+          src={item.imageUrl}
+          alt=""
+          aria-hidden
+          className="absolute inset-0 w-full h-full object-cover"
+        />
+      )}
+
+      {/* 顶部渐变（保证 eyebrow/title 可读） */}
       <div
         aria-hidden
-        className="absolute inset-x-0 bottom-0"
+        className="absolute left-0 right-0 top-0"
         style={{
-          top: '40%',
-          background: 'linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.55) 55%, rgba(0,0,0,0.85) 100%)',
+          height: '50%',
+          background: 'linear-gradient(180deg, rgba(0,0,0,0.55) 0%, rgba(0,0,0,0.15) 60%, rgba(0,0,0,0) 100%)',
+        }}
+      />
+      {/* 底部渐变（保证底部玻璃条可读） */}
+      <div
+        aria-hidden
+        className="absolute left-0 right-0 bottom-0"
+        style={{
+          height: '45%',
+          background: 'linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.55) 55%, rgba(0,0,0,0.88) 100%)',
         }}
       />
 
-      {/* 顶部 eyebrow + 标题 + 副标 */}
+      {/* 顶部 eyebrow + 标题 */}
       <div
         className="absolute left-0 right-0 top-0 flex flex-col"
-        style={{ padding: 20, gap: 6 }}
+        style={{ padding: 22, gap: 6 }}
       >
         <div
           style={{
             ...AS_TYPE.eyebrow,
-            color: eyebrowColor ?? AS_COLOR.blue,
-            textShadow: '0 1px 2px rgba(0,0,0,0.4)',
+            color: item.eyebrowColor ?? AS_COLOR.blue,
+            textShadow: '0 1px 3px rgba(0,0,0,0.5)',
           }}
         >
-          {eyebrow}
+          {item.eyebrow}
         </div>
         <div
           style={{
-            ...AS_TYPE.featuredTitle,
+            fontSize: 30,
+            fontWeight: 700,
+            letterSpacing: '-0.02em',
+            lineHeight: 1.1,
             color: AS_COLOR.label,
-            textShadow: '0 2px 8px rgba(0,0,0,0.4)',
-            maxWidth: '90%',
+            textShadow: '0 2px 10px rgba(0,0,0,0.55)',
+            maxWidth: '92%',
           }}
         >
-          {title}
+          {item.title}
         </div>
-        {subtitle && (
+        {item.subtitle && (
           <div
+            className="line-clamp-1"
             style={{
-              ...AS_TYPE.featuredSubtitle,
-              color: 'rgba(255,255,255,0.85)',
-              textShadow: '0 1px 4px rgba(0,0,0,0.4)',
-              maxWidth: '90%',
+              fontSize: 14,
+              fontWeight: 400,
+              color: 'rgba(255,255,255,0.82)',
+              textShadow: '0 1px 4px rgba(0,0,0,0.5)',
+              marginTop: 2,
             }}
           >
-            {subtitle}
+            {item.subtitle}
           </div>
         )}
       </div>
 
-      {/* 底部玻璃条：icon + 名字 + 一句话 + Pill */}
+      {/* 底部玻璃条：icon + name + tagline + Pill */}
       <div
         className="absolute left-0 right-0 bottom-0 flex items-center gap-3"
-        style={{ padding: 14 }}
+        style={{ padding: 16 }}
       >
-        <AppStoreAppIcon Icon={footer.Icon} accent={accent} size={48} onImage />
+        <AppStoreAppIcon Icon={item.footer.Icon} accent={item.accent} size={48} onImage />
         <div className="min-w-0 flex-1">
           <div
             className="truncate"
             style={{ ...AS_TYPE.itemTitle, color: AS_COLOR.label }}
           >
-            {footer.name}
+            {item.footer.name}
           </div>
           <div
             className="truncate"
-            style={{ ...AS_TYPE.itemSubtitle, color: 'rgba(255,255,255,0.75)' }}
+            style={{ ...AS_TYPE.itemSubtitle, color: 'rgba(255,255,255,0.78)' }}
           >
-            {footer.tagline}
+            {item.footer.tagline}
           </div>
         </div>
-        <AppStorePill label={pillLabel} caption={pillCaption} variant="onImage" />
+        <AppStorePill
+          label={item.pillLabel ?? '打开'}
+          variant="onImage"
+          onClick={(e) => { e.stopPropagation(); item.onClick(); }}
+        />
       </div>
     </button>
   );

--- a/prd-admin/src/layouts/AppShell.tsx
+++ b/prd-admin/src/layouts/AppShell.tsx
@@ -59,6 +59,8 @@ import { AvatarEditDialog } from '@/components/ui/AvatarEditDialog';
 import { Dialog } from '@/components/ui/Dialog';
 import { MobileDrawer } from '@/components/ui/MobileDrawer';
 import { MobileTabBar } from '@/components/ui/MobileTabBar';
+import { MobileSafeBoundary } from '@/components/MobileSafeBoundary';
+import { MobileCompatGate } from '@/components/MobileCompatGate';
 import { resolveAvatarUrl } from '@/lib/avatar';
 import { UserAvatar } from '@/components/ui/UserAvatar';
 import { getAdminNotifications, handleAdminNotification, handleAllAdminNotifications, updateMyAvatar, uploadMyAvatar } from '@/services';
@@ -472,7 +474,16 @@ export default function AppShell() {
   }, [loadNotifications, user?.userId]);
 
   return (
-    <div className="h-full w-full relative overflow-hidden" style={{ background: 'var(--bg-base)' }}>
+    <div
+      className="w-full relative overflow-hidden"
+      style={{
+        background: 'var(--bg-base)',
+        // 移动端：用 dvh 跟随视口（修 iOS Safari 地址栏收缩导致的高度抖动 / 黑带）
+        // 桌面端：保持 h:100% 依赖 #root，避免破坏现有侧栏/浮层布局
+        minHeight: '100dvh',
+        height: '100%',
+      }}
+    >
       <SystemDialogHost />
       <GlobalDefectSubmitDialog />
       <TipsDrawer />
@@ -1348,9 +1359,14 @@ export default function AppShell() {
             )}
           >
             <div className="flex-1 min-h-0 relative">
-              <Suspense fallback={<InlinePageLoader />}>
-                <Outlet />
-              </Suspense>
+              {/* 移动端兼容门槛：根据路由显示 banner / 模态，非阻断式 */}
+              {isMobile && <MobileCompatGate pathname={location.pathname} />}
+              {/* ErrorBoundary：渲染异常时显示友好错误 + 重试，避免整棵树卸载成纯黑 */}
+              <MobileSafeBoundary resetKey={location.pathname}>
+                <Suspense fallback={<InlinePageLoader />}>
+                  <Outlet />
+                </Suspense>
+              </MobileSafeBoundary>
               {/* 每日小贴士跳转后的 DOM 脉冲光圈。key=pathname 保证每次路由切换都重新读取 sessionStorage */}
               <SpotlightOverlay key={location.pathname} />
             </div>

--- a/prd-admin/src/layouts/AppShell.tsx
+++ b/prd-admin/src/layouts/AppShell.tsx
@@ -630,11 +630,12 @@ export default function AppShell() {
         )
       )}
       {/* ── 移动端: 顶部导航栏 ── */}
+      {/* 首页 (isHomePage) 做 Apple Today 式透明顶栏：隐藏中间 title + 右侧铃铛，让页面内 Hero 承担标题职责 */}
       {isMobile && (
         <header
           className="fixed top-0 left-0 right-0 z-100 flex items-center gap-3 px-4"
           style={{
-            ...glassMobileHeader,
+            ...(isHomePage ? { background: 'transparent' } : glassMobileHeader),
             height: 'calc(var(--mobile-header-height, 48px) + env(safe-area-inset-top, 0px))',
             paddingTop: 'env(safe-area-inset-top, 0px)',
           }}
@@ -648,32 +649,37 @@ export default function AppShell() {
           >
             <Menu size={20} />
           </button>
-          <div className="flex-1 min-w-0 text-center">
-            <span className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
-              {visibleItems.find((it) => it.key === activeKey)?.label || 'PRD Agent'}
-            </span>
-          </div>
-          <ChangelogBell size={18} compact />
-          <button
-            type="button"
-            onClick={() => {
-              setNotificationDialogOpen(true);
-              void loadNotifications({ silent: true });
-            }}
-            className="relative h-9 w-9 inline-flex items-center justify-center rounded-xl"
-            style={{ color: 'var(--text-secondary)' }}
-            aria-label="通知"
-          >
-            <Bell size={18} />
-            {notificationCount > 0 && (
-              <span
-                className="absolute top-1 right-1 h-4 w-4 rounded-full flex items-center justify-center text-[9px] font-bold"
-                style={{ background: 'var(--accent-gold)', color: '#1a1a1a' }}
-              >
-                {notificationCount > 9 ? '9+' : notificationCount}
+          {!isHomePage && (
+            <div className="flex-1 min-w-0 text-center">
+              <span className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
+                {visibleItems.find((it) => it.key === activeKey)?.label || 'PRD Agent'}
               </span>
-            )}
-          </button>
+            </div>
+          )}
+          {isHomePage && <div className="flex-1" />}
+          {!isHomePage && <ChangelogBell size={18} compact />}
+          {!isHomePage && (
+            <button
+              type="button"
+              onClick={() => {
+                setNotificationDialogOpen(true);
+                void loadNotifications({ silent: true });
+              }}
+              className="relative h-9 w-9 inline-flex items-center justify-center rounded-xl"
+              style={{ color: 'var(--text-secondary)' }}
+              aria-label="通知"
+            >
+              <Bell size={18} />
+              {notificationCount > 0 && (
+                <span
+                  className="absolute top-1 right-1 h-4 w-4 rounded-full flex items-center justify-center text-[9px] font-bold"
+                  style={{ background: 'var(--accent-gold)', color: '#1a1a1a' }}
+                >
+                  {notificationCount > 9 ? '9+' : notificationCount}
+                </span>
+              )}
+            </button>
+          )}
         </header>
       )}
 

--- a/prd-admin/src/layouts/AppShell.tsx
+++ b/prd-admin/src/layouts/AppShell.tsx
@@ -630,7 +630,11 @@ export default function AppShell() {
         )
       )}
       {/* ── 移动端: 顶部导航栏 ── */}
-      {/* 首页 (isHomePage) 做 Apple Today 式透明顶栏：隐藏中间 title + 右侧铃铛，让页面内 Hero 承担标题职责 */}
+      {/* 首页 (isHomePage) 做 Apple Today 式透明顶栏：
+       *   - 左: menu 按钮
+       *   - 中: 空
+       *   - 右: 头像按钮（带通知红点）—— 点击 → /profile
+       *   文字标题职责交给页面内 Hero */}
       {isMobile && (
         <header
           className="fixed top-0 left-0 right-0 z-100 flex items-center gap-3 px-4"
@@ -674,6 +678,58 @@ export default function AppShell() {
                 <span
                   className="absolute top-1 right-1 h-4 w-4 rounded-full flex items-center justify-center text-[9px] font-bold"
                   style={{ background: 'var(--accent-gold)', color: '#1a1a1a' }}
+                >
+                  {notificationCount > 9 ? '9+' : notificationCount}
+                </span>
+              )}
+            </button>
+          )}
+          {/* 首页右上角头像按钮 —— Apple Today 范式 */}
+          {isHomePage && (
+            <button
+              type="button"
+              onClick={() => navigate('/profile')}
+              className="relative h-9 w-9 inline-flex items-center justify-center rounded-full overflow-hidden transition-opacity active:opacity-60"
+              style={{ border: '1px solid rgba(255,255,255,0.12)', background: 'rgba(255,255,255,0.05)', padding: 0 }}
+              aria-label="个人中心"
+            >
+              {user?.avatarUrl || user?.avatarFileName ? (
+                <UserAvatar
+                  src={resolveAvatarUrl({
+                    username: user?.username,
+                    userType: user?.userType,
+                    botKind: user?.botKind,
+                    avatarFileName: user?.avatarFileName ?? null,
+                    avatarUrl: user?.avatarUrl,
+                  })}
+                  alt="avatar"
+                  className="h-full w-full object-cover"
+                />
+              ) : (
+                <span className="text-[13px] font-semibold" style={{ color: 'var(--text-primary)' }}>
+                  {(user?.displayName || user?.username || '?')[0]}
+                </span>
+              )}
+              {notificationCount > 0 && (
+                <span
+                  className="absolute"
+                  style={{
+                    top: -2,
+                    right: -2,
+                    minWidth: 16,
+                    height: 16,
+                    padding: '0 4px',
+                    borderRadius: 999,
+                    background: '#FF453A',
+                    color: '#fff',
+                    fontSize: 9,
+                    fontWeight: 700,
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    border: '2px solid #000',
+                    lineHeight: 1,
+                  }}
                 >
                   {notificationCount > 9 ? '9+' : notificationCount}
                 </span>

--- a/prd-admin/src/layouts/AppShell.tsx
+++ b/prd-admin/src/layouts/AppShell.tsx
@@ -488,7 +488,8 @@ export default function AppShell() {
       <GlobalDefectSubmitDialog />
       <TipsDrawer />
       <CommandPalette />
-      {toastNotification && (
+      {/* 移动端顶栏已有 Bell 按钮，隐藏右下浮球避免和 MobileTabBar "+" 重叠 */}
+      {!isMobile && toastNotification && (
         toastCollapsed ? (
           // 收缩状态：浮动按钮
           <button
@@ -1250,8 +1251,9 @@ export default function AppShell() {
                         className="rounded-[16px] border px-4 py-3"
                         style={{ borderColor: tone.border, background: tone.bg }}
                       >
-                        <div className="flex items-start justify-between gap-3">
-                          <div className="min-w-0">
+                        {/* 窄屏竖排（移动端 / 窄浏览器），宽屏水平分栏；按钮列 shrink-0 + 按钮文字 whitespace-nowrap，防止被挤成竖排单字 */}
+                        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
+                          <div className="min-w-0 flex-1">
                             <div className="text-[13px] font-semibold" style={{ color: 'var(--text-primary)' }}>
                               {item.title}
                             </div>
@@ -1312,11 +1314,11 @@ export default function AppShell() {
                               {new Date(item.createdAt).toLocaleString()}
                             </div>
                           </div>
-                          <div className="flex flex-col items-end gap-2">
+                          <div className="shrink-0 flex flex-row sm:flex-col items-stretch sm:items-end gap-2">
                             {item.actionUrl && (
                               <button
                                 type="button"
-                                className="rounded-full px-3 py-1.5 text-[12px] transition-all hover:bg-white/20 active:scale-[0.97]"
+                                className="rounded-full px-3 py-1.5 text-[12px] whitespace-nowrap transition-all hover:bg-white/20 active:scale-[0.97]"
                                 style={{ background: 'rgba(255, 255, 255, 0.15)', color: 'var(--text-primary)' }}
                                 onClick={() => handleNotification(item.id, item.actionUrl)}
                               >
@@ -1325,7 +1327,7 @@ export default function AppShell() {
                             )}
                             <button
                               type="button"
-                              className="rounded-full px-3 py-1.5 text-[12px] transition-all hover:brightness-110 active:scale-[0.97]"
+                              className="rounded-full px-3 py-1.5 text-[12px] whitespace-nowrap transition-all hover:brightness-110 active:scale-[0.97]"
                               style={{ background: 'var(--accent-gold)', color: '#1a1a1a' }}
                               onClick={() => handleNotification(item.id)}
                             >

--- a/prd-admin/src/lib/appStoreTokens.ts
+++ b/prd-admin/src/lib/appStoreTokens.ts
@@ -1,0 +1,126 @@
+/**
+ * App Store（iOS 暗色模式）页面级复刻的设计 tokens。
+ *
+ * 目的：所有"苹果风"移动端页面共用同一套字号/间距/色彩，
+ * 避免每次写 Tailwind 类名都要重新斟酌比例 —— 苹果设计之所以不显山不露水，
+ * 核心就是**严格的纪律性**：字号只在几个固定档位跳、间距只在几个刻度上走。
+ *
+ * 参考：iOS 18 Human Interface Guidelines + App Store Today tab 实测尺寸。
+ * 所有数值都是 px，Tailwind 用 arbitrary value 套用。
+ */
+
+/* ───────────── 色彩（iOS Dark Mode 系统色 + App Store 专用） ───────────── */
+
+export const AS_COLOR = {
+  /** 页面背景：App Store Today 暗色是纯黑，不是 #141418 那种微灰 */
+  bg: '#000000',
+
+  /** 一级文字（标题） */
+  label: '#FFFFFF',
+  /** 二级文字（副标题、日期） */
+  labelSecondary: 'rgba(235, 235, 245, 0.60)',
+  /** 三级文字（placeholder、极弱提示） */
+  labelTertiary: 'rgba(235, 235, 245, 0.30)',
+
+  /** iOS 分隔线（列表 hairline） */
+  separator: 'rgba(84, 84, 88, 0.34)',
+  /** 极细装饰边（卡片描边） */
+  hairline: 'rgba(255, 255, 255, 0.08)',
+
+  /** 卡片面（无图时兜底） */
+  surface: 'rgba(255, 255, 255, 0.05)',
+  surfaceHover: 'rgba(255, 255, 255, 0.08)',
+
+  /** Pill 按钮底 —— App Store Get 按钮的灰色 */
+  pillBg: 'rgba(120, 120, 128, 0.24)',
+
+  /** iOS System Colors（暗色）—— 用于强调色、上眉色等 */
+  blue: '#0A84FF',
+  green: '#30D158',
+  orange: '#FF9F0A',
+  yellow: '#FFD60A',
+  red: '#FF453A',
+  pink: '#FF375F',
+  purple: '#BF5AF2',
+  teal: '#64D2FF',
+  indigo: '#5E5CE6',
+} as const;
+
+/* ───────────── 字号阶梯（严格的 9 档，不允许出现中间值） ───────────── */
+
+export const AS_TYPE = {
+  /** 页面主标题（Today / 下午好）—— SF Pro Display Bold */
+  heroTitle: { fontSize: 34, fontWeight: 700, letterSpacing: '-0.02em', lineHeight: 1.08 },
+  /** Hero 副标题（日期、一行描述） */
+  heroSubtitle: { fontSize: 15, fontWeight: 400, letterSpacing: '-0.01em', lineHeight: 1.3 },
+
+  /** 区块标题（智能体 / 工具 / 最近活动）—— App Store "Must-Have Apps" 级 */
+  sectionTitle: { fontSize: 26, fontWeight: 700, letterSpacing: '-0.01em', lineHeight: 1.1 },
+  /** 区块"See All" 右侧字 */
+  sectionAction: { fontSize: 17, fontWeight: 400, letterSpacing: '-0.01em' },
+
+  /** 上眉 eyebrow（NOW AVAILABLE / EARTH DAY）—— 全大写 tracking-wide 粗体 */
+  eyebrow: { fontSize: 11, fontWeight: 800, letterSpacing: '0.08em', textTransform: 'uppercase' as const },
+
+  /** Featured 卡片内的主标题（覆盖图片） */
+  featuredTitle: { fontSize: 28, fontWeight: 700, letterSpacing: '-0.02em', lineHeight: 1.1 },
+  /** Featured 卡片副标题 */
+  featuredSubtitle: { fontSize: 15, fontWeight: 400, lineHeight: 1.35 },
+
+  /** 列表/卡片里的 app 名 */
+  itemTitle: { fontSize: 17, fontWeight: 600, letterSpacing: '-0.01em', lineHeight: 1.2 },
+  /** 列表/卡片里的副标题 */
+  itemSubtitle: { fontSize: 13, fontWeight: 400, lineHeight: 1.3 },
+
+  /** Get / Open / Update Pill 按钮文字 */
+  pill: { fontSize: 15, fontWeight: 600, letterSpacing: '-0.01em' },
+  /** 极小附加说明（In-App Purchases） */
+  caption: { fontSize: 11, fontWeight: 400, lineHeight: 1.2 },
+} as const;
+
+/* ───────────── 间距阶梯（基于 4 的倍数 + 常用值） ───────────── */
+
+export const AS_SPACE = {
+  /** 页面左右 gutter */
+  gutter: 20,
+  /** 区块之间垂直间距 */
+  sectionGap: 36,
+  /** 区块标题到内容 */
+  titleGap: 16,
+  /** 列表项垂直 padding */
+  listItemPaddingY: 14,
+  /** List 分隔线从 icon 右侧开始（icon 52 + 左 padding 20） */
+  listDividerInset: 72,
+
+  /** Featured 卡片圆角 */
+  featuredRadius: 22,
+  /** Shelf 卡片圆角 */
+  shelfCardRadius: 18,
+  /** App icon 圆角 */
+  iconRadius: 12,
+  /** Pill 按钮圆角（rounded-full 等价） */
+  pillRadius: 999,
+} as const;
+
+/* ───────────── 尺寸 ───────────── */
+
+export const AS_SIZE = {
+  /** Featured 卡片的纵横比（参考 App Store "NOW AVAILABLE" 大卡） */
+  featuredAspect: '16 / 11',
+  /** Shelf 横滑卡片的宽度（近乎全宽，第二张探头） */
+  shelfCardWidth: 308,
+  /** Shelf 横滑卡片高度（水平卡片，icon 左 + 文字中 + 按钮右） */
+  shelfCardHeight: 88,
+  /** Shelf 卡片间距 */
+  shelfGap: 12,
+  /** App icon 尺寸（列表 + Featured 底部条） */
+  appIconSize: 52,
+  /** Pill 按钮高度 */
+  pillHeight: 30,
+} as const;
+
+/* ───────────── 苹果级字体栈 ───────────── */
+
+/** iOS/Mac 用户看到 SF Pro，其他系统 fallback 到 Inter 或系统 sans */
+export const AS_FONT_FAMILY =
+  '-apple-system, BlinkMacSystemFont, "SF Pro Display", "SF Pro Text", "Inter", "Segoe UI", Roboto, sans-serif';

--- a/prd-admin/src/lib/clientErrorReporter.ts
+++ b/prd-admin/src/lib/clientErrorReporter.ts
@@ -1,0 +1,172 @@
+/**
+ * 客户端错误上报 —— 全局捕获 window.error + unhandledrejection + React 渲染错误。
+ *
+ * 目标：不再依赖用户手动反馈"页面黑屏"。错误自动进入 sessionStorage 环形缓冲，
+ * /_dev/mobile-audit 页面可以一眼查出本次会话中哪个路由崩溃、崩在哪一行。
+ *
+ * V1：仅客户端存储。V2（后续）：叠加 POST 到后端 /api/client-error-logs 做跨会话归档。
+ */
+
+export type ClientErrorKind = 'render' | 'window-error' | 'unhandled-rejection' | 'console-error';
+
+export interface ClientErrorEntry {
+  id: string;
+  ts: number;
+  kind: ClientErrorKind;
+  message: string;
+  stack?: string;
+  componentStack?: string;
+  url: string;
+  userAgent: string;
+  viewport: string;
+  /** source file if available */
+  source?: string;
+  line?: number;
+  column?: number;
+}
+
+const STORAGE_KEY = 'map.client-errors.v1';
+const MAX_ENTRIES = 50;
+
+function readBuffer(): ClientErrorEntry[] {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed) ? (parsed as ClientErrorEntry[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeBuffer(entries: ClientErrorEntry[]): void {
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  } catch {
+    // quota exceeded etc. —— 丢掉最旧的一半再试
+    try {
+      sessionStorage.setItem(STORAGE_KEY, JSON.stringify(entries.slice(-Math.floor(MAX_ENTRIES / 2))));
+    } catch {
+      // silently give up
+    }
+  }
+}
+
+function genId(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function recordClientError(partial: Omit<ClientErrorEntry, 'id' | 'ts'>): void {
+  const entry: ClientErrorEntry = {
+    id: genId(),
+    ts: Date.now(),
+    ...partial,
+  };
+  const buf = readBuffer();
+  buf.push(entry);
+  if (buf.length > MAX_ENTRIES) buf.splice(0, buf.length - MAX_ENTRIES);
+  writeBuffer(buf);
+
+  // 同时 console.error 方便 DevTools 查看
+  console.error('[ClientError]', entry.kind, entry.message, entry);
+}
+
+export function getClientErrors(): ClientErrorEntry[] {
+  return readBuffer();
+}
+
+export function clearClientErrors(): void {
+  try {
+    sessionStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+let installed = false;
+
+/**
+ * 在 main.tsx 启动阶段调用一次。重复调用安全（幂等）。
+ */
+export function installGlobalErrorReporter(): void {
+  if (installed || typeof window === 'undefined') return;
+  installed = true;
+
+  window.addEventListener('error', (ev) => {
+    // 资源加载错误（img/script/link failed）—— 有 target 但没 error 对象
+    const target = ev.target as (HTMLElement | Window | null);
+    if (target && target !== window && (target as HTMLElement).tagName) {
+      const tag = (target as HTMLElement).tagName.toLowerCase();
+      if (tag === 'img' || tag === 'script' || tag === 'link') {
+        const src =
+          (target as HTMLImageElement).src ||
+          (target as HTMLLinkElement).href ||
+          '(unknown)';
+        recordClientError({
+          kind: 'window-error',
+          message: `Resource load failed: ${tag} ${src}`,
+          url: window.location.href,
+          userAgent: navigator.userAgent,
+          viewport: `${window.innerWidth}x${window.innerHeight}`,
+        });
+        return;
+      }
+    }
+    recordClientError({
+      kind: 'window-error',
+      message: ev.message || 'Unknown error',
+      stack: ev.error?.stack,
+      source: ev.filename,
+      line: ev.lineno,
+      column: ev.colno,
+      url: window.location.href,
+      userAgent: navigator.userAgent,
+      viewport: `${window.innerWidth}x${window.innerHeight}`,
+    });
+  }, true);
+
+  window.addEventListener('unhandledrejection', (ev) => {
+    const reason = ev.reason;
+    const message =
+      reason instanceof Error
+        ? reason.message
+        : typeof reason === 'string'
+          ? reason
+          : (() => {
+              try {
+                return JSON.stringify(reason);
+              } catch {
+                return String(reason);
+              }
+            })();
+    recordClientError({
+      kind: 'unhandled-rejection',
+      message,
+      stack: reason instanceof Error ? reason.stack : undefined,
+      url: window.location.href,
+      userAgent: navigator.userAgent,
+      viewport: `${window.innerWidth}x${window.innerHeight}`,
+    });
+  });
+
+  // 劫持 console.error —— 可选，但对"静默错误"有帮助。控制频率：只记带 Error 的。
+  const origConsoleError = console.error.bind(console);
+  console.error = (...args: unknown[]) => {
+    try {
+      const firstErr = args.find((a) => a instanceof Error) as Error | undefined;
+      if (firstErr) {
+        recordClientError({
+          kind: 'console-error',
+          message: firstErr.message,
+          stack: firstErr.stack,
+          url: window.location.href,
+          userAgent: navigator.userAgent,
+          viewport: `${window.innerWidth}x${window.innerHeight}`,
+        });
+      }
+    } catch {
+      // never let reporting itself crash
+    }
+    origConsoleError(...args);
+  };
+}

--- a/prd-admin/src/lib/mobileCompatibility.ts
+++ b/prd-admin/src/lib/mobileCompatibility.ts
@@ -1,0 +1,82 @@
+/**
+ * 移动端兼容性注册表。
+ *
+ * 判定标准：手机竖屏（<768px）上访问时，能达到什么体验。
+ *  - `full`    : 完整可用（阅读、文本交互为主的页面）
+ *  - `limited` : 基本可用，但部分能力受限（宽表格、多列面板、复杂图表）—— 顶部显示黄色 banner
+ *  - `pc-only` : 移动端几乎不可用（大型画布、拖拽编辑器、并排多栏），打开时弹"建议 PC"门槛提示
+ *
+ * 注册键使用 **路由前缀**（路径最长匹配优先）。未注册的路由默认 `unknown`，
+ * MobileCompatGate 会显示一条非常轻量的「未做移动端专项适配」提示。
+ *
+ * 新增一个 Agent 或页面时，按「移动端实际能用到什么程度」填一行即可。
+ */
+
+export type MobileCompatLevel = 'full' | 'limited' | 'pc-only';
+
+export interface MobileCompatEntry {
+  level: MobileCompatLevel;
+  /** 自定义提示文案；不填使用默认 */
+  note?: string;
+}
+
+export const MOBILE_COMPAT_REGISTRY: Record<string, MobileCompatEntry> = {
+  // ── 完整可用：文本 / 列表型 ──
+  '/':                        { level: 'full' },
+  '/profile':                 { level: 'full' },
+  '/notifications':           { level: 'full' },
+  '/my-assets':               { level: 'full' },
+  '/ai-toolbox':              { level: 'full' },
+  '/prd-agent':               { level: 'full' },
+  '/defect-agent':            { level: 'full' },
+  '/report-agent':            { level: 'full' },
+  '/skills':                  { level: 'full' },
+  '/literary-agent':          { level: 'full', note: '阅读/查看正常，深度编辑建议 PC' },
+  '/marketplace':             { level: 'full' },
+  '/library':                 { level: 'full' },
+  '/shortcuts-agent':         { level: 'full' },
+
+  // ── 受限：可以用但体验降级 ──
+  '/executive':               { level: 'limited', note: '图表较宽，横屏查看更佳' },
+  '/users':                   { level: 'limited', note: '表格较宽，横向滑动查看' },
+  '/mds':                     { level: 'limited', note: '模型配置项较多，建议 PC 编辑' },
+  '/logs':                    { level: 'limited', note: '日志表格较宽，建议横屏' },
+  '/settings':                { level: 'limited' },
+  '/prompts':                 { level: 'limited' },
+  '/automations':             { level: 'limited' },
+  '/assets':                  { level: 'limited' },
+  '/open-platform':           { level: 'limited' },
+  '/review-agent':            { level: 'limited' },
+  '/pr-review':               { level: 'limited', note: 'diff 阅读较挤，建议 PC' },
+  '/lab':                     { level: 'limited' },
+
+  // ── PC 专属：画布 / 拖拽 / 大屏复杂交互 ──
+  '/visual-agent':            { level: 'pc-only', note: '视觉创作画布需要桌面端鼠标操作' },
+  '/visual-agent-fullscreen': { level: 'pc-only' },
+  '/workflow-agent':          { level: 'pc-only', note: '工作流画布需要桌面端鼠标操作' },
+  '/video-agent':             { level: 'pc-only', note: '视频生成需要大屏预览' },
+  '/transcript-agent':        { level: 'pc-only', note: '转录工作台信息密度高' },
+  '/showcase':                { level: 'pc-only', note: '瀑布流展示专为宽屏设计' },
+};
+
+/**
+ * 按最长前缀匹配 —— `/prd-agent/sessions/abc` 也会命中 `/prd-agent`。
+ * 入参应为 `location.pathname`。
+ */
+export function resolveMobileCompat(pathname: string): MobileCompatEntry | null {
+  // 完全匹配优先
+  if (MOBILE_COMPAT_REGISTRY[pathname]) return MOBILE_COMPAT_REGISTRY[pathname];
+
+  // 前缀匹配：在所有 key 中找最长能匹配 pathname 开头的
+  const normalized = pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
+  let best: { key: string; entry: MobileCompatEntry } | null = null;
+  for (const [key, entry] of Object.entries(MOBILE_COMPAT_REGISTRY)) {
+    if (key === '/') continue; // 根路径只做完全匹配
+    if (normalized === key || normalized.startsWith(key + '/')) {
+      if (!best || key.length > best.key.length) {
+        best = { key, entry };
+      }
+    }
+  }
+  return best?.entry ?? null;
+}

--- a/prd-admin/src/main.tsx
+++ b/prd-admin/src/main.tsx
@@ -2,9 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from '@/app/App';
+import { installGlobalErrorReporter } from '@/lib/clientErrorReporter';
 import '@/styles/tailwind.css';
 import '@/styles/tokens.css';
 import '@/styles/globals.css';
+
+installGlobalErrorReporter();
 
 function shouldAutoPlayBackdropOnLoad(): boolean {
   // Dev HMR 会反复执行入口模块；避免热更新时误触发“自动播放”

--- a/prd-admin/src/pages/MobileHomePage.tsx
+++ b/prd-admin/src/pages/MobileHomePage.tsx
@@ -128,6 +128,7 @@ export default function MobileHomePage() {
 
     return rotated.slice(0, 5).map((a) => {
       const eyebrowMeta = AGENT_EYEBROW[a.agentKey ?? ''] ?? { label: '今日推荐', color: '#0A84FF' };
+      const coverUrl = buildDefaultCoverUrl(cdnBase, a.agentKey);
       return {
         key: a.id,
         eyebrow: eyebrowMeta.label,
@@ -135,10 +136,11 @@ export default function MobileHomePage() {
         title: a.name,
         subtitle: undefined, // 刻意不放副标 —— 苹果 Today 大卡主标下一行极少，大多只有 1 句足够
         videoUrl: buildDefaultVideoUrl(cdnBase, a.agentKey),
-        imageUrl: buildDefaultCoverUrl(cdnBase, a.agentKey),
+        imageUrl: coverUrl,
         accent: accentFor(a.agentKey),
         footer: {
           Icon: iconFor(a.icon),
+          iconImageUrl: coverUrl, // 底部小 icon 用同一张封面图，iOS app icon 质感
           name: a.name,
           tagline: a.description,
         },
@@ -180,13 +182,14 @@ export default function MobileHomePage() {
           </section>
         )}
 
-        {/* ── 智能体横滑 ── */}
+        {/* ── 智能体横滑（封面图作为 iOS app icon） ── */}
         {agents.length > 0 && (
           <AppStoreSection title="智能体" onShowAll={() => navigate('/ai-toolbox')}>
             <AppStoreShelf
               items={agents.map((a) => ({
                 key: a.id,
                 Icon: iconFor(a.icon),
+                iconImageUrl: buildDefaultCoverUrl(cdnBase, a.agentKey),
                 accent: accentFor(a.agentKey),
                 title: a.name,
                 subtitle: a.description,

--- a/prd-admin/src/pages/MobileHomePage.tsx
+++ b/prd-admin/src/pages/MobileHomePage.tsx
@@ -16,15 +16,15 @@ import type { ToolboxItem } from '@/services/real/aiToolbox';
 import { getAdminNotifications, getMobileFeed, getMobileStats } from '@/services';
 import type { AdminNotificationItem } from '@/services/contracts/notifications';
 import type { FeedItem, MobileStats } from '@/services/contracts/mobile';
-import { resolveAvatarUrl } from '@/lib/avatar';
 import { resolveMobileCompat } from '@/lib/mobileCompatibility';
-import { buildDefaultCoverUrl } from '@/lib/homepageAssetSlots';
+import { buildDefaultCoverUrl, buildDefaultVideoUrl } from '@/lib/homepageAssetSlots';
 import {
   AppStoreHero,
-  AppStoreFeatured,
+  AppStoreFeaturedCarousel,
   AppStoreSection,
   AppStoreShelf,
   AppStoreRankedList,
+  type FeaturedItem,
 } from '@/components/mobile/appStore';
 import { AS_COLOR, AS_SPACE, AS_FONT_FAMILY, AS_TYPE } from '@/lib/appStoreTokens';
 
@@ -67,9 +67,22 @@ const FEED_ICON: Record<string, { icon: LucideIcon; accent: { from: string; to: 
 
 /* ─────────── 页面 ─────────── */
 
+/** 每个 Agent 的上眉 eyebrow 标签（苹果 NOW AVAILABLE / MEET THE DEVELOPER 风，极简） */
+const AGENT_EYEBROW: Record<string, { label: string; color: string }> = {
+  'prd-agent':       { label: '产品神器',     color: '#0A84FF' },
+  'visual-agent':    { label: '创作之眼',     color: '#BF5AF2' },
+  'literary-agent':  { label: '写作新搭档',   color: '#30D158' },
+  'defect-agent':    { label: '缺陷追踪',     color: '#FF9F0A' },
+  'video-agent':     { label: '文字生视频',   color: '#FF375F' },
+  'report-agent':    { label: '周报自动化',   color: '#5E5CE6' },
+  'review-agent':    { label: '产品评审员',   color: '#FFD60A' },
+  'pr-review':       { label: 'PR 智能审查',  color: '#64D2FF' },
+  'shortcuts-agent': { label: '快捷指令',     color: '#FFD60A' },
+  'transcript-agent':{ label: '音视频转录',   color: '#FF375F' },
+};
+
 export default function MobileHomePage() {
   const navigate = useNavigate();
-  const user = useAuthStore((s) => s.user);
   const cdnBase = useAuthStore((s) => s.cdnBaseUrl ?? '');
   const [notifications, setNotifications] = useState<AdminNotificationItem[]>([]);
   const [feed, setFeed] = useState<FeedItem[]>([]);
@@ -94,43 +107,46 @@ export default function MobileHomePage() {
     })();
   }, []);
 
-  /* ── 今日问候 + 日期 ── */
-  // 在组件挂载时锁定时间，避免 useMemo 依赖不稳定（页面开着几小时后再切问候语不是关键需求）
-  const now = useMemo(() => new Date(), []);
-  const greeting = useMemo(() => {
-    const h = now.getHours();
-    if (h < 6) return '夜深了';
-    if (h < 12) return '早上好';
-    if (h < 14) return '中午好';
-    if (h < 18) return '下午好';
-    return '晚上好';
-  }, [now]);
-
-  const dateEyebrow = useMemo(() => {
-    const weekday = ['星期日','星期一','星期二','星期三','星期四','星期五','星期六'][now.getDay()];
-    return `${weekday} · ${now.getMonth() + 1} 月 ${now.getDate()} 日`;
-  }, [now]);
-
-  const displayName = user?.displayName || user?.username || '';
-  const avatarUrl = user ? resolveAvatarUrl(user) : null;
-
   /* ── 数据分类 ── */
   const agents = useMemo(() => BUILTIN_TOOLS.filter((t) => t.kind === 'agent'), []);
   const tools = useMemo(() => BUILTIN_TOOLS.filter((t) => t.kind === 'tool'), []);
 
-  /* ── 今日精选（基于日期 rotate） ── */
-  const featured = useMemo(() => {
-    if (agents.length === 0) return null;
+  /* ── 推荐 Carousel 项（有视频资产优先，无资产不上榜） ── */
+  const featuredItems: FeaturedItem[] = useMemo(() => {
+    // 只取有视频或图片资产的 agent，才能撑起海报级大卡
+    const withMedia = agents.filter((a) => {
+      if (!a.agentKey) return false;
+      return Boolean(buildDefaultVideoUrl(cdnBase, a.agentKey) || buildDefaultCoverUrl(cdnBase, a.agentKey));
+    });
+    // 按日期 rotate 起始位置，让每天首卡不同
+    const now = new Date();
     const dayOfYear = Math.floor(
       (now.getTime() - new Date(now.getFullYear(), 0, 0).getTime()) / 86400000,
     );
-    return agents[dayOfYear % agents.length];
-  }, [agents, now]);
+    const offset = withMedia.length > 0 ? dayOfYear % withMedia.length : 0;
+    const rotated = [...withMedia.slice(offset), ...withMedia.slice(0, offset)];
 
-  const featuredImage = useMemo(() => {
-    if (!featured?.agentKey) return null;
-    return buildDefaultCoverUrl(cdnBase, featured.agentKey);
-  }, [featured, cdnBase]);
+    return rotated.slice(0, 5).map((a) => {
+      const eyebrowMeta = AGENT_EYEBROW[a.agentKey ?? ''] ?? { label: '今日推荐', color: '#0A84FF' };
+      return {
+        key: a.id,
+        eyebrow: eyebrowMeta.label,
+        eyebrowColor: eyebrowMeta.color,
+        title: a.name,
+        subtitle: undefined, // 刻意不放副标 —— 苹果 Today 大卡主标下一行极少，大多只有 1 句足够
+        videoUrl: buildDefaultVideoUrl(cdnBase, a.agentKey),
+        imageUrl: buildDefaultCoverUrl(cdnBase, a.agentKey),
+        accent: accentFor(a.agentKey),
+        footer: {
+          Icon: iconFor(a.icon),
+          name: a.name,
+          tagline: a.description,
+        },
+        onClick: () => navigate(a.routePath ?? `/ai-toolbox?item=${a.id}`),
+        pillLabel: '打开',
+      };
+    });
+  }, [agents, cdnBase, navigate]);
 
   const handleItemClick = (item: ToolboxItem) => {
     navigate(item.routePath ?? `/ai-toolbox?item=${item.id}`);
@@ -141,9 +157,6 @@ export default function MobileHomePage() {
     const c = resolveMobileCompat(item.routePath);
     if (c?.level === 'pc-only') {
       return { label: 'PC', color: '#FCA5A5', bg: 'rgba(255, 69, 58, 0.22)' };
-    }
-    if (c?.level === 'limited') {
-      return { label: '部分', color: '#FFD60A', bg: 'rgba(255, 214, 10, 0.18)' };
     }
     return undefined;
   };
@@ -157,49 +170,19 @@ export default function MobileHomePage() {
       }}
     >
       <div style={{ paddingBottom: 120 }}>
-        {/* ── Hero ── */}
-        <AppStoreHero
-          eyebrow={dateEyebrow}
-          title={`${greeting}${displayName ? '，' + displayName : ''}`}
-          subtitle="看看今天能帮你做什么"
-          trailing={
-            <AvatarBadge
-              avatarUrl={avatarUrl}
-              fallback={displayName[0]}
-              notifCount={notifications.length}
-              onClick={() => navigate('/profile')}
-            />
-          }
-        />
+        {/* ── Hero：一个词，和苹果 Today 对齐 ── */}
+        <AppStoreHero title="今日" />
 
-        {/* ── Featured 大卡（今日推荐 Agent） ── */}
-        {featured && (
-          <section style={{ marginTop: AS_SPACE.sectionGap }}>
-            <AppStoreFeatured
-              eyebrow="今日推荐"
-              eyebrowColor="#FFD60A"
-              title={featured.name}
-              subtitle={featured.description}
-              imageUrl={featuredImage}
-              accent={accentFor(featured.agentKey)}
-              footer={{
-                Icon: iconFor(featured.icon),
-                name: featured.name,
-                tagline: (featured.tags ?? []).slice(0, 3).join(' · '),
-              }}
-              onClick={() => handleItemClick(featured)}
-              pillLabel="打开"
-            />
+        {/* ── Featured 海报级轮播 ── */}
+        {featuredItems.length > 0 && (
+          <section style={{ marginTop: 20 }}>
+            <AppStoreFeaturedCarousel items={featuredItems} />
           </section>
         )}
 
-        {/* ── 智能体（横滑） ── */}
+        {/* ── 智能体横滑 ── */}
         {agents.length > 0 && (
-          <AppStoreSection
-            title="智能体"
-            caption="AI 全生命周期 · 有专属存储与界面"
-            onShowAll={() => navigate('/ai-toolbox')}
-          >
+          <AppStoreSection title="智能体" onShowAll={() => navigate('/ai-toolbox')}>
             <AppStoreShelf
               items={agents.map((a) => ({
                 key: a.id,
@@ -216,11 +199,7 @@ export default function MobileHomePage() {
 
         {/* ── 工具（Top 榜单） ── */}
         {tools.length > 0 && (
-          <AppStoreSection
-            title="工具"
-            caption="专项能力 · 即开即用"
-            onShowAll={() => navigate('/ai-toolbox')}
-          >
+          <AppStoreSection title="工具" onShowAll={() => navigate('/ai-toolbox')}>
             <AppStoreRankedList
               numbered
               items={tools.map((t) => ({
@@ -230,7 +209,6 @@ export default function MobileHomePage() {
                 title: t.name,
                 subtitle: t.description,
                 pillLabel: '打开',
-                pillCaption: compatTagFor(t)?.label === 'PC' ? '建议 PC 使用' : undefined,
                 onClick: () => handleItemClick(t),
               }))}
             />
@@ -242,90 +220,19 @@ export default function MobileHomePage() {
 
         {/* ── 通知（榜单风） ── */}
         {notifications.length > 0 && (
-          <AppStoreSection
-            title="通知"
-            caption={`${notifications.length} 条待处理`}
-            onShowAll={() => navigate('/notifications')}
-          >
+          <AppStoreSection title="通知" onShowAll={() => navigate('/notifications')}>
             <NotificationsList notifications={notifications.slice(0, 4)} />
           </AppStoreSection>
         )}
 
         {/* ── 最近活动 ── */}
         {feed.length > 0 && (
-          <AppStoreSection
-            title="最近活动"
-          >
+          <AppStoreSection title="最近活动">
             <FeedList feed={feed.slice(0, 6)} onNavigate={(to) => navigate(to)} />
           </AppStoreSection>
         )}
       </div>
     </div>
-  );
-}
-
-/* ─────────────── 顶部头像 + 通知红点 ─────────────── */
-
-function AvatarBadge({ avatarUrl, fallback, notifCount, onClick }: {
-  avatarUrl: string | null;
-  fallback: string;
-  notifCount: number;
-  onClick?: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="relative transition-opacity active:opacity-60"
-      style={{ border: 'none', background: 'transparent', padding: 0 }}
-      aria-label="个人中心"
-    >
-      <div
-        style={{
-          width: 40,
-          height: 40,
-          borderRadius: 999,
-          overflow: 'hidden',
-          background: AS_COLOR.surface,
-          border: `1px solid ${AS_COLOR.hairline}`,
-        }}
-      >
-        {avatarUrl ? (
-          <img src={avatarUrl} alt="" className="w-full h-full object-cover" />
-        ) : (
-          <div
-            className="w-full h-full flex items-center justify-center"
-            style={{ ...AS_TYPE.itemTitle, color: AS_COLOR.label }}
-          >
-            {fallback || '?'}
-          </div>
-        )}
-      </div>
-      {notifCount > 0 && (
-        <span
-          className="absolute"
-          style={{
-            top: -2,
-            right: -2,
-            minWidth: 18,
-            height: 18,
-            padding: '0 5px',
-            borderRadius: 999,
-            background: AS_COLOR.red,
-            color: AS_COLOR.label,
-            fontSize: 10,
-            fontWeight: 700,
-            display: 'inline-flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            border: `2px solid ${AS_COLOR.bg}`,
-            lineHeight: 1,
-          }}
-        >
-          {notifCount > 99 ? '99+' : notifCount}
-        </span>
-      )}
-    </button>
   );
 }
 
@@ -425,15 +332,11 @@ function NotificationsList({ notifications }: { notifications: AdminNotification
             </div>
             {n.message && (
               <div
-                className="line-clamp-2"
+                className="truncate"
                 style={{
                   ...AS_TYPE.itemSubtitle,
                   color: AS_COLOR.labelSecondary,
                   marginTop: 2,
-                  display: '-webkit-box',
-                  WebkitLineClamp: 2,
-                  WebkitBoxOrient: 'vertical',
-                  overflow: 'hidden',
                 }}
               >
                 {n.message}

--- a/prd-admin/src/pages/MobileHomePage.tsx
+++ b/prd-admin/src/pages/MobileHomePage.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import * as LucideIcons from 'lucide-react';
 import {
   MessageSquare,
   Image,
-  PenLine,
   Bug,
   Bell,
   ChevronRight,
@@ -12,41 +12,20 @@ import {
   Sparkles,
   Download,
   Paperclip,
-  ClipboardCheck,
+  Bot,
+  Monitor,
+  Dot,
   type LucideIcon,
 } from 'lucide-react';
 import { useAuthStore } from '@/stores/authStore';
+import { BUILTIN_TOOLS } from '@/stores/toolboxStore';
+import type { ToolboxItem } from '@/services/real/aiToolbox';
 import { getAdminNotifications, getMobileFeed, getMobileStats } from '@/services';
 import type { AdminNotificationItem } from '@/services/contracts/notifications';
 import type { FeedItem, MobileStats } from '@/services/contracts/mobile';
 import { resolveAvatarUrl } from '@/lib/avatar';
 import { UserAvatar } from '@/components/ui/UserAvatar';
-
-/* ── 快捷 Agent 入口 ── */
-interface QuickAgent {
-  key: string;
-  label: string;
-  icon: LucideIcon;
-  path: string;
-  color: string;
-  bg: string;
-}
-
-const QUICK_AGENTS_BASE: QuickAgent[] = [
-  { key: 'prd',      label: 'PRD',    icon: MessageSquare, path: '/prd-agent',      color: '#818CF8', bg: 'rgba(129,140,248,0.15)' },
-  { key: 'visual',   label: '视觉',   icon: Image,         path: '/visual-agent',   color: '#FB923C', bg: 'rgba(251,146,60,0.15)' },
-  { key: 'literary', label: '文学',   icon: PenLine,       path: '/literary-agent', color: '#34D399', bg: 'rgba(52,211,153,0.15)' },
-  { key: 'showcase', label: '广场',   icon: Sparkles,      path: '/showcase',       color: '#A78BFA', bg: 'rgba(167,139,250,0.15)' },
-];
-
-const QUICK_AGENT_PR_REVIEW: QuickAgent = {
-  key: 'pr-review',
-  label: 'PR 审查智能体',
-  icon: ClipboardCheck,
-  path: '/pr-review',
-  color: '#A5B4FC',
-  bg: 'rgba(99,102,241,0.18)',
-};
+import { resolveMobileCompat, type MobileCompatLevel } from '@/lib/mobileCompatibility';
 
 /* ── Feed 项类型图标 ── */
 const FEED_ICON: Record<string, { icon: LucideIcon; color: string }> = {
@@ -72,20 +51,54 @@ const STAT_CARDS: StatCard[] = [
   { key: 'tokens',   label: 'Token', icon: Zap,            color: '#60A5FA', getValue: (s) => s.totalTokens, format: (v) => v >= 10000 ? `${(v / 1000).toFixed(1)}k` : String(v) },
 ];
 
+/* ── 卡片主题色（按图标名）—— 与桌面 AgentLauncher 对齐 ── */
+const ACCENT: Record<string, { from: string; to: string }> = {
+  FileText:  { from: '#3B82F6', to: '#60A5FA' },
+  Palette:   { from: '#A855F7', to: '#C084FC' },
+  PenTool:   { from: '#10B981', to: '#34D399' },
+  Bug:       { from: '#F97316', to: '#FB923C' },
+  Video:     { from: '#F43F5E', to: '#FB7185' },
+  Swords:    { from: '#F59E0B', to: '#FBBF24' },
+  Code2:     { from: '#10B981', to: '#6EE7B7' },
+  Languages: { from: '#06B6D4', to: '#67E8F9' },
+  FileSearch:{ from: '#EAB308', to: '#FDE68A' },
+  BarChart3: { from: '#8B5CF6', to: '#C4B5FD' },
+  Bot:       { from: '#6366F1', to: '#A5B4FC' },
+  FileBarChart: { from: '#6366F1', to: '#818CF8' },
+  Workflow:  { from: '#14B8A6', to: '#5EEAD4' },
+  Zap:       { from: '#F59E0B', to: '#FCD34D' },
+  Globe:     { from: '#0EA5E9', to: '#38BDF8' },
+  ClipboardCheck: { from: '#6366F1', to: '#A5B4FC' },
+  ScanSearch: { from: '#8B5CF6', to: '#C4B5FD' },
+  Wand2:     { from: '#8B5CF6', to: '#C4B5FD' },
+  AudioLines: { from: '#EC4899', to: '#F9A8D4' },
+};
+
+function getAccent(iconName: string) {
+  return ACCENT[iconName] ?? { from: '#6366F1', to: '#A5B4FC' };
+}
+
+function getIcon(iconName: string): LucideIcon {
+  const icons = LucideIcons as unknown as Record<string, LucideIcon>;
+  return icons[iconName] ?? Bot;
+}
+
 /**
- * 移动端首页 — 快捷入口 + 统计 + Feed + 通知。
+ * 移动端首页 — 问候 + 苹果 App Store 风智能体/工具横滑区 + 统计 + Feed + 通知。
+ *
+ * 横滑区块布局：
+ *  - 每张卡片 132×140，overflow-x-auto + snap-x + snap-mandatory
+ *  - 超出当前视口左右滑动查看更多（参考 iOS App Store "今日" tab）
+ *  - 右上角兼容性徽章：pc-only 显示灰色"PC"、limited 显示黄色圆点
  */
 export default function MobileHomePage() {
   const navigate = useNavigate();
   const user = useAuthStore((s) => s.user);
-  const permissions = useAuthStore((s) => s.permissions ?? []);
   const [notifications, setNotifications] = useState<AdminNotificationItem[]>([]);
   const [feed, setFeed] = useState<FeedItem[]>([]);
   const [stats, setStats] = useState<MobileStats | null>(null);
 
   useEffect(() => {
-    // 并行拉取 feed + stats + notifications
-    // 每个请求单独 catch —— 一个失败不影响其他渲染，也不会把整个首页拖成黑屏
     (async () => {
       const [feedRes, statsRes, notifRes] = await Promise.allSettled([
         getMobileFeed({ limit: 10 }),
@@ -115,13 +128,14 @@ export default function MobileHomePage() {
 
   const avatarUrl = user ? resolveAvatarUrl(user) : null;
 
-  const quickAgents = useMemo(() => {
-    const list = [...QUICK_AGENTS_BASE];
-    if (permissions.includes('pr-review.use')) {
-      list.unshift(QUICK_AGENT_PR_REVIEW);
-    }
-    return list;
-  }, [permissions]);
+  const agents = useMemo(
+    () => BUILTIN_TOOLS.filter((t) => t.kind === 'agent'),
+    [],
+  );
+  const tools = useMemo(
+    () => BUILTIN_TOOLS.filter((t) => t.kind === 'tool'),
+    [],
+  );
 
   return (
     <div className="h-full min-h-0 overflow-auto" style={{ background: 'var(--bg-base)' }}>
@@ -155,40 +169,23 @@ export default function MobileHomePage() {
           </div>
         </div>
 
-        {/* ── 快捷 Agent 入口 ── */}
-        <div className="mb-5">
-          <div
-            className="text-xs font-medium mb-3 px-2.5 py-1 rounded-md inline-block bg-black/20 backdrop-blur-md shadow-sm border border-white/5"
-            style={{ color: 'var(--text-primary)' }}
-          >
-            快捷入口
-          </div>
-          <div className={`grid gap-3 ${quickAgents.length > 4 ? 'grid-cols-5' : 'grid-cols-4'}`}>
-            {quickAgents.map((agent) => {
-              const AgentIcon = agent.icon;
-              return (
-                <button
-                  key={agent.key}
-                  onClick={() => navigate(agent.path)}
-                  className="surface-inset flex flex-col items-center gap-2 py-3 rounded-2xl transition-all active:scale-95"
-                >
-                  <div
-                    className="w-10 h-10 rounded-xl flex items-center justify-center"
-                    style={{ background: agent.bg }}
-                  >
-                    <AgentIcon size={20} style={{ color: agent.color }} />
-                  </div>
-                  <span
-                    className="text-[10px] font-medium text-center leading-tight px-1.5 py-0.5 mt-0.5 rounded bg-black/20 backdrop-blur-md shadow-sm border border-white/5 line-clamp-2"
-                    style={{ color: 'var(--text-primary)' }}
-                  >
-                    {agent.label}
-                  </span>
-                </button>
-              );
-            })}
-          </div>
-        </div>
+        {/* ── 智能体横滑 ── */}
+        <Shelf
+          title="智能体"
+          subtitle={`${agents.length} 个`}
+          items={agents}
+          onItemClick={(item) => navigate(item.routePath ?? `/ai-toolbox?item=${item.id}`)}
+          onMoreClick={() => navigate('/ai-toolbox')}
+        />
+
+        {/* ── 工具横滑 ── */}
+        <Shelf
+          title="工具"
+          subtitle={`${tools.length} 个`}
+          items={tools}
+          onItemClick={(item) => navigate(item.routePath ?? `/ai-toolbox?item=${item.id}`)}
+          onMoreClick={() => navigate('/ai-toolbox')}
+        />
 
         {/* ── 统计卡片 (近 7 日) ── */}
         {stats && (
@@ -346,5 +343,144 @@ export default function MobileHomePage() {
         )}
       </div>
     </div>
+  );
+}
+
+/* ============ 横滑卡片区块（App Store 风）============ */
+
+interface ShelfProps {
+  title: string;
+  subtitle?: string;
+  items: ToolboxItem[];
+  onItemClick: (item: ToolboxItem) => void;
+  onMoreClick?: () => void;
+}
+
+function Shelf({ title, subtitle, items, onItemClick, onMoreClick }: ShelfProps) {
+  if (items.length === 0) return null;
+  return (
+    <div className="mb-5 -mx-5">
+      {/* 标题行 —— 不滑动，保留左右内边距 */}
+      <div className="px-5 mb-3 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <div
+            className="text-xs font-semibold px-2.5 py-1 rounded-md bg-black/20 backdrop-blur-md shadow-sm border border-white/5"
+            style={{ color: 'var(--text-primary)' }}
+          >
+            {title}
+          </div>
+          {subtitle && (
+            <span className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
+              {subtitle}
+            </span>
+          )}
+        </div>
+        {onMoreClick && (
+          <button
+            type="button"
+            onClick={onMoreClick}
+            className="inline-flex items-center gap-0.5 text-[11px] px-2 py-0.5 rounded transition-colors active:scale-95"
+            style={{ color: 'var(--text-muted)' }}
+          >
+            全部
+            <ChevronRight size={12} />
+          </button>
+        )}
+      </div>
+
+      {/* 横滑容器 */}
+      <div
+        className="flex gap-3 overflow-x-auto snap-x snap-mandatory px-5 pb-1"
+        style={{
+          scrollbarWidth: 'none',
+          WebkitOverflowScrolling: 'touch',
+          overscrollBehaviorX: 'contain',
+        }}
+      >
+        {items.map((item) => (
+          <ShelfCard key={item.id} item={item} onClick={() => onItemClick(item)} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ShelfCard({ item, onClick }: { item: ToolboxItem; onClick: () => void }) {
+  const Icon = getIcon(item.icon);
+  const accent = getAccent(item.icon);
+  // 兼容性徽章：根据 routePath 查注册表
+  const compat = item.routePath ? resolveMobileCompat(item.routePath) : null;
+  const level: MobileCompatLevel | null = compat?.level ?? null;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="relative shrink-0 snap-start rounded-2xl p-3 flex flex-col items-start text-left transition-all active:scale-95"
+      style={{
+        width: 140,
+        minHeight: 148,
+        background: 'rgba(255, 255, 255, 0.04)',
+        border: '1px solid rgba(255, 255, 255, 0.06)',
+      }}
+    >
+      {/* 右上角兼容性徽章 */}
+      {level === 'pc-only' && (
+        <span
+          className="absolute top-2 right-2 inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[9px] font-semibold"
+          style={{
+            background: 'rgba(248, 113, 113, 0.18)',
+            color: '#fca5a5',
+          }}
+          aria-label="建议在 PC 上使用"
+        >
+          <Monitor size={9} /> PC
+        </span>
+      )}
+      {level === 'limited' && (
+        <span
+          className="absolute top-2 right-2 inline-flex items-center justify-center"
+          style={{ color: '#fbbf24' }}
+          aria-label="移动端体验受限"
+        >
+          <Dot size={18} />
+        </span>
+      )}
+
+      {/* WIP 施工中角标 */}
+      {item.wip && (
+        <span
+          className="absolute top-2 left-2 inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-semibold"
+          style={{ background: 'rgba(251, 146, 60, 0.18)', color: '#fdba74' }}
+        >
+          施工中
+        </span>
+      )}
+
+      {/* 图标 */}
+      <div
+        className="w-11 h-11 rounded-2xl flex items-center justify-center mb-2 mt-1"
+        style={{
+          background: `linear-gradient(135deg, ${accent.from}33, ${accent.to}22)`,
+          border: `1px solid ${accent.from}44`,
+        }}
+      >
+        <Icon size={22} style={{ color: accent.from }} />
+      </div>
+
+      {/* 名称 + 描述 */}
+      <div
+        className="text-[13px] font-semibold leading-tight line-clamp-1 w-full"
+        style={{ color: 'var(--text-primary)' }}
+      >
+        {item.name}
+      </div>
+      <div
+        className="text-[11px] leading-snug mt-1 line-clamp-2 w-full"
+        style={{ color: 'var(--text-muted)' }}
+      >
+        {item.description}
+      </div>
+    </button>
   );
 }

--- a/prd-admin/src/pages/MobileHomePage.tsx
+++ b/prd-admin/src/pages/MobileHomePage.tsx
@@ -85,15 +85,22 @@ export default function MobileHomePage() {
 
   useEffect(() => {
     // 并行拉取 feed + stats + notifications
+    // 每个请求单独 catch —— 一个失败不影响其他渲染，也不会把整个首页拖成黑屏
     (async () => {
-      const [feedRes, statsRes, notifRes] = await Promise.all([
+      const [feedRes, statsRes, notifRes] = await Promise.allSettled([
         getMobileFeed({ limit: 10 }),
         getMobileStats({ days: 7 }),
         getAdminNotifications(),
       ]);
-      if (feedRes.success) setFeed(feedRes.data.items ?? []);
-      if (statsRes.success) setStats(statsRes.data);
-      if (notifRes.success) setNotifications(notifRes.data.items?.filter((n) => n.status === 'open') ?? []);
+      if (feedRes.status === 'fulfilled' && feedRes.value.success) {
+        setFeed(feedRes.value.data.items ?? []);
+      }
+      if (statsRes.status === 'fulfilled' && statsRes.value.success) {
+        setStats(statsRes.value.data);
+      }
+      if (notifRes.status === 'fulfilled' && notifRes.value.success) {
+        setNotifications(notifRes.value.data.items?.filter((n) => n.status === 'open') ?? []);
+      }
     })();
   }, []);
 

--- a/prd-admin/src/pages/MobileHomePage.tsx
+++ b/prd-admin/src/pages/MobileHomePage.tsx
@@ -3,18 +3,11 @@ import { useNavigate } from 'react-router-dom';
 import * as LucideIcons from 'lucide-react';
 import {
   MessageSquare,
-  Image,
+  Image as ImageIcon,
   Bug,
   Bell,
   ChevronRight,
-  Zap,
-  MessagesSquare,
-  Sparkles,
-  Download,
-  Paperclip,
   Bot,
-  Monitor,
-  Dot,
   type LucideIcon,
 } from 'lucide-react';
 import { useAuthStore } from '@/stores/authStore';
@@ -24,76 +17,60 @@ import { getAdminNotifications, getMobileFeed, getMobileStats } from '@/services
 import type { AdminNotificationItem } from '@/services/contracts/notifications';
 import type { FeedItem, MobileStats } from '@/services/contracts/mobile';
 import { resolveAvatarUrl } from '@/lib/avatar';
-import { UserAvatar } from '@/components/ui/UserAvatar';
-import { resolveMobileCompat, type MobileCompatLevel } from '@/lib/mobileCompatibility';
+import { resolveMobileCompat } from '@/lib/mobileCompatibility';
+import { buildDefaultCoverUrl } from '@/lib/homepageAssetSlots';
+import {
+  AppStoreHero,
+  AppStoreFeatured,
+  AppStoreSection,
+  AppStoreShelf,
+  AppStoreRankedList,
+} from '@/components/mobile/appStore';
+import { AS_COLOR, AS_SPACE, AS_FONT_FAMILY, AS_TYPE } from '@/lib/appStoreTokens';
 
-/* ── Feed 项类型图标 ── */
-const FEED_ICON: Record<string, { icon: LucideIcon; color: string }> = {
-  'prd-session':       { icon: MessageSquare, color: '#818CF8' },
-  'visual-workspace':  { icon: Image,         color: '#FB923C' },
-  'defect':            { icon: Bug,           color: '#F87171' },
+/* ─────────── Agent 主题色（iOS System Colors 级，不刺眼） ─────────── */
+
+const AGENT_ACCENT: Record<string, { from: string; to: string }> = {
+  'prd-agent':       { from: '#0A84FF', to: '#64D2FF' },  // iOS Blue → Teal
+  'visual-agent':    { from: '#BF5AF2', to: '#FF375F' },  // iOS Purple → Pink
+  'literary-agent':  { from: '#30D158', to: '#64D2FF' },  // iOS Green → Teal
+  'defect-agent':    { from: '#FF9F0A', to: '#FF453A' },  // iOS Orange → Red
+  'video-agent':     { from: '#FF375F', to: '#BF5AF2' },  // iOS Pink → Purple
+  'report-agent':    { from: '#5E5CE6', to: '#0A84FF' },  // iOS Indigo → Blue
+  'review-agent':    { from: '#FFD60A', to: '#FF9F0A' },  // iOS Yellow → Orange
+  'pr-review':       { from: '#5E5CE6', to: '#64D2FF' },  // iOS Indigo → Teal
+  'shortcuts-agent': { from: '#FFD60A', to: '#FF9F0A' },  // iOS Yellow → Orange
+  'transcript-agent':{ from: '#FF375F', to: '#BF5AF2' },  // Pink → Purple
+  'workflow-agent':  { from: '#30D158', to: '#64D2FF' },  // Green → Teal
+  'arena':           { from: '#FF9F0A', to: '#FFD60A' },  // Orange → Yellow
 };
 
-/* ── 统计卡片 ── */
-interface StatCard {
-  key: string;
-  label: string;
-  icon: LucideIcon;
-  color: string;
-  getValue: (s: MobileStats) => number;
-  format?: (v: number) => string;
+const DEFAULT_ACCENT = { from: '#0A84FF', to: '#5E5CE6' };
+
+function accentFor(agentKey?: string): { from: string; to: string } {
+  if (!agentKey) return DEFAULT_ACCENT;
+  return AGENT_ACCENT[agentKey] ?? DEFAULT_ACCENT;
 }
 
-const STAT_CARDS: StatCard[] = [
-  { key: 'sessions', label: '会话', icon: MessagesSquare, color: '#818CF8', getValue: (s) => s.sessions },
-  { key: 'messages', label: '消息', icon: MessageSquare,  color: '#34D399', getValue: (s) => s.messages },
-  { key: 'images',   label: '生图', icon: Sparkles,       color: '#FB923C', getValue: (s) => s.imageGenerations },
-  { key: 'tokens',   label: 'Token', icon: Zap,            color: '#60A5FA', getValue: (s) => s.totalTokens, format: (v) => v >= 10000 ? `${(v / 1000).toFixed(1)}k` : String(v) },
-];
-
-/* ── 卡片主题色（按图标名）—— 与桌面 AgentLauncher 对齐 ── */
-const ACCENT: Record<string, { from: string; to: string }> = {
-  FileText:  { from: '#3B82F6', to: '#60A5FA' },
-  Palette:   { from: '#A855F7', to: '#C084FC' },
-  PenTool:   { from: '#10B981', to: '#34D399' },
-  Bug:       { from: '#F97316', to: '#FB923C' },
-  Video:     { from: '#F43F5E', to: '#FB7185' },
-  Swords:    { from: '#F59E0B', to: '#FBBF24' },
-  Code2:     { from: '#10B981', to: '#6EE7B7' },
-  Languages: { from: '#06B6D4', to: '#67E8F9' },
-  FileSearch:{ from: '#EAB308', to: '#FDE68A' },
-  BarChart3: { from: '#8B5CF6', to: '#C4B5FD' },
-  Bot:       { from: '#6366F1', to: '#A5B4FC' },
-  FileBarChart: { from: '#6366F1', to: '#818CF8' },
-  Workflow:  { from: '#14B8A6', to: '#5EEAD4' },
-  Zap:       { from: '#F59E0B', to: '#FCD34D' },
-  Globe:     { from: '#0EA5E9', to: '#38BDF8' },
-  ClipboardCheck: { from: '#6366F1', to: '#A5B4FC' },
-  ScanSearch: { from: '#8B5CF6', to: '#C4B5FD' },
-  Wand2:     { from: '#8B5CF6', to: '#C4B5FD' },
-  AudioLines: { from: '#EC4899', to: '#F9A8D4' },
-};
-
-function getAccent(iconName: string) {
-  return ACCENT[iconName] ?? { from: '#6366F1', to: '#A5B4FC' };
-}
-
-function getIcon(iconName: string): LucideIcon {
+function iconFor(iconName: string): LucideIcon {
   const icons = LucideIcons as unknown as Record<string, LucideIcon>;
   return icons[iconName] ?? Bot;
 }
 
-/**
- * 移动端首页 — 问候 + 苹果 App Store 风智能体/工具横滑区 + 统计 + Feed + 通知。
- *
- * 横滑区块布局：
- *  - 每张卡片 132×140，overflow-x-auto + snap-x + snap-mandatory
- *  - 超出当前视口左右滑动查看更多（参考 iOS App Store "今日" tab）
- *  - 右上角兼容性徽章：pc-only 显示灰色"PC"、limited 显示黄色圆点
- */
+/* ─────────── Feed 类型映射 ─────────── */
+
+const FEED_ICON: Record<string, { icon: LucideIcon; accent: { from: string; to: string } }> = {
+  'prd-session':      { icon: MessageSquare, accent: { from: '#0A84FF', to: '#64D2FF' } },
+  'visual-workspace': { icon: ImageIcon,     accent: { from: '#BF5AF2', to: '#FF375F' } },
+  'defect':           { icon: Bug,           accent: { from: '#FF9F0A', to: '#FF453A' } },
+};
+
+/* ─────────── 页面 ─────────── */
+
 export default function MobileHomePage() {
   const navigate = useNavigate();
   const user = useAuthStore((s) => s.user);
+  const cdnBase = useAuthStore((s) => s.cdnBaseUrl ?? '');
   const [notifications, setNotifications] = useState<AdminNotificationItem[]>([]);
   const [feed, setFeed] = useState<FeedItem[]>([]);
   const [stats, setStats] = useState<MobileStats | null>(null);
@@ -117,370 +94,425 @@ export default function MobileHomePage() {
     })();
   }, []);
 
+  /* ── 今日问候 + 日期 ── */
+  // 在组件挂载时锁定时间，避免 useMemo 依赖不稳定（页面开着几小时后再切问候语不是关键需求）
+  const now = useMemo(() => new Date(), []);
   const greeting = useMemo(() => {
-    const h = new Date().getHours();
+    const h = now.getHours();
     if (h < 6) return '夜深了';
     if (h < 12) return '早上好';
     if (h < 14) return '中午好';
     if (h < 18) return '下午好';
     return '晚上好';
-  }, []);
+  }, [now]);
 
+  const dateEyebrow = useMemo(() => {
+    const weekday = ['星期日','星期一','星期二','星期三','星期四','星期五','星期六'][now.getDay()];
+    return `${weekday} · ${now.getMonth() + 1} 月 ${now.getDate()} 日`;
+  }, [now]);
+
+  const displayName = user?.displayName || user?.username || '';
   const avatarUrl = user ? resolveAvatarUrl(user) : null;
 
-  const agents = useMemo(
-    () => BUILTIN_TOOLS.filter((t) => t.kind === 'agent'),
-    [],
-  );
-  const tools = useMemo(
-    () => BUILTIN_TOOLS.filter((t) => t.kind === 'tool'),
-    [],
-  );
+  /* ── 数据分类 ── */
+  const agents = useMemo(() => BUILTIN_TOOLS.filter((t) => t.kind === 'agent'), []);
+  const tools = useMemo(() => BUILTIN_TOOLS.filter((t) => t.kind === 'tool'), []);
+
+  /* ── 今日精选（基于日期 rotate） ── */
+  const featured = useMemo(() => {
+    if (agents.length === 0) return null;
+    const dayOfYear = Math.floor(
+      (now.getTime() - new Date(now.getFullYear(), 0, 0).getTime()) / 86400000,
+    );
+    return agents[dayOfYear % agents.length];
+  }, [agents, now]);
+
+  const featuredImage = useMemo(() => {
+    if (!featured?.agentKey) return null;
+    return buildDefaultCoverUrl(cdnBase, featured.agentKey);
+  }, [featured, cdnBase]);
+
+  const handleItemClick = (item: ToolboxItem) => {
+    navigate(item.routePath ?? `/ai-toolbox?item=${item.id}`);
+  };
+
+  const compatTagFor = (item: ToolboxItem) => {
+    if (!item.routePath) return undefined;
+    const c = resolveMobileCompat(item.routePath);
+    if (c?.level === 'pc-only') {
+      return { label: 'PC', color: '#FCA5A5', bg: 'rgba(255, 69, 58, 0.22)' };
+    }
+    if (c?.level === 'limited') {
+      return { label: '部分', color: '#FFD60A', bg: 'rgba(255, 214, 10, 0.18)' };
+    }
+    return undefined;
+  };
 
   return (
-    <div className="h-full min-h-0 overflow-auto" style={{ background: 'var(--bg-base)' }}>
-      <div className="px-5 pt-6 pb-28">
-
-        {/* ── 问候区 ── */}
-        <div className="flex items-center gap-3 mb-6">
-          {avatarUrl ? (
-            <UserAvatar src={avatarUrl} className="w-11 h-11 rounded-full object-cover" />
-          ) : (
-            <div
-              className="w-11 h-11 rounded-full flex items-center justify-center text-sm font-semibold"
-              style={{ background: 'rgba(255,255,255,0.08)', color: 'var(--text-primary)' }}
-            >
-              {(user?.displayName || user?.username || '?')[0]}
-            </div>
-          )}
-          <div className="flex flex-col items-start">
-            <div
-              className="text-lg font-semibold px-2.5 py-0.5 rounded-lg bg-black/20 backdrop-blur-md shadow-sm border border-white/5"
-              style={{ color: 'var(--text-primary)', textShadow: '0 1px 3px rgba(0,0,0,0.5)' }}
-            >
-              {greeting}，{user?.displayName || user?.username}
-            </div>
-            <div
-              className="text-xs mt-1.5 px-2 py-0.5 rounded-md bg-black/20 backdrop-blur-md shadow-sm border border-white/5"
-              style={{ color: 'var(--text-muted)' }}
-            >
-              看看今天能帮你做什么
-            </div>
-          </div>
-        </div>
-
-        {/* ── 智能体横滑 ── */}
-        <Shelf
-          title="智能体"
-          subtitle={`${agents.length} 个`}
-          items={agents}
-          onItemClick={(item) => navigate(item.routePath ?? `/ai-toolbox?item=${item.id}`)}
-          onMoreClick={() => navigate('/ai-toolbox')}
+    <div
+      className="h-full min-h-0 overflow-auto"
+      style={{
+        background: AS_COLOR.bg,
+        fontFamily: AS_FONT_FAMILY,
+      }}
+    >
+      <div style={{ paddingBottom: 120 }}>
+        {/* ── Hero ── */}
+        <AppStoreHero
+          eyebrow={dateEyebrow}
+          title={`${greeting}${displayName ? '，' + displayName : ''}`}
+          subtitle="看看今天能帮你做什么"
+          trailing={
+            <AvatarBadge
+              avatarUrl={avatarUrl}
+              fallback={displayName[0]}
+              notifCount={notifications.length}
+              onClick={() => navigate('/profile')}
+            />
+          }
         />
 
-        {/* ── 工具横滑 ── */}
-        <Shelf
-          title="工具"
-          subtitle={`${tools.length} 个`}
-          items={tools}
-          onItemClick={(item) => navigate(item.routePath ?? `/ai-toolbox?item=${item.id}`)}
-          onMoreClick={() => navigate('/ai-toolbox')}
-        />
-
-        {/* ── 统计卡片 (近 7 日) ── */}
-        {stats && (
-          <div className="mb-5">
-            <div
-              className="text-xs font-medium mb-3 px-2.5 py-1 rounded-md inline-block bg-black/20 backdrop-blur-md shadow-sm border border-white/5"
-              style={{ color: 'var(--text-primary)' }}
-            >
-              近 7 日统计
-            </div>
-            <div className="grid grid-cols-4 gap-2">
-              {STAT_CARDS.map((card) => {
-                const CardIcon = card.icon;
-                const val = card.getValue(stats);
-                const display = card.format ? card.format(val) : String(val);
-                return (
-                  <div
-                    key={card.key}
-                    className="surface-inset flex flex-col items-center gap-1.5 py-3 rounded-xl"
-                  >
-                    <CardIcon size={16} className="mb-0.5" style={{ color: card.color }} />
-                    <div
-                      className="text-base font-bold px-2 py-0.5 rounded-md bg-black/20 backdrop-blur-md shadow-sm border border-white/5"
-                      style={{ color: 'var(--text-primary)', textShadow: '0 1px 2px rgba(0,0,0,0.5)' }}
-                    >
-                      {display}
-                    </div>
-                    <div
-                      className="text-[10px] px-1.5 py-0.5 rounded bg-black/20 backdrop-blur-md shadow-sm border border-white/5"
-                      style={{ color: 'var(--text-muted)' }}
-                    >
-                      {card.label}
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          </div>
+        {/* ── Featured 大卡（今日推荐 Agent） ── */}
+        {featured && (
+          <section style={{ marginTop: AS_SPACE.sectionGap }}>
+            <AppStoreFeatured
+              eyebrow="今日推荐"
+              eyebrowColor="#FFD60A"
+              title={featured.name}
+              subtitle={featured.description}
+              imageUrl={featuredImage}
+              accent={accentFor(featured.agentKey)}
+              footer={{
+                Icon: iconFor(featured.icon),
+                name: featured.name,
+                tagline: (featured.tags ?? []).slice(0, 3).join(' · '),
+              }}
+              onClick={() => handleItemClick(featured)}
+              pillLabel="打开"
+            />
+          </section>
         )}
 
-        {/* ── 通知摘要 ── */}
+        {/* ── 智能体（横滑） ── */}
+        {agents.length > 0 && (
+          <AppStoreSection
+            title="智能体"
+            caption="AI 全生命周期 · 有专属存储与界面"
+            onShowAll={() => navigate('/ai-toolbox')}
+          >
+            <AppStoreShelf
+              items={agents.map((a) => ({
+                key: a.id,
+                Icon: iconFor(a.icon),
+                accent: accentFor(a.agentKey),
+                title: a.name,
+                subtitle: a.description,
+                tag: compatTagFor(a),
+                onClick: () => handleItemClick(a),
+              }))}
+            />
+          </AppStoreSection>
+        )}
+
+        {/* ── 工具（Top 榜单） ── */}
+        {tools.length > 0 && (
+          <AppStoreSection
+            title="工具"
+            caption="专项能力 · 即开即用"
+            onShowAll={() => navigate('/ai-toolbox')}
+          >
+            <AppStoreRankedList
+              numbered
+              items={tools.map((t) => ({
+                key: t.id,
+                Icon: iconFor(t.icon),
+                accent: accentFor(t.agentKey),
+                title: t.name,
+                subtitle: t.description,
+                pillLabel: '打开',
+                pillCaption: compatTagFor(t)?.label === 'PC' ? '建议 PC 使用' : undefined,
+                onClick: () => handleItemClick(t),
+              }))}
+            />
+          </AppStoreSection>
+        )}
+
+        {/* ── 近 7 日统计（极简 chip 排） ── */}
+        {stats && <StatsRow stats={stats} />}
+
+        {/* ── 通知（榜单风） ── */}
         {notifications.length > 0 && (
-          <div className="mb-5">
-            <div className="flex items-center justify-between mb-3">
-              <div
-                className="text-xs font-medium px-2.5 py-1 rounded-md inline-block bg-black/20 backdrop-blur-md shadow-sm border border-white/5"
-                style={{ color: 'var(--text-primary)' }}
-              >
-                通知
-              </div>
-              <div
-                className="text-[11px] px-2 py-0.5 rounded-md bg-black/20 backdrop-blur-md shadow-sm border border-white/5"
-                style={{ color: 'var(--text-muted)' }}
-              >
-                {notifications.length} 条未读
-              </div>
-            </div>
-            <div className="space-y-2">
-              {notifications.slice(0, 3).map((n) => (
-                <div
-                  key={n.id}
-                  className="surface-inset flex items-start gap-3 p-3 rounded-xl"
-                >
-                  <Bell size={16} className="mt-0.5 shrink-0" style={{ color: 'var(--text-muted)' }} />
-                  <div className="flex-1 min-w-0">
-                    <div
-                      className="text-sm font-medium truncate px-1.5 py-0.5 rounded bg-black/20 w-fit max-w-full backdrop-blur-md shadow-sm border border-white/5"
-                      style={{ color: 'var(--text-primary)' }}
-                    >
-                      {n.title}
-                    </div>
-                    {n.message && (
-                      <div
-                        className="text-xs mt-1 line-clamp-2 px-1.5 py-0.5 rounded bg-black/20 w-fit backdrop-blur-md shadow-sm border border-white/5"
-                        style={{ color: 'var(--text-muted)' }}
-                      >
-                        {n.message}
-                      </div>
-                    )}
-                    {n.attachments && n.attachments.length > 0 && (
-                      <div className="flex flex-wrap gap-1.5 mt-1.5">
-                        {n.attachments.map((att, idx) => (
-                          <a
-                            key={idx}
-                            href={att.url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-[11px] transition-colors"
-                            style={{
-                              background: 'var(--surface-elevated)',
-                              color: 'var(--text-secondary)',
-                              border: '1px solid var(--border-default)',
-                            }}
-                            onClick={(e) => e.stopPropagation()}
-                          >
-                            <Paperclip size={10} />
-                            <span className="truncate max-w-[120px]">{att.name}</span>
-                            <Download size={10} className="shrink-0 opacity-60" />
-                          </a>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
+          <AppStoreSection
+            title="通知"
+            caption={`${notifications.length} 条待处理`}
+            onShowAll={() => navigate('/notifications')}
+          >
+            <NotificationsList notifications={notifications.slice(0, 4)} />
+          </AppStoreSection>
         )}
 
-        {/* ── Feed 流 (最近活动) ── */}
+        {/* ── 最近活动 ── */}
         {feed.length > 0 && (
-          <div>
-            <div
-              className="text-xs font-medium mb-3 px-2.5 py-1 rounded-md inline-block bg-black/20 backdrop-blur-md shadow-sm border border-white/5"
-              style={{ color: 'var(--text-primary)' }}
-            >
-              最近活动
-            </div>
-            <div className="space-y-2">
-              {feed.map((item) => {
-                const meta = FEED_ICON[item.type] ?? { icon: MessageSquare, color: '#818CF8' };
-                const FeedIcon = meta.icon;
-                return (
-                  <button
-                    key={item.id}
-                    onClick={() => navigate(item.navigateTo)}
-                    className="surface-inset w-full flex items-center gap-3 p-3 rounded-xl text-left transition-all active:scale-[0.98]"
-                  >
-                    <div
-                      className="w-9 h-9 rounded-lg flex items-center justify-center shrink-0"
-                      style={{ background: `${meta.color}20` }}
-                    >
-                      <FeedIcon size={18} style={{ color: meta.color }} />
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <div
-                        className="text-sm font-medium truncate px-1.5 py-0.5 rounded bg-black/20 w-fit max-w-full backdrop-blur-md shadow-sm border border-white/5"
-                        style={{ color: 'var(--text-primary)' }}
-                      >
-                        {item.title}
-                      </div>
-                      <div
-                        className="text-[11px] truncate mt-1 px-1.5 py-0.5 rounded bg-black/20 w-fit max-w-full backdrop-blur-md shadow-sm border border-white/5"
-                        style={{ color: 'var(--text-muted)' }}
-                      >
-                        {item.subtitle}
-                      </div>
-                    </div>
-                    <ChevronRight size={16} style={{ color: 'var(--text-muted)' }} className="shrink-0" />
-                  </button>
-                );
-              })}
-            </div>
-          </div>
+          <AppStoreSection
+            title="最近活动"
+          >
+            <FeedList feed={feed.slice(0, 6)} onNavigate={(to) => navigate(to)} />
+          </AppStoreSection>
         )}
       </div>
     </div>
   );
 }
 
-/* ============ 横滑卡片区块（App Store 风）============ */
+/* ─────────────── 顶部头像 + 通知红点 ─────────────── */
 
-interface ShelfProps {
-  title: string;
-  subtitle?: string;
-  items: ToolboxItem[];
-  onItemClick: (item: ToolboxItem) => void;
-  onMoreClick?: () => void;
-}
-
-function Shelf({ title, subtitle, items, onItemClick, onMoreClick }: ShelfProps) {
-  if (items.length === 0) return null;
-  return (
-    <div className="mb-5 -mx-5">
-      {/* 标题行 —— 不滑动，保留左右内边距 */}
-      <div className="px-5 mb-3 flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <div
-            className="text-xs font-semibold px-2.5 py-1 rounded-md bg-black/20 backdrop-blur-md shadow-sm border border-white/5"
-            style={{ color: 'var(--text-primary)' }}
-          >
-            {title}
-          </div>
-          {subtitle && (
-            <span className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
-              {subtitle}
-            </span>
-          )}
-        </div>
-        {onMoreClick && (
-          <button
-            type="button"
-            onClick={onMoreClick}
-            className="inline-flex items-center gap-0.5 text-[11px] px-2 py-0.5 rounded transition-colors active:scale-95"
-            style={{ color: 'var(--text-muted)' }}
-          >
-            全部
-            <ChevronRight size={12} />
-          </button>
-        )}
-      </div>
-
-      {/* 横滑容器 */}
-      <div
-        className="flex gap-3 overflow-x-auto snap-x snap-mandatory px-5 pb-1"
-        style={{
-          scrollbarWidth: 'none',
-          WebkitOverflowScrolling: 'touch',
-          overscrollBehaviorX: 'contain',
-        }}
-      >
-        {items.map((item) => (
-          <ShelfCard key={item.id} item={item} onClick={() => onItemClick(item)} />
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function ShelfCard({ item, onClick }: { item: ToolboxItem; onClick: () => void }) {
-  const Icon = getIcon(item.icon);
-  const accent = getAccent(item.icon);
-  // 兼容性徽章：根据 routePath 查注册表
-  const compat = item.routePath ? resolveMobileCompat(item.routePath) : null;
-  const level: MobileCompatLevel | null = compat?.level ?? null;
-
+function AvatarBadge({ avatarUrl, fallback, notifCount, onClick }: {
+  avatarUrl: string | null;
+  fallback: string;
+  notifCount: number;
+  onClick?: () => void;
+}) {
   return (
     <button
       type="button"
       onClick={onClick}
-      className="relative shrink-0 snap-start rounded-2xl p-3 flex flex-col items-start text-left transition-all active:scale-95"
-      style={{
-        width: 140,
-        minHeight: 148,
-        background: 'rgba(255, 255, 255, 0.04)',
-        border: '1px solid rgba(255, 255, 255, 0.06)',
-      }}
+      className="relative transition-opacity active:opacity-60"
+      style={{ border: 'none', background: 'transparent', padding: 0 }}
+      aria-label="个人中心"
     >
-      {/* 右上角兼容性徽章 */}
-      {level === 'pc-only' && (
-        <span
-          className="absolute top-2 right-2 inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[9px] font-semibold"
-          style={{
-            background: 'rgba(248, 113, 113, 0.18)',
-            color: '#fca5a5',
-          }}
-          aria-label="建议在 PC 上使用"
-        >
-          <Monitor size={9} /> PC
-        </span>
-      )}
-      {level === 'limited' && (
-        <span
-          className="absolute top-2 right-2 inline-flex items-center justify-center"
-          style={{ color: '#fbbf24' }}
-          aria-label="移动端体验受限"
-        >
-          <Dot size={18} />
-        </span>
-      )}
-
-      {/* WIP 施工中角标 */}
-      {item.wip && (
-        <span
-          className="absolute top-2 left-2 inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-semibold"
-          style={{ background: 'rgba(251, 146, 60, 0.18)', color: '#fdba74' }}
-        >
-          施工中
-        </span>
-      )}
-
-      {/* 图标 */}
       <div
-        className="w-11 h-11 rounded-2xl flex items-center justify-center mb-2 mt-1"
         style={{
-          background: `linear-gradient(135deg, ${accent.from}33, ${accent.to}22)`,
-          border: `1px solid ${accent.from}44`,
+          width: 40,
+          height: 40,
+          borderRadius: 999,
+          overflow: 'hidden',
+          background: AS_COLOR.surface,
+          border: `1px solid ${AS_COLOR.hairline}`,
         }}
       >
-        <Icon size={22} style={{ color: accent.from }} />
+        {avatarUrl ? (
+          <img src={avatarUrl} alt="" className="w-full h-full object-cover" />
+        ) : (
+          <div
+            className="w-full h-full flex items-center justify-center"
+            style={{ ...AS_TYPE.itemTitle, color: AS_COLOR.label }}
+          >
+            {fallback || '?'}
+          </div>
+        )}
       </div>
-
-      {/* 名称 + 描述 */}
-      <div
-        className="text-[13px] font-semibold leading-tight line-clamp-1 w-full"
-        style={{ color: 'var(--text-primary)' }}
-      >
-        {item.name}
-      </div>
-      <div
-        className="text-[11px] leading-snug mt-1 line-clamp-2 w-full"
-        style={{ color: 'var(--text-muted)' }}
-      >
-        {item.description}
-      </div>
+      {notifCount > 0 && (
+        <span
+          className="absolute"
+          style={{
+            top: -2,
+            right: -2,
+            minWidth: 18,
+            height: 18,
+            padding: '0 5px',
+            borderRadius: 999,
+            background: AS_COLOR.red,
+            color: AS_COLOR.label,
+            fontSize: 10,
+            fontWeight: 700,
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            border: `2px solid ${AS_COLOR.bg}`,
+            lineHeight: 1,
+          }}
+        >
+          {notifCount > 99 ? '99+' : notifCount}
+        </span>
+      )}
     </button>
+  );
+}
+
+/* ─────────────── 近 7 日统计（极简横排） ─────────────── */
+
+function StatsRow({ stats }: { stats: MobileStats }) {
+  const items = [
+    { label: '会话', value: stats.sessions },
+    { label: '消息', value: stats.messages },
+    { label: '生图', value: stats.imageGenerations },
+    {
+      label: 'Token',
+      value: stats.totalTokens >= 10000
+        ? `${(stats.totalTokens / 1000).toFixed(1)}k`
+        : String(stats.totalTokens),
+    },
+  ];
+
+  return (
+    <AppStoreSection title="近 7 日">
+      <div
+        className="grid grid-cols-4"
+        style={{
+          margin: `0 ${AS_SPACE.gutter}px`,
+          borderRadius: AS_SPACE.shelfCardRadius,
+          background: AS_COLOR.surface,
+          border: `1px solid ${AS_COLOR.hairline}`,
+          overflow: 'hidden',
+        }}
+      >
+        {items.map((it, i) => (
+          <div
+            key={it.label}
+            className="flex flex-col items-center justify-center"
+            style={{
+              padding: '16px 4px',
+              borderRight: i < items.length - 1 ? `0.5px solid ${AS_COLOR.hairline}` : undefined,
+            }}
+          >
+            <div
+              style={{
+                fontSize: 22,
+                fontWeight: 700,
+                color: AS_COLOR.label,
+                letterSpacing: '-0.02em',
+                lineHeight: 1.1,
+              }}
+            >
+              {it.value}
+            </div>
+            <div
+              style={{
+                fontSize: 11,
+                fontWeight: 500,
+                color: AS_COLOR.labelSecondary,
+                marginTop: 4,
+                letterSpacing: '0.02em',
+              }}
+            >
+              {it.label}
+            </div>
+          </div>
+        ))}
+      </div>
+    </AppStoreSection>
+  );
+}
+
+/* ─────────────── 通知列表 ─────────────── */
+
+function NotificationsList({ notifications }: { notifications: AdminNotificationItem[] }) {
+  return (
+    <div style={{ padding: `0 ${AS_SPACE.gutter}px` }}>
+      {notifications.map((n, idx) => (
+        <div
+          key={n.id}
+          className="flex items-start gap-3 relative"
+          style={{ padding: '14px 0' }}
+        >
+          <div
+            className="shrink-0 flex items-center justify-center"
+            style={{
+              width: 36,
+              height: 36,
+              borderRadius: 10,
+              background: 'rgba(255, 159, 10, 0.16)',
+            }}
+          >
+            <Bell size={16} strokeWidth={2} style={{ color: AS_COLOR.orange }} />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div
+              className="truncate"
+              style={{ ...AS_TYPE.itemTitle, color: AS_COLOR.label, fontSize: 15 }}
+            >
+              {n.title}
+            </div>
+            {n.message && (
+              <div
+                className="line-clamp-2"
+                style={{
+                  ...AS_TYPE.itemSubtitle,
+                  color: AS_COLOR.labelSecondary,
+                  marginTop: 2,
+                  display: '-webkit-box',
+                  WebkitLineClamp: 2,
+                  WebkitBoxOrient: 'vertical',
+                  overflow: 'hidden',
+                }}
+              >
+                {n.message}
+              </div>
+            )}
+          </div>
+          {idx < notifications.length - 1 && (
+            <div
+              className="absolute bottom-0"
+              style={{
+                left: 48,
+                right: 0,
+                height: 0.5,
+                background: AS_COLOR.separator,
+              }}
+            />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/* ─────────────── Feed 列表 ─────────────── */
+
+function FeedList({ feed, onNavigate }: { feed: FeedItem[]; onNavigate: (to: string) => void }) {
+  return (
+    <div style={{ padding: `0 ${AS_SPACE.gutter}px` }}>
+      {feed.map((item, idx) => {
+        const meta = FEED_ICON[item.type] ?? { icon: MessageSquare, accent: DEFAULT_ACCENT };
+        const Icon = meta.icon;
+        return (
+          <button
+            key={item.id}
+            type="button"
+            onClick={() => onNavigate(item.navigateTo)}
+            className="w-full flex items-center gap-3 text-left transition-opacity active:opacity-60 relative"
+            style={{ padding: '12px 0' }}
+          >
+            <div
+              className="shrink-0 flex items-center justify-center"
+              style={{
+                width: 40,
+                height: 40,
+                borderRadius: 10,
+                background: `linear-gradient(135deg, ${meta.accent.from}, ${meta.accent.to})`,
+              }}
+            >
+              <Icon size={18} strokeWidth={2.2} style={{ color: '#FFFFFF' }} />
+            </div>
+            <div className="min-w-0 flex-1">
+              <div
+                className="truncate"
+                style={{ ...AS_TYPE.itemTitle, color: AS_COLOR.label, fontSize: 15 }}
+              >
+                {item.title}
+              </div>
+              <div
+                className="truncate"
+                style={{ ...AS_TYPE.itemSubtitle, color: AS_COLOR.labelSecondary, marginTop: 2 }}
+              >
+                {item.subtitle}
+              </div>
+            </div>
+            <ChevronRight size={18} style={{ color: AS_COLOR.labelTertiary }} className="shrink-0" />
+            {idx < feed.length - 1 && (
+              <div
+                className="absolute bottom-0"
+                style={{
+                  left: 52,
+                  right: 0,
+                  height: 0.5,
+                  background: AS_COLOR.separator,
+                }}
+              />
+            )}
+          </button>
+        );
+      })}
+    </div>
   );
 }

--- a/prd-admin/src/pages/_dev/MobileAuditPage.tsx
+++ b/prd-admin/src/pages/_dev/MobileAuditPage.tsx
@@ -1,15 +1,27 @@
-import { useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useBreakpoint } from '@/hooks/useBreakpoint';
+import { getClientErrors, clearClientErrors, type ClientErrorEntry } from '@/lib/clientErrorReporter';
+import { MOBILE_COMPAT_REGISTRY, type MobileCompatLevel } from '@/lib/mobileCompatibility';
 
 /**
  * 移动端适配审计工具 — 开发专用。
- * 将所有后台页面以 375×667 的 iframe 并排展示，方便一眼扫描移动端渲染效果。
- * 访问路径：/_dev/mobile-audit
- * 前提：需要先登录（iframe 共享 cookie）。
+ *
+ * 双视图：
+ *   1. 预览墙：所有页面以 375×667 iframe 并排渲染
+ *   2. 诊断面板：每路由自动加载并检测"黑屏 / console 错误 / 未捕获异常"，输出表格
+ *
+ * 访问路径：/_dev/mobile-audit（需先登录，iframe 共享 cookie）
  */
 
-const ROUTES: Array<{ path: string; label: string; group: string }> = [
+interface RouteEntry {
+  path: string;
+  label: string;
+  group: string;
+}
+
+const ROUTES: RouteEntry[] = [
   // ── 已适配 ──
+  { path: '/', label: '首页', group: '✅ 已适配' },
   { path: '/executive', label: '总裁面板', group: '✅ 已适配' },
   { path: '/ai-toolbox', label: 'AI 百宝箱', group: '✅ 已适配' },
   { path: '/prd-agent', label: 'PRD 协作', group: '✅ 已适配' },
@@ -36,12 +48,29 @@ const VIEWPORT_W = 375;
 const VIEWPORT_H = 667;
 const SCALE = 0.45;
 
+/** 诊断一个路由的可见性 */
+interface DiagResult {
+  path: string;
+  status: 'pending' | 'ok' | 'blank' | 'error' | 'timeout';
+  textLen: number;
+  /** body.innerText 首 140 字，供人眼识别 */
+  textPreview: string;
+  errors: string[];
+  elapsedMs: number;
+  compat: MobileCompatLevel | 'unknown';
+}
+
+type ViewMode = 'wall' | 'diag';
+
 export default function MobileAuditPage() {
   const { isMobile } = useBreakpoint();
+  const [view, setView] = useState<ViewMode>('diag');
   const [selectedGroup, setSelectedGroup] = useState<string | null>(null);
-
-  const groups = [...new Set(ROUTES.map((r) => r.group))];
-  const filtered = selectedGroup ? ROUTES.filter((r) => r.group === selectedGroup) : ROUTES;
+  const groups = useMemo(() => [...new Set(ROUTES.map((r) => r.group))], []);
+  const filtered = useMemo(
+    () => (selectedGroup ? ROUTES.filter((r) => r.group === selectedGroup) : ROUTES),
+    [selectedGroup],
+  );
 
   return (
     <div style={{ background: '#0a0a0c', minHeight: '100vh', padding: isMobile ? 12 : 32 }}>
@@ -49,123 +78,549 @@ export default function MobileAuditPage() {
         <h1 style={{ color: '#f7f7fb', fontSize: 20, fontWeight: 700, marginBottom: 8 }}>
           Mobile Audit — 移动端适配审计
         </h1>
-        <p style={{ color: 'rgba(255,255,255,0.5)', fontSize: 13, marginBottom: 20 }}>
-          所有页面以 {VIEWPORT_W}×{VIEWPORT_H} 视口渲染。需先登录后访问此页。点击卡片可跳转对应页面。
+        <p style={{ color: 'rgba(255,255,255,0.5)', fontSize: 13, marginBottom: 16 }}>
+          自动以 {VIEWPORT_W}×{VIEWPORT_H} 视口加载每个路由，检测黑屏 / JS 报错。需先登录后访问。
         </p>
 
+        {/* 视图切换 */}
+        <div style={{ display: 'flex', gap: 8, marginBottom: 16 }}>
+          <TabButton active={view === 'diag'} onClick={() => setView('diag')}>
+            🔬 诊断报告
+          </TabButton>
+          <TabButton active={view === 'wall'} onClick={() => setView('wall')}>
+            🖼 预览墙
+          </TabButton>
+          <TabButton active={false} onClick={() => window.location.reload()}>
+            ↻ 重新审计
+          </TabButton>
+        </div>
+
         {/* 分组过滤 */}
-        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 24 }}>
-          <button
-            onClick={() => setSelectedGroup(null)}
-            style={{
-              padding: '4px 12px',
-              borderRadius: 8,
-              fontSize: 12,
-              fontWeight: 600,
-              border: 'none',
-              cursor: 'pointer',
-              background: !selectedGroup ? 'rgba(99,102,241,0.9)' : 'rgba(255,255,255,0.08)',
-              color: !selectedGroup ? '#1a1a1a' : 'rgba(255,255,255,0.7)',
-            }}
-          >
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 20 }}>
+          <Pill active={!selectedGroup} onClick={() => setSelectedGroup(null)}>
             全部 ({ROUTES.length})
-          </button>
+          </Pill>
           {groups.map((g) => {
             const count = ROUTES.filter((r) => r.group === g).length;
             return (
-              <button
+              <Pill
                 key={g}
+                active={selectedGroup === g}
                 onClick={() => setSelectedGroup(g === selectedGroup ? null : g)}
-                style={{
-                  padding: '4px 12px',
-                  borderRadius: 8,
-                  fontSize: 12,
-                  fontWeight: 600,
-                  border: 'none',
-                  cursor: 'pointer',
-                  background: selectedGroup === g ? 'rgba(99,102,241,0.9)' : 'rgba(255,255,255,0.08)',
-                  color: selectedGroup === g ? '#1a1a1a' : 'rgba(255,255,255,0.7)',
-                }}
               >
                 {g} ({count})
-              </button>
+              </Pill>
             );
           })}
         </div>
 
-        {/* 预览网格 */}
-        <div
-          style={{
-            display: 'grid',
-            gridTemplateColumns: `repeat(auto-fill, minmax(${Math.round(VIEWPORT_W * SCALE + 16)}px, 1fr))`,
-            gap: 16,
-          }}
-        >
-          {filtered.map((route) => (
-            <div
-              key={route.path}
-              style={{
-                borderRadius: 12,
-                border: '1px solid rgba(255,255,255,0.08)',
-                background: 'rgba(255,255,255,0.02)',
-                overflow: 'hidden',
-              }}
-            >
-              {/* 标题 */}
-              <div
-                style={{
-                  padding: '8px 12px',
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                  borderBottom: '1px solid rgba(255,255,255,0.06)',
-                }}
-              >
-                <div>
-                  <div style={{ color: '#f7f7fb', fontSize: 12, fontWeight: 600 }}>{route.label}</div>
-                  <div style={{ color: 'rgba(255,255,255,0.4)', fontSize: 10 }}>{route.path}</div>
-                </div>
-                <a
-                  href={route.path}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  style={{
-                    color: 'rgba(99,102,241,0.8)',
-                    fontSize: 10,
-                    textDecoration: 'none',
-                  }}
-                >
-                  打开 ↗
-                </a>
-              </div>
+        {view === 'diag' ? (
+          <DiagView routes={filtered} />
+        ) : (
+          <WallView routes={filtered} isMobile={isMobile} />
+        )}
 
-              {/* iframe 预览 */}
-              <div
-                style={{
-                  width: Math.round(VIEWPORT_W * SCALE),
-                  height: Math.round(VIEWPORT_H * SCALE),
-                  overflow: 'hidden',
-                  margin: '8px auto',
-                }}
-              >
-                <iframe
-                  src={route.path}
-                  title={route.label}
-                  style={{
-                    width: VIEWPORT_W,
-                    height: VIEWPORT_H,
-                    border: 'none',
-                    transform: `scale(${SCALE})`,
-                    transformOrigin: 'top left',
-                    pointerEvents: 'none',
-                  }}
-                  loading="lazy"
-                />
-              </div>
-            </div>
-          ))}
-        </div>
+        <ClientErrorPanel />
       </div>
     </div>
   );
 }
+
+/* ───────────── 诊断视图 ───────────── */
+
+function DiagView({ routes }: { routes: RouteEntry[] }) {
+  const [results, setResults] = useState<Record<string, DiagResult>>(() => {
+    const init: Record<string, DiagResult> = {};
+    for (const r of routes) {
+      init[r.path] = {
+        path: r.path,
+        status: 'pending',
+        textLen: 0,
+        textPreview: '',
+        errors: [],
+        elapsedMs: 0,
+        compat: MOBILE_COMPAT_REGISTRY[r.path]?.level ?? 'unknown',
+      };
+    }
+    return init;
+  });
+
+  // 用 ref 挂 iframe，避免重渲染触发重新加载
+  const iframeRefs = useRef<Record<string, HTMLIFrameElement | null>>({});
+
+  const handleIframeLoad = useCallback((route: RouteEntry, startAt: number) => {
+    const iframe = iframeRefs.current[route.path];
+    if (!iframe) return;
+    // 让子应用完成首屏渲染后再采样（懒加载路由 / Suspense / 异步请求）
+    setTimeout(() => {
+      try {
+        const doc = iframe.contentDocument;
+        const win = iframe.contentWindow;
+        const text = (doc?.body?.innerText ?? '').trim();
+        const elapsedMs = Date.now() - startAt;
+        // 检测 sessionStorage 中的客户端错误（子 iframe 与父页同域同 session）
+        let errors: string[] = [];
+        try {
+          const raw = win?.sessionStorage?.getItem('map.client-errors.v1');
+          if (raw) {
+            const arr = JSON.parse(raw) as ClientErrorEntry[];
+            errors = (arr ?? [])
+              .filter((e) => {
+                try {
+                  return new URL(e.url).pathname.startsWith(route.path);
+                } catch {
+                  return false;
+                }
+              })
+              .map((e) => `[${e.kind}] ${e.message}`);
+          }
+        } catch {
+          // sessionStorage 在某些跨域场景下不可读
+        }
+
+        let status: DiagResult['status'] = 'ok';
+        if (text.length < 20) status = 'blank';
+        if (errors.length > 0) status = 'error';
+
+        setResults((prev) => ({
+          ...prev,
+          [route.path]: {
+            ...prev[route.path],
+            status,
+            textLen: text.length,
+            textPreview: text.slice(0, 140),
+            errors,
+            elapsedMs,
+          },
+        }));
+      } catch {
+        setResults((prev) => ({
+          ...prev,
+          [route.path]: {
+            ...prev[route.path],
+            status: 'error',
+            errors: ['无法读取 iframe 文档（可能跨域或已卸载）'],
+            elapsedMs: Date.now() - startAt,
+          },
+        }));
+      }
+    }, 3500);
+  }, []);
+
+  // timeout watchdog：iframe 15s 还是 pending → 超时
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setResults((prev) => {
+        const next = { ...prev };
+        for (const k of Object.keys(next)) {
+          if (next[k].status === 'pending') {
+            next[k] = { ...next[k], status: 'timeout', errors: ['加载超时 >15s'] };
+          }
+        }
+        return next;
+      });
+    }, 15000);
+    return () => clearTimeout(timer);
+  }, [routes]);
+
+  const summary = useMemo(() => {
+    const s = { ok: 0, blank: 0, error: 0, timeout: 0, pending: 0 };
+    for (const r of Object.values(results)) s[r.status]++;
+    return s;
+  }, [results]);
+
+  return (
+    <div>
+      {/* 汇总条 */}
+      <div
+        style={{
+          display: 'flex',
+          gap: 12,
+          padding: 12,
+          borderRadius: 12,
+          background: 'rgba(255,255,255,0.04)',
+          border: '1px solid rgba(255,255,255,0.06)',
+          marginBottom: 16,
+          color: 'rgba(255,255,255,0.85)',
+          fontSize: 13,
+          flexWrap: 'wrap',
+        }}
+      >
+        <SummaryChip label="通过" color="#34D399" count={summary.ok} />
+        <SummaryChip label="黑屏" color="#F87171" count={summary.blank} />
+        <SummaryChip label="报错" color="#FB923C" count={summary.error} />
+        <SummaryChip label="超时" color="#FBBF24" count={summary.timeout} />
+        <SummaryChip label="扫描中" color="#818CF8" count={summary.pending} />
+      </div>
+
+      {/* 结果表 */}
+      <div
+        style={{
+          borderRadius: 12,
+          border: '1px solid rgba(255,255,255,0.08)',
+          overflow: 'hidden',
+          marginBottom: 16,
+        }}
+      >
+        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12 }}>
+          <thead>
+            <tr style={{ background: 'rgba(255,255,255,0.04)', color: 'rgba(255,255,255,0.55)' }}>
+              <th style={th}>路由</th>
+              <th style={th}>状态</th>
+              <th style={th}>兼容</th>
+              <th style={th}>耗时</th>
+              <th style={th}>内容预览 / 错误</th>
+              <th style={th}></th>
+            </tr>
+          </thead>
+          <tbody>
+            {routes.map((route) => {
+              const r = results[route.path];
+              const badgeColor = statusColor(r?.status ?? 'pending');
+              return (
+                <tr key={route.path} style={{ borderTop: '1px solid rgba(255,255,255,0.04)' }}>
+                  <td style={td}>
+                    <div style={{ color: '#f7f7fb', fontWeight: 600 }}>{route.label}</div>
+                    <div style={{ color: 'rgba(255,255,255,0.4)', fontSize: 10 }}>{route.path}</div>
+                  </td>
+                  <td style={td}>
+                    <span
+                      style={{
+                        display: 'inline-block',
+                        padding: '2px 8px',
+                        borderRadius: 6,
+                        background: `${badgeColor}22`,
+                        color: badgeColor,
+                        fontWeight: 600,
+                      }}
+                    >
+                      {r?.status ?? 'pending'}
+                    </span>
+                  </td>
+                  <td style={td}>
+                    <CompatBadge level={r?.compat ?? 'unknown'} />
+                  </td>
+                  <td style={{ ...td, color: 'rgba(255,255,255,0.5)' }}>
+                    {r?.elapsedMs ? `${r.elapsedMs}ms` : '—'}
+                  </td>
+                  <td style={{ ...td, color: 'rgba(255,255,255,0.7)', maxWidth: 420 }}>
+                    {r?.errors && r.errors.length > 0 ? (
+                      <div style={{ color: '#f87171' }}>
+                        {r.errors.slice(0, 3).map((e, i) => (
+                          <div key={i} style={{ marginBottom: 2 }}>{e}</div>
+                        ))}
+                        {r.errors.length > 3 && <div>...还有 {r.errors.length - 3} 条</div>}
+                      </div>
+                    ) : (
+                      <div
+                        style={{
+                          color: 'rgba(255,255,255,0.5)',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        {r?.textPreview || '...'}
+                        {r && r.textLen > 0 && (
+                          <span style={{ color: 'rgba(255,255,255,0.25)', marginLeft: 6 }}>
+                            ({r.textLen} 字)
+                          </span>
+                        )}
+                      </div>
+                    )}
+                  </td>
+                  <td style={td}>
+                    <a
+                      href={route.path}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      style={{ color: '#818CF8', fontSize: 11, textDecoration: 'none' }}
+                    >
+                      打开 ↗
+                    </a>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {/* 隐藏 iframe 用于扫描（不渲染在视觉层） */}
+      <div style={{ position: 'absolute', width: 0, height: 0, overflow: 'hidden' }} aria-hidden>
+        {routes.map((route) => (
+          <iframe
+            key={route.path}
+            ref={(el) => {
+              iframeRefs.current[route.path] = el;
+            }}
+            src={route.path}
+            title={`scan-${route.path}`}
+            style={{ width: VIEWPORT_W, height: VIEWPORT_H, border: 'none' }}
+            onLoad={() => handleIframeLoad(route, Date.now())}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ───────────── 预览墙视图 ───────────── */
+
+function WallView({ routes, isMobile }: { routes: RouteEntry[]; isMobile: boolean }) {
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: `repeat(auto-fill, minmax(${Math.round(VIEWPORT_W * SCALE + 16)}px, 1fr))`,
+        gap: 16,
+      }}
+    >
+      {routes.map((route) => (
+        <div
+          key={route.path}
+          style={{
+            borderRadius: 12,
+            border: '1px solid rgba(255,255,255,0.08)',
+            background: 'rgba(255,255,255,0.02)',
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            style={{
+              padding: '8px 12px',
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              borderBottom: '1px solid rgba(255,255,255,0.06)',
+            }}
+          >
+            <div>
+              <div style={{ color: '#f7f7fb', fontSize: 12, fontWeight: 600 }}>{route.label}</div>
+              <div style={{ color: 'rgba(255,255,255,0.4)', fontSize: 10 }}>{route.path}</div>
+            </div>
+            <a
+              href={route.path}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ color: 'rgba(99,102,241,0.8)', fontSize: 10, textDecoration: 'none' }}
+            >
+              打开 ↗
+            </a>
+          </div>
+          <div
+            style={{
+              width: Math.round(VIEWPORT_W * SCALE),
+              height: Math.round(VIEWPORT_H * SCALE),
+              overflow: 'hidden',
+              margin: '8px auto',
+            }}
+          >
+            <iframe
+              src={route.path}
+              title={route.label}
+              style={{
+                width: VIEWPORT_W,
+                height: VIEWPORT_H,
+                border: 'none',
+                transform: `scale(${SCALE})`,
+                transformOrigin: 'top left',
+                pointerEvents: isMobile ? 'none' : 'auto',
+              }}
+              loading="lazy"
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/* ───────────── 客户端错误面板 ───────────── */
+
+function ClientErrorPanel() {
+  const [entries, setEntries] = useState<ClientErrorEntry[]>([]);
+
+  useEffect(() => {
+    const refresh = () => setEntries(getClientErrors());
+    refresh();
+    const timer = setInterval(refresh, 2000);
+    return () => clearInterval(timer);
+  }, []);
+
+  if (entries.length === 0) return null;
+
+  return (
+    <div
+      style={{
+        marginTop: 24,
+        padding: 16,
+        borderRadius: 12,
+        border: '1px solid rgba(248, 113, 113, 0.25)',
+        background: 'rgba(248, 113, 113, 0.06)',
+      }}
+    >
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+        <div style={{ color: '#f87171', fontSize: 14, fontWeight: 700 }}>
+          ⚠ 本次会话捕获到 {entries.length} 条客户端错误
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            clearClientErrors();
+            setEntries([]);
+          }}
+          style={{
+            padding: '4px 10px',
+            borderRadius: 6,
+            border: '1px solid rgba(255,255,255,0.12)',
+            background: 'transparent',
+            color: 'rgba(255,255,255,0.6)',
+            fontSize: 11,
+            cursor: 'pointer',
+          }}
+        >
+          清空
+        </button>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8, maxHeight: 360, overflow: 'auto' }}>
+        {entries.slice().reverse().map((e) => (
+          <details
+            key={e.id}
+            style={{
+              padding: 10,
+              borderRadius: 8,
+              background: 'rgba(0,0,0,0.3)',
+              fontSize: 12,
+              color: 'rgba(255,255,255,0.8)',
+            }}
+          >
+            <summary style={{ cursor: 'pointer', listStyle: 'none' }}>
+              <span style={{ color: '#f87171', fontWeight: 600 }}>[{e.kind}]</span>
+              <span style={{ marginLeft: 8 }}>{e.message}</span>
+              <span style={{ marginLeft: 8, color: 'rgba(255,255,255,0.4)', fontSize: 10 }}>
+                {new Date(e.ts).toLocaleTimeString()} · {e.viewport}
+              </span>
+            </summary>
+            <div style={{ marginTop: 8, fontSize: 11, color: 'rgba(255,255,255,0.55)' }}>
+              <div>URL: {e.url}</div>
+              {e.source && <div>Source: {e.source}:{e.line}:{e.column}</div>}
+              {e.stack && (
+                <pre style={{ margin: '6px 0 0', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                  {e.stack}
+                </pre>
+              )}
+              {e.componentStack && (
+                <pre style={{ margin: '6px 0 0', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                  -- Component stack --{e.componentStack}
+                </pre>
+              )}
+            </div>
+          </details>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ───────────── 原子组件 ───────────── */
+
+function TabButton({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        padding: '6px 14px',
+        borderRadius: 10,
+        fontSize: 12,
+        fontWeight: 600,
+        border: 'none',
+        cursor: 'pointer',
+        background: active ? 'rgba(99,102,241,0.9)' : 'rgba(255,255,255,0.06)',
+        color: active ? '#1a1a1a' : 'rgba(255,255,255,0.75)',
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+function Pill({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        padding: '4px 12px',
+        borderRadius: 8,
+        fontSize: 12,
+        fontWeight: 600,
+        border: 'none',
+        cursor: 'pointer',
+        background: active ? 'rgba(99,102,241,0.9)' : 'rgba(255,255,255,0.08)',
+        color: active ? '#1a1a1a' : 'rgba(255,255,255,0.7)',
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+function SummaryChip({ label, color, count }: { label: string; color: string; count: number }) {
+  return (
+    <span>
+      <span style={{ color, fontWeight: 700 }}>● {count}</span>
+      <span style={{ marginLeft: 4, color: 'rgba(255,255,255,0.6)' }}>{label}</span>
+    </span>
+  );
+}
+
+function CompatBadge({ level }: { level: MobileCompatLevel | 'unknown' }) {
+  const map: Record<string, { color: string; text: string }> = {
+    full:     { color: '#34D399', text: '完整' },
+    limited:  { color: '#FBBF24', text: '受限' },
+    'pc-only':{ color: '#F87171', text: '仅 PC' },
+    unknown:  { color: '#9CA3AF', text: '未标' },
+  };
+  const m = map[level];
+  return (
+    <span
+      style={{
+        display: 'inline-block',
+        padding: '2px 8px',
+        borderRadius: 6,
+        background: `${m.color}22`,
+        color: m.color,
+        fontWeight: 600,
+        fontSize: 11,
+      }}
+    >
+      {m.text}
+    </span>
+  );
+}
+
+function statusColor(s: DiagResult['status']): string {
+  switch (s) {
+    case 'ok': return '#34D399';
+    case 'blank': return '#F87171';
+    case 'error': return '#FB923C';
+    case 'timeout': return '#FBBF24';
+    default: return '#818CF8';
+  }
+}
+
+const th: React.CSSProperties = {
+  textAlign: 'left',
+  padding: '10px 12px',
+  fontWeight: 600,
+  fontSize: 11,
+  textTransform: 'uppercase',
+  letterSpacing: 0.4,
+};
+
+const td: React.CSSProperties = {
+  padding: '10px 12px',
+  verticalAlign: 'top',
+};

--- a/prd-admin/src/styles/globals.css
+++ b/prd-admin/src/styles/globals.css
@@ -1856,3 +1856,52 @@ html[data-perf-mode="performance"] .btn-primary-anim {
   background: var(--gold-gradient);
   background-size: 100% 100%;
 }
+
+/* ═══════════════════════════════════════════════════════════════════
+   App Store 式水波纹切换（View Transition API + clip-path circle 扩散）
+   仅作用于 [data-ripple-transition] 容器，不影响整页
+   ═══════════════════════════════════════════════════════════════════ */
+
+/* 没用 View Transition 的浏览器（Safari < 18.2）静默降级为普通切换 */
+@supports (view-transition-name: x) {
+  [data-ripple-transition] {
+    view-transition-name: as-ripple-surface;
+  }
+
+  ::view-transition-old(as-ripple-surface),
+  ::view-transition-new(as-ripple-surface) {
+    animation: none;
+    mix-blend-mode: normal;
+  }
+
+  ::view-transition-new(as-ripple-surface) {
+    animation: as-ripple-reveal 520ms cubic-bezier(0.22, 0.61, 0.36, 1);
+  }
+
+  ::view-transition-old(as-ripple-surface) {
+    animation: as-ripple-fade 360ms ease-out;
+  }
+}
+
+/* 水波纹扩散：从 CSS 变量指定的坐标向外扩散 */
+@keyframes as-ripple-reveal {
+  from {
+    clip-path: circle(0% at var(--as-ripple-x, 50%) var(--as-ripple-y, 50%));
+  }
+  to {
+    clip-path: circle(140% at var(--as-ripple-x, 50%) var(--as-ripple-y, 50%));
+  }
+}
+
+/* 旧内容淡出（被水波纹盖住） */
+@keyframes as-ripple-fade {
+  from { opacity: 1; }
+  to   { opacity: 0; }
+}
+
+/* 降级：浏览器不支持 view-transition 时，给 snap scroll 一点平滑 */
+@supports not (view-transition-name: x) {
+  [data-ripple-transition] {
+    scroll-behavior: smooth;
+  }
+}


### PR DESCRIPTION
## Summary

Introduces a comprehensive mobile error handling and diagnostics system to prevent silent blackscreen failures and enable rapid detection of broken routes. Includes a new `/_dev/mobile-audit` page for automated route health scanning, global error boundary for graceful degradation, and mobile compatibility gating.

## Key Changes

### Error Handling & Reporting
- **`clientErrorReporter.ts`** (new): Global error capture system that records render errors, unhandled rejections, window errors, and console errors to sessionStorage (50-entry ring buffer). Automatically installed on app startup.
- **`MobileSafeBoundary.tsx`** (new): Error boundary component that catches render crashes, displays user-friendly recovery UI (retry/home/copy stack), and forwards errors to clientErrorReporter. Prevents entire app unmount on single component failure.

### Mobile Audit Tool
- **`MobileAuditPage.tsx`** (major refactor): Dual-view diagnostic page (`/_dev/mobile-audit`):
  - **Diagnostic view**: Auto-loads each route in hidden iframes, detects blank screens (<20 chars), JS errors, and timeouts (>15s). Displays results in sortable table with status badges, error details, and compatibility levels.
  - **Preview wall**: Visual grid of all routes at 375×667 scale for quick visual scanning.
  - Includes summary stats (pass/blank/error/timeout/pending counts) and real-time client error panel.

### Mobile Compatibility System
- **`mobileCompatibility.ts`** (new): Registry mapping routes to compatibility levels (`full`/`limited`/`pc-only`) with longest-prefix matching for nested routes.
- **`MobileCompatGate.tsx`** (new): Route-level gating component that:
  - Shows yellow banner for `limited` routes (non-blocking)
  - Shows full-screen modal for `pc-only` routes with "continue" or "copy link" options
  - Dismissal state persisted per session

### Integration
- **`AppShell.tsx`**: Wrapped with `MobileSafeBoundary` and `MobileCompatGate` for global error protection and compatibility warnings.
- **`MobileHomePage.tsx`**: Changed `Promise.all` → `Promise.allSettled` to prevent single API failure from blanking entire page.
- **`main.tsx`**: Calls `installGlobalErrorReporter()` on startup.

## Implementation Details

- Error entries include viewport size, URL, stack trace, component stack (React), and timestamp for correlation with audit logs.
- Audit tool uses 3.5s delay after iframe load to allow lazy routes/Suspense/async requests to settle before sampling.
- Compatibility dismissals stored in sessionStorage (per-session, not persistent).
- All UI components use dark theme matching existing design system.
- Audit tool accessible only after login (iframes share cookie).

https://claude.ai/code/session_01Sczq2cEDuDy53AkKQcU3Mg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global app shell rendering and installs global error/console hooks; also rewrites mobile home UI and adds an automated route-audit tool, so regressions could impact broad mobile navigation/rendering.
> 
> **Overview**
> Adds a mobile-focused resilience and diagnostics layer: a new `MobileSafeBoundary` error boundary to prevent render-crash black screens, a global `clientErrorReporter` that captures `window.error`/`unhandledrejection`/`console.error` into a sessionStorage ring buffer, and an enhanced `/_dev/mobile-audit` page that auto-scans routes in iframes for blank screens/errors/timeouts and shows a live error panel.
> 
> Introduces a route-based mobile compatibility registry (`full`/`limited`/`pc-only`) plus `MobileCompatGate` UI (banner or blocking gate), and integrates both the gate and error boundary into `AppShell` along with mobile layout fixes (min `100dvh`, hide mobile notification floater, narrow-screen notification action layout, and a `ChangelogBell` selector memoization fix to stop re-render/request storms).
> 
> Reworks `MobileHomePage` to an App Store Today-style design system: new `appStoreTokens` + `mobile/appStore` component set (Hero, featured poster carousel w/ video+poster+mesh fallbacks and View Transition ripple dots, shelves/ranked lists), switches data loading to `Promise.allSettled`, and drives agent/tool sections from `BUILTIN_TOOLS` with pc-only badges and default cover/video assets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c924ec6206b6f878923d31074b58695e75295e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->