### PR TITLE
Refactor toolbox ownership model: allow using public items without forking

### DIFF
--- a/changelogs/2026-04-22_toolbox-ownership-fix.md
+++ b/changelogs/2026-04-22_toolbox-ownership-fix.md
@@ -8,3 +8,4 @@
 | feat | prd-admin | 别人 7 天内发布的公开条目卡片左上角加红底脉动 NEW 徽章（基于 createdAt 计算，窗口期常量 NEW_BADGE_WINDOW_MS = 7 天） |
 | refactor | prd-admin | ToolCard/ToolDetail 4 处 window.confirm 与 confirm 全部替换为 systemDialog.confirm（含 tone='danger'/confirmText/cancelText）；与项目统一的模态风格一致，不再出现浏览器原生弹框 |
 | chore | prd-admin | ToolboxItem 类型声明补上 createdByUserId（与后端 camelCase 对齐）和 ownership 字段；旧的 createdBy 保留仅为兼容历史调用点 |
+| refactor | prd-admin | 百宝箱卡片从 3:4 竖板改 4:3 横板，网格最小宽度 180→240px，对齐首页 AgentGrid 视觉语言；删除"定制版"徽章；BUILTIN 卡片底部不再显示 MAP/官方/作者等特殊标记，仅保留使用次数 + 收藏星，保持"默认智能体样子" |

--- a/changelogs/2026-04-22_toolbox-ownership-fix.md
+++ b/changelogs/2026-04-22_toolbox-ownership-fix.md
@@ -1,0 +1,5 @@
+| fix | prd-api | 放宽 5 处所有权闸门 — GetItem/RunItem/CreateSession/TriggerWorkflow/DirectChat 允许自己创建的或 IsPublic=true 的条目（抽取 FindVisibleItemAsync helper）；编辑/删除/发布依然严格仅限创建者。用户公开发布后，别人从此能真正运行原版而不是被迫 Fork |
+| fix | prd-admin | 点别人公开的卡片不再偷偷创建副本 — ToolCard/ToolDetail 都把 marketplace 卡片点击改为打开详情抽屉；「创建副本」必须在详情页或右下角按钮显式点击并二次 confirm 才会触发，彻底消除"反复误复制"的反人类流程 |
+| feat | prd-admin | 百宝箱首页从 5 tab 改为 3 权属筛选（全部 / 我的 / 别人的）+ 收藏；loadItems 一次性合并 BUILTIN + /items + /marketplace，按 ownership 字段区分；公开发布的智能体立即出现在所有用户的「全部 / 别人的」里 |
+| feat | prd-admin | 别人 7 天内发布的公开条目卡片左上角加红底脉动 NEW 徽章（基于 createdAt 计算，窗口期常量 NEW_BADGE_WINDOW_MS = 7 天）；详情抽屉顶部新增「来自社区」蓝色 chip，带解释 tooltip |
+| chore | prd-admin | ToolboxItem 类型声明补上 createdByUserId（与后端 camelCase 对齐）和 ownership 字段；旧的 createdBy 保留仅为兼容历史调用点 |

--- a/changelogs/2026-04-22_toolbox-ownership-fix.md
+++ b/changelogs/2026-04-22_toolbox-ownership-fix.md
@@ -1,5 +1,10 @@
 | fix | prd-api | 放宽 5 处所有权闸门 — GetItem/RunItem/CreateSession/TriggerWorkflow/DirectChat 允许自己创建的或 IsPublic=true 的条目（抽取 FindVisibleItemAsync helper）；编辑/删除/发布依然严格仅限创建者。用户公开发布后，别人从此能真正运行原版而不是被迫 Fork |
+| fix | prd-api | 新增 EnrichCreatorInfoAsync helper — GetItem / ListItems / ListPublicItems 返回前按 Users 集合批量回填 CreatedByName / CreatedByAvatarFileName（只填缺失字段）。老数据从此不再显示"匿名用户"，作者名和头像正常可见 |
 | fix | prd-admin | 点别人公开的卡片不再偷偷创建副本 — ToolCard/ToolDetail 都把 marketplace 卡片点击改为打开详情抽屉；「创建副本」必须在详情页或右下角按钮显式点击并二次 confirm 才会触发，彻底消除"反复误复制"的反人类流程 |
+| fix | prd-admin | BUILTIN 官方工具误挂「施工中」徽章 — isOwnCustomCard / isCustom 两处判定收紧，硬排除 type='builtin'，不再用 createdByName 兜底（因为 BUILTIN普通版硬编码 createdByName='官方'，之前所有用户都看到「施工中」标记） |
+| fix | prd-admin | BUILTIN 官方工具用 MAP 品牌徽标代替首字母圆形块 — 之前容易被误认为"某个用户的头像"；同时 authorAvatarUrl 对 BUILTIN 强制返回 null，杜绝意外展示当前登录用户头像 |
+| fix | prd-admin | 详情顶部「来自社区」chip 改为显示真实作者名 `由 {name} 发布`；meta 信息行对 isOthersPublic 强制渲染作者字段（即使没有 createdByName 也显示 `用户 #xxxxxx`）；卡片上"匿名用户"fallback 同步替换为 `用户 #xxxxxx` |
 | feat | prd-admin | 百宝箱首页从 5 tab 改为 3 权属筛选（全部 / 我的 / 别人的）+ 收藏；loadItems 一次性合并 BUILTIN + /items + /marketplace，按 ownership 字段区分；公开发布的智能体立即出现在所有用户的「全部 / 别人的」里 |
-| feat | prd-admin | 别人 7 天内发布的公开条目卡片左上角加红底脉动 NEW 徽章（基于 createdAt 计算，窗口期常量 NEW_BADGE_WINDOW_MS = 7 天）；详情抽屉顶部新增「来自社区」蓝色 chip，带解释 tooltip |
+| feat | prd-admin | 别人 7 天内发布的公开条目卡片左上角加红底脉动 NEW 徽章（基于 createdAt 计算，窗口期常量 NEW_BADGE_WINDOW_MS = 7 天） |
+| refactor | prd-admin | ToolCard/ToolDetail 4 处 window.confirm 与 confirm 全部替换为 systemDialog.confirm（含 tone='danger'/confirmText/cancelText）；与项目统一的模态风格一致，不再出现浏览器原生弹框 |
 | chore | prd-admin | ToolboxItem 类型声明补上 createdByUserId（与后端 camelCase 对齐）和 ownership 字段；旧的 createdBy 保留仅为兼容历史调用点 |

--- a/prd-admin/src/pages/ai-toolbox/AiToolboxPage.tsx
+++ b/prd-admin/src/pages/ai-toolbox/AiToolboxPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo } from 'react';
 import { GlassCard } from '@/components/design/GlassCard';
 import { TabBar, type TabBarItem } from '@/components/design/TabBar';
 import { useToolboxStore, type ToolboxCategory, type ToolboxPageTab } from '@/stores/toolboxStore';
-import { Package, Search, Plus, Sparkles, Boxes, User, Wrench, Star, Globe2 } from 'lucide-react';
+import { Package, Search, Plus, Boxes, User, Wrench, Star, Globe2 } from 'lucide-react';
 import { MapSectionLoader } from '@/components/ui/VideoLoader';
 import { Button } from '@/components/design/Button';
 import { useBreakpoint } from '@/hooks/useBreakpoint';
@@ -18,12 +18,16 @@ const PAGE_TABS: TabBarItem[] = [
   { key: 'capabilities', label: '基础能力', icon: <Wrench size={14} /> },
 ];
 
+// 三张筛选卡片（+ 收藏），按"权属"维度组织：
+//   全部   = BUILTIN + 我的 + 别人公开的
+//   我的   = 我自己创建/Fork 的（不含 BUILTIN，BUILTIN 永远可用于所有人）
+//   别人的 = 别人创建并公开的
+// 这样"公开发布"就是让自己的条目出现在其他用户的「全部/别人的」里。
 const CATEGORY_TABS: TabBarItem[] = [
   { key: 'all', label: '全部', icon: <Boxes size={14} /> },
+  { key: 'mine', label: '我的', icon: <User size={14} /> },
+  { key: 'others', label: '别人的', icon: <Globe2 size={14} /> },
   { key: 'favorite', label: '收藏', icon: <Star size={14} /> },
-  { key: 'builtin', label: '内置工具', icon: <Sparkles size={14} /> },
-  { key: 'custom', label: '我创建的', icon: <User size={14} /> },
-  { key: 'marketplace', label: '公开市场', icon: <Globe2 size={14} /> },
 ];
 
 // 页面容器样式 — 页面级不使用 surface 类，保持透明让卡片自身表达玻璃质感
@@ -41,13 +45,10 @@ export default function AiToolboxPage() {
     itemsLoading,
     selectedItem,
     favoriteIds,
-    marketplaceItems,
-    marketplaceLoading,
     setPageTab,
     setCategory,
     setSearchQuery,
     loadItems,
-    loadMarketplaceItems,
     startCreate,
   } = useToolboxStore();
 
@@ -55,37 +56,19 @@ export default function AiToolboxPage() {
     loadItems();
   }, [loadItems]);
 
