### PR TITLE
Fix model resolution to respect user-selected models and add adaptive model support

### DIFF
--- a/.claude/rules/compute-then-send.md
+++ b/.claude/rules/compute-then-send.md
@@ -1,0 +1,150 @@
+---
+globs: ["prd-api/src/**/*.cs"]
+---
+
+# 外部调用必须分"算/发"两阶段（Compute-then-Send）
+
+外部调用（LLM / 图片生成 / 视频生成 / 第三方 API）必须把**计算阶段**（决定用哪个模型、哪个平台、哪条 URL）和**发送阶段**（真正发 HTTP 并处理响应）拆成两个独立步骤。**发送阶段不得在内部"再算一次"**。
+
+---
+
+## 为什么（整日排查的血泪）
+
+2026-04-23 视觉创作"选 A 给 B"bug 排查一整天的根因：
+
+```
+调用链                              结果
+┌─────────────────────────────────────────────────────────────────┐
+│ Controller: run.ModelId = "stub-image" (用户选的)                │
+│      ↓                                                           │
+│ Worker → OpenAIImageClient.GenerateAsync                         │
+│   第1次: gateway.ResolveModelAsync(..., modelName="stub-image")  │
+│          → 返回 stub-image ✓                                     │
+│          effectiveModelName = "stub-image"                       │
+│          reqBody.model = "stub-image" ✓                          │
+│      ↓                                                           │
+│   调 gateway.SendRawAsync(req)                                   │
+│      ↓                                                           │
+│     【LlmGateway.SendRawAsync 内部第2次 Resolve】                 │
+│   第2次: _modelResolver.ResolveAsync(..., null) ← 硬编码 null    │
+│          → 返回第一个池的模型 = "gpt-image-2-all"                │
+│      ↓                                                           │
+│     requestBody["model"] = resolution.ActualModel  ← 覆盖！       │
+│          实际上游 body.model = "gpt-image-2-all" ✗               │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**同一个"选模型"的逻辑跑了两次，第二次把第一次的结果覆盖了**。为打这个补丁，花了一天试了 8 轮修复（Round 1-5 改 Infrastructure 不生效 → Round 6 Controller 预设 DirectModel → Round 7 DI 装饰器拦截第 1 次 → Round 8 AsyncLocal/实例字段尝试跨"兄弟 await"共享 expectedModel 给第 2 次），全都是在绕这个"内部二次 resolve"。
+
+**真正的问题不是 resolve 写错了，是根本不该在 send 阶段再 resolve**。
+
+---
+
+## 强制规则
+
+### 1. 发送阶段接收"已解析结果"，不得再调 resolver
+
+**❌ 错误写法**（当前 `LlmGateway.SendRawAsync`）
+
+```csharp
+public async Task<GatewayRawResponse> SendRawAsync(GatewayRawRequest request, CancellationToken ct)
+{
+    // ⚠ 违反分层：在发送阶段又调了一次 resolve
+    var resolution = await _modelResolver.ResolveAsync(
+        request.AppCallerCode, request.ModelType, null, ct);
+
+    requestBody["model"] = resolution.ActualModel;  // 覆盖调用方已算好的
+    ...
+}
+```
+
+**✅ 正确写法**
+
+```csharp
+// 计算阶段：独立，纯函数，可测
+var resolved = await _modelResolver.ResolveAsync(
+    appCallerCode, modelType, expectedModel: userPicked, ct);
+
+// 发送阶段：只接收已解析结果，不再查任何东西
+var response = await _gateway.SendWithResolvedAsync(new GatewayRawRequest
+{
+    Resolved = resolved,      // ← 已算好，直接用
+    RequestBody = body,
+    ...
+}, ct);
+```
+
+### 2. 签名里带 "expectedModel" / "modelName" 的函数禁止再做模型选择
+
+如果函数签名已经有 `modelName` 参数（= 调用方明确指定要用的模型），**不得**在内部调 `ResolveModelAsync`、`SelectBestModel`、"池默认选择"等逻辑。调用方传了就直接用，最多做"healthy 探活 + 查平台 API URL"。
+
+**适用方法**：`OpenAIImageClient.GenerateAsync(..., modelName)` / `LlmGateway.SendStreamAsync` / 任何名字里出现 `modelName` / `model` / `modelId` 的下游发送函数。
+
+### 3. 同一次 HTTP/业务请求，resolver 最多被调用一次
+
+用 scope 级 DI 或 `LlmRequestContext` 里的字段记录"本次请求的解析结果"。之后所有读取都从这个已缓存的结果拿，不重复解析。
+
+**判断准则**：如果某条调用链里 `IModelResolver.ResolveAsync` 会被调两次以上，立即重构 —— 要么合并，要么把第二次改成"读缓存"。
+
+### 4. 禁止用 DI 装饰器 / AsyncLocal / 实例字段 "跨兄弟调用"传递状态
+
+这些都是在"内部二次 resolve"这个反模式上打补丁，**越补越脆**：
+- DI 装饰器：每次 DI 改动都可能绕过
+- AsyncLocal：ExecutionContext 在 await 前 capture，被调用方写入不会回传给调用方的 continuation（兄弟调用场景直接失效）
+- Scoped 实例字段：依赖 "两次调用在同一 scope 内命中同一实例"，遇到 `_scopeFactory.CreateScope()` 新建 scope / Transient 服务就断
+
+**正确的做法不是"让兄弟调用看见彼此的 state"，而是"让发送阶段只接收参数，压根不需要 state"**。
+
+### 5. 所有外部调用类必须暴露"纯计算"入口供单元测试
+
+```csharp
+public interface IImageGenResolver         // 纯计算，可在单测 mock DB
+{
+    Task<ImageGenResolution> ResolveAsync(ImageGenRequest req, CancellationToken ct);
+}
+
+public interface IImageGenSender            // 只发 HTTP，参数全从 Resolution 取
+{
+    Task<ImageGenResponse> SendAsync(ImageGenResolution resolved, ImageGenRequestBody body, CancellationToken ct);
+}
+```
+
+上层业务：
+```csharp
+var resolved = await resolver.ResolveAsync(req, ct);
+if (resolved.NeedsUserConfirmation) { /* 弹窗询问 */ return; }
+var resp = await sender.SendAsync(resolved, body, ct);
+```
+
+测试：
+- `ResolveAsync` 单测：mock `MongoDbContext`，断言 Tier1/2/3 匹配、Unavailable 降级等逻辑
+- `SendAsync` 单测：mock `HttpClient`，断言 URL / headers / body.model 字段
+- 彻底脱钩，不需要跑 Docker/CDS 就能验证整个调度
+
+---
+
+## 审计清单（改 `LlmGateway.SendRawAsync` / `OpenAIImageClient.GenerateAsync` / 新加 LLM 调用类时）
+
+- [ ] 同一逻辑请求中，`IModelResolver.ResolveAsync` 只被调一次
+- [ ] 如果函数签名有 `modelName` / `expectedModel`，函数内不得再 resolve
+- [ ] 发送阶段拿到的 `model` / `platformId` / `apiUrl` 全部来自一个 `Resolution` 对象
+- [ ] 有纯"计算"入口（不发 HTTP、不写 DB 业务状态）可供单测
+- [ ] 没有用 DI 装饰器 / AsyncLocal / 实例字段 跨调用链传递 expectedModel
+
+---
+
+## 当前仓库的债务（待偿还）
+
+| 文件 | 债务 | 偿还方向 |
+|------|------|----------|
+| `prd-api/src/PrdAgent.Infrastructure/LlmGateway/LlmGateway.cs` SendRawAsync / SendStreamAsync | 内部二次 `_modelResolver.ResolveAsync(..., null)` 覆盖 body.model | 增加 `SendWithResolvedAsync(Resolution resolved, body)` 重载，旧方法 `[Obsolete]` |
+| `prd-api/src/PrdAgent.Infrastructure/LLM/OpenAIImageClient.cs` GenerateAsync | Line 165 先 resolve，随后调 SendRawAsync 再被 resolve 一次 | 改为调 `SendWithResolvedAsync`，传入已 resolve 的结果 |
+| `prd-api/src/PrdAgent.Api/Services/ExpectedModelRespectingResolver.cs` | 整个类都是"二次 resolve"反模式的补丁 | 重构完成后删除整个文件 |
+| `prd-api/src/PrdAgent.Api/Controllers/Api/ResolverDebugController.cs` 的 test-chain / simulate-worker | 这两个端点存在意义就是因为反模式的存在 | 可保留 inspect / test，删除 test-chain / simulate-worker |
+
+---
+
+## 相关
+
+- `.claude/skills/llm-call-trace/SKILL.md` — 大模型调用链路排查 skill（从这次的血泪经验总结）
+- 对应详细设计：`doc/design.compute-then-send.md`（待补）

--- a/.claude/skills/llm-call-trace/SKILL.md
+++ b/.claude/skills/llm-call-trace/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: llm-call-trace
+description: 排查大模型调用链路问题的方法论。当出现"前端选 A 后端跑 B"、"LLM 日志 model 字段不对"、"自定义模型调度被忽略"类 bug 时触发。强制走"捕获前端真实请求 → DB 真实状态 → 每层 resolve 调用审计 → 对比 LLM 日志实际 body.model"的顺序，禁止靠 DI 装饰器/AsyncLocal 打补丁。触发词："/llm-trace", "模型调用不对", "LLM 日志不符", "选 A 给 B", "trace model".
+---
+
+# LLM Call Trace — 大模型调用链路排查
+
+当用户报告"模型被换了"、"前端选 X 但日志显示 Y"、"自定义模型调度不生效"类 bug，**必须**按本 skill 顺序执行，禁止凭直觉加补丁。
+
+---
+
+## 核心原则（这次血泪来的）
+
+1. **不看装饰器，看 LLM 日志的 `Model` 字段** —— 这是真实上游 body.model，是验证的终极 ground truth。
+2. **前端请求 body 从 `apirequestlogs` 集合读**，不要猜。
+3. **"多次 resolve 互相覆盖"才是真正问题**，不是哪一次 resolve 写错了。
+4. **禁止用 DI 装饰器 / AsyncLocal / 实例字段 跨兄弟调用传递 state**。这是补丁，不是修复（见 `.claude/rules/compute-then-send.md`）。
+
+---
+
+## 触发条件
+
+- 用户说 "/llm-trace"、"模型调用不对"、"LLM 日志不符"、"选 A 给 B"
+- 业务截图/日志显示"用户期望模型"和"LLM 日志 Model 字段"不一致
+- 涉及 `IModelResolver` / `ILlmGateway.SendRawAsync` / `ILlmGateway.SendStreamAsync` / `OpenAIImageClient` 等路径
+
+---
+
+## 强制执行顺序（缺一步都会走弯路）
+
+### Step 1. 冻结现场：记下"前端声称选了什么、LLM 日志记了什么"
+
+从截图/日志抓：
+- 前端 UI 显示的"用户期望"（通常是 picker 选的 model 名）
+- LLM 调用日志页面的 `Model` 列 + `专属模型池` 列
+- `requestId` 前 8 位
+
+**不要急着修代码**。写在笔记里：`期望=X, 实际=Y, requestId=xxx`。
+
+### Step 2. 读前端发送的**真实请求 body**（不是猜的）
+
+用 MongoDB / CDS 查 `apirequestlogs` 集合：
+
+```javascript
+db.apirequestlogs.find({
+  Path: /image-gen.runs$/
+}).sort({StartedAt: -1}).limit(5)
+```
+
+重点看 body JSON 里的字段：
+- `modelId` / `configModelId` / `platformId` ← 前端实际发了什么？
+- `userMessageContent` 里的 `(@model:xxx)` token ← 仅展示用，不影响后端
+
+**判断**：如果前端发的 `modelId` 就是错的，那是前端 bug；如果前端发对了，问题在后端。
+
+### Step 3. 读 `image_gen_runs` / 等价 run 记录在 DB 里的真实状态
+
+```javascript
+db.image_gen_runs.find({WorkspaceId: "xxx"})
+  .sort({CreatedAt: -1}).limit(3)
+```
+
+关注 `ModelId`、`PlatformId`、`ModelResolutionType`、`ModelGroupName`。
+
+判断：
+- `run.ModelId == 前端发送的 modelId` → Controller 层无覆盖
+- `run.ModelId != 前端发送的 modelId` → Controller 或 Worker 某处覆盖了，找修改点
+- `ModelResolutionType=2 (DedicatedPool)` 且 `ModelId` 被改 → Worker `ResolveModelGroupAsync` 覆盖
+- `ModelResolutionType=0 (DirectModel)` 但 LLM 日志里 Model 被改 → **问题在下游 SendRawAsync / SendStreamAsync 的二次 resolve**（这次血泪的根因）
+
+### Step 4. 审计 resolve 调用次数
+
+全文 grep：
+```bash
+grep -rn "_modelResolver.ResolveAsync\|_gateway.ResolveModelAsync\|IModelResolver.*ResolveAsync" prd-api/src/
+```
+
+对每条调用链（Controller → Worker → Client → Gateway → upstream HTTP），数一下"同一逻辑请求中 resolve 被调几次"：
+- **== 1 次**：✓ 符合 `compute-then-send.md` 规则
+- **>= 2 次**：✗ **根因在这里**。不要去给第二次、第三次打补丁，而是合并成一次
+
+### Step 5. 在独立端点里验证匹配算法本身对不对（离线、可重复）
+
+本仓库已有的调试端点（位于 `prd-api/src/PrdAgent.Api/Controllers/Api/ResolverDebugController.cs`）：
+
+```bash
+# 查 AppCaller 绑定池
+curl -H "X-AI-Access-Key: $AI_ACCESS_KEY" \
+  "$BASE/api/debug/resolver/inspect?appCallerCode=visual-agent.image.text2img::generation"
+
+# 单次 Tier 匹配测试
+curl -H "X-AI-Access-Key: $AI_ACCESS_KEY" -H "Content-Type: application/json" \
+  -X POST "$BASE/api/debug/resolver/test" \
+  -d '{"appCallerCode":"...","expectedModel":"stub-image"}'
+```
+
+**如果 `/test` 返回的 `actualModel` 是对的，但真实请求的 LLM 日志 `Model` 还是错的 → 100% 是下游二次 resolve 覆盖了**。
+
+### Step 6. 判定根因类型（对号入座）
+
+| 症状 | 根因 | 不要做 | 要做 |
+|------|------|------|------|
+| run.ModelId 就错了 | Controller/Worker 覆盖 | 不要在 OpenAIImageClient 层拦截 | 修 Controller/Worker 的覆盖点 |
+| run.ModelId 对但 LLM 日志错 | 下游 SendRawAsync 二次 resolve | 不要加 DI 装饰器、AsyncLocal 等补丁 | 把 send 函数改为接收已 resolve 结果 |
+| Tier 匹配本身错 | `FindPreferredModel` 逻辑或数据问题 | 不要加归一化匹配兜底 | 修 `FindPreferredModel` / 修 DB 里 pool.Code |
+| Unavailable 池被跳过换了另一个 | scheduler 的健康降级 | 不要偷偷换 | 返回失败让前端询问用户（参考 smart fallback 开关）|
+
+### Step 7. 单元测试前置（修完以后）
+
+```csharp
+// 验证 resolve 计算层
+[Fact]
+public async Task ResolveAsync_ExpectedModel_Hits_Tier3_When_Pool_Code_Matches()
+{
+    var resolver = new ModelResolver(mockDb, mockConfig, mockLogger);
+    var result = await resolver.ResolveAsync("visual-agent.image.text2img::generation", "generation", "gpt-image-1-5");
+    Assert.Equal("gpt-image-1.5", result.ActualModel);
+}
+
+// 验证 send 层不会再次 resolve
+[Fact]
+public async Task SendAsync_DoesNotCallResolver()
+{
+    var mockResolver = new Mock<IModelResolver>();
+    var sender = new ImageGenSender(mockHttp, ...);
+    await sender.SendAsync(preResolved, body, CancellationToken.None);
+    mockResolver.Verify(x => x.ResolveAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+        Times.Never);  // ← 发送函数不能内部 resolve
+}
+```
+
+**上线前必须有这两类单测**。没有就说明你还是走在"打补丁"的老路上。
+
+---
+
+## 反面案例（本 skill 的来源）
+
+2026-04-23 "选 stub-image 给 gpt-image-2-all" bug，花一整天、8 轮修复，**其中 5 轮 (Round 1-5) 完全无效**（CDS 部署层缓存 + 改错层），剩余 3 轮（Round 6-8）都是"给内部二次 resolve 打补丁"的 DI 装饰器方案。
+
+全部走错的真正原因：**没有先按本 skill 的 Step 1-4 顺序追根因，而是凭直觉在猜**。一旦按 Step 4 审计到"SendRawAsync 内部 Line 561 的硬编码 null 二次 resolve"，修复方向就清楚了——不是加补丁，是消除第二次 resolve。
+
+---
+
+## 一句话总结
+
+> **别靠补丁在 state 传递上较劲。分两阶段写代码（算一次 + 发一次），从源头避免"互相覆盖"。**
+
+详细规则 → `.claude/rules/compute-then-send.md`
+
+---
+
+## 相关
+
+- `.claude/rules/compute-then-send.md` — 强制规则
+- `prd-api/src/PrdAgent.Api/Controllers/Api/ResolverDebugController.cs` — inspect / test 两个调试端点（test-chain / simulate-worker / trigger-real-gen 是反模式时代的产物，等重构完成后删除）
+- `.claude/skills/deep-trace` — 跨层数据流追踪，本 skill 专注 LLM 调用链的子集

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,6 +229,7 @@ cd prd-api && dotnet build --no-restore 2>&1 | grep -E "error CS|warning CS" | h
 | `cds-first-verification.md` | 任何可执行代码改动 (`.cs`, `.ts`, `.tsx`, `.rs`, Dockerfile) | 本地无 SDK ≠ 无法验证：必须用 `/cds-deploy` 兜底，禁止把验证负担转嫁给用户 |
 | `cds-auto-deploy.md` | 已 link GitHub 的项目交付收尾 | push 即部署 — 不再提示用户手动跑 `/cds-deploy-pipeline`；CDS 通过 webhook 自动建分支 + 构建 + 部署；UI 开着时必须有"分支出现 + 构建中"动画 |
 | `gesture-unification.md` | 任何可平移/缩放的 2D 画布（ReactFlow / 自定义 DOM canvas / Konva 等） | 手势统一：两指拖动=平移、双指捏合或 ⌘/Ctrl+滚轮=缩放、禁止双击缩放；提供 ReactFlow + 自定义 canvas 两套标准配置 |
+| `compute-then-send.md` | `prd-api/src/**/*.cs` 里 LLM / 外部 API 调用类（ILlmGateway / OpenAIImageClient 等） | 外部调用必须分"算/发"两阶段：发送阶段接收已解析结果不得再 resolve；禁止用 DI 装饰器 / AsyncLocal / 实例字段 在兄弟调用间传递 state |
 
 ---
 
@@ -266,6 +267,7 @@ cd prd-api && dotnet build --no-restore 2>&1 | grep -E "error CS|warning CS" | h
 | **code-hygiene** | `/hygiene` | 输入代码变更 → 检测死代码/兼容垫片/命名残留/冗余参数等 10 类技术债，输出清理建议 |
 | **deep-trace** | `/deep-trace` | 输入代码变更 → 跨层（C#→JSON→Rust→React）验证字段名、类型、序列化、空值处理的正确性 |
 | **llm-visibility** | `/visibility` | 输入代码变更 → 扫描所有 LLM 调用点，检查是否符合「禁止空白等待」原则，输出合规报告 |
+| **llm-call-trace** | `/llm-trace` | 前端选 A 后端跑 B / LLM 日志 model 不对时 → 按"前端 body → DB run → resolve 调用次数审计 → LLM 日志 Model"的顺序定位，避免凭直觉打补丁（本仓库血泪技能） |
 | **feature-emerge** | `/emerge` | 输入任意模块/痛点 → 扫描该模块能力 + 全局横向能力（Gateway / Bridge / Run-Worker / Attachment）→ 四层发散（基线/差异化/智力/疯狂）→ 收敛推荐波次。通用涌现，不限文档 |
 | **cn-brief-summary** | `200字总结` | 无需输入 → 在回复末尾自动追加 ≤200 字中文通俗总结 |
 | **dev-completion-report** | `/dev-report` | 开发完成后 → 输出三段式报告：200 字总结 + 总结清单（改动/风险/测试/验收）+ 行业对比分析 |

--- a/changelogs/2026-04-22_image-model-respect-and-adaptive.md
+++ b/changelogs/2026-04-22_image-model-respect-and-adaptive.md
@@ -1,0 +1,6 @@
+| fix | prd-api | ModelResolver 在 expectedModel 命中候选池时优先尊重前端指定的模型，避免 DedicatedPool 静默换模型 |
+| feat | prd-api | 新增「自适应模型」适配类型 SizeConstraintTypes.Adaptive + SizeParamFormats.None：尺寸由 prompt 决定，请求体不注入 size/n/quality/aspect_ratio |
+| feat | prd-api | 注册 gpt-image-2-all（自适应）、gpt-image-1.5（标准 size 白名单）、nano-banana-2（aspectRatio 驼峰参数）三个新生图模型适配 |
+| feat | prd-api | ImageGenRunWorker SSE runStart / imageDone 事件加上实际调度结果（modelId、modelGroupName、isAdaptive、resolutionType），前端可用此覆盖原本"前端选中的模型"展示 |
+| feat | prd-admin | 视觉创作生图卡片显示后端实际使用的模型（来自 SSE），不再误显示前端 picker 选中的模型；自适应模型尺寸标签显示"自适应"而非"1K · 1:1" |
+| feat | prd-admin | 模型适配信息（getVisualAgentAdapterInfo / getModelAdapterInfo*）返回 isAdaptive 字段，组合面板的尺寸 chip 在自适应模型下展示"自适应" |

--- a/changelogs/2026-04-22_image-model-respect-round2.md
+++ b/changelogs/2026-04-22_image-model-respect-round2.md
@@ -1,0 +1,2 @@
+| fix | prd-api | ModelResolver 尊重 expectedModel 的搜索范围扩大：候选池未命中时继续在同类型所有池 + LLMModels 直连里查找，避免"用户选的模型不在 AppCaller 绑定池"时被静默换成池默认项 |
+| fix | prd-admin | 自适应模型（gpt-image-2-all 等）下 composer 两处尺寸 chip 改为静态展示，不再打开会暴露无关尺寸选项的 popover，消除"自适应但弹出 1:1/16:9 选项"的矛盾感 |

--- a/changelogs/2026-04-22_image-model-respect-round3.md
+++ b/changelogs/2026-04-22_image-model-respect-round3.md
@@ -1,0 +1,1 @@
+| fix | prd-api | ImageGenRunWorker.ResolveModelGroupAsync 新增"用户显式选择优先"短路：当 run.ModelId + run.PlatformId 都有值（Controller 已强校验必须提供），直接标 DirectModel 并跳过 scheduler，仅旁路查出该模型所属池名用于展示。彻底根治"picker 选了 gpt-image-1.5，后台被 scheduler 换成 gpt-image-2-all"的问题——前端 picker 里能选的必然能用，能用就不该再"尝试匹配" |

--- a/changelogs/2026-04-22_image-model-respect-round4.md
+++ b/changelogs/2026-04-22_image-model-respect-round4.md
@@ -1,0 +1,2 @@
+| fix | prd-api | 撤回 round3 的"跳过 scheduler"短路。零信任原则下 scheduler 是防御验证层不能省略。真正根因修在匹配本身——picker 发送 pool Code 作 modelId（如 "gpt-image-1-5" 带横线），旧匹配在"池所有模型被标 Unavailable"时整池跳过→回落到第一个池；另外 "gpt-image-1-5" vs "gpt-image-1.5" 命名差异也需兜底 |
+| feat | prd-api | FindPreferredModel 增强：新增 Tier4 归一化匹配（去点/横线/下划线后比较），同档位池命中时不再因"模型 Unavailable"整池跳过（尊重"能选就代表能用"原则，真实请求失败时再让上游降级）；每档写详细 info/warn 日志便于未来定位命名不一致问题 |

--- a/changelogs/2026-04-22_image-model-respect-round5.md
+++ b/changelogs/2026-04-22_image-model-respect-round5.md
@@ -1,0 +1,3 @@
+| fix | prd-api | FindPreferredModel 撤回 Tier4 归一化匹配（命名由系统自动填充不会漂移，无需兜底）；Tier3 恢复严格健康守门，池内全部 Unavailable 时返回 null，让前端做明确的用户引导 |
+| feat | prd-admin | 视觉创作新增"智能切换"偏好（默认开启，sessionStorage 持久化）：picker 里选的模型被判为不可用时前端弹窗三选一（切换到可用模型/仍使用原模型/取消），禁止后端静默换模型；关闭开关进入严格模式，直接按用户选择发送不弹窗 |
+| feat | prd-admin | 用户消息气泡下方新增「用户期望：xxx」紫色徽标，来自 @model token，让用户发送后直观看到自己期望使用的模型 |

--- a/changelogs/2026-04-22_image-model-respect-round6-controller-fix.md
+++ b/changelogs/2026-04-22_image-model-respect-round6-controller-fix.md
@@ -1,0 +1,2 @@
+| fix | prd-api | ImageMasterController / ImageGenController 创建 run 时立即标 ModelResolutionType=DirectModel，让 Worker.ResolveModelGroupAsync 走早返回分支，不再调用 scheduler 覆盖用户显式选择的 modelId。这是 round1-5 的最终落脚点：Controller 层尊重用户选择，彻底断绝 DedicatedPool scheduler 把 picker 选择换成 candidateGroups[0] 的行为（即之前用户看到的"选 gpt-image-1.5 给 gpt-image-2-all"问题） |
+| chore | prd-api | ModelResolver.cs 撤回诊断代码（_diag_resolver 集合写入 + DIAG-* LogError），恢复 round5 的干净实现 |

--- a/changelogs/2026-04-22_image-model-respect-round7-decorator.md
+++ b/changelogs/2026-04-22_image-model-respect-round7-decorator.md
@@ -1,0 +1,3 @@
+| fix | prd-api | 新增 ExpectedModelRespectingResolver 装饰器（Api.dll，能正常部署），包裹 Infrastructure.dll 里"改了无法生效"的 ModelResolver。所有 ResolveAsync 调用先在 Api 层做 Tier1/2/3 匹配（精确 ModelId → 前缀 → 池名/Code），命中就返回 FromPool，未命中才委派内部老 resolver。解决 Round 6 遗留的"OpenAIImageClient 内部调度仍然换模型"问题 |
+| feat | prd-api | 新增 /api/debug/resolver/test 调试端点：不跑生图，直接接收 {appCallerCode, modelType, expectedModel}，返回候选池快照 + 每档匹配过程 + 实际 resolver 返回值。让"选 A 给 B"问题可独立、快速、反复测试，不用每次都跑真实生图 |
+| feat | prd-api | 配套 /api/debug/resolver/inspect 只读端点：列出某 AppCaller 的绑定池、健康状态、模型列表（健康状态整数值也一并返回便于排查） |

--- a/prd-admin/src/pages/ai-chat/AdvancedVisualAgentTab.tsx
+++ b/prd-admin/src/pages/ai-chat/AdvancedVisualAgentTab.tsx
@@ -106,6 +106,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, typ
 import { useAuthStore } from '@/stores/authStore';
 import { useLayoutStore } from '@/stores/layoutStore';
 import { useGlobalDefectStore } from '@/stores/globalDefectStore';
+import { useVisualAgentPrefsStore } from '@/stores/visualAgentPrefsStore';
 
 import { MessageContentRenderer } from './components/MessageContentRenderer';
 import { ChatMessageItem } from './components/ChatMessageItem';
@@ -1102,6 +1103,16 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
   const [modelPrefAuto, setModelPrefAuto] = useState(true);
   const [modelPrefModelId, setModelPrefModelId] = useState<string>('');
   const [modelPrefReady, setModelPrefReady] = useState(false);
+  // 用户偏好：智能切换（遇到不可用模型时是否弹窗询问）；默认 true，关闭则进入严格模式
+  const smartModelFallback = useVisualAgentPrefsStore((s) => s.smartModelFallback);
+  const setSmartModelFallback = useVisualAgentPrefsStore((s) => s.setSmartModelFallback);
+  // 模型切换确认对话框
+  type FallbackPrompt = {
+    original: { id: string; label: string };
+    suggestion: { id: string; label: string } | null;
+    resolve: (choice: 'switch' | 'keep' | 'cancel') => void;
+  };
+  const [fallbackPrompt, setFallbackPrompt] = useState<FallbackPrompt | null>(null);
   const modelPrefSaveRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [sizeSelectorOpen, setSizeSelectorOpen] = useState(false);
   const sizeSelectorRef = useRef<HTMLDivElement>(null);
@@ -3445,12 +3456,36 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
     const forcedPick = extractForcedImageModel(directPrompt ? displayText : requestText);
     const reqText = String(forcedPick.clean ?? '').trim();
     if (!reqText) return;
-    const pickedModel = forcedPick.forced ?? effectiveModel;
+    let pickedModel = forcedPick.forced ?? effectiveModel;
     if (!pickedModel) {
       const msg = modelsLoading ? '模型加载中' : '暂无可用生图模型（请配置 image-gen 模型池或启用 isImageGen 模型）';
       setError(msg);
       pushMsg('Assistant', '暂无可用生图模型（请配置 image-gen 模型池或启用 isImageGen 模型）');
       return;
+    }
+
+    // ===== 发送前健康预检（非严格模式才检查）=====
+    // 原则："picker 能选就代表可用"被 healthStatus 动态打破时，由前端明确询问用户，
+    // 避免后端静默切换造成"选 A 给 B"的黑盒体验。严格模式下跳过该预检。
+    if (smartModelFallback && !pickedModel.enabled) {
+      const suggestion = allImageGenModels.find((x) => x.enabled && x.id !== pickedModel!.id) ?? null;
+      const originalLabel = pickedModel.name || pickedModel.modelName || '当前模型';
+      const suggestionLabel = suggestion ? (suggestion.name || suggestion.modelName || '') : '';
+      const choice = await new Promise<'switch' | 'keep' | 'cancel'>((resolve) => {
+        setFallbackPrompt({
+          original: { id: pickedModel!.id, label: originalLabel },
+          suggestion: suggestion ? { id: suggestion.id, label: suggestionLabel } : null,
+          resolve,
+        });
+      });
+      setFallbackPrompt(null);
+      if (choice === 'cancel') return;
+      if (choice === 'switch' && suggestion) {
+        pickedModel = suggestion;
+        setModelPrefAuto(false);
+        setModelPrefModelId(suggestion.id);
+      }
+      // 'keep' → 保留原选择继续
     }
 
     setError('');
@@ -6732,6 +6767,48 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
                               return '绘图模型';
                             })()}
                           </div>
+
+                          {/* 智能切换开关：遇到不可用模型时，默认会弹窗询问是否切换；关闭后进入严格模式，直接按用户选择发送 */}
+                          <div
+                            className="flex items-center justify-between gap-2 px-2 py-1.5 mx-1 mb-1 rounded-[10px]"
+                            style={{ background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.06)' }}
+                          >
+                            <div className="min-w-0 flex-1">
+                              <div className="text-[11px] font-medium" style={{ color: 'var(--text-primary)' }}>
+                                智能切换
+                              </div>
+                              <div className="text-[10px] mt-0.5" style={{ color: 'var(--text-muted, rgba(255,255,255,0.45))' }}>
+                                {smartModelFallback
+                                  ? '发送前若当前模型不可用，会询问是否切换到其他可用模型'
+                                  : '严格模式：直接使用你选的模型，不做任何切换/提示'}
+                              </div>
+                            </div>
+                            <button
+                              type="button"
+                              role="switch"
+                              aria-checked={smartModelFallback}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setSmartModelFallback(!smartModelFallback);
+                              }}
+                              className="shrink-0 relative inline-flex items-center rounded-full transition-colors"
+                              style={{
+                                width: 32,
+                                height: 18,
+                                background: smartModelFallback ? 'rgba(129, 140, 248, 0.7)' : 'rgba(255,255,255,0.15)',
+                              }}
+                              title={smartModelFallback ? '关闭后进入严格模式' : '打开后遇到不可用模型会询问切换'}
+                            >
+                              <span
+                                className="absolute top-0.5 rounded-full bg-white transition-transform"
+                                style={{
+                                  width: 14,
+                                  height: 14,
+                                  transform: smartModelFallback ? 'translateX(15px)' : 'translateX(2px)',
+                                }}
+                              />
+                            </button>
+                          </div>
                           <div className="max-h-[320px] overflow-auto p-1">
                             {allImageGenModels
                               .slice()
@@ -8597,6 +8674,49 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
           </div>
         </div>
       ) : null}
+
+      {/* 模型不可用 · 切换确认对话框（智能切换开启时出现；严格模式下不会到这里） */}
+      <Dialog
+        open={fallbackPrompt !== null}
+        onOpenChange={(open) => {
+          if (!open && fallbackPrompt) {
+            // 对话框被关闭（蒙版/ESC）→ 视为取消
+            fallbackPrompt.resolve('cancel');
+          }
+        }}
+        title="当前模型不可用"
+        maxWidth={460}
+        content={
+          fallbackPrompt ? (
+            <div className="flex flex-col gap-3">
+              <div className="text-[13px]" style={{ color: 'var(--text-primary)' }}>
+                你选择的 <span className="font-semibold" style={{ color: 'rgba(165,180,252,0.95)' }}>{fallbackPrompt.original.label}</span> 当前被标记为不可用。
+                {fallbackPrompt.suggestion ? (
+                  <> 是否改用 <span className="font-semibold" style={{ color: 'rgba(74,222,128,0.95)' }}>{fallbackPrompt.suggestion.label}</span>？</>
+                ) : (
+                  <> 暂时没有其他可用模型可切换。</>
+                )}
+              </div>
+              <div className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
+                在模型面板中可关闭「智能切换」进入严格模式，遇到不可用模型时直接按你选的发送、不再提示。
+              </div>
+              <div className="flex items-center justify-end gap-2 mt-1">
+                <Button variant="secondary" size="sm" onClick={() => fallbackPrompt.resolve('cancel')}>
+                  取消
+                </Button>
+                <Button variant="secondary" size="sm" onClick={() => fallbackPrompt.resolve('keep')}>
+                  仍使用 {fallbackPrompt.original.label}
+                </Button>
+                {fallbackPrompt.suggestion ? (
+                  <Button variant="primary" size="sm" onClick={() => fallbackPrompt.resolve('switch')}>
+                    切换到 {fallbackPrompt.suggestion.label}
+                  </Button>
+                ) : null}
+              </div>
+            </div>
+          ) : null
+        }
+      />
 
       <Dialog
         open={preview.open}

--- a/prd-admin/src/pages/ai-chat/AdvancedVisualAgentTab.tsx
+++ b/prd-admin/src/pages/ai-chat/AdvancedVisualAgentTab.tsx
@@ -6519,6 +6519,20 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
 
                   <div className="mt-2 flex items-center justify-between gap-2">
                     {/* 尺寸选择器 */}
+                    {/* 自适应模型：渲染一个非交互的静态 chip，避免打开一个仅用于迷惑的尺寸面板 */}
+                    {currentModelIsAdaptive ? (
+                      <span
+                        className="inline-flex items-center gap-1 rounded-full px-2.5 h-6 text-[11px] font-medium"
+                        style={{
+                          background: 'rgba(34, 197, 94, 0.08)',
+                          border: '1px solid rgba(34, 197, 94, 0.25)',
+                          color: 'rgba(74, 222, 128, 0.75)',
+                        }}
+                        title="该模型为自适应尺寸，具体尺寸由 prompt 描述决定（可在 prompt 中写「横版 16:9」等）"
+                      >
+                        <span style={{ whiteSpace: 'nowrap' }}>自适应</span>
+                      </span>
+                    ) : (
                     <Popover.Root open={quickSizeOpen} onOpenChange={(open) => {
                       setQuickSizeOpen(open);
                       // 打开时检查并自动修正不支持的尺寸
@@ -6560,10 +6574,6 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
                           onClick={(e) => e.stopPropagation()}
                         >
                           {(() => {
-                            // 自适应模型：尺寸由 prompt 决定，不展示具体 WxH，直接标"自适应"
-                            if (currentModelIsAdaptive) {
-                              return <span style={{ whiteSpace: 'nowrap' }}>自适应</span>;
-                            }
                             const size = composerSize ?? autoSizeForSelectedImage ?? imageGenSize;
                             const tier = detectTierFromSize(size);
                             const aspect = sizeToAspectMap.get(size.toLowerCase()) || detectAspectFromSize(size);
@@ -6679,6 +6689,7 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
                         </Popover.Content>
                       </Popover.Portal>
                     </Popover.Root>
+                    )}
 
                     {/* 模型选择器 */}
                     <DropdownMenu.Root open={quickModelOpen} onOpenChange={setQuickModelOpen}>
@@ -7915,10 +7926,13 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
                       color: 'var(--text-secondary)',
                       fontSize: 11,
                       fontWeight: 600,
+                      cursor: currentModelIsAdaptive ? 'default' : 'pointer',
+                      opacity: currentModelIsAdaptive ? 0.7 : 1,
                     }}
                     aria-label="尺寸比例"
-                    title="选择分辨率和比例"
-                    onClick={() => setSizeSelectorOpen((v) => !v)}
+                    title={currentModelIsAdaptive ? '该模型为自适应尺寸，具体尺寸由 prompt 描述决定' : '选择分辨率和比例'}
+                    disabled={currentModelIsAdaptive}
+                    onClick={() => { if (!currentModelIsAdaptive) setSizeSelectorOpen((v) => !v); }}
                   >
                     {(() => {
                       // 自适应模型：尺寸由 prompt 决定，标"自适应"
@@ -7934,7 +7948,9 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
                         <span style={{ whiteSpace: 'nowrap' }}>{tierLabel} · {aspect || '1:1'}</span>
                       );
                     })()}
-                    <span className="text-[9px]" style={{ color: 'rgba(255,255,255,0.55)' }}>▾</span>
+                    {currentModelIsAdaptive ? null : (
+                      <span className="text-[9px]" style={{ color: 'rgba(255,255,255,0.55)' }}>▾</span>
+                    )}
                   </button>
 
                   {/* 尺寸/比例 Popover */}

--- a/prd-admin/src/pages/ai-chat/AdvancedVisualAgentTab.tsx
+++ b/prd-admin/src/pages/ai-chat/AdvancedVisualAgentTab.tsx
@@ -515,6 +515,12 @@ type GenDoneMeta = {
   prompt?: string;
   runId?: string;
   modelPool?: string;
+  /** 后端实际调度后使用的模型（覆盖前端选择的 modelPool 展示） */
+  actualModel?: string;
+  /** 后端实际调度命中的模型池名 */
+  actualModelPool?: string;
+  /** 后端判断此次调用使用的是自适应模型（前端应显示"自适应"而不是具体 WxH） */
+  isAdaptive?: boolean;
   genType?: 'text2img' | 'img2img' | 'vision';
   imageRefShas?: string[];
 };
@@ -976,6 +982,13 @@ type ImageGenRunStreamPayload = {
   url?: unknown;
   originalUrl?: unknown;
   originalSha256?: unknown;
+  // 后端 runStart / imageDone 推送的实际调度结果（用于"展示实际使用的模型"）
+  modelId?: unknown;
+  modelGroupName?: unknown;
+  platformId?: unknown;
+  isAdaptive?: unknown;
+  adapterDisplayName?: unknown;
+  resolutionType?: unknown;
 };
 
 function buildTemplate(name: string) {
@@ -1151,12 +1164,15 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
   type SizeOption = { size: string; aspectRatio: string };
   type SizesByResolutionType = Record<'1k' | '2k' | '4k', SizeOption[]>;
   const [sizesByResolution, setSizesByResolution] = useState<SizesByResolutionType>({ '1k': [], '2k': [], '4k': [] });
+  // 当前模型是否为自适应模型（gpt-image-2-all 等）：true 时尺寸选择器应展示"自适应"
+  const [currentModelIsAdaptive, setCurrentModelIsAdaptive] = useState(false);
 
   useEffect(() => {
     // 使用模型池 code（对于 visual-agent 就是 modelName）获取尺寸配置
     const modelCode = effectiveModel?.modelName;
     if (!modelCode) {
       setSizesByResolution({ '1k': [], '2k': [], '4k': [] });
+      setCurrentModelIsAdaptive(false);
       return;
     }
 
@@ -1169,11 +1185,16 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
             '2k': Array.isArray(data['2k']) ? data['2k'] : [],
             '4k': Array.isArray(data['4k']) ? data['4k'] : [],
           });
+          setCurrentModelIsAdaptive(res.data.isAdaptive === true);
         } else {
           setSizesByResolution({ '1k': [], '2k': [], '4k': [] });
+          setCurrentModelIsAdaptive(false);
         }
       })
-      .catch(() => setSizesByResolution({ '1k': [], '2k': [], '4k': [] }));
+      .catch(() => {
+        setSizesByResolution({ '1k': [], '2k': [], '4k': [] });
+        setCurrentModelIsAdaptive(false);
+      });
   }, [effectiveModel]);
 
   // 按比例分组，每个比例只保留一个尺寸
@@ -3881,7 +3902,21 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
               )
             );
             const modelPoolName = pickedModel?.name || pickedModel?.modelName || '';
-            pushMsg('Assistant', buildGenDoneContent({ src: u, refSrc: refSrc || undefined, prompt: displayPrompt || undefined, runId, modelPool: modelPoolName, imageRefShas }));
+            // 优先用后端 imageDone 事件携带的实际调度结果（actualModel + isAdaptive）
+            const actualModelFromSse = String(o.modelId ?? '').trim() || undefined;
+            const actualPoolFromSse = String(o.modelGroupName ?? '').trim() || undefined;
+            const isAdaptiveFromSse = o.isAdaptive === true;
+            pushMsg('Assistant', buildGenDoneContent({
+              src: u,
+              refSrc: refSrc || undefined,
+              prompt: displayPrompt || undefined,
+              runId,
+              modelPool: modelPoolName,
+              actualModel: actualModelFromSse,
+              actualModelPool: actualPoolFromSse,
+              isAdaptive: isAdaptiveFromSse,
+              imageRefShas,
+            }));
             // 自动投稿：生图完成后自动提交到作品广场（受开关控制）
             if (asset?.id && autoSubmitEnabledRef.current) {
               autoSubmitImages([asset.id]).catch(() => {});
@@ -4105,7 +4140,16 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
                     : x
                 )
               );
-              pushMsg('Assistant', buildGenDoneContent({ src: u, refSrc: refSrc || undefined, prompt, runId, modelPool: modelPoolName }));
+              pushMsg('Assistant', buildGenDoneContent({
+                src: u,
+                refSrc: refSrc || undefined,
+                prompt,
+                runId,
+                modelPool: modelPoolName,
+                actualModel: String(o.modelId ?? '').trim() || undefined,
+                actualModelPool: String(o.modelGroupName ?? '').trim() || undefined,
+                isAdaptive: o.isAdaptive === true,
+              }));
             } else if (t === 'imageError' || t === 'error') {
               const msg = String(o.errorMessage ?? '快捷操作失败');
               setCanvas((prev) => prev.map((x) => (x.key === key ? { ...x, status: 'error', errorMessage: msg } : x)));
@@ -6516,6 +6560,10 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
                           onClick={(e) => e.stopPropagation()}
                         >
                           {(() => {
+                            // 自适应模型：尺寸由 prompt 决定，不展示具体 WxH，直接标"自适应"
+                            if (currentModelIsAdaptive) {
+                              return <span style={{ whiteSpace: 'nowrap' }}>自适应</span>;
+                            }
                             const size = composerSize ?? autoSizeForSelectedImage ?? imageGenSize;
                             const tier = detectTierFromSize(size);
                             const aspect = sizeToAspectMap.get(size.toLowerCase()) || detectAspectFromSize(size);
@@ -7873,6 +7921,10 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
                     onClick={() => setSizeSelectorOpen((v) => !v)}
                   >
                     {(() => {
+                      // 自适应模型：尺寸由 prompt 决定，标"自适应"
+                      if (currentModelIsAdaptive) {
+                        return <span style={{ whiteSpace: 'nowrap' }}>自适应</span>;
+                      }
                       const size = composerSize ?? autoSizeForSelectedImage ?? imageGenSize;
                       const tier = detectTierFromSize(size);
                       // 优先使用后端返回的 aspectRatio，避免 GCD 计算偏差（如 1344x768 应该是 16:9 而不是 7:4）
@@ -8975,7 +9027,16 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
                       ? { ...x, kind: 'image' as const, status: 'done' as const, src: u, originalSrc: originalU, assetId: (asset?.id || '').trim() || x.assetId, sha256: (asset?.sha256 || '').trim() || x.sha256, originalSha256: originalSha.trim() || x.originalSha256, syncStatus: 'synced' as const, syncError: null }
                       : x
                   ));
-                  pushMsg('Assistant', buildGenDoneContent({ src: u, refSrc, prompt: desc.trim(), runId, modelPool: modelPoolName }));
+                  pushMsg('Assistant', buildGenDoneContent({
+                    src: u,
+                    refSrc,
+                    prompt: desc.trim(),
+                    runId,
+                    modelPool: modelPoolName,
+                    actualModel: String(o.modelId ?? '').trim() || undefined,
+                    actualModelPool: String(o.modelGroupName ?? '').trim() || undefined,
+                    isAdaptive: o.isAdaptive === true,
+                  }));
                 } else if (t === 'imageError' || t === 'error') {
                   const msg = String(o.errorMessage ?? '草图生图失败');
                   setCanvas(prev => prev.map(x => x.key === genKey ? { ...x, status: 'error' as const, errorMessage: msg } : x));

--- a/prd-admin/src/pages/ai-chat/components/ChatMessageItem.tsx
+++ b/prd-admin/src/pages/ai-chat/components/ChatMessageItem.tsx
@@ -410,6 +410,9 @@ export const ChatMessageItem = memo(function ChatMessageItem({
   const MSG_COLLAPSE_THRESHOLD = 100;
   const isLongMsg = msgBody.length > MSG_COLLAPSE_THRESHOLD;
 
+  // 用户消息气泡下方的"用户期望：xxx 模型"标签：从 @model:xxx token 解析
+  const expectedModelForUser = isUser ? String(modeledMsg.model ?? '').trim() : '';
+
   return (
     <div className={`flex flex-col gap-0.5 ${isUser ? 'items-end' : 'items-start'}`}>
       <div
@@ -440,6 +443,26 @@ export const ChatMessageItem = memo(function ChatMessageItem({
           </button>
         ) : null}
       </div>
+      {/* 用户期望模型徽标（仅用户消息 + 有 @model token 时显示），让用户发送后明确知道自己期望的模型 */}
+      {isUser && expectedModelForUser ? (
+        <div className="flex items-center gap-1 pr-1" title={`用户期望使用：${expectedModelForUser}`}>
+          <span
+            className="inline-flex items-center gap-1 rounded-full px-1.5"
+            style={{
+              height: 16,
+              fontSize: 9,
+              lineHeight: '14px',
+              fontWeight: 600,
+              border: '1px solid rgba(129,140,248,0.25)',
+              background: 'rgba(99,102,241,0.08)',
+              color: 'rgba(165,180,252,0.85)',
+            }}
+          >
+            <span style={{ opacity: 0.7 }}>用户期望</span>
+            <span style={{ whiteSpace: 'nowrap' }}>{expectedModelForUser}</span>
+          </span>
+        </div>
+      ) : null}
       <span
         className={`text-[9px] tabular-nums select-none ${isUser ? 'pr-1' : 'pl-1'}`}
         style={{ color: 'var(--text-muted, rgba(255,255,255,0.38))' }}

--- a/prd-admin/src/pages/ai-chat/components/ChatMessageItem.tsx
+++ b/prd-admin/src/pages/ai-chat/components/ChatMessageItem.tsx
@@ -29,6 +29,12 @@ type GenDoneMeta = {
   prompt?: string;
   runId?: string;
   modelPool?: string;
+  /** 后端实际调度使用的模型（来自 SSE runStart / imageDone 的 modelId），优先于 modelPool 展示 */
+  actualModel?: string;
+  /** 后端实际命中的模型池名 */
+  actualModelPool?: string;
+  /** 后端判断此次调用使用的是自适应模型：前端应显示"自适应"而不是具体 WxH */
+  isAdaptive?: boolean;
   genType?: 'text2img' | 'img2img' | 'vision';
   imageRefShas?: string[];
 };
@@ -100,10 +106,16 @@ function MessageMetadataInline({
   sizeToAspectMap?: Map<string, string>;
 }) {
   if (!size && !model) return null;
-  const tier = detectTierFromSize(size || '');
-  const aspect = size ? (sizeToAspectMap?.get(size.toLowerCase()) || detectAspectFromSize(size)) : '';
+  // 自适应模型：不走 tier/aspect 解析，直接显示"自适应"
+  const isAdaptiveSize = size === '自适应' || size === 'adaptive' || size === 'auto';
+  const tier = isAdaptiveSize ? '' : detectTierFromSize(size || '');
+  const aspect = isAdaptiveSize || !size
+    ? ''
+    : (sizeToAspectMap?.get(size.toLowerCase()) || detectAspectFromSize(size));
   const tierLabel = tier === '4k' ? '4K' : tier === '2k' ? '2K' : '1K';
-  const sizeLabel = aspect ? `${tierLabel} · ${aspect}` : size;
+  const sizeLabel = isAdaptiveSize
+    ? '自适应'
+    : (aspect ? `${tierLabel} · ${aspect}` : size);
   return (
     <div className="flex flex-wrap items-center justify-between w-full gap-1.5 !mt-0">
       {size ? (
@@ -286,15 +298,25 @@ export const ChatMessageItem = memo(function ChatMessageItem({
       msgModel = String(modeledMsg.model ?? '').trim();
     }
 
-    if (originalUserMsg && !msgSize) {
+    // ── 服务端权威覆盖 ──
+    // actualModel / isAdaptive 由后端 SSE 写入 GEN_DONE meta，优先级高于
+    // 用户消息里的 @model:xxx token（那个只是前端 picker 的选择，可能与后台调度不一致）
+    const meta = parseGenDone(m.content);
+    if (meta?.actualModel) {
+      msgModel = String(meta.actualModel).trim();
+    } else if (meta?.actualModelPool) {
+      msgModel = String(meta.actualModelPool).trim();
+    }
+
+    // 自适应模型：尺寸由 prompt 决定，不应显示具体 WxH
+    if (meta?.isAdaptive) {
+      msgSize = '自适应';
+    } else if (originalUserMsg && !msgSize) {
       msgSize = '1024x1024';
     }
 
-    if (!msgModel) {
-      const meta = parseGenDone(m.content);
-      if (meta && meta.modelPool) {
-        msgModel = meta.modelPool;
-      }
+    if (!msgModel && meta?.modelPool) {
+      msgModel = meta.modelPool;
     }
 
     return (

--- a/prd-admin/src/services/contracts/models.ts
+++ b/prd-admin/src/services/contracts/models.ts
@@ -76,6 +76,8 @@ export type ModelAdapterInfo = {
   limitations?: ModelAdapterLimitations;
   supportsImageToImage?: boolean;
   supportsInpainting?: boolean;
+  /** 自适应模型：true 表示尺寸由 prompt 决定，前端不应展示尺寸选择器 */
+  isAdaptive?: boolean;
 };
 
 export type ModelAdapterInfoBrief = {
@@ -87,6 +89,8 @@ export type ModelAdapterInfoBrief = {
   sizesCount?: number;
   sizesByResolution?: Record<string, SizeOptionFromBackend[]>;
   notes?: string[];
+  /** 自适应模型标识 */
+  isAdaptive?: boolean;
 };
 
 export type GetModelAdapterInfoContract = (modelId: string) => Promise<ApiResponse<ModelAdapterInfo>>;

--- a/prd-admin/src/stores/visualAgentPrefsStore.ts
+++ b/prd-admin/src/stores/visualAgentPrefsStore.ts
@@ -1,0 +1,30 @@
+/**
+ * 视觉创作偏好 store
+ *
+ * 前端轻量偏好：仅影响"发送前的预检"UX，不替代后端的模型调度决策。
+ * - smartModelFallback: true（默认）= 发送前若检测到用户选的模型不可用，弹窗询问是否切换
+ *                      false（严格模式）= 直接按用户选择发送，不弹窗，让后端去做调度/降级
+ *
+ * 持久化：sessionStorage（遵守项目 no-localstorage 规则）。
+ */
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+
+interface VisualAgentPrefsState {
+  /** 智能切换（默认开启）。关闭后进入严格模式：不弹窗询问，直接按用户选择发送。 */
+  smartModelFallback: boolean;
+  setSmartModelFallback: (v: boolean) => void;
+}
+
+export const useVisualAgentPrefsStore = create<VisualAgentPrefsState>()(
+  persist(
+    (set) => ({
+      smartModelFallback: true,
+      setSmartModelFallback: (v: boolean) => set({ smartModelFallback: v }),
+    }),
+    {
+      name: 'visual-agent-prefs',
+      storage: createJSONStorage(() => sessionStorage),
+    }
+  )
+);

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ImageGenController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ImageGenController.cs
@@ -199,6 +199,7 @@ public class ImageGenController : ControllerBase
             },
             supportsImageToImage = adapterInfo.SupportsImageToImage,
             supportsInpainting = adapterInfo.SupportsInpainting,
+            isAdaptive = adapterInfo.IsAdaptive,
         }));
     }
 

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ImageGenController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ImageGenController.cs
@@ -1490,6 +1490,8 @@ public class ImageGenController : ControllerBase
             ConfigModelId = cfgModelId,
             PlatformId = platformId,
             ModelId = modelId,
+            // ⚠ 用户显式选择优先：同 ImageMasterController.CreateWorkspaceImageGenRun。
+            ModelResolutionType = PrdAgent.Core.Models.ModelResolutionType.DirectModel,
             Size = size,
             ResponseFormat = responseFormat,
             MaxConcurrency = maxConc,

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ImageMasterController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ImageMasterController.cs
@@ -1477,6 +1477,11 @@ public class ImageMasterController : ControllerBase
                 ConfigModelId = cfgModelId,
                 PlatformId = platformId,
                 ModelId = modelId,
+                // ⚠ 用户显式选择优先：前端 picker 发来的 (platformId, modelId) 已是用户可见的可用模型。
+                // 提前标 ModelResolutionType=DirectModel，使 Worker 的 ResolveModelGroupAsync 走早返回分支，
+                // 避免 scheduler 把用户选择覆盖成"第一个池的第一个模型"（gpt-image-2-all）。
+                // 这是所有 Round 修复的最终落脚点：Controller 层直接尊重用户选择。
+                ModelResolutionType = PrdAgent.Core.Models.ModelResolutionType.DirectModel,
                 Size = size,
                 ResponseFormat = responseFormat,
                 MaxConcurrency = 1,

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ModelsController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ModelsController.cs
@@ -756,6 +756,7 @@ public class ModelsController : ControllerBase
             },
             supportsImageToImage = adapterInfo.SupportsImageToImage,
             supportsInpainting = adapterInfo.SupportsInpainting,
+            isAdaptive = adapterInfo.IsAdaptive,
         }));
     }
 
@@ -815,6 +816,7 @@ public class ModelsController : ControllerBase
             },
             supportsImageToImage = adapterInfo.SupportsImageToImage,
             supportsInpainting = adapterInfo.SupportsInpainting,
+            isAdaptive = adapterInfo.IsAdaptive,
         }));
     }
 
@@ -853,6 +855,7 @@ public class ModelsController : ControllerBase
                     sizesCount = totalSizesCount,
                     sizesByResolution = adapterInfo.SizesByResolution,
                     notes = adapterInfo.Notes,
+                    isAdaptive = adapterInfo.IsAdaptive,
                 };
             }
             else

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ResolverDebugController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ResolverDebugController.cs
@@ -127,6 +127,71 @@ public class ResolverDebugController : ControllerBase
     }
 
     /// <summary>
+    /// 双调用测试：在**同一 async 链中**依次调用 IModelResolver.ResolveAsync 两次 —
+    /// 第 1 次带 expectedModel（模拟 OpenAIImageClient 入口），第 2 次传 null
+    /// （模拟 LlmGateway.SendRawAsync 内部的硬编码 null 调用）。
+    /// 如果装饰器的 AsyncLocal 生效，第 2 次应该自动恢复 expectedModel 并返回同样的 actualModel。
+    /// </summary>
+    [HttpPost("test-chain")]
+    public async Task<IActionResult> TestChain(
+        [FromBody] ResolverTestRequest body,
+        CancellationToken ct)
+    {
+        var code = (body?.AppCallerCode ?? string.Empty).Trim();
+        var type = string.IsNullOrWhiteSpace(body?.ModelType) ? "generation" : body.ModelType.Trim();
+        var expected = string.IsNullOrWhiteSpace(body?.ExpectedModel) ? null : body.ExpectedModel.Trim();
+        if (string.IsNullOrWhiteSpace(code)) return BadRequest(new { error = "appCallerCode 不能为空" });
+
+        _logger.LogWarning("[TestChain] === START === code={Code} expected='{Expected}'", code, expected ?? "(null)");
+
+        // 第 1 次：带 expectedModel（模拟 OpenAIImageClient.GenerateAsync 入口）
+        ModelResolutionResult? r1 = null;
+        string? err1 = null;
+        try { r1 = await _resolver.ResolveAsync(code, type, expected, ct); }
+        catch (Exception ex) { err1 = ex.Message; }
+
+        // 第 2 次：expectedModel=null（模拟 LlmGateway.SendRawAsync 内部）
+        // 重要：同一 async method 内，AsyncLocal 应该保留第 1 次的值
+        ModelResolutionResult? r2 = null;
+        string? err2 = null;
+        try { r2 = await _resolver.ResolveAsync(code, type, null, ct); }
+        catch (Exception ex) { err2 = ex.Message; }
+
+        _logger.LogWarning(
+            "[TestChain] === END === call1(expected={E1}) → actual={A1} pool={P1} | call2(null) → actual={A2} pool={P2}",
+            expected ?? "(null)",
+            r1?.ActualModel ?? "(null)",
+            r1?.ModelGroupName ?? "(null)",
+            r2?.ActualModel ?? "(null)",
+            r2?.ModelGroupName ?? "(null)");
+
+        return Ok(new
+        {
+            input = new { appCallerCode = code, modelType = type, expectedModel = expected },
+            call1_with_expected = new
+            {
+                error = err1,
+                actualModel = r1?.ActualModel,
+                modelGroupName = r1?.ModelGroupName,
+                resolutionType = r1?.ResolutionType,
+                success = r1?.Success,
+            },
+            call2_with_null = new
+            {
+                error = err2,
+                actualModel = r2?.ActualModel,
+                modelGroupName = r2?.ModelGroupName,
+                resolutionType = r2?.ResolutionType,
+                success = r2?.Success,
+            },
+            asyncLocalWorks = r1?.ActualModel == r2?.ActualModel,
+            verdict = r1?.ActualModel == r2?.ActualModel
+                ? "AsyncLocal WORKS — SendRawAsync 内部 null 调用会得到正确 model"
+                : $"AsyncLocal BROKEN — call1={r1?.ActualModel} call2={r2?.ActualModel}（这就是实际生图时 SendRawAsync 覆盖上游 model 的原因）"
+        });
+    }
+
+    /// <summary>
     /// 只读探查：列出 AppCaller 及其绑定池的完整信息（供前端 debug 面板查看）。
     /// </summary>
     [HttpGet("inspect")]

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ResolverDebugController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ResolverDebugController.cs
@@ -25,16 +25,79 @@ public class ResolverDebugController : ControllerBase
 {
     private readonly MongoDbContext _db;
     private readonly IModelResolver _resolver;
+    private readonly PrdAgent.Infrastructure.LlmGateway.ILlmGateway _gateway;
+    private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<ResolverDebugController> _logger;
 
     public ResolverDebugController(
         MongoDbContext db,
         IModelResolver resolver,
+        PrdAgent.Infrastructure.LlmGateway.ILlmGateway gateway,
+        IServiceScopeFactory scopeFactory,
         ILogger<ResolverDebugController> logger)
     {
         _db = db;
         _resolver = resolver;
+        _gateway = gateway;
+        _scopeFactory = scopeFactory;
         _logger = logger;
+    }
+
+    /// <summary>
+    /// 模拟 Worker 真实路径：用 _scopeFactory.CreateScope() 创建新 scope（而不是当前 HTTP 请求 scope），
+    /// 在新 scope 里解析 ILlmGateway，调用两次 ResolveModelAsync，对比 instance hash 和结果。
+    /// 目的：验证 test-chain 在 HTTP scope 里正常但真实 Worker 路径里的 LLM 日志仍然错误之谜。
+    /// </summary>
+    [HttpPost("simulate-worker")]
+    public async Task<IActionResult> SimulateWorker(
+        [FromBody] ResolverTestRequest body,
+        CancellationToken ct)
+    {
+        var code = (body?.AppCallerCode ?? string.Empty).Trim();
+        var type = string.IsNullOrWhiteSpace(body?.ModelType) ? "generation" : body.ModelType.Trim();
+        var expected = string.IsNullOrWhiteSpace(body?.ExpectedModel) ? null : body.ExpectedModel.Trim();
+
+        _logger.LogWarning("[SimulateWorker] === Creating new scope via _scopeFactory.CreateScope() ===");
+
+        // 和 ImageGenRunWorker Line 224 一样的调用方式
+        using var scope = _scopeFactory.CreateScope();
+        var gatewayInScope = scope.ServiceProvider.GetRequiredService<PrdAgent.Infrastructure.LlmGateway.ILlmGateway>();
+        var resolverInScope = scope.ServiceProvider.GetRequiredService<IModelResolver>();
+
+        var resolverHash = resolverInScope.GetHashCode().ToString("X");
+        var gatewayHash = gatewayInScope.GetHashCode().ToString("X");
+
+        _logger.LogWarning("[SimulateWorker] resolver hash in new scope: {RH}, gateway hash: {GH}", resolverHash, gatewayHash);
+
+        // 第 1 次：通过 gateway.ResolveModelAsync（和 OpenAIImageClient line 165 一样）
+        var r1 = await gatewayInScope.ResolveModelAsync(code, type, expected, ct);
+
+        // 第 2 次：通过 IModelResolver 直接（和 LlmGateway.SendRawAsync line 561 一样传 null）
+        var r2 = await resolverInScope.ResolveAsync(code, type, null, ct);
+
+        return Ok(new
+        {
+            note = "模拟 Worker 使用 _scopeFactory.CreateScope() 新建 scope",
+            resolverInstanceHashInNewScope = resolverHash,
+            gatewayInstanceHashInNewScope = gatewayHash,
+            call1_via_gateway = new
+            {
+                actualModel = r1.ActualModel,
+                modelGroupName = r1.ModelGroupName,
+                success = r1.Success,
+            },
+            call2_via_resolver_null = new
+            {
+                actualModel = r2.ActualModel,
+                modelGroupName = r2.ModelGroupName,
+                resolutionType = r2.ResolutionType,
+                success = r2.Success,
+            },
+            sameModelBothCalls = r1.ActualModel == r2.ActualModel,
+            verdict = r1.ActualModel == r2.ActualModel
+                ? "在 _scopeFactory 新建的 scope 里也正常"
+                : $"在 _scopeFactory 新建的 scope 里失效！call1={r1.ActualModel} call2={r2.ActualModel} — 这就是 Worker 实际路径的问题"
+        });
     }
 
     /// <summary>

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ResolverDebugController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ResolverDebugController.cs
@@ -44,6 +44,81 @@ public class ResolverDebugController : ControllerBase
     }
 
     /// <summary>
+    /// 触发真实 OpenAIImageClient.GenerateUnifiedAsync（走完整 Worker 链路），然后返回
+    /// `_diag_resolver_calls` 集合里相关的装饰器调用记录，查明为何 LLM 日志里 model 被换。
+    /// </summary>
+    [HttpPost("trigger-real-gen")]
+    public async Task<IActionResult> TriggerRealGen(
+        [FromBody] ResolverTestRequest body,
+        CancellationToken ct)
+    {
+        var code = (body?.AppCallerCode ?? "visual-agent.image.text2img::generation").Trim();
+        var expected = string.IsNullOrWhiteSpace(body?.ExpectedModel) ? "stub-image" : body.ExpectedModel.Trim();
+
+        // 清空诊断集合
+        var diagColl = _db.Database.GetCollection<MongoDB.Bson.BsonDocument>("_diag_resolver_calls");
+        diagColl.DeleteMany(new MongoDB.Bson.BsonDocument());
+
+        var runStartTs = DateTime.UtcNow;
+        _logger.LogWarning("[TriggerRealGen] === START === code={Code} expected={Expected}", code, expected);
+
+        // 按 ImageGenRunWorker Line 224 的方式新建 scope
+        using var scope = _scopeFactory.CreateScope();
+        var imageClient = scope.ServiceProvider.GetRequiredService<PrdAgent.Infrastructure.LLM.OpenAIImageClient>();
+
+        string? err = null;
+        bool success = false;
+        string? returnedModel = null;
+        try
+        {
+            var res = await imageClient.GenerateUnifiedAsync(
+                prompt: "test prompt (trigger-real-gen debug)",
+                n: 1,
+                size: "1024x1024",
+                responseFormat: "url",
+                ct: ct,
+                appCallerCode: code,
+                images: null,
+                modelId: expected,       // stub-image 池 code
+                platformId: "platform4", // stub 平台
+                modelName: expected);    // = modelId
+            success = res.Success;
+            err = res.Error?.Message;
+            returnedModel = res.Data?.Images?.FirstOrDefault()?.Url ?? "(no url)";
+        }
+        catch (Exception ex)
+        {
+            err = ex.Message + " | " + ex.GetType().Name;
+        }
+
+        // 读 _diag_resolver_calls 里本次触发的记录
+        var diagRecords = diagColl.Find(new MongoDB.Bson.BsonDocument("ts",
+                new MongoDB.Bson.BsonDocument("$gte", runStartTs)))
+            .Sort(new MongoDB.Bson.BsonDocument("ts", 1))
+            .ToList();
+
+        return Ok(new
+        {
+            input = new { appCallerCode = code, expectedModel = expected },
+            gen = new { success, error = err, returnedUrl = returnedModel },
+            decoratorCalls = diagRecords.Select(r => new
+            {
+                ts = r.GetValue("ts", "").ToString(),
+                instanceHash = r.GetValue("instanceHash", "").AsString,
+                rawExpected = r.GetValue("rawExpected", "").AsString,
+                pendingBefore = r.GetValue("pendingBefore", "").AsString,
+                pendingAfter = r.GetValue("pendingAfter", "").AsString,
+                effective = r.GetValue("effective", "").AsString,
+                branch = r.GetValue("branch", "").AsString,
+                returnedModel = r.GetValue("returnedModel", "").AsString,
+                returnedPool = r.GetValue("returnedPool", "").AsString,
+                stack = r.GetValue("stack", "").AsString,
+            }).ToList(),
+            totalDecoratorCalls = diagRecords.Count
+        });
+    }
+
+    /// <summary>
     /// 模拟 Worker 真实路径：用 _scopeFactory.CreateScope() 创建新 scope（而不是当前 HTTP 请求 scope），
     /// 在新 scope 里解析 ILlmGateway，调用两次 ResolveModelAsync，对比 instance hash 和结果。
     /// 目的：验证 test-chain 在 HTTP scope 里正常但真实 Worker 路径里的 LLM 日志仍然错误之谜。

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ResolverDebugController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ResolverDebugController.cs
@@ -1,0 +1,257 @@
+using Microsoft.AspNetCore.Mvc;
+using MongoDB.Driver;
+using PrdAgent.Core.Models;
+using PrdAgent.Infrastructure.Database;
+using PrdAgent.Infrastructure.LlmGateway;
+
+namespace PrdAgent.Api.Controllers.Api;
+
+/// <summary>
+/// 模型调度调试端点 —— 不跑生图、直接暴露 Tier 匹配算法。
+///
+/// 目的：让"选 A 给 B"问题可以独立测试，避免每次都触发真实生图。
+/// 所有返回都是 JSON，前端/Postman/curl 都能直接调。
+///
+/// 路径：
+///   POST /api/debug/resolver/test
+///   GET  /api/debug/resolver/inspect?appCallerCode=xxx&modelType=xxx
+///
+/// ⚠ 本接口仅供调试，正式上线前应改为管理员专属权限（目前用 [AllowAnonymous]
+/// 以便跨浏览器快速 curl；上线前收紧）。
+/// </summary>
+[ApiController]
+[Route("api/debug/resolver")]
+public class ResolverDebugController : ControllerBase
+{
+    private readonly MongoDbContext _db;
+    private readonly IModelResolver _resolver;
+    private readonly ILogger<ResolverDebugController> _logger;
+
+    public ResolverDebugController(
+        MongoDbContext db,
+        IModelResolver resolver,
+        ILogger<ResolverDebugController> logger)
+    {
+        _db = db;
+        _resolver = resolver;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// 完整的匹配算法测试：走当前注册的 IModelResolver（包含装饰器），并返回
+    /// 候选池状态 + 每档匹配细节 + 最终解析结果。
+    /// </summary>
+    [HttpPost("test")]
+    public async Task<IActionResult> Test(
+        [FromBody] ResolverTestRequest body,
+        CancellationToken ct)
+    {
+        var code = (body?.AppCallerCode ?? string.Empty).Trim();
+        var type = string.IsNullOrWhiteSpace(body?.ModelType) ? "generation" : body.ModelType.Trim();
+        var expected = string.IsNullOrWhiteSpace(body?.ExpectedModel) ? null : body.ExpectedModel.Trim();
+
+        if (string.IsNullOrWhiteSpace(code))
+            return BadRequest(new { error = "appCallerCode 不能为空" });
+
+        _logger.LogInformation(
+            "[ResolverDebug] Test 请求: code={Code} type={Type} expected='{Expected}'",
+            code, type, expected ?? "(null)");
+
+        // 1. 读 AppCaller
+        var appCaller = await _db.LLMAppCallers
+            .Find(a => a.AppCode == code)
+            .FirstOrDefaultAsync(ct);
+        var requirement = appCaller?.ModelRequirements.FirstOrDefault(r => r.ModelType == type);
+
+        // 2. 读候选池
+        var groups = new List<ModelGroup>();
+        if (requirement?.ModelGroupIds != null && requirement.ModelGroupIds.Count > 0)
+        {
+            groups = await _db.ModelGroups
+                .Find(g => requirement.ModelGroupIds.Contains(g.Id))
+                .SortBy(g => g.Priority)
+                .ToListAsync(ct);
+        }
+
+        // 3. 独立跑一遍 Tier1/2/3（和装饰器同一套逻辑，用于返回 step-by-step 诊断）
+        var steps = new List<object>();
+        SimulateMatch(groups, expected, steps);
+
+        // 4. 再通过真实 IModelResolver 调用，拿到实际返回
+        ModelResolutionResult? actual = null;
+        string? actualError = null;
+        try
+        {
+            actual = await _resolver.ResolveAsync(code, type, expected, ct);
+        }
+        catch (Exception ex)
+        {
+            actualError = ex.Message;
+        }
+
+        return Ok(new
+        {
+            input = new { appCallerCode = code, modelType = type, expectedModel = expected },
+            appCallerFound = appCaller != null,
+            bound = requirement != null,
+            candidatePools = groups.Select(g => new
+            {
+                id = g.Id,
+                name = g.Name,
+                code = g.Code,
+                priority = g.Priority,
+                models = g.Models?.Select(m => new
+                {
+                    modelId = m.ModelId,
+                    platformId = m.PlatformId,
+                    health = m.HealthStatus.ToString(),
+                    priority = m.Priority
+                }).ToArray()
+            }).ToArray(),
+            matchingTrace = steps,
+            liveResolverOutput = actual == null ? null : new
+            {
+                success = actual.Success,
+                resolutionType = actual.ResolutionType,
+                expectedModel = actual.ExpectedModel,
+                actualModel = actual.ActualModel,
+                actualPlatformId = actual.ActualPlatformId,
+                actualPlatformName = actual.ActualPlatformName,
+                modelGroupId = actual.ModelGroupId,
+                modelGroupName = actual.ModelGroupName,
+                apiUrl = actual.ApiUrl,
+                errorMessage = actual.ErrorMessage
+            },
+            liveResolverError = actualError,
+        });
+    }
+
+    /// <summary>
+    /// 只读探查：列出 AppCaller 及其绑定池的完整信息（供前端 debug 面板查看）。
+    /// </summary>
+    [HttpGet("inspect")]
+    public async Task<IActionResult> Inspect(
+        [FromQuery] string appCallerCode,
+        [FromQuery] string modelType = "generation",
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(appCallerCode))
+            return BadRequest(new { error = "appCallerCode required" });
+
+        var code = appCallerCode.Trim();
+        var appCaller = await _db.LLMAppCallers
+            .Find(a => a.AppCode == code)
+            .FirstOrDefaultAsync(ct);
+
+        if (appCaller == null)
+            return Ok(new { appCallerCode = code, found = false });
+
+        var req = appCaller.ModelRequirements.FirstOrDefault(r => r.ModelType == modelType);
+        var groups = new List<ModelGroup>();
+        if (req?.ModelGroupIds != null && req.ModelGroupIds.Count > 0)
+        {
+            groups = await _db.ModelGroups
+                .Find(g => req.ModelGroupIds.Contains(g.Id))
+                .SortBy(g => g.Priority)
+                .ToListAsync(ct);
+        }
+
+        return Ok(new
+        {
+            appCallerCode = code,
+            found = true,
+            modelType,
+            modelGroupIds = req?.ModelGroupIds ?? new List<string>(),
+            pools = groups.Select(g => new
+            {
+                id = g.Id,
+                name = g.Name,
+                code = g.Code,
+                priority = g.Priority,
+                modelType = g.ModelType,
+                isDefaultForType = g.IsDefaultForType,
+                models = g.Models?.Select(m => new
+                {
+                    modelId = m.ModelId,
+                    platformId = m.PlatformId,
+                    health = m.HealthStatus.ToString(),
+                    healthInt = (int)m.HealthStatus,
+                    priority = m.Priority
+                }).ToArray()
+            })
+        });
+    }
+
+    private static void SimulateMatch(List<ModelGroup> groups, string? expected, List<object> steps)
+    {
+        if (string.IsNullOrWhiteSpace(expected))
+        {
+            steps.Add(new { tier = 0, note = "expectedModel 为空 → 跳过匹配", result = "skip" });
+            return;
+        }
+
+        // Tier 1: ModelId 精确
+        foreach (var g in groups)
+        {
+            if (g.Models == null) continue;
+            foreach (var m in g.Models)
+            {
+                var healthy = m.HealthStatus != ModelHealthStatus.Unavailable;
+                var hit = string.Equals(m.ModelId, expected, StringComparison.OrdinalIgnoreCase);
+                if (hit && healthy)
+                {
+                    steps.Add(new { tier = 1, status = "HIT", pool = g.Name, modelId = m.ModelId, reason = "ModelId 精确" });
+                    return;
+                }
+            }
+        }
+        steps.Add(new { tier = 1, status = "miss", reason = "无 ModelId 精确匹配" });
+
+        // Tier 2: 前缀
+        foreach (var g in groups)
+        {
+            if (g.Models == null) continue;
+            foreach (var m in g.Models)
+            {
+                var healthy = m.HealthStatus != ModelHealthStatus.Unavailable;
+                var pref = !string.IsNullOrEmpty(m.ModelId) && m.ModelId.StartsWith(expected, StringComparison.OrdinalIgnoreCase);
+                if (pref && healthy)
+                {
+                    steps.Add(new { tier = 2, status = "HIT", pool = g.Name, modelId = m.ModelId, reason = $"'{m.ModelId}' starts with '{expected}'" });
+                    return;
+                }
+            }
+        }
+        steps.Add(new { tier = 2, status = "miss", reason = "无 ModelId 前缀匹配" });
+
+        // Tier 3: 池名 / 池 Code
+        foreach (var g in groups)
+        {
+            if (g.Models == null || g.Models.Count == 0) continue;
+            var byName = string.Equals(g.Name, expected, StringComparison.OrdinalIgnoreCase);
+            var byCode = string.Equals(g.Code, expected, StringComparison.OrdinalIgnoreCase);
+            if (!byName && !byCode) continue;
+
+            var picked =
+                g.Models.FirstOrDefault(m => m.HealthStatus == ModelHealthStatus.Healthy)
+                ?? g.Models.FirstOrDefault(m => m.HealthStatus == ModelHealthStatus.Degraded);
+            if (picked != null)
+            {
+                steps.Add(new { tier = 3, status = "HIT", pool = g.Name, modelId = picked.ModelId, reason = byCode ? "池 Code 精确" : "池 Name 精确" });
+                return;
+            }
+
+            steps.Add(new { tier = 3, status = "pool matched but no healthy model", pool = g.Name });
+        }
+        steps.Add(new { tier = 3, status = "miss", reason = "池名/Code 均未匹配 expectedModel" });
+
+        steps.Add(new { final = "ALL_MISS", note = "将委派给内部 resolver（可能跑老代码）" });
+    }
+
+    public class ResolverTestRequest
+    {
+        public string? AppCallerCode { get; set; }
+        public string? ModelType { get; set; }
+        public string? ExpectedModel { get; set; }
+    }
+}

--- a/prd-api/src/PrdAgent.Api/Program.cs
+++ b/prd-api/src/PrdAgent.Api/Program.cs
@@ -162,7 +162,9 @@ builder.Services.AddScoped<PrdAgent.Infrastructure.ModelPool.IPoolFailoverNotifi
 builder.Services.AddHostedService<PrdAgent.Infrastructure.ModelPool.ModelPoolHealthProbeService>();
 
 // 模型调度执行器（支持单元测试 Mock）
-builder.Services.AddScoped<PrdAgent.Infrastructure.LlmGateway.IModelResolver, PrdAgent.Infrastructure.LlmGateway.ModelResolver>();
+// 先注册具体的 ModelResolver，再用装饰器包裹（Api 层拦截，绕过 Infrastructure.dll 部署 bug）
+builder.Services.AddScoped<PrdAgent.Infrastructure.LlmGateway.ModelResolver>();
+builder.Services.AddScoped<PrdAgent.Infrastructure.LlmGateway.IModelResolver, PrdAgent.Api.Services.ExpectedModelRespectingResolver>();
 
 // LLM Gateway 统一守门员（所有大模型调用必须通过此接口）
 builder.Services.AddScoped<PrdAgent.Infrastructure.LlmGateway.ILlmGateway, PrdAgent.Infrastructure.LlmGateway.LlmGateway>();

--- a/prd-api/src/PrdAgent.Api/Services/ExpectedModelRespectingResolver.cs
+++ b/prd-api/src/PrdAgent.Api/Services/ExpectedModelRespectingResolver.cs
@@ -56,34 +56,72 @@ public class ExpectedModelRespectingResolver : IModelResolver
     {
         var traceId = Guid.NewGuid().ToString("N")[..8];
 
-        // ===== 关键：expectedModel 从 AsyncLocal 回放 =====
-        // 背景：LlmGateway.SendRawAsync 内部再次调用 ResolveAsync 时 expectedModel 硬编码 null
-        // （Infrastructure.dll 代码，改了部署不生效）。我们在第一次调用时把 expectedModel 存入
-        // AsyncLocal，第二次调用 null 时从 AsyncLocal 读回。
+        // ===== 全链路诊断：每次调用写 MongoDB _diag_resolver_calls =====
+        var instanceHash = this.GetHashCode().ToString("X");
+        var pendingBefore = _pendingExpected;
+        var stackFrames = new System.Diagnostics.StackTrace(1, false).GetFrames()
+            ?.Take(8)
+            .Select(f => $"{f.GetMethod()?.DeclaringType?.Name}.{f.GetMethod()?.Name}")
+            .ToList() ?? new List<string>();
+
+        // ===== 关键：expectedModel 从 instance field 回放 =====
         var effectiveExpected = expectedModel;
         if (string.IsNullOrWhiteSpace(effectiveExpected) && !string.IsNullOrWhiteSpace(_pendingExpected))
         {
             effectiveExpected = _pendingExpected;
             _logger.LogInformation(
-                "[Resolver-Decorator:{Trace}] expectedModel=null，从 scope 实例字段恢复 '{Recovered}'（同 DI scope 前一次 ResolveAsync）",
+                "[Resolver-Decorator:{Trace}] expectedModel=null，从 scope 实例字段恢复 '{Recovered}'",
                 traceId, effectiveExpected);
         }
         else if (!string.IsNullOrWhiteSpace(expectedModel))
         {
-            // 存入实例字段，供同 DI scope 后续调用读取
             _pendingExpected = expectedModel;
         }
 
+        // 写诊断（同步，避免与下游 await 交叉）
+        try
+        {
+            _db.Database.GetCollection<MongoDB.Bson.BsonDocument>("_diag_resolver_calls").InsertOne(
+                new MongoDB.Bson.BsonDocument
+                {
+                    { "_id", traceId },
+                    { "ts", DateTime.UtcNow },
+                    { "instanceHash", instanceHash },
+                    { "appCallerCode", appCallerCode ?? "" },
+                    { "modelType", modelType ?? "" },
+                    { "rawExpected", expectedModel ?? "(null)" },
+                    { "pendingBefore", pendingBefore ?? "(null)" },
+                    { "pendingAfter", _pendingExpected ?? "(null)" },
+                    { "effective", effectiveExpected ?? "(null)" },
+                    { "stack", string.Join(" <- ", stackFrames) }
+                });
+        }
+        catch (Exception dex) { _logger.LogWarning(dex, "[Resolver-Decorator:{Trace}] diag write failed", traceId); }
+
         _logger.LogInformation(
-            "[Resolver-Decorator:{Trace}] ENTRY appCallerCode={Code} modelType={Type} expectedModel='{Raw}' effective='{Effective}'",
-            traceId, appCallerCode, modelType, expectedModel ?? "(null)", effectiveExpected ?? "(null)");
+            "[Resolver-Decorator:{Trace}] ENTRY hash={Hash} appCallerCode={Code} raw='{Raw}' pendingBefore='{PB}' effective='{Effective}'",
+            traceId, instanceHash, appCallerCode,
+            expectedModel ?? "(null)", pendingBefore ?? "(null)", effectiveExpected ?? "(null)");
 
         if (string.IsNullOrWhiteSpace(effectiveExpected))
         {
             _logger.LogInformation(
                 "[Resolver-Decorator:{Trace}] 无 effectiveExpected → 委派内部 resolver",
                 traceId);
-            return await _inner.ResolveAsync(appCallerCode, modelType, expectedModel, ct);
+            var delegated = await _inner.ResolveAsync(appCallerCode, modelType, expectedModel, ct);
+            try
+            {
+                _db.Database.GetCollection<MongoDB.Bson.BsonDocument>("_diag_resolver_calls").UpdateOne(
+                    new MongoDB.Bson.BsonDocument { { "_id", traceId } },
+                    new MongoDB.Bson.BsonDocument { { "$set", new MongoDB.Bson.BsonDocument
+                    {
+                        { "branch", "DELEGATED" },
+                        { "returnedModel", delegated.ActualModel ?? "(null)" },
+                        { "returnedPool", delegated.ModelGroupName ?? "(null)" }
+                    }}});
+            }
+            catch { }
+            return delegated;
         }
 
         // 后续匹配逻辑用 effectiveExpected 代替 expectedModel
@@ -212,6 +250,21 @@ public class ExpectedModelRespectingResolver : IModelResolver
         _logger.LogInformation(
             "[Resolver-Decorator:{Trace}] 返回 FromPool: pool={Pool} model={Model} platform={Platform}",
             traceId, group.Name, selectedModel.ModelId, platform.Name);
+
+        // 诊断回写
+        try
+        {
+            _db.Database.GetCollection<MongoDB.Bson.BsonDocument>("_diag_resolver_calls").UpdateOne(
+                new MongoDB.Bson.BsonDocument { { "_id", traceId } },
+                new MongoDB.Bson.BsonDocument { { "$set", new MongoDB.Bson.BsonDocument
+                {
+                    { "branch", "HIT_FROM_POOL" },
+                    { "returnedModel", selectedModel.ModelId ?? "(null)" },
+                    { "returnedPool", group.Name ?? "(null)" },
+                    { "returnedPlatform", platform.Name ?? "(null)" }
+                }}});
+        }
+        catch { }
 
         return ModelResolutionResult.FromPool(
             resolutionType, expectedModel, selectedModel, group, platform, apiKey);

--- a/prd-api/src/PrdAgent.Api/Services/ExpectedModelRespectingResolver.cs
+++ b/prd-api/src/PrdAgent.Api/Services/ExpectedModelRespectingResolver.cs
@@ -19,10 +19,17 @@ namespace PrdAgent.Api.Services;
 /// </summary>
 public class ExpectedModelRespectingResolver : IModelResolver
 {
-    // 同一请求链内缓存 expectedModel —— 解决 LlmGateway.SendRawAsync 内部二次调用 ResolveAsync
-    // 时 expectedModel 被硬编码成 null 的问题。AsyncLocal 随 ExecutionContext 在 await
-    // 链中自然传递，不会跨 HTTP 请求污染。
-    private static readonly AsyncLocal<string?> _pendingExpectedModel = new();
+    // 同一 DI scope 内缓存 expectedModel —— 解决 LlmGateway.SendRawAsync 内部二次调用
+    // ResolveAsync 时 expectedModel 被硬编码成 null 的问题。
+    //
+    // 为什么是 instance field 而不是 AsyncLocal：
+    //   - AsyncLocal 从"被调用方"写入，值不会 flow 回"调用方"后续调用（ExecutionContext capture 是
+    //     在 await 之前拍快照的）。实测 test-chain 里 call1 写入的值 call2 读不到。
+    //   - 装饰器注册为 Scoped，同一个 scope（同一次 HTTP 请求 / 同一次 Worker run）里 DI 给出的
+    //     是同一个实例。所以实例字段能跨 OpenAIImageClient.GenerateAsync 和 LlmGateway.SendRawAsync
+    //     两次 ResolveAsync 调用自然传递。
+    //   - 并发安全：Scoped 每个请求独立实例，没有跨请求污染。
+    private string? _pendingExpected;
 
     private readonly ModelResolver _inner;
     private readonly MongoDbContext _db;
@@ -54,17 +61,17 @@ public class ExpectedModelRespectingResolver : IModelResolver
         // （Infrastructure.dll 代码，改了部署不生效）。我们在第一次调用时把 expectedModel 存入
         // AsyncLocal，第二次调用 null 时从 AsyncLocal 读回。
         var effectiveExpected = expectedModel;
-        if (string.IsNullOrWhiteSpace(effectiveExpected) && !string.IsNullOrWhiteSpace(_pendingExpectedModel.Value))
+        if (string.IsNullOrWhiteSpace(effectiveExpected) && !string.IsNullOrWhiteSpace(_pendingExpected))
         {
-            effectiveExpected = _pendingExpectedModel.Value;
+            effectiveExpected = _pendingExpected;
             _logger.LogInformation(
-                "[Resolver-Decorator:{Trace}] expectedModel=null，从 AsyncLocal 恢复 '{Recovered}'（来自同请求链前一次 ResolveAsync）",
+                "[Resolver-Decorator:{Trace}] expectedModel=null，从 scope 实例字段恢复 '{Recovered}'（同 DI scope 前一次 ResolveAsync）",
                 traceId, effectiveExpected);
         }
         else if (!string.IsNullOrWhiteSpace(expectedModel))
         {
-            // 存入 AsyncLocal，供同请求链后续调用读取
-            _pendingExpectedModel.Value = expectedModel;
+            // 存入实例字段，供同 DI scope 后续调用读取
+            _pendingExpected = expectedModel;
         }
 
         _logger.LogInformation(

--- a/prd-api/src/PrdAgent.Api/Services/ExpectedModelRespectingResolver.cs
+++ b/prd-api/src/PrdAgent.Api/Services/ExpectedModelRespectingResolver.cs
@@ -19,6 +19,11 @@ namespace PrdAgent.Api.Services;
 /// </summary>
 public class ExpectedModelRespectingResolver : IModelResolver
 {
+    // 同一请求链内缓存 expectedModel —— 解决 LlmGateway.SendRawAsync 内部二次调用 ResolveAsync
+    // 时 expectedModel 被硬编码成 null 的问题。AsyncLocal 随 ExecutionContext 在 await
+    // 链中自然传递，不会跨 HTTP 请求污染。
+    private static readonly AsyncLocal<string?> _pendingExpectedModel = new();
+
     private readonly ModelResolver _inner;
     private readonly MongoDbContext _db;
     private readonly IConfiguration _config;
@@ -43,17 +48,39 @@ public class ExpectedModelRespectingResolver : IModelResolver
         CancellationToken ct = default)
     {
         var traceId = Guid.NewGuid().ToString("N")[..8];
-        _logger.LogInformation(
-            "[Resolver-Decorator:{Trace}] ENTRY appCallerCode={Code} modelType={Type} expectedModel='{Expected}'",
-            traceId, appCallerCode, modelType, expectedModel ?? "(null)");
 
-        if (string.IsNullOrWhiteSpace(expectedModel))
+        // ===== 关键：expectedModel 从 AsyncLocal 回放 =====
+        // 背景：LlmGateway.SendRawAsync 内部再次调用 ResolveAsync 时 expectedModel 硬编码 null
+        // （Infrastructure.dll 代码，改了部署不生效）。我们在第一次调用时把 expectedModel 存入
+        // AsyncLocal，第二次调用 null 时从 AsyncLocal 读回。
+        var effectiveExpected = expectedModel;
+        if (string.IsNullOrWhiteSpace(effectiveExpected) && !string.IsNullOrWhiteSpace(_pendingExpectedModel.Value))
+        {
+            effectiveExpected = _pendingExpectedModel.Value;
+            _logger.LogInformation(
+                "[Resolver-Decorator:{Trace}] expectedModel=null，从 AsyncLocal 恢复 '{Recovered}'（来自同请求链前一次 ResolveAsync）",
+                traceId, effectiveExpected);
+        }
+        else if (!string.IsNullOrWhiteSpace(expectedModel))
+        {
+            // 存入 AsyncLocal，供同请求链后续调用读取
+            _pendingExpectedModel.Value = expectedModel;
+        }
+
+        _logger.LogInformation(
+            "[Resolver-Decorator:{Trace}] ENTRY appCallerCode={Code} modelType={Type} expectedModel='{Raw}' effective='{Effective}'",
+            traceId, appCallerCode, modelType, expectedModel ?? "(null)", effectiveExpected ?? "(null)");
+
+        if (string.IsNullOrWhiteSpace(effectiveExpected))
         {
             _logger.LogInformation(
-                "[Resolver-Decorator:{Trace}] 未指定 expectedModel → 委派内部 resolver",
+                "[Resolver-Decorator:{Trace}] 无 effectiveExpected → 委派内部 resolver",
                 traceId);
             return await _inner.ResolveAsync(appCallerCode, modelType, expectedModel, ct);
         }
+
+        // 后续匹配逻辑用 effectiveExpected 代替 expectedModel
+        expectedModel = effectiveExpected;
 
         // 查 AppCaller 绑定的候选池
         var appCaller = await _db.LLMAppCallers

--- a/prd-api/src/PrdAgent.Api/Services/ExpectedModelRespectingResolver.cs
+++ b/prd-api/src/PrdAgent.Api/Services/ExpectedModelRespectingResolver.cs
@@ -1,0 +1,197 @@
+using MongoDB.Driver;
+using PrdAgent.Core.Models;
+using PrdAgent.Infrastructure.Database;
+using PrdAgent.Infrastructure.LlmGateway;
+
+namespace PrdAgent.Api.Services;
+
+/// <summary>
+/// IModelResolver 装饰器（Api.dll 层）—— 绕过 Infrastructure.dll 部署缓存 bug。
+///
+/// 背景：Round 1-5 修复在 ModelResolver.FindPreferredModel 中加了"尊重 expectedModel"的
+/// 匹配逻辑，但 CDS 部署层对 Infrastructure.dll 的改动缓存了老版本（publish 成功但 dotnet
+/// 进程加载的是老 DLL）。数小时的诊断确认 Api.dll 能正常部署，Infrastructure.dll 不能。
+///
+/// 本装饰器在 Api.dll 里实现完整的 expectedModel 匹配（Tier1/2/3），拦截所有 ResolveAsync
+/// 调用。命中则直接返回 FromPool；未命中才委派给内部的 ModelResolver（可能是老版本）。
+///
+/// 待 CDS 部署 bug 解决后本装饰器可撤回。
+/// </summary>
+public class ExpectedModelRespectingResolver : IModelResolver
+{
+    private readonly ModelResolver _inner;
+    private readonly MongoDbContext _db;
+    private readonly IConfiguration _config;
+    private readonly ILogger<ExpectedModelRespectingResolver> _logger;
+
+    public ExpectedModelRespectingResolver(
+        ModelResolver inner,
+        MongoDbContext db,
+        IConfiguration config,
+        ILogger<ExpectedModelRespectingResolver> logger)
+    {
+        _inner = inner;
+        _db = db;
+        _config = config;
+        _logger = logger;
+    }
+
+    public async Task<ModelResolutionResult> ResolveAsync(
+        string appCallerCode,
+        string modelType,
+        string? expectedModel = null,
+        CancellationToken ct = default)
+    {
+        var traceId = Guid.NewGuid().ToString("N")[..8];
+        _logger.LogInformation(
+            "[Resolver-Decorator:{Trace}] ENTRY appCallerCode={Code} modelType={Type} expectedModel='{Expected}'",
+            traceId, appCallerCode, modelType, expectedModel ?? "(null)");
+
+        if (string.IsNullOrWhiteSpace(expectedModel))
+        {
+            _logger.LogInformation(
+                "[Resolver-Decorator:{Trace}] 未指定 expectedModel → 委派内部 resolver",
+                traceId);
+            return await _inner.ResolveAsync(appCallerCode, modelType, expectedModel, ct);
+        }
+
+        // 查 AppCaller 绑定的候选池
+        var appCaller = await _db.LLMAppCallers
+            .Find(a => a.AppCode == appCallerCode)
+            .FirstOrDefaultAsync(ct);
+        if (appCaller == null)
+        {
+            _logger.LogWarning(
+                "[Resolver-Decorator:{Trace}] AppCaller 未注册 → 委派内部 resolver",
+                traceId);
+            return await _inner.ResolveAsync(appCallerCode, modelType, expectedModel, ct);
+        }
+
+        var requirement = appCaller.ModelRequirements.FirstOrDefault(r => r.ModelType == modelType);
+        if (requirement == null || requirement.ModelGroupIds.Count == 0)
+        {
+            _logger.LogInformation(
+                "[Resolver-Decorator:{Trace}] AppCaller 未绑定 {Type} 池 → 委派内部 resolver",
+                traceId, modelType);
+            return await _inner.ResolveAsync(appCallerCode, modelType, expectedModel, ct);
+        }
+
+        var candidateGroups = await _db.ModelGroups
+            .Find(g => requirement.ModelGroupIds.Contains(g.Id))
+            .SortBy(g => g.Priority)
+            .ToListAsync(ct);
+
+        _logger.LogInformation(
+            "[Resolver-Decorator:{Trace}] 候选池 {Count} 个: [{Pools}] key='{Key}'",
+            traceId, candidateGroups.Count,
+            string.Join(", ", candidateGroups.Select(g => $"{g.Name}(code={g.Code})")),
+            expectedModel);
+
+        // Tier 1：池内某个 ModelId 精确匹配 expectedModel
+        foreach (var g in candidateGroups)
+        {
+            if (g.Models == null) continue;
+            var m = g.Models.FirstOrDefault(x =>
+                x.HealthStatus != ModelHealthStatus.Unavailable &&
+                string.Equals(x.ModelId, expectedModel, StringComparison.OrdinalIgnoreCase));
+            if (m != null)
+            {
+                _logger.LogInformation(
+                    "[Resolver-Decorator:{Trace}] Tier1 命中: pool={Pool} modelId={ModelId}",
+                    traceId, g.Name, m.ModelId);
+                return await BuildFromPoolAsync(g, m, expectedModel, "DedicatedPool", traceId, ct);
+            }
+        }
+
+        // Tier 2：ModelId 前缀匹配
+        foreach (var g in candidateGroups)
+        {
+            if (g.Models == null) continue;
+            var m = g.Models.FirstOrDefault(x =>
+                x.HealthStatus != ModelHealthStatus.Unavailable &&
+                !string.IsNullOrEmpty(x.ModelId) &&
+                x.ModelId.StartsWith(expectedModel, StringComparison.OrdinalIgnoreCase));
+            if (m != null)
+            {
+                _logger.LogInformation(
+                    "[Resolver-Decorator:{Trace}] Tier2 命中（前缀）: pool={Pool} modelId={ModelId}",
+                    traceId, g.Name, m.ModelId);
+                return await BuildFromPoolAsync(g, m, expectedModel, "DedicatedPool", traceId, ct);
+            }
+        }
+
+        // Tier 3：池名 / 池 Code 精确匹配（picker 发的 modelId 实际是池 Code）
+        foreach (var g in candidateGroups)
+        {
+            if (g.Models == null || g.Models.Count == 0) continue;
+            var byName = string.Equals(g.Name, expectedModel, StringComparison.OrdinalIgnoreCase);
+            var byCode = string.Equals(g.Code, expectedModel, StringComparison.OrdinalIgnoreCase);
+            if (!byName && !byCode) continue;
+
+            var picked =
+                g.Models.FirstOrDefault(x => x.HealthStatus == ModelHealthStatus.Healthy)
+                ?? g.Models.FirstOrDefault(x => x.HealthStatus == ModelHealthStatus.Degraded);
+            if (picked != null)
+            {
+                _logger.LogInformation(
+                    "[Resolver-Decorator:{Trace}] Tier3 命中（池{By}）: pool={Pool} modelId={ModelId} health={Health}",
+                    traceId, byCode ? "Code" : "Name", g.Name, picked.ModelId, picked.HealthStatus);
+                return await BuildFromPoolAsync(g, picked, expectedModel, "DedicatedPool", traceId, ct);
+            }
+
+            _logger.LogWarning(
+                "[Resolver-Decorator:{Trace}] Tier3 池名/Code 匹配 {Pool} 但无可用模型",
+                traceId, g.Name);
+        }
+
+        _logger.LogWarning(
+            "[Resolver-Decorator:{Trace}] ✗ expectedModel='{Expected}' 所有档位未命中 → 委派内部 resolver",
+            traceId, expectedModel);
+        return await _inner.ResolveAsync(appCallerCode, modelType, expectedModel, ct);
+    }
+
+    private async Task<ModelResolutionResult> BuildFromPoolAsync(
+        ModelGroup group,
+        ModelGroupItem selectedModel,
+        string? expectedModel,
+        string resolutionType,
+        string traceId,
+        CancellationToken ct)
+    {
+        var platform = await _db.LLMPlatforms
+            .Find(p => p.Id == selectedModel.PlatformId && p.Enabled)
+            .FirstOrDefaultAsync(ct);
+        if (platform == null)
+        {
+            _logger.LogWarning(
+                "[Resolver-Decorator:{Trace}] 命中池 {Pool} 的平台 {Pid} 未找到或未启用 → 返回 NotFound",
+                traceId, group.Name, selectedModel.PlatformId);
+            return ModelResolutionResult.NotFound(expectedModel,
+                $"命中池 {group.Name} 但平台 {selectedModel.PlatformId} 未启用");
+        }
+
+        var jwtSecret = _config["Jwt:Secret"] ?? "DefaultEncryptionKey32Bytes!!!!";
+        var apiKey = string.IsNullOrEmpty(platform.ApiKeyEncrypted)
+            ? null
+            : Core.Helpers.ApiKeyCrypto.Decrypt(platform.ApiKeyEncrypted, jwtSecret);
+
+        _logger.LogInformation(
+            "[Resolver-Decorator:{Trace}] 返回 FromPool: pool={Pool} model={Model} platform={Platform}",
+            traceId, group.Name, selectedModel.ModelId, platform.Name);
+
+        return ModelResolutionResult.FromPool(
+            resolutionType, expectedModel, selectedModel, group, platform, apiKey);
+    }
+
+    // ---- 其余接口方法全部委派给内部 ModelResolver ----
+
+    public Task<List<AvailableModelPool>> GetAvailablePoolsAsync(
+        string appCallerCode, string modelType, CancellationToken ct = default)
+        => _inner.GetAvailablePoolsAsync(appCallerCode, modelType, ct);
+
+    public Task RecordSuccessAsync(ModelResolutionResult resolution, CancellationToken ct = default)
+        => _inner.RecordSuccessAsync(resolution, ct);
+
+    public Task RecordFailureAsync(ModelResolutionResult resolution, CancellationToken ct = default)
+        => _inner.RecordFailureAsync(resolution, ct);
+}

--- a/prd-api/src/PrdAgent.Api/Services/ImageGenRunWorker.cs
+++ b/prd-api/src/PrdAgent.Api/Services/ImageGenRunWorker.cs
@@ -198,6 +198,8 @@ public class ImageGenRunWorker : BackgroundService
             await _db.ImageGenRuns.UpdateOneAsync(x => x.Id == run.Id, Builders<ImageGenRun>.Update.Set(x => x.Total, total), cancellationToken: ct);
         }
 
+        // 推送实际使用的模型信息（前端用此覆盖原本"前端选中的模型"展示）
+        var startAdapter = ImageGenModelAdapterRegistry.TryMatch(run.ModelId);
         await AppendEventAsync(run, "run", new
         {
             type = "runStart",
@@ -206,6 +208,11 @@ public class ImageGenRunWorker : BackgroundService
             modelId = run.ModelId,
             platformId = run.PlatformId,
             configModelId = run.ConfigModelId,
+            modelGroupName = run.ModelGroupName,
+            modelGroupId = run.ModelGroupId,
+            resolutionType = run.ModelResolutionType?.ToString(),
+            isAdaptive = startAdapter?.SizeConstraintType == SizeConstraintTypes.Adaptive,
+            adapterDisplayName = startAdapter?.DisplayName,
             size = run.Size,
             responseFormat = run.ResponseFormat
         }, ct);
@@ -618,6 +625,7 @@ public class ImageGenRunWorker : BackgroundService
                         // ===== 日志图片填充：input 来自前端 COS URL，output 来自生成结果 =====
                         await PatchLogImagesAsync(run, curItemIndex, imageIndex, loadedImageRefs, res.Data.Images, ct);
 
+                        var doneAdapter = ImageGenModelAdapterRegistry.TryMatch(run.ModelId);
                         await AppendEventAsync(run, "image", new
                         {
                             type = "imageDone",
@@ -630,6 +638,8 @@ public class ImageGenRunWorker : BackgroundService
                             sizeAdjusted,
                             ratioAdjusted,
                             modelId = run.ModelId,
+                            modelGroupName = run.ModelGroupName,
+                            isAdaptive = doneAdapter?.SizeConstraintType == SizeConstraintTypes.Adaptive,
                             platformId = run.PlatformId,
                             base64,
                             url,

--- a/prd-api/src/PrdAgent.Api/Services/ImageGenRunWorker.cs
+++ b/prd-api/src/PrdAgent.Api/Services/ImageGenRunWorker.cs
@@ -1307,11 +1307,58 @@ public class ImageGenRunWorker : BackgroundService
         if (run.ModelResolutionType.HasValue)
         {
             _logger.LogInformation(
-                "[视觉创作-专属模型匹配] 跳过匹配（已有解析信息）: resolutionType={ResolutionType}, 使用模型={ModelId}", 
+                "[视觉创作-专属模型匹配] 跳过匹配（已有解析信息）: resolutionType={ResolutionType}, 使用模型={ModelId}",
                 run.ModelResolutionType, run.ModelId ?? "(null)");
             return;
         }
 
+        // ========== 用户显式选择优先原则 ==========
+        // Controller 在 CreateRun 阶段已校验：必须提供 configModelId 或 (platformId + modelId)。
+        // 因此到了 Worker 时 run.ModelId + run.PlatformId 一定都已写入（配置模型 ID 也被翻译成 ModelName）。
+        // 这两个值代表"用户从 picker 里亲手选的模型"——picker 只展示可用模型，能选就必然能用。
+        // 在此前提下不应再调用 scheduler 去"尝试匹配池"，否则会出现"选 A 给 B"的体验缺陷。
+        // 这里仅做一件额外的事：为了日志/UI 展示，尝试把该模型归属到它所在的池（纯旁路，不覆盖选择）。
+        if (!string.IsNullOrWhiteSpace(frontendExpectedModelId) && !string.IsNullOrWhiteSpace(frontendExpectedPlatformId))
+        {
+            // 旁路查询该模型在哪个池（用于 runStart 事件里的 modelGroupName，不影响实际调用）
+            string? poolIdSidecar = null;
+            string? poolNameSidecar = null;
+            try
+            {
+                var hostingGroup = await _db.ModelGroups
+                    .Find(g => g.Models != null && g.Models.Any(m =>
+                        m.ModelId == frontendExpectedModelId &&
+                        m.PlatformId == frontendExpectedPlatformId))
+                    .FirstOrDefaultAsync(ct);
+                if (hostingGroup != null)
+                {
+                    poolIdSidecar = hostingGroup.Id;
+                    poolNameSidecar = hostingGroup.Name;
+                }
+            }
+            catch (Exception sideEx)
+            {
+                _logger.LogDebug(sideEx, "[生图模型匹配] 旁路池名查询失败（忽略，不影响主流程）");
+            }
+
+            _logger.LogInformation(
+                "[生图模型匹配] 尊重用户显式选择 → 跳过 scheduler: modelId={ModelId}, platformId={PlatformId}, 归属池={Pool}",
+                frontendExpectedModelId, frontendExpectedPlatformId, poolNameSidecar ?? "(不在任何池)");
+
+            var directUpdate = Builders<ImageGenRun>.Update
+                .Set(x => x.ModelResolutionType, ModelResolutionType.DirectModel)
+                .Set(x => x.ModelGroupId, poolIdSidecar)
+                .Set(x => x.ModelGroupName, poolNameSidecar);
+
+            run.ModelResolutionType = ModelResolutionType.DirectModel;
+            run.ModelGroupId = poolIdSidecar;
+            run.ModelGroupName = poolNameSidecar;
+
+            await _db.ImageGenRuns.UpdateOneAsync(x => x.Id == run.Id, directUpdate, cancellationToken: ct);
+            return;
+        }
+
+        // 走到这里说明 Controller 的校验被绕过或字段丢失——降级到 scheduler
         ModelResolutionType resolutionType = ModelResolutionType.DirectModel; // 默认为直连单模型
         string? modelGroupId = null;
         string? modelGroupName = null;

--- a/prd-api/src/PrdAgent.Api/Services/ImageGenRunWorker.cs
+++ b/prd-api/src/PrdAgent.Api/Services/ImageGenRunWorker.cs
@@ -1312,53 +1312,6 @@ public class ImageGenRunWorker : BackgroundService
             return;
         }
 
-        // ========== 用户显式选择优先原则 ==========
-        // Controller 在 CreateRun 阶段已校验：必须提供 configModelId 或 (platformId + modelId)。
-        // 因此到了 Worker 时 run.ModelId + run.PlatformId 一定都已写入（配置模型 ID 也被翻译成 ModelName）。
-        // 这两个值代表"用户从 picker 里亲手选的模型"——picker 只展示可用模型，能选就必然能用。
-        // 在此前提下不应再调用 scheduler 去"尝试匹配池"，否则会出现"选 A 给 B"的体验缺陷。
-        // 这里仅做一件额外的事：为了日志/UI 展示，尝试把该模型归属到它所在的池（纯旁路，不覆盖选择）。
-        if (!string.IsNullOrWhiteSpace(frontendExpectedModelId) && !string.IsNullOrWhiteSpace(frontendExpectedPlatformId))
-        {
-            // 旁路查询该模型在哪个池（用于 runStart 事件里的 modelGroupName，不影响实际调用）
-            string? poolIdSidecar = null;
-            string? poolNameSidecar = null;
-            try
-            {
-                var hostingGroup = await _db.ModelGroups
-                    .Find(g => g.Models != null && g.Models.Any(m =>
-                        m.ModelId == frontendExpectedModelId &&
-                        m.PlatformId == frontendExpectedPlatformId))
-                    .FirstOrDefaultAsync(ct);
-                if (hostingGroup != null)
-                {
-                    poolIdSidecar = hostingGroup.Id;
-                    poolNameSidecar = hostingGroup.Name;
-                }
-            }
-            catch (Exception sideEx)
-            {
-                _logger.LogDebug(sideEx, "[生图模型匹配] 旁路池名查询失败（忽略，不影响主流程）");
-            }
-
-            _logger.LogInformation(
-                "[生图模型匹配] 尊重用户显式选择 → 跳过 scheduler: modelId={ModelId}, platformId={PlatformId}, 归属池={Pool}",
-                frontendExpectedModelId, frontendExpectedPlatformId, poolNameSidecar ?? "(不在任何池)");
-
-            var directUpdate = Builders<ImageGenRun>.Update
-                .Set(x => x.ModelResolutionType, ModelResolutionType.DirectModel)
-                .Set(x => x.ModelGroupId, poolIdSidecar)
-                .Set(x => x.ModelGroupName, poolNameSidecar);
-
-            run.ModelResolutionType = ModelResolutionType.DirectModel;
-            run.ModelGroupId = poolIdSidecar;
-            run.ModelGroupName = poolNameSidecar;
-
-            await _db.ImageGenRuns.UpdateOneAsync(x => x.Id == run.Id, directUpdate, cancellationToken: ct);
-            return;
-        }
-
-        // 走到这里说明 Controller 的校验被绕过或字段丢失——降级到 scheduler
         ModelResolutionType resolutionType = ModelResolutionType.DirectModel; // 默认为直连单模型
         string? modelGroupId = null;
         string? modelGroupName = null;

--- a/prd-api/src/PrdAgent.Infrastructure/LLM/ImageGenModelAdapterConfig.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LLM/ImageGenModelAdapterConfig.cs
@@ -27,6 +27,8 @@ public static class SizeConstraintTypes
     public const string Range = "range";
     /// <summary>仅支持比例枚举（具体像素由模型决定）</summary>
     public const string AspectRatio = "aspect_ratio";
+    /// <summary>自适应：模型不接受 size/aspect_ratio 字段，尺寸由 prompt 描述决定</summary>
+    public const string Adaptive = "adaptive";
 }
 
 /// <summary>
@@ -40,6 +42,8 @@ public static class SizeParamFormats
     public const string WidthHeight = "{width,height}";
     /// <summary>aspect_ratio 比例格式（如 1:1）</summary>
     public const string AspectRatio = "aspect_ratio";
+    /// <summary>不传任何尺寸参数（由 prompt 决定）</summary>
+    public const string None = "none";
 }
 
 /// <summary>
@@ -155,6 +159,12 @@ public class SizeAdaptationResult
 
     /// <summary>是否进行了比例调整</summary>
     public bool RatioAdjusted { get; set; }
+
+    /// <summary>
+    /// 是否为自适应模型：true 表示模型不接受任何 size/aspect_ratio 字段，
+    /// 调用方必须跳过尺寸参数注入，最终输出尺寸由 prompt 内容决定。
+    /// </summary>
+    public bool IsAdaptive { get; set; }
 }
 
 /// <summary>
@@ -183,6 +193,9 @@ public class ImageGenRequestParams
     /// <summary>匹配到的适配器名称（如 doubao-seedream-4-5*）</summary>
     public string? AdapterName { get; set; }
 
-    /// <summary>参数格式类型（WxH / {width,height} / aspect_ratio）</summary>
+    /// <summary>参数格式类型（WxH / {width,height} / aspect_ratio / none）</summary>
     public string SizeParamFormat { get; set; } = SizeParamFormats.WxH;
+
+    /// <summary>是否为自适应模型：true 表示请求体不应包含任何尺寸字段</summary>
+    public bool IsAdaptive { get; set; }
 }

--- a/prd-api/src/PrdAgent.Infrastructure/LLM/ImageGenModelAdapterRegistry.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LLM/ImageGenModelAdapterRegistry.cs
@@ -36,6 +36,22 @@ public static class ImageGenModelAdapterRegistry
     /// </summary>
     public static SizeAdaptationResult NormalizeSize(ImageGenModelAdapterConfig config, string? requestedSize)
     {
+        // 自适应：不做尺寸归一化，输出尺寸由 prompt 决定
+        if (config.SizeConstraintType == SizeConstraintTypes.Adaptive)
+        {
+            TryParseSize(requestedSize, out var aw, out var ah);
+            return new SizeAdaptationResult
+            {
+                Size = string.IsNullOrWhiteSpace(requestedSize) ? string.Empty : requestedSize.Trim(),
+                Width = aw,
+                Height = ah,
+                AspectRatio = aw > 0 && ah > 0 ? FindClosestRatio((double)aw / ah, GetAllRatiosFromConfig(config)) : null,
+                IsAdaptive = true,
+                SizeAdjusted = false,
+                RatioAdjusted = false,
+            };
+        }
+
         var result = new SizeAdaptationResult();
         var allSizes = GetAllSizesFromConfig(config);
         var allRatios = GetAllRatiosFromConfig(config);
@@ -276,6 +292,15 @@ public static class ImageGenModelAdapterRegistry
                     targetParams["resolution"] = sizeResult.Resolution;
                 }
                 break;
+
+            case SizeParamFormats.None:
+                // 自适应模型：不注入任何尺寸参数，并清掉调用方可能误传的 size/width/height/aspect_ratio
+                targetParams.Remove("size");
+                targetParams.Remove("width");
+                targetParams.Remove("height");
+                targetParams.Remove("aspect_ratio");
+                targetParams.Remove("resolution");
+                break;
         }
     }
 
@@ -309,6 +334,7 @@ public static class ImageGenModelAdapterRegistry
             Notes = config.Notes,
             SupportsImageToImage = config.SupportsImageToImage,
             SupportsInpainting = config.SupportsInpainting,
+            IsAdaptive = config.SizeConstraintType == SizeConstraintTypes.Adaptive,
         };
     }
 
@@ -384,13 +410,20 @@ public static class ImageGenModelAdapterRegistry
         result.HasAdapter = true;
         result.AdapterName = config.ModelIdPattern;
         result.SizeParamFormat = config.SizeParamFormat;
+        result.IsAdaptive = config.SizeConstraintType == SizeConstraintTypes.Adaptive;
 
         // 1. 尺寸归一化
         var sizeResult = NormalizeSize(config, requestedSize);
         result.Adaptation = sizeResult;
 
-        // 2. 应用尺寸参数格式（WxH / width+height / aspect_ratio）
+        // 2. 应用尺寸参数格式（WxH / width+height / aspect_ratio / none）
         ApplySizeParams(config, sizeResult, result.SizeParams);
+
+        // 2.1 ParamRenames 同样作用到 SizeParams（如 aspect_ratio → aspectRatio for nano-banana-2）
+        if (config.ParamRenames.Count > 0 && result.SizeParams.Count > 0)
+        {
+            result.SizeParams = TransformParams(config, result.SizeParams);
+        }
 
         // 3. 参数重命名（如 model -> model_name）
         if (extraParams != null)
@@ -527,4 +560,7 @@ public class ImageGenAdapterInfo
     public List<string> Notes { get; set; } = new();
     public bool SupportsImageToImage { get; set; }
     public bool SupportsInpainting { get; set; }
+
+    /// <summary>是否为自适应模型：true 表示前端不应展示尺寸选择器，应展示"自适应"徽标</summary>
+    public bool IsAdaptive { get; set; }
 }

--- a/prd-api/src/PrdAgent.Infrastructure/LLM/ImageGenModelConfigs.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LLM/ImageGenModelConfigs.cs
@@ -14,9 +14,123 @@ public static class ImageGenModelConfigs
 {
     /// <summary>
     /// 所有已知的生图模型适配配置
+    ///
+    /// ⚠️ 顺序重要：基于 ModelIdPattern 前缀匹配，越长越具体的 pattern 必须排在前面。
+    /// 例如 "nano-banana-2*" 必须排在 "nano-banana*" 之前，否则后者会先吃掉所有 nano-banana-* 输入。
     /// </summary>
     public static readonly List<ImageGenModelAdapterConfig> Configs = new()
     {
+        // ===== gpt-image-2-all（自适应模型：尺寸由 prompt 描述决定）=====
+        // 接口：apiyi 等 OpenAI 兼容网关
+        // 关键点：
+        //   1. 不接受 size / n / quality / aspect_ratio 字段（传了会 400）
+        //   2. 尺寸/比例需写进 prompt 最前面（如 "横版 16:9 电影画幅，..."）
+        //   3. b64_json 字段已含 data:image/png;base64, 前缀（OpenAIImageClient 已有兼容处理）
+        new ImageGenModelAdapterConfig
+        {
+            ModelIdPattern = "gpt-image-2-all*",
+            DisplayName = "gpt-image-2-all（自适应）",
+            Provider = "OpenAI 兼容（apiyi）",
+            PlatformType = "openai",
+            LastUpdated = "2026-04-22",
+            SizeConstraintType = SizeConstraintTypes.Adaptive,
+            SizeConstraintDescription = "自适应模型：不接受尺寸字段，输出尺寸由 prompt 描述决定（推荐把尺寸词写在最前面）",
+            SizesByResolution = new Dictionary<string, List<SizeOption>>
+            {
+                // 仅作展示参考，调用时 *不* 会作为 size 参数发送
+                ["1k"] = new()
+                {
+                    new("1024x1024", "1:1"),
+                    new("1344x768", "16:9"),
+                    new("768x1344", "9:16"),
+                    new("1248x832", "3:2"),
+                    new("832x1248", "2:3"),
+                },
+                ["2k"] = new(),
+                ["4k"] = new(),
+            },
+            SizeParamFormat = SizeParamFormats.None,
+            Notes = new List<string>
+            {
+                "尺寸/比例请写进 prompt 最前面（推荐：'横版 16:9 电影画幅，...' / '竖版 9:16 海报，...'）",
+                "不传 size / n / quality / aspect_ratio，否则会触发参数校验错误",
+                "b64_json 已含 data:image/png;base64, 前缀，无需手动拼接",
+                "兼容 /v1/images/generations、/v1/images/edits、/v1/chat/completions 三端点",
+            },
+            SupportsImageToImage = true,
+            SupportsInpainting = false,
+        },
+
+        // ===== gpt-image-1.5（标准 size 参数）=====
+        // 与传统 OpenAI 兼容：通过 size 字段控制尺寸
+        new ImageGenModelAdapterConfig
+        {
+            ModelIdPattern = "gpt-image-1.5*",
+            DisplayName = "GPT-Image-1.5",
+            Provider = "OpenAI 兼容",
+            PlatformType = "openai",
+            LastUpdated = "2026-04-22",
+            SizeConstraintType = SizeConstraintTypes.Whitelist,
+            SizeConstraintDescription = "通过 size 参数控制尺寸（标准 OpenAI 风格白名单）",
+            SizesByResolution = new Dictionary<string, List<SizeOption>>
+            {
+                ["1k"] = new()
+                {
+                    new("1024x1024", "1:1"),
+                    new("1024x1536", "2:3"),
+                    new("1536x1024", "3:2"),
+                    new("1024x1792", "9:16"),
+                    new("1792x1024", "16:9"),
+                },
+                ["2k"] = new(),
+                ["4k"] = new(),
+            },
+            SizeParamFormat = SizeParamFormats.WxH,
+            MaxWidth = 1792,
+            MaxHeight = 1792,
+            MinWidth = 1024,
+            MinHeight = 1024,
+            Notes = new List<string> { "文字渲染能力强（5 星）", "通过标准 size 参数控制尺寸" },
+            SupportsImageToImage = true,
+            SupportsInpainting = true,
+        },
+
+        // ===== Nano Banana 2（aspectRatio 参数）=====
+        // ⚠️ 必须排在 nano-banana* 之前
+        new ImageGenModelAdapterConfig
+        {
+            ModelIdPattern = "nano-banana-2*",
+            DisplayName = "Nano Banana 2",
+            Provider = "Google",
+            LastUpdated = "2026-04-22",
+            SizeConstraintType = SizeConstraintTypes.AspectRatio,
+            SizeConstraintDescription = "通过 aspectRatio 参数控制比例，具体像素由模型决定",
+            SizesByResolution = new Dictionary<string, List<SizeOption>>
+            {
+                ["1k"] = new()
+                {
+                    new("1024x1024", "1:1"),
+                    new("1344x768", "16:9"),
+                    new("768x1344", "9:16"),
+                    new("1248x832", "3:2"),
+                    new("832x1248", "2:3"),
+                    new("1184x864", "4:3"),
+                    new("864x1184", "3:4"),
+                },
+                ["2k"] = new(),
+                ["4k"] = new(),
+            },
+            SizeParamFormat = SizeParamFormats.AspectRatio,
+            ParamRenames = new Dictionary<string, string> { { "aspect_ratio", "aspectRatio" } },
+            Notes = new List<string>
+            {
+                "通过 aspectRatio 参数控制比例（驼峰格式，注意与 aspect_ratio 区别）",
+                "文字渲染 4 星，多图融合走 inlineData",
+            },
+            SupportsImageToImage = true,
+            SupportsInpainting = true,
+        },
+
         // ===== Gemini Nano-Banana 系列 =====
         new ImageGenModelAdapterConfig
         {

--- a/prd-api/src/PrdAgent.Infrastructure/LLM/OpenAIImageClient.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LLM/OpenAIImageClient.cs
@@ -226,7 +226,11 @@ public class OpenAIImageClient
         {
             adapterConfig = ImageGenModelAdapterRegistry.TryMatch(effectiveModelName);
             adapterSizeResult = reqParams.Adaptation;
-            size = adapterSizeResult.Size;
+            // 自适应模型不覆盖 size（保留 null/空），避免后续注入到请求体
+            if (!reqParams.IsAdaptive)
+            {
+                size = adapterSizeResult.Size;
+            }
 
             if (adapterConfig != null)
             {
@@ -235,6 +239,13 @@ public class OpenAIImageClient
                     ? allSizes.Take(64).ToList()
                     : null;
             }
+        }
+
+        // 自适应模型：标准化 size 为 null，避免后续路径错误注入
+        var isAdaptiveModel = reqParams.HasAdapter && reqParams.IsAdaptive;
+        if (isAdaptiveModel)
+        {
+            size = null;
         }
 
         // 非 Volces 且无适配器：尝试命中"允许尺寸白名单"缓存，避免先 400 再重试
@@ -361,10 +372,14 @@ public class OpenAIImageClient
                     var exchangeBody = new JsonObject
                     {
                         ["prompt"] = prompt,
-                        ["n"] = n,
                     };
-                    if (!string.IsNullOrWhiteSpace(requestedSizeNorm))
-                        exchangeBody["size"] = requestedSizeNorm;
+                    // 自适应模型不带 n / size（上游会因未知字段 400）
+                    if (!isAdaptiveModel)
+                    {
+                        exchangeBody["n"] = n;
+                        if (!string.IsNullOrWhiteSpace(requestedSizeNorm))
+                            exchangeBody["size"] = requestedSizeNorm;
+                    }
 
                     // 图生图：将参考图转为 data URI 放入 image_urls
                     if (initImageBase64 != null)
@@ -573,7 +588,8 @@ public class OpenAIImageClient
             gatewayResp = await SendViaGatewayAsync(ct);
 
             // 平台特定的尺寸错误处理：使用适配器自动修正
-            if (initImageBase64 == null && gatewayResp.StatusCode == 400)
+            // 自适应模型完全不发尺寸字段，跳过此分支以免 reqObj 不存在 size 属性时 NRE
+            if (initImageBase64 == null && gatewayResp.StatusCode == 400 && !isAdaptiveModel)
             {
                 var firstBody = gatewayResp.Content ?? string.Empty;
                 if (TryExtractUpstreamErrorMessage(firstBody, out var errMsg))
@@ -590,7 +606,8 @@ public class OpenAIImageClient
             }
 
             // 非 Volces：某些 OpenAI 兼容网关会对 size 采用"白名单尺寸"校验
-            if (!isVolces && gatewayResp.StatusCode == 400)
+            // 自适应模型不发 size，无需走此分支
+            if (!isVolces && gatewayResp.StatusCode == 400 && !isAdaptiveModel)
             {
                 var firstBody = gatewayResp.Content ?? string.Empty;
                 if (TryExtractUpstreamErrorMessage(firstBody, out var errMsg2) &&

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/ModelResolver.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/ModelResolver.cs
@@ -156,8 +156,36 @@ public class ModelResolver : IModelResolver
                 $"未找到可用模型: AppCallerCode={appCallerCode}, ModelType={modelType}");
         }
 
+        // ========== 第 5.5 步：若调用方指定了 expectedModel，优先尊重 ==========
+        // 在所有候选池中寻找匹配 expectedModel（按 ModelId / 池名 模糊匹配）的可用条目
+        ModelGroup? preferredGroup = null;
+        ModelGroupItem? preferredItem = null;
+        if (!string.IsNullOrWhiteSpace(expectedModel))
+        {
+            var (g, m) = FindPreferredModel(candidateGroups, expectedModel);
+            if (g != null && m != null)
+            {
+                preferredGroup = g;
+                preferredItem = m;
+                _logger.LogInformation(
+                    "[ModelResolver] 命中 expectedModel: {Expected} → 池 {PoolName} 中的模型 {ModelId}",
+                    expectedModel, g.Name, m.ModelId);
+            }
+            else
+            {
+                _logger.LogInformation(
+                    "[ModelResolver] expectedModel '{Expected}' 在候选池中未找到匹配（池：[{Pools}]），将走默认调度",
+                    expectedModel, string.Join(", ", candidateGroups.Select(x => x.Name)));
+            }
+        }
+
         // ========== 第六步：从模型池中选择最佳模型 ==========
-        foreach (var group in candidateGroups)
+        // 若上一步命中 expectedModel，将该池放在最前面优先尝试
+        var orderedGroups = preferredGroup != null
+            ? new[] { preferredGroup }.Concat(candidateGroups.Where(g => g.Id != preferredGroup.Id)).ToList()
+            : candidateGroups;
+
+        foreach (var group in orderedGroups)
         {
             // 诊断：模型池内容
             _logger.LogInformation(
@@ -167,7 +195,10 @@ public class ModelResolver : IModelResolver
                 string.Join(", ", group.Models?.Select(m =>
                     $"{m.ModelId}(Health={m.HealthStatus}, Platform={m.PlatformId})") ?? Array.Empty<string>()));
 
-            var selectedModel = SelectBestModel(group);
+            // expectedModel 命中的池：直接用命中的具体条目；否则按健康度选最优
+            var selectedModel = (preferredGroup != null && group.Id == preferredGroup.Id)
+                ? preferredItem
+                : SelectBestModel(group);
             if (selectedModel == null)
             {
                 _logger.LogWarning(
@@ -522,6 +553,58 @@ public class ModelResolver : IModelResolver
             return null;
         }
         return exchange;
+    }
+
+    /// <summary>
+    /// 在候选池列表中寻找用户期望的模型。
+    /// 匹配规则（按优先级）：
+    ///   1. 池中某个 ModelId 完全匹配 expectedModel（忽略大小写）
+    ///   2. 池中某个 ModelId 是 expectedModel 的前缀（用于带版本号的容差）
+    ///   3. 池名（ModelGroup.Name / Code）匹配 expectedModel
+    /// 返回的条目必须不是 Unavailable 状态。
+    /// </summary>
+    private static (ModelGroup? group, ModelGroupItem? item) FindPreferredModel(
+        List<ModelGroup> groups, string expectedModel)
+    {
+        if (groups.Count == 0 || string.IsNullOrWhiteSpace(expectedModel))
+            return (null, null);
+
+        var key = expectedModel.Trim();
+
+        // 优先级 1：ModelId 精确匹配
+        foreach (var g in groups)
+        {
+            if (g.Models == null) continue;
+            var exact = g.Models.FirstOrDefault(m =>
+                m.HealthStatus != ModelHealthStatus.Unavailable &&
+                string.Equals(m.ModelId, key, StringComparison.OrdinalIgnoreCase));
+            if (exact != null) return (g, exact);
+        }
+
+        // 优先级 2：ModelId 前缀匹配（如 expected="gemini-3-pro" 命中 "gemini-3-pro-image-preview"）
+        foreach (var g in groups)
+        {
+            if (g.Models == null) continue;
+            var prefix = g.Models.FirstOrDefault(m =>
+                m.HealthStatus != ModelHealthStatus.Unavailable &&
+                m.ModelId != null &&
+                m.ModelId.StartsWith(key, StringComparison.OrdinalIgnoreCase));
+            if (prefix != null) return (g, prefix);
+        }
+
+        // 优先级 3：池名/池 Code 匹配
+        foreach (var g in groups)
+        {
+            var matchByPool =
+                string.Equals(g.Name, key, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(g.Code, key, StringComparison.OrdinalIgnoreCase);
+            if (!matchByPool || g.Models == null) continue;
+
+            var any = g.Models.FirstOrDefault(m => m.HealthStatus != ModelHealthStatus.Unavailable);
+            if (any != null) return (g, any);
+        }
+
+        return (null, null);
     }
 
     private ModelGroupItem? SelectBestModel(ModelGroup group)

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/ModelResolver.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/ModelResolver.cs
@@ -33,7 +33,23 @@ public class ModelResolver : IModelResolver
         string? expectedModel = null,
         CancellationToken ct = default)
     {
-        // ⚠ 诊断用：Error 级别确保任何 logging filter 下都出现在 stdout
+        // ⚠ 诊断：直接写 MongoDB 集合 _diag_resolver（绕过 stdout 不可靠问题）
+        var diagId = Guid.NewGuid().ToString("N");
+        try
+        {
+            var coll = _db.Database.GetCollection<MongoDB.Bson.BsonDocument>("_diag_resolver");
+            await coll.InsertOneAsync(new MongoDB.Bson.BsonDocument
+            {
+                { "_id", diagId },
+                { "phase", "ENTRY" },
+                { "ts", DateTime.UtcNow },
+                { "appCallerCode", appCallerCode ?? "(null)" },
+                { "modelType", modelType ?? "(null)" },
+                { "expectedModel", expectedModel ?? "(null)" }
+            }, cancellationToken: ct);
+        }
+        catch { /* swallow */ }
+
         _logger.LogError(
             "[DIAG-ResolveAsync] ENTRY appCallerCode={Code}, modelType={Type}, expectedModel='{Expected}'",
             appCallerCode, modelType, expectedModel ?? "(null)");
@@ -630,7 +646,34 @@ public class ModelResolver : IModelResolver
 
         var key = expectedModel.Trim();
 
-        // ⚠ 诊断 LogError
+        // ⚠ 诊断：MongoDB 记录 FindPreferredModel 的输入
+        try
+        {
+            var coll = _db.Database.GetCollection<MongoDB.Bson.BsonDocument>("_diag_resolver");
+            var poolsArr = new MongoDB.Bson.BsonArray();
+            foreach (var g in groups)
+            {
+                poolsArr.Add(new MongoDB.Bson.BsonDocument
+                {
+                    { "name", g.Name ?? "" },
+                    { "code", g.Code ?? "" },
+                    { "modelsCount", g.Models?.Count ?? 0 },
+                    { "firstModelId", g.Models?.FirstOrDefault()?.ModelId ?? "" },
+                    { "firstModelHealth", g.Models?.FirstOrDefault()?.HealthStatus.ToString() ?? "" }
+                });
+            }
+            await coll.InsertOneAsync(new MongoDB.Bson.BsonDocument
+            {
+                { "_id", Guid.NewGuid().ToString("N") },
+                { "phase", "FindPreferredModel_ENTRY" },
+                { "ts", DateTime.UtcNow },
+                { "key", key },
+                { "groupCount", groups.Count },
+                { "pools", poolsArr }
+            });
+        }
+        catch { }
+
         _logger.LogError(
             "[DIAG-FindPreferredModel] 开始 key='{Key}' 候选池共{Count}: [{Pools}]",
             key, groups.Count,
@@ -686,6 +729,22 @@ public class ModelResolver : IModelResolver
                 ?? g.Models.FirstOrDefault(m => m.HealthStatus == ModelHealthStatus.Degraded);
             if (picked != null)
             {
+                try
+                {
+                    var coll = _db.Database.GetCollection<MongoDB.Bson.BsonDocument>("_diag_resolver");
+                    coll.InsertOne(new MongoDB.Bson.BsonDocument
+                    {
+                        { "_id", Guid.NewGuid().ToString("N") },
+                        { "phase", "Tier3_HIT" },
+                        { "ts", DateTime.UtcNow },
+                        { "key", key },
+                        { "poolName", g.Name ?? "" },
+                        { "poolCode", g.Code ?? "" },
+                        { "modelId", picked.ModelId ?? "" }
+                    });
+                }
+                catch { }
+
                 _logger.LogError(
                     "[DIAG-Tier3] ✓ 命中: pool={Pool}, modelId={ModelId}, health={Health}",
                     g.Name, picked.ModelId, picked.HealthStatus);
@@ -697,6 +756,18 @@ public class ModelResolver : IModelResolver
                 g.Name, g.Models.Count);
         }
 
+        try
+        {
+            var coll = _db.Database.GetCollection<MongoDB.Bson.BsonDocument>("_diag_resolver");
+            coll.InsertOne(new MongoDB.Bson.BsonDocument
+            {
+                { "_id", Guid.NewGuid().ToString("N") },
+                { "phase", "ALL_TIERS_MISS" },
+                { "ts", DateTime.UtcNow },
+                { "key", key }
+            });
+        }
+        catch { }
         _logger.LogError(
             "[DIAG-FindPreferredModel] ✗ 所有档位未命中: key='{Key}'",
             key);

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/ModelResolver.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/ModelResolver.cs
@@ -608,14 +608,14 @@ public class ModelResolver : IModelResolver
     /// <summary>
     /// 在候选池列表中寻找用户期望的模型。
     /// 匹配规则（按优先级）：
-    ///   1. 池中某个 ModelId 完全匹配 expectedModel
+    ///   1. 池中某个 ModelId 完全匹配 expectedModel（健康模型优先）
     ///   2. 池中某个 ModelId 是 expectedModel 的前缀（容差：带版本号）
-    ///   3. 池名 / 池 Code 匹配 expectedModel（前端发的是池 Code，例如 "gpt-image-1-5"）
-    ///   4. 归一化匹配（去掉点/横线/下划线后比较，兜住"gpt-image-1.5" vs "gpt-image-1-5" 这类命名不一致）
+    ///   3. 池名 / 池 Code 匹配 expectedModel（前端 picker 发的就是池 Code）
     ///
-    /// 健康状态处理：遵守"能选就代表能用"原则 —— 前端 picker 是后端给出的可用清单，
-    /// 用户选了就必须尊重。即便池里所有模型都被临时标 Unavailable，也先返回"最不差的那个"
-    /// 并写一条 warning 日志，让调用方在真实请求失败时再走降级。
+    /// 健康约束：只返回非 Unavailable 的模型。用户选的池若全部不可用，
+    /// 返回 (null, null) 让上层走"询问用户是否切换"路径（前端发起请求前已做预检）。
+    /// 这里不做命名归一化（如 "1.5" ↔ "1-5"）——池 Code 是系统自动填充的，
+    /// 不会出现用户手填造成的命名漂移。
     /// </summary>
     private (ModelGroup? group, ModelGroupItem? item) FindPreferredModel(
         List<ModelGroup> groups, string expectedModel)
@@ -624,24 +624,23 @@ public class ModelResolver : IModelResolver
             return (null, null);
 
         var key = expectedModel.Trim();
-        var keyNorm = Normalize(key);
 
         _logger.LogInformation(
-            "[ModelResolver] FindPreferredModel 开始: key='{Key}' (归一化='{Norm}'), 候选池={Count} [{Names}]",
-            key, keyNorm, groups.Count,
+            "[ModelResolver] FindPreferredModel 开始: key='{Key}', 候选池={Count} [{Names}]",
+            key, groups.Count,
             string.Join(", ", groups.Select(g => $"{g.Name}(code={g.Code})")));
 
-        // 优先级 1：ModelId 精确匹配（健康优先，缺省容忍非健康）
+        // 优先级 1：ModelId 精确匹配
         foreach (var g in groups)
         {
             if (g.Models == null) continue;
-            var exactHealthy = g.Models.FirstOrDefault(m =>
+            var exact = g.Models.FirstOrDefault(m =>
                 m.HealthStatus != ModelHealthStatus.Unavailable &&
                 string.Equals(m.ModelId, key, StringComparison.OrdinalIgnoreCase));
-            if (exactHealthy != null)
+            if (exact != null)
             {
-                _logger.LogInformation("[ModelResolver] Tier1 命中: pool={Pool}, modelId={ModelId}", g.Name, exactHealthy.ModelId);
-                return (g, exactHealthy);
+                _logger.LogInformation("[ModelResolver] Tier1 命中: pool={Pool}, modelId={ModelId}", g.Name, exact.ModelId);
+                return (g, exact);
             }
         }
 
@@ -655,67 +654,41 @@ public class ModelResolver : IModelResolver
                 m.ModelId.StartsWith(key, StringComparison.OrdinalIgnoreCase));
             if (prefix != null)
             {
-                _logger.LogInformation("[ModelResolver] Tier2 命中: pool={Pool}, modelId={ModelId} (前缀匹配 key='{Key}')", g.Name, prefix.ModelId, key);
+                _logger.LogInformation("[ModelResolver] Tier2 命中: pool={Pool}, modelId={ModelId}", g.Name, prefix.ModelId);
                 return (g, prefix);
             }
         }
 
-        // 优先级 3 + 4：池名/Code 匹配 + 归一化匹配（合并一次扫描，避免重复遍历）
-        // 用户的原则"能选就代表能用"：picker 展示了池就意味着可用；健康状态只作挑选顺序，不作拒绝理由
+        // 优先级 3：池名/池 Code 精确匹配（picker 发的 modelId 实际是池 Code）
         foreach (var g in groups)
         {
             if (g.Models == null || g.Models.Count == 0) continue;
-
-            var matchExact =
+            var matchByPool =
                 string.Equals(g.Name, key, StringComparison.OrdinalIgnoreCase) ||
                 string.Equals(g.Code, key, StringComparison.OrdinalIgnoreCase);
-            var matchNorm = !matchExact && (
-                string.Equals(Normalize(g.Name), keyNorm, StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(Normalize(g.Code), keyNorm, StringComparison.OrdinalIgnoreCase));
+            if (!matchByPool) continue;
 
-            if (!matchExact && !matchNorm) continue;
-
-            // 取最佳：Healthy > Degraded > 其他（含 Unavailable 也不排除）
+            // Healthy > Degraded；Unavailable 不选（交给前端走"询问切换"）
             var picked =
                 g.Models.FirstOrDefault(m => m.HealthStatus == ModelHealthStatus.Healthy)
-                ?? g.Models.FirstOrDefault(m => m.HealthStatus == ModelHealthStatus.Degraded)
-                ?? g.Models.First();
-
-            var tier = matchExact ? "Tier3(池名/Code 精确)" : "Tier4(池名归一化)";
-            if (picked.HealthStatus == ModelHealthStatus.Unavailable)
-            {
-                _logger.LogWarning(
-                    "[ModelResolver] {Tier} 命中但模型被标为 Unavailable，仍尊重用户选择返回: pool={Pool}, modelId={ModelId}。如真实请求失败将走降级。",
-                    tier, g.Name, picked.ModelId);
-            }
-            else
+                ?? g.Models.FirstOrDefault(m => m.HealthStatus == ModelHealthStatus.Degraded);
+            if (picked != null)
             {
                 _logger.LogInformation(
-                    "[ModelResolver] {Tier} 命中: pool={Pool}, modelId={ModelId}, health={Health}",
-                    tier, g.Name, picked.ModelId, picked.HealthStatus);
+                    "[ModelResolver] Tier3 命中: pool={Pool}, modelId={ModelId}, health={Health}",
+                    g.Name, picked.ModelId, picked.HealthStatus);
+                return (g, picked);
             }
-            return (g, picked);
+
+            _logger.LogInformation(
+                "[ModelResolver] Tier3 池名/Code 匹配但池内无可用模型: pool={Pool} (共{Count}个, 全部 Unavailable)",
+                g.Name, g.Models.Count);
         }
 
         _logger.LogInformation(
-            "[ModelResolver] FindPreferredModel 所有档位未命中: key='{Key}'。候选池 Code=[{Codes}]",
-            key, string.Join(", ", groups.Select(g => g.Code ?? "(无code)")));
+            "[ModelResolver] FindPreferredModel 所有档位未命中: key='{Key}'",
+            key);
         return (null, null);
-    }
-
-    /// <summary>
-    /// 归一化字符串：转小写 + 去掉所有非字母数字字符（点/横线/下划线/空格）。
-    /// 用于兜住 "gpt-image-1.5" vs "gpt-image-1-5" vs "gpt_image_15" 这类命名不一致。
-    /// </summary>
-    private static string Normalize(string? s)
-    {
-        if (string.IsNullOrEmpty(s)) return string.Empty;
-        var sb = new System.Text.StringBuilder(s.Length);
-        foreach (var ch in s)
-        {
-            if (char.IsLetterOrDigit(ch)) sb.Append(char.ToLowerInvariant(ch));
-        }
-        return sb.ToString();
     }
 
     private ModelGroupItem? SelectBestModel(ModelGroup group)

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/ModelResolver.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/ModelResolver.cs
@@ -608,53 +608,114 @@ public class ModelResolver : IModelResolver
     /// <summary>
     /// 在候选池列表中寻找用户期望的模型。
     /// 匹配规则（按优先级）：
-    ///   1. 池中某个 ModelId 完全匹配 expectedModel（忽略大小写）
-    ///   2. 池中某个 ModelId 是 expectedModel 的前缀（用于带版本号的容差）
-    ///   3. 池名（ModelGroup.Name / Code）匹配 expectedModel
-    /// 返回的条目必须不是 Unavailable 状态。
+    ///   1. 池中某个 ModelId 完全匹配 expectedModel
+    ///   2. 池中某个 ModelId 是 expectedModel 的前缀（容差：带版本号）
+    ///   3. 池名 / 池 Code 匹配 expectedModel（前端发的是池 Code，例如 "gpt-image-1-5"）
+    ///   4. 归一化匹配（去掉点/横线/下划线后比较，兜住"gpt-image-1.5" vs "gpt-image-1-5" 这类命名不一致）
+    ///
+    /// 健康状态处理：遵守"能选就代表能用"原则 —— 前端 picker 是后端给出的可用清单，
+    /// 用户选了就必须尊重。即便池里所有模型都被临时标 Unavailable，也先返回"最不差的那个"
+    /// 并写一条 warning 日志，让调用方在真实请求失败时再走降级。
     /// </summary>
-    private static (ModelGroup? group, ModelGroupItem? item) FindPreferredModel(
+    private (ModelGroup? group, ModelGroupItem? item) FindPreferredModel(
         List<ModelGroup> groups, string expectedModel)
     {
         if (groups.Count == 0 || string.IsNullOrWhiteSpace(expectedModel))
             return (null, null);
 
         var key = expectedModel.Trim();
+        var keyNorm = Normalize(key);
 
-        // 优先级 1：ModelId 精确匹配
+        _logger.LogInformation(
+            "[ModelResolver] FindPreferredModel 开始: key='{Key}' (归一化='{Norm}'), 候选池={Count} [{Names}]",
+            key, keyNorm, groups.Count,
+            string.Join(", ", groups.Select(g => $"{g.Name}(code={g.Code})")));
+
+        // 优先级 1：ModelId 精确匹配（健康优先，缺省容忍非健康）
         foreach (var g in groups)
         {
             if (g.Models == null) continue;
-            var exact = g.Models.FirstOrDefault(m =>
+            var exactHealthy = g.Models.FirstOrDefault(m =>
                 m.HealthStatus != ModelHealthStatus.Unavailable &&
                 string.Equals(m.ModelId, key, StringComparison.OrdinalIgnoreCase));
-            if (exact != null) return (g, exact);
+            if (exactHealthy != null)
+            {
+                _logger.LogInformation("[ModelResolver] Tier1 命中: pool={Pool}, modelId={ModelId}", g.Name, exactHealthy.ModelId);
+                return (g, exactHealthy);
+            }
         }
 
-        // 优先级 2：ModelId 前缀匹配（如 expected="gemini-3-pro" 命中 "gemini-3-pro-image-preview"）
+        // 优先级 2：ModelId 前缀匹配
         foreach (var g in groups)
         {
             if (g.Models == null) continue;
             var prefix = g.Models.FirstOrDefault(m =>
                 m.HealthStatus != ModelHealthStatus.Unavailable &&
-                m.ModelId != null &&
+                !string.IsNullOrEmpty(m.ModelId) &&
                 m.ModelId.StartsWith(key, StringComparison.OrdinalIgnoreCase));
-            if (prefix != null) return (g, prefix);
+            if (prefix != null)
+            {
+                _logger.LogInformation("[ModelResolver] Tier2 命中: pool={Pool}, modelId={ModelId} (前缀匹配 key='{Key}')", g.Name, prefix.ModelId, key);
+                return (g, prefix);
+            }
         }
 
-        // 优先级 3：池名/池 Code 匹配
+        // 优先级 3 + 4：池名/Code 匹配 + 归一化匹配（合并一次扫描，避免重复遍历）
+        // 用户的原则"能选就代表能用"：picker 展示了池就意味着可用；健康状态只作挑选顺序，不作拒绝理由
         foreach (var g in groups)
         {
-            var matchByPool =
+            if (g.Models == null || g.Models.Count == 0) continue;
+
+            var matchExact =
                 string.Equals(g.Name, key, StringComparison.OrdinalIgnoreCase) ||
                 string.Equals(g.Code, key, StringComparison.OrdinalIgnoreCase);
-            if (!matchByPool || g.Models == null) continue;
+            var matchNorm = !matchExact && (
+                string.Equals(Normalize(g.Name), keyNorm, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(Normalize(g.Code), keyNorm, StringComparison.OrdinalIgnoreCase));
 
-            var any = g.Models.FirstOrDefault(m => m.HealthStatus != ModelHealthStatus.Unavailable);
-            if (any != null) return (g, any);
+            if (!matchExact && !matchNorm) continue;
+
+            // 取最佳：Healthy > Degraded > 其他（含 Unavailable 也不排除）
+            var picked =
+                g.Models.FirstOrDefault(m => m.HealthStatus == ModelHealthStatus.Healthy)
+                ?? g.Models.FirstOrDefault(m => m.HealthStatus == ModelHealthStatus.Degraded)
+                ?? g.Models.First();
+
+            var tier = matchExact ? "Tier3(池名/Code 精确)" : "Tier4(池名归一化)";
+            if (picked.HealthStatus == ModelHealthStatus.Unavailable)
+            {
+                _logger.LogWarning(
+                    "[ModelResolver] {Tier} 命中但模型被标为 Unavailable，仍尊重用户选择返回: pool={Pool}, modelId={ModelId}。如真实请求失败将走降级。",
+                    tier, g.Name, picked.ModelId);
+            }
+            else
+            {
+                _logger.LogInformation(
+                    "[ModelResolver] {Tier} 命中: pool={Pool}, modelId={ModelId}, health={Health}",
+                    tier, g.Name, picked.ModelId, picked.HealthStatus);
+            }
+            return (g, picked);
         }
 
+        _logger.LogInformation(
+            "[ModelResolver] FindPreferredModel 所有档位未命中: key='{Key}'。候选池 Code=[{Codes}]",
+            key, string.Join(", ", groups.Select(g => g.Code ?? "(无code)")));
         return (null, null);
+    }
+
+    /// <summary>
+    /// 归一化字符串：转小写 + 去掉所有非字母数字字符（点/横线/下划线/空格）。
+    /// 用于兜住 "gpt-image-1.5" vs "gpt-image-1-5" vs "gpt_image_15" 这类命名不一致。
+    /// </summary>
+    private static string Normalize(string? s)
+    {
+        if (string.IsNullOrEmpty(s)) return string.Empty;
+        var sb = new System.Text.StringBuilder(s.Length);
+        foreach (var ch in s)
+        {
+            if (char.IsLetterOrDigit(ch)) sb.Append(char.ToLowerInvariant(ch));
+        }
+        return sb.ToString();
     }
 
     private ModelGroupItem? SelectBestModel(ModelGroup group)

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/ModelResolver.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/ModelResolver.cs
@@ -157,25 +157,75 @@ public class ModelResolver : IModelResolver
         }
 
         // ========== 第 5.5 步：若调用方指定了 expectedModel，优先尊重 ==========
-        // 在所有候选池中寻找匹配 expectedModel（按 ModelId / 池名 模糊匹配）的可用条目
+        // 搜索顺序（广度递增）：
+        //   1. 候选池（AppCaller 绑定的池）
+        //   2. 该 ModelType 下的所有池（AppCaller 未绑定但平台有配置的池）
+        //   3. LLMModels 直连（既不在任何池也可以按 ModelName 查到的单模型）
+        // 前两档命中都会把匹配到的池加入 candidateGroups 头部；第三档直接返回 Legacy 结果。
         ModelGroup? preferredGroup = null;
         ModelGroupItem? preferredItem = null;
         if (!string.IsNullOrWhiteSpace(expectedModel))
         {
+            // 档 1：候选池
             var (g, m) = FindPreferredModel(candidateGroups, expectedModel);
             if (g != null && m != null)
             {
                 preferredGroup = g;
                 preferredItem = m;
                 _logger.LogInformation(
-                    "[ModelResolver] 命中 expectedModel: {Expected} → 池 {PoolName} 中的模型 {ModelId}",
+                    "[ModelResolver] 命中 expectedModel（候选池）: {Expected} → 池 {PoolName} 中的模型 {ModelId}",
                     expectedModel, g.Name, m.ModelId);
             }
             else
             {
-                _logger.LogInformation(
-                    "[ModelResolver] expectedModel '{Expected}' 在候选池中未找到匹配（池：[{Pools}]），将走默认调度",
-                    expectedModel, string.Join(", ", candidateGroups.Select(x => x.Name)));
+                // 档 2：该 ModelType 下的所有池（包括未绑定到 AppCaller 的）
+                var allTypeGroups = await _db.ModelGroups
+                    .Find(x => x.ModelType == modelType)
+                    .ToListAsync(ct);
+                var knownIds = candidateGroups.Select(x => x.Id).ToHashSet();
+                var extraGroups = allTypeGroups.Where(x => !knownIds.Contains(x.Id)).ToList();
+                if (extraGroups.Count > 0)
+                {
+                    var (g2, m2) = FindPreferredModel(extraGroups, expectedModel);
+                    if (g2 != null && m2 != null)
+                    {
+                        preferredGroup = g2;
+                        preferredItem = m2;
+                        candidateGroups.Insert(0, g2); // 纳入主循环以便走统一的 Exchange / Platform 解析路径
+                        resolutionType = "DirectModel"; // 越出 AppCaller 绑定范围 → 直连语义
+                        _logger.LogInformation(
+                            "[ModelResolver] 命中 expectedModel（全量池兜底）: {Expected} → 池 {PoolName} 中的模型 {ModelId}",
+                            expectedModel, g2.Name, m2.ModelId);
+                    }
+                }
+
+                // 档 3：LLMModels 直连（按 ModelName 查）
+                if (preferredGroup == null)
+                {
+                    var direct = await _db.LLMModels
+                        .Find(x => x.Enabled && x.ModelName == expectedModel.Trim())
+                        .FirstOrDefaultAsync(ct);
+                    if (direct != null)
+                    {
+                        var platform = await _db.LLMPlatforms
+                            .Find(p => p.Id == direct.PlatformId && p.Enabled)
+                            .FirstOrDefaultAsync(ct);
+                        if (platform != null)
+                        {
+                            var apiKey = string.IsNullOrEmpty(platform.ApiKeyEncrypted)
+                                ? null
+                                : ApiKeyCrypto.Decrypt(platform.ApiKeyEncrypted, jwtSecret);
+                            _logger.LogInformation(
+                                "[ModelResolver] 命中 expectedModel（LLMModels 直连）: {Expected} → platform={Platform}",
+                                expectedModel, platform.Name);
+                            return ModelResolutionResult.FromLegacy(expectedModel, direct, platform, apiKey);
+                        }
+                    }
+
+                    _logger.LogInformation(
+                        "[ModelResolver] expectedModel '{Expected}' 在所有池和 LLMModels 都未找到匹配，将走默认调度（候选池：[{Pools}]）",
+                        expectedModel, string.Join(", ", candidateGroups.Select(x => x.Name)));
+                }
             }
         }
 

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/ModelResolver.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/ModelResolver.cs
@@ -33,27 +33,6 @@ public class ModelResolver : IModelResolver
         string? expectedModel = null,
         CancellationToken ct = default)
     {
-        // ⚠ 诊断：直接写 MongoDB 集合 _diag_resolver（绕过 stdout 不可靠问题）
-        var diagId = Guid.NewGuid().ToString("N");
-        try
-        {
-            var coll = _db.Database.GetCollection<MongoDB.Bson.BsonDocument>("_diag_resolver");
-            await coll.InsertOneAsync(new MongoDB.Bson.BsonDocument
-            {
-                { "_id", diagId },
-                { "phase", "ENTRY" },
-                { "ts", DateTime.UtcNow },
-                { "appCallerCode", appCallerCode ?? "(null)" },
-                { "modelType", modelType ?? "(null)" },
-                { "expectedModel", expectedModel ?? "(null)" }
-            }, cancellationToken: ct);
-        }
-        catch { /* swallow */ }
-
-        _logger.LogError(
-            "[DIAG-ResolveAsync] ENTRY appCallerCode={Code}, modelType={Type}, expectedModel='{Expected}'",
-            appCallerCode, modelType, expectedModel ?? "(null)");
-
         var plan = new ModelResolutionPlan
         {
             AppCallerCode = appCallerCode,
@@ -646,38 +625,10 @@ public class ModelResolver : IModelResolver
 
         var key = expectedModel.Trim();
 
-        // ⚠ 诊断：MongoDB 记录 FindPreferredModel 的输入（同步 InsertOne，因为本方法不是 async）
-        try
-        {
-            var coll = _db.Database.GetCollection<MongoDB.Bson.BsonDocument>("_diag_resolver");
-            var poolsArr = new MongoDB.Bson.BsonArray();
-            foreach (var g in groups)
-            {
-                poolsArr.Add(new MongoDB.Bson.BsonDocument
-                {
-                    { "name", g.Name ?? "" },
-                    { "code", g.Code ?? "" },
-                    { "modelsCount", g.Models?.Count ?? 0 },
-                    { "firstModelId", g.Models?.FirstOrDefault()?.ModelId ?? "" },
-                    { "firstModelHealth", g.Models?.FirstOrDefault()?.HealthStatus.ToString() ?? "" }
-                });
-            }
-            coll.InsertOne(new MongoDB.Bson.BsonDocument
-            {
-                { "_id", Guid.NewGuid().ToString("N") },
-                { "phase", "FindPreferredModel_ENTRY" },
-                { "ts", DateTime.UtcNow },
-                { "key", key },
-                { "groupCount", groups.Count },
-                { "pools", poolsArr }
-            });
-        }
-        catch { }
-
-        _logger.LogError(
-            "[DIAG-FindPreferredModel] 开始 key='{Key}' 候选池共{Count}: [{Pools}]",
+        _logger.LogInformation(
+            "[ModelResolver] FindPreferredModel 开始: key='{Key}', 候选池={Count} [{Pools}]",
             key, groups.Count,
-            string.Join(" | ", groups.Select(g => $"Name='{g.Name}' Code='{g.Code}' ModelCount={g.Models?.Count ?? 0} FirstModelId='{g.Models?.FirstOrDefault()?.ModelId ?? "(none)"}'")));
+            string.Join(", ", groups.Select(g => $"{g.Name}(code={g.Code})")));
 
         // 优先级 1：ModelId 精确匹配
         foreach (var g in groups)
@@ -712,16 +663,10 @@ public class ModelResolver : IModelResolver
         foreach (var g in groups)
         {
             if (g.Models == null || g.Models.Count == 0) continue;
-            var nameMatch = string.Equals(g.Name, key, StringComparison.OrdinalIgnoreCase);
-            var codeMatch = string.Equals(g.Code, key, StringComparison.OrdinalIgnoreCase);
-
-            // ⚠ 诊断：每个候选池的比较结果都 LogError
-            _logger.LogError(
-                "[DIAG-Tier3] 检查池 Name='{Name}' (len={NLen}) vs key='{Key}' (len={KLen}) nameMatch={NM}; Code='{Code}' (len={CLen}) codeMatch={CM}",
-                g.Name ?? "(null)", g.Name?.Length ?? -1, key, key.Length, nameMatch,
-                g.Code ?? "(null)", g.Code?.Length ?? -1, codeMatch);
-
-            if (!nameMatch && !codeMatch) continue;
+            var matchByPool =
+                string.Equals(g.Name, key, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(g.Code, key, StringComparison.OrdinalIgnoreCase);
+            if (!matchByPool) continue;
 
             // Healthy > Degraded；Unavailable 不选（交给前端走"询问切换"）
             var picked =
@@ -729,47 +674,19 @@ public class ModelResolver : IModelResolver
                 ?? g.Models.FirstOrDefault(m => m.HealthStatus == ModelHealthStatus.Degraded);
             if (picked != null)
             {
-                try
-                {
-                    var coll = _db.Database.GetCollection<MongoDB.Bson.BsonDocument>("_diag_resolver");
-                    coll.InsertOne(new MongoDB.Bson.BsonDocument
-                    {
-                        { "_id", Guid.NewGuid().ToString("N") },
-                        { "phase", "Tier3_HIT" },
-                        { "ts", DateTime.UtcNow },
-                        { "key", key },
-                        { "poolName", g.Name ?? "" },
-                        { "poolCode", g.Code ?? "" },
-                        { "modelId", picked.ModelId ?? "" }
-                    });
-                }
-                catch { }
-
-                _logger.LogError(
-                    "[DIAG-Tier3] ✓ 命中: pool={Pool}, modelId={ModelId}, health={Health}",
+                _logger.LogInformation(
+                    "[ModelResolver] Tier3 命中: pool={Pool}, modelId={ModelId}, health={Health}",
                     g.Name, picked.ModelId, picked.HealthStatus);
                 return (g, picked);
             }
 
-            _logger.LogError(
-                "[DIAG-Tier3] 池名/Code 匹配但池内无可用模型: pool={Pool} (共{Count}个, 全部 Unavailable)",
+            _logger.LogInformation(
+                "[ModelResolver] Tier3 池名/Code 匹配但池内无可用模型: pool={Pool} (共{Count}个)",
                 g.Name, g.Models.Count);
         }
 
-        try
-        {
-            var coll = _db.Database.GetCollection<MongoDB.Bson.BsonDocument>("_diag_resolver");
-            coll.InsertOne(new MongoDB.Bson.BsonDocument
-            {
-                { "_id", Guid.NewGuid().ToString("N") },
-                { "phase", "ALL_TIERS_MISS" },
-                { "ts", DateTime.UtcNow },
-                { "key", key }
-            });
-        }
-        catch { }
-        _logger.LogError(
-            "[DIAG-FindPreferredModel] ✗ 所有档位未命中: key='{Key}'",
+        _logger.LogInformation(
+            "[ModelResolver] FindPreferredModel 所有档位未命中: key='{Key}'",
             key);
         return (null, null);
     }

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/ModelResolver.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/ModelResolver.cs
@@ -33,6 +33,11 @@ public class ModelResolver : IModelResolver
         string? expectedModel = null,
         CancellationToken ct = default)
     {
+        // ⚠ 诊断用：Error 级别确保任何 logging filter 下都出现在 stdout
+        _logger.LogError(
+            "[DIAG-ResolveAsync] ENTRY appCallerCode={Code}, modelType={Type}, expectedModel='{Expected}'",
+            appCallerCode, modelType, expectedModel ?? "(null)");
+
         var plan = new ModelResolutionPlan
         {
             AppCallerCode = appCallerCode,
@@ -625,10 +630,11 @@ public class ModelResolver : IModelResolver
 
         var key = expectedModel.Trim();
 
-        _logger.LogInformation(
-            "[ModelResolver] FindPreferredModel 开始: key='{Key}', 候选池={Count} [{Names}]",
+        // ⚠ 诊断 LogError
+        _logger.LogError(
+            "[DIAG-FindPreferredModel] 开始 key='{Key}' 候选池共{Count}: [{Pools}]",
             key, groups.Count,
-            string.Join(", ", groups.Select(g => $"{g.Name}(code={g.Code})")));
+            string.Join(" | ", groups.Select(g => $"Name='{g.Name}' Code='{g.Code}' ModelCount={g.Models?.Count ?? 0} FirstModelId='{g.Models?.FirstOrDefault()?.ModelId ?? "(none)"}'")));
 
         // 优先级 1：ModelId 精确匹配
         foreach (var g in groups)
@@ -663,10 +669,16 @@ public class ModelResolver : IModelResolver
         foreach (var g in groups)
         {
             if (g.Models == null || g.Models.Count == 0) continue;
-            var matchByPool =
-                string.Equals(g.Name, key, StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(g.Code, key, StringComparison.OrdinalIgnoreCase);
-            if (!matchByPool) continue;
+            var nameMatch = string.Equals(g.Name, key, StringComparison.OrdinalIgnoreCase);
+            var codeMatch = string.Equals(g.Code, key, StringComparison.OrdinalIgnoreCase);
+
+            // ⚠ 诊断：每个候选池的比较结果都 LogError
+            _logger.LogError(
+                "[DIAG-Tier3] 检查池 Name='{Name}' (len={NLen}) vs key='{Key}' (len={KLen}) nameMatch={NM}; Code='{Code}' (len={CLen}) codeMatch={CM}",
+                g.Name ?? "(null)", g.Name?.Length ?? -1, key, key.Length, nameMatch,
+                g.Code ?? "(null)", g.Code?.Length ?? -1, codeMatch);
+
+            if (!nameMatch && !codeMatch) continue;
 
             // Healthy > Degraded；Unavailable 不选（交给前端走"询问切换"）
             var picked =
@@ -674,19 +686,19 @@ public class ModelResolver : IModelResolver
                 ?? g.Models.FirstOrDefault(m => m.HealthStatus == ModelHealthStatus.Degraded);
             if (picked != null)
             {
-                _logger.LogInformation(
-                    "[ModelResolver] Tier3 命中: pool={Pool}, modelId={ModelId}, health={Health}",
+                _logger.LogError(
+                    "[DIAG-Tier3] ✓ 命中: pool={Pool}, modelId={ModelId}, health={Health}",
                     g.Name, picked.ModelId, picked.HealthStatus);
                 return (g, picked);
             }
 
-            _logger.LogInformation(
-                "[ModelResolver] Tier3 池名/Code 匹配但池内无可用模型: pool={Pool} (共{Count}个, 全部 Unavailable)",
+            _logger.LogError(
+                "[DIAG-Tier3] 池名/Code 匹配但池内无可用模型: pool={Pool} (共{Count}个, 全部 Unavailable)",
                 g.Name, g.Models.Count);
         }
 
-        _logger.LogInformation(
-            "[ModelResolver] FindPreferredModel 所有档位未命中: key='{Key}'",
+        _logger.LogError(
+            "[DIAG-FindPreferredModel] ✗ 所有档位未命中: key='{Key}'",
             key);
         return (null, null);
     }

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/ModelResolver.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/ModelResolver.cs
@@ -646,7 +646,7 @@ public class ModelResolver : IModelResolver
 
         var key = expectedModel.Trim();
 
-        // ⚠ 诊断：MongoDB 记录 FindPreferredModel 的输入
+        // ⚠ 诊断：MongoDB 记录 FindPreferredModel 的输入（同步 InsertOne，因为本方法不是 async）
         try
         {
             var coll = _db.Database.GetCollection<MongoDB.Bson.BsonDocument>("_diag_resolver");
@@ -662,7 +662,7 @@ public class ModelResolver : IModelResolver
                     { "firstModelHealth", g.Models?.FirstOrDefault()?.HealthStatus.ToString() ?? "" }
                 });
             }
-            await coll.InsertOneAsync(new MongoDB.Bson.BsonDocument
+            coll.InsertOne(new MongoDB.Bson.BsonDocument
             {
                 { "_id", Guid.NewGuid().ToString("N") },
                 { "phase", "FindPreferredModel_ENTRY" },


### PR DESCRIPTION
## Summary

This PR addresses a critical issue where user-selected models were being silently replaced by the backend scheduler, and adds support for adaptive models (like gpt-image-2-all) that determine output dimensions from prompt descriptions rather than explicit size parameters.

## Key Changes

### Model Resolution Fixes
- **ModelResolver**: Enhanced to respect `expectedModel` parameter across three tiers:
  - Tier 1: Exact match in candidate pools
  - Tier 2: Match in all pools of the same model type
  - Tier 3: Direct lookup in LLMModels collection
  - Falls back to default scheduling only when no match found

- **ExpectedModelRespectingResolver**: New decorator in Api.dll layer that wraps Infrastructure.dll's ModelResolver to work around deployment caching issues. Uses instance-field caching (not AsyncLocal) to preserve expectedModel across multiple ResolveAsync calls within the same DI scope (e.g., OpenAIImageClient → LlmGateway.SendRawAsync chain).

- **ImageGenRunWorker**: Sets `ModelResolutionType=DirectModel` when user explicitly selects a model, preventing scheduler from overriding the choice.

### Adaptive Model Support
- **ImageGenModelAdapterConfig**: Added `SizeConstraintTypes.Adaptive` for models that don't accept size/aspect_ratio parameters (e.g., gpt-image-2-all)
- **ImageGenModelAdapterRegistry**: Updated `NormalizeSize()` to skip size normalization for adaptive models
- **OpenAIImageClient**: Prevents size parameter injection for adaptive models
- **Frontend**: Added `isAdaptive` flag to model metadata; size selector displays "自适应" (adaptive) instead of specific dimensions

### Frontend UX Improvements
- **Smart Model Fallback**: New preference toggle (default: enabled) in `visualAgentPrefsStore`
  - When enabled: Pre-send health check with user confirmation dialog if selected model is unavailable
  - When disabled: Strict mode—send as-is, let backend handle fallback
- **Model Metadata Display**: Backend now pushes actual resolved model info (modelId, modelGroupName, platformId, isAdaptive) via SSE, frontend displays actual model used instead of user selection

### Debugging Infrastructure
- **ResolverDebugController**: New debug endpoints for troubleshooting model resolution:
  - `/api/debug/resolver/test`: Full matching algorithm trace with step-by-step diagnostics
  - `/api/debug/resolver/test-chain`: Dual-call test simulating OpenAIImageClient → LlmGateway chain
  - `/api/debug/resolver/simulate-worker`: Tests resolution in new scope (mimics Worker behavior)
  - `/api/debug/resolver/trigger-real-gen`: Triggers real image generation and captures decorator call logs

### Documentation
- **llm-call-trace.md**: Comprehensive skill guide for debugging "model was swapped" issues
- **compute-then-send.md**: Architectural rule enforcing separation of model resolution (compute) from HTTP sending (send) phases
- Multiple changelog entries documenting the 8-round iterative fix process

## Implementation Details

- **Scoped DI Registration**: ExpectedModelRespectingResolver registered as Scoped decorator wrapping ModelResolver
- **Diagnostic Logging**: All resolver calls write to `_diag_resolver_calls` MongoDB collection for audit trail
- **Backward Compatibility**: Adaptive model support is opt-in via config; existing models unaffected
- **No AsyncLocal**: Deliberately avoided AsyncLocal for cross-call state sharing due to ExecutionContext capture semantics; instance fields work correctly within Scoped lifetime

https://claude.ai/code/session_01V34BH9LdwkPVJYmchQND7e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core model resolution and image-generation request shaping (including new adaptive models), so regressions could change what model/params are sent upstream. Adds new debug endpoints and client-side fallback UX, which may affect production behavior if not access-controlled or tested end-to-end.
> 
> **Overview**
> Fixes the “user picked model A but backend ran model B” class of issues by **making resolution prefer `expectedModel`** (including broader fallback search) and by marking image-gen runs as `DirectModel` at creation so the worker/scheduler doesn’t silently override explicit user choices.
> 
> Adds **adaptive image model support** (e.g. `gpt-image-2-all`) by introducing `SizeConstraintTypes.Adaptive`/`SizeParamFormats.None`, ensuring `OpenAIImageClient` and the adapter registry **omit size-related fields** for those models, and registering new/updated adapter configs.
> 
> Improves observability/UX by pushing **actual resolved model metadata** in SSE `runStart`/`imageDone` events and updating the admin UI to display server-authoritative model/size (including “自适应”), plus a session-persisted **“smart fallback”** toggle that prompts before sending when a chosen model is marked unavailable. Also adds resolver debugging endpoints and internal guidance docs (`compute-then-send`, `llm-call-trace`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f4d8e24fffeb069fae427fe1dbea220817014f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->