### PR TITLE
Fix command palette hover/keyboard highlight and permission filtering

### DIFF
--- a/changelogs/2026-04-22_cmd-k-hover-separation.md
+++ b/changelogs/2026-04-22_cmd-k-hover-separation.md
@@ -1,0 +1,1 @@
+| fix | prd-admin | 命令面板 hover 持续高亮 follow-up：将鼠标 hoveredId 从键盘 selectedId 彻底分离——鼠标进出只写 hoveredId、键盘方向键清 hoveredId，视觉 activeId = hoveredId ?? selectedId。前一版残留的"mouseEnter 也 setSelectedId"被移除，离开卡片高亮立即熄灭 |

--- a/changelogs/2026-04-22_cmd-k-keyboard-highlight-gated.md
+++ b/changelogs/2026-04-22_cmd-k-keyboard-highlight-gated.md
@@ -1,0 +1,1 @@
+| fix | prd-admin | 命令面板鼠标离开卡片后"跳转"到最近项的视觉 bug：默认 selectedId 指向 flatList[0]（常是"最近使用"第一张），hover 清掉后 activeId 回落到它导致高亮瞬移。新增 keyboardEngaged flag，仅在用户真正按过方向键 / 有搜索词时才渲染键盘态高亮，否则无 hover 即完全无高亮 |

--- a/changelogs/2026-04-22_cmd-k-palette-ui-fixes.md
+++ b/changelogs/2026-04-22_cmd-k-palette-ui-fixes.md
@@ -1,0 +1,3 @@
+| fix | prd-admin | 命令面板（Cmd+K）取消按权限过滤入口：请求日志 / 提示词 / 实验室 / 自动化规则 / 模型中心 / 团队协作等条目不再因当前用户缺少细粒度权限而完全隐藏，改由目标页自行校验 authz |
+| fix | prd-admin | 命令面板卡片鼠标移出后 hover 高亮立即消失：拆分本地 isHovered 与键盘 selectedId，视觉取两者或，不再卡住在上次停留的卡上 |
+| fix | prd-admin | 命令面板搜索框聚焦改为圆角矩形：包一层 label 容器承载 focus-within ring（圆角 + 紫色描边），input 本体加 no-focus-ring 压掉全局 :focus-visible 直角 outline |

--- a/prd-admin/src/components/agent-switcher/AgentSwitcher.tsx
+++ b/prd-admin/src/components/agent-switcher/AgentSwitcher.tsx
@@ -176,9 +176,12 @@ export function AgentSwitcher() {
     togglePin,
   } = useAgentSwitcherStore();
 
-  // 鼠标 hover 用独立 state，与键盘的 selectedId 正交；
-  // 视觉高亮 activeId = hoveredId ?? selectedId（hover 优先，离开立即让位给键盘态）。
+  // 鼠标 hover 用独立 state，与键盘的 selectedId 正交。
   const [hoveredId, setHoveredId] = useState<string | null>(null);
+  // 是否已启用键盘导航——避免刚打开面板、用户还没按任何方向键时，
+  // selectedId（默认指向第一项，用于 Enter 的目标）就把高亮画在"最近使用"第一张上，
+  // 让用户误以为鼠标一离开就跳转到某项。仅键盘真正启动后才渲染键盘态高亮。
+  const [keyboardEngaged, setKeyboardEngaged] = useState(false);
 
   // 目录（按权限过滤）
   const catalog = useMemo(
@@ -299,12 +302,14 @@ export function AgentSwitcher() {
     }
   }, [isOpen, flatList, selectedId, setSelectedId]);
 
