### PR TITLE
Fix Remotion rendering by embedding Node.js and prd-video in Docker

### DIFF
--- a/.github/workflows/server-deploy.yml
+++ b/.github/workflows/server-deploy.yml
@@ -64,8 +64,11 @@ jobs:
         id: build
         uses: docker/build-push-action@v5
         with:
-          context: .
+          context: ./prd-api
           file: ./prd-api/Dockerfile
+          # prd-video 以独立命名上下文注入，Dockerfile 通过 --from=video 引用
+          build-contexts: |
+            video=./prd-video
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/server-deploy.yml
+++ b/.github/workflows/server-deploy.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'prd-api/**'
+      - 'prd-video/**'
       - '.github/workflows/server-deploy.yml'
   workflow_dispatch:
     inputs:
@@ -63,7 +64,7 @@ jobs:
         id: build
         uses: docker/build-push-action@v5
         with:
-          context: ./prd-api
+          context: .
           file: ./prd-api/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/changelogs/2026-04-22_fix-video-remotion-render.md
+++ b/changelogs/2026-04-22_fix-video-remotion-render.md
@@ -1,0 +1,3 @@
+| fix | prd-api | Dockerfile 安装 Node.js 20 + pnpm，嵌入 prd-video 源码及依赖，修复 Remotion 渲染 npx 找不到问题 |
+| fix | docker-compose | 构建上下文改为仓库根，新增 VideoAgent__RemotionProjectPath=/prd-video 环境变量 |
+| fix | ci | server-deploy.yml 构建上下文改为仓库根，触发路径加入 prd-video/** |

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -40,8 +40,10 @@ services:
 
   api:
     build:
-      context: .
-      dockerfile: prd-api/Dockerfile
+      context: ./prd-api
+      dockerfile: Dockerfile
+      additional_contexts:
+        video: ./prd-video
     image: prdagent-api:dev
     container_name: prdagent-api
     ports:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -40,8 +40,8 @@ services:
 
   api:
     build:
-      context: ./prd-api
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: prd-api/Dockerfile
     image: prdagent-api:dev
     container_name: prdagent-api
     ports:
@@ -82,6 +82,8 @@ services:
       # OpenRouter 视频生成 API（Seedance / Wan / Veo / Sora 统一入口）
       - OpenRouter__ApiKey=${OPENROUTER_API_KEY:-}
       - OpenRouter__BaseUrl=${OPENROUTER_BASE_URL:-https://openrouter.ai/api/v1}
+      # Remotion 分镜预览渲染路径（dev 镜像构建时已嵌入 prd-video）
+      - VideoAgent__RemotionProjectPath=/prd-video
     # 重要：此 API 容器建议只读，避免任何本地落盘（你这种”可写层 1MB”环境必开）
     read_only: true
     # 允许少量临时写入到内存（tmpfs），避免 .NET/HTTP 栈因无 /tmp 可写而异常；不会落到磁盘

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,8 @@ services:
       # 未配置时 video-agent 的"直出模式"会返回友好错误；配置后自动启用
       - OpenRouter__ApiKey=${OPENROUTER_API_KEY:-}
       - OpenRouter__BaseUrl=${OPENROUTER_BASE_URL:-https://openrouter.ai/api/v1}
+      # Remotion 分镜预览渲染路径（镜像构建时已嵌入 prd-video，无需挂载）
+      - VideoAgent__RemotionProjectPath=/prd-video
     # 重要：此 API 容器建议只读，避免任何本地落盘（你这种“可写层 1MB”环境必开）
     read_only: true
     # 允许少量临时写入到内存（tmpfs），避免 .NET/HTTP 栈因无 /tmp 可写而异常；不会落到磁盘

--- a/prd-api/Dockerfile
+++ b/prd-api/Dockerfile
@@ -1,19 +1,34 @@
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+# 安装 Node.js 20 + pnpm，供 Remotion 分镜预览渲染（VideoGenRunWorker 调用 npx）
+RUN apt-get update && apt-get install -y curl ca-certificates && \
+    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y nodejs && \
+    npm install -g pnpm && \
+    rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 EXPOSE 80
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
-COPY ["src/PrdAgent.Api/PrdAgent.Api.csproj", "src/PrdAgent.Api/"]
-COPY ["src/PrdAgent.Core/PrdAgent.Core.csproj", "src/PrdAgent.Core/"]
-COPY ["src/PrdAgent.Infrastructure/PrdAgent.Infrastructure.csproj", "src/PrdAgent.Infrastructure/"]
+COPY ["prd-api/src/PrdAgent.Api/PrdAgent.Api.csproj", "src/PrdAgent.Api/"]
+COPY ["prd-api/src/PrdAgent.Core/PrdAgent.Core.csproj", "src/PrdAgent.Core/"]
+COPY ["prd-api/src/PrdAgent.Infrastructure/PrdAgent.Infrastructure.csproj", "src/PrdAgent.Infrastructure/"]
 RUN dotnet restore "src/PrdAgent.Api/PrdAgent.Api.csproj"
-COPY . .
+COPY prd-api/ .
 WORKDIR "/src/src/PrdAgent.Api"
 # publish 会自动 build：避免 build + publish 双编译；并复用上一步 restore 的缓存
 RUN dotnet publish "PrdAgent.Api.csproj" -c Release -o /app/publish /p:UseAppHost=false --no-restore
 
+# 安装 prd-video 依赖（独立 stage，避免污染 dotnet build 缓存）
+FROM node:20-slim AS video-deps
+WORKDIR /prd-video
+COPY prd-video/package.json prd-video/pnpm-lock.yaml ./
+RUN npm install -g pnpm && pnpm install --frozen-lockfile
+
 FROM base AS final
 WORKDIR /app
 COPY --from=build /app/publish .
+# 嵌入 prd-video 源码 + 预装依赖，供 Remotion 渲染使用
+COPY prd-video /prd-video
+COPY --from=video-deps /prd-video/node_modules /prd-video/node_modules
 ENTRYPOINT ["dotnet", "PrdAgent.Api.dll"]

--- a/prd-api/Dockerfile
+++ b/prd-api/Dockerfile
@@ -10,25 +10,26 @@ EXPOSE 80
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
-COPY ["prd-api/src/PrdAgent.Api/PrdAgent.Api.csproj", "src/PrdAgent.Api/"]
-COPY ["prd-api/src/PrdAgent.Core/PrdAgent.Core.csproj", "src/PrdAgent.Core/"]
-COPY ["prd-api/src/PrdAgent.Infrastructure/PrdAgent.Infrastructure.csproj", "src/PrdAgent.Infrastructure/"]
+COPY ["src/PrdAgent.Api/PrdAgent.Api.csproj", "src/PrdAgent.Api/"]
+COPY ["src/PrdAgent.Core/PrdAgent.Core.csproj", "src/PrdAgent.Core/"]
+COPY ["src/PrdAgent.Infrastructure/PrdAgent.Infrastructure.csproj", "src/PrdAgent.Infrastructure/"]
 RUN dotnet restore "src/PrdAgent.Api/PrdAgent.Api.csproj"
-COPY prd-api/ .
+COPY . .
 WORKDIR "/src/src/PrdAgent.Api"
 # publish 会自动 build：避免 build + publish 双编译；并复用上一步 restore 的缓存
 RUN dotnet publish "PrdAgent.Api.csproj" -c Release -o /app/publish /p:UseAppHost=false --no-restore
 
-# 安装 prd-video 依赖（独立 stage，避免污染 dotnet build 缓存）
+# 安装 prd-video 依赖（独立 stage；通过 --build-context video=./prd-video 注入，不污染 dotnet 缓存）
 FROM node:20-slim AS video-deps
 WORKDIR /prd-video
-COPY prd-video/package.json prd-video/pnpm-lock.yaml ./
+# "video" 是构建时通过 --build-context video=./prd-video 传入的命名上下文
+COPY --from=video package.json pnpm-lock.yaml ./
 RUN npm install -g pnpm && pnpm install --frozen-lockfile
 
 FROM base AS final
 WORKDIR /app
 COPY --from=build /app/publish .
 # 嵌入 prd-video 源码 + 预装依赖，供 Remotion 渲染使用
-COPY prd-video /prd-video
+COPY --from=video . /prd-video
 COPY --from=video-deps /prd-video/node_modules /prd-video/node_modules
 ENTRYPOINT ["dotnet", "PrdAgent.Api.dll"]


### PR DESCRIPTION
## Summary
This PR fixes Remotion video rendering by installing Node.js 20 and pnpm in the Docker base image, and embedding the prd-video source code and dependencies directly into the container. This resolves issues where `npx` commands called by VideoGenRunWorker couldn't find the required Node.js environment.

## Key Changes

- **Dockerfile updates**:
  - Added Node.js 20 and pnpm installation to the base stage for Remotion rendering support
  - Created a separate `video-deps` build stage to pre-install prd-video dependencies without polluting the .NET build cache
  - Embedded prd-video source code and node_modules into the final image at `/prd-video`
  - Updated COPY paths to account for monorepo structure (prefixed with `prd-api/`)

- **Docker Compose configuration**:
  - Changed build context from `./prd-api` to `.` (repository root) to support multi-directory builds
  - Added `VideoAgent__RemotionProjectPath=/prd-video` environment variable to both `docker-compose.yml` and `docker-compose.dev.yml`

- **CI/CD pipeline**:
  - Updated `server-deploy.yml` build context to repository root
  - Added `prd-video/**` to workflow trigger paths to rebuild when video dependencies change

## Implementation Details

The solution uses a multi-stage Docker build approach:
1. Base stage: Installs Node.js 20 and pnpm for runtime Remotion support
2. Build stage: Compiles .NET application with updated monorepo paths
3. Video-deps stage: Pre-installs prd-video dependencies in isolation
4. Final stage: Combines .NET binaries with embedded prd-video code and dependencies

This approach ensures that Remotion can execute `npx` commands at runtime without requiring additional setup, while keeping the .NET build cache clean and optimized.

https://claude.ai/code/session_01JoyGhVenZvBvweBNeJkh6m

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the runtime contents and build pipeline of the production API image by adding Node/pnpm and bundling a second project, which can impact image size, build caching, and deploy behavior if paths or dependencies are mispackaged.
> 
> **Overview**
> Fixes Remotion rendering inside the `prd-api` container by **adding a Node.js 20 + pnpm runtime** to the Docker image and **embedding the `prd-video` project (plus preinstalled `node_modules`)** via a dedicated `video-deps` stage and BuildKit named build contexts.
> 
> Updates local/production orchestration and CI to support this packaging: `docker-compose*.yml` passes the `prd-video` build context and sets `VideoAgent__RemotionProjectPath=/prd-video`, while `server-deploy.yml` rebuilds on `prd-video/**` changes and injects `prd-video` as a `build-context` during the image build. Adds a changelog entry documenting the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45f94d06ce266b85e6bca7d275f634a760a6eb3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->