-  // Lazy-load marketplace when user switches to it; refetch on keyword change.
-  useEffect(() => {
-    if (category !== 'marketplace') return;
-    const handle = window.setTimeout(() => {
-      loadMarketplaceItems(searchQuery.trim() || undefined);
-    }, 250);
-    return () => window.clearTimeout(handle);
-  }, [category, searchQuery, loadMarketplaceItems]);
-
-  const isMarketplace = category === 'marketplace';
-
-  // Filter items based on category and search
+  // Filter items based on ownership category + search
+  // items 已经由 loadItems 预先合并成 BUILTIN + 我的(ownership='mine') + 别人公开的(ownership='others')
   const filteredItems = useMemo(() => {
-    if (isMarketplace) {
-      // Server-side keyword filtering already applied; show as-is.
-      return marketplaceItems;
-    }
-
     let result = items;
 
-    // Filter by category
-    // 注：后端 ToolboxItem 可能没有 type 字段，用 createdBy/createdByName 作为兜底判定
-    const isUserCreated = (it: (typeof items)[number]) =>
-      it.type === 'custom' || !!it.createdBy || !!it.createdByName;
-    if (category === 'builtin') {
-      result = result.filter((item) => item.type === 'builtin' && !isUserCreated(item));
-    } else if (category === 'custom') {
-      result = result.filter(isUserCreated);
+    if (category === 'mine') {
+      result = result.filter((item) => item.ownership === 'mine');
+    } else if (category === 'others') {
+      result = result.filter((item) => item.ownership === 'others');
     } else if (category === 'favorite') {
       result = result.filter((item) => favoriteIds.has(item.id));
     }
+    // category === 'all' 不过滤，展示 BUILTIN + 我的 + 别人公开的
 
     // Filter by search
     if (searchQuery.trim()) {
@@ -99,9 +82,10 @@ export default function AiToolboxPage() {
     }
 
     return result;
-  }, [isMarketplace, marketplaceItems, items, category, searchQuery, favoriteIds]);
+  }, [items, category, searchQuery, favoriteIds]);
 