-  // 输入框聚焦
+  // 输入框聚焦 + 面板关闭时复位键盘态 / hover
   useEffect(() => {
     if (isOpen) {
       const t = setTimeout(() => inputRef.current?.focus(), 60);
       return () => clearTimeout(t);
     }
+    setKeyboardEngaged(false);
+    setHoveredId(null);
   }, [isOpen]);
 
   const launchItem = useCallback(
@@ -344,7 +349,8 @@ export function AgentSwitcher() {
         e.preventDefault();
         const next = (curIdx + delta + flatList.length) % flatList.length;
         setSelectedId(flatList[next].id);
-        // 用户切回键盘态：强制清除 hover，避免 hoveredId 压住键盘高亮
+        // 用户切回键盘态：启用键盘高亮 + 强制清除 hover
+        setKeyboardEngaged(true);
         setHoveredId(null);
       };
 
@@ -518,7 +524,10 @@ export function AgentSwitcher() {
                       onMouseLeave={() => setHoveredId(null)}
                     >
                       {section.items.map((item) => {
-                        const activeId = hoveredId ?? selectedId;
+                        // 搜索时也视为"键盘态"——用户一按 Enter 就会发射 selectedId
+                        // 所以必须提前让他看到下一次 Enter 会打开哪张卡。
+                        const showKeyboardHighlight = keyboardEngaged || searchQuery.trim().length > 0;
+                        const activeId = hoveredId ?? (showKeyboardHighlight ? selectedId : null);
                         return (
                         <LauncherCard
                           key={`${section.key}:${item.id}`}

--- a/prd-admin/src/components/agent-switcher/AgentSwitcher.tsx
+++ b/prd-admin/src/components/agent-switcher/AgentSwitcher.tsx
@@ -42,34 +42,30 @@ function getIcon(name: string, size = 18) {
 /** 单张卡片（紧凑方形，可放 5 列） */
 function LauncherCard({
   item,
-  isSelected,
+  isActive,
   isPinned,
   onClick,
   onMouseEnter,
+  onMouseLeave,
   onTogglePin,
   badge,
 }: {
   item: LauncherItem;
-  isSelected: boolean;
+  isActive: boolean;
   isPinned: boolean;
   onClick: () => void;
   onMouseEnter: () => void;
+  onMouseLeave: () => void;
   onTogglePin: (e: React.MouseEvent) => void;
   badge?: string;
 }) {
   const accent = item.accentColor ?? '#818CF8';
-  // 本地 hover 状态：鼠标离开时立即清除，避免 selectedId 被键盘/上次 hover 卡住后"持续高亮"
-  const [isHovered, setIsHovered] = useState(false);
-  const isActive = isSelected || isHovered;
   return (
     <button
       type="button"
       onClick={onClick}
-      onMouseEnter={() => {
-        setIsHovered(true);
-        onMouseEnter();
-      }}
-      onMouseLeave={() => setIsHovered(false)}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
       className="group relative text-left outline-none focus:outline-none flex"
       style={{ width: '100%' }}
       title={item.description}
@@ -179,6 +175,10 @@ export function AgentSwitcher() {
     addRecentVisit,
     togglePin,
   } = useAgentSwitcherStore();
+
+  // 鼠标 hover 用独立 state，与键盘的 selectedId 正交；
+  // 视觉高亮 activeId = hoveredId ?? selectedId（hover 优先，离开立即让位给键盘态）。
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
 
   // 目录（按权限过滤）
   const catalog = useMemo(
@@ -344,6 +344,8 @@ export function AgentSwitcher() {
         e.preventDefault();
         const next = (curIdx + delta + flatList.length) % flatList.length;
         setSelectedId(flatList[next].id);
+        // 用户切回键盘态：强制清除 hover，避免 hoveredId 压住键盘高亮
+        setHoveredId(null);
       };
 
       switch (e.key) {
@@ -511,15 +513,21 @@ export function AgentSwitcher() {
                         {section.items.length}
                       </span>
                     </div>
-                    <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-2 items-stretch">
-                      {section.items.map((item) => (
+                    <div
+                      className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-2 items-stretch"
+                      onMouseLeave={() => setHoveredId(null)}
+                    >
+                      {section.items.map((item) => {
+                        const activeId = hoveredId ?? selectedId;
+                        return (
                         <LauncherCard
                           key={`${section.key}:${item.id}`}
                           item={item}
-                          isSelected={selectedId === item.id}
+                          isActive={activeId === item.id}
                           isPinned={pinnedIds.includes(item.id)}
                           onClick={() => launchItem(item)}
-                          onMouseEnter={() => setSelectedId(item.id)}
+                          onMouseEnter={() => setHoveredId(item.id)}
+                          onMouseLeave={() => setHoveredId(null)}
                           onTogglePin={(e) => {
                             e.stopPropagation();
                             togglePin(item.id);
@@ -534,7 +542,8 @@ export function AgentSwitcher() {
                               : undefined
                           }
                         />
-                      ))}
+                        );
+                      })}
                     </div>
                   </div>
                 ))}

--- a/prd-admin/src/components/agent-switcher/AgentSwitcher.tsx
+++ b/prd-admin/src/components/agent-switcher/AgentSwitcher.tsx
@@ -11,7 +11,7 @@
  * 存储：复用 agentSwitcherStore 的 pinnedIds / usageCounts / recentVisits（sessionStorage 持久化）
  */
 
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { createPortal } from 'react-dom';
 import * as LucideIcons from 'lucide-react';
@@ -58,11 +58,18 @@ function LauncherCard({
   badge?: string;
 }) {
   const accent = item.accentColor ?? '#818CF8';
+  // 本地 hover 状态：鼠标离开时立即清除，避免 selectedId 被键盘/上次 hover 卡住后"持续高亮"
+  const [isHovered, setIsHovered] = useState(false);
+  const isActive = isSelected || isHovered;
   return (
     <button
       type="button"
       onClick={onClick}
-      onMouseEnter={onMouseEnter}
+      onMouseEnter={() => {
+        setIsHovered(true);
+        onMouseEnter();
+      }}
+      onMouseLeave={() => setIsHovered(false)}
       className="group relative text-left outline-none focus:outline-none flex"
       style={{ width: '100%' }}
       title={item.description}
@@ -71,14 +78,14 @@ function LauncherCard({
         className="relative w-full rounded-[12px] p-2.5 flex flex-col items-start gap-1.5 transition-all duration-200 cursor-pointer"
         style={{
           minHeight: 96,
-          background: isSelected
+          background: isActive
             ? `linear-gradient(135deg, ${accent}22 0%, rgba(255,255,255,0.03) 100%)`
             : 'rgba(255, 255, 255, 0.025)',
-          border: `1px solid ${isSelected ? `${accent}55` : 'rgba(255,255,255,0.06)'}`,
-          boxShadow: isSelected
+          border: `1px solid ${isActive ? `${accent}55` : 'rgba(255,255,255,0.06)'}`,
+          boxShadow: isActive
             ? `0 0 0 1px ${accent}40 inset, 0 6px 20px -8px ${accent}55`
             : '0 1px 4px rgba(0,0,0,0.2)',
-          transform: isSelected ? 'translateY(-1px)' : 'translateY(0)',
+          transform: isActive ? 'translateY(-1px)' : 'translateY(0)',
         }}
       >
         {/* 顶部：图标 + 徽标 */}
@@ -86,9 +93,9 @@ function LauncherCard({
           <div
             className="shrink-0 w-8 h-8 rounded-[8px] flex items-center justify-center"
             style={{
-              background: isSelected ? `${accent}20` : 'rgba(255,255,255,0.04)',
-              color: isSelected ? accent : 'rgba(255,255,255,0.75)',
-              border: `1px solid ${isSelected ? `${accent}40` : 'rgba(255,255,255,0.06)'}`,
+              background: isActive ? `${accent}20` : 'rgba(255,255,255,0.04)',
+              color: isActive ? accent : 'rgba(255,255,255,0.75)',
+              border: `1px solid ${isActive ? `${accent}40` : 'rgba(255,255,255,0.06)'}`,
             }}
           >
             {getIcon(item.icon, 15)}
@@ -116,7 +123,7 @@ function LauncherCard({
         {/* 名称（长名也换行显示，不截断） */}
         <div
           className="text-[12.5px] font-semibold leading-tight w-full break-words"
-          style={{ color: isSelected ? '#fff' : 'rgba(255,255,255,0.92)' }}
+          style={{ color: isActive ? '#fff' : 'rgba(255,255,255,0.92)' }}
         >
           {item.name}
         </div>
@@ -125,7 +132,7 @@ function LauncherCard({
         <div
           className="text-[10.5px] leading-snug w-full break-words"
           style={{
-            color: isSelected ? 'rgba(255,255,255,0.72)' : 'rgba(255,255,255,0.44)',
+            color: isActive ? 'rgba(255,255,255,0.72)' : 'rgba(255,255,255,0.44)',
           }}
         >
           {item.description}
@@ -137,7 +144,7 @@ function LauncherCard({
           onClick={onTogglePin}
           className="absolute top-1.5 right-1.5 w-5 h-5 rounded-[5px] flex items-center justify-center transition-opacity"
           style={{
-            opacity: isPinned ? 1 : isSelected ? 0.85 : 0,
+            opacity: isPinned ? 1 : isActive ? 0.85 : 0,
             background: isPinned ? `${accent}30` : 'rgba(255,255,255,0.05)',
             color: isPinned ? accent : 'rgba(255,255,255,0.6)',
             border: `1px solid ${isPinned ? `${accent}60` : 'rgba(255,255,255,0.08)'}`,
@@ -418,26 +425,40 @@ export function AgentSwitcher() {
             className="shrink-0 flex items-center gap-3 px-5 h-[60px]"
             style={{ borderBottom: '1px solid rgba(255,255,255,0.06)' }}
           >
-            <Search size={18} style={{ color: 'rgba(255,255,255,0.4)' }} />
-            <input
-              ref={inputRef}
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              placeholder="搜索 Agent、工具或页面..."
-              className="flex-1 bg-transparent outline-none text-[15px]"
-              style={{ color: '#fff' }}
-            />
-            {searchQuery && (
-              <button
-                type="button"
-                onClick={() => setSearchQuery('')}
-                className="w-6 h-6 rounded-md flex items-center justify-center"
-                style={{ background: 'rgba(255,255,255,0.06)', color: 'rgba(255,255,255,0.6)' }}
-                aria-label="清空搜索"
-              >
-                <X size={12} />
-              </button>
-            )}
+            {/* 内嵌搜索容器：focus-within 时展示圆角矩形 ring —
+                 全局 :focus-visible 的矩形 outline 会在纯 input 上表现为直角，
+                 用 no-focus-ring 压掉后由本容器承担视觉反馈。 */}
+            <label
+              className="flex-1 flex items-center gap-2 h-10 px-3 rounded-xl transition-colors cursor-text agent-switcher-search"
+              style={{
+                background: 'rgba(255,255,255,0.04)',
+                border: '1px solid rgba(255,255,255,0.08)',
+              }}
+            >
+              <Search size={16} style={{ color: 'rgba(255,255,255,0.4)' }} />
+              <input
+                ref={inputRef}
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="搜索 Agent、工具或页面..."
+                className="flex-1 bg-transparent outline-none text-[15px] no-focus-ring"
+                style={{ color: '#fff' }}
+              />
+              {searchQuery && (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    setSearchQuery('');
+                  }}
+                  className="w-5 h-5 rounded-md flex items-center justify-center"
+                  style={{ background: 'rgba(255,255,255,0.08)', color: 'rgba(255,255,255,0.6)' }}
+                  aria-label="清空搜索"
+                >
+                  <X size={11} />
+                </button>
+              )}
+            </label>
             <div
               className="text-[11px] px-2 py-1 rounded"
               style={{
@@ -575,6 +596,11 @@ export function AgentSwitcher() {
             opacity: 1;
             transform: translateY(0) scale(1);
           }
+        }
+        .agent-switcher-search:focus-within {
+          background: rgba(255,255,255,0.06);
+          border-color: rgba(129,140,248,0.6);
+          box-shadow: 0 0 0 2px rgba(99,102,241,0.35);
         }
       `}</style>
     </div>,

--- a/prd-admin/src/lib/launcherCatalog.ts
+++ b/prd-admin/src/lib/launcherCatalog.ts
@@ -234,25 +234,16 @@ function buildInfraItems(): LauncherItem[] {
 }
 
 /**
- * 按当前用户权限与 isRoot 过滤出完整目录。
- * - isRoot = true：绕过所有权限校验
- * - permission 为字符串：必须拥有该权限
- * - permission 为数组：任一命中即可
+ * 返回完整目录。命令面板作为"发现入口"工具展示全部条目，
+ * 实际访问权限由目标页面自行校验（每个 Controller / 页面都有各自的 authz 门控）。
+ * 这样用户不会因为"某项没权限"就整条看不到，产生"功能丢失"的错觉。
+ *
+ * opts 保留签名以便调用方日后按需过滤，当前实现忽略。
  */
-export function getLauncherCatalog(opts: {
+export function getLauncherCatalog(_opts: {
   permissions: string[];
   isRoot: boolean;
 }): LauncherItem[] {
-  const { permissions, isRoot } = opts;
-  const perms = new Set(permissions);
-  const hasPerm = (p: string) => isRoot || perms.has(p) || perms.has('super');
-
-  const match = (item: LauncherItem) => {
-    if (!item.permission) return true;
-    if (Array.isArray(item.permission)) return item.permission.some(hasPerm);
-    return hasPerm(item.permission);
-  };
-
   const all = [
     ...buildAgentItems(),
     ...buildToolboxItems(),
@@ -269,7 +260,7 @@ export function getLauncherCatalog(opts: {
     dedup.push(it);
   }
 
-  return dedup.filter(match);
+  return dedup;
 }
 
 /** 按 id 查找 LauncherItem */


### PR DESCRIPTION
## Summary
Refactored the command palette (Cmd+K) to separate mouse hover state from keyboard navigation state, remove permission-based filtering of launcher items, and improve the search input styling.

## Key Changes

### Hover/Keyboard State Separation
- Split `isSelected` into two independent states:
  - `hoveredId`: tracks mouse hover position (cleared on mouse leave)
  - `keyboardEngaged`: flag that enables keyboard highlight only after user presses arrow keys or enters a search query
- Renamed `isSelected` prop to `isActive` in `LauncherCard` for clarity
- Visual highlight (`activeId`) now uses: `hoveredId ?? (showKeyboardHighlight ? selectedId : null)`
- This prevents the visual bug where moving the mouse away would cause the highlight to "jump" to the first item in the recent section

### Permission Filtering Removal
- Modified `getLauncherCatalog()` to return all launcher items without permission-based filtering
- Rationale: The command palette serves as a discovery tool; actual access control is enforced by individual pages/controllers via their own authorization checks
- Users no longer see items mysteriously disappear due to missing fine-grained permissions

### Search Input Styling
- Wrapped the search input in a `<label>` container with rounded corners and subtle background
- Added `focus-within` styles: rounded border with purple ring shadow
- Applied `no-focus-ring` class to the input itself to suppress the global `:focus-visible` outline
- Improved visual feedback when the search field is focused

### Keyboard Navigation Improvements
- Arrow key navigation now sets `keyboardEngaged = true` and clears `hoveredId` to prevent visual conflicts
- Panel close resets both `keyboardEngaged` and `hoveredId` to clean state
- Search query presence also triggers keyboard highlight visibility (user expects Enter to work on the selected item)

## Implementation Details
- Added `useState` import for `hoveredId` and `keyboardEngaged` state
- Added `onMouseLeave` handler to `LauncherCard` component
- Grid container has `onMouseLeave` to clear hover when leaving the entire section
- Keyboard highlight only renders when `keyboardEngaged || searchQuery.trim().length > 0`

https://claude.ai/code/session_01Dq2BrMachWYffo4eTMEFSU

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI/UX behavior changes in a high-traffic navigation surface (Cmd+K) plus removal of permission-based hiding, which may expose links users cannot access if downstream authz checks are incomplete.
> 
> **Overview**
> Fixes Cmd+K command palette highlight glitches by **fully separating mouse hover from keyboard selection**: introduces `hoveredId` + `keyboardEngaged`, clears hover on mouse leave, and only shows keyboard highlight after arrow-key navigation or when a search query is present.
> 
> Stops filtering launcher entries by permission in `getLauncherCatalog()`, so the palette (and other consumers) always show the full catalog and rely on destination pages/controllers to enforce authorization.
> 
> Polishes the search UI by wrapping the input in a rounded `label` container with `:focus-within` ring styling and suppressing the global input focus outline via `no-focus-ring`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c651b4e52cc4db7e5183a631a07a6a9181d09d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->