### PR TITLE
Fix prompt leakage in image generation messages and auth logout

### DIFF
--- a/changelogs/2026-04-22_fix-cookie-prompt-bugs.md
+++ b/changelogs/2026-04-22_fix-cookie-prompt-bugs.md
@@ -1,0 +1,3 @@
+| fix | prd-admin | 修复直接打开页面时网络波动导致误注销问题（App.tsx 仅在 UNAUTHORIZED 时注销，DISCONNECTED/SERVER_UNAVAILABLE 不再触发 logout） |
+| fix | prd-api | 修复生图消息记录中泄漏系统前缀的问题（ImageGenRunWorker 存储 [GEN_DONE]/[GEN_ERROR] 时统一剥离 "Generate an image based on the following description:" 前缀） |
+| fix | prd-api | 修复参考图风格提示词泄漏到消息记录的问题（ImageGenRunPlanItem 新增 DisplayPrompt 字段保存用户原始 prompt，ImageGenController 和 LiteraryAgentImageGenController 在追加风格提示词前先保存原始 prompt） |

--- a/prd-admin/src/app/App.tsx
+++ b/prd-admin/src/app/App.tsx
@@ -212,7 +212,12 @@ export default function App() {
     (async () => {
       const res = await getAdminAuthzMe();
       if (!res.success) {
-        logout();
+        // 仅 UNAUTHORIZED 才注销；网络中断/服务不可用不应导致注销
+        // apiClient 已在 401 响应时处理了 logout+跳转，这里只作兜底
+        const code = res.error?.code;
+        if (!code || code === 'UNAUTHORIZED') {
+          logout();
+        }
         return;
       }
       if (!permissionsLoaded) {

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ImageGenController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ImageGenController.cs
@@ -1474,10 +1474,12 @@ public class ImageGenController : ControllerBase
         }
 
         // 如果有参考图风格提示词，追加到每个 plan item 的 prompt 中
+        // DisplayPrompt 在追加前保存原始用户 prompt，避免系统提示词泄漏到消息记录
         if (!string.IsNullOrWhiteSpace(referenceImagePrompt) && initImageAssetSha256 != null)
         {
             for (var i = 0; i < plan.Count; i++)
             {
+                plan[i].DisplayPrompt = plan[i].Prompt;
                 plan[i].Prompt = $"{referenceImagePrompt}\n\n{plan[i].Prompt}";
             }
         }

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/LiteraryAgentImageGenController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/LiteraryAgentImageGenController.cs
@@ -193,10 +193,12 @@ public class LiteraryAgentImageGenController : ControllerBase
         }
 
         // 如果有参考图风格提示词，追加到每个 plan item 的 prompt 中
+        // DisplayPrompt 在追加前保存原始用户 prompt，避免系统提示词泄漏到消息记录
         if (!string.IsNullOrWhiteSpace(referenceImagePrompt) && initImageAssetSha256 != null)
         {
             for (var i = 0; i < plan.Count; i++)
             {
+                plan[i].DisplayPrompt = plan[i].Prompt;
                 plan[i].Prompt = $"{referenceImagePrompt}\n\n{plan[i].Prompt}";
             }
         }

--- a/prd-api/src/PrdAgent.Api/Services/ImageGenRunWorker.cs
+++ b/prd-api/src/PrdAgent.Api/Services/ImageGenRunWorker.cs
@@ -914,12 +914,18 @@ public class ImageGenRunWorker : BackgroundService
     }
 
     /// <summary>
-    /// 剥离前端追加的生图意图前缀，该前缀仅用于 LLM 调用，不应存入展示字段。
+    /// 剥离前端追加的生图意图前缀（支持循环剥除历史积累的多重前缀），
+    /// 该前缀仅用于 LLM 调用，不应存入展示字段。
     /// </summary>
     private static string StripImageGenPrefix(string prompt)
     {
         const string prefix = "Generate an image based on the following description:\n";
-        return prompt.StartsWith(prefix, StringComparison.Ordinal) ? prompt[prefix.Length..].Trim() : prompt;
+        var result = prompt;
+        while (result.StartsWith(prefix, StringComparison.Ordinal))
+        {
+            result = result[prefix.Length..].TrimStart('\n');
+        }
+        return result.Trim();
     }
 
     private static bool TryParseWxH(string? raw, out int w, out int h)

--- a/prd-api/src/PrdAgent.Api/Services/ImageGenRunWorker.cs
+++ b/prd-api/src/PrdAgent.Api/Services/ImageGenRunWorker.cs
@@ -236,11 +236,14 @@ public class ImageGenRunWorker : BackgroundService
             }
 
             var count = Math.Clamp(items[itemIndex].Count <= 0 ? 1 : items[itemIndex].Count, 1, 5);
