### PR TITLE
Fix multi-project isolation vulnerabilities in CDS compose discovery

### DIFF
--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -761,11 +761,16 @@ export function createBranchRouter(deps: RouterDeps): Router {
 
   // ── Remote branches ──
 
-  router.get('/remote-branches', async (_req, res) => {
+  router.get('/remote-branches', async (req, res) => {
     try {
+      const projectId = typeof req.query.project === 'string' ? req.query.project : null;
+      const repoRoot = projectId
+        ? stateService.getProjectRepoRoot(projectId, config.repoRoot)
+        : config.repoRoot;
+
       await shell.exec(
         'GIT_TERMINAL_PROMPT=0 git fetch origin --prune',
-        { cwd: config.repoRoot, timeout: 30_000 },
+        { cwd: repoRoot, timeout: 30_000 },
       );
 
       const SEP = '<SEP>';
@@ -776,7 +781,7 @@ export function createBranchRouter(deps: RouterDeps): Router {
 
       const result = await shell.exec(
         `git for-each-ref --sort=-committerdate --format="${format}" refs/remotes/origin`,
-        { cwd: config.repoRoot },
+        { cwd: repoRoot },
       );
 
       const branches = result.stdout
@@ -1003,6 +1008,18 @@ export function createBranchRouter(deps: RouterDeps): Router {
           error: 'project_not_ready',
           cloneStatus: targetProject.cloneStatus,
           message: statusMsg[targetProject.cloneStatus] || `项目克隆状态异常: ${targetProject.cloneStatus}`,
+        });
+        return;
+      }
+      // G1.5 补充: 项目配置了独立 gitRepoUrl 但从未克隆（cloneStatus 为
+      // undefined 说明 reposBase 未设置，willClone=false）。如果放行，
+      // getProjectRepoRoot 会静默回退到 config.repoRoot，创建出错误仓库的
+      // worktree。这里主动拦截，提示用户先配置 CDS_REPOS_BASE 再克隆。
+      if (targetProject.gitRepoUrl && !targetProject.repoPath && !targetProject.cloneStatus) {
+        res.status(409).json({
+          error: 'project_repo_not_cloned',
+          message: `项目配置了独立仓库（${targetProject.gitRepoUrl}），但尚未克隆。` +
+            `请确保服务器已设置 CDS_REPOS_BASE 环境变量，然后通过项目设置触发克隆（POST /api/projects/${effectiveProjectId}/clone）。`,
         });
         return;
       }

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -3912,17 +3912,24 @@ export function createBranchRouter(deps: RouterDeps): Router {
     res.json({ services });
   });
 
-  // Discover infrastructure services from compose files in the repo
-  router.get('/infra/discover', (_req, res) => {
+  // Discover infrastructure services from compose files in the project repo
+  router.get('/infra/discover', (req, res) => {
     try {
-      const composeFiles = discoverComposeFiles(config.repoRoot);
+      // Scope discovery to the current project's own repo root only.
+      // Using config.repoRoot (the CDS host directory) would expose compose
+      // files belonging to other projects.
+      const queryProject = typeof req.query.project === 'string' ? req.query.project : null;
+      const effectiveProjectId = queryProject || 'default';
+      const scanRoot = stateService.getProjectRepoRoot(effectiveProjectId, config.repoRoot);
+
+      const composeFiles = discoverComposeFiles(scanRoot);
       const discovered: { file: string; services: ComposeServiceDef[] }[] = [];
 
       for (const file of composeFiles) {
         try {
           const services = parseComposeFile(file);
           if (services.length > 0) {
-            discovered.push({ file: path.relative(config.repoRoot, file), services });
+            discovered.push({ file: path.relative(scanRoot, file), services });
           }
         } catch { /* skip unparseable files */ }
       }
@@ -4160,7 +4167,14 @@ export function createBranchRouter(deps: RouterDeps): Router {
     if (composeYaml) {
       defs = parseComposeString(composeYaml);
     } else {
-      const composeFiles = discoverComposeFiles(config.repoRoot);
+      // Scope discovery to the current project's repo root only.
+      // Using config.repoRoot (the shared CDS host dir) would expose compose
+      // files from other projects — same isolation fix as /infra/discover.
+      const queryProject = typeof req.query.project === 'string' ? req.query.project : null;
+      const bodyProject = typeof req.body.projectId === 'string' ? req.body.projectId : null;
+      const effectiveProjectId = queryProject || bodyProject || 'default';
+      const scanRoot = stateService.getProjectRepoRoot(effectiveProjectId, config.repoRoot);
+      const composeFiles = discoverComposeFiles(scanRoot);
       const seenIds = new Set<string>();
       for (const file of composeFiles) {
         try {

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -934,10 +934,14 @@ export function createBranchRouter(deps: RouterDeps): Router {
     });
 
     // Compute container capacity: (memoryGB - 1) * 2
+    // maxContainers is the global server limit, so runningContainers must also
+    // count ALL projects — not just the project-filtered `branches` above.
+    // Otherwise a multi-project setup shows "181/186" for project A even when
+    // project B has 10 additional containers running (actual free = 171/186).
     const totalMemGB = Math.round(os.totalmem() / (1024 * 1024 * 1024));
     const maxContainers = Math.max(2, (totalMemGB - 1) * 2);
     let runningContainers = 0;
-    for (const b of branches) {
+    for (const b of Object.values(state.branches)) {
       for (const svc of Object.values(b.services)) {
         if (svc.status === 'running' || svc.status === 'building' || svc.status === 'starting') {
           runningContainers++;

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -3100,13 +3100,33 @@ export function createBranchRouter(deps: RouterDeps): Router {
     // while hex UUIDs look like random noise in the topology view.
     const idSuffix = projectId === 'default' ? '' : `-${projectSlug}`;
 
-    // Task 1: prefer the project's own cds-compose.yaml over the
-    // hardcoded template. This fixes the Redis-connect crash on forked
-    // projects — the template was missing MongoDB/Redis/JWT env vars,
-    // while cds-compose.yaml carries the full runtime contract.
+    // Task 1: prefer a cds-compose file over the hardcoded template.
+    // Search order (first match wins):
+    //   1. CDS host dir (config.repoRoot) with project-slug prefix —
+    //      e.g. mytapd-cds-compose.yaml next to the CDS installation.
+    //      This is the "independent" mode: the file lives outside the
+    //      project's git repo so it never gets committed there.
+    //   2. CDS host dir (config.repoRoot) with generic name —
+    //      cds-compose.yaml next to CDS itself (default/single-project).
+    //   3. Project repo root — backward compat for repos that already
+    //      committed the file (or where projectRepoRoot == config.repoRoot).
     let composeYaml: string | null = null;
-    for (const filename of ['cds-compose.yaml', 'cds-compose.yml']) {
-      const composePath = path.join(projectRepoRoot, filename);
+    const composeCandidates: string[] = [
+      // CDS host dir, project-prefixed (future "independent" mode)
+      path.join(config.repoRoot, `${projectSlug}-cds-compose.yaml`),
+      path.join(config.repoRoot, `${projectSlug}-cds-compose.yml`),
+      // CDS host dir, generic name
+      path.join(config.repoRoot, 'cds-compose.yaml'),
+      path.join(config.repoRoot, 'cds-compose.yml'),
+      // Project repo root (backward compat / committed file)
+      path.join(projectRepoRoot, 'cds-compose.yaml'),
+      path.join(projectRepoRoot, 'cds-compose.yml'),
+    ];
+    // De-duplicate paths (projectRepoRoot may equal config.repoRoot for legacy)
+    const seen = new Set<string>();
+    for (const composePath of composeCandidates) {
+      if (seen.has(composePath)) continue;
+      seen.add(composePath);
       if (fs.existsSync(composePath)) {
         try {
           composeYaml = fs.readFileSync(composePath, 'utf8');

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -4540,33 +4540,33 @@ export function createBranchRouter(deps: RouterDeps): Router {
     res.json({ version });
   });
 
-  // GET /api/export-skill — export unified cds skill as tar.gz
+  // GET /api/export-skill — export all CDS skills as a single tar.gz bundle
   //
-  // 2026-04-18 重构：合并 cds-project-scan + cds-deploy-pipeline + smoke-test
-  // 为单一 cds 技能，带 cli/ Python CLI + reference/ 按需文档 + SKILL.md 入口。
-  // 旧入参 `?legacy=1` 仍能导出 cds-project-scan 单独的文档（向后兼容）。
+  // 打包内容（全量，不分 legacy / unified）：
+  //   .claude/skills/cds/                — 统一技能（主入口 + CLI + reference）
+  //   .claude/skills/cds-deploy-pipeline/ — 部署流水线技能
+  //   .claude/skills/cds-project-scan/   — 扫描技能（向后兼容旧工作流）
+  //
+  // 旧入参 `?legacy=1` 保留：仍能仅导出 cds-project-scan（向后兼容）。
   router.get('/export-skill', (req, res) => {
     try {
       const useLegacy = req.query.legacy === '1';
-      const skillName = useLegacy ? 'cds-project-scan' : 'cds';
-      const skillDir = path.join(config.repoRoot, '.claude', 'skills', skillName);
-      if (!fs.existsSync(skillDir)) {
-        res.status(404).json({ error: `未找到 ${skillName} 技能目录` });
-        return;
-      }
+
+      // 解析 skills 根目录：优先 config.repoRoot，兜底父目录（CDS 部署为子目录时）
+      const skillsRoot = ((): string => {
+        const primary = path.join(config.repoRoot, '.claude', 'skills');
+        if (fs.existsSync(primary)) return primary;
+        const parent = path.join(config.repoRoot, '..', '.claude', 'skills');
+        if (fs.existsSync(parent)) return parent;
+        return primary; // 返回原路径，后续报错
+      })();
 
       // Build pack in a temp directory
       const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
-      const packName = `${skillName}-skill-${timestamp}`;
+      const packName = useLegacy ? `cds-project-scan-skill-${timestamp}` : `cds-skills-${timestamp}`;
       const tmpDir = path.join(config.repoRoot, '.cds', 'tmp');
       const packDir = path.join(tmpDir, packName);
 
-      // Recursively copy the whole skill directory (captures cli/ and
-      // reference/ subdirs without per-file enumeration). This mirrors
-      // whatever layout the skill author uses so the drop-in on the
-      // consumer side stays identical to the source.
-      const targetSkillDir = path.join(packDir, '.claude', 'skills', skillName);
-      fs.mkdirSync(targetSkillDir, { recursive: true });
       const copyRecursive = (src: string, dst: string) => {
         const stat = fs.statSync(src);
         if (stat.isDirectory()) {
@@ -4578,19 +4578,39 @@ export function createBranchRouter(deps: RouterDeps): Router {
           fs.copyFileSync(src, dst);
         }
       };
-      copyRecursive(skillDir, targetSkillDir);
+
+      // 要打包的技能列表
+      const skillsToCopy: string[] = useLegacy
+        ? ['cds-project-scan']
+        : ['cds', 'cds-deploy-pipeline', 'cds-project-scan'];
+
+      let copiedCount = 0;
+      for (const skillName of skillsToCopy) {
+        const skillDir = path.join(skillsRoot, skillName);
+        if (!fs.existsSync(skillDir)) continue;
+        const targetSkillDir = path.join(packDir, '.claude', 'skills', skillName);
+        fs.mkdirSync(targetSkillDir, { recursive: true });
+        copyRecursive(skillDir, targetSkillDir);
+        copiedCount++;
+      }
+
+      if (copiedCount === 0) {
+        res.status(404).json({ error: `未找到 CDS 技能目录（已查找：${skillsRoot}）` });
+        return;
+      }
 
       // README tailored to the new unified skill
       const readme = useLegacy
         ? `# CDS 部署技能包 (legacy: cds-project-scan)\n\n将 \`.claude/skills/cds-project-scan/\` 复制到目标项目的对应路径。\n`
-        : `# CDS 技能包 (统一版)
+        : `# CDS 技能包（全套，共 ${copiedCount} 个技能）
 
+包含：cds（主技能）、cds-deploy-pipeline（部署流水线）、cds-project-scan（扫描）。
 覆盖 CDS 全生命周期：扫描项目 → Agent 鉴权 → 部署 → 就绪检测 → 分层冒烟 → 故障诊断。
 
 ## 三分钟安装
 
 \`\`\`bash
-# 1. 解压到你项目的根目录（保留 .claude/skills/cds/ 结构）
+# 1. 解压到你项目的根目录（会在 .claude/skills/ 下放置所有 cds 技能）
 tar -xzf ${packName}.tar.gz --strip-components=1
 
 # 2. 加 alias（推荐）

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -3101,24 +3101,12 @@ export function createBranchRouter(deps: RouterDeps): Router {
     const idSuffix = projectId === 'default' ? '' : `-${projectSlug}`;
 
     // Task 1: prefer a cds-compose file over the hardcoded template.
-    // Search order (first match wins):
-    //   1. CDS host dir (config.repoRoot) with project-slug prefix —
-    //      e.g. mytapd-cds-compose.yaml next to the CDS installation.
-    //      This is the "independent" mode: the file lives outside the
-    //      project's git repo so it never gets committed there.
-    //   2. CDS host dir (config.repoRoot) with generic name —
-    //      cds-compose.yaml next to CDS itself (default/single-project).
-    //   3. Project repo root — backward compat for repos that already
-    //      committed the file (or where projectRepoRoot == config.repoRoot).
+    // Only search inside the project's own git repo (projectRepoRoot).
+    // Never search config.repoRoot — that is the CDS host directory shared
+    // across all projects, so reading from it would let one project's compose
+    // file silently contaminate a different project's build profiles.
     let composeYaml: string | null = null;
     const composeCandidates: string[] = [
-      // CDS host dir, project-prefixed (future "independent" mode)
-      path.join(config.repoRoot, `${projectSlug}-cds-compose.yaml`),
-      path.join(config.repoRoot, `${projectSlug}-cds-compose.yml`),
-      // CDS host dir, generic name
-      path.join(config.repoRoot, 'cds-compose.yaml'),
-      path.join(config.repoRoot, 'cds-compose.yml'),
-      // Project repo root (backward compat / committed file)
       path.join(projectRepoRoot, 'cds-compose.yaml'),
       path.join(projectRepoRoot, 'cds-compose.yml'),
     ];
@@ -3178,11 +3166,19 @@ export function createBranchRouter(deps: RouterDeps): Router {
 
         stateService.save();
 
+        // Report env vars that still have TODO placeholder values so the
+        // frontend can open the env editor immediately after quickstart.
+        const allProjectEnv = stateService.getCustomEnv(projectId);
+        const pendingEnvVars = Object.entries(allProjectEnv)
+          .filter(([, v]) => typeof v === 'string' && v.startsWith('TODO:'))
+          .map(([k]) => k);
+
         res.status(201).json({
           message: `快速启动: 已从 cds-compose.yaml 创建 ${seeded.length} 个构建配置`,
           profiles: seeded,
           detectedPackageManager: pm,
           source: 'cds-compose',
+          pendingEnvVars,
         });
         return;
       }

--- a/cds/src/services/proxy.ts
+++ b/cds/src/services/proxy.ts
@@ -753,6 +753,9 @@ h2{font-size:18px;color:#f0f6fc;margin-bottom:8px}
     // Non-HTML resources (JS/CSS/images) keep compression intact.
 
     // Track web access for activity monitor
+    // accessLogged prevents double-emitting when the error handler fires first
+    // and then clientRes.on('finish') also fires for the synthetic response.
+    let accessLogged = false;
     if (branchCtx?.trackAccess && this.onAccess) {
       const onAccessCb = this.onAccess;
       const method = clientReq.method || 'GET';
@@ -760,7 +763,10 @@ h2{font-size:18px;color:#f0f6fc;margin-bottom:8px}
       const branchId = branchCtx.branchId;
       const profileId = branchCtx.profileId;
       clientRes.on('finish', () => {
-        onAccessCb(branchId, method, reqPath, clientRes.statusCode, Date.now() - proxyStart, profileId);
+        if (!accessLogged) {
+          accessLogged = true;
+          onAccessCb(branchId, method, reqPath, clientRes.statusCode, Date.now() - proxyStart, profileId);
+        }
       });
     }
 
@@ -829,6 +835,21 @@ h2{font-size:18px;color:#f0f6fc;margin-bottom:8px}
 
     proxyReq.on('error', (err: NodeJS.ErrnoException) => {
       console.error(`[proxy] upstream error: ${err.message} → ${upstream}`);
+      // Emit activity event immediately so the failure appears in Activity Monitor.
+      // We do this here rather than relying on clientRes.on('finish') because the
+      // synthetic response we send (loading page or 502) would show status 200/502
+      // from the finish event — emitting 502 here better reflects what happened.
+      if (branchCtx?.trackAccess && this.onAccess && !accessLogged) {
+        accessLogged = true;
+        this.onAccess(
+          branchCtx.branchId,
+          clientReq.method || 'GET',
+          clientReq.url || '/',
+          502,
+          Date.now() - proxyStart,
+          branchCtx.profileId,
+        );
+      }
       if (clientRes.headersSent) return;
 
       // Connection-level errors to the upstream container (not yet listening,

--- a/cds/web/app.js
+++ b/cds/web/app.js
@@ -650,6 +650,23 @@ function initStateStream() {
       if (data.capacity) {
         clusterCapacity = data.capacity;
       }
+      // In single-node mode data.capacity is null, but data.branches carries
+      // ALL branches across ALL projects. Recompute global runningContainers
+      // so the capacity badge stays accurate without waiting for the next
+      // loadBranches() poll (5 s). maxContainers / totalMemGB are unchanged.
+      if (!data.capacity && Array.isArray(data.branches)) {
+        var globalRunning = 0;
+        for (var _gb of data.branches) {
+          if (_gb.services) {
+            for (var _svc of Object.values(_gb.services)) {
+              if (_svc.status === 'running' || _svc.status === 'building' || _svc.status === 'starting') {
+                globalRunning++;
+              }
+            }
+          }
+        }
+        containerCapacity = Object.assign({}, containerCapacity, { runningContainers: globalRunning });
+      }
       if (typeof data.schedulerEnabled === 'boolean') {
         schedulerEnabled = data.schedulerEnabled;
       }

--- a/cds/web/app.js
+++ b/cds/web/app.js
@@ -510,6 +510,11 @@ async function bootstrapCurrentProjectLabel() {
   if (body && body.name) {
     label.textContent = body.name;
     label.title = '项目：' + body.name + '（点击返回列表）';
+    // Cache for other UI elements (e.g. quickstart banner hint).
+    window._currentProjectName = body.name;
+    // Re-render profiles now that we have the name, so the banner hint
+    // shows the actual project name instead of the ID.
+    renderProfiles();
   }
 }
 
@@ -4108,6 +4113,12 @@ function renderProfiles() {
   // Profiles are now rendered inside modal, this just controls the quickstart banner
   const banner = document.getElementById('quickstartBanner');
   if (buildProfiles.length === 0) {
+    // Dynamically update the hint text to show the actual project name
+    const hint = document.getElementById('quickstartBannerHint');
+    if (hint) {
+        const projName = window._currentProjectName || CURRENT_PROJECT_ID || '当前项目';
+      hint.innerHTML = `优先读取 <strong>${esc(projName)}</strong> 项目仓库下的 <code>cds-compose.yaml</code>；否则使用内置 api/admin 模板`;
+    }
     banner.classList.remove('hidden');
   } else {
     banner.classList.add('hidden');
@@ -4151,6 +4162,15 @@ async function runQuickstart() {
     const data = await api('POST', '/quickstart', { projectId: CURRENT_PROJECT_ID });
     showToast(data.message, 'success');
     await loadProfiles();
+    // When compose file was found and some vars still have TODO placeholders,
+    // automatically open the env editor so the user can fill them in before
+    // starting branches.
+    if (data.source === 'cds-compose' && data.pendingEnvVars && data.pendingEnvVars.length > 0) {
+      await loadEnvVars(CURRENT_PROJECT_ID);
+      envScope = CURRENT_PROJECT_ID;
+      showToast(`已导入配置，请填写 ${data.pendingEnvVars.length} 个待填写的环境变量`, 'info');
+      openEnvModal();
+    }
   } catch (e) { showToast(e.message, 'error'); }
 }
 

--- a/cds/web/app.js
+++ b/cds/web/app.js
@@ -595,10 +595,16 @@ function initStateStream() {
     try {
       const data = JSON.parse(e.data);
       if (data.branches) {
+        // broadcastState() sends ALL branches across all projects. Scope to the
+        // current project here so a dashboard opened on project B doesn't absorb
+        // project A's branches. This mirrors the ?project= filter on GET /branches.
+        const projectBranches = data.branches.filter(
+          b => (b.projectId || 'default') === CURRENT_PROJECT_ID
+        );
         // Merge commit info: state-stream has no git data, so preserve existing subject/commitSha
         // Only update status and service states from server push
         const branchMap = new Map(branches.map(b => [b.id, b]));
-        for (const pushed of data.branches) {
+        for (const pushed of projectBranches) {
           const existing = branchMap.get(pushed.id);
           if (existing) {
             // Preserve git info, update status/services/executorId
@@ -620,8 +626,8 @@ function initStateStream() {
             branches.push(pushed);
           }
         }
-        // Remove branches that no longer exist
-        const pushedIds = new Set(data.branches.map(b => b.id));
+        // Remove branches that no longer exist in this project's scope
+        const pushedIds = new Set(projectBranches.map(b => b.id));
         const removedIds = branches.filter(b => !pushedIds.has(b.id)).map(b => b.id);
         branches = branches.filter(b => pushedIds.has(b.id));
         for (const rid of removedIds) freshlyArrived.delete(rid);

--- a/cds/web/index.html
+++ b/cds/web/index.html
@@ -77,7 +77,7 @@
     <div id="quickstartBanner" class="quickstart-banner hidden">
       <div class="quickstart-content">
         <strong>尚未初始化构建配置</strong>
-        <span>优先读取项目中的 <code>cds-compose.yaml</code>；未找到则回落到内置 api/admin 模板</span>
+        <span>检测到 <code>cds-compose.yaml</code> 时自动导入；否则使用内置 api/admin 模板</span>
       </div>
       <button class="primary sm" onclick="runQuickstart()">初始化构建配置</button>
     </div>

--- a/cds/web/index.html
+++ b/cds/web/index.html
@@ -77,7 +77,7 @@
     <div id="quickstartBanner" class="quickstart-banner hidden">
       <div class="quickstart-content">
         <strong>尚未初始化构建配置</strong>
-        <span>检测到 <code>cds-compose.yaml</code> 时自动导入；否则使用内置 api/admin 模板</span>
+        <span id="quickstartBannerHint">优先读取项目仓库下的 <code>cds-compose.yaml</code>；否则使用内置 api/admin 模板</span>
       </div>
       <button class="primary sm" onclick="runQuickstart()">初始化构建配置</button>
     </div>

--- a/cds/web/projects.js
+++ b/cds/web/projects.js
@@ -1025,7 +1025,7 @@ window.cdsDoLogout = cdsDoLogout;
     a.click();
     document.body.removeChild(a);
     if (typeof showToast === 'function') {
-      showToast('正在下载 cds 技能包…解压到你项目的 .claude/skills/ 即可', 'info', 4000);
+      showToast('正在下载 CDS 技能包（cds + cds-deploy-pipeline + cds-project-scan）…解压到项目根目录即可', 'info', 5000);
     }
   };
 

--- a/cds/web/projects.js
+++ b/cds/web/projects.js
@@ -935,7 +935,9 @@ window.cdsDoLogout = cdsDoLogout;
       'style="position:absolute;top:10px;right:' + keyRight + 'px;' +
       'width:26px;height:26px;border-radius:6px;border:1px solid var(--card-border);' +
       'background:var(--bg-card);cursor:pointer;display:inline-flex;align-items:center;' +
-      'justify-content:center;font-size:13px;color:var(--text-secondary);padding:0">🔑</button>';
+      'justify-content:center;color:var(--text-secondary);padding:0">' +
+      '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="7.5" cy="15.5" r="5.5"/><path d="m21 2-9.6 9.6"/><path d="m15.5 7.5 3 3L22 7l-3-3"/></svg>' +
+      '</button>';
     var downloadSkillBtn =
       '<button class="cds-project-card-download-skill" ' +
       'title="下载 cds 技能包 (tar.gz) — 解压到项目 .claude/skills/ 即可在 Claude Code 里调用 cdscli" ' +
@@ -943,7 +945,9 @@ window.cdsDoLogout = cdsDoLogout;
       'style="position:absolute;top:10px;right:' + dlRight + 'px;' +
       'width:26px;height:26px;border-radius:6px;border:1px solid var(--card-border);' +
       'background:var(--bg-card);cursor:pointer;display:inline-flex;align-items:center;' +
-      'justify-content:center;font-size:13px;color:var(--text-secondary);padding:0">📦</button>';
+      'justify-content:center;color:var(--text-secondary);padding:0">' +
+      '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>' +
+      '</button>';
 
     var totalServices =
       ((services && services.profiles && services.profiles.length) || 0) +

--- a/doc/rule.cds-project-isolation-audit.md
+++ b/doc/rule.cds-project-isolation-audit.md
@@ -1,0 +1,171 @@
+# CDS 多项目隔离审计规则
+
+> 状态: active | 作者: Claude Code | 创建: 2026-04-22
+> 根因: 三次跨项目数据污染事件暴露了 MECE 矩阵的系统性盲区
+
+---
+
+## 事故回顾（2026-04-22）
+
+### 发生了什么
+
+myTapd 项目的 `cds-compose.yaml` 被导入到 default/prd-agent 项目，导致：
+
+| 受污染的对象 | 污染内容 | 影响 |
+|-------------|---------|------|
+| buildProfiles.api | 被 Spring Boot/Maven 配置覆盖 | prd-agent API 无法构建 |
+| buildProfiles.web | 新增 miduo-frontend 配置 | prd-agent 多出一个不属于它的前端 |
+| infraServices | 新增 MySQL、MinIO | default 项目基础设施列表出现异类 |
+| globalEnv | 注入 SPRING_* 变量 | 所有容器的环境变量被 Spring Boot 配置污染 |
+| buildProfiles.api.env | 紧急修复时 env 段被清空 | Redis/MongoDB 连接串丢失，API 崩溃 |
+
+### 根本原因
+
+`POST /quickstart` 的 `composeCandidates` 数组包含 `config.repoRoot`（CDS 宿主目录），而 CDS 宿主目录是**所有项目共享**的，在其中发现的第一个 `cds-compose.yaml` 会被无差别地应用到当前项目。
+
+---
+
+## MECE 矩阵为何漏掉这个问题
+
+### 原矩阵的盲区分析
+
+旧矩阵检查了「数据写入隔离」（buildProfiles/infraServices/envVars 是否按 projectId 存储），但漏掉了以下三类：
+
+| 审计维度 | 旧矩阵 | 应有 |
+|---------|--------|------|
+| **文件读取向量** | ❌ 未覆盖 | 每个读文件操作的根目录是否隔离到项目 repo root |
+| **入口点完整性** | ❌ 未覆盖 | 所有写数据的入口点（不只是 /import-config）是否都被审计 |
+| **共享资源污染** | ❌ 未覆盖 | globalEnv、infra、proxy.ts 等跨项目共享的对象是否有越界写 |
+| **紧急修复后的数据完整性** | ❌ 未覆盖 | 手工修复 API 后是否验证了 env/dependsOn 的完整性 |
+
+### 具体遗漏的入口点
+
+| 端点 | 污染类型 | 修复 |
+|------|---------|------|
+| `POST /quickstart` | composeCandidates 扫描共享目录 | 改用 projectRepoRoot |
+| `GET /infra/discover` | discoverComposeFiles(config.repoRoot) | 改用 projectRepoRoot |
+| `POST /infra/quickstart` | discoverComposeFiles(config.repoRoot) | 改用 projectRepoRoot |
+| `PUT /api/build-profiles/:id` | 手工修复时丢失 env 段 | 需要修复后完整验证 |
+
+---
+
+## 新版审计清单（MECE 扩展版）
+
+每次修改 CDS 多项目相关代码时，逐条过以下矩阵：
+
+### 维度 1：数据写入隔离（原有）
+
+- [ ] buildProfiles 的 CRUD 操作都带 `projectId`
+- [ ] infraServices 的 CRUD 操作都带 `projectId`
+- [ ] envVars 的写入带正确的 `scope`（项目 ID 或 `_global`）
+- [ ] routingRules 的写入带 `projectId`
+
+### 维度 2：文件读取隔离（新增 ⭐）
+
+- [ ] **所有 `discoverComposeFiles()` 调用** — 根目录是 `stateService.getProjectRepoRoot(projectId, config.repoRoot)` 还是共享的 `config.repoRoot`？
+- [ ] **所有 `parseCdsCompose()` / `parseComposeFile()` 调用** — 文件路径是从哪个目录发现的？
+- [ ] **所有 `readFileSync/existsSync` + repoRoot 的组合** — 是否可能读到其他项目的文件？
+
+判定规则：凡是根目录是 `config.repoRoot` 且没有项目过滤的，都是隔离漏洞。
+
+### 维度 3：入口点完整性（新增 ⭐）
+
+修改了一个入口点的隔离后，必须搜索**所有其他入口点**：
+
+```bash
+# 找出所有可能触发 compose 发现/解析的入口
+grep -n "discoverComposeFiles\|parseCdsCompose\|parseComposeFile\|composeCandidates" \
+  cds/src/routes/branches.ts
+```
+
+- [ ] `/quickstart` — compose 文件候选路径
+- [ ] `/infra/discover` — compose 文件发现根目录
+- [ ] `/infra/quickstart` — compose 文件发现根目录
+- [ ] `/import-config` — 用户主动导入（已有项目参数，相对安全）
+- [ ] 未来新增的任何扫描类端点
+
+### 维度 4：共享资源污染（新增 ⭐）
+
+- [ ] `globalEnv` — 新增的全局 env 键是否适合所有项目？`SPRING_*` 这类框架特定键不应进全局
+- [ ] `infraServices` — 从 compose 导入的 infra 是否正确绑定了 `projectId`？
+- [ ] `proxy.ts getBuildProfiles()` — 路由分发时是否只用当前分支的项目下的 profiles？
+
+### 维度 5：修复后数据完整性（新增 ⭐）
+
+任何通过 API 手工修复 buildProfile 后，必须验证：
+
+```bash
+# 检查 env 段不为空
+curl "$CDS/api/build-profiles?project=<id>" | jq '.profiles[] | {id, env, dependsOn}'
+
+# 关键字段：
+# - env 不能是 {}（空对象）
+# - dependsOn 只含本项目的 infra service id
+# - containerPort 和 command 中的端口一致
+```
+
+- [ ] `env` 段包含所有连接串（MongoDB、Redis 等）
+- [ ] `dependsOn` 只引用属于本项目的 infra service
+- [ ] `containerPort` 与 `command` 中的 `--urls` 端口一致
+
+---
+
+## 永久性防御规则
+
+### 规则 1：discoverComposeFiles 只允许项目 repo root
+
+```typescript
+// ✅ 正确
+const scanRoot = stateService.getProjectRepoRoot(projectId, config.repoRoot);
+const files = discoverComposeFiles(scanRoot);
+
+// ❌ 禁止 — 会扫描到所有项目的 compose 文件
+const files = discoverComposeFiles(config.repoRoot);
+```
+
+### 规则 2：全局 env 禁止框架专用键
+
+进全局 env 的键必须满足：
+- 对所有项目（.NET / Spring Boot / Node.js）都无害
+- 不含框架特定前缀（`SPRING_*` / `DJANGO_*` / `RAILS_*`）
+- 只放真正的跨项目共享密钥（如 `AI_ACCESS_KEY`、`PREVIEW_DOMAIN`）
+
+### 规则 3：紧急修复后的完整性校验
+
+手工 `PUT /api/build-profiles/:id` 修复后，立即运行验证脚本：
+
+```bash
+curl -sf -H "X-AI-Access-Key: $AI_ACCESS_KEY" \
+  "$CDS/api/build-profiles?project=<id>" | \
+  python3 -c "
+import json, sys
+for p in json.load(sys.stdin).get('profiles', []):
+    env_ok = bool(p.get('env'))
+    deps_ok = bool(p.get('dependsOn'))
+    print(f'{p[\"id\"]}: env={\"OK\" if env_ok else \"EMPTY!\"}  deps={p.get(\"dependsOn\")}')"
+```
+
+### 规则 4：infra 删除后检查 dependsOn 引用
+
+删除 infra service 后，扫描所有 buildProfiles 的 `dependsOn`，移除悬空引用：
+
+```bash
+# 例：删除 mysql 后
+curl "$CDS/api/build-profiles?project=default" | \
+  jq '.profiles[] | select(.dependsOn[] == "mysql") | .id'
+```
+
+---
+
+## 已修复的漏洞记录
+
+| 提交 | 修复内容 |
+|------|---------|
+| 5d30b54 | `composeCandidates` 移除所有 config.repoRoot 路径 |
+| 5d30b54 | quickstartBannerHint 动态显示项目名 |
+| 5d30b54 | runQuickstart 导入后自动打开 TODO env 编辑器 |
+| 3ad379f | `GET /infra/discover` 改用 projectRepoRoot |
+| 3ad379f | `POST /infra/quickstart` 改用 projectRepoRoot |
+| 手工修复 | 删除 default 项目的 mysql、minio infra（污染残留） |
+| 手工修复 | 恢复 api buildProfile 的 env、dependsOn、containerPort |
+| 手工修复 | 删除 globalEnv 中的 SPRING_* 污染变量 |

--- a/mytapd-cds-compose.yml
+++ b/mytapd-cds-compose.yml
@@ -1,0 +1,168 @@
+# CDS Compose 配置 — myTapd 项目
+# 由 /cds-scan 自动生成 (2026-04-22)
+#
+# 导入方式：CDS Dashboard → 设置 → 一键导入 → 粘贴此内容
+#
+# ⚠ Nacos 旁路说明：
+#   CDS 开发环境不连接 Nacos，所有原本由 ticket-platform-secrets.yaml
+#   提供的配置项改为 env var 直接注入。Spring Boot 的松散绑定规则保证
+#   SPRING_DATASOURCE_URL 等变量能覆盖 Nacos 里的同名 key。
+
+x-cds-project:
+  name: myTapd
+  description: "myTapd 项目协作平台 (Spring Boot 2.7 + Vue 3 + MySQL 8 + Redis + MinIO)"
+  repo: https://github.com/midoutech/mytapd.git
+
+# 全局共享环境变量 — CDS 自动注入所有容器，services.*.environment 中禁止重复声明
+x-cds-env:
+  # ── 数据库凭证 ──
+  SPRING_DATASOURCE_USERNAME: "TODO: 请填写实际值"
+  SPRING_DATASOURCE_PASSWORD: "TODO: 请填写实际值"
+
+  # ── Redis ──
+  SPRING_REDIS_PASSWORD: "TODO: 请填写实际值（无密码则留空字符串）"
+
+  # ── JWT ──
+  JWT_SECRET: "TODO: 请填写实际值"
+
+  # ── 邮件（可选，不配置则邮件功能不可用）──
+  SPRING_MAIL_HOST: "TODO: 请填写实际值"
+  SPRING_MAIL_PORT: "465"
+  SPRING_MAIL_USERNAME: "TODO: 请填写实际值"
+  SPRING_MAIL_PASSWORD: "TODO: 请填写实际值"
+
+  # ── MinIO（本地存储，CDS 自动启动）──
+  MINIO_ACCESS_KEY: "minioadmin"
+  MINIO_SECRET_KEY: "minioadmin123"
+
+  # ── 七牛云（可选，替代 MinIO 用于生产文件存储）──
+  QINIU_ACCESS_KEY: "TODO: 请填写实际值（不使用七牛云可留空）"
+  QINIU_SECRET_KEY: "TODO: 请填写实际值"
+  QINIU_BUCKET: "TODO: 请填写实际值"
+  QINIU_DOMAIN: "TODO: 请填写实际值"
+
+  # ── 企业微信（可选）──
+  WECOM_CORP_ID: "TODO: 请填写实际值（不使用企业微信可留空）"
+  WECOM_AGENT_ID: "TODO: 请填写实际值"
+  WECOM_SECRET: "TODO: 请填写实际值"
+
+  # ── Miduo SSO（可选，CDS 开发环境可关闭）──
+  MIDUO_SSO_KEY: "TODO: 请填写实际值（不需要 SSO 可留空）"
+  MIDUO_SSO_VERIFY_URL: "TODO: 请填写实际值"
+
+  # ── 开发登录快捷（dev 环境专用）──
+  DEV_LOGIN_ENABLE: "true"
+  DEV_LOGIN_USER_ID: "TODO: 请填写测试用户 ID"
+
+services:
+  # ── App Services (有相对路径 volume mount) ──
+
+  api:
+    image: maven:3.9-eclipse-temurin-8
+    working_dir: /app
+    volumes:
+      - ./ticket-platform:/app
+    ports:
+      - "8080"
+    command: >-
+      mvn -Dmaven.test.skip=true
+      spring-boot:run
+      -pl ticket-bootstrap
+    depends_on:
+      mysql: { condition: service_healthy }
+      redis: { condition: service_healthy }
+    environment:
+      # Spring 配置
+      SPRING_PROFILES_ACTIVE: dev
+      # 禁用 Nacos — secrets 改由上方 x-cds-env 直接注入
+      SPRING_CLOUD_NACOS_CONFIG_ENABLED: "false"
+      SPRING_CLOUD_NACOS_DISCOVERY_ENABLED: "false"
+      # MySQL 连接串（用 CDS 注入的 infra 地址）
+      SPRING_DATASOURCE_URL: "jdbc:mysql://${CDS_HOST}:${CDS_MYSQL_PORT}/ticket_platform?useUnicode=true&characterEncoding=utf8mb4&serverTimezone=Asia/Shanghai&allowPublicKeyRetrieval=true&useSSL=false"
+      SPRING_DATASOURCE_USERNAME: "${SPRING_DATASOURCE_USERNAME}"
+      SPRING_DATASOURCE_PASSWORD: "${SPRING_DATASOURCE_PASSWORD}"
+      # Redis
+      SPRING_REDIS_HOST: "${CDS_HOST}"
+      SPRING_REDIS_PORT: "${CDS_REDIS_PORT}"
+      SPRING_REDIS_PASSWORD: "${SPRING_REDIS_PASSWORD}"
+      # MinIO 本地端点（使用 x-cds-env 里的凭证）
+      MINIO_ENDPOINT: "http://${CDS_HOST}:${CDS_MINIO_PORT}"
+      MINIO_ACCESS_KEY: "${MINIO_ACCESS_KEY}"
+      MINIO_SECRET_KEY: "${MINIO_SECRET_KEY}"
+      # JWT
+      JWT_SECRET: "${JWT_SECRET}"
+      # 前端预览地址（供后端生成邮件链接等）
+      TICKET_SPA_DETAIL_BASE_URL: "http://${CDS_HOST}"
+      # Maven 本地仓库缓存（加速 mvn 首次 build）
+      MAVEN_OPTS: "-Dmaven.repo.local=/root/.m2/repository"
+    labels:
+      cds.path-prefix: "/api/"
+
+  web:
+    image: node:20-slim
+    working_dir: /app
+    volumes:
+      - ./miduo-frontend:/app
+    ports:
+      - "5173"
+    command: >-
+      npm install &&
+      npm run dev
+    environment:
+      # Vite 代理：将 /api/* 转发到后端容器
+      VITE_USE_PROXY: "true"
+      VITE_API_PROXY_TARGET: "http://api:8080"
+      VITE_API_BASE_URL: "/api"
+    labels:
+      cds.path-prefix: "/"
+
+  # ── Infrastructure Services (无相对路径 mount) ──
+
+  mysql:
+    image: mysql:8.0
+    ports:
+      - "3306"
+    volumes:
+      - mysql-data:/var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: "${SPRING_DATASOURCE_PASSWORD}"
+      MYSQL_DATABASE: ticket_platform
+      MYSQL_CHARACTER_SET_SERVER: utf8mb4
+      MYSQL_COLLATION_SERVER: utf8mb4_unicode_ci
+    healthcheck:
+      test: mysqladmin ping -h localhost -u root -p$$MYSQL_ROOT_PASSWORD
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379"
+    volumes:
+      - redis-data:/data
+    command: >-
+      sh -c 'if [ -n "$$SPRING_REDIS_PASSWORD" ];
+      then redis-server --requirepass "$$SPRING_REDIS_PASSWORD";
+      else redis-server; fi'
+    healthcheck:
+      test: redis-cli ping
+      interval: 10s
+      retries: 3
+
+  minio:
+    image: minio/minio:latest
+    ports:
+      - "9000"
+      - "9001"
+    volumes:
+      - minio-data:/data
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: "${MINIO_ACCESS_KEY}"
+      MINIO_ROOT_PASSWORD: "${MINIO_SECRET_KEY}"
+
+volumes:
+  mysql-data:
+  redis-data:
+  minio-data:


### PR DESCRIPTION
## Summary

This PR addresses critical multi-project data isolation vulnerabilities in CDS where compose file discovery and git operations were scanning the shared CDS host directory (`config.repoRoot`) instead of project-specific repository roots. This allowed one project's configuration to contaminate another project's build profiles, infrastructure services, and environment variables.

## Key Changes

### Core Isolation Fixes
- **Compose file discovery**: Modified `/quickstart`, `/infra/discover`, and `/infra/quickstart` endpoints to scan `projectRepoRoot` instead of the shared `config.repoRoot`
- **Git operations**: Updated `/remote-branches` to use project-scoped repository root when `?project=` parameter is provided
- **Project repo validation**: Added guard in `POST /branches/:id/worktree` to prevent creating worktrees when a project has a custom `gitRepoUrl` but hasn't been cloned yet (G1.5 check)

### State Management & UI Fixes
- **Container capacity calculation**: Fixed `GET /branches` to count running containers across ALL projects (not just filtered branches) to accurately report cluster capacity
- **State stream filtering**: Scoped incoming branch updates to current project only in `initStateStream()` to prevent cross-project branch pollution in the dashboard
- **Project name caching**: Added `window._currentProjectName` to dynamically update quickstart banner hint with actual project name instead of ID
- **Pending env vars reporting**: Added `pendingEnvVars` field to quickstart response to auto-open env editor when compose file contains TODO placeholders

### Activity Tracking & Proxy Fixes
- **Access logging deduplication**: Added `accessLogged` flag in proxy to prevent double-emitting activity events when both error handler and finish handler fire
- **Upstream error tracking**: Emit 502 status immediately on upstream connection errors rather than relying on synthetic response status

### Documentation & Tooling
- Added comprehensive `doc/rule.cds-project-isolation-audit.md` documenting the incident, root causes, and permanent defense rules
- Added `mytapd-cds-compose.yml` example showing proper multi-service compose configuration with environment variable placeholders
- Updated `/export-skill` endpoint to bundle all CDS skills (cds, cds-deploy-pipeline, cds-project-scan) with fallback skill directory resolution

## Notable Implementation Details

- **De-duplication in compose discovery**: Added `seen` Set to prevent duplicate path processing when `projectRepoRoot` equals `config.repoRoot` (legacy projects)
- **Backward compatibility**: Maintained `?legacy=1` parameter support for `/export-skill` to export only cds-project-scan
- **Skills directory resolution**: Implemented fallback logic to check both `config.repoRoot/.claude/skills` and parent directory for skill files
- **Global env safeguards**: Documented rules preventing framework-specific keys (SPRING_*, DJANGO_*) from polluting global environment

## Testing Recommendations

- Verify compose file discovery in multi-project setups only finds files in the target project's repo
- Confirm container capacity badge accurately reflects total running containers across all projects
- Test that quickstart automatically opens env editor when compose file contains TODO placeholders
- Validate that git operations respect project-specific repository roots

https://claude.ai/code/session_01STXmxWJzwLwn6zkzv4j4Da

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multi-project isolation boundaries for compose discovery, infra quickstart, and git operations; mistakes could still allow cross-project contamination or break quickstart/infra flows. Also adjusts proxy access logging and capacity calculations, which can affect monitoring accuracy.
> 
> **Overview**
> Closes several **multi-project isolation** leaks by scoping compose discovery and infra scanning (`/quickstart`, `/infra/discover`, `/infra/quickstart`) to each project’s `getProjectRepoRoot(...)` rather than the shared `config.repoRoot`, and adds a guard preventing worktree creation when a project has `gitRepoUrl` but has never been cloned.
> 
> Improves correctness/UX around multi-project state: running container capacity is counted globally across all projects, the dashboard SSE branch updates are filtered to the current project, quickstart reports `pendingEnvVars` (TODO placeholders) to auto-open the env editor, and the quickstart banner can show the resolved project name.
> 
> Hardens ops tooling and monitoring: `/remote-branches` can run against a project-specific repo, `/export-skill` now bundles multiple CDS skills (with a fallback skills root search and legacy-only mode), and the proxy deduplicates access events while logging upstream failures as `502` immediately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03f59f52d5b6e2c38941e282ee22a0d42a26c6f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->