-  const gridLoading = isMarketplace ? marketplaceLoading : itemsLoading;
+  const gridLoading = itemsLoading;
+  const isOthersCategory = category === 'others';
 
   // Render based on current view
   if (view === 'detail' && selectedItem) {
@@ -209,19 +193,21 @@ export default function AiToolboxPage() {
               <div className="text-sm font-medium mb-0.5" style={{ color: 'rgba(255, 255, 255, 0.8)' }}>
                 {searchQuery
                   ? '没有找到匹配的工具'
-                  : isMarketplace
-                  ? '市场还没有公开的智能体'
+                  : isOthersCategory
+                  ? '还没有其他人公开发布智能体'
+                  : category === 'mine'
+                  ? '你还没有创建过智能体'
                   : '暂无工具'}
               </div>
               <div className="text-xs" style={{ color: 'rgba(255, 255, 255, 0.45)' }}>
                 {searchQuery
                   ? '尝试其他关键词'
-                  : isMarketplace
-                  ? '在「我创建的」里把工具发布到市场，让大家都能 Fork'
+                  : isOthersCategory
+                  ? '等待其他用户把工具发布到市场，公开后会带 NEW 徽章出现在这里'
                   : '点击右上角创建你的第一个智能体'}
               </div>
             </div>
-            {category === 'custom' && !searchQuery && (
+            {category === 'mine' && !searchQuery && (
               <Button variant="primary" size="sm" onClick={startCreate}>
                 <Plus size={13} />
                 创建智能体
@@ -231,7 +217,13 @@ export default function AiToolboxPage() {
         ) : (
           <div className="grid gap-3" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))' }}>
             {filteredItems.map((item) => (
-              <ToolCard key={item.id} item={item} source={isMarketplace ? 'marketplace' : 'mine'} />
+              // source 走 item.ownership：别人公开的 = 'marketplace' 分支（显示 Fork 数/NEW 徽章；点击打开详情抽屉而非直接 Fork）；
+              // 自己或 BUILTIN = 'mine' 分支
+              <ToolCard
+                key={item.id}
+                item={item}
+                source={item.ownership === 'others' ? 'marketplace' : 'mine'}
+              />
             ))}
           </div>
         )}

--- a/prd-admin/src/pages/ai-toolbox/AiToolboxPage.tsx
+++ b/prd-admin/src/pages/ai-toolbox/AiToolboxPage.tsx
@@ -215,7 +215,7 @@ export default function AiToolboxPage() {
             )}
           </GlassCard>
         ) : (
-          <div className="grid gap-3" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))' }}>
+          <div className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))' }}>
             {filteredItems.map((item) => (
               // source 走 item.ownership：别人公开的 = 'marketplace' 分支（显示 Fork 数/NEW 徽章；点击打开详情抽屉而非直接 Fork）；
               // 自己或 BUILTIN = 'mine' 分支

--- a/prd-admin/src/pages/ai-toolbox/components/ToolCard.tsx
+++ b/prd-admin/src/pages/ai-toolbox/components/ToolCard.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from 'react';
 import type { ToolboxItem } from '@/services';
-import { useToolboxStore } from '@/stores/toolboxStore';
+import { useToolboxStore, NEW_BADGE_WINDOW_MS } from '@/stores/toolboxStore';
 import { useNavigate } from 'react-router-dom';
 import { DesktopDownloadDialog } from '@/components/ui/DesktopDownloadDialog';
 import { useAuthStore } from '@/stores/authStore';
@@ -54,8 +54,9 @@ interface ToolCardProps {
   item: ToolboxItem;
   /**
    * 卡片来源：
-   * - 'mine'（默认）：用户自己的工具列表，点击进入详情；自定义工具支持快捷"编辑"
-   * - 'marketplace'：他人公开的工具，点击 = Fork 到自己列表
+   * - 'mine'（默认）：BUILTIN 或用户自己的条目，点击进入详情；自定义工具支持快捷"编辑"
+   * - 'marketplace'：他人公开的条目，点击**打开详情抽屉**（不直接 Fork！）
+   *   用户必须在详情里显式点【创建副本】才会生成 Fork；平时只是"使用别人公开的原件"。
    */
   source?: 'mine' | 'marketplace';
 }
@@ -185,9 +186,10 @@ export function ToolCard({ item, source = 'mine' }: ToolCardProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
 
   const isMarketplaceCard = source === 'marketplace';
-  // 双重判定：有 createdByUserId 也视为用户自建（兼容后端旧数据未返回 type 字段）
+  // 双重判定：有 createdByUserId/createdBy 也视为用户自建（兼容后端旧数据未返回 type 字段）
   const isOwnCustomCard =
-    source === 'mine' && (item.type === 'custom' || !!item.createdBy || !!item.createdByName);
+    source === 'mine' &&
+    (item.type === 'custom' || !!item.createdByUserId || !!item.createdBy || !!item.createdByName);
   /** 新创建但还没公开发布的工具 — 脉动高亮「公开发布」按钮，引导用户完成发布动作 */
   const needsPublishHint = isOwnCustomCard && !item.isPublic && newUnpublishedIds.has(item.id);
   /** 内置但非"定制版"（无独立路由页），可以被克隆为我的副本 */
@@ -197,6 +199,11 @@ export function ToolCard({ item, source = 'mine' }: ToolCardProps) {
     !isOwnCustomCard &&
     !item.routePath &&
     item.agentKey !== 'prd-agent';
+  /** 别人公开 ≤ 7 天内 → 卡片右上角红底 NEW 徽章，帮助用户发现新发布 */
+  const isNewByOthers =
+    isMarketplaceCard &&
+    !!item.createdAt &&
+    Date.now() - new Date(item.createdAt).getTime() < NEW_BADGE_WINDOW_MS;
 
   // 作者名 fallback 策略：
   // 1) 后端返回的 createdByName 优先
@@ -216,10 +223,13 @@ export function ToolCard({ item, source = 'mine' }: ToolCardProps) {
   // 1) 后端返回的 createdByAvatarFileName → resolveAvatarUrl 拼 CDN（公开市场里别人也能显示真头像）
   // 2) 当作者就是当前登录用户时 → authStore.avatarUrl（后端还没回写头像字段的老数据兜底）
   // 3) 首字母圆形块（内置"官方"/旧数据等）
+  // 后端返回的字段是 createdByUserId（从 CreatedByUserId 驼峰化），历史代码里的 createdBy 是
+  // 未被后端填充过的残留字段。两个都对比，确保与当前用户对照能正确判断 isMe。
   const isMe =
     !!currentUser?.userId &&
-    (item.createdBy === currentUser.userId ||
-      (isOwnCustomCard && !item.createdBy));
+    (item.createdByUserId === currentUser.userId ||
+      item.createdBy === currentUser.userId ||
+      (isOwnCustomCard && !item.createdByUserId && !item.createdBy));
   const authorAvatarUrl = item.createdByAvatarFileName
     ? resolveAvatarUrl({ avatarFileName: item.createdByAvatarFileName })
     : isMe
@@ -228,12 +238,23 @@ export function ToolCard({ item, source = 'mine' }: ToolCardProps) {
 
   const handleFork = async () => {
     if (forking) return;
+    // 显式二次确认 —— 避免用户误点"拿来吧"后反复创建副本（反人类设计的历史教训）
+    const ok = window.confirm(
+      `确定要把「${item.name}」复制一份到你的百宝箱吗？\n\n` +
+        `复制后你将拥有独立的副本，可以自由修改提示词、模型等参数；` +
+        `原作者的更新不会再同步给你。\n\n` +
+        `如果只是想使用原版，直接在详情里对话即可，不需要创建副本。`
+    );
+    if (!ok) return;
     setForking(true);
     try {
       const forked = await forkItem(item.id);
       if (forked) {
-        // 跳到「我创建的」让用户立刻看到 Fork 出来的副本
-        setCategory('custom');
+        // 跳到「我的」让用户立刻看到 Fork 出来的副本
+        setCategory('mine');
+        toast.success('已创建副本', '你的副本已出现在「我的」筛选里');
+      } else {
+        toast.error('创建副本失败');
       }
     } finally {
       setForking(false);
@@ -241,11 +262,8 @@ export function ToolCard({ item, source = 'mine' }: ToolCardProps) {
   };
 
   const handleClick = () => {
-    if (isMarketplaceCard) {
-      // 市场卡片：直接 Fork，避免再多一步进详情
-      void handleFork();
-      return;
-    }
+    // 不管卡片是"我的"还是"别人公开的"，点击一律打开详情抽屉 —— 不再偷偷 Fork。
+    // 「创建副本」只能通过详情里或 Fork 按钮显式二次确认后才触发。
     if (item.agentKey === 'prd-agent') {
       setDownloadDialogOpen(true);
       return;
@@ -286,8 +304,10 @@ export function ToolCard({ item, source = 'mine' }: ToolCardProps) {
     const newValue = !item.isPublic;
     if (newValue) {
       const ok = window.confirm(
-        '公开发布后，所有用户都能在百宝箱「公开市场」Tab 看到并 Fork 这个智能体' +
-          '（包含名称、描述、提示词、标签）。\n\n确定要公开发布吗？'
+        '公开发布后，其他用户会在百宝箱首页的「全部 / 别人的」里看到这个智能体' +
+          '（包含名称、描述、提示词、标签；7 天内带 NEW 徽章）。\n\n' +
+          '其他用户默认使用原版（数据存自己名下）；显式「创建副本」才会复制一份。\n\n' +
+          '确定要公开发布吗？'
       );
       if (!ok) return;
     }
@@ -426,6 +446,26 @@ export function ToolCard({ item, source = 'mine' }: ToolCardProps) {
           background: `linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0) 40%, rgba(0,0,0,0.85) 75%, rgba(0,0,0,0.95) 100%)`,
         }}
       />
+
+      {/* NEW 徽章 — 别人 7 天内发布的公开条目，左上角红底脉动，帮助用户一眼看到新发布 */}
+      {isNewByOthers && (
+        <div
+          className="absolute top-1.5 left-1.5 z-30 text-[10px] font-bold px-1.5 py-0.5 rounded-md inline-flex items-center gap-0.5 animate-pulse"
+          style={{
+            background: 'linear-gradient(135deg, #ef4444, #dc2626)',
+            color: '#fff',
+            letterSpacing: '0.05em',
+            boxShadow: '0 2px 8px rgba(239, 68, 68, 0.55), 0 0 0 1px rgba(255,255,255,0.2) inset',
+          }}
+          title={`这是一个 ${Math.max(
+            1,
+            Math.round((Date.now() - new Date(item.createdAt).getTime()) / 86400000)
+          )} 天内新发布的公开智能体`}
+        >
+          <Sparkles size={9} />
+          NEW
+        </div>
+      )}
 
       {/* Hover 时顶部边框流光高光边缘 */}
       <div
@@ -648,7 +688,7 @@ export function ToolCard({ item, source = 'mine' }: ToolCardProps) {
                   {authorName}
                 </span>
               </div>
-              {/* 右侧：marketplace 模式显示 Fork 数 + Fork 按钮；自有卡片显示使用次数 + 快捷编辑 + 收藏 */}
+              {/* 右侧：别人公开的（marketplace）显示 Fork 数 +「我要创建副本」按钮；自有卡片显示使用次数 + 快捷编辑 + 收藏 */}
               <div className="flex items-center gap-1.5 shrink-0">
                 {isMarketplaceCard ? (
                   <>
@@ -656,7 +696,7 @@ export function ToolCard({ item, source = 'mine' }: ToolCardProps) {
                       <span
                         className="flex items-center gap-0.5 text-[10px]"
                         style={{ color: 'rgba(255, 255, 255, 0.5)' }}
-                        title="被 Fork 次数"
+                        title="被复制成副本的次数"
                       >
                         <GitFork size={10} style={{ color: palette.soft }} />
                         {item.forkCount}
@@ -664,6 +704,7 @@ export function ToolCard({ item, source = 'mine' }: ToolCardProps) {
                     )}
                     <button
                       onClick={(e) => {
+                        // 显式按钮 + handleFork 自带二次 confirm —— 避免"点一下就偷偷复制"的反人类流程
                         e.stopPropagation();
                         void handleFork();
                       }}
@@ -674,10 +715,10 @@ export function ToolCard({ item, source = 'mine' }: ToolCardProps) {
                         color: palette.soft,
                         border: `1px solid ${palette.from}40`,
                       }}
-                      title="复制到我的百宝箱"
+                      title="显式创建副本到我的百宝箱（会弹窗确认）；只想使用原版的话直接点卡片主体即可"
                     >
                       <GitFork size={11} />
-                      {forking ? 'Fork 中…' : 'Fork'}
+                      {forking ? '复制中…' : '创建副本'}
                     </button>
                   </>
                 ) : (

--- a/prd-admin/src/pages/ai-toolbox/components/ToolCard.tsx
+++ b/prd-admin/src/pages/ai-toolbox/components/ToolCard.tsx
@@ -376,7 +376,8 @@ export function ToolCard({ item, source = 'mine' }: ToolCardProps) {
         backdropFilter: 'blur(12px)',
         WebkitBackdropFilter: 'blur(12px)',
         border: '1px solid rgba(255, 255, 255, 0.08)',
-        aspectRatio: '3 / 4',
+        // 横板 4:3 — 对齐首页 AgentGrid 的视觉语言，比原来的 3:4 竖板更紧凑
+        aspectRatio: '4 / 3',
       }}
     >
       {/* 噪点纹理涂层 */}
@@ -635,19 +636,20 @@ export function ToolCard({ item, source = 'mine' }: ToolCardProps) {
         )}
 
         {/* Footer —
-         * 定制版（有独立路由页）：显示「定制版」徽章，不显示作者
-         * 其它所有：显示作者头像/名字 + 状态徽章
-         *   - 用户自建 && !isPublic → 橙色「施工中」
-         *   - isPublic              → 绿色「已公开」
-         *   - 对话型内置             → 无状态徽章（官方默认公开）
+         * 规则：只有"用户创建的通用智能体"（我的 + 别人公开的）才显示作者头像。
+         * BUILTIN（含定制版 + 普通版）一律按"默认智能体样子"处理，不加特殊标记 —
+         * 不再有「定制版」/「官方」/「MAP」徽标，保持卡片整洁。
+         *   - 我的未公开 → 橙色「施工中」
+         *   - 我的已公开 → 绿色「已公开」
+         *   - 别人公开   → 右侧 Fork 数 +「创建副本」按钮（NEW 徽章在顶部独立渲染）
          */}
         <div
           className="flex items-center justify-between gap-1 pt-1.5"
           style={{ borderTop: '1px solid rgba(255, 255, 255, 0.08)' }}
         >
-          {!isCustomized ? (
+          {(isOwnCustomCard || isMarketplaceCard) ? (
             <>
-              {/* 作者头像 + 名字 + 状态徽章 */}
+              {/* 用户创建的智能体：左侧 头像 + 名字 + 状态徽章 */}
               <div className="flex items-center gap-1 min-w-0">
                 {isOwnCustomCard && !item.isPublic && (
                   <span
@@ -671,35 +673,13 @@ export function ToolCard({ item, source = 'mine' }: ToolCardProps) {
                       color: '#6ee7b7',
                       border: '1px solid rgba(16, 185, 129, 0.45)',
                     }}
-                    title="已公开到市场，他人可 Fork"
+                    title="已公开到市场，他人可使用或 Fork"
                   >
                     <Globe2 size={10} />
                     已公开
                   </span>
                 )}
-                {isBuiltin ? (
-                  // BUILTIN官方 工具 → MAP 品牌徽标（与 VideoLoader 一致的 M/A/P 三色缩写），
-                  // 不再用首字母圆形块误导成"某用户头像"
-                  <div
-                    className="shrink-0 flex items-center justify-center rounded-md font-bold tracking-wide"
-                    style={{
-                      width: 22,
-                      height: 14,
-                      background:
-                        'linear-gradient(135deg, rgba(192,192,204,0.18), rgba(106,106,122,0.08))',
-                      border: '1px solid rgba(192,192,204,0.35)',
-                      color: '#e0e0ec',
-                      fontSize: 8,
-                      letterSpacing: '0.08em',
-                      lineHeight: 1,
-                      fontFamily:
-                        "'Inter', 'SF Pro Display', -apple-system, system-ui, sans-serif",
-                    }}
-                    title="MAP 平台官方工具"
-                  >
-                    MAP
-                  </div>
-                ) : authorAvatarUrl ? (
+                {authorAvatarUrl ? (
                   <img
                     src={authorAvatarUrl}
                     alt={authorName}
@@ -727,7 +707,7 @@ export function ToolCard({ item, source = 'mine' }: ToolCardProps) {
                   {authorName}
                 </span>
               </div>
-              {/* 右侧：别人公开的（marketplace）显示 Fork 数 +「我要创建副本」按钮；自有卡片显示使用次数 + 快捷编辑 + 收藏 */}
+              {/* 右侧：别人公开的 → Fork 数 +「创建副本」按钮；自己的 → 使用次数 + 收藏 */}
               <div className="flex items-center gap-1.5 shrink-0">
                 {isMarketplaceCard ? (
                   <>
@@ -790,34 +770,18 @@ export function ToolCard({ item, source = 'mine' }: ToolCardProps) {
               </div>
             </>
           ) : (
+            // BUILTIN（定制版或普通版）：默认智能体样子，仅使用次数 + 收藏，无作者无徽章
             <>
-              {/* 定制版：徽章 + 收藏（定制版是官方独立页面，不需要作者信息） */}
               <div className="flex items-center gap-1 min-w-0">
-                {item.wip && (
+                {item.usageCount > 0 && (
                   <span
-                    className="shrink-0 text-[10px] px-1.5 py-0.5 rounded font-medium inline-flex items-center gap-1"
-                    style={{
-                      background: 'rgba(245, 158, 11, 0.18)',
-                      color: '#fcd34d',
-                      border: '1px solid rgba(245, 158, 11, 0.45)',
-                    }}
-                    title="未正式发布"
+                    className="flex items-center gap-0.5 text-[10px]"
+                    style={{ color: 'rgba(255, 255, 255, 0.45)' }}
                   >
-                    <HardHat size={10} />
-                    施工中
+                    <Zap size={10} style={{ color: palette.soft }} />
+                    {item.usageCount >= 1000 ? `${(item.usageCount / 1000).toFixed(1)}k` : item.usageCount}
                   </span>
                 )}
-                <span
-                  className="text-[10px] px-1.5 py-0.5 rounded font-medium inline-flex items-center gap-1"
-                  style={{
-                    background: `${palette.from}25`,
-                    color: palette.soft,
-                    border: `1px solid ${palette.from}40`,
-                  }}
-                >
-                  <Sparkles size={10} />
-                  定制版
-                </span>
               </div>
               <button
                 onClick={handleToggleFavorite}

--- a/prd-admin/src/pages/ai-toolbox/components/ToolCard.tsx
+++ b/prd-admin/src/pages/ai-toolbox/components/ToolCard.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import { DesktopDownloadDialog } from '@/components/ui/DesktopDownloadDialog';
 import { useAuthStore } from '@/stores/authStore';
 import { toast } from '@/lib/toast';
+import { systemDialog } from '@/lib/systemDialog';
 import { resolveAvatarUrl } from '@/lib/avatar';
 import {
   ArrowUpRight,
@@ -186,10 +187,14 @@ export function ToolCard({ item, source = 'mine' }: ToolCardProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
 
   const isMarketplaceCard = source === 'marketplace';
-  // 双重判定：有 createdByUserId/createdBy 也视为用户自建（兼容后端旧数据未返回 type 字段）
+  const isBuiltin = item.type === 'builtin';
+  // "我自建的"严格判定：必须不是 BUILTIN，且满足 custom/或有后端返回的创建者 id 字段。
+  // 不能再用 createdByName 兜底 —— BUILTIN普通版（如代码审查员）硬编码 createdByName='官方'，
+  // 如果走 createdByName 兜底就会被误判成"自建草稿"，进而错挂「施工中」徽章给所有用户看。
   const isOwnCustomCard =
     source === 'mine' &&
-    (item.type === 'custom' || !!item.createdByUserId || !!item.createdBy || !!item.createdByName);
+    !isBuiltin &&
+    (item.type === 'custom' || !!item.createdByUserId || !!item.createdBy);
   /** 新创建但还没公开发布的工具 — 脉动高亮「公开发布」按钮，引导用户完成发布动作 */
   const needsPublishHint = isOwnCustomCard && !item.isPublic && newUnpublishedIds.has(item.id);
   /** 内置但非"定制版"（无独立路由页），可以被克隆为我的副本 */
@@ -206,31 +211,32 @@ export function ToolCard({ item, source = 'mine' }: ToolCardProps) {
     Date.now() - new Date(item.createdAt).getTime() < NEW_BADGE_WINDOW_MS;
 
   // 作者名 fallback 策略：
-  // 1) 后端返回的 createdByName 优先
-  // 2) 用户自建 + 未返回 name（GetUserName() 依赖 JWT "name" claim，可能为空）→ 用当前登录用户的 displayName
-  // 3) marketplace 卡片：后端必然返回 createdByName，兜底"匿名用户"
-  // 4) 其它（内置等）：兜底"官方"
+  // 1) 后端返回的 createdByName 优先（后端已在 /marketplace + GetItem 上按 User 表回填）
+  // 2) 我自己创建的 → 用当前登录用户的 displayName/username（JWT name claim 兜底）
+  // 3) BUILTIN → "官方"
+  // 4) 其它（公开条目但后端也查不到作者）→ 根据 createdByUserId 末 6 位生成"用户 #xxxxxx"，而不是误导性的"匿名用户"
   const currentUser = useAuthStore((s) => s.user);
   const authorName =
     item.createdByName ||
-    (isOwnCustomCard
+    (isBuiltin
+      ? '官方'
+      : isOwnCustomCard
       ? currentUser?.displayName || currentUser?.username || '我'
-      : isMarketplaceCard
-      ? '匿名用户'
+      : (item.createdByUserId || item.createdBy)
+      ? `用户 #${(item.createdByUserId || item.createdBy || '').slice(-6)}`
       : '官方');
 
-  // 头像 URL — 优先级：
-  // 1) 后端返回的 createdByAvatarFileName → resolveAvatarUrl 拼 CDN（公开市场里别人也能显示真头像）
-  // 2) 当作者就是当前登录用户时 → authStore.avatarUrl（后端还没回写头像字段的老数据兜底）
-  // 3) 首字母圆形块（内置"官方"/旧数据等）
-  // 后端返回的字段是 createdByUserId（从 CreatedByUserId 驼峰化），历史代码里的 createdBy 是
-  // 未被后端填充过的残留字段。两个都对比，确保与当前用户对照能正确判断 isMe。
+  // 后端返回的字段是 createdByUserId（PascalCase→camelCase），历史代码里的 createdBy 是未被后端填充过的残留字段。
+  // 两个都对比，确保与当前用户对照能正确判断 isMe。
   const isMe =
     !!currentUser?.userId &&
     (item.createdByUserId === currentUser.userId ||
       item.createdBy === currentUser.userId ||
       (isOwnCustomCard && !item.createdByUserId && !item.createdBy));
-  const authorAvatarUrl = item.createdByAvatarFileName
+  // 头像 URL — BUILTIN官方 走 MAP 品牌徽标（下方 JSX 专门渲染），不走 img 通道
+  const authorAvatarUrl = isBuiltin
+    ? null
+    : item.createdByAvatarFileName
     ? resolveAvatarUrl({ avatarFileName: item.createdByAvatarFileName })
     : isMe
     ? currentUser?.avatarUrl || null
@@ -239,12 +245,14 @@ export function ToolCard({ item, source = 'mine' }: ToolCardProps) {
   const handleFork = async () => {
     if (forking) return;
     // 显式二次确认 —— 避免用户误点"拿来吧"后反复创建副本（反人类设计的历史教训）
-    const ok = window.confirm(
-      `确定要把「${item.name}」复制一份到你的百宝箱吗？\n\n` +
-        `复制后你将拥有独立的副本，可以自由修改提示词、模型等参数；` +
-        `原作者的更新不会再同步给你。\n\n` +
-        `如果只是想使用原版，直接在详情里对话即可，不需要创建副本。`
-    );
+    const ok = await systemDialog.confirm({
+      title: `创建「${item.name}」的副本？`,
+      message:
+        '复制后你将拥有独立的副本，可以自由修改提示词、模型等参数；原作者的更新不会再同步给你。\n\n' +
+        '如果只是想使用原版，直接在详情里对话即可，不需要创建副本。',
+      confirmText: '创建副本',
+      cancelText: '取消',
+    });
     if (!ok) return;
     setForking(true);
     try {
@@ -303,12 +311,15 @@ export function ToolCard({ item, source = 'mine' }: ToolCardProps) {
     if (togglingPublish) return;
     const newValue = !item.isPublic;
     if (newValue) {
-      const ok = window.confirm(
-        '公开发布后，其他用户会在百宝箱首页的「全部 / 别人的」里看到这个智能体' +
+      const ok = await systemDialog.confirm({
+        title: '确认公开发布',
+        message:
+          '公开发布后，其他用户会在百宝箱首页的「全部 / 别人的」里看到这个智能体' +
           '（包含名称、描述、提示词、标签；7 天内带 NEW 徽章）。\n\n' +
-          '其他用户默认使用原版（数据存自己名下）；显式「创建副本」才会复制一份。\n\n' +
-          '确定要公开发布吗？'
-      );
+          '其他用户默认使用原版（数据存自己名下）；显式「创建副本」才会复制一份。',
+        confirmText: '公开发布',
+        cancelText: '取消',
+      });
       if (!ok) return;
     }
     setTogglingPublish(true);
@@ -323,7 +334,13 @@ export function ToolCard({ item, source = 'mine' }: ToolCardProps) {
 
   const handleDelete = async (e: React.MouseEvent) => {
     e.stopPropagation();
-    const ok = window.confirm(`确定删除「${item.name}」吗？此操作不可恢复。`);
+    const ok = await systemDialog.confirm({
+      title: `删除「${item.name}」？`,
+      message: '此操作不可恢复。该智能体下你自己的所有会话与消息也会失去入口（数据会短暂保留但无法继续对话）。',
+      tone: 'danger',
+      confirmText: '删除',
+      cancelText: '取消',
+    });
     if (!ok) return;
     const success = await deleteItem(item.id);
     if (success) toast.success('已删除');
@@ -660,7 +677,29 @@ export function ToolCard({ item, source = 'mine' }: ToolCardProps) {
                     已公开
                   </span>
                 )}
-                {authorAvatarUrl ? (
+                {isBuiltin ? (
+                  // BUILTIN官方 工具 → MAP 品牌徽标（与 VideoLoader 一致的 M/A/P 三色缩写），
+                  // 不再用首字母圆形块误导成"某用户头像"
+                  <div
+                    className="shrink-0 flex items-center justify-center rounded-md font-bold tracking-wide"
+                    style={{
+                      width: 22,
+                      height: 14,
+                      background:
+                        'linear-gradient(135deg, rgba(192,192,204,0.18), rgba(106,106,122,0.08))',
+                      border: '1px solid rgba(192,192,204,0.35)',
+                      color: '#e0e0ec',
+                      fontSize: 8,
+                      letterSpacing: '0.08em',
+                      lineHeight: 1,
+                      fontFamily:
+                        "'Inter', 'SF Pro Display', -apple-system, system-ui, sans-serif",
+                    }}
+                    title="MAP 平台官方工具"
+                  >
+                    MAP
+                  </div>
+                ) : authorAvatarUrl ? (
                   <img
                     src={authorAvatarUrl}
                     alt={authorName}

--- a/prd-admin/src/pages/ai-toolbox/components/ToolDetail.tsx
+++ b/prd-admin/src/pages/ai-toolbox/components/ToolDetail.tsx
@@ -120,7 +120,8 @@ function validateFile(file: File): string | null {
 }
 
 export function ToolDetail() {
-  const { selectedItem, backToGrid, startEdit, deleteItem, togglePublish } = useToolboxStore();
+  const { selectedItem, backToGrid, startEdit, deleteItem, togglePublish, forkItem, setCategory } = useToolboxStore();
+  const currentUser = useAuthStore((s) => s.user);
   const [input, setInput] = useState('');
   const [isDeleting, setIsDeleting] = useState(false);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -155,6 +156,9 @@ export function ToolDetail() {
 
   // Share state (Agent C)
   const [isSharing, setIsSharing] = useState(false);
+
+  // Fork（创建副本）正在执行 — 需要放在所有 early return 之前，避免违反 Rules of Hooks
+  const [isForking, setIsForking] = useState(false);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -352,8 +356,10 @@ export function ToolDetail() {
     // 公开是面向全体用户的动作，加一次确认避免误点
     if (newValue) {
       const ok = window.confirm(
-        '公开发布后，所有用户都能在百宝箱「公开市场」Tab 看到并 Fork 这个智能体' +
-          '（包含名称、描述、提示词、标签）。\n\n确定要公开发布吗？'
+        '公开发布后，其他用户会在百宝箱首页的「全部 / 别人的」筛选里看到这个智能体' +
+          '（包含名称、描述、提示词、标签；对话 7 天内会带 NEW 徽章）。\n\n' +
+          '其他用户默认使用的是你的原版（数据存在他们自己名下）；只有显式点「创建副本」才会复制一份独立修改。\n\n' +
+          '确定要公开发布吗？'
       );
       if (!ok) return;
     }
@@ -396,9 +402,22 @@ export function ToolDetail() {
 
   const IconComponent = getIconComponent(selectedItem.icon);
   const accentHue = getAccentHue(selectedItem.icon);
-  // 后端 ToolboxItem 可能未返回 type 字段，回退用 createdBy/createdByName 判定是否为用户自建
+  // 后端 ToolboxItem 可能未返回 type 字段，回退用 createdByUserId/createdBy/createdByName 判定是否为用户自建
   const isCustom =
-    selectedItem.type === 'custom' || !!selectedItem.createdBy || !!selectedItem.createdByName;
+    selectedItem.type === 'custom' ||
+    !!selectedItem.createdByUserId ||
+    !!selectedItem.createdBy ||
+    !!selectedItem.createdByName;
+  // 严格"我创建的"判定：用 createdByUserId 对比当前登录用户 — 只有这种情况才能编辑/删除/发布
+  const isMineAuthored =
+    isCustom &&
+    !!currentUser?.userId &&
+    ((selectedItem.createdByUserId && selectedItem.createdByUserId === currentUser.userId) ||
+      (selectedItem.createdBy && selectedItem.createdBy === currentUser.userId) ||
+      // 前端 store 标记兜底：ownership='mine' 时一律视为我的（BUILTIN 没有 ownership，fall through 到下面的分支）
+      selectedItem.ownership === 'mine');
+  // "别人的公开条目"：自定义条目 + 非 BUILTIN + 不是我创建的
+  const isOthersPublic = isCustom && !isMineAuthored;
 
   // Get welcome message and starters from item (custom) or defaults (builtin)
   const welcomeMessage = selectedItem.welcomeMessage || getWelcomeText(selectedItem.agentKey);
@@ -628,6 +647,30 @@ export function ToolDetail() {
     setIsDeleting(false);
   };
 
+  // 消费者显式点击「创建副本」才触发 Fork —— 不再由卡片点击隐式触发，防止反复误操作
+  const handleCreateFork = async () => {
+    if (isForking) return;
+    const ok = window.confirm(
+      `确定要把「${selectedItem.name}」复制一份到你的百宝箱吗？\n\n` +
+        `复制后你将拥有独立的副本，可自由修改提示词、模型等参数；原作者的更新不会再同步给你。\n\n` +
+        `只是想使用原版的话，直接在右侧对话即可，不需要创建副本。`
+    );
+    if (!ok) return;
+    setIsForking(true);
+    try {
+      const forked = await forkItem(selectedItem.id);
+      if (forked) {
+        toast.success('已创建副本', '已切换到「我的」筛选；打开副本即可编辑');
+        setCategory('mine');
+        backToGrid();
+      } else {
+        toast.error('创建副本失败，请稍后重试');
+      }
+    } finally {
+      setIsForking(false);
+    }
+  };
+
   const handleRegenerate = (assistantMsgId: string) => {
     if (isLoading) return;
     const idx = messages.findIndex(m => m.id === assistantMsgId);
@@ -715,7 +758,8 @@ export function ToolDetail() {
                 分享对话
               </Button>
             )}
-            {isCustom ? (
+            {isMineAuthored ? (
+              // 我创建的：可以发布/取消发布、编辑、删除
               <>
                 <Button
                   variant="secondary"
@@ -723,8 +767,8 @@ export function ToolDetail() {
                   onClick={handleTogglePublish}
                   title={
                     isPublic
-                      ? '已公开 — 他人可在「公开市场」Tab 中找到并 Fork 此智能体；点击取消公开'
-                      : '公开到「公开市场」Tab，让其他用户都能看到并 Fork 此智能体'
+                      ? '已公开 — 其他用户在首页的「全部/别人的」筛选里能看到并使用；点击取消公开'
+                      : '公开后其他用户能在首页的「全部/别人的」里看到并直接使用；想复制修改要显式点「创建副本」'
                   }
                   style={isPublic ? { color: '#6ee7b7', borderColor: 'rgba(16, 185, 129, 0.45)' } : undefined}
                 >
@@ -740,7 +784,20 @@ export function ToolDetail() {
                   删除
                 </Button>
               </>
+            ) : isOthersPublic ? (
+              // 别人公开的：不能编辑 / 删除 / 再次发布；只能「使用原版（右侧对话）」或「显式创建副本」
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={handleCreateFork}
+                disabled={isForking}
+                title="把这个公开条目复制成我的副本，复制后可独立修改；只想使用原版直接在右侧对话即可（数据存在我自己名下）"
+              >
+                <Copy size={14} />
+                {isForking ? '复制中…' : '创建副本'}
+              </Button>
             ) : !selectedItem.routePath && (
+              // BUILTIN 非定制版：保留原有"复制并编辑为我的新智能体"能力
               <Button
                 variant="secondary"
                 size="sm"
@@ -785,11 +842,24 @@ export function ToolDetail() {
                 <span
                   className="text-[10px] px-1.5 py-0.5 rounded-full"
                   style={{
-                    background: isCustom ? 'rgba(34, 197, 94, 0.15)' : `hsla(${accentHue}, 60%, 50%, 0.15)`,
-                    color: isCustom ? 'rgb(74, 222, 128)' : `hsla(${accentHue}, 70%, 70%, 1)`,
+                    background: isOthersPublic
+                      ? 'rgba(59, 130, 246, 0.18)'
+                      : isCustom
+                      ? 'rgba(34, 197, 94, 0.15)'
+                      : `hsla(${accentHue}, 60%, 50%, 0.15)`,
+                    color: isOthersPublic
+                      ? '#93c5fd'
+                      : isCustom
+                      ? 'rgb(74, 222, 128)'
+                      : `hsla(${accentHue}, 70%, 70%, 1)`,
                   }}
+                  title={
+                    isOthersPublic
+                      ? '这是其他用户公开的智能体。你可以直接使用（你的对话记录会单独存在自己名下），或创建副本后自由修改。'
+                      : undefined
+                  }
                 >
-                  {isCustom ? '自定义' : '内置工具'}
+                  {isOthersPublic ? '来自社区' : isCustom ? '自定义' : '内置工具'}
                 </span>
               </div>
             </div>

--- a/prd-admin/src/pages/ai-toolbox/components/ToolDetail.tsx
+++ b/prd-admin/src/pages/ai-toolbox/components/ToolDetail.tsx
@@ -45,6 +45,7 @@ import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import 'katex/dist/katex.min.css';
 import { toast } from '@/lib/toast';
+import { systemDialog } from '@/lib/systemDialog';
 import { SseTypingBlock } from '@/components/sse/SseTypingBlock';
 
 // 图标组件映射
@@ -355,12 +356,15 @@ export function ToolDetail() {
     const newValue = !isPublic;
     // 公开是面向全体用户的动作，加一次确认避免误点
     if (newValue) {
-      const ok = window.confirm(
-        '公开发布后，其他用户会在百宝箱首页的「全部 / 别人的」筛选里看到这个智能体' +
+      const ok = await systemDialog.confirm({
+        title: '确认公开发布',
+        message:
+          '公开发布后，其他用户会在百宝箱首页的「全部 / 别人的」筛选里看到这个智能体' +
           '（包含名称、描述、提示词、标签；对话 7 天内会带 NEW 徽章）。\n\n' +
-          '其他用户默认使用的是你的原版（数据存在他们自己名下）；只有显式点「创建副本」才会复制一份独立修改。\n\n' +
-          '确定要公开发布吗？'
-      );
+          '其他用户默认使用的是你的原版（数据存在他们自己名下）；只有显式点「创建副本」才会复制一份独立修改。',
+        confirmText: '公开发布',
+        cancelText: '取消',
+      });
       if (!ok) return;
     }
     const ok = await togglePublish(selectedItem.id, newValue);
@@ -402,19 +406,19 @@ export function ToolDetail() {
 
   const IconComponent = getIconComponent(selectedItem.icon);
   const accentHue = getAccentHue(selectedItem.icon);
-  // 后端 ToolboxItem 可能未返回 type 字段，回退用 createdByUserId/createdBy/createdByName 判定是否为用户自建
+  // 严格判定"用户自建"：必须不是 BUILTIN + 有 custom 标志或后端返回的创建者 id。
+  // 不能用 createdByName 兜底，因为 BUILTIN普通版硬编码 createdByName='官方'，会误伤。
+  const isBuiltin = selectedItem.type === 'builtin';
   const isCustom =
-    selectedItem.type === 'custom' ||
-    !!selectedItem.createdByUserId ||
-    !!selectedItem.createdBy ||
-    !!selectedItem.createdByName;
+    !isBuiltin &&
+    (selectedItem.type === 'custom' || !!selectedItem.createdByUserId || !!selectedItem.createdBy);
   // 严格"我创建的"判定：用 createdByUserId 对比当前登录用户 — 只有这种情况才能编辑/删除/发布
   const isMineAuthored =
     isCustom &&
     !!currentUser?.userId &&
     ((selectedItem.createdByUserId && selectedItem.createdByUserId === currentUser.userId) ||
       (selectedItem.createdBy && selectedItem.createdBy === currentUser.userId) ||
-      // 前端 store 标记兜底：ownership='mine' 时一律视为我的（BUILTIN 没有 ownership，fall through 到下面的分支）
+      // 前端 store 标记兜底：ownership='mine' 时一律视为我的
       selectedItem.ownership === 'mine');
   // "别人的公开条目"：自定义条目 + 非 BUILTIN + 不是我创建的
   const isOthersPublic = isCustom && !isMineAuthored;
@@ -641,7 +645,14 @@ export function ToolDetail() {
   };
 
   const handleDelete = async () => {
-    if (!confirm('确定要删除这个智能体吗？')) return;
+    const ok = await systemDialog.confirm({
+      title: `删除「${selectedItem.name}」？`,
+      message: '此操作不可恢复。如果已经公开过，其他用户的历史会话数据会保留在他们自己名下但无法继续对话。',
+      tone: 'danger',
+      confirmText: '删除',
+      cancelText: '取消',
+    });
+    if (!ok) return;
     setIsDeleting(true);
     await deleteItem(selectedItem.id);
     setIsDeleting(false);
@@ -650,11 +661,14 @@ export function ToolDetail() {
   // 消费者显式点击「创建副本」才触发 Fork —— 不再由卡片点击隐式触发，防止反复误操作
   const handleCreateFork = async () => {
     if (isForking) return;
-    const ok = window.confirm(
-      `确定要把「${selectedItem.name}」复制一份到你的百宝箱吗？\n\n` +
-        `复制后你将拥有独立的副本，可自由修改提示词、模型等参数；原作者的更新不会再同步给你。\n\n` +
-        `只是想使用原版的话，直接在右侧对话即可，不需要创建副本。`
-    );
+    const ok = await systemDialog.confirm({
+      title: `创建「${selectedItem.name}」的副本？`,
+      message:
+        '复制后你将拥有独立的副本，可自由修改提示词、模型等参数；原作者的更新不会再同步给你。\n\n' +
+        '只是想使用原版的话，直接在右侧对话即可，不需要创建副本。',
+      confirmText: '创建副本',
+      cancelText: '取消',
+    });
     if (!ok) return;
     setIsForking(true);
     try {
@@ -702,9 +716,16 @@ export function ToolDetail() {
     toast.success('对话已导出');
   };
 
-  const handleClearChat = () => {
+  const handleClearChat = async () => {
     if (messages.length === 0) return;
-    if (!confirm('确定清空当前会话消息？')) return;
+    const ok = await systemDialog.confirm({
+      title: '清空当前会话？',
+      message: '将清除当前会话中所有消息（仅从前端界面移除，服务端已保存的历史不受影响）。',
+      tone: 'danger',
+      confirmText: '清空',
+      cancelText: '取消',
+    });
+    if (!ok) return;
     setMessages([]);
   };
 
@@ -718,7 +739,7 @@ export function ToolDetail() {
         handleNewSession();
       } else if (mod && e.shiftKey && e.key === 'Backspace') {
         e.preventDefault();
-        handleClearChat();
+        void handleClearChat();
       } else if (mod && e.shiftKey && e.key === 'E') {
         e.preventDefault();
         handleExportChat();
@@ -840,7 +861,7 @@ export function ToolDetail() {
               <div className="flex-1 min-w-0">
                 <div className="font-medium text-sm truncate" style={{ color: 'var(--text-primary)' }}>{selectedItem.name}</div>
                 <span
-                  className="text-[10px] px-1.5 py-0.5 rounded-full"
+                  className="text-[10px] px-1.5 py-0.5 rounded-full truncate max-w-[12rem]"
                   style={{
                     background: isOthersPublic
                       ? 'rgba(59, 130, 246, 0.18)'
@@ -855,11 +876,15 @@ export function ToolDetail() {
                   }}
                   title={
                     isOthersPublic
-                      ? '这是其他用户公开的智能体。你可以直接使用（你的对话记录会单独存在自己名下），或创建副本后自由修改。'
+                      ? `由「${selectedItem.createdByName || '未知用户'}」公开发布。你可以直接使用（你的对话记录会单独存在自己名下），或创建副本后自由修改。`
                       : undefined
                   }
                 >
-                  {isOthersPublic ? '来自社区' : isCustom ? '自定义' : '内置工具'}
+                  {isOthersPublic
+                    ? `由 ${selectedItem.createdByName || '未知用户'} 发布`
+                    : isCustom
+                    ? '自定义'
+                    : '内置工具'}
                 </span>
               </div>
             </div>
@@ -867,7 +892,17 @@ export function ToolDetail() {
             <div className="space-y-1.5 text-[11px]" style={{ color: 'var(--text-muted)' }}>
               {currentModel && <div className="flex items-center gap-1.5"><Cpu size={11} /><span>{currentModel}</span></div>}
               {selectedItem.usageCount > 0 && <div className="flex items-center gap-1.5"><Zap size={11} /><span>已使用 {selectedItem.usageCount} 次</span></div>}
-              {selectedItem.createdByName && <div className="flex items-center gap-1.5"><User size={11} /><span>{selectedItem.createdByName}</span></div>}
+              {(selectedItem.createdByName || isOthersPublic) && (
+                <div className="flex items-center gap-1.5">
+                  <User size={11} />
+                  <span>
+                    {selectedItem.createdByName ||
+                      (selectedItem.createdByUserId
+                        ? `用户 #${selectedItem.createdByUserId.slice(-6)}`
+                        : '未知用户')}
+                  </span>
+                </div>
+              )}
               <div className="flex items-center gap-1.5"><Calendar size={11} /><span>{formatDistanceToNow(new Date(selectedItem.createdAt))}</span></div>
             </div>
             {selectedItem.tags.length > 0 && (

--- a/prd-admin/src/services/real/aiToolbox.ts
+++ b/prd-admin/src/services/real/aiToolbox.ts
@@ -33,10 +33,20 @@ export interface ToolboxItem {
   conversationStarters?: string[];
   temperature?: number;
   enableMemory?: boolean;
+  /** 后端返回的创建者 userId — 与当前登录用户对比判断 ownership */
+  createdByUserId?: string;
+  /** @deprecated 后端返回字段是 createdByUserId，此字段保留仅为兼容历史调用点 */
   createdBy?: string;
   createdByName?: string;
   /** 创建者头像文件名（后端返回）— 配合 resolveAvatarUrl 拼完整 URL 展示 */
   createdByAvatarFileName?: string | null;
+  /**
+   * 前端归一化字段（非后端返回）：用于在百宝箱首页区分"我的"vs"别人的"。
+   * - 'mine'  : BUILTIN 工具，或我自己创建/Fork 的条目
+   * - 'others': 别人创建并公开的条目（来自 /marketplace 合并进来的）
+   * 由 toolboxStore 在 loadItems 时按 createdByUserId 打标。
+   */
+  ownership?: 'mine' | 'others';
   usageCount: number;
   tags: string[];
   createdAt: string;

--- a/prd-admin/src/stores/toolboxStore.ts
+++ b/prd-admin/src/stores/toolboxStore.ts
@@ -17,11 +17,22 @@ import type {
   ToolboxRunEvent,
   AgentInfo,
 } from '@/services';
+import { useAuthStore } from '@/stores/authStore';
 import { toast } from '@/lib/toast';
 
 export type ToolboxView = 'grid' | 'detail' | 'create' | 'edit' | 'running' | 'quick-create';
-export type ToolboxCategory = 'all' | 'builtin' | 'custom' | 'favorite' | 'marketplace';
+/**
+ * 首页三类筛选卡片：
+ * - 'all'    : 全部（BUILTIN + 我的 + 别人公开的，去重后合并）
+ * - 'mine'   : 我的（BUILTIN + 我自己创建/Fork 的，含私有与已公开）
+ * - 'others' : 别人的（仅别人创建并公开的；不含 BUILTIN）
+ * - 'favorite': 收藏（保留独立 chip，兼容原有行为）
+ */
+export type ToolboxCategory = 'all' | 'mine' | 'others' | 'favorite';
 export type ToolboxPageTab = 'toolbox' | 'capabilities';
+
+/** NEW 徽章的窗口期：别人公开 ≤ 7 天内的条目会在卡片上亮红色 NEW 徽章 */
+export const NEW_BADGE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 
 const FAVORITES_STORAGE_KEY = 'toolbox-favorites';
 /** 新创建但未公开的智能体 ID 集合 — 用来给「🌍 公开发布」按钮加脉动高亮，解决用户"发布入口找不到"的问题 */
@@ -391,41 +402,78 @@ export const useToolboxStore = create<ToolboxState>((set, get) => ({
 
   editingItem: null,
 
-  // Load all items (builtin + custom)
+  // Load all items (BUILTIN + 我的 + 别人公开的，一次性合并供首页三卡片筛选)
+  //
+  // 先前设计把"别人公开的"藏在独立的「公开市场」Tab 里，首页只显示 BUILTIN + 自己的，
+  // 导致用户反映"我公开发布了别人却看不到"。现在直接把两路数据合并进 items，
+  // 由 ownership 字段区分归属：
+  //   BUILTIN      → ownership 留空（只显示在"全部"）
+  //   我的自建/Fork → ownership = 'mine'
+  //   别人公开的    → ownership = 'others'
   loadItems: async () => {
     if (get().itemsLoading) return; // 防止并发重复加载
     set({ itemsLoading: true });
     try {
-      const res = await listToolboxItems();
-      const raw = res.success && res.data ? res.data.items : [];
-      // 后端 ToolboxItem 模型没有 type/category 字段，前端需要归一化
-      // 否则会被误判为"系统内置"，导致作者头像、编辑按钮等 custom-only UI 失效
-      const customItems = raw.map((it) => ({
+      const currentUserId = useAuthStore.getState().user?.userId ?? null;
+
+      // /items → 自己创建（含公开和未公开）；/marketplace → 所有公开项（含自己和别人的）
+      const [minesRes, publicRes] = await Promise.all([
+        listToolboxItems().catch(() => null),
+        listMarketplaceItems({ page: 1, pageSize: 100 }).catch(() => null),
+      ]);
+
+      const minesRaw = minesRes?.success && minesRes.data ? minesRes.data.items : [];
+      const publicRaw = publicRes?.success && publicRes.data ? publicRes.data.items : [];
+
+      // 后端 ToolboxItem 没有 type/category 字段，前端归一化，避免被 ToolCard 误判为"系统内置"
+      const mineItems: ToolboxItem[] = minesRaw.map((it) => ({
         ...it,
         type: 'custom' as const,
         category: 'custom' as const,
+        ownership: 'mine' as const,
       }));
-      set({ items: [...BUILTIN_TOOLS, ...customItems] });
+
+      // 从 /marketplace 里剔除自己的（已经在 mineItems 里了），剩下的标为 'others'
+      const mineIds = new Set(mineItems.map((it) => it.id));
+      const othersItems: ToolboxItem[] = publicRaw
+        .filter((it) => !mineIds.has(it.id))
+        .filter((it) => !currentUserId || it.createdByUserId !== currentUserId)
+        .map((it) => ({
+          ...it,
+          type: 'custom' as const,
+          category: 'custom' as const,
+          ownership: 'others' as const,
+        }));
+
+      set({
+        items: [...BUILTIN_TOOLS, ...mineItems, ...othersItems],
+        // marketplaceItems 保留以兼容旧调用方，但首页不再单独用它过滤
+        marketplaceItems: othersItems,
+      });
     } catch {
-      // 即使API失败，也显示内置工具
+      // 即使 API 失败，也显示内置工具
       set({ items: BUILTIN_TOOLS });
     } finally {
       set({ itemsLoading: false });
     }
   },
 
-  // Load marketplace (publicly shared) items
+  // 独立加载公开市场（遗留入口：旧「公开市场」Tab / 外部搜索场景仍可用）
   loadMarketplaceItems: async (keyword?: string) => {
     if (get().marketplaceLoading) return;
     set({ marketplaceLoading: true });
     try {
       const res = await listMarketplaceItems({ keyword, page: 1, pageSize: 50 });
       const items = res.success && res.data ? res.data.items : [];
-      // 后端返回的字段是裸 ToolboxItem，需要补全 type/category 让 ToolCard 渲染
+      const currentUserId = useAuthStore.getState().user?.userId ?? null;
       const normalized = items.map((it) => ({
         ...it,
         type: 'custom' as const,
         category: 'custom' as const,
+        ownership:
+          currentUserId && it.createdByUserId === currentUserId
+            ? ('mine' as const)
+            : ('others' as const),
       }));
       set({ marketplaceItems: normalized });
     } catch {

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/AiToolboxController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/AiToolboxController.cs
@@ -75,6 +75,38 @@ public class AiToolboxController : ControllerBase
     }
 
     /// <summary>
+    /// 对一批 item 就地回填 CreatedByName / CreatedByAvatarFileName（只填充缺失字段，不覆盖已有值）。
+    /// 老数据可能没落盘作者信息，前端上会显示成"匿名用户"，这个 helper 让读路径统一按 Users 集合补齐。
+    /// </summary>
+    private async Task EnrichCreatorInfoAsync(IEnumerable<ToolboxItem> items, CancellationToken ct)
+    {
+        var needLookup = items
+            .Where(x => !string.IsNullOrWhiteSpace(x.CreatedByUserId) &&
+                        (string.IsNullOrWhiteSpace(x.CreatedByName) || string.IsNullOrWhiteSpace(x.CreatedByAvatarFileName)))
+            .Select(x => x.CreatedByUserId)
+            .Distinct()
+            .ToList();
+        if (needLookup.Count == 0) return;
+
+        var users = await _db.Users
+            .Find(Builders<User>.Filter.In(u => u.UserId, needLookup))
+            .ToListAsync(ct);
+        var userMap = users.ToDictionary(u => u.UserId);
+
+        foreach (var it in items)
+        {
+            if (string.IsNullOrWhiteSpace(it.CreatedByUserId)) continue;
+            if (!userMap.TryGetValue(it.CreatedByUserId, out var u)) continue;
+            if (string.IsNullOrWhiteSpace(it.CreatedByName))
+            {
+                it.CreatedByName = !string.IsNullOrWhiteSpace(u.DisplayName) ? u.DisplayName : u.Username;
+            }
+            if (string.IsNullOrWhiteSpace(it.CreatedByAvatarFileName))
+                it.CreatedByAvatarFileName = u.AvatarFileName;
+        }
+    }
+
+    /// <summary>
     /// 发送消息到百宝箱
     /// 自动识别意图并路由到合适的 Agent
     /// </summary>
@@ -460,6 +492,8 @@ public class AiToolboxController : ControllerBase
             .Limit(200)
             .ToListAsync(ct);
 
+        // 老数据 CreatedByName / CreatedByAvatarFileName 可能为空，按 Users 集合批量回填
+        await EnrichCreatorInfoAsync(items, ct);
         return Ok(ApiResponse<object>.Ok(new { items }));
     }
 
@@ -475,6 +509,8 @@ public class AiToolboxController : ControllerBase
         if (item == null)
             return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "工具不存在或未公开"));
 
+        // 老数据可能作者字段为空，按 Users 集合回填，避免前端显示"匿名用户"
+        await EnrichCreatorInfoAsync(new[] { item }, ct);
         return Ok(ApiResponse<ToolboxItem>.Ok(item));
     }
 
@@ -595,6 +631,8 @@ public class AiToolboxController : ControllerBase
             .Limit(pageSize)
             .ToListAsync(ct);
 
+        // 市场列表必须显示真实作者名 / 头像 —— 老数据没落盘时按 Users 集合批量补齐，避免前端显示"匿名用户"
+        await EnrichCreatorInfoAsync(items, ct);
         return Ok(ApiResponse<object>.Ok(new { items, total, page, pageSize }));
     }
 

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/AiToolboxController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/AiToolboxController.cs
@@ -61,6 +61,20 @@ public class AiToolboxController : ControllerBase
         User.FindFirst("name")?.Value;
 
     /// <summary>
+    /// 查找"对当前用户可见"的智能体：自己创建的，或被创建者公开过的。
+    /// 读取/运行/开新会话都走这个可见性口径；编辑/删除/发布仍走 CreatedByUserId == userId 严格闸。
+    /// </summary>
+    private async Task<ToolboxItem?> FindVisibleItemAsync(string id, string userId, CancellationToken ct)
+    {
+        var filter = Builders<ToolboxItem>.Filter.And(
+            Builders<ToolboxItem>.Filter.Eq(x => x.Id, id),
+            Builders<ToolboxItem>.Filter.Or(
+                Builders<ToolboxItem>.Filter.Eq(x => x.CreatedByUserId, userId),
+                Builders<ToolboxItem>.Filter.Eq(x => x.IsPublic, true)));
+        return await _db.ToolboxItems.Find(filter).FirstOrDefaultAsync(ct);
+    }
+
+    /// <summary>
     /// 发送消息到百宝箱
     /// 自动识别意图并路由到合适的 Agent
     /// </summary>
@@ -456,9 +470,10 @@ public class AiToolboxController : ControllerBase
     public async Task<IActionResult> GetItem(string id, CancellationToken ct)
     {
         var userId = GetUserId();
-        var item = await _db.ToolboxItems.Find(x => x.Id == id && x.CreatedByUserId == userId).FirstOrDefaultAsync(ct);
+        // 读取口径：自己的 + 他人公开的都能看到详情（否则"公开"毫无意义）
+        var item = await FindVisibleItemAsync(id, userId, ct);
         if (item == null)
-            return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "工具不存在"));
+            return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "工具不存在或未公开"));
 
         return Ok(ApiResponse<ToolboxItem>.Ok(item));
     }
@@ -653,9 +668,10 @@ public class AiToolboxController : ControllerBase
     public async Task<IActionResult> RunItem(string id, [FromBody] RunToolboxItemRequest request, CancellationToken ct)
     {
         var userId = GetUserId();
-        var item = await _db.ToolboxItems.Find(x => x.Id == id && x.CreatedByUserId == userId).FirstOrDefaultAsync(ct);
+        // 运行口径：自己的 + 他人公开的都能运行；使用次数落在 item 上，与 run 的 UserId 分离
+        var item = await FindVisibleItemAsync(id, userId, ct);
         if (item == null)
-            return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "工具不存在"));
+            return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "工具不存在或未公开"));
 
         // 增加使用次数
         await _db.ToolboxItems.UpdateOneAsync(
@@ -725,13 +741,13 @@ public class AiToolboxController : ControllerBase
     {
         var userId = GetUserId();
 
-        // 验证智能体存在
-        var item = await _db.ToolboxItems.Find(x => x.Id == itemId && x.CreatedByUserId == userId).FirstOrDefaultAsync(ct);
+        // 验证智能体存在（自己的 + 他人公开的都允许开会话；会话本身按 (UserId, ItemId) 落库，数据边界不受影响）
+        var item = await FindVisibleItemAsync(itemId, userId, ct);
         if (item == null)
         {
             // 也允许内置 Agent 创建会话（itemId 以 builtin- 开头）
             if (!itemId.StartsWith("builtin-", StringComparison.Ordinal))
-                return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "智能体不存在"));
+                return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "智能体不存在或未公开"));
         }
 
         var session = new ToolboxSession
@@ -1031,9 +1047,10 @@ public class AiToolboxController : ControllerBase
         CancellationToken ct)
     {
         var userId = GetUserId();
-        var item = await _db.ToolboxItems.Find(x => x.Id == id && x.CreatedByUserId == userId).FirstOrDefaultAsync(ct);
+        // 触发口径与运行一致：自己的 + 他人公开的都可以触发（工作流执行记录 UserId=当前用户，与创建者隔离）
+        var item = await FindVisibleItemAsync(id, userId, ct);
         if (item == null)
-            return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "智能体不存在"));
+            return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "智能体不存在或未公开"));
 
         if (!item.EnabledTools.Contains("workflowTrigger") || string.IsNullOrWhiteSpace(item.WorkflowId))
             return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "该智能体未启用工作流能力或未绑定工作流"));
@@ -1112,11 +1129,11 @@ public class AiToolboxController : ControllerBase
         if (!string.IsNullOrWhiteSpace(request.ItemId))
         {
             // 自定义智能体：从 DB 加载配置
-            var item = await _db.ToolboxItems.Find(x => x.Id == request.ItemId && x.CreatedByUserId == userId)
-                .FirstOrDefaultAsync(CancellationToken.None);
+            // 可见性口径：自己创建的 + 他人公开的都允许对话（否则"公开发布"对消费者毫无意义）
+            var item = await FindVisibleItemAsync(request.ItemId, userId, CancellationToken.None);
             if (item == null)
             {
-                await WriteSseEventAsync("error", new { code = "NOT_FOUND", message = "智能体不存在" });
+                await WriteSseEventAsync("error", new { code = "NOT_FOUND", message = "智能体不存在或未公开" });
                 return;
             }
             systemPrompt = item.SystemPrompt;


### PR DESCRIPTION
## Summary

This PR fundamentally restructures how the AI Toolbox handles item ownership and visibility. Previously, clicking a public item would immediately fork it. Now users can directly use public items created by others without forking, and forking requires explicit confirmation. The backend now enforces proper visibility rules while maintaining strict edit/delete permissions.

## Key Changes

### Backend (prd-api)
- **Visibility refactoring**: Extracted `FindVisibleItemAsync()` helper to allow reading/running/opening sessions for both user's own items AND publicly shared items (GetItem, RunItem, CreateSession, TriggerWorkflow, DirectChat)
- **Author info enrichment**: Added `EnrichCreatorInfoAsync()` to backfill missing `CreatedByName` and `CreatedByAvatarFileName` from Users collection, eliminating "anonymous user" fallbacks in old data
- **Strict edit/delete gates**: Edit, delete, and publish operations remain restricted to `CreatedByUserId == userId` only

### Frontend (prd-admin)

**Ownership model**:
- Replaced `'builtin' | 'custom' | 'marketplace'` categories with `'all' | 'mine' | 'others' | 'favorite'`
- Added `ownership` field to ToolboxItem: `'mine'` (BUILTIN or user-created) vs `'others'` (public items from others)
- Merged marketplace items into main items list during `loadItems()` with ownership tags

**ToolCard behavior**:
- Clicking any card (marketplace or own) now opens detail drawer instead of auto-forking
- Fork button shows explicit "Create Copy" with confirmation dialog
- Added NEW badge (red pulsing) for items published ≤7 days ago
- Fixed BUILTIN detection: now strictly checks `type === 'builtin'` instead of fallback to `createdByName`, preventing false "draft" badges on official tools
- BUILTIN tools now display "MAP" brand badge instead of avatar placeholder

**ToolDetail**:
- Added explicit "Create Copy" button for public items with confirmation
- Updated publish confirmation messaging to clarify that others use the original by default
- Improved author display logic with proper fallbacks for missing creator info

**Dialog improvements**:
- Replaced `window.confirm()` with `systemDialog.confirm()` for better UX in publish, delete, and fork operations
- Added detailed confirmation messages explaining implications

## Implementation Details

- `NEW_BADGE_WINDOW_MS` constant (7 days) controls new item highlighting
- Author name resolution priority: backend `createdByName` → current user displayName → "User #xxxxxx" → "Official"
- Avatar URL logic: BUILTIN returns null (uses MAP badge), others use `createdByAvatarFileName` or current user's avatar
- Strict `isMineAuthored` check uses `createdByUserId` comparison, not fallback to `createdByName`
- Fork confirmation prevents accidental duplicate creation from repeated clicks

https://claude.ai/code/session_01Ju3bbB5fa1Z8LXZiHJhnJf

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes visibility/authorization gates for reading and running toolbox items and refactors how the admin UI merges and classifies items, so mistakes could expose non-public items or break access for legitimate users.
> 
> **Overview**
> **Public items are now usable without forking.** The API introduces `FindVisibleItemAsync` and updates `GetItem`, `RunItem`, `CreateSession`, `TriggerWorkflow`, and `DirectChat` to allow access to items that are either *owned by the caller* or *public*, while keeping edit/delete/publish restrictions creator-only.
> 
> **Creator info is backfilled on read paths.** The API adds `EnrichCreatorInfoAsync` and applies it to item and marketplace listing/detail responses to populate missing `createdByName`/`createdByAvatarFileName` from the Users collection.
> 
> **Admin toolbox UI switches to an ownership-based model.** The homepage tabs become `all`/`mine`/`others` (+ favorites), `loadItems` now merges `/items` + `/marketplace` + BUILTIN into one list with an `ownership` tag, and card clicks always open the detail drawer; creating a copy (fork) is only via explicit buttons with `systemDialog.confirm`.
> 
> **UX and rendering fixes.** Adds a 7-day pulsing `NEW` badge for others’ recently published items, replaces browser confirms with `systemDialog.confirm`, tightens BUILTIN vs custom detection to avoid incorrect WIP badges, and updates card layout to a 4:3 grid with simplified BUILTIN footer rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08b45f9ea794cc187cb119268645c1d03280b9ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->