### PR TITLE
fix(prd-api): 使用系统 Chromium 彻底解决 Remotion 渲染在只读容器中失败的问题

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -86,11 +86,15 @@ services:
       - OpenRouter__BaseUrl=${OPENROUTER_BASE_URL:-https://openrouter.ai/api/v1}
       # Remotion 分镜预览渲染路径（dev 镜像构建时已嵌入 prd-video）
       - VideoAgent__RemotionProjectPath=/prd-video
+      # 系统 Chromium wrapper（注入 --no-sandbox 等 Docker headless 必需标志）
+      - CHROMIUM_EXECUTABLE_PATH=/usr/local/bin/chromium-docker
     # 重要：此 API 容器建议只读，避免任何本地落盘（你这种”可写层 1MB”环境必开）
     read_only: true
     # 允许少量临时写入到内存（tmpfs），避免 .NET/HTTP 栈因无 /tmp 可写而异常；不会落到磁盘
     tmpfs:
       - /tmp
+    # Chromium 渲染需要足够的共享内存；Docker 默认 64MB 偶发 OOM，调到 256MB
+    shm_size: '256m'
     volumes:
       # ffmpeg 静态编译版（转录工作台 ASR 音频格式转换 + 知识库字幕生成用）
       # 与生产 docker-compose.yml 保持一致

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,11 +91,16 @@ services:
       - OpenRouter__BaseUrl=${OPENROUTER_BASE_URL:-https://openrouter.ai/api/v1}
       # Remotion 分镜预览渲染路径（镜像构建时已嵌入 prd-video，无需挂载）
       - VideoAgent__RemotionProjectPath=/prd-video
-    # 重要：此 API 容器建议只读，避免任何本地落盘（你这种“可写层 1MB”环境必开）
+      # 系统 Chromium wrapper（注入 --no-sandbox 等 Docker headless 必需标志）
+      # 让 Remotion 跳过自动下载，直接使用镜像内预装的 Chromium
+      - CHROMIUM_EXECUTABLE_PATH=/usr/local/bin/chromium-docker
+    # 重要：此 API 容器建议只读，避免任何本地落盘（你这种”可写层 1MB”环境必开）
     read_only: true
     # 允许少量临时写入到内存（tmpfs），避免 .NET/HTTP 栈因无 /tmp 可写而异常；不会落到磁盘
     tmpfs:
       - /tmp
+    # Chromium 渲染需要足够的共享内存；Docker 默认 64MB 偶发 OOM，调到 256MB
+    shm_size: '256m'
     volumes:
       - ./deploy/assets/fonts:/app/Assets/Fonts
       # ffmpeg 静态编译版（转录工作台 ASR 音频格式转换用）

--- a/prd-api/Dockerfile
+++ b/prd-api/Dockerfile
@@ -1,9 +1,14 @@
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
-# 安装 Node.js 20 + pnpm，供 Remotion 分镜预览渲染（VideoGenRunWorker 调用 npx）
+# 安装 Node.js 20 + pnpm + 系统 Chromium（供 Remotion 分镜预览渲染用）
+# 系统 Chromium 可避免 Remotion 在 read-only 容器内自行下载 Chromium 时因写不进
+# node_modules/.remotion 而崩溃；wrapper 脚本注入 Docker headless 必需的 Chrome 标志
 RUN apt-get update && apt-get install -y curl ca-certificates && \
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get install -y nodejs && \
+    apt-get install -y nodejs chromium fonts-noto && \
     npm install -g pnpm && \
+    printf '#!/bin/sh\nexec /usr/bin/chromium --no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage "$@"\n' \
+        > /usr/local/bin/chromium-docker && \
+    chmod +x /usr/local/bin/chromium-docker && \
     rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 EXPOSE 80

--- a/prd-video/remotion.config.ts
+++ b/prd-video/remotion.config.ts
@@ -2,3 +2,9 @@ import { Config } from "@remotion/cli/config";
 
 Config.setVideoImageFormat("jpeg");
 Config.setOverwriteOutput(true);
+
+// Docker 容器中使用系统 Chromium，跳过 Remotion 自动下载流程
+// 本地开发不设置此变量，Remotion 使用自己下载的 Chromium
+if (process.env.CHROMIUM_EXECUTABLE_PATH) {
+  Config.setChromiumExecutablePath(process.env.CHROMIUM_EXECUTABLE_PATH);
+}


### PR DESCRIPTION
上一轮修复了 npx/prd-video 不存在的问题，但 Remotion 仍会尝试向
node_modules/.remotion 写入自己下载的 Chromium（read_only 容器写不进）。

根本修复：
- Dockerfile：apt 安装系统 Chromium + fonts-noto；创建 wrapper 脚本 /usr/local/bin/chromium-docker，预注入 --no-sandbox / --disable-setuid-sandbox / --disable-dev-shm-usage（Docker 容器以 root 运行时必需）
- remotion.config.ts：读取 CHROMIUM_EXECUTABLE_PATH 环境变量后调用 Config.setChromiumExecutablePath()，Remotion 跳过自动下载逻辑，不再访问 node_modules/.remotion
- docker-compose.yml / dev：注入 CHROMIUM_EXECUTABLE_PATH + shm_size: 256m （防止 Chromium 因 /dev/shm 不足 OOM）
- 本地开发不设置 CHROMIUM_EXECUTABLE_PATH 时行为不变，Remotion 仍使用自下载版本

https://claude.ai/code/session_01JoyGhVenZvBvweBNeJkh6m

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes container runtime/dependency setup for headless Chromium rendering; risk is mainly around image size/build time and potential Chromium/Remotion compatibility issues in production.
> 
> **Overview**
> Fixes Remotion rendering failures in `read_only` Docker containers by **preinstalling system Chromium** in the `prd-api` image (plus a `chromium-docker` wrapper injecting required headless flags) and wiring Remotion to use it when `CHROMIUM_EXECUTABLE_PATH` is set.
> 
> Updates both `docker-compose.yml` and `docker-compose.dev.yml` to set `CHROMIUM_EXECUTABLE_PATH` and increase `shm_size` to `256m` to reduce Chromium OOMs during rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f0a645ea4e56a3706d5927daee8ffdebae9333e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->