+            // 用户可见的 prompt（不含系统前缀/风格提示词），用于消息记录和重试
+            var displayPrompt = items[itemIndex].DisplayPrompt?.Trim();
             for (var k = 0; k < count; k++)
             {
                 var curItemIndex = itemIndex;
                 var imageIndex = k;
                 var curPrompt = prompt;
+                var curDisplayPrompt = displayPrompt;
                 var reqSize = ResolveSize(run, items[itemIndex]);
 
                 tasks.Add(Task.Run(async () =>
@@ -433,7 +436,7 @@ public class ImageGenRunWorker : BackgroundService
                             await _db.ImageGenRuns.UpdateOneAsync(x => x.Id == run.Id, Builders<ImageGenRun>.Update.Inc(x => x.Failed, 1), cancellationToken: ct);
 
                             var guardGenType = "unresolved";
-                            var guardPayload = JsonSerializer.Serialize(new { msg = guardMsg, prompt = curPrompt, runId = run.Id, modelPool = run.ModelGroupName, genType = guardGenType }, JsonOptions);
+                            var guardPayload = JsonSerializer.Serialize(new { msg = guardMsg, prompt = curDisplayPrompt ?? StripImageGenPrefix(curPrompt), runId = run.Id, modelPool = run.ModelGroupName, genType = guardGenType }, JsonOptions);
                             var errMsgContent = $"[GEN_ERROR]{guardPayload}";
                             var errMsgId = await SaveWorkspaceMessageAsync(run.WorkspaceId ?? string.Empty, run.OwnerAdminId, "Assistant", errMsgContent, ct);
 
@@ -553,7 +556,7 @@ public class ImageGenRunWorker : BackgroundService
                             var errRefSrc = loadedImageRefs.FirstOrDefault()?.CosUrl;
                             var errImageRefShas = loadedImageRefs.Count > 0 ? loadedImageRefs.Select(r => r.Sha256).Where(s => !string.IsNullOrEmpty(s)).ToList() : null;
                             var errGenType = loadedImageRefs.Count > 1 ? "vision" : (loadedImageRefs.Count == 1 ? "img2img" : "text2img");
-                            var errMsgContent = $"[GEN_ERROR]{JsonSerializer.Serialize(new { msg, refSrc = errRefSrc, prompt = curPrompt, runId = run.Id, modelPool = run.ModelGroupName, genType = errGenType, imageRefShas = errImageRefShas }, JsonOptions)}";
+                            var errMsgContent = $"[GEN_ERROR]{JsonSerializer.Serialize(new { msg, refSrc = errRefSrc, prompt = curDisplayPrompt ?? StripImageGenPrefix(curPrompt), runId = run.Id, modelPool = run.ModelGroupName, genType = errGenType, imageRefShas = errImageRefShas }, JsonOptions)}";
 
                             // 失败时也记录 input images（方便日志排查参考图问题）
                             await PatchLogImagesAsync(run, curItemIndex, imageIndex, loadedImageRefs, null, ct);
@@ -612,7 +615,7 @@ public class ImageGenRunWorker : BackgroundService
                         var doneRefSrc = loadedImageRefs.FirstOrDefault()?.CosUrl;
                         var doneImageRefShas = loadedImageRefs.Count > 0 ? loadedImageRefs.Select(r => r.Sha256).Where(s => !string.IsNullOrEmpty(s)).ToList() : null;
                         var doneGenType = loadedImageRefs.Count > 1 ? "vision" : (loadedImageRefs.Count == 1 ? "img2img" : "text2img");
-                        var doneMsgContent = $"[GEN_DONE]{JsonSerializer.Serialize(new { src = url ?? string.Empty, refSrc = doneRefSrc, prompt = curPrompt, runId = run.Id, modelPool = run.ModelGroupName, genType = doneGenType, imageRefShas = doneImageRefShas }, JsonOptions)}";
+                        var doneMsgContent = $"[GEN_DONE]{JsonSerializer.Serialize(new { src = url ?? string.Empty, refSrc = doneRefSrc, prompt = curDisplayPrompt ?? StripImageGenPrefix(curPrompt), runId = run.Id, modelPool = run.ModelGroupName, genType = doneGenType, imageRefShas = doneImageRefShas }, JsonOptions)}";
                         var doneMsgId = await SaveWorkspaceMessageAsync(run.WorkspaceId ?? string.Empty, run.OwnerAdminId, "Assistant", doneMsgContent, ct);
 
                         // ===== 日志图片填充：input 来自前端 COS URL，output 来自生成结果 =====

--- a/prd-api/src/PrdAgent.Core/Models/ImageGenRun.cs
+++ b/prd-api/src/PrdAgent.Core/Models/ImageGenRun.cs
@@ -157,6 +157,11 @@ public class ImageGenRunPlanItem
     public string Prompt { get; set; } = string.Empty;
     public int Count { get; set; } = 1;
     public string? Size { get; set; }
+    /// <summary>
+    /// 用户可见的原始 prompt（不含系统前缀/风格提示词）。
+    /// 保存到消息时使用此字段，避免系统提示泄漏给用户。
+    /// </summary>
+    public string? DisplayPrompt { get; set; }
 }
 
 


### PR DESCRIPTION
## Summary
This PR addresses three related issues where system prompts and style hints were being exposed in user-facing message records, and fixes an overly aggressive logout behavior during network issues.

## Key Changes

### Backend - Image Generation Prompt Handling
- **Added `DisplayPrompt` field** to `ImageGenRunPlanItem` model to store the original user prompt before system prefixes and style hints are appended
- **Updated `ImageGenController` and `LiteraryAgentImageGenController`** to save the original prompt to `DisplayPrompt` before appending reference image style prompts
- **Modified `ImageGenRunWorker`** to use `DisplayPrompt` (or stripped version of full prompt) when recording generation results in `[GEN_DONE]` and `[GEN_ERROR]` messages, preventing system prompts from leaking to users
- **Enhanced `StripImageGenPrefix` method** to handle multiple accumulated prefixes through looping, ensuring complete removal of the "Generate an image based on the following description:" prefix

### Frontend - Authentication Logout Logic
- **Fixed overly aggressive logout** in `App.tsx` to only trigger logout on `UNAUTHORIZED` errors, not on network disconnection or server unavailability errors
- Added clarifying comments that the apiClient already handles 401 responses with logout+redirect, making this a fallback measure

## Implementation Details
- The `DisplayPrompt` field is populated before any system prompts are appended, ensuring it captures the pure user input
- The `StripImageGenPrefix` method now uses a while loop to handle edge cases where the prefix might be duplicated
- The logout logic now checks the error code explicitly, preventing false logouts during transient network issues

https://claude.ai/code/session_01KrUCmJw7touz3zQNebAQkY

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how image-generation prompts are persisted in `[GEN_DONE]/[GEN_ERROR]` messages and adjusts logout behavior on auth refresh failures, which could affect user-visible history and session handling.
> 
> **Overview**
> Fixes two user-facing regressions around **auth stability** and **image-generation message privacy**.
> 
> In `prd-admin`, the auth refresh flow in `App.tsx` now logs out **only** when the `getAdminAuthzMe` failure is `UNAUTHORIZED`, avoiding false logouts on network disconnect/service unavailable cases.
> 
> In `prd-api`, image-generation runs now preserve a separate `DisplayPrompt` (added to `ImageGenRunPlanItem`) before reference-image style hints are appended, and `ImageGenRunWorker` uses `DisplayPrompt` (or a strengthened `StripImageGenPrefix` that strips repeated prefixes) when writing `[GEN_DONE]`/`[GEN_ERROR]` workspace messages to prevent leaking system/style prompt content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa0ef4d1d4f6054e20048cd01b9858f789bb9b35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->