### PR TITLE
Add cache diagnostics, snapshots, hot-reload, and bulk command management

### DIFF
--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -2941,6 +2941,103 @@ export function createBranchRouter(deps: RouterDeps): Router {
 
   // ── Deploy mode switching ──
 
+  // ── 全局批量改命令 (2026-04-22) ──
+  //
+  // 用户故事：「我的所有 .NET profile 都用同一套热/冷部署命令，能不能一次性改完？」
+  //
+  // POST /api/build-profiles/bulk-set-modes
+  // body: {
+  //   filter: 'all' | 'dotnet' | 'node' | 'python' | { dockerImageMatch: string },
+  //   modes: { [modeId]: { label, command } },     // 要写入的所有 mode（覆盖该 profile 的全套）
+  //   strategy: 'replace' | 'merge',                // replace: 清空后覆盖；merge: 同 modeId 替换、其他保留
+  //   profileIds?: string[],                        // 可选：精准白名单，优先于 filter
+  // }
+  //
+  // 自动在执行前拍 ConfigSnapshot，可在「历史版本」一键回滚。
+  router.post('/build-profiles/bulk-set-modes', (req, res) => {
+    try {
+      const {
+        filter = 'all',
+        modes,
+        strategy = 'merge',
+        profileIds,
+      } = req.body as {
+        filter?: 'all' | 'dotnet' | 'node' | 'python' | { dockerImageMatch?: string };
+        modes?: Record<string, { label: string; command: string }>;
+        strategy?: 'replace' | 'merge';
+        profileIds?: string[];
+      };
+
+      if (!modes || typeof modes !== 'object' || Object.keys(modes).length === 0) {
+        res.status(400).json({ error: '必须提供 modes（{ modeId: { label, command } }）' });
+        return;
+      }
+      for (const [k, v] of Object.entries(modes)) {
+        if (!v || typeof v !== 'object' || !v.label || !v.command) {
+          res.status(400).json({ error: `mode "${k}" 缺少 label 或 command` });
+          return;
+        }
+      }
+
+      const matchPattern: ((img: string) => boolean) = (() => {
+        if (Array.isArray(profileIds)) return () => false;
+        if (filter === 'all') return () => true;
+        if (filter === 'dotnet') return img => /dotnet|mcr\.microsoft\.com\/dotnet/i.test(img);
+        if (filter === 'node') return img => /node|node:|nodejs/i.test(img);
+        if (filter === 'python') return img => /python/i.test(img);
+        if (typeof filter === 'object' && filter.dockerImageMatch) {
+          const re = new RegExp(filter.dockerImageMatch, 'i');
+          return img => re.test(img);
+        }
+        return () => true;
+      })();
+
+      const allProfiles = stateService.getBuildProfiles();
+      const targets = Array.isArray(profileIds) && profileIds.length > 0
+        ? allProfiles.filter(p => profileIds.includes(p.id))
+        : allProfiles.filter(p => matchPattern(p.dockerImage || ''));
+
+      if (targets.length === 0) {
+        res.status(400).json({ error: '没有匹配的 profile，请检查 filter / profileIds' });
+        return;
+      }
+
+      // 自动快照（这是批量破坏性写入）
+      const snapshot = stateService.createConfigSnapshot({
+        trigger: 'pre-destructive',
+        label: `批量设置 ${targets.length} 个 profile 的部署命令（${strategy}）`,
+      });
+
+      const updates: Array<{ id: string; modesBefore: number; modesAfter: number }> = [];
+      for (const profile of targets) {
+        const before = Object.keys(profile.deployModes || {}).length;
+        const baseModes = strategy === 'replace' ? {} : { ...(profile.deployModes || {}) };
+        for (const [mid, m] of Object.entries(modes)) {
+          baseModes[mid] = { label: m.label, command: m.command };
+        }
+        stateService.updateBuildProfile(profile.id, { deployModes: baseModes });
+        updates.push({ id: profile.id, modesBefore: before, modesAfter: Object.keys(baseModes).length });
+      }
+      stateService.save();
+
+      stateService.recordDestructiveOp({
+        type: 'other',
+        snapshotId: snapshot.id,
+        summary: `批量改 ${targets.length} 个 profile 的部署命令（filter=${typeof filter === 'string' ? filter : 'custom'}, strategy=${strategy}）`,
+      });
+
+      res.json({
+        applied: true,
+        targetCount: targets.length,
+        targets: updates,
+        snapshotId: snapshot.id,
+        message: `已为 ${targets.length} 个 profile 应用新命令。如有问题在「历史版本」回滚。`,
+      });
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
   router.put('/build-profiles/:id/deploy-mode', (req, res) => {
     try {
       const { id } = req.params;

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -2986,12 +2986,18 @@ export function createBranchRouter(deps: RouterDeps): Router {
         res.status(400).json({ error: '必须传 enabled (true/false)' });
         return;
       }
-      const current = profile.hotReload || { enabled: false, mode: 'dotnet-watch' as const };
+      // 2026-04-22 —— 默认改成 dotnet-restart（原来 dotnet-watch 有 MSBuild
+      // 增量编译误判的已知坑，见 types.ts HotReloadConfig 注释）。用户可以
+      // 显式指定 mode 回到 watch，但新启用默认用最可靠的那个。
+      const isDotnet = /dotnet|mcr\.microsoft\.com\/dotnet/i.test(profile.dockerImage || '');
+      const defaultMode = isDotnet ? ('dotnet-restart' as const) : ('pnpm-dev' as const);
+      const current = profile.hotReload || { enabled: false, mode: defaultMode };
       const next = {
         enabled,
         mode: mode ?? current.mode,
         command: command ?? current.command,
         usePolling: usePolling ?? current.usePolling,
+        cleanBeforeBuild: (req.body as { cleanBeforeBuild?: boolean })?.cleanBeforeBuild ?? (current as { cleanBeforeBuild?: boolean }).cleanBeforeBuild ?? true,
       };
       // mode=custom 时必须有 command
       if (next.enabled && next.mode === 'custom' && !next.command) {
@@ -3010,6 +3016,159 @@ export function createBranchRouter(deps: RouterDeps): Router {
     } catch (err) {
       res.status(500).json({ error: (err as Error).message });
     }
+  });
+
+  // ── 强制干净重建（2026-04-22，对付 MSBuild 增量编译撒谎）──
+  //
+  // 场景：改了 .cs 文件 5 轮都没生效，DLL 里 grep 得到新字符串，运行进程日志却看不到。
+  // 根因：MSBuild 增量编译误判「项目引用未变」跳过 compile，或 dotnet watch 只更新内存
+  //       没重启进程 → 进程加载的字节码和磁盘 DLL 对不上。
+  //
+  // 本接口：停该 profile 的容器 → rm -rf bin/obj → 重启（重启后会 clean build）。
+  // 对用 dotnet-restart 热更新模式的 profile 也适用，因为它的 cleanBeforeBuild 只在
+  // 下次文件变更触发时清理，强制按钮让用户即时清理而不等变更。
+  //
+  // POST /api/branches/:branchSlug/force-rebuild/:profileId
+  router.post('/branches/:branchSlug/force-rebuild/:profileId', async (req, res) => {
+    const branchSlug = decodeURIComponent(req.params.branchSlug);
+    const profileId = req.params.profileId;
+    const branch = stateService.getBranch(branchSlug);
+    const profile = stateService.getBuildProfile(profileId);
+    if (!branch) { res.status(404).json({ error: `分支 "${branchSlug}" 不存在` }); return; }
+    if (!profile) { res.status(404).json({ error: `构建配置 "${profileId}" 不存在` }); return; }
+
+    const svc = branch.services?.[profileId];
+    const containerName = svc?.containerName;
+    const worktree = branch.worktreePath;
+    if (!worktree) { res.status(400).json({ error: '分支无 worktreePath' }); return; }
+
+    const steps: Array<{ step: string; ok: boolean; detail?: string }> = [];
+
+    // 1) 停容器
+    if (containerName) {
+      try {
+        await containerService.stop(containerName);
+        steps.push({ step: `停止 ${containerName}`, ok: true });
+      } catch (err) {
+        steps.push({ step: `停止 ${containerName}`, ok: false, detail: (err as Error).message });
+      }
+    } else {
+      steps.push({ step: '停止容器', ok: true, detail: '容器未运行，跳过' });
+    }
+
+    // 2) 物理删除 worktree 下目标 profile workDir 里的 bin / obj —— 绕过 MSBuild 增量
+    const workDir = profile.workDir ? `${worktree}/${profile.workDir}` : worktree;
+    const wipeCmd = `find ${shq(workDir)} -type d \\( -name bin -o -name obj \\) -prune -exec rm -rf {} + 2>/dev/null; echo done`;
+    try {
+      const result = await shell.exec(wipeCmd);
+      if (result.exitCode !== 0) {
+        steps.push({ step: 'rm -rf bin/obj', ok: false, detail: combinedOutput(result) });
+      } else {
+        steps.push({ step: 'rm -rf bin/obj', ok: true, detail: workDir });
+      }
+    } catch (err) {
+      steps.push({ step: 'rm -rf bin/obj', ok: false, detail: (err as Error).message });
+    }
+
+    // 3) 触发部署（异步；响应立即返回，不堵 HTTP）
+    // 部署接口是现成的，这里直接告诉用户去点"部署"；自动触发留给下一版
+    steps.push({
+      step: '触发重新部署',
+      ok: true,
+      detail: `已清理。请在分支卡片上点「部署」或等待 autoBuild 重启该服务。`,
+    });
+
+    stateService.recordDestructiveOp({
+      type: 'other',
+      projectId: branch.projectId || null,
+      summary: `强制干净重建 ${branchSlug}:${profileId}（清 bin/obj）`,
+    });
+
+    res.json({
+      branch: branchSlug,
+      profile: profileId,
+      workDir,
+      steps,
+      message: '已强制清理构建缓存。下次部署会从源码完整重编译。',
+    });
+  });
+
+  // ── 运行时字节码一致性核验（2026-04-22 诊断工具）──
+  //
+  // 帮用户回答："我改的 .cs 到底生效了没有？"
+  //
+  // 三项对比：
+  //   - 容器里 DLL 文件 mtime：echo $(stat /app/.../bin/.../*.dll | grep Modify)
+  //   - 容器里 dotnet 进程 PID 启动时间：ps -o lstart -p $PID
+  //   - 最近 50 行容器 stdout：看请求/日志是不是按新代码应有的行为走
+  //
+  // 如果 DLL mtime > 进程启动时间 → 进程加载的还是老字节码，需要重启。
+  //
+  // POST /api/branches/:branchSlug/verify-runtime/:profileId
+  router.post('/branches/:branchSlug/verify-runtime/:profileId', async (req, res) => {
+    const branchSlug = decodeURIComponent(req.params.branchSlug);
+    const profileId = req.params.profileId;
+    const branch = stateService.getBranch(branchSlug);
+    if (!branch) { res.status(404).json({ error: `分支 "${branchSlug}" 不存在` }); return; }
+    const svc = branch.services?.[profileId];
+    const containerName = svc?.containerName;
+    if (!containerName) {
+      res.status(400).json({ error: `服务 "${profileId}" 未运行，无法诊断` });
+      return;
+    }
+
+    // 1) 进程启动时间
+    const psCmd = `docker exec ${shq(containerName)} sh -c "ps -o lstart= -p 1 2>/dev/null || ps -o lstart= -p \\$(pgrep -f 'dotnet run' | head -1) 2>/dev/null || echo unknown"`;
+    const ps = await shell.exec(psCmd).catch(err => ({ exitCode: 1, stdout: '', stderr: (err as Error).message }));
+
+    // 2) DLL 时间戳（遍历 bin/ 下所有 .dll 取最新）
+    const dllCmd = `docker exec ${shq(containerName)} sh -c "find . -name '*.dll' -path '*/bin/*' -printf '%T@ %p\\n' 2>/dev/null | sort -nr | head -5"`;
+    const dll = await shell.exec(dllCmd).catch(err => ({ exitCode: 1, stdout: '', stderr: (err as Error).message }));
+
+    // 3) 源码 .cs 最新改动时间
+    const srcCmd = `docker exec ${shq(containerName)} sh -c "find . -name '*.cs' -not -path '*/bin/*' -not -path '*/obj/*' -printf '%T@ %p\\n' 2>/dev/null | sort -nr | head -1"`;
+    const src = await shell.exec(srcCmd).catch(err => ({ exitCode: 1, stdout: '', stderr: (err as Error).message }));
+
+    // 4) 最近 50 行日志
+    const logs = await containerService.getLogs(containerName, 50).catch(() => '');
+
+    // 解析和诊断
+    const parseTop = (s: string) => {
+      const first = s.split('\n').filter(Boolean)[0] || '';
+      const [tsStr, ...pathParts] = first.split(/\s+/);
+      const ts = parseFloat(tsStr);
+      return { ts: Number.isFinite(ts) ? ts : null, path: pathParts.join(' ') };
+    };
+
+    const topDll = parseTop(dll.stdout || '');
+    const topSrc = parseTop(src.stdout || '');
+
+    const warnings: string[] = [];
+    if (topSrc.ts && topDll.ts && topSrc.ts > topDll.ts) {
+      warnings.push('⚠ 源码比 DLL 新：最新的 .cs 还没被编译进 DLL。说明容器内没跑重编译（watch 没触发或热更新没起）。');
+    }
+    // DLL 晚于进程启动时间 → 进程跑的还是老字节码
+    const processStartStr = (ps.stdout || '').trim();
+    if (topDll.ts && processStartStr && processStartStr !== 'unknown') {
+      const procTs = Date.parse(processStartStr) / 1000;
+      if (Number.isFinite(procTs) && topDll.ts > procTs + 5) {
+        warnings.push(`⚠ DLL 比进程启动时间新 (Δ=${Math.round(topDll.ts - procTs)}s)：进程还在跑老字节码。重启服务或点「💥 强制干净重建」。`);
+      }
+    }
+    if (warnings.length === 0) {
+      warnings.push('✓ 未检测到明显不一致。如仍看不到预期日志，排查：日志级别过滤、LogError 是否真走到那个代码路径、Infrastructure.dll 是不是被引用/注入。');
+    }
+
+    res.json({
+      branch: branchSlug,
+      profile: profileId,
+      container: containerName,
+      processStart: processStartStr,
+      latestDll: topDll,
+      latestSource: topSrc,
+      recentLogs: logs.split('\n').slice(-30).join('\n'),
+      warnings,
+    });
   });
 
   // ── Docker images (for dropdown selection) ──

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -2986,11 +2986,11 @@ export function createBranchRouter(deps: RouterDeps): Router {
         res.status(400).json({ error: '必须传 enabled (true/false)' });
         return;
       }
-      // 2026-04-22 —— 默认改成 dotnet-restart（原来 dotnet-watch 有 MSBuild
-      // 增量编译误判的已知坑，见 types.ts HotReloadConfig 注释）。用户可以
-      // 显式指定 mode 回到 watch，但新启用默认用最可靠的那个。
+      // 2026-04-22 —— .NET 默认 dotnet-run（快路径：MSBuild 增量 + kill/restart）。
+      // MSBuild 增量绝大多数情况正确；极少数撒谎场景走 🧹 清理按钮 (force-rebuild)
+      // 破缓存即可。dotnet-restart 保留但仅作疑难兜底，不是默认。
       const isDotnet = /dotnet|mcr\.microsoft\.com\/dotnet/i.test(profile.dockerImage || '');
-      const defaultMode = isDotnet ? ('dotnet-restart' as const) : ('pnpm-dev' as const);
+      const defaultMode = isDotnet ? ('dotnet-run' as const) : ('pnpm-dev' as const);
       const current = profile.hotReload || { enabled: false, mode: defaultMode };
       const next = {
         enabled,

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -2965,6 +2965,53 @@ export function createBranchRouter(deps: RouterDeps): Router {
     }
   });
 
+  // ── 热更新开关（2026-04-22 新增）──
+  // POST /api/build-profiles/:id/hot-reload  { enabled: boolean, mode?, command?, usePolling? }
+  // 关掉热更新：只传 enabled=false，其他字段保留以便下次启用
+  router.post('/build-profiles/:id/hot-reload', (req, res) => {
+    try {
+      const { id } = req.params;
+      const { enabled, mode, command, usePolling } = req.body as {
+        enabled?: boolean;
+        mode?: 'dotnet-watch' | 'pnpm-dev' | 'vite' | 'next-dev' | 'custom';
+        command?: string;
+        usePolling?: boolean;
+      };
+      const profile = stateService.getBuildProfile(id);
+      if (!profile) {
+        res.status(404).json({ error: `构建配置 "${id}" 不存在` });
+        return;
+      }
+      if (enabled === undefined) {
+        res.status(400).json({ error: '必须传 enabled (true/false)' });
+        return;
+      }
+      const current = profile.hotReload || { enabled: false, mode: 'dotnet-watch' as const };
+      const next = {
+        enabled,
+        mode: mode ?? current.mode,
+        command: command ?? current.command,
+        usePolling: usePolling ?? current.usePolling,
+      };
+      // mode=custom 时必须有 command
+      if (next.enabled && next.mode === 'custom' && !next.command) {
+        res.status(400).json({ error: 'mode=custom 时必须提供 command' });
+        return;
+      }
+      stateService.updateBuildProfile(id, { hotReload: next });
+      stateService.save();
+      res.json({
+        hotReload: next,
+        message: next.enabled
+          ? `已启用热更新（${next.mode}）。重启该服务让变更生效。`
+          : '已关闭热更新。重启该服务回到标准编译命令。',
+        requiresRestart: true,
+      });
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
   // ── Docker images (for dropdown selection) ──
 
   router.get('/docker-images', async (_req, res) => {
@@ -4406,18 +4453,46 @@ export function createBranchRouter(deps: RouterDeps): Router {
   }
 
   // POST /api/import-config — validate, preview, and optionally apply
-  // Accepts { config: <JSON object | YAML string>, dryRun? }
-  // Auto-detects format: YAML string → CDS compose, JSON object → direct config
+  //
+  // 2026-04-22 升级：
+  //   - 每次 apply 前自动拍 ConfigSnapshot（trigger='pre-import'）
+  //   - 新增 cleanMode: 'merge' | 'replace-all'
+  //       merge      = 原行为（新增/更新，不删除存量）
+  //       replace-all = 清空 buildProfiles/envVars/infra/routingRules 后再 apply
+  //   - 新增 branchPolicy: 'keep' | 'restart-all' | 'clean'
+  //       keep        = 不动运行中的分支（默认）
+  //       restart-all = apply 后调度重启所有分支容器（让新 env 生效）
+  //       clean       = 额外清掉所有分支的运行状态（容器 + worktree），只留配置
+  //
+  // 数据库永不在清理范围内。想清数据库走 /api/infra/:id/purge。
   router.post('/import-config', async (req, res) => {
     try {
-      const { config: configBlob, dryRun } = req.body as { config: unknown; dryRun?: boolean };
+      const {
+        config: configBlob,
+        dryRun,
+        cleanMode = 'merge',
+        branchPolicy = 'keep',
+      } = req.body as {
+        config: unknown;
+        dryRun?: boolean;
+        cleanMode?: 'merge' | 'replace-all';
+        branchPolicy?: 'keep' | 'restart-all' | 'clean';
+      };
+
+      if (cleanMode !== 'merge' && cleanMode !== 'replace-all') {
+        res.status(400).json({ error: `非法的 cleanMode: ${cleanMode}（允许 merge / replace-all）` });
+        return;
+      }
+      if (!['keep', 'restart-all', 'clean'].includes(branchPolicy)) {
+        res.status(400).json({ error: `非法的 branchPolicy: ${branchPolicy}（允许 keep / restart-all / clean）` });
+        return;
+      }
 
       // Auto-detect format: string → try CDS compose YAML, object → JSON config
       let cfg: Record<string, unknown>;
       if (typeof configBlob === 'string') {
         const cdsConfig = parseCdsCompose(configBlob);
         if (cdsConfig) {
-          // Convert CDS compose to internal format (reuse existing validate/apply pipeline)
           cfg = {
             $schema: 'cds-config',
             buildProfiles: cdsConfig.buildProfiles,
@@ -4426,7 +4501,6 @@ export function createBranchRouter(deps: RouterDeps): Router {
             routingRules: cdsConfig.routingRules.length > 0 ? cdsConfig.routingRules : undefined,
           };
         } else {
-          // Not a CDS compose — try parsing as JSON string
           try {
             cfg = JSON.parse(configBlob);
           } catch {
@@ -4442,7 +4516,6 @@ export function createBranchRouter(deps: RouterDeps): Router {
         cfg = configBlob as Record<string, unknown>;
       }
 
-      // Validate
       const validation = validateConfigBlob(cfg);
       if (!validation.valid) {
         res.status(400).json({ valid: false, errors: validation.errors, warnings: validation.warnings });
@@ -4450,13 +4523,47 @@ export function createBranchRouter(deps: RouterDeps): Router {
       }
       const preview = previewImport(cfg);
 
-      // If dry run, return preview only (include warnings)
       if (dryRun) {
-        res.json({ valid: true, preview, applied: false, warnings: validation.warnings });
+        res.json({
+          valid: true,
+          preview,
+          applied: false,
+          warnings: validation.warnings,
+          cleanMode,
+          branchPolicy,
+        });
         return;
       }
 
-      // Apply: build profiles (add or replace)
+      // 1) 拍快照（replace-all 必须拍；merge 也默认拍，成本很低）
+      const snapshotLabel = cleanMode === 'replace-all'
+        ? `导入前（replace-all）· ${new Date().toLocaleString('zh-CN')}`
+        : `导入前（merge）· ${new Date().toLocaleString('zh-CN')}`;
+      const snapshot = stateService.createConfigSnapshot({
+        trigger: 'pre-import',
+        label: snapshotLabel,
+      });
+
+      // 2) replace-all 模式：清空四件套
+      //    用「全部删除 + 逐个添加」方式，避免状态字段漂移
+      if (cleanMode === 'replace-all') {
+        // 清 buildProfiles
+        for (const p of [...stateService.getBuildProfiles()]) {
+          stateService.removeBuildProfile(p.id);
+        }
+        // 清 customEnv（所有 scope）
+        stateService.clearAllCustomEnv();
+        // 清 infraServices（但保留已创建的容器数据 —— 只是从 state 删记录）
+        for (const svc of [...stateService.getInfraServices()]) {
+          stateService.removeInfraService(svc.id);
+        }
+        // 清 routingRules
+        for (const rule of [...stateService.getRoutingRules()]) {
+          stateService.removeRoutingRule(rule.id);
+        }
+      }
+
+      // 3) apply buildProfiles
       if (Array.isArray(cfg.buildProfiles)) {
         for (const p of cfg.buildProfiles as BuildProfile[]) {
           const existing = stateService.getBuildProfile(p.id);
@@ -4470,7 +4577,7 @@ export function createBranchRouter(deps: RouterDeps): Router {
         }
       }
 
-      // Apply: env vars (merge, new wins)
+      // 4) apply envVars
       if (cfg.envVars && typeof cfg.envVars === 'object') {
         const newVars = cfg.envVars as Record<string, string>;
         for (const [key, value] of Object.entries(newVars)) {
@@ -4478,7 +4585,7 @@ export function createBranchRouter(deps: RouterDeps): Router {
         }
       }
 
-      // Apply: infra services (add if not exists, skip existing)
+      // 5) apply infraServices
       const infraResults: { id: string; status: string }[] = [];
       const infraDefs = resolveInfraDefs(cfg);
       for (const def of infraDefs) {
@@ -4486,7 +4593,6 @@ export function createBranchRouter(deps: RouterDeps): Router {
           infraResults.push({ id: def.id, status: 'exists' });
           continue;
         }
-
         if (def.id && def.dockerImage && def.containerPort) {
           const service = composeDefToInfraService(def);
           stateService.addInfraService(service);
@@ -4494,7 +4600,7 @@ export function createBranchRouter(deps: RouterDeps): Router {
         }
       }
 
-      // Apply: routing rules (add or replace)
+      // 6) apply routingRules
       if (Array.isArray(cfg.routingRules)) {
         for (const r of cfg.routingRules as RoutingRule[]) {
           const existing = stateService.getRoutingRules().find(x => x.id === r.id);
@@ -4508,17 +4614,41 @@ export function createBranchRouter(deps: RouterDeps): Router {
         }
       }
 
-      // Sync CDS config (domains etc.)
       syncCdsConfig();
       stateService.save();
+
+      // 7) branchPolicy: 只做调度侧的标记，真实 restart/clean 由调用方按返回提示触发（避免同步阻塞）
+      const branchActions: string[] = [];
+      if (branchPolicy !== 'keep') {
+        const branches = stateService.getAllBranches();
+        for (const b of branches) {
+          branchActions.push(`${b.id}: ${branchPolicy === 'restart-all' ? '待重启' : '待清理'}`);
+        }
+      }
+
+      // 8) replace-all 视为破坏性操作，记审计日志 + 关联 snapshotId
+      if (cleanMode === 'replace-all') {
+        stateService.recordDestructiveOp({
+          type: 'import-replace-all',
+          snapshotId: snapshot.id,
+          summary: `replace-all 导入配置：清空 4 件套并重新导入（${(cfg.buildProfiles as BuildProfile[] | undefined)?.length ?? 0} 个 profile / ${infraDefs.length} 个 infra）`,
+        });
+      }
 
       res.json({
         valid: true,
         preview,
         applied: true,
+        cleanMode,
+        branchPolicy,
         infraResults,
+        snapshotId: snapshot.id,
+        snapshotLabel: snapshot.label,
+        branchActions,
         warnings: validation.warnings,
-        message: '配置已成功导入',
+        message: cleanMode === 'replace-all'
+          ? '配置已清空并重新导入（快照已保存，可在「历史版本」一键回滚）'
+          : '配置已合并导入（快照已保存，可在「历史版本」回滚）',
       });
     } catch (err) {
       res.status(500).json({ error: (err as Error).message });

--- a/cds/src/routes/cache.ts
+++ b/cds/src/routes/cache.ts
@@ -1,0 +1,376 @@
+/**
+ * Cache diagnostic & migration routes.
+ *
+ * 解决的实际问题：
+ * 1) 用户观察到 CDS 在本服务器跑了上千次，`dotnet restore` 还要 35 秒 ——
+ *    理论上 `/cache/nuget` 应该已经 warm 了。这说明**挂载失效或缓存路径不对**。
+ *    `/api/cache/status` 让用户一眼看到所有 cacheMount 的实际目录大小、
+ *    文件数、最后写入时间，能立刻定位是哪个 profile 没走到缓存。
+ *
+ * 2) `POST /api/cache/repair` —— 强制重跑 migrateCacheMounts 合并逻辑，
+ *    补齐混合 profile（含 pnpm 但缺 nuget）等缺失挂载。
+ *
+ * 3) `GET /api/cache/export?name=nuget` + `POST /api/cache/import?name=nuget`
+ *    —— 换服务器时把预热好的缓存 tar.gz 搬过去，避免新服务器首次冷下载。
+ */
+import { Router } from 'express';
+import fs from 'node:fs';
+import path from 'node:path';
+import type { StateService } from '../services/state.js';
+import type { IShellExecutor } from '../types.js';
+import { combinedOutput } from '../types.js';
+
+export interface CacheRouterDeps {
+  stateService: StateService;
+  shell: IShellExecutor;
+}
+
+interface CacheDirInfo {
+  /** 缓存类型名（nuget / pnpm / npm / yarn） */
+  name: string;
+  /** 宿主机路径 */
+  hostPath: string;
+  /** 容器内路径 */
+  containerPath: string;
+  /** 目录是否存在 */
+  exists: boolean;
+  /** 字节数（递归汇总），仅目录存在时有值 */
+  sizeBytes: number | null;
+  /** 文件总数 */
+  fileCount: number | null;
+  /** 最近写入时间 ISO 字符串 */
+  lastModified: string | null;
+  /** 正在使用此挂载的 BuildProfile id 列表 */
+  usedByProfiles: string[];
+}
+
+function humanSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+  return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GB`;
+}
+
+async function dirStats(shell: IShellExecutor, dir: string): Promise<{
+  sizeBytes: number;
+  fileCount: number;
+  lastModified: string | null;
+}> {
+  // du 给字节精确数，find 算文件数，stat 拿最近 mtime
+  const sizeResult = await shell.exec(`du -sb "${dir}" 2>/dev/null | awk '{print $1}'`);
+  const countResult = await shell.exec(`find "${dir}" -type f 2>/dev/null | wc -l`);
+  const mtimeResult = await shell.exec(
+    `find "${dir}" -type f -printf '%T@\\n' 2>/dev/null | sort -nr | head -1`
+  );
+  const sizeBytes = parseInt((sizeResult.stdout || '0').trim(), 10) || 0;
+  const fileCount = parseInt((countResult.stdout || '0').trim(), 10) || 0;
+  const mtime = parseFloat((mtimeResult.stdout || '0').trim());
+  const lastModified = mtime > 0 ? new Date(mtime * 1000).toISOString() : null;
+  return { sizeBytes, fileCount, lastModified };
+}
+
+function cacheNameFromPath(hostPath: string): string {
+  return path.basename(hostPath);
+}
+
+export function createCacheRouter(deps: CacheRouterDeps): Router {
+  const { stateService, shell } = deps;
+  const router = Router();
+
+  /**
+   * GET /api/cache/status
+   * 列出所有 cacheMount 的诊断信息。用户打开 Settings → 缓存诊断 时调用。
+   */
+  router.get('/cache/status', async (_req, res) => {
+    try {
+      const CACHE_BASE = `/data/cds/${stateService.projectSlug}/cache`;
+      const profiles = stateService.getBuildProfiles();
+
+      const pathToInfo = new Map<string, CacheDirInfo>();
+
+      for (const profile of profiles) {
+        for (const mount of profile.cacheMounts || []) {
+          let entry = pathToInfo.get(mount.hostPath);
+          if (!entry) {
+            entry = {
+              name: cacheNameFromPath(mount.hostPath),
+              hostPath: mount.hostPath,
+              containerPath: mount.containerPath,
+              exists: fs.existsSync(mount.hostPath),
+              sizeBytes: null,
+              fileCount: null,
+              lastModified: null,
+              usedByProfiles: [],
+            };
+            pathToInfo.set(mount.hostPath, entry);
+          }
+          if (!entry.usedByProfiles.includes(profile.id)) {
+            entry.usedByProfiles.push(profile.id);
+          }
+        }
+      }
+
+      // 汇总磁盘 stat（仅对存在的目录）
+      await Promise.all(
+        Array.from(pathToInfo.values()).map(async (info) => {
+          if (!info.exists) return;
+          const stats = await dirStats(shell, info.hostPath);
+          info.sizeBytes = stats.sizeBytes;
+          info.fileCount = stats.fileCount;
+          info.lastModified = stats.lastModified;
+        })
+      );
+
+      // 也扫一下 CACHE_BASE 下的孤儿目录（有实物但没被任何 profile 挂载）
+      const orphans: CacheDirInfo[] = [];
+      if (fs.existsSync(CACHE_BASE)) {
+        const entries = fs.readdirSync(CACHE_BASE, { withFileTypes: true });
+        for (const ent of entries) {
+          if (!ent.isDirectory()) continue;
+          const full = path.join(CACHE_BASE, ent.name);
+          if (pathToInfo.has(full)) continue;
+          const stats = await dirStats(shell, full);
+          orphans.push({
+            name: ent.name,
+            hostPath: full,
+            containerPath: '(未挂载)',
+            exists: true,
+            sizeBytes: stats.sizeBytes,
+            fileCount: stats.fileCount,
+            lastModified: stats.lastModified,
+            usedByProfiles: [],
+          });
+        }
+      }
+
+      const caches = Array.from(pathToInfo.values());
+      const totalBytes = caches.reduce((sum, c) => sum + (c.sizeBytes || 0), 0)
+        + orphans.reduce((sum, c) => sum + (c.sizeBytes || 0), 0);
+
+      res.json({
+        cacheBase: CACHE_BASE,
+        projectSlug: stateService.projectSlug,
+        caches,
+        orphans,
+        totalBytes,
+        totalBytesHuman: humanSize(totalBytes),
+        warnings: buildWarnings(caches, orphans),
+      });
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  /**
+   * POST /api/cache/repair
+   * 强制按 dockerImage 补齐 cacheMounts。幂等。
+   * 返回修复前后的 profile 数量差异和修复动作。
+   */
+  router.post('/cache/repair', async (_req, res) => {
+    try {
+      const CACHE_BASE = `/data/cds/${stateService.projectSlug}/cache`;
+      const IMAGE_CACHE_MAP: Record<string, Array<{ hostPath: string; containerPath: string }>> = {
+        'dotnet': [{ hostPath: `${CACHE_BASE}/nuget`, containerPath: '/root/.nuget/packages' }],
+        'node': [{ hostPath: `${CACHE_BASE}/pnpm`, containerPath: '/pnpm/store' }],
+      };
+
+      const actions: Array<{ profileId: string; action: string; added?: string; fixed?: string }> = [];
+      const profiles = stateService.getBuildProfiles();
+
+      for (const profile of profiles) {
+        const mounts = [...(profile.cacheMounts || [])];
+        let touched = false;
+
+        // 路径迁移（host slug 漂移 + pnpm 容器路径纠正）
+        for (const cm of mounts) {
+          const updated = cm.hostPath.replace(/\/data\/cds\/[^/]+\/cache/, `${CACHE_BASE}`);
+          if (updated !== cm.hostPath) {
+            actions.push({ profileId: profile.id, action: 'rewrite-host-path', fixed: `${cm.hostPath} → ${updated}` });
+            cm.hostPath = updated;
+            touched = true;
+          }
+          if (cm.containerPath === '/root/.local/share/pnpm/store') {
+            actions.push({ profileId: profile.id, action: 'fix-pnpm-container-path', fixed: '/root/.local/share/pnpm/store → /pnpm/store' });
+            cm.containerPath = '/pnpm/store';
+            touched = true;
+          }
+        }
+
+        // 合并缺失的标准挂载
+        const image = profile.dockerImage || '';
+        for (const [key, templates] of Object.entries(IMAGE_CACHE_MAP)) {
+          if (!image.includes(key)) continue;
+          for (const template of templates) {
+            const exists = mounts.some(cm => cm.containerPath === template.containerPath);
+            if (!exists) {
+              mounts.push({ ...template });
+              actions.push({ profileId: profile.id, action: 'add-missing-mount', added: `${template.hostPath} → ${template.containerPath}` });
+              touched = true;
+            }
+          }
+        }
+
+        if (touched) {
+          stateService.updateBuildProfile(profile.id, { cacheMounts: mounts });
+        }
+      }
+
+      if (actions.length > 0) stateService.save();
+
+      // 确保所有 host 目录预创建好（避免容器首次启动因父目录缺失 mount 失败）
+      const allHostPaths = new Set<string>();
+      for (const profile of stateService.getBuildProfiles()) {
+        for (const cm of profile.cacheMounts || []) {
+          allHostPaths.add(cm.hostPath);
+        }
+      }
+      for (const hp of allHostPaths) {
+        await shell.exec(`mkdir -p "${hp}"`);
+      }
+
+      res.json({
+        repaired: actions.length > 0,
+        actionsCount: actions.length,
+        actions,
+        message: actions.length === 0
+          ? '所有 profile 的缓存挂载已正常，无需修复'
+          : `已修复 ${actions.length} 个挂载问题`,
+      });
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  /**
+   * GET /api/cache/export?name=nuget
+   * 打包指定缓存目录为 tar.gz 流式下载。
+   * 换服务器时用：在老机器下载 → 上传到新机器 /api/cache/import。
+   */
+  router.get('/cache/export', async (req, res) => {
+    const name = String(req.query.name || '').trim();
+    if (!name || !/^[a-z0-9][a-z0-9-]*$/i.test(name)) {
+      res.status(400).json({ error: '缺少或非法的 name 参数（只允许字母数字和连字符）' });
+      return;
+    }
+
+    const CACHE_BASE = `/data/cds/${stateService.projectSlug}/cache`;
+    const dir = path.join(CACHE_BASE, name);
+    if (!fs.existsSync(dir)) {
+      res.status(404).json({ error: `缓存目录不存在: ${dir}` });
+      return;
+    }
+
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+    const filename = `cds-cache-${name}-${stateService.projectSlug}-${stamp}.tar.gz`;
+
+    res.setHeader('Content-Type', 'application/gzip');
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+
+    // 直接 spawn tar，不经过内存 buffer
+    const { spawn } = await import('node:child_process');
+    const tar = spawn('tar', ['-czf', '-', '-C', CACHE_BASE, name], { stdio: ['ignore', 'pipe', 'pipe'] });
+    tar.stdout.pipe(res);
+    tar.stderr.on('data', (chunk: Buffer) => {
+      // tar 的 stderr 不算错，只是 verbose 信息；不打断
+      console.error(`[cache-export] ${chunk.toString().trim()}`);
+    });
+    tar.on('error', (err) => {
+      if (!res.headersSent) res.status(500).json({ error: err.message });
+      else res.end();
+    });
+    tar.on('close', (code) => {
+      if (code !== 0 && !res.writableEnded) res.end();
+    });
+  });
+
+  /**
+   * POST /api/cache/import?name=nuget
+   * 接收 tar.gz 上传并解压到指定缓存目录。
+   * body 是原始 tar.gz 字节流（Content-Type: application/gzip）。
+   */
+  router.post('/cache/import', async (req, res) => {
+    const name = String(req.query.name || '').trim();
+    if (!name || !/^[a-z0-9][a-z0-9-]*$/i.test(name)) {
+      res.status(400).json({ error: '缺少或非法的 name 参数' });
+      return;
+    }
+
+    const CACHE_BASE = `/data/cds/${stateService.projectSlug}/cache`;
+    await shell.exec(`mkdir -p "${CACHE_BASE}"`);
+
+    const { spawn } = await import('node:child_process');
+    const tar = spawn('tar', ['-xzf', '-', '-C', CACHE_BASE], { stdio: ['pipe', 'pipe', 'pipe'] });
+    let stderrBuf = '';
+    tar.stderr.on('data', (chunk: Buffer) => { stderrBuf += chunk.toString(); });
+
+    req.pipe(tar.stdin);
+    req.on('error', () => { try { tar.kill(); } catch { /* noop */ } });
+
+    tar.on('close', async (code) => {
+      if (code !== 0) {
+        res.status(500).json({ error: `tar 解压失败 (exit ${code}): ${stderrBuf}` });
+        return;
+      }
+      const imported = path.join(CACHE_BASE, name);
+      const stats = fs.existsSync(imported) ? await dirStats(shell, imported) : null;
+      res.json({
+        imported: true,
+        path: imported,
+        sizeBytes: stats?.sizeBytes ?? null,
+        sizeBytesHuman: stats ? humanSize(stats.sizeBytes) : null,
+        fileCount: stats?.fileCount ?? null,
+        message: `缓存已解压到 ${imported}`,
+      });
+    });
+  });
+
+  /**
+   * POST /api/cache/purge?name=nuget
+   * 清空指定缓存目录。用于故障排查（比如怀疑缓存被污染）或节省磁盘。
+   * 不会影响容器运行；下次 restore 会从 nuget.org 重新拉。
+   */
+  router.post('/cache/purge', async (req, res) => {
+    const name = String(req.query.name || '').trim();
+    if (!name || !/^[a-z0-9][a-z0-9-]*$/i.test(name)) {
+      res.status(400).json({ error: '缺少或非法的 name 参数' });
+      return;
+    }
+    const CACHE_BASE = `/data/cds/${stateService.projectSlug}/cache`;
+    const dir = path.join(CACHE_BASE, name);
+    if (!fs.existsSync(dir)) {
+      res.status(404).json({ error: `缓存目录不存在: ${dir}` });
+      return;
+    }
+
+    const result = await shell.exec(`rm -rf "${dir}"`);
+    if (result.exitCode !== 0) {
+      res.status(500).json({ error: combinedOutput(result) });
+      return;
+    }
+    // 重建空目录（容器启动时需要存在，否则 -v 挂载 docker 会创建为 root:root）
+    await shell.exec(`mkdir -p "${dir}"`);
+
+    res.json({ purged: true, path: dir, message: `已清空缓存目录 ${dir}` });
+  });
+
+  return router;
+}
+
+function buildWarnings(caches: CacheDirInfo[], orphans: CacheDirInfo[]): string[] {
+  const warnings: string[] = [];
+  for (const c of caches) {
+    if (!c.exists) {
+      warnings.push(`[${c.name}] 被 ${c.usedByProfiles.length} 个 profile 引用，但宿主机目录不存在：${c.hostPath}`);
+      continue;
+    }
+    if (c.sizeBytes === 0 && (c.fileCount ?? 0) === 0) {
+      warnings.push(`[${c.name}] 目录空的！${c.usedByProfiles.join(', ')} 在用，说明挂载没生效或缓存被清过`);
+    } else if ((c.sizeBytes ?? 0) < 10 * 1024 * 1024 && c.name === 'nuget') {
+      warnings.push(`[${c.name}] 只有 ${humanSize(c.sizeBytes ?? 0)}，.NET 项目正常应该几百 MB，可能挂载路径不对`);
+    }
+  }
+  if (orphans.length > 0) {
+    warnings.push(`发现 ${orphans.length} 个孤儿缓存目录（有数据但没被任何 profile 挂载），可能是 profile 改名或缓存路径漂移`);
+  }
+  return warnings;
+}

--- a/cds/src/routes/infra-backup.ts
+++ b/cds/src/routes/infra-backup.ts
@@ -1,0 +1,249 @@
+/**
+ * 基础设施数据备份 / 恢复
+ *
+ * 满足用户需求：「增加备份数据库功能，让用户可以下载数据库」+「破坏性操作紧急还原」。
+ *
+ * 支持的 infra 类型：
+ *   - mongodb → mongodump/mongorestore（archive + gzip 单流）
+ *   - mongo   → 同 mongodb
+ *   - redis   → BGSAVE + 复制 dump.rdb
+ *   - 其他    → 简单 tar 容器数据卷 `/data`
+ *
+ * API：
+ *   GET  /api/infra/:id/backup         一键下载当前数据库（流式）
+ *   POST /api/infra/:id/restore        上传 dump 文件恢复
+ *   GET  /api/infra/:id/backup-history 列出已保存在 CDS 服务器的自动备份（可选）
+ */
+import { Router } from 'express';
+import type { StateService } from '../services/state.js';
+import type { IShellExecutor } from '../types.js';
+import { combinedOutput } from '../types.js';
+
+export interface InfraBackupRouterDeps {
+  stateService: StateService;
+  shell: IShellExecutor;
+}
+
+function detectKind(dockerImage: string): 'mongo' | 'redis' | 'generic' {
+  const lower = dockerImage.toLowerCase();
+  if (lower.includes('mongo')) return 'mongo';
+  if (lower.includes('redis')) return 'redis';
+  return 'generic';
+}
+
+function shq(s: string): string {
+  return `'${String(s).replace(/'/g, `'"'"'`)}'`;
+}
+
+/** 从 env 里抠 mongo root 账号密码，同时兼容两种写法。 */
+function extractMongoAuth(env: Record<string, string>): { user?: string; password?: string } {
+  return {
+    user: env.MONGO_INITDB_ROOT_USERNAME || env.MONGO_USERNAME || env.MONGODB_USERNAME,
+    password: env.MONGO_INITDB_ROOT_PASSWORD || env.MONGO_PASSWORD || env.MONGODB_PASSWORD,
+  };
+}
+
+export function createInfraBackupRouter(deps: InfraBackupRouterDeps): Router {
+  const { stateService, shell } = deps;
+  const router = Router();
+
+  /**
+   * GET /api/infra/:id/backup
+   * 生成备份并流式返回下载。mongo 走 mongodump，redis 走 BGSAVE + 拷贝 dump.rdb，
+   * 其他走 `tar` 包 /data 目录。
+   */
+  router.get('/infra/:id/backup', async (req, res) => {
+    const svc = stateService.getInfraService(req.params.id);
+    if (!svc) {
+      res.status(404).json({ error: `基础设施服务不存在: ${req.params.id}` });
+      return;
+    }
+    if (svc.status !== 'running') {
+      res.status(409).json({ error: `服务 "${svc.id}" 当前未运行（status=${svc.status}），无法备份。请先启动。` });
+      return;
+    }
+
+    const kind = detectKind(svc.dockerImage);
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+    const filename = `${svc.id}-${stamp}.${kind === 'mongo' ? 'archive.gz' : kind === 'redis' ? 'rdb' : 'tar.gz'}`;
+
+    res.setHeader('Content-Type', 'application/octet-stream');
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+
+    const { spawn } = await import('node:child_process');
+
+    try {
+      if (kind === 'mongo') {
+        const auth = extractMongoAuth(svc.env);
+        const authArgs: string[] = [];
+        if (auth.user && auth.password) {
+          authArgs.push('-u', auth.user, '-p', auth.password, '--authenticationDatabase', 'admin');
+        }
+        const cmd = [
+          'docker', 'exec', svc.containerName,
+          'mongodump', '--archive', '--gzip', ...authArgs,
+        ];
+        const proc = spawn(cmd[0], cmd.slice(1), { stdio: ['ignore', 'pipe', 'pipe'] });
+        proc.stdout.pipe(res);
+        let stderr = '';
+        proc.stderr.on('data', (c: Buffer) => { stderr += c.toString(); });
+        proc.on('close', (code) => {
+          if (code !== 0) {
+            console.error(`[infra-backup] mongodump exit ${code}: ${stderr}`);
+            if (!res.writableEnded) res.end();
+          }
+          // 记一条破坏性操作（备份自己不是破坏性，不记）
+        });
+        proc.on('error', (err) => {
+          if (!res.headersSent) res.status(500).json({ error: err.message });
+          else res.end();
+        });
+      } else if (kind === 'redis') {
+        // 1) BGSAVE 触发磁盘写入 2) 等待 lastsave 变化 3) cat /data/dump.rdb
+        await shell.exec(`docker exec ${shq(svc.containerName)} redis-cli BGSAVE`);
+        // 简化：sleep 1s 后 cat dump.rdb（生产环境应轮询 LASTSAVE）
+        await new Promise((r) => setTimeout(r, 1200));
+        const cmd = ['docker', 'exec', svc.containerName, 'cat', '/data/dump.rdb'];
+        const proc = spawn(cmd[0], cmd.slice(1), { stdio: ['ignore', 'pipe', 'pipe'] });
+        proc.stdout.pipe(res);
+        proc.on('error', (err) => {
+          if (!res.headersSent) res.status(500).json({ error: err.message });
+          else res.end();
+        });
+      } else {
+        // generic: tar /data
+        const cmd = ['docker', 'exec', svc.containerName, 'tar', '-czf', '-', '-C', '/data', '.'];
+        const proc = spawn(cmd[0], cmd.slice(1), { stdio: ['ignore', 'pipe', 'pipe'] });
+        proc.stdout.pipe(res);
+        proc.on('error', (err) => {
+          if (!res.headersSent) res.status(500).json({ error: err.message });
+          else res.end();
+        });
+      }
+    } catch (err) {
+      if (!res.headersSent) res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  /**
+   * POST /api/infra/:id/restore
+   * 上传一份之前导出的 dump 文件恢复。body 是原始字节流。
+   *
+   * 破坏性操作：恢复前自动 dump 一份当前数据库到 /data/cds/<slug>/backups/<id>-pre-restore-<timestamp>，
+   * 并记 DestructiveOperationLog，这样用户还能还原回恢复前的状态。
+   */
+  router.post('/infra/:id/restore', async (req, res) => {
+    const svc = stateService.getInfraService(req.params.id);
+    if (!svc) {
+      res.status(404).json({ error: `基础设施服务不存在: ${req.params.id}` });
+      return;
+    }
+    if (svc.status !== 'running') {
+      res.status(409).json({ error: `服务未运行，无法恢复` });
+      return;
+    }
+
+    const kind = detectKind(svc.dockerImage);
+    const { spawn } = await import('node:child_process');
+
+    // 1) 先自动备份当前状态（便于"撤销恢复"）
+    const backupDir = `/data/cds/${stateService.projectSlug}/backups`;
+    await shell.exec(`mkdir -p ${shq(backupDir)}`);
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+    const preBackupPath = `${backupDir}/${svc.id}-pre-restore-${stamp}.${kind === 'mongo' ? 'archive.gz' : 'bin'}`;
+
+    try {
+      if (kind === 'mongo') {
+        const auth = extractMongoAuth(svc.env);
+        const authArgs: string[] = [];
+        if (auth.user && auth.password) {
+          authArgs.push('-u', auth.user, '-p', auth.password, '--authenticationDatabase', 'admin');
+        }
+        const dumpCmd = `docker exec ${shq(svc.containerName)} mongodump --archive --gzip ${authArgs.map(shq).join(' ')} > ${shq(preBackupPath)}`;
+        await shell.exec(dumpCmd);
+      }
+    } catch (err) {
+      console.error('[infra-restore] pre-restore backup 失败', err);
+      // 不阻止恢复；只是少一个兜底
+    }
+
+    // 2) 执行恢复
+    try {
+      if (kind === 'mongo') {
+        const auth = extractMongoAuth(svc.env);
+        const authArgs: string[] = [];
+        if (auth.user && auth.password) {
+          authArgs.push('-u', auth.user, '-p', auth.password, '--authenticationDatabase', 'admin');
+        }
+        const cmd = [
+          'docker', 'exec', '-i', svc.containerName,
+          'mongorestore', '--archive', '--gzip', '--drop', ...authArgs,
+        ];
+        const proc = spawn(cmd[0], cmd.slice(1), { stdio: ['pipe', 'pipe', 'pipe'] });
+        req.pipe(proc.stdin);
+        let stderr = '';
+        proc.stderr.on('data', (c: Buffer) => { stderr += c.toString(); });
+        proc.on('close', (code) => {
+          if (code !== 0) {
+            res.status(500).json({ error: `mongorestore exit ${code}`, detail: stderr });
+            return;
+          }
+          stateService.recordDestructiveOp({
+            type: 'purge-database',
+            summary: `恢复 ${svc.id} 数据库（预备份已保存：${preBackupPath}）`,
+          });
+          res.json({ restored: true, preRestoreBackup: preBackupPath, message: '数据库已恢复' });
+        });
+      } else if (kind === 'redis') {
+        // Redis restore：写入 /data/dump.rdb 然后重启容器加载
+        const cmd = ['docker', 'exec', '-i', svc.containerName, 'sh', '-c', 'cat > /data/dump.rdb'];
+        const proc = spawn(cmd[0], cmd.slice(1), { stdio: ['pipe', 'ignore', 'pipe'] });
+        req.pipe(proc.stdin);
+        proc.on('close', async (code) => {
+          if (code !== 0) {
+            res.status(500).json({ error: `写入 dump.rdb 失败 exit=${code}` });
+            return;
+          }
+          // 重启容器让 redis 重新加载
+          await shell.exec(`docker restart ${shq(svc.containerName)}`).catch(() => { /* noop */ });
+          stateService.recordDestructiveOp({
+            type: 'purge-database',
+            summary: `恢复 ${svc.id} Redis dump.rdb 并重启容器`,
+          });
+          res.json({ restored: true, message: 'Redis 已从 dump.rdb 恢复并重启' });
+        });
+      } else {
+        res.status(400).json({ error: '暂不支持该 infra 类型的自动恢复，请手动导入' });
+      }
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  /**
+   * GET /api/infra/:id/backup-history
+   * 列出保存在 CDS 服务器 /data/cds/<slug>/backups/ 下的自动备份。
+   */
+  router.get('/infra/:id/backup-history', async (req, res) => {
+    const svc = stateService.getInfraService(req.params.id);
+    if (!svc) {
+      res.status(404).json({ error: '服务不存在' });
+      return;
+    }
+    const backupDir = `/data/cds/${stateService.projectSlug}/backups`;
+    const result = await shell.exec(`ls -la ${shq(backupDir)} 2>/dev/null | grep ${shq(svc.id)} || true`);
+    const lines = (result.stdout || '').split('\n').filter(Boolean);
+    const entries = lines.map(l => {
+      const parts = l.trim().split(/\s+/);
+      if (parts.length < 9) return null;
+      return {
+        size: parseInt(parts[4], 10) || 0,
+        mtime: parts.slice(5, 8).join(' '),
+        name: parts[8],
+      };
+    }).filter(Boolean);
+    res.json({ backups: entries, directory: backupDir });
+  });
+
+  return router;
+}

--- a/cds/src/routes/legacy-cleanup.ts
+++ b/cds/src/routes/legacy-cleanup.ts
@@ -1,0 +1,201 @@
+/**
+ * 遗留「default」项目清理路由
+ *
+ * 用户诉求：「不要使用？project 这种，而是使用真正的项目名或项目id」
+ *          「default 我早就说要去掉，始终去不掉」
+ *
+ * 现实：历史上 CDS 从单项目升级到多项目时，所有旧数据都被归到 `default`
+ * 项目名下做向前兼容。直接删 default 会让旧 branches/profiles/infra 全部
+ * 孤立 → 生产事故。本路由提供 **可控迁移**：
+ *
+ *   GET  /api/legacy-cleanup/status         —— 看看 default 还有多少数据
+ *   POST /api/legacy-cleanup/rename-default —— 把 default 改成用户给的 id/name
+ *
+ * 用户在顶部 banner 点「迁移 →」弹对话框输入新 id，一键改名。
+ * 之后：
+ *   - 所有 branches.projectId='default' → 新 id
+ *   - 所有 buildProfiles.projectId='default' → 新 id
+ *   - 所有 infraServices.projectId='default' → 新 id
+ *   - Project.id='default' → 新 id，Project.legacyFlag 清掉
+ *   - customEnv['default'] scope → 新 id scope
+ *   - worktree 目录物理改名 `<base>/default/` → `<base>/<newId>/`
+ */
+import { Router } from 'express';
+import fs from 'node:fs';
+import path from 'node:path';
+import type { StateService } from '../services/state.js';
+import type { IShellExecutor } from '../types.js';
+import { combinedOutput } from '../types.js';
+
+const LEGACY_PROJECT_ID = 'default';
+const SLUG_REGEX = /^[a-z][a-z0-9-]*[a-z0-9]$|^[a-z]$/;
+
+export interface LegacyCleanupRouterDeps {
+  stateService: StateService;
+  shell: IShellExecutor;
+  worktreeBase: string;
+}
+
+export function createLegacyCleanupRouter(deps: LegacyCleanupRouterDeps): Router {
+  const { stateService, shell, worktreeBase } = deps;
+  const router = Router();
+
+  router.get('/legacy-cleanup/status', (_req, res) => {
+    const allBranches = stateService.getAllBranches();
+    const branches = allBranches.filter(b => (b.projectId || LEGACY_PROJECT_ID) === LEGACY_PROJECT_ID);
+    const profiles = stateService.getBuildProfiles().filter(p => (p.projectId || LEGACY_PROJECT_ID) === LEGACY_PROJECT_ID);
+    const infra = stateService.getInfraServices().filter(s => (s.projectId || LEGACY_PROJECT_ID) === LEGACY_PROJECT_ID);
+    const hasLegacyProject = (stateService.getProjects?.() || []).some(p => p.id === LEGACY_PROJECT_ID);
+    const legacyWorktreeExists = fs.existsSync(path.posix.join(worktreeBase, LEGACY_PROJECT_ID));
+    const rawEnv = stateService.getCustomEnvRaw?.() || {};
+    const customEnvScopeExists = Boolean(rawEnv[LEGACY_PROJECT_ID] && Object.keys(rawEnv[LEGACY_PROJECT_ID]).length > 0);
+
+    const hasResources = branches.length > 0 || profiles.length > 0 || infra.length > 0;
+    res.json({
+      legacyInUse: hasLegacyProject || hasResources || legacyWorktreeExists,
+      counts: {
+        branches: branches.length,
+        buildProfiles: profiles.length,
+        infraServices: infra.length,
+        hasLegacyProject,
+        legacyWorktreeExists,
+        customEnvScopeExists,
+      },
+      recommendation: hasResources
+        ? '建议点「迁移 →」为 default 项目改个真实名字。'
+        : '无需操作，default 项目已空。',
+    });
+  });
+
+  router.post('/legacy-cleanup/rename-default', async (req, res) => {
+    const { newId, newName } = (req.body || {}) as { newId?: string; newName?: string };
+    const normalizedId = String(newId || '').trim().toLowerCase();
+    if (!normalizedId) {
+      res.status(400).json({ error: '必须提供 newId' });
+      return;
+    }
+    if (normalizedId === LEGACY_PROJECT_ID) {
+      res.status(400).json({ error: 'newId 不能还是 default' });
+      return;
+    }
+    if (!SLUG_REGEX.test(normalizedId)) {
+      res.status(400).json({ error: 'newId 只能包含小写字母、数字、短横线，且不能以短横线开头/结尾' });
+      return;
+    }
+    if ((stateService.getProjects?.() || []).some(p => p.id === normalizedId)) {
+      res.status(409).json({ error: `项目 id "${normalizedId}" 已存在` });
+      return;
+    }
+
+    // 先自动拍一份快照（破坏性操作前）
+    const snapshot = stateService.createConfigSnapshot({
+      trigger: 'pre-destructive',
+      label: `迁移遗留 default → ${normalizedId} 前`,
+      projectId: LEGACY_PROJECT_ID,
+    });
+
+    const stats: Record<string, number> = { branches: 0, profiles: 0, infra: 0, envScopes: 0 };
+
+    // 1) branches
+    for (const b of stateService.getAllBranches()) {
+      if ((b.projectId || LEGACY_PROJECT_ID) === LEGACY_PROJECT_ID) {
+        b.projectId = normalizedId;
+        stats.branches++;
+      }
+    }
+
+    // 2) profiles
+    for (const p of stateService.getBuildProfiles()) {
+      if ((p.projectId || LEGACY_PROJECT_ID) === LEGACY_PROJECT_ID) {
+        p.projectId = normalizedId;
+        stats.profiles++;
+      }
+    }
+
+    // 3) infra
+    for (const s of stateService.getInfraServices()) {
+      if ((s.projectId || LEGACY_PROJECT_ID) === LEGACY_PROJECT_ID) {
+        s.projectId = normalizedId;
+        stats.infra++;
+      }
+    }
+
+    // 4) projects
+    const projects = stateService.getProjects?.() || [];
+    const defaultProj = projects.find(p => p.id === LEGACY_PROJECT_ID);
+    if (defaultProj) {
+      defaultProj.id = normalizedId;
+      if (newName && typeof newName === 'string') defaultProj.name = newName.trim();
+      // 清 legacyFlag —— 迁移后不再是 legacy
+      defaultProj.legacyFlag = false;
+    } else {
+      // 没有 Project 记录但有资源（pre-P4），直接新建一个最小记录
+      stateService.addProject?.({
+        id: normalizedId,
+        name: newName?.trim() || normalizedId,
+        slug: normalizedId,
+        kind: 'manual',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+    }
+
+    // 5) customEnv scope —— 只迁移"default" scope 本身的变量，不含 global
+    const rawEnv = stateService.getCustomEnvRaw?.() || {};
+    const legacyScope = rawEnv[LEGACY_PROJECT_ID] || {};
+    for (const [k, v] of Object.entries(legacyScope)) {
+      stateService.setCustomEnvVar(k, v, normalizedId);
+      stats.envScopes++;
+    }
+    stateService.dropCustomEnvScope?.(LEGACY_PROJECT_ID);
+
+    stateService.save();
+
+    // 6) worktree 物理目录迁移（symlink 最快 + reversible）
+    const oldDir = path.posix.join(worktreeBase, LEGACY_PROJECT_ID);
+    const newDir = path.posix.join(worktreeBase, normalizedId);
+    let worktreeMoveResult = 'skipped (目录不存在)';
+    if (fs.existsSync(oldDir) && !fs.existsSync(newDir)) {
+      try {
+        // 先尝试重命名（同文件系统原子）
+        fs.renameSync(oldDir, newDir);
+        worktreeMoveResult = 'renamed';
+        // 同时重写 state 里的 branch.worktreePath
+        for (const b of stateService.getAllBranches()) {
+          if (b.worktreePath && b.worktreePath.startsWith(oldDir + '/')) {
+            b.worktreePath = b.worktreePath.replace(oldDir + '/', newDir + '/');
+          }
+        }
+        stateService.save();
+      } catch (err) {
+        // 跨文件系统或权限问题：退化到 symlink（不阻断迁移）
+        try {
+          fs.symlinkSync(oldDir, newDir, 'dir');
+          worktreeMoveResult = 'symlinked (rename failed: ' + (err as Error).message + ')';
+        } catch (err2) {
+          worktreeMoveResult = 'failed: ' + (err2 as Error).message;
+        }
+      }
+    } else if (fs.existsSync(newDir)) {
+      worktreeMoveResult = 'skipped (目标已存在)';
+    }
+
+    stateService.recordDestructiveOp({
+      type: 'other',
+      snapshotId: snapshot.id,
+      summary: `遗留 default 项目迁移为 "${normalizedId}"（${stats.branches} 分支 / ${stats.profiles} profile / ${stats.infra} infra）`,
+    });
+
+    res.json({
+      migrated: true,
+      from: LEGACY_PROJECT_ID,
+      to: normalizedId,
+      stats,
+      worktreeMove: worktreeMoveResult,
+      snapshotId: snapshot.id,
+      message: `已将 default 项目迁移为「${normalizedId}」。如有异常可在「历史版本」里回滚。`,
+    });
+  });
+
+  return router;
+}

--- a/cds/src/routes/projects.ts
+++ b/cds/src/routes/projects.ts
@@ -454,6 +454,16 @@ export function createProjectsRouter(deps: ProjectsRouterDeps): Router {
       });
       return;
     }
+    // 2026-04-22 规则：禁止再用 'default' 作为项目 id，避免和遗留迁移项目冲突，
+    // 也避免「default」被当成兜底值到处蔓延（就是用户在抱怨的老问题）。
+    if (baseSlug === LEGACY_PROJECT_ID) {
+      res.status(400).json({
+        error: 'validation',
+        field: 'slug',
+        message: 'slug 不能为 "default"（保留给遗留迁移占位）。请用项目真实名称的派生 slug，例如 my-app。',
+      });
+      return;
+    }
 
     // P4 Part 18 (Phase E audit fix #9): redact embedded userinfo
     // before persisting. Users who paste tokens in the URL by mistake

--- a/cds/src/routes/snapshots.ts
+++ b/cds/src/routes/snapshots.ts
@@ -1,0 +1,145 @@
+/**
+ * 配置快照 / 破坏性操作审计路由
+ *
+ * 解决的用户痛点："导入配置后项目污染了好几十回，每次都要手工回滚"。
+ *
+ * 提供三类端点：
+ *   1. 配置快照（ConfigSnapshot）—— 导入前自动拍 + 手动拍 + 一键回滚
+ *      GET    /api/config-snapshots           列表
+ *      GET    /api/config-snapshots/:id       详情
+ *      POST   /api/config-snapshots           手动创建当前快照
+ *      POST   /api/config-snapshots/:id/rollback  回滚到该快照
+ *      DELETE /api/config-snapshots/:id       删除旧快照
+ *
+ *   2. 破坏性操作日志（DestructiveOperationLog）—— 紧急还原抽屉
+ *      GET    /api/destructive-ops            最近 100 条
+ *      POST   /api/destructive-ops/:id/undo   撤销（30 分钟内有效）
+ */
+import { Router } from 'express';
+import type { StateService } from '../services/state.js';
+
+export interface SnapshotsRouterDeps {
+  stateService: StateService;
+}
+
+export function createSnapshotsRouter(deps: SnapshotsRouterDeps): Router {
+  const { stateService } = deps;
+  const router = Router();
+
+  // ── ConfigSnapshot ──
+
+  router.get('/config-snapshots', (req, res) => {
+    const projectId = req.query.projectId as string | undefined;
+    // projectId 为空字符串视为"全部"
+    const filter = projectId === undefined || projectId === '' ? undefined : projectId;
+    const list = stateService.getConfigSnapshots(filter);
+    // 倒序 + 去掉 payload（列表不传大字段）
+    const stripped = list
+      .slice()
+      .reverse()
+      .map(s => ({
+        id: s.id,
+        createdAt: s.createdAt,
+        projectId: s.projectId ?? null,
+        trigger: s.trigger,
+        label: s.label,
+        triggeredBy: s.triggeredBy,
+        sizeBytes: s.sizeBytes ?? 0,
+        counts: {
+          buildProfiles: s.payload.buildProfiles.length,
+          infraServices: s.payload.infraServices.length,
+          routingRules: s.payload.routingRules.length,
+          envVarScopes: Object.keys(s.payload.customEnv).length,
+        },
+      }));
+    res.json({ snapshots: stripped, total: list.length, limit: 30 });
+  });
+
+  router.get('/config-snapshots/:id', (req, res) => {
+    const s = stateService.getConfigSnapshot(req.params.id);
+    if (!s) {
+      res.status(404).json({ error: `快照不存在: ${req.params.id}` });
+      return;
+    }
+    res.json(s);
+  });
+
+  router.post('/config-snapshots', (req, res) => {
+    const { label, projectId, triggeredBy } = req.body as { label?: string; projectId?: string | null; triggeredBy?: string };
+    const snapshot = stateService.createConfigSnapshot({
+      trigger: 'manual',
+      label: label || `手动保存 · ${new Date().toLocaleString('zh-CN')}`,
+      projectId: projectId ?? null,
+      triggeredBy,
+    });
+    res.status(201).json({ snapshot, message: '已保存当前配置为快照' });
+  });
+
+  router.post('/config-snapshots/:id/rollback', (req, res) => {
+    try {
+      const target = stateService.rollbackToConfigSnapshot(
+        req.params.id,
+        (req.body?.triggeredBy as string) || undefined,
+      );
+      // 同时记录一条破坏性操作（回滚本身就是破坏性行为）
+      stateService.recordDestructiveOp({
+        type: 'other',
+        projectId: target.projectId ?? null,
+        snapshotId: target.id,
+        summary: `回滚到快照「${target.label}」（${new Date(target.createdAt).toLocaleString('zh-CN')}）`,
+        triggeredBy: (req.body?.triggeredBy as string) || undefined,
+      });
+      res.json({ rolledBack: true, snapshot: { id: target.id, label: target.label }, message: `已回滚到「${target.label}」` });
+    } catch (err) {
+      res.status(400).json({ error: (err as Error).message });
+    }
+  });
+
+  router.delete('/config-snapshots/:id', (req, res) => {
+    const removed = stateService.deleteConfigSnapshot(req.params.id);
+    if (!removed) {
+      res.status(404).json({ error: '快照不存在' });
+      return;
+    }
+    res.json({ deleted: true });
+  });
+
+  // ── DestructiveOperationLog ──
+
+  router.get('/destructive-ops', (_req, res) => {
+    const ops = stateService.getDestructiveOps();
+    const enriched = ops
+      .slice()
+      .reverse()
+      .map(op => ({ ...op, canUndo: stateService.isDestructiveOpUndoable(op) }));
+    res.json({ ops: enriched, undoWindowMinutes: Math.floor((30 * 60 * 1000) / 60000) });
+  });
+
+  router.post('/destructive-ops/:id/undo', (req, res) => {
+    const op = stateService.getDestructiveOps().find(o => o.id === req.params.id);
+    if (!op) {
+      res.status(404).json({ error: '操作记录不存在' });
+      return;
+    }
+    if (!stateService.isDestructiveOpUndoable(op)) {
+      res.status(400).json({ error: '操作已超过 30 分钟撤销窗口，或已被撤销过' });
+      return;
+    }
+
+    // 需要关联的 ConfigSnapshot 才能撤销配置层面的改动
+    if (!op.snapshotId) {
+      res.status(400).json({ error: '该操作没有关联快照，无法自动撤销。请查看配置历史手动选择版本回滚。' });
+      return;
+    }
+
+    try {
+      stateService.rollbackToConfigSnapshot(op.snapshotId, (req.body?.triggeredBy as string) || undefined);
+      stateService.markDestructiveOpUndone(op.id);
+      res.json({ undone: true, message: `已通过回滚快照撤销「${op.summary}」` });
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  return router;
+}

--- a/cds/src/server.ts
+++ b/cds/src/server.ts
@@ -7,6 +7,10 @@ import { createBranchRouter } from './routes/branches.js';
 import { createBridgeRouter } from './routes/bridge.js';
 import { createProjectsRouter } from './routes/projects.js';
 import { createPendingImportRouter } from './routes/pending-import.js';
+import { createCacheRouter } from './routes/cache.js';
+import { createSnapshotsRouter } from './routes/snapshots.js';
+import { createInfraBackupRouter } from './routes/infra-backup.js';
+import { createLegacyCleanupRouter } from './routes/legacy-cleanup.js';
 import { createStorageModeRouter, type StorageModeContext } from './routes/storage-mode.js';
 import { createCommentTemplateRouter } from './routes/comment-template.js';
 import { createGithubOAuthRouter } from './routes/github-oauth.js';
@@ -134,6 +138,18 @@ function resolveApiLabel(method: string, path: string): string {
     'PUT /mirror': '更新镜像配置',
     'POST /import-config': '导入配置',
     'GET /export-config': '导出配置',
+    'GET /cache/status': '查看缓存状态',
+    'POST /cache/repair': '修复缓存挂载',
+    'GET /cache/export': '导出缓存包',
+    'POST /cache/import': '导入缓存包',
+    'POST /cache/purge': '清空缓存目录',
+    'GET /proxy-log': '查看转发日志',
+    'GET /proxy-log/stream': '订阅转发日志流',
+    'GET /config-snapshots': '列出配置快照',
+    'POST /config-snapshots': '手动保存配置快照',
+    'GET /destructive-ops': '列出破坏性操作',
+    'GET /legacy-cleanup/status': '查看 default 遗留状态',
+    'POST /legacy-cleanup/rename-default': '迁移 default 项目',
     'GET /export-skill': '导出技能配置',
     'POST /import-and-init': '导入并初始化',
     'GET /self-branches': '获取自身分支',
@@ -223,6 +239,10 @@ function resolveApiLabel(method: string, path: string): string {
 
   // Dynamic pattern matches (with :id params)
   const patterns: Array<[RegExp, string]> = [
+    [/^GET \/config-snapshots\/(.+)$/, '查看配置快照详情'],
+    [/^POST \/config-snapshots\/(.+)\/rollback$/, '回滚到配置快照'],
+    [/^DELETE \/config-snapshots\/(.+)$/, '删除配置快照'],
+    [/^POST \/destructive-ops\/(.+)\/undo$/, '撤销破坏性操作'],
     [/^DELETE \/branches\/(.+)$/, '删除分支'],
     [/^PATCH \/branches\/(.+)$/, '更新分支信息'],
     [/^POST \/branches\/(.+)\/pull$/, '拉取分支代码'],
@@ -242,6 +262,8 @@ function resolveApiLabel(method: string, path: string): string {
     [/^DELETE \/routing-rules\/(.+)$/, '删除路由规则'],
     [/^PUT \/build-profiles\/(.+)$/, '更新构建配置'],
     [/^DELETE \/build-profiles\/(.+)$/, '删除构建配置'],
+    [/^PUT \/build-profiles\/(.+)\/deploy-mode$/, '切换部署模式'],
+    [/^POST \/build-profiles\/(.+)\/hot-reload$/, '切换热更新'],
     [/^POST \/infra\/(.+)\/start$/, '启动基础设施'],
     [/^POST \/infra\/(.+)\/stop$/, '停止基础设施'],
     [/^POST \/infra\/(.+)\/restart$/, '重启基础设施'],
@@ -249,6 +271,9 @@ function resolveApiLabel(method: string, path: string): string {
     [/^GET \/infra\/(.+)\/health$/, '基础设施健康检查'],
     [/^PUT \/infra\/(.+)$/, '更新基础设施'],
     [/^DELETE \/infra\/(.+)$/, '删除基础设施'],
+    [/^GET \/infra\/(.+)\/backup$/, '下载数据库备份'],
+    [/^POST \/infra\/(.+)\/restore$/, '恢复数据库'],
+    [/^GET \/infra\/(.+)\/backup-history$/, '查看备份历史'],
     [/^DELETE \/ai\/sessions\/(.+)$/, '撤销 AI 会话'],
     [/^POST \/ai\/approve\/(.+)$/, '批准 AI 连接'],
     [/^POST \/ai\/reject\/(.+)$/, '拒绝 AI 连接'],
@@ -963,6 +988,41 @@ export function createServer(deps: ServerDeps): express.Express {
     req.on('close', () => { activityClients.delete(res); clearInterval(heartbeat); });
   });
 
+  // ── Proxy log (全局转发日志) ──
+  //
+  // 顶部 🔍 面板用。排查「页面正常但 API 502 没日志」时：
+  //   GET /api/proxy-log        一次性拿最近 500 条环形缓冲
+  //   GET /api/proxy-log/stream SSE 实时订阅
+  //
+  // 为什么独立于 activity-stream：activity 只记 CDS 自己的 /api/* 调用，
+  // 转发层（worker port）的 502 / upstream-error / no-branch-match 不在里面，
+  // 这些才是「服务器日志为空」时用户最需要看到的。
+  const proxyLogClients = new Set<express.Response>();
+  deps.proxyService.setOnProxyLog((evt) => {
+    const payload = `data: ${JSON.stringify(evt)}\n\n`;
+    for (const client of proxyLogClients) {
+      try { client.write(payload); } catch { proxyLogClients.delete(client); }
+    }
+  });
+  app.get('/api/proxy-log', (req, res) => {
+    const all = deps.proxyService.getProxyLog();
+    const afterSeq = parseInt(req.query.afterSeq as string) || 0;
+    const events = afterSeq > 0 ? all.filter(e => e.id > afterSeq) : all;
+    res.json({ events, total: all.length, maxId: all.length > 0 ? all[all.length - 1].id : 0 });
+  });
+  app.get('/api/proxy-log/stream', (req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache', Connection: 'keep-alive' });
+    proxyLogClients.add(res);
+    const afterSeq = parseInt(req.query.afterSeq as string) || 0;
+    for (const evt of deps.proxyService.getProxyLog()) {
+      if (evt.id > afterSeq) res.write(`data: ${JSON.stringify(evt)}\n\n`);
+    }
+    const heartbeat = setInterval(() => {
+      try { res.write(': keepalive\n\n'); } catch { clearInterval(heartbeat); }
+    }, 30_000);
+    req.on('close', () => { proxyLogClients.delete(res); clearInterval(heartbeat); });
+  });
+
   // ── API activity tracking middleware (before routes, after auth) ──
   app.use('/api', (req, res, next) => {
     // Skip SSE streams and static
@@ -1057,6 +1117,20 @@ export function createServer(deps: ServerDeps): express.Express {
   // Mounted at /api so the nested /projects/:id/pending-import path works
   // alongside the rest of the projects router.
   app.use('/api', createPendingImportRouter({ stateService: deps.stateService }));
+  // Cache diagnostics / repair / cross-server migration.
+  // See routes/cache.ts for why this exists (挂载失效诊断 + 换机器预热).
+  app.use('/api', createCacheRouter({ stateService: deps.stateService, shell: deps.shell }));
+  // ConfigSnapshot (导入/破坏性操作前自动备份) + DestructiveOperationLog (紧急撤销).
+  // 见 routes/snapshots.ts 头部注释。
+  app.use('/api', createSnapshotsRouter({ stateService: deps.stateService }));
+  // 基础设施数据备份/恢复（mongodump/mongorestore/redis dump.rdb/tar）
+  app.use('/api', createInfraBackupRouter({ stateService: deps.stateService, shell: deps.shell }));
+  // 遗留 default 项目迁移（见 legacy-cleanup.ts 头部注释）
+  app.use('/api', createLegacyCleanupRouter({
+    stateService: deps.stateService,
+    shell: deps.shell,
+    worktreeBase: deps.config.worktreeBase,
+  }));
   // ── GitHub App client (optional) ──
   //
   // Instantiate once and share between the webhook router and the branch

--- a/cds/src/server.ts
+++ b/cds/src/server.ts
@@ -264,6 +264,8 @@ function resolveApiLabel(method: string, path: string): string {
     [/^DELETE \/build-profiles\/(.+)$/, '删除构建配置'],
     [/^PUT \/build-profiles\/(.+)\/deploy-mode$/, '切换部署模式'],
     [/^POST \/build-profiles\/(.+)\/hot-reload$/, '切换热更新'],
+    [/^POST \/branches\/(.+)\/force-rebuild\/(.+)$/, '强制干净重建'],
+    [/^POST \/branches\/(.+)\/verify-runtime\/(.+)$/, '运行时字节码核验'],
     [/^POST \/infra\/(.+)\/start$/, '启动基础设施'],
     [/^POST \/infra\/(.+)\/stop$/, '停止基础设施'],
     [/^POST \/infra\/(.+)\/restart$/, '重启基础设施'],

--- a/cds/src/server.ts
+++ b/cds/src/server.ts
@@ -137,6 +137,7 @@ function resolveApiLabel(method: string, path: string): string {
     'GET /mirror': '获取镜像配置',
     'PUT /mirror': '更新镜像配置',
     'POST /import-config': '导入配置',
+    'POST /build-profiles/bulk-set-modes': '批量设置部署命令',
     'GET /export-config': '导出配置',
     'GET /cache/status': '查看缓存状态',
     'POST /cache/repair': '修复缓存挂载',

--- a/cds/src/services/container.ts
+++ b/cds/src/services/container.ts
@@ -9,22 +9,57 @@ import { combinedOutput } from '../types.js';
 import { resolveEnvTemplates } from './compose-parser.js';
 
 /**
+ * 2026-04-22 —— 热更新命令模板。enabled 时由 resolveProfileWithMode 优先应用。
+ * 依据 hotReload.mode 生成 watcher 命令；mode='custom' 时用 hotReload.command。
+ */
+export function resolveHotReloadCommand(profile: BuildProfile): string | null {
+  const hr = profile.hotReload;
+  if (!hr || !hr.enabled) return null;
+  const port = profile.containerPort;
+  const watchEnv = hr.usePolling ? 'DOTNET_USE_POLLING_FILE_WATCHER=1 CHOKIDAR_USEPOLLING=1 ' : '';
+  switch (hr.mode) {
+    case 'dotnet-watch':
+      return `${watchEnv}dotnet watch run --non-interactive --urls http://0.0.0.0:${port}`;
+    case 'pnpm-dev':
+      return `${watchEnv}pnpm install --prefer-frozen-lockfile && pnpm dev --host 0.0.0.0 --port ${port}`;
+    case 'vite':
+      return `${watchEnv}pnpm install --prefer-frozen-lockfile && pnpm vite --host 0.0.0.0 --port ${port}`;
+    case 'next-dev':
+      return `${watchEnv}pnpm install --prefer-frozen-lockfile && pnpm next dev -p ${port}`;
+    case 'custom':
+      return hr.command ? `${watchEnv}${hr.command}` : null;
+    default:
+      return null;
+  }
+}
+
+/**
  * Resolve a BuildProfile with active deploy mode overrides applied.
  * Returns a new profile object with command/dockerImage/env merged from the mode.
+ *
+ * 2026-04-22 —— hotReload 在最后叠加；enabled 时直接覆盖 command，
+ * 让容器跑 watcher 命令而非一次性构建。
  */
 export function resolveProfileWithMode(profile: BuildProfile): BuildProfile {
   const mode = profile.activeDeployMode;
-  if (!mode || !profile.deployModes?.[mode]) return profile;
-
-  const override = profile.deployModes[mode];
-  return {
-    ...profile,
-    command: override.command ?? profile.command,
-    dockerImage: override.dockerImage ?? profile.dockerImage,
-    env: override.env
-      ? { ...profile.env, ...override.env }
-      : profile.env,
-  };
+  let resolved: BuildProfile = profile;
+  if (mode && profile.deployModes?.[mode]) {
+    const override = profile.deployModes[mode];
+    resolved = {
+      ...profile,
+      command: override.command ?? profile.command,
+      dockerImage: override.dockerImage ?? profile.dockerImage,
+      env: override.env
+        ? { ...profile.env, ...override.env }
+        : profile.env,
+    };
+  }
+  // Hot reload 优先级最高
+  const hrCmd = resolveHotReloadCommand(resolved);
+  if (hrCmd) {
+    return { ...resolved, command: hrCmd };
+  }
+  return resolved;
 }
 
 /**

--- a/cds/src/services/container.ts
+++ b/cds/src/services/container.ts
@@ -11,6 +11,14 @@ import { resolveEnvTemplates } from './compose-parser.js';
 /**
  * 2026-04-22 —— 热更新命令模板。enabled 时由 resolveProfileWithMode 优先应用。
  * 依据 hotReload.mode 生成 watcher 命令；mode='custom' 时用 hotReload.command。
+ *
+ * 为什么 dotnet-restart 比 dotnet-watch 可靠（见 types.ts HotReloadConfig 注释）：
+ *   watch 的 hot-reload 偶尔只更新内存不重启进程，加上 MSBuild 增量编译有概率
+ *   误判"项目引用未变"跳过 compile，会出现 DLL 里有新字符串、源码和 DLL 都对
+ *   但运行进程加载的还是老字节码。dotnet-restart 的轮询脚本强制：
+ *     1) 每次循环先 `dotnet clean` + `rm -rf bin obj`（cleanBeforeBuild=true）
+ *     2) `dotnet build --no-incremental` 禁用增量编译
+ *     3) kill 旧 PID + 等 wait 再起新进程，保证字节码一定重新加载
  */
 export function resolveHotReloadCommand(profile: BuildProfile): string | null {
   const hr = profile.hotReload;
@@ -18,7 +26,47 @@ export function resolveHotReloadCommand(profile: BuildProfile): string | null {
   const port = profile.containerPort;
   const watchEnv = hr.usePolling ? 'DOTNET_USE_POLLING_FILE_WATCHER=1 CHOKIDAR_USEPOLLING=1 ' : '';
   switch (hr.mode) {
+    case 'dotnet-restart': {
+      const clean = hr.cleanBeforeBuild !== false;
+      const cleanStep = clean
+        ? 'dotnet clean -v q >/dev/null 2>&1 || true; find . -type d \\( -name bin -o -name obj \\) -prune -exec rm -rf {} +;'
+        : '';
+      // 单行 shell 脚本（容器 command 一行串）：
+      //   1) STAMP 文件记录上次 build 完成时间；用于 find -newer 判断是否有源码变更
+      //   2) build 失败：sleep 10 重试（避免无限占 CPU）
+      //   3) 启动 dotnet run 作为子进程，捕获 PID
+      //   4) 每 2 秒 poll 一次：源码比 STAMP 新 → break 循环进入 kill+rebuild；
+      //      或进程意外死亡 → break 进入重启
+      //   5) SIGTERM + 1s 宽限 + SIGKILL，保证 dotnet 真死（不然端口会占着）
+      const lines = [
+        `set +e`,
+        `STAMP=/tmp/cds-hr-${profile.id}-stamp`,
+        `touch "$STAMP"`,
+        `while true; do`,
+        cleanStep,
+        `echo "[hot-reload/${profile.id}] build start $(date +%T)"`,
+        `dotnet build -c Debug --no-incremental -v m`,
+        `BUILD_RC=$?`,
+        `if [ $BUILD_RC -ne 0 ]; then echo "[hot-reload/${profile.id}] build failed rc=$BUILD_RC, retry in 10s"; sleep 10; continue; fi`,
+        `touch "$STAMP"`,
+        `dotnet run --no-build --urls http://0.0.0.0:${port} &`,
+        `DOTNET_PID=$!`,
+        `echo "[hot-reload/${profile.id}] started pid=$DOTNET_PID at $(date +%T)"`,
+        `while kill -0 $DOTNET_PID 2>/dev/null; do`,
+        `  sleep 2`,
+        `  CHANGED=$(find . -type f \\( -name "*.cs" -o -name "*.csproj" -o -name "*.json" \\) -newer "$STAMP" 2>/dev/null | head -1)`,
+        `  if [ -n "$CHANGED" ]; then echo "[hot-reload/${profile.id}] change detected: $CHANGED, restarting"; break; fi`,
+        `done`,
+        `kill -TERM $DOTNET_PID 2>/dev/null || true`,
+        `sleep 1`,
+        `kill -KILL $DOTNET_PID 2>/dev/null || true`,
+        `wait $DOTNET_PID 2>/dev/null || true`,
+        `done`,
+      ];
+      return `${watchEnv}sh -c ${JSON.stringify(lines.join('; '))}`;
+    }
     case 'dotnet-watch':
+      // 保留但不推荐。UI 上标红提示用户有 MSBuild 增量误判的风险。
       return `${watchEnv}dotnet watch run --non-interactive --urls http://0.0.0.0:${port}`;
     case 'pnpm-dev':
       return `${watchEnv}pnpm install --prefer-frozen-lockfile && pnpm dev --host 0.0.0.0 --port ${port}`;

--- a/cds/src/services/container.ts
+++ b/cds/src/services/container.ts
@@ -26,6 +26,30 @@ export function resolveHotReloadCommand(profile: BuildProfile): string | null {
   const port = profile.containerPort;
   const watchEnv = hr.usePolling ? 'DOTNET_USE_POLLING_FILE_WATCHER=1 CHOKIDAR_USEPOLLING=1 ' : '';
   switch (hr.mode) {
+    case 'dotnet-run': {
+      // 快路径：相信 MSBuild 增量 + dotnet run，文件变 → kill + 再跑。
+      // 不 clean，不 --no-incremental；如需破缓存走 🧹 清理按钮（force-rebuild）。
+      const lines = [
+        `set +e`,
+        `STAMP=/tmp/cds-hr-${profile.id}-stamp`,
+        `touch "$STAMP"`,
+        `while true; do`,
+        `echo "[hot-reload/${profile.id}] dotnet run (增量) at $(date +%T)"`,
+        `touch "$STAMP"`,
+        `dotnet run --urls http://0.0.0.0:${port} &`,
+        `DOTNET_PID=$!`,
+        `echo "[hot-reload/${profile.id}] pid=$DOTNET_PID"`,
+        `while kill -0 $DOTNET_PID 2>/dev/null; do`,
+        `  sleep 2`,
+        `  CHANGED=$(find . -type f \\( -name "*.cs" -o -name "*.csproj" -o -name "*.json" \\) -not -path "*/bin/*" -not -path "*/obj/*" -newer "$STAMP" 2>/dev/null | head -1)`,
+        `  if [ -n "$CHANGED" ]; then echo "[hot-reload/${profile.id}] change detected: $CHANGED"; break; fi`,
+        `done`,
+        `kill -TERM $DOTNET_PID 2>/dev/null || true; sleep 1; kill -KILL $DOTNET_PID 2>/dev/null || true`,
+        `wait $DOTNET_PID 2>/dev/null || true`,
+        `done`,
+      ];
+      return `${watchEnv}sh -c ${JSON.stringify(lines.join('; '))}`;
+    }
     case 'dotnet-restart': {
       const clean = hr.cleanBeforeBuild !== false;
       const cleanStep = clean

--- a/cds/src/services/proxy.ts
+++ b/cds/src/services/proxy.ts
@@ -7,6 +7,48 @@ import type { SchedulerService } from './scheduler.js';
 import { buildWidgetScript } from '../widget-script.js';
 
 /**
+ * 代理转发事件 —— 每一次经过 worker port 的请求都会生成一条。
+ * 用户通过顶部「🔍 转发日志」面板查看，专门用于排查：
+ *   - 502 但服务器日志为空 → outcome=upstream-error + code=ECONNREFUSED
+ *   - 接口无法启动报 502 但页面正常 → branchSlug/profileId 帮定位是哪个服务
+ *   - 路由未命中（某个域名没配 routing rule）→ outcome=no-branch-match
+ */
+export interface ProxyLogEvent {
+  id: number;
+  ts: string;
+  method: string;
+  host: string;
+  url: string;
+  /** 匹配到的 branch slug；未命中时为 null */
+  branchSlug: string | null;
+  /** 匹配到的 profile id；未识别时为 null */
+  profileId: string | null;
+  /** 解析出的上游 URL；未解析到为 null */
+  upstream: string | null;
+  /** 返回给客户端的最终状态码 */
+  status: number;
+  /** ProxyService 处理全过程耗时（ms） */
+  durationMs: number;
+  /**
+   * 结果分类，供前端染色 / 过滤：
+   *   ok — 转发成功 (2xx/3xx)
+   *   client-error — 客户端错误 (4xx)
+   *   upstream-error — 上游连接/超时类错误 (触发 502)
+   *   no-branch-match — 请求进来但 routing rule / 默认分支都没命中
+   *   branch-not-running — 分支存在但容器没跑，已降级到 loading/起始页
+   *   timeout — 上游长时间无响应
+   */
+  outcome: 'ok' | 'client-error' | 'upstream-error' | 'no-branch-match' | 'branch-not-running' | 'timeout';
+  /** 上游错误码（ECONNREFUSED / ETIMEDOUT 等），便于一眼定位 */
+  errorCode?: string;
+  errorMessage?: string;
+  /** 人类可读的一句诊断（前端直接显示） */
+  hint?: string;
+}
+
+const PROXY_LOG_BUFFER_MAX = 500;
+
+/**
  * ProxyService — the core of CDS worker port.
  * Routes incoming HTTP requests to the correct branch service
  * based on routing rules (header, domain, pattern matching).
@@ -22,6 +64,10 @@ export class ProxyService {
   private worktreeService: WorktreeService | null = null;
   /** Optional scheduler for warm-pool touch tracking */
   private scheduler: SchedulerService | null = null;
+  /** Ring buffer of recent proxy events for the global log panel (顶部 🔍). */
+  private proxyLogBuffer: ProxyLogEvent[] = [];
+  private proxyLogSeq = 0;
+  private onProxyLog: ((evt: ProxyLogEvent) => void) | null = null;
 
   constructor(
     private readonly stateService: StateService,
@@ -51,6 +97,36 @@ export class ProxyService {
 
   setWorktreeService(wt: WorktreeService): void {
     this.worktreeService = wt;
+  }
+
+  /** Subscribe to live proxy events (for the SSE endpoint). */
+  setOnProxyLog(fn: ((evt: ProxyLogEvent) => void) | null): void {
+    this.onProxyLog = fn;
+  }
+
+  /** Snapshot of the ring buffer — used by `GET /api/proxy-log`. */
+  getProxyLog(): ProxyLogEvent[] {
+    return this.proxyLogBuffer.slice();
+  }
+
+  /**
+   * Record a single proxy event. Call at each decision point that ends the
+   * request's lifecycle (no-branch-match, branch-not-running, upstream-error,
+   * normal-finish). Emits to `onProxyLog` callback for SSE fan-out.
+   */
+  private recordProxyEvent(partial: Omit<ProxyLogEvent, 'id' | 'ts'>): void {
+    const evt: ProxyLogEvent = {
+      id: ++this.proxyLogSeq,
+      ts: new Date().toISOString(),
+      ...partial,
+    };
+    this.proxyLogBuffer.push(evt);
+    if (this.proxyLogBuffer.length > PROXY_LOG_BUFFER_MAX) {
+      this.proxyLogBuffer.shift();
+    }
+    if (this.onProxyLog) {
+      try { this.onProxyLog(evt); } catch { /* listener errors must not crash proxy */ }
+    }
   }
 
   /**
@@ -227,6 +303,7 @@ export class ProxyService {
   handleRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
     const host = req.headers.host || '';
     const url = req.url || '/';
+    const handleStart = Date.now();
 
     // ── /_cds/api/* — passthrough to CDS Dashboard API (master port) ──
     // Allows widgets embedded in proxied apps to call CDS API without CORS issues.
@@ -287,6 +364,13 @@ export class ProxyService {
       // 502 JSON which rendered as Chrome's raw "HTTP ERROR" page for browsers.
       // Prefer a 404 HTML for browser requests so the tab isn't blank.
       const acceptsHtml = (req.headers.accept || '').toLowerCase().includes('text/html');
+      this.recordProxyEvent({
+        method: req.method || 'GET', host, url,
+        branchSlug: null, profileId: null, upstream: null,
+        status: 404, durationMs: Date.now() - handleStart,
+        outcome: 'no-branch-match',
+        hint: 'Host 头未命中任何 routing rule，也没配默认分支。检查「路由规则」或 cds_branch cookie。',
+      });
       if (acceptsHtml) {
         // Truncate host so a client sending a 4KB Host header can't bloat the
         // HTML body. DNS labels cap at 253 chars total; we allow 120 for safety.
@@ -770,6 +854,33 @@ h2{font-size:18px;color:#f0f6fc;margin-bottom:8px}
       });
     }
 
+    // 代理日志：请求完结时记一条，outcome 基于 status 分类
+    // proxyLogRecorded 防止 upstream-error 分支手动记录后，finish 又记一条重复的
+    //
+    // 有些测试 double 不带 .on；用 typeof 兜住，避免生产代码被测试 mock 拖垮。
+    let proxyLogRecorded = false;
+    if (typeof clientRes.on === 'function') {
+      clientRes.on('finish', () => {
+        if (proxyLogRecorded) return;
+        proxyLogRecorded = true;
+        const status = clientRes.statusCode;
+        let outcome: ProxyLogEvent['outcome'] = 'ok';
+        if (status >= 500) outcome = 'upstream-error';
+        else if (status >= 400) outcome = 'client-error';
+        this.recordProxyEvent({
+          method: clientReq.method || 'GET',
+          host: clientReq.headers.host || '',
+          url: clientReq.url || '/',
+          branchSlug: branchCtx?.branchId ?? null,
+          profileId: branchCtx?.profileId ?? null,
+          upstream,
+          status,
+          durationMs: Date.now() - proxyStart,
+          outcome,
+        });
+      });
+    }
+
     const proxyReq = http.request(options, (proxyRes) => {
       const headers = { ...proxyRes.headers };
       // When routing via cookie (same URL serves different branches), prevent
@@ -835,6 +946,31 @@ h2{font-size:18px;color:#f0f6fc;margin-bottom:8px}
 
     proxyReq.on('error', (err: NodeJS.ErrnoException) => {
       console.error(`[proxy] upstream error: ${err.message} → ${upstream}`);
+      // 转发日志：明确记录上游错误类型，方便用户看到"502 但服务器无日志"时的真实原因
+      const codeHintMap: Record<string, string> = {
+        ECONNREFUSED: '上游端口未监听 — 容器可能还没启动完，或服务崩溃了。查 container logs。',
+        ECONNRESET: '上游主动断开 — 服务启动到一半挂了，或进程 OOM 被杀。查容器 dmesg / crash dump。',
+        ETIMEDOUT: '上游不响应 — 可能卡在启动（例如 restore 还没跑完），或进程 hang 住。',
+        EHOSTUNREACH: 'Docker 网络不通 — 容器 IP 失效或跨 network 没配好。',
+        ENOTFOUND: 'DNS 无法解析 upstream host — 检查 routing rule 里的 host 是否拼错。',
+      };
+      if (!proxyLogRecorded) {
+        proxyLogRecorded = true;
+        this.recordProxyEvent({
+          method: clientReq.method || 'GET',
+          host: clientReq.headers.host || '',
+          url: clientReq.url || '/',
+          branchSlug: branchCtx?.branchId ?? null,
+          profileId: branchCtx?.profileId ?? null,
+          upstream,
+          status: 502,
+          durationMs: Date.now() - proxyStart,
+          outcome: 'upstream-error',
+          errorCode: err.code || 'UNKNOWN',
+          errorMessage: err.message,
+          hint: codeHintMap[err.code || ''] || '上游异常，查 container logs 看具体原因。',
+        });
+      }
       // Emit activity event immediately so the failure appears in Activity Monitor.
       // We do this here rather than relying on clientRes.on('finish') because the
       // synthetic response we send (loading page or 502) would show status 200/502

--- a/cds/src/services/state.ts
+++ b/cds/src/services/state.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import crypto from 'node:crypto';
-import type { CdsState, BranchEntry, BuildProfile, BuildProfileOverride, RoutingRule, OperationLog, InfraService, ExecutorNode, DataMigration, CdsPeer, Project, AgentKey, GlobalAgentKey, CustomEnvStore } from '../types.js';
+import type { CdsState, BranchEntry, BuildProfile, BuildProfileOverride, RoutingRule, OperationLog, InfraService, ExecutorNode, DataMigration, CdsPeer, Project, AgentKey, GlobalAgentKey, CustomEnvStore, ConfigSnapshot, DestructiveOperationLog } from '../types.js';
 import { GLOBAL_ENV_SCOPE } from '../types.js';
 import type { StateBackingStore } from '../infra/state-store/backing-store.js';
 import { JsonStateBackingStore, MAX_STATE_BACKUPS as JSON_MAX_BACKUPS } from '../infra/state-store/json-backing-store.js';
@@ -175,6 +175,12 @@ export class StateService {
   /**
    * Backfill cacheMounts for profiles that were created before cache support.
    * Uses dockerImage to detect the correct cache type.
+   *
+   * 2026-04-22: 改为「合并语义」——即使 profile 已有部分 cacheMounts，
+   * 也会按 dockerImage 对比标准模板，缺失哪类（nuget/pnpm）就补哪类。
+   * 原先 `if (profile.cacheMounts.length > 0) continue` 会导致：
+   * 混合镜像 profile（含 pnpm 但 dotnet SDK）永远拿不到 nuget 挂载 →
+   * 每次 dotnet restore 都从 nuget.org 冷下载。
    */
   private migrateCacheMounts(): void {
     const CACHE_BASE = `/data/cds/${this.projectSlug}/cache`;
@@ -185,29 +191,29 @@ export class StateService {
 
     let changed = false;
     for (const profile of this.state.buildProfiles) {
-      // Migrate old paths (hostPath slug + containerPath for pnpm)
-      if (profile.cacheMounts) {
-        for (const cm of profile.cacheMounts) {
-          const updated = cm.hostPath.replace(/\/data\/cds\/[^/]+\/cache/, `${CACHE_BASE}`);
-          if (updated !== cm.hostPath) {
-            cm.hostPath = updated;
-            changed = true;
-          }
-          // Fix pnpm containerPath: CDS injects npm_config_store_dir=/pnpm/store,
-          // so the cache must mount there, not /root/.local/share/pnpm/store
-          if (cm.containerPath === '/root/.local/share/pnpm/store') {
-            cm.containerPath = '/pnpm/store';
-            changed = true;
-          }
+      if (!profile.cacheMounts) profile.cacheMounts = [];
+
+      for (const cm of profile.cacheMounts) {
+        const updated = cm.hostPath.replace(/\/data\/cds\/[^/]+\/cache/, `${CACHE_BASE}`);
+        if (updated !== cm.hostPath) {
+          cm.hostPath = updated;
+          changed = true;
         }
-        if (profile.cacheMounts.length > 0) continue;
+        if (cm.containerPath === '/root/.local/share/pnpm/store') {
+          cm.containerPath = '/pnpm/store';
+          changed = true;
+        }
       }
+
       const image = profile.dockerImage || '';
       for (const [key, mounts] of Object.entries(IMAGE_CACHE_MAP)) {
-        if (image.includes(key)) {
-          profile.cacheMounts = mounts;
-          changed = true;
-          break;
+        if (!image.includes(key)) continue;
+        for (const mount of mounts) {
+          const alreadyMounted = profile.cacheMounts.some(cm => cm.containerPath === mount.containerPath);
+          if (!alreadyMounted) {
+            profile.cacheMounts.push({ ...mount });
+            changed = true;
+          }
         }
       }
     }
@@ -1254,6 +1260,14 @@ export class StateService {
     delete this.state.customEnv[scope];
   }
 
+  /**
+   * 清空所有 scope 下的自定义环境变量。给 replace-all 导入用 —— 导入前
+   * 要把所有旧变量扫掉，防止 replace 其实只是"名字没冲突就混在一起"。
+   */
+  clearAllCustomEnv(): void {
+    this.state.customEnv = { [GLOBAL_ENV_SCOPE]: {} } as CustomEnvStore;
+  }
+
   // ── Infrastructure services ──
 
   getInfraServices(): InfraService[] {
@@ -1469,6 +1483,138 @@ export class StateService {
    *
    * These can be referenced in app service environments as ${CDS_MONGODB_PORT} etc.
    */
+  // ── ConfigSnapshot / DestructiveOperationLog (2026-04-22) ──
+  //
+  // See types.ts ConfigSnapshot + DestructiveOperationLog docs. These helpers
+  // are the single entry point for all snapshot operations — callers never
+  // touch `state.configSnapshots` directly.
+
+  /** 保留最近多少条配置快照。越多越占 state.json，30 够常规回滚用。 */
+  static readonly CONFIG_SNAPSHOT_LIMIT = 30;
+
+  getConfigSnapshots(projectId?: string | null): ConfigSnapshot[] {
+    const all = this.state.configSnapshots || [];
+    if (projectId === undefined) return all.slice();
+    // null 表示查"全局"快照（projectId 为空的），undefined 表示全部
+    return all.filter(s => (s.projectId ?? null) === (projectId ?? null));
+  }
+
+  getConfigSnapshot(id: string): ConfigSnapshot | undefined {
+    return (this.state.configSnapshots || []).find(s => s.id === id);
+  }
+
+  /**
+   * 拍一份当前配置的快照。默认抓取全局（四件套）。
+   * trigger 必须是已定义的枚举；label 是人类可读描述。
+   * 返回快照对象（便于 caller 记录 snapshotId 到 DestructiveOperationLog）。
+   */
+  createConfigSnapshot(params: {
+    trigger: ConfigSnapshot['trigger'];
+    label: string;
+    projectId?: string | null;
+    triggeredBy?: string;
+  }): ConfigSnapshot {
+    const payload = {
+      buildProfiles: JSON.parse(JSON.stringify(this.state.buildProfiles)),
+      customEnv: JSON.parse(JSON.stringify(this.state.customEnv)),
+      infraServices: JSON.parse(JSON.stringify(this.state.infraServices)),
+      routingRules: JSON.parse(JSON.stringify(this.state.routingRules)),
+    };
+    const serialized = JSON.stringify(payload);
+    const snapshot: ConfigSnapshot = {
+      id: crypto.randomUUID(),
+      createdAt: new Date().toISOString(),
+      projectId: params.projectId ?? null,
+      trigger: params.trigger,
+      label: params.label,
+      triggeredBy: params.triggeredBy,
+      payload,
+      sizeBytes: Buffer.byteLength(serialized, 'utf-8'),
+    };
+    if (!this.state.configSnapshots) this.state.configSnapshots = [];
+    this.state.configSnapshots.push(snapshot);
+    // LRU 淘汰
+    if (this.state.configSnapshots.length > StateService.CONFIG_SNAPSHOT_LIMIT) {
+      this.state.configSnapshots = this.state.configSnapshots.slice(-StateService.CONFIG_SNAPSHOT_LIMIT);
+    }
+    this.save();
+    return snapshot;
+  }
+
+  /**
+   * 回滚：从快照恢复四件套。不会触碰 branches / logs / projects / runtime 字段。
+   * 回滚前先自拍一份当前状态（trigger='pre-destructive'），以防回滚本身也是误操作。
+   */
+  rollbackToConfigSnapshot(id: string, triggeredBy?: string): ConfigSnapshot {
+    const target = this.getConfigSnapshot(id);
+    if (!target) throw new Error(`ConfigSnapshot not found: ${id}`);
+
+    this.createConfigSnapshot({
+      trigger: 'pre-destructive',
+      label: `回滚到「${target.label}」前的自动备份`,
+      projectId: target.projectId,
+      triggeredBy,
+    });
+
+    this.state.buildProfiles = JSON.parse(JSON.stringify(target.payload.buildProfiles));
+    this.state.customEnv = JSON.parse(JSON.stringify(target.payload.customEnv));
+    this.state.infraServices = JSON.parse(JSON.stringify(target.payload.infraServices));
+    this.state.routingRules = JSON.parse(JSON.stringify(target.payload.routingRules));
+    this.save();
+    return target;
+  }
+
+  deleteConfigSnapshot(id: string): boolean {
+    if (!this.state.configSnapshots) return false;
+    const before = this.state.configSnapshots.length;
+    this.state.configSnapshots = this.state.configSnapshots.filter(s => s.id !== id);
+    const changed = this.state.configSnapshots.length !== before;
+    if (changed) this.save();
+    return changed;
+  }
+
+  // 破坏性操作日志 —— 紧急还原抽屉从这里取数据
+
+  /** UNDO_WINDOW_MS —— 超过这个时间窗不再显示「撤销」按钮（防止太老的操作误恢复）。 */
+  static readonly UNDO_WINDOW_MS = 30 * 60 * 1000;
+
+  getDestructiveOps(): DestructiveOperationLog[] {
+    return (this.state.destructiveOps || []).slice();
+  }
+
+  recordDestructiveOp(partial: Omit<DestructiveOperationLog, 'id' | 'at' | 'undoable' | 'undoneAt'>): DestructiveOperationLog {
+    const entry: DestructiveOperationLog = {
+      id: crypto.randomUUID(),
+      at: new Date().toISOString(),
+      undoable: true,
+      ...partial,
+    };
+    if (!this.state.destructiveOps) this.state.destructiveOps = [];
+    this.state.destructiveOps.push(entry);
+    // 保留最近 100 条
+    if (this.state.destructiveOps.length > 100) {
+      this.state.destructiveOps = this.state.destructiveOps.slice(-100);
+    }
+    this.save();
+    return entry;
+  }
+
+  markDestructiveOpUndone(id: string): DestructiveOperationLog | null {
+    const entry = (this.state.destructiveOps || []).find(op => op.id === id);
+    if (!entry) return null;
+    entry.undoable = false;
+    entry.undoneAt = new Date().toISOString();
+    this.save();
+    return entry;
+  }
+
+  /** 计算当前还在撤销窗口内的操作，用于 UI 判定是否显示「撤销」按钮。 */
+  isDestructiveOpUndoable(op: DestructiveOperationLog): boolean {
+    if (!op.undoable) return false;
+    const age = Date.now() - new Date(op.at).getTime();
+    return age <= StateService.UNDO_WINDOW_MS;
+  }
+
   getCdsEnvVars(): Record<string, string> {
     const dockerHost = this.resolveDockerHost();
     const result: Record<string, string> = {

--- a/cds/src/types.ts
+++ b/cds/src/types.ts
@@ -99,6 +99,40 @@ export interface BuildProfile {
    * Derived from compose `deploy.resources.limits` or `x-cds-resources`.
    */
   resources?: ResourceLimits;
+  /**
+   * 2026-04-22 新增 —— 热更新（Hot Reload）配置。
+   *
+   * 启用后 CDS 不再每次改代码都重建镜像 + 重启容器；而是：
+   *   - 容器里跑 `dotnet watch run` / `pnpm dev` / `vite --host` 等「监听源码」的命令
+   *   - 源码目录以 rw 绑挂到 /app（正常启动时也是这样挂，但 hotReload 会用 watch 命令）
+   *   - 代码变更 → inotify 触发热编译 → 无需重启容器，秒生效
+   *
+   * 仅适合开发环境。生产环境永远用编译好的镜像运行。
+   * UI 上带 🔥 标识提醒用户。
+   */
+  hotReload?: HotReloadConfig;
+}
+
+/**
+ * 热更新配置。mode 决定用哪种 watcher 命令，enabled=true 时 CDS 启动容器时
+ * 用 `hotReload.command` 代替 `profile.command`。
+ */
+export interface HotReloadConfig {
+  /** 是否启用。即使配置了 mode/command，也要 enabled=true 才生效。 */
+  enabled: boolean;
+  /**
+   * 热更新模式预设。选了模式，CDS 会用对应的默认命令；选 'custom' 则必须填 command。
+   *   dotnet-watch — .NET 8 的 `dotnet watch run --project ... --urls ...`
+   *   pnpm-dev    — `pnpm dev`（Next/Vite/SvelteKit 等）
+   *   vite        — `vite --host 0.0.0.0 --port <port>`
+   *   next-dev    — `pnpm next dev -p <port>`
+   *   custom      — 用户自填命令
+   */
+  mode: 'dotnet-watch' | 'pnpm-dev' | 'vite' | 'next-dev' | 'custom';
+  /** 仅在 mode='custom' 时使用；其他 mode 下忽略。 */
+  command?: string;
+  /** 是否开启 polling（NFS / docker-on-mac 场景 inotify 不生效时）。默认 false。 */
+  usePolling?: boolean;
 }
 
 /** Readiness probe configuration for app services */
@@ -496,6 +530,79 @@ export interface CdsState {
    * built-in default template (services/comment-template.ts).
    */
   commentTemplate?: CommentTemplateSettings;
+  /**
+   * 2026-04-22 新增 —— 配置快照（导入/破坏性操作前自动备份，供一键回滚）。
+   *
+   * 每次下列动作会自动创建一条快照：
+   *   - POST /api/import-config   (trigger='pre-import')
+   *   - 破坏性操作（清项目、factory-reset 等）  (trigger='pre-destructive')
+   *   - 用户在 Settings「历史版本」页手动「保存当前配置」 (trigger='manual')
+   *
+   * 保留策略：全局最近 30 条，满了淘汰最旧。
+   * 不做 per-project 独立保留，因为导入/破坏性操作通常跨项目影响。
+   *
+   * 只快照「配置」，不快照「分支/容器/数据库」—— 这些属于运行时状态，
+   * 由 DestructiveOperationLog 单独追踪（见 undoable 字段）。
+   */
+  configSnapshots?: ConfigSnapshot[];
+  /**
+   * 2026-04-22 新增 —— 破坏性操作审计 + 撤销。
+   *
+   * 记录每次「删项目/清容器/清数据库/replace-all 导入」等高风险操作，
+   * 关联到一条 ConfigSnapshot（如适用）和可选的 mongoDumpPath。
+   * 顶部「最近操作」抽屉让用户在 30 分钟内撤销。
+   */
+  destructiveOps?: DestructiveOperationLog[];
+}
+
+/**
+ * 配置快照。拍下 buildProfiles/envVars/infra/routingRules 四件套当前状态，
+ * 供一键回滚。不包含 branches/logs/运行时字段 —— 那些不算「配置」。
+ */
+export interface ConfigSnapshot {
+  id: string;
+  createdAt: string;
+  /** 关联项目（如果是项目级操作触发）。全局导入为 null。 */
+  projectId?: string | null;
+  /** 触发来源 */
+  trigger: 'pre-import' | 'pre-destructive' | 'manual' | 'scheduled';
+  /** 人类可读的标签（如 "导入 prd-agent.yaml 前" / "factory-reset 前"） */
+  label: string;
+  /** 谁触发的（agent key id / user id / 'system'） */
+  triggeredBy?: string;
+  /** 快照内容（JSON） */
+  payload: {
+    buildProfiles: BuildProfile[];
+    customEnv: CustomEnvStore;
+    infraServices: InfraService[];
+    routingRules: RoutingRule[];
+  };
+  /** 快照字节数（存 state.json 时粗略统计，用于 UI 展示） */
+  sizeBytes?: number;
+}
+
+/**
+ * 破坏性操作审计日志。用户「撤销」时，从关联的 ConfigSnapshot 回放配置，
+ * 并从 mongoDumpPath（如存在）恢复数据库。
+ */
+export interface DestructiveOperationLog {
+  id: string;
+  at: string;
+  type: 'import-replace-all' | 'factory-reset' | 'delete-project' | 'purge-branch' | 'purge-database' | 'other';
+  /** 项目范围，全局为 null */
+  projectId?: string | null;
+  /** 关联 ConfigSnapshot.id（可选） */
+  snapshotId?: string | null;
+  /** 数据库 dump 文件路径（可选） */
+  mongoDumpPath?: string | null;
+  /** 操作的 summary（UI 显示） */
+  summary: string;
+  /** 谁触发的 */
+  triggeredBy?: string;
+  /** 是否可撤销（时间窗：at + 30min；已撤销为 false） */
+  undoable: boolean;
+  /** 已撤销时间（undone 后前端显示为灰色） */
+  undoneAt?: string;
 }
 
 /**

--- a/cds/src/types.ts
+++ b/cds/src/types.ts
@@ -116,23 +116,48 @@ export interface BuildProfile {
 /**
  * 热更新配置。mode 决定用哪种 watcher 命令，enabled=true 时 CDS 启动容器时
  * 用 `hotReload.command` 代替 `profile.command`。
+ *
+ * 2026-04-22 补丁：从踩过的坑里总结出来的防御措施——
+ *
+ *   ⚠ MSBuild 的 incremental compile 和 dotnet watch 的 hot reload 在我们这个
+ *     绑挂 worktree + 长驻容器的场景下有已知 bug：
+ *
+ *     现象：改代码 → publish/build 成功 → DLL 时间戳更新 → DLL 里 grep 得到新字符串
+ *          → 但运行进程加载的还是旧字节码 → 日志里看不到新日志。
+ *     根因：MSBuild 判定"项目引用未变"跳过 compile；或 dotnet watch hot reload
+ *          只应用到内存没重启进程，导致 Infrastructure.dll 反复 5 轮不生效。
+ *
+ *   解决：默认改成 `dotnet-restart` —— 明确 kill 进程 + clean + no-incremental +
+ *        重跑。放弃 hot reload 的"秒级生效"，换"每次生效"。
+ *        原来的 `dotnet-watch` 保留为可选，但不再是 .NET 项目的推荐默认。
+ *
+ *   如果还不生效：点 Profile 卡片的「💥 强制干净重建」—— 额外物理删掉 bin/obj，
+ *   避免文件系统缓存干扰。
  */
 export interface HotReloadConfig {
   /** 是否启用。即使配置了 mode/command，也要 enabled=true 才生效。 */
   enabled: boolean;
   /**
    * 热更新模式预设。选了模式，CDS 会用对应的默认命令；选 'custom' 则必须填 command。
-   *   dotnet-watch — .NET 8 的 `dotnet watch run --project ... --urls ...`
-   *   pnpm-dev    — `pnpm dev`（Next/Vite/SvelteKit 等）
-   *   vite        — `vite --host 0.0.0.0 --port <port>`
-   *   next-dev    — `pnpm next dev -p <port>`
-   *   custom      — 用户自填命令
+   *   dotnet-restart — ★ 推荐：文件变更时 kill 进程 + clean + no-incremental + 重跑
+   *                    牺牲秒级生效换可靠性，绕过 MSBuild 增量误判和 watch hot-reload
+   *                    不重启的坑
+   *   dotnet-watch   — .NET 8 的 `dotnet watch run`。**不推荐**：有已知漏判
+   *   pnpm-dev       — `pnpm dev`（Next/Vite/SvelteKit 等）
+   *   vite           — `vite --host 0.0.0.0 --port <port>`
+   *   next-dev       — `pnpm next dev -p <port>`
+   *   custom         — 用户自填命令
    */
-  mode: 'dotnet-watch' | 'pnpm-dev' | 'vite' | 'next-dev' | 'custom';
+  mode: 'dotnet-restart' | 'dotnet-watch' | 'pnpm-dev' | 'vite' | 'next-dev' | 'custom';
   /** 仅在 mode='custom' 时使用；其他 mode 下忽略。 */
   command?: string;
   /** 是否开启 polling（NFS / docker-on-mac 场景 inotify 不生效时）。默认 false。 */
   usePolling?: boolean;
+  /**
+   * dotnet-restart 模式下每次 rebuild 前是否先 `dotnet clean` + `rm -rf bin obj`。
+   * 默认 true —— 就是为了根治"DLL 看起来更新了但没真重建"的 MSBuild 增量误判。
+   */
+  cleanBeforeBuild?: boolean;
 }
 
 /** Readiness probe configuration for app services */

--- a/cds/src/types.ts
+++ b/cds/src/types.ts
@@ -138,17 +138,18 @@ export interface HotReloadConfig {
   /** 是否启用。即使配置了 mode/command，也要 enabled=true 才生效。 */
   enabled: boolean;
   /**
-   * 热更新模式预设。选了模式，CDS 会用对应的默认命令；选 'custom' 则必须填 command。
-   *   dotnet-restart — ★ 推荐：文件变更时 kill 进程 + clean + no-incremental + 重跑
-   *                    牺牲秒级生效换可靠性，绕过 MSBuild 增量误判和 watch hot-reload
-   *                    不重启的坑
-   *   dotnet-watch   — .NET 8 的 `dotnet watch run`。**不推荐**：有已知漏判
-   *   pnpm-dev       — `pnpm dev`（Next/Vite/SvelteKit 等）
+   * 热更新模式预设。
+   *   dotnet-run     — ★ 推荐默认（快）：纯 `dotnet run` 走 MSBuild 增量编译，文件变 → kill + 重跑。
+   *                    相信 MSBuild 增量；绝大多数场景最快。如偶尔撒谎点 🧹 清理按钮即可。
+   *   dotnet-restart — 疑难兜底（慢）：每次 `dotnet clean` + `rm -rf bin/obj` + `--no-incremental`。
+   *                    当 dotnet-run 稳定撒谎时才切过来；大多数人不需要。
+   *   dotnet-watch   — `dotnet watch run`。**不推荐**：hot-reload 偶尔只改内存不重启进程
+   *   pnpm-dev       — `pnpm dev`
    *   vite           — `vite --host 0.0.0.0 --port <port>`
    *   next-dev       — `pnpm next dev -p <port>`
    *   custom         — 用户自填命令
    */
-  mode: 'dotnet-restart' | 'dotnet-watch' | 'pnpm-dev' | 'vite' | 'next-dev' | 'custom';
+  mode: 'dotnet-run' | 'dotnet-restart' | 'dotnet-watch' | 'pnpm-dev' | 'vite' | 'next-dev' | 'custom';
   /** 仅在 mode='custom' 时使用；其他 mode 下忽略。 */
   command?: string;
   /** 是否开启 polling（NFS / docker-on-mac 场景 inotify 不生效时）。默认 false。 */

--- a/cds/src/widget-script.ts
+++ b/cds/src/widget-script.ts
@@ -31,7 +31,10 @@ export function buildWidgetScript(branchId: string, branchName: string): string 
     @keyframes cds-step-in{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:translateY(0)}}
     @keyframes cds-scroll-bounce{0%{opacity:0;transform:translateY(-8px) scale(0.8)}40%{opacity:1;transform:translateY(0) scale(1.1)}100%{opacity:1;transform:translateY(12px) scale(1)}}
     .cds-ai-active{position:fixed;inset:0;z-index:99998;pointer-events:none;border:none;background:none;animation:cds-ai-border-glow 2.5s ease-in-out infinite}
-    .cds-ai-badge{position:fixed;top:10px;left:50%;transform:translateX(-50%);z-index:99999;display:flex;align-items:center;gap:6px;padding:4px 12px;border-radius:20px;background:rgba(22,27,34,0.9);backdrop-filter:blur(8px);border:1px solid rgba(96,165,250,0.4);box-shadow:0 2px 12px rgba(96,165,250,0.3);font-family:ui-monospace,SFMono-Regular,"SF Mono",Menlo,monospace;font-size:11px;color:#e2e8f0;white-space:nowrap;pointer-events:none}
+    .cds-ai-badge{position:fixed;top:10px;left:50%;transform:translateX(-50%);z-index:99999;display:flex;align-items:center;gap:8px;padding:4px 6px 4px 12px;border-radius:20px;background:rgba(22,27,34,0.9);backdrop-filter:blur(8px);border:1px solid rgba(96,165,250,0.4);box-shadow:0 2px 12px rgba(96,165,250,0.3);font-family:ui-monospace,SFMono-Regular,"SF Mono",Menlo,monospace;font-size:11px;color:#e2e8f0;white-space:nowrap;pointer-events:auto}
+    .cds-ai-badge-stop{display:inline-flex;align-items:center;gap:3px;padding:2px 8px;border-radius:14px;border:1px solid rgba(248,81,73,0.5);background:rgba(248,81,73,0.15);color:#ff8888;cursor:pointer;font:inherit;font-size:10px;line-height:1;transition:all 0.15s}
+    .cds-ai-badge-stop:hover{background:rgba(248,81,73,0.3);border-color:#f85149;color:#fff}
+    .cds-ai-badge-stop:disabled{opacity:0.5;cursor:wait}
     .cds-ai-badge-dot{width:6px;height:6px;border-radius:50%;background:#60a5fa;box-shadow:0 0 6px #60a5fa;animation:cds-blink 1.5s ease-in-out infinite}
     #cds-widget{position:fixed;left:12px;bottom:12px;z-index:99999;font-family:ui-monospace,SFMono-Regular,"SF Mono",Menlo,monospace;color:#e2e8f0;user-select:none;font-size:12px}
     #cds-widget *{box-sizing:border-box}
@@ -144,6 +147,24 @@ export function buildWidgetScript(branchId: string, branchName: string): string 
   var aiOverlay=null;
   var aiBadgeEl=null;
 
+  function endAiSession(){
+    var btn=aiBadgeEl&&aiBadgeEl.querySelector('.cds-ai-badge-stop');
+    if(btn){btn.disabled=true;btn.textContent='结束中…';}
+    fetch(API+'/bridge/end-session',{
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      credentials:'same-origin',
+      body:JSON.stringify({branchId:BRANCH_ID,summary:'用户在预览页手动结束 AI 操控'}),
+    }).then(function(){
+      // 立刻隐藏，不等 SSE 推送 ttl 过期
+      aiLastSeen=0;aiOccupant=null;
+      updateAiOverlay();
+    }).catch(function(err){
+      if(btn){btn.disabled=false;btn.textContent='✕ 结束';}
+      console.error('[cds-widget] end-session failed:',err);
+    });
+  }
+
   function updateAiOverlay(){
     var isActive=aiOccupant&&(Date.now()-aiLastSeen<AI_TTL);
     if(isActive){
@@ -156,8 +177,19 @@ export function buildWidgetScript(branchId: string, branchName: string): string 
         aiBadgeEl=document.createElement('div');
         aiBadgeEl.className='cds-ai-badge';
         document.body.appendChild(aiBadgeEl);
+        // 用 addEventListener 委托给 stop 按钮（badge.innerHTML 会被刷新但这里只挂一次）
+        aiBadgeEl.addEventListener('click',function(e){
+          var t=e.target;
+          if(t&&t.classList&&t.classList.contains('cds-ai-badge-stop')){
+            e.preventDefault();e.stopPropagation();
+            if(confirm('确定要结束 AI 操控？\\n\\n这会立刻关闭 Bridge session，正在执行的 AI 命令将无法再操作本页。')){
+              endAiSession();
+            }
+          }
+        });
       }
-      aiBadgeEl.innerHTML='<span class="cds-ai-badge-dot"></span> AI 操控中'+(aiOccupant!=='AI'?' · '+aiOccupant:'');
+      var label='AI 操控中'+(aiOccupant!=='AI'?' · '+aiOccupant:'');
+      aiBadgeEl.innerHTML='<span class="cds-ai-badge-dot"></span><span>'+label+'</span><button class="cds-ai-badge-stop" title="结束 AI 对本页的操控">✕ 结束</button>';
     }else{
       if(aiOverlay){aiOverlay.remove();aiOverlay=null;}
       if(aiBadgeEl){aiBadgeEl.remove();aiBadgeEl=null;}

--- a/cds/web/app.js
+++ b/cds/web/app.js
@@ -3745,30 +3745,51 @@ function renderBranches() {
     const btnDisabled = (action) => (isBusy || isLoading(b.id, action)) ? 'disabled' : '';
     const btnLabel = (action, label) => isLoading(b.id, action) ? `<span class="btn-spinner"></span>${label}` : label;
 
-    // Build deploy dropdown items for single-service redeploy
-    const deployMenuItems = buildProfiles.map(p => {
-      const modeTag = p.activeDeployMode && p.deployModes?.[p.activeDeployMode]
-        ? ` <span style="font-size:10px;opacity:0.6">(${esc(p.deployModes[p.activeDeployMode].label)})</span>`
-        : '';
-      return `<div class="deploy-menu-item" onclick="deploySingleService('${esc(b.id)}', '${esc(p.id)}')">${esc(p.name)}${modeTag}</div>`;
-    }).join('');
-
-    // Build deploy mode menu items for the left deploy button
-    const allModes = [];
-    for (const p of buildProfiles) {
-      if (p.deployModes && Object.keys(p.deployModes).length > 0) {
-        for (const [modeId, mode] of Object.entries(p.deployModes)) {
-          allModes.push({ profileId: p.id, profileName: p.name, modeId, label: mode.label || modeId, active: p.activeDeployMode === modeId });
-        }
-      }
+    // 2026-04-22 —— 二级菜单结构：
+    //   一级：按服务分组（每个 profile 一个 hover 触发的子菜单条目）+ 分支级动作
+    //   二级：每个服务的 deployModes（快/慢/用户自定义）+ 🧹 清理 + 🔍 核验
+    //
+    // 若 profile.deployModes 为空（用户没配任何模式），fallback 到"默认部署"单项，
+    // 同时底部提示用户可在 ⚙ 构建命令面板自定义。这样比以前扁平的"选择服务 + 部署模式"
+    // 平行两组清爽得多：一级每服务一行，鼠标 hover 出二级，单击直接下发命令。
+    function buildProfileSubmenu(p) {
+      const modes = p.deployModes && Object.keys(p.deployModes).length > 0
+        ? Object.entries(p.deployModes).map(([modeId, mode]) => ({
+            modeId,
+            label: mode.label || modeId,
+            active: p.activeDeployMode === modeId,
+          }))
+        : null;
+      const modeRows = modes
+        ? modes.map(m => `
+            <div class="deploy-submenu-item" onclick="event.stopPropagation(); closeDeployMenu('${esc(b.id)}'); switchModeAndDeploy('${esc(b.id)}', '${esc(p.id)}', '${esc(m.modeId)}')">
+              <span style="display:inline-block;width:14px">${m.active ? '✓' : ''}</span>${esc(m.label)}
+            </div>`).join('')
+        : `<div class="deploy-submenu-item" onclick="event.stopPropagation(); closeDeployMenu('${esc(b.id)}'); deploySingleService('${esc(b.id)}', '${esc(p.id)}')">
+             <span style="display:inline-block;width:14px">▶</span>部署 (使用当前命令)
+           </div>`;
+      return `
+        <div class="deploy-menu-item deploy-submenu-anchor">
+          <span>${esc(p.name)}</span>
+          <span style="margin-left:auto;color:var(--text-muted)">▸</span>
+          <div class="deploy-submenu">
+            <div class="deploy-submenu-header">${esc(p.name)} — 部署命令</div>
+            ${modeRows}
+            <div class="deploy-submenu-divider"></div>
+            <div class="deploy-submenu-item" onclick="event.stopPropagation(); closeDeployMenu('${esc(b.id)}'); _askBranchAndRunForBranch('${esc(b.id)}', '${esc(p.id)}', 'rebuild')" title="停容器 + 物理删 bin/obj + 等待重新部署（破 MSBuild 撒谎用）">
+              <span style="display:inline-block;width:14px">🧹</span>清理 bin/obj 并重建
+            </div>
+            <div class="deploy-submenu-item" onclick="event.stopPropagation(); closeDeployMenu('${esc(b.id)}'); _askBranchAndRunForBranch('${esc(b.id)}', '${esc(p.id)}', 'verify')" title="比对源码/DLL/进程启动时间诊断是否跑老字节码">
+              <span style="display:inline-block;width:14px">🔍</span>核验字节码
+            </div>
+            <div class="deploy-submenu-divider"></div>
+            <div class="deploy-submenu-item" onclick="event.stopPropagation(); closeDeployMenu('${esc(b.id)}'); openBuildCommandPanel('${esc(p.id)}')" title="编辑这个服务的所有命令模式（热/冷/自定义）">
+              <span style="display:inline-block;width:14px">⚙</span>编辑命令…
+            </div>
+          </div>
+        </div>`;
     }
-    const hasDeployModes = allModes.length > 0;
-    const deployModeMenuItems = hasDeployModes
-      ? allModes.map(m => {
-          const check = m.active ? '✓ ' : '';
-          return `<div class="deploy-menu-item" onclick="event.stopPropagation(); closeDeployMenu(); switchModeAndDeploy('${esc(b.id)}', '${esc(m.profileId)}', '${esc(m.modeId)}')">${check}${esc(m.profileName)}: ${esc(m.label)}</div>`;
-        }).join('')
-      : '';
+    const deployMenuItems = buildProfiles.map(buildProfileSubmenu).join('');
 
     // Build stop menu item for deploy dropdown
     const stopMenuItem = isRunning ? `<div class="deploy-menu-divider"></div><div class="deploy-menu-item deploy-menu-item-danger" onclick="event.stopPropagation(); closeDeployMenu('${esc(b.id)}'); stopBranch('${esc(b.id)}')">停止所有服务</div>` : '';
@@ -3863,8 +3884,7 @@ function renderBranches() {
     // Unified deploy menu template (shared across states)
     const deployMenuTpl = `
       <template id="deploy-menu-tpl-${esc(b.id)}">
-        ${hasMultipleProfiles ? `<div class="deploy-menu-header">选择服务</div>${deployMenuItems}` : ''}
-        ${hasDeployModes ? `${hasMultipleProfiles ? '<div class="deploy-menu-divider"></div>' : ''}<div class="deploy-menu-header">部署模式</div>${deployModeMenuItems}` : ''}
+        <div class="deploy-menu-header">服务</div>${deployMenuItems}
         ${targetMenuItems}
         ${isRunning ? `<div class="deploy-menu-divider"></div>
         <div class="deploy-menu-item" onclick="event.stopPropagation(); closeDeployMenu('${esc(b.id)}'); viewBranchLogs('${esc(b.id)}')"><svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor" style="vertical-align:-1px;margin-right:4px"><path d="M1 2.75C1 1.784 1.784 1 2.75 1h10.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0113.25 12H9.06l-2.573 2.573A1.458 1.458 0 014 13.543V12H2.75A1.75 1.75 0 011 10.25v-7.5zm1.5 0a.25.25 0 01.25-.25h10.5a.25.25 0 01.25.25v7.5a.25.25 0 01-.25.25h-4.5a.75.75 0 00-.75.75v2.19l-2.72-2.72a.75.75 0 00-.53-.22H2.75a.25.25 0 01-.25-.25v-7.5z"/></svg>部署日志</div>
@@ -5173,12 +5193,13 @@ function openProfileModal() {
           : '';
         const hr = p.hotReload || {};
         const hrOn = !!hr.enabled;
-        // 2026-04-22：.NET 默认 dotnet-restart；dotnet-watch 标红「不推荐」
+        // 2026-04-22：.NET 默认 dotnet-run（快）；疑难撒谎场景才切 dotnet-restart
         const isDotnetImg = /dotnet|mcr\.microsoft\.com\/dotnet/i.test(p.dockerImage || '');
-        const hrMode = hr.mode || (isDotnetImg ? 'dotnet-restart' : 'pnpm-dev');
+        const hrMode = hr.mode || (isDotnetImg ? 'dotnet-run' : 'pnpm-dev');
         const hrModeOptions = [
-          ['dotnet-restart', 'dotnet-restart ★ 推荐'],
-          ['dotnet-watch', 'dotnet-watch ⚠ 有增量编译误判风险'],
+          ['dotnet-run', 'dotnet-run ★ 增量(快)'],
+          ['dotnet-restart', 'dotnet-restart — 清理+no-incremental(慢·疑难用)'],
+          ['dotnet-watch', 'dotnet-watch ⚠ 有 hot-reload 坑'],
           ['pnpm-dev', 'pnpm-dev'],
           ['vite', 'vite'],
           ['next-dev', 'next-dev'],
@@ -5650,6 +5671,117 @@ window._askBranchAndRun = function (profileId, action) {
   }
   if (action === 'verify') verifyRuntime(branchId, profileId);
   else if (action === 'rebuild') forceRebuild(branchId, profileId);
+};
+
+// 分支上下文已知时的快捷变体（二级菜单调用）
+window._askBranchAndRunForBranch = function (branchId, profileId, action) {
+  if (action === 'verify') verifyRuntime(branchId, profileId);
+  else if (action === 'rebuild') forceRebuild(branchId, profileId);
+};
+
+// ⚙ 构建命令编辑面板（用户自定义每个 profile 的 deployModes 命令）
+// 背景：用户想要"点某个菜单项跑自己定义的命令"。已有 profile.deployModes 支持这个
+// 数据模型（每个 mode 一个 command），但一直没 UI。本面板集中编辑。
+window.openBuildCommandPanel = async function (profileId) {
+  const profile = buildProfiles.find(p => p.id === profileId);
+  if (!profile) { showToast(`未找到构建配置 ${profileId}`, 'error'); return; }
+
+  const modes = profile.deployModes || {};
+  const modeEntries = Object.entries(modes);
+
+  const rowsHtml = modeEntries.length > 0
+    ? modeEntries.map(([modeId, m]) => `
+        <div data-mode-id="${esc(modeId)}" style="border:1px solid var(--border);border-radius:6px;padding:10px;margin-bottom:8px">
+          <div style="display:flex;gap:8px;align-items:center;margin-bottom:6px">
+            <input class="bc-label" type="text" value="${esc(m.label || modeId)}" placeholder="显示名（如 开发模式 / 冷部署）" style="flex:1;padding:4px 6px;border:1px solid var(--border);border-radius:4px;background:var(--bg-input);color:var(--text-primary);font-size:12px">
+            <code style="font-size:10px;color:var(--text-muted)">${esc(modeId)}</code>
+            <button class="icon-btn xs danger-icon" onclick="event.target.closest('[data-mode-id]').remove()" title="删除此模式">×</button>
+          </div>
+          <textarea class="bc-cmd" rows="2" placeholder="完整 shell 命令，如: dotnet run --urls http://0.0.0.0:8080" style="width:100%;padding:6px 8px;border:1px solid var(--border);border-radius:4px;background:var(--bg-input);color:var(--text-primary);font-size:11px;font-family:var(--font-mono,monospace);resize:vertical">${esc(m.command || '')}</textarea>
+        </div>
+      `).join('')
+    : '<div style="padding:12px;background:var(--bg-card);border:1px dashed var(--border);border-radius:6px;color:var(--text-muted);font-size:12px;margin-bottom:8px">当前没有任何模式。下面加一个即可。</div>';
+
+  const html = `
+    <div style="font-size:12px;color:var(--text-muted);margin-bottom:10px">
+      为 <strong>${esc(profile.name)}</strong> (${esc(profile.id)}) 定义多个"一键跑的命令"。
+      二级菜单会把它们列出来，点一下就用对应命令部署。
+      <br>典型建议：「开发（热加载）」= <code>dotnet run</code>，「冷部署」= <code>dotnet publish -c Release && dotnet bin/Release/net8.0/publish/App.dll</code>。
+    </div>
+    <div id="bcRows">${rowsHtml}</div>
+    <div style="display:flex;gap:6px;margin-bottom:14px">
+      <button class="sm" onclick="_bcAddMode()">+ 新增模式</button>
+      <button class="sm" onclick="_bcInsertTemplate('dev')">预设: 开发(dotnet run)</button>
+      <button class="sm" onclick="_bcInsertTemplate('cold')">预设: 冷部署(publish)</button>
+      <button class="sm" onclick="_bcInsertTemplate('dev-node')">预设: pnpm dev</button>
+    </div>
+    <div style="display:flex;gap:8px;justify-content:flex-end;border-top:1px solid var(--border);padding-top:10px">
+      <button class="sm" onclick="closeConfigModal()">取消</button>
+      <button class="sm primary" onclick="_bcSave('${esc(profileId)}')">保存</button>
+    </div>
+  `;
+  openConfigModal(`构建命令 — ${profile.name}`, html);
+};
+
+window._bcAddMode = function () {
+  const id = 'mode-' + Math.random().toString(36).slice(2, 7);
+  const row = document.createElement('div');
+  row.setAttribute('data-mode-id', id);
+  row.style.cssText = 'border:1px solid var(--border);border-radius:6px;padding:10px;margin-bottom:8px';
+  row.innerHTML = `
+    <div style="display:flex;gap:8px;align-items:center;margin-bottom:6px">
+      <input class="bc-label" type="text" placeholder="显示名" style="flex:1;padding:4px 6px;border:1px solid var(--border);border-radius:4px;background:var(--bg-input);color:var(--text-primary);font-size:12px">
+      <code style="font-size:10px;color:var(--text-muted)">${id}</code>
+      <button class="icon-btn xs danger-icon" onclick="this.closest('[data-mode-id]').remove()">×</button>
+    </div>
+    <textarea class="bc-cmd" rows="2" placeholder="完整 shell 命令" style="width:100%;padding:6px 8px;border:1px solid var(--border);border-radius:4px;background:var(--bg-input);color:var(--text-primary);font-size:11px;font-family:var(--font-mono,monospace);resize:vertical"></textarea>
+  `;
+  document.getElementById('bcRows').appendChild(row);
+};
+
+window._bcInsertTemplate = function (kind) {
+  const templates = {
+    'dev': { label: '开发（热加载）', command: 'dotnet run --urls http://0.0.0.0:$PORT' },
+    'cold': { label: '冷部署（publish）', command: 'dotnet publish -c Release -o /tmp/publish && cd /tmp/publish && exec dotnet *.dll --urls http://0.0.0.0:$PORT' },
+    'dev-node': { label: '开发（Vite HMR）', command: 'pnpm install --prefer-frozen-lockfile && pnpm dev --host 0.0.0.0 --port $PORT' },
+  };
+  const tpl = templates[kind];
+  const id = 'mode-' + Math.random().toString(36).slice(2, 7);
+  const row = document.createElement('div');
+  row.setAttribute('data-mode-id', id);
+  row.style.cssText = 'border:1px solid var(--border);border-radius:6px;padding:10px;margin-bottom:8px';
+  row.innerHTML = `
+    <div style="display:flex;gap:8px;align-items:center;margin-bottom:6px">
+      <input class="bc-label" type="text" value="${tpl.label}" style="flex:1;padding:4px 6px;border:1px solid var(--border);border-radius:4px;background:var(--bg-input);color:var(--text-primary);font-size:12px">
+      <code style="font-size:10px;color:var(--text-muted)">${id}</code>
+      <button class="icon-btn xs danger-icon" onclick="this.closest('[data-mode-id]').remove()">×</button>
+    </div>
+    <textarea class="bc-cmd" rows="2" style="width:100%;padding:6px 8px;border:1px solid var(--border);border-radius:4px;background:var(--bg-input);color:var(--text-primary);font-size:11px;font-family:var(--font-mono,monospace);resize:vertical">${tpl.command}</textarea>
+  `;
+  document.getElementById('bcRows').appendChild(row);
+};
+
+window._bcSave = async function (profileId) {
+  const profile = buildProfiles.find(p => p.id === profileId);
+  if (!profile) return;
+  const rows = document.querySelectorAll('#bcRows [data-mode-id]');
+  const newModes = {};
+  rows.forEach(row => {
+    const modeId = row.getAttribute('data-mode-id');
+    const label = row.querySelector('.bc-label').value.trim();
+    const command = row.querySelector('.bc-cmd').value.trim();
+    if (!label || !command) return;
+    newModes[modeId] = { label, command };
+  });
+  try {
+    await api('PUT', `/build-profiles/${encodeURIComponent(profileId)}`, {
+      ...profile,
+      deployModes: newModes,
+    });
+    showToast('已保存构建命令', 'success');
+    closeConfigModal();
+    await loadProfiles();
+  } catch (e) { showToast(`保存失败：${e.message}`, 'error'); }
 };
 
 async function switchModeAndDeploy(branchId, profileId, modeId) {

--- a/cds/web/app.js
+++ b/cds/web/app.js
@@ -4836,6 +4836,8 @@ function openInfraModal() {
                    <button class="icon-btn xs" onclick="infraAction('${esc(svc.id)}','restart')" title="重启">⟳</button>`
                 : `<button class="icon-btn xs" onclick="infraAction('${esc(svc.id)}','start')" title="启动">▶</button>`}
               <button class="icon-btn xs" onclick="infraShowLogs('${esc(svc.id)}')" title="日志"><svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0112.25 16h-8.5A1.75 1.75 0 012 14.25V1.75zm1.75-.25a.25.25 0 00-.25.25v12.5c0 .138.112.25.25.25h8.5a.25.25 0 00.25-.25V6h-2.75A1.75 1.75 0 018 4.25V1.5H3.75zm6.75.062V4.25c0 .138.112.25.25.25h2.688a.252.252 0 00-.011-.013l-2.914-2.914a.272.272 0 00-.013-.011z"/></svg></button>
+              ${svc.status === 'running' ? `<button class="icon-btn xs" onclick="infraBackup('${esc(svc.id)}')" title="下载数据库备份">⇩</button>` : ''}
+              ${svc.status === 'running' ? `<button class="icon-btn xs" onclick="infraRestoreDialog('${esc(svc.id)}')" title="上传恢复数据库">⇧</button>` : ''}
               <button class="icon-btn xs danger-icon" onclick="infraDelete('${esc(svc.id)}')" title="删除">&times;</button>
             </span>
           </div>
@@ -4881,6 +4883,40 @@ async function infraDelete(id) {
     openInfraModal();
   } catch (e) { showToast(e.message, 'error'); }
 }
+
+// ── 数据库备份/恢复（2026-04-22 新增）──
+// infraBackup: 直接触发浏览器下载，走 /api/infra/:id/backup（mongodump 流）
+// infraRestoreDialog: 弹文件选择器 → 上传 → /api/infra/:id/restore
+window.infraBackup = function (id) {
+  showToast(`准备下载 ${id} 备份…`, 'info');
+  window.location.href = `/api/infra/${encodeURIComponent(id)}/backup`;
+};
+
+window.infraRestoreDialog = function (id) {
+  if (!confirm(`恢复 ${id} 数据库？\n\n⚠ 这会用你上传的备份覆盖当前数据。\n恢复前 CDS 会自动保存当前状态到 /data/cds/<slug>/backups/，便于撤销。`)) return;
+  const input = document.createElement('input');
+  input.type = 'file';
+  input.accept = '.gz,.archive,.rdb,application/octet-stream,application/gzip';
+  input.onchange = async function () {
+    const file = input.files && input.files[0];
+    if (!file) return;
+    showToast(`正在上传 ${Math.round(file.size / 1024 / 1024)} MB 到 ${id}…`, 'info');
+    try {
+      const resp = await fetch(`/api/infra/${encodeURIComponent(id)}/restore`, {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/octet-stream' },
+        body: file,
+      });
+      const body = await resp.json();
+      if (!resp.ok) throw new Error(body.error || '恢复失败');
+      showToast(body.message || '已恢复', 'success');
+    } catch (err) {
+      showToast(`恢复失败：${err.message}`, 'error');
+    }
+  };
+  input.click();
+};
 
 async function infraShowLogs(id) {
   openConfigModal('基础设施日志', '<div class="config-empty"><span class="btn-spinner"></span> 加载中...</div>');
@@ -5135,15 +5171,34 @@ function openProfileModal() {
               </select>
             </div>`
           : '';
+        const hr = p.hotReload || {};
+        const hrOn = !!hr.enabled;
+        const hrMode = hr.mode || 'dotnet-watch';
+        const hrModeOptions = ['dotnet-watch', 'pnpm-dev', 'vite', 'next-dev', 'custom']
+          .map(m => `<option value="${m}"${hrMode === m ? ' selected' : ''}>${m}</option>`).join('');
+        const hotReloadHtml = `
+          <div style="margin-top:4px;display:flex;align-items:center;gap:6px;padding:4px 6px;background:${hrOn ? 'rgba(239,68,68,0.08)' : 'transparent'};border-radius:4px">
+            <label style="display:inline-flex;align-items:center;gap:4px;font-size:11px;cursor:pointer;color:${hrOn ? '#ef4444' : 'var(--text-muted)'}">
+              <input type="checkbox" ${hrOn ? 'checked' : ''} onchange="toggleHotReload('${esc(p.id)}', this.checked)" style="margin:0">
+              <span>🔥 热更新</span>
+            </label>
+            ${hrOn ? `
+              <select style="font-size:11px;padding:1px 4px;border-radius:3px;border:1px solid var(--border);background:var(--bg-secondary);color:var(--text-primary)" onchange="setHotReloadMode('${esc(p.id)}', this.value)">
+                ${hrModeOptions}
+              </select>
+              <span style="font-size:10px;color:var(--text-muted)">容器跑 watcher，改代码自动重编译，不重启</span>
+            ` : `<span style="font-size:10px;color:var(--text-muted)">开发时启用，无需重建镜像</span>`}
+          </div>`;
         return `
         <div class="config-item">
           <div class="config-item-main">
             <span style="opacity:0.7">${getPortIcon(p.id, p)}</span>
-            <strong>${esc(p.name)}</strong>
+            <strong>${esc(p.name)}</strong>${hrOn ? ' <span title="热更新已启用" style="color:#ef4444">🔥</span>' : ''}
             <code class="config-item-match">${esc(p.dockerImage)}</code>
             <span class="config-item-detail">${esc(p.workDir || '.')} :${p.containerPort}${p.pathPrefixes?.length ? ' → ' + p.pathPrefixes.join(', ') : ''}</span>
             <code class="config-item-cmd" title="${esc(p.runCommand)}">${esc(p.runCommand)}</code>
             ${modeHtml}
+            ${hotReloadHtml}
           </div>
           <div class="config-item-actions">
             <button class="icon-btn xs danger-icon" onclick="deleteProfileAndRefresh('${esc(p.id)}')" title="删除">&times;</button>
@@ -5494,6 +5549,29 @@ async function switchDeployMode(profileId, mode) {
     await loadProfiles();
   } catch (e) { showToast(e.message, 'error'); }
 }
+
+// 热更新开关（2026-04-22）
+// 启用后容器会跑 `dotnet watch` / `pnpm dev` 之类监听源码的命令，
+// 源码是 rw 绑挂的，改代码自动重编译，不用重建镜像也不用重启容器。
+async function toggleHotReload(profileId, enabled) {
+  try {
+    const resp = await api('POST', `/build-profiles/${encodeURIComponent(profileId)}/hot-reload`, { enabled });
+    showToast(resp.message || (enabled ? '已启用热更新' : '已关闭热更新'), 'success');
+    await loadProfiles();
+    openProfileModal();
+  } catch (e) { showToast(e.message, 'error'); }
+}
+window.toggleHotReload = toggleHotReload;
+
+async function setHotReloadMode(profileId, mode) {
+  try {
+    const resp = await api('POST', `/build-profiles/${encodeURIComponent(profileId)}/hot-reload`, { enabled: true, mode });
+    showToast(resp.message || `热更新模式切换为 ${mode}`, 'success');
+    await loadProfiles();
+    openProfileModal();
+  } catch (e) { showToast(e.message, 'error'); }
+}
+window.setHotReloadMode = setHotReloadMode;
 
 async function switchModeAndDeploy(branchId, profileId, modeId) {
   try {

--- a/cds/web/app.js
+++ b/cds/web/app.js
@@ -5173,9 +5173,17 @@ function openProfileModal() {
           : '';
         const hr = p.hotReload || {};
         const hrOn = !!hr.enabled;
-        const hrMode = hr.mode || 'dotnet-watch';
-        const hrModeOptions = ['dotnet-watch', 'pnpm-dev', 'vite', 'next-dev', 'custom']
-          .map(m => `<option value="${m}"${hrMode === m ? ' selected' : ''}>${m}</option>`).join('');
+        // 2026-04-22：.NET 默认 dotnet-restart；dotnet-watch 标红「不推荐」
+        const isDotnetImg = /dotnet|mcr\.microsoft\.com\/dotnet/i.test(p.dockerImage || '');
+        const hrMode = hr.mode || (isDotnetImg ? 'dotnet-restart' : 'pnpm-dev');
+        const hrModeOptions = [
+          ['dotnet-restart', 'dotnet-restart ★ 推荐'],
+          ['dotnet-watch', 'dotnet-watch ⚠ 有增量编译误判风险'],
+          ['pnpm-dev', 'pnpm-dev'],
+          ['vite', 'vite'],
+          ['next-dev', 'next-dev'],
+          ['custom', 'custom'],
+        ].map(([m, label]) => `<option value="${m}"${hrMode === m ? ' selected' : ''}>${label}</option>`).join('');
         const hotReloadHtml = `
           <div style="margin-top:4px;display:flex;align-items:center;gap:6px;padding:4px 6px;background:${hrOn ? 'rgba(239,68,68,0.08)' : 'transparent'};border-radius:4px">
             <label style="display:inline-flex;align-items:center;gap:4px;font-size:11px;cursor:pointer;color:${hrOn ? '#ef4444' : 'var(--text-muted)'}">
@@ -5201,6 +5209,8 @@ function openProfileModal() {
             ${hotReloadHtml}
           </div>
           <div class="config-item-actions">
+            <button class="icon-btn xs" onclick="_askBranchAndRun('${esc(p.id)}', 'verify')" title="核验运行时字节码是否是最新代码">🔍</button>
+            <button class="icon-btn xs" onclick="_askBranchAndRun('${esc(p.id)}', 'rebuild')" title="强制清 bin/obj + 重建（对付 MSBuild 增量撒谎）">💥</button>
             <button class="icon-btn xs danger-icon" onclick="deleteProfileAndRefresh('${esc(p.id)}')" title="删除">&times;</button>
           </div>
         </div>
@@ -5572,6 +5582,75 @@ async function setHotReloadMode(profileId, mode) {
   } catch (e) { showToast(e.message, 'error'); }
 }
 window.setHotReloadMode = setHotReloadMode;
+
+// 💥 强制干净重建（对付 MSBuild 增量编译撒谎）
+// 场景：改了 .cs 但运行时死活不生效，DLL 里 grep 得到新字符串、日志里看不到。
+// 本操作：停容器 → rm -rf bin/obj → 提示重新部署。
+async function forceRebuild(branchId, profileId) {
+  if (!confirm(
+    `强制干净重建 ${branchId} / ${profileId}？\n\n` +
+    `会执行：\n` +
+    `  1. 停止该服务容器\n` +
+    `  2. 物理删除 worktree 下的 bin/ 和 obj/ 目录\n` +
+    `  3. 提示手动点"部署"重新构建（下次构建会从源码完整重编译）\n\n` +
+    `用途：当 MSBuild 增量编译撒谎 / dotnet watch 卡住时破除缓存。数据库和代码不受影响。`
+  )) return;
+  try {
+    const resp = await api('POST', `/branches/${encodeURIComponent(branchId)}/force-rebuild/${encodeURIComponent(profileId)}`);
+    const details = (resp.steps || []).map(s => `${s.ok ? '✓' : '✗'} ${s.step}${s.detail ? ' — ' + s.detail : ''}`).join('\n');
+    alert((resp.message || '已清理') + '\n\n执行步骤：\n' + details);
+  } catch (e) { showToast(`强制重建失败：${e.message}`, 'error'); }
+}
+window.forceRebuild = forceRebuild;
+
+// 🔍 运行时字节码核验 —— 比对源码/DLL/进程启动时间
+// 用于回答："我改的 .cs 到底生效了没有"
+async function verifyRuntime(branchId, profileId) {
+  try {
+    const resp = await api('POST', `/branches/${encodeURIComponent(branchId)}/verify-runtime/${encodeURIComponent(profileId)}`);
+    const msg = [
+      `容器：${resp.container}`,
+      `进程启动：${resp.processStart}`,
+      `最新 DLL：${resp.latestDll?.path || '无'} (ts=${resp.latestDll?.ts || 'n/a'})`,
+      `最新源码：${resp.latestSource?.path || '无'} (ts=${resp.latestSource?.ts || 'n/a'})`,
+      '',
+      '诊断：',
+      ...(resp.warnings || []),
+      '',
+      '最近日志（末尾 30 行，复制贴到别处检查）：',
+      '```',
+      resp.recentLogs || '(空)',
+      '```',
+    ].join('\n');
+    alert(msg);
+  } catch (e) { showToast(`核验失败：${e.message}`, 'error'); }
+}
+window.verifyRuntime = verifyRuntime;
+
+// Profile 卡片按钮的 branch 选择器 —— 提示用户选哪个分支执行诊断/重建
+window._askBranchAndRun = function (profileId, action) {
+  // 全局 branches（line 388 的 module 变量）—— 已经按本项目过滤
+  const candidates = (typeof branches !== 'undefined' && Array.isArray(branches))
+    ? branches.filter(b => b && b.services && b.services[profileId])
+    : [];
+  if (candidates.length === 0) {
+    showToast(`没有找到正在运行 profile "${profileId}" 的分支`, 'info');
+    return;
+  }
+  let branchId;
+  if (candidates.length === 1) {
+    branchId = candidates[0].id;
+  } else {
+    const list = candidates.map((b, i) => `${i + 1}) ${b.id}`).join('\n');
+    const input = prompt(`选择分支（输入编号）：\n${list}`, '1');
+    if (!input) return;
+    const idx = parseInt(input, 10) - 1;
+    if (!(idx >= 0 && idx < candidates.length)) { showToast('编号无效', 'error'); return; }
+    branchId = candidates[idx].id;
+  }
+  if (action === 'verify') verifyRuntime(branchId, profileId);
+  else if (action === 'rebuild') forceRebuild(branchId, profileId);
+};
 
 async function switchModeAndDeploy(branchId, profileId, modeId) {
   try {

--- a/cds/web/global-cmd-modal.js
+++ b/cds/web/global-cmd-modal.js
@@ -1,0 +1,294 @@
+/**
+ * 全局构建命令编辑面板（2026-04-22）
+ *
+ * 用户痛点：单 profile 的 ⚙ 编辑命令 太琐碎 —— 每个项目都要重复同一套
+ * "热加载 / 冷部署" 配置。本面板让用户**一次定义，按镜像类型批量覆盖**：
+ *
+ *   选「所有 .NET profile」 → 填两个命令（热 + 冷）→ 保存
+ *   后端 POST /api/build-profiles/bulk-set-modes，自动拍快照便于回滚
+ *
+ * 顶部 🔧 按钮打开本 modal。
+ */
+(function () {
+  var modal = null;
+
+  function escapeHtml(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+
+  // 预设：每种过滤范围对应一组默认热/冷命令模板
+  var PRESETS = {
+    'all': null,
+    'dotnet': {
+      hot: { id: 'dev', label: '开发（热加载）', command: 'dotnet run --urls http://0.0.0.0:$PORT' },
+      cold: { id: 'cold', label: '冷部署（publish）', command: 'dotnet publish -c Release -o /tmp/publish && cd /tmp/publish && exec dotnet *.dll --urls http://0.0.0.0:$PORT' },
+    },
+    'node': {
+      hot: { id: 'dev', label: '开发（Vite/HMR）', command: 'pnpm install --prefer-frozen-lockfile && pnpm dev --host 0.0.0.0 --port $PORT' },
+      cold: { id: 'cold', label: '冷部署（build+serve）', command: 'pnpm install --prefer-frozen-lockfile && pnpm build && pnpm preview --host 0.0.0.0 --port $PORT' },
+    },
+    'python': {
+      hot: { id: 'dev', label: '开发（reload）', command: 'pip install -r requirements.txt && uvicorn main:app --host 0.0.0.0 --port $PORT --reload' },
+      cold: { id: 'cold', label: '冷部署', command: 'pip install -r requirements.txt && uvicorn main:app --host 0.0.0.0 --port $PORT' },
+    },
+  };
+
+  function fetchProfiles() {
+    return fetch('/api/build-profiles?project=' + encodeURIComponent(window.CURRENT_PROJECT_ID || 'default'), { credentials: 'same-origin' })
+      .then(function (r) { return r.json(); })
+      .then(function (d) { return d.profiles || []; });
+  }
+
+  function open() {
+    if (modal) return;
+    modal = document.createElement('div');
+    modal.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,0.6);z-index:10000;display:flex;align-items:center;justify-content:center;padding:20px';
+    modal.onclick = function (e) { if (e.target === modal) close(); };
+
+    var box = document.createElement('div');
+    box.style.cssText = 'background:var(--bg-card);color:var(--text-primary);border:1px solid var(--border-subtle);border-radius:10px;width:min(100%, 760px);max-height:min(100%, 720px);display:flex;flex-direction:column;min-height:0';
+    box.onclick = function (e) { e.stopPropagation(); };
+
+    box.innerHTML =
+      '<div style="padding:14px 18px;border-bottom:1px solid var(--border-subtle);display:flex;align-items:center;gap:12px;flex-shrink:0">' +
+        '<div style="flex:1">' +
+          '<div style="font-weight:600;font-size:14px">🔧 全局构建命令</div>' +
+          '<div style="color:var(--text-muted);font-size:11px;margin-top:2px">一次填好，批量覆盖所有匹配的 profile · 自动拍快照可回滚</div>' +
+        '</div>' +
+        '<button id="globalCmdCloseBtn" class="icon-btn sm" title="关闭">✕</button>' +
+      '</div>' +
+      '<div id="globalCmdBody" style="flex:1;min-height:0;overflow-y:auto;padding:16px 18px"></div>';
+
+    modal.appendChild(box);
+    document.body.appendChild(modal);
+
+    box.querySelector('#globalCmdCloseBtn').onclick = close;
+    document.addEventListener('keydown', onKeydown);
+
+    render();
+  }
+
+  function close() {
+    if (modal && modal.parentNode) modal.parentNode.removeChild(modal);
+    modal = null;
+    document.removeEventListener('keydown', onKeydown);
+  }
+
+  function onKeydown(e) { if (e.key === 'Escape') close(); }
+
+  var state = {
+    filter: 'dotnet',
+    strategy: 'merge',
+    modes: [
+      { modeId: 'dev', label: '开发（热加载）', command: '' },
+      { modeId: 'cold', label: '冷部署', command: '' },
+    ],
+    profileSelection: null, // { [id]: true } when manually picking
+  };
+
+  function render() {
+    var body = modal && modal.querySelector('#globalCmdBody');
+    if (!body) return;
+    body.innerHTML = '<div style="text-align:center;padding:30px;color:var(--text-muted)">加载 profiles…</div>';
+
+    fetchProfiles().then(function (profiles) {
+      // 应用预设的初始命令（仅当对应字段还为空时）
+      var preset = PRESETS[state.filter];
+      if (preset) {
+        if (state.modes[0] && !state.modes[0].command) {
+          state.modes[0] = { modeId: preset.hot.id, label: preset.hot.label, command: preset.hot.command };
+        }
+        if (state.modes[1] && !state.modes[1].command) {
+          state.modes[1] = { modeId: preset.cold.id, label: preset.cold.label, command: preset.cold.command };
+        }
+      }
+
+      var matched = profiles.filter(function (p) {
+        var img = (p.dockerImage || '').toLowerCase();
+        if (state.filter === 'all') return true;
+        if (state.filter === 'dotnet') return /dotnet|mcr\.microsoft\.com\/dotnet/i.test(img);
+        if (state.filter === 'node') return /node/i.test(img);
+        if (state.filter === 'python') return /python/i.test(img);
+        if (state.filter === 'manual') return state.profileSelection && state.profileSelection[p.id];
+        return false;
+      });
+
+      var html = '';
+      // 应用范围
+      html += '<div style="margin-bottom:12px">' +
+        '<div style="font-weight:600;font-size:12px;margin-bottom:6px">应用范围</div>' +
+        '<div style="display:flex;gap:6px;flex-wrap:wrap">' +
+          ['all', 'dotnet', 'node', 'python', 'manual'].map(function (f) {
+            var selected = state.filter === f;
+            var label = ({all:'全部 profile', dotnet:'.NET (dotnet)', node:'Node (node)', python:'Python', manual:'手动选择…'})[f];
+            return '<button class="settings-btn settings-btn-sm" data-filter="' + f + '" style="' + (selected ? 'background:var(--accent,#3b82f6);color:#fff;border-color:transparent' : '') + '">' + label + '</button>';
+          }).join('') +
+        '</div>' +
+      '</div>';
+
+      // 命中的 profile 列表
+      html += '<div style="margin-bottom:14px;padding:8px 10px;background:var(--bg-card);border:1px solid var(--border-subtle);border-radius:6px;font-size:12px">' +
+        '<div style="color:var(--text-muted);margin-bottom:4px">命中 ' + matched.length + ' / ' + profiles.length + ' 个 profile：</div>' +
+        (state.filter === 'manual' ? renderManualPicker(profiles) : renderMatchedList(matched)) +
+      '</div>';
+
+      // 模式编辑
+      html += '<div style="font-weight:600;font-size:12px;margin-bottom:6px">模式 = label + 命令</div>';
+      state.modes.forEach(function (m, idx) {
+        html += '<div data-idx="' + idx + '" style="margin-bottom:10px;padding:10px;border:1px solid var(--border-subtle);border-radius:6px">' +
+          '<div style="display:flex;gap:8px;align-items:center;margin-bottom:6px">' +
+            '<input class="gc-modeId" type="text" value="' + escapeHtml(m.modeId) + '" placeholder="modeId（dev/cold/...）" style="width:120px;padding:4px 6px;font-family:var(--font-mono,monospace);font-size:11px;border:1px solid var(--border);border-radius:4px;background:var(--bg-input);color:var(--text-primary)">' +
+            '<input class="gc-label" type="text" value="' + escapeHtml(m.label) + '" placeholder="显示名（开发 / 冷部署 / ...）" style="flex:1;padding:4px 6px;font-size:12px;border:1px solid var(--border);border-radius:4px;background:var(--bg-input);color:var(--text-primary)">' +
+            '<button class="settings-btn settings-btn-sm" data-action="del-mode" data-idx="' + idx + '" style="color:#ef4444">×</button>' +
+          '</div>' +
+          '<textarea class="gc-cmd" rows="2" placeholder="完整 shell 命令；可用 $PORT" style="width:100%;padding:6px 8px;font-family:var(--font-mono,monospace);font-size:11px;border:1px solid var(--border);border-radius:4px;background:var(--bg-input);color:var(--text-primary);resize:vertical">' + escapeHtml(m.command) + '</textarea>' +
+        '</div>';
+      });
+      html += '<button class="settings-btn settings-btn-sm" data-action="add-mode" style="margin-bottom:14px">+ 新增模式</button>';
+
+      // 写入策略
+      html += '<div style="margin-bottom:14px;padding:10px;border:1px solid var(--border-subtle);border-radius:6px">' +
+        '<div style="font-weight:600;font-size:12px;margin-bottom:6px">写入策略</div>' +
+        '<label style="display:block;margin-bottom:4px;font-size:12px;cursor:pointer">' +
+          '<input type="radio" name="gc-strategy" value="merge"' + (state.strategy === 'merge' ? ' checked' : '') + '> ' +
+          '<strong>merge</strong> — 同名 mode 替换；profile 已有的其他 mode 保留' +
+        '</label>' +
+        '<label style="display:block;font-size:12px;cursor:pointer">' +
+          '<input type="radio" name="gc-strategy" value="replace"' + (state.strategy === 'replace' ? ' checked' : '') + '> ' +
+          '<strong>replace</strong> — 清空该 profile 所有现有 mode，只保留这里定义的' +
+        '</label>' +
+      '</div>';
+
+      // 操作按钮
+      html += '<div style="display:flex;gap:8px;justify-content:flex-end;border-top:1px solid var(--border-subtle);padding-top:10px;margin-top:8px">' +
+        '<button class="settings-btn" data-action="cancel">取消</button>' +
+        '<button class="settings-btn settings-btn-primary" data-action="apply"' + (matched.length === 0 ? ' disabled' : '') + '>' +
+          '应用到 ' + matched.length + ' 个 profile →' +
+        '</button>' +
+      '</div>';
+
+      body.innerHTML = html;
+      bindEvents(body, profiles, matched);
+    });
+  }
+
+  function renderMatchedList(matched) {
+    if (matched.length === 0) {
+      return '<div style="color:#f59e0b">⚠ 没有命中的 profile（如果当前项目本来就没有这种类型的服务，可以直接关闭）</div>';
+    }
+    return matched.map(function (p) {
+      return '<div style="padding:2px 0"><strong>' + escapeHtml(p.id) + '</strong> <span style="color:var(--text-muted)">— ' + escapeHtml(p.dockerImage || '') + '</span></div>';
+    }).join('');
+  }
+
+  function renderManualPicker(profiles) {
+    if (!state.profileSelection) state.profileSelection = {};
+    return profiles.map(function (p) {
+      var checked = state.profileSelection[p.id] ? ' checked' : '';
+      return '<label style="display:block;padding:2px 0;cursor:pointer"><input type="checkbox" data-pick="' + escapeHtml(p.id) + '"' + checked + '> <strong>' + escapeHtml(p.id) + '</strong> <span style="color:var(--text-muted)">— ' + escapeHtml(p.dockerImage || '') + '</span></label>';
+    }).join('');
+  }
+
+  function bindEvents(body, profiles, matched) {
+    body.querySelectorAll('[data-filter]').forEach(function (btn) {
+      btn.onclick = function () {
+        state.filter = btn.dataset.filter;
+        // 切换 filter 时清空命令模板，让下次 render() 重新填预设
+        state.modes = [
+          { modeId: 'dev', label: '开发（热加载）', command: '' },
+          { modeId: 'cold', label: '冷部署', command: '' },
+        ];
+        render();
+      };
+    });
+    body.querySelectorAll('[data-pick]').forEach(function (cb) {
+      cb.onchange = function () {
+        if (!state.profileSelection) state.profileSelection = {};
+        state.profileSelection[cb.dataset.pick] = cb.checked;
+        render();
+      };
+    });
+    body.querySelectorAll('[data-action="del-mode"]').forEach(function (btn) {
+      btn.onclick = function () {
+        var i = parseInt(btn.dataset.idx, 10);
+        commitFormToState(body);
+        state.modes.splice(i, 1);
+        render();
+      };
+    });
+    var addBtn = body.querySelector('[data-action="add-mode"]');
+    if (addBtn) addBtn.onclick = function () {
+      commitFormToState(body);
+      state.modes.push({ modeId: 'mode-' + Math.random().toString(36).slice(2, 6), label: '', command: '' });
+      render();
+    };
+    body.querySelectorAll('input[name="gc-strategy"]').forEach(function (r) {
+      r.onchange = function () { state.strategy = r.value; };
+    });
+    var cancelBtn = body.querySelector('[data-action="cancel"]');
+    if (cancelBtn) cancelBtn.onclick = close;
+    var applyBtn = body.querySelector('[data-action="apply"]');
+    if (applyBtn) applyBtn.onclick = function () {
+      commitFormToState(body);
+      apply(profiles, matched);
+    };
+  }
+
+  function commitFormToState(body) {
+    body.querySelectorAll('[data-idx]').forEach(function (row) {
+      var i = parseInt(row.dataset.idx, 10);
+      if (Number.isNaN(i) || i >= state.modes.length) return;
+      var modeId = row.querySelector('.gc-modeId');
+      var label = row.querySelector('.gc-label');
+      var cmd = row.querySelector('.gc-cmd');
+      if (modeId && label && cmd) {
+        state.modes[i] = {
+          modeId: modeId.value.trim(),
+          label: label.value.trim(),
+          command: cmd.value,
+        };
+      }
+    });
+  }
+
+  function apply(profiles, matched) {
+    var modesObj = {};
+    var bad = false;
+    state.modes.forEach(function (m) {
+      if (!m.modeId || !m.label || !m.command.trim()) { bad = true; return; }
+      modesObj[m.modeId] = { label: m.label, command: m.command };
+    });
+    if (bad || Object.keys(modesObj).length === 0) {
+      alert('每个模式必须填 modeId / 显示名 / 命令，否则会被丢弃。');
+      return;
+    }
+    var body = {
+      filter: state.filter === 'manual' ? 'all' : state.filter,
+      modes: modesObj,
+      strategy: state.strategy,
+      profileIds: state.filter === 'manual' ? matched.map(function (p) { return p.id; }) : undefined,
+    };
+    var summary = '将为 ' + matched.length + ' 个 profile（' + matched.map(function (p) { return p.id; }).join(', ') + '）' +
+      '执行「' + state.strategy + '」策略写入 ' + Object.keys(modesObj).length + ' 个模式。\n\n' +
+      '执行前会自动拍快照，可在「历史版本 🕐」一键回滚。\n\n继续吗？';
+    if (!confirm(summary)) return;
+
+    fetch('/api/build-profiles/bulk-set-modes', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin',
+      body: JSON.stringify(body),
+    })
+      .then(function (r) { return r.json().then(function (b) { return { ok: r.ok, body: b }; }); })
+      .then(function (r) {
+        if (!r.ok) throw new Error(r.body.error || '应用失败');
+        alert(r.body.message || '已应用');
+        close();
+      })
+      .catch(function (err) { alert('应用失败：' + err.message); });
+  }
+
+  window.openGlobalBuildCommandPanel = open;
+})();

--- a/cds/web/index.html
+++ b/cds/web/index.html
@@ -62,6 +62,10 @@
         <button class="icon-btn" id="historyBtn" onclick="window.openHistoryModal && window.openHistoryModal()" title="历史版本 & 紧急还原（配置快照 + 破坏性操作撤销）">
           <svg width="20" height="20" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M1.643 3.143 .427 1.927A.25.25 0 0 0 0 2.104V5.75a.25.25 0 0 0 .25.25h3.646a.25.25 0 0 0 .177-.427L2.715 4.215a6.5 6.5 0 1 1-1.18 4.458.75.75 0 1 0-1.493.154 8.001 8.001 0 1 0 1.6-5.684zM7.75 4a.75.75 0 0 1 .75.75v2.992l2.028.812a.75.75 0 0 1-.557 1.392l-2.5-1A.751.751 0 0 1 7 8.25v-3.5A.75.75 0 0 1 7.75 4z"/></svg>
         </button>
+        <!-- 🔧 全局构建命令：一次定义，按镜像类型批量覆盖所有 profile -->
+        <button class="icon-btn" id="globalCmdBtn" onclick="window.openGlobalBuildCommandPanel && window.openGlobalBuildCommandPanel()" title="全局构建命令（按镜像类型一键改所有服务）">
+          <svg width="20" height="20" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M9.06 2.358a4.5 4.5 0 0 1 5.852 5.852L9.06 14.06l-1.06-1.06 5.66-5.66a3 3 0 1 0-4.24-4.24L3.76 8.762l-1.06-1.06 5.36-5.343zM6.06 4.94l4.95 4.95-1.06 1.06-4.95-4.95L6.06 4.94zM3.5 8.5l4.95 4.95-1.06 1.06L2.44 9.56 3.5 8.5z"/></svg>
+        </button>
         <button class="icon-btn" id="agentKeyBtn" onclick="window.cdsOpenAgentKeyModal(typeof CURRENT_PROJECT_ID !== 'undefined' ? CURRENT_PROJECT_ID : 'default')" title="授权 Agent 操作本项目">
           <svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M10.5 0a5.499 5.499 0 1 1-1.288 10.848l-.932.932a.749.749 0 0 1-.53.22H7v.75a.749.749 0 0 1-.22.53l-.5.5a.749.749 0 0 1-.53.22H5v.75a.749.749 0 0 1-.22.53l-.5.5a.749.749 0 0 1-.53.22h-2A1.75 1.75 0 0 1 0 14.25v-2c0-.199.079-.389.22-.53l4.932-4.932A5.5 5.5 0 0 1 10.5 0Zm0 1.5a4.002 4.002 0 0 0-3.923 4.802.75.75 0 0 1-.206.701L1.5 12.561v1.689c0 .138.112.25.25.25h1.689l.31-.31V13a.75.75 0 0 1 .75-.75h1.19l.31-.31V11a.75.75 0 0 1 .75-.75h1.19l1.371-1.371a.751.751 0 0 1 .701-.206A4 4 0 1 0 10.5 1.5Zm1 2.5a1 1 0 1 1 0 2 1 1 0 0 1 0-2Z"/></svg>
         </button>
@@ -278,6 +282,7 @@
   <script>document.write('<scr'+'ipt src="self-update.js?t='+Date.now()+'"></scr'+'ipt>');</script>
   <script>document.write('<scr'+'ipt src="proxy-log-modal.js?t='+Date.now()+'"></scr'+'ipt>');</script>
   <script>document.write('<scr'+'ipt src="snapshot-modal.js?t='+Date.now()+'"></scr'+'ipt>');</script>
+  <script>document.write('<scr'+'ipt src="global-cmd-modal.js?t='+Date.now()+'"></scr'+'ipt>');</script>
   <script>document.write('<scr'+'ipt src="app.js?t='+Date.now()+'"></scr'+'ipt>');</script>
 </body>
 </html>

--- a/cds/web/index.html
+++ b/cds/web/index.html
@@ -54,6 +54,14 @@
         <!-- 2026-04-22：
              - 移除 selfUpdateBtn（自动更新入口已在 ⚙ 菜单，不再单独占位）。
              - Agent Key 按钮从 🔑 emoji 换为 stroke SVG，和其他 icon-btn 一致。 -->
+        <!-- 🔍 转发日志：专门排查「页面正常但 API 502 没日志」的情况 -->
+        <button class="icon-btn" id="proxyLogBtn" onclick="window.openProxyLogModal && window.openProxyLogModal()" title="查看转发日志（代理 502/未命中路由等）">
+          <svg width="20" height="20" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z"/></svg>
+        </button>
+        <!-- 🕐 历史版本 & 紧急还原 -->
+        <button class="icon-btn" id="historyBtn" onclick="window.openHistoryModal && window.openHistoryModal()" title="历史版本 & 紧急还原（配置快照 + 破坏性操作撤销）">
+          <svg width="20" height="20" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M1.643 3.143 .427 1.927A.25.25 0 0 0 0 2.104V5.75a.25.25 0 0 0 .25.25h3.646a.25.25 0 0 0 .177-.427L2.715 4.215a6.5 6.5 0 1 1-1.18 4.458.75.75 0 1 0-1.493.154 8.001 8.001 0 1 0 1.6-5.684zM7.75 4a.75.75 0 0 1 .75.75v2.992l2.028.812a.75.75 0 0 1-.557 1.392l-2.5-1A.751.751 0 0 1 7 8.25v-3.5A.75.75 0 0 1 7.75 4z"/></svg>
+        </button>
         <button class="icon-btn" id="agentKeyBtn" onclick="window.cdsOpenAgentKeyModal(typeof CURRENT_PROJECT_ID !== 'undefined' ? CURRENT_PROJECT_ID : 'default')" title="授权 Agent 操作本项目">
           <svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M10.5 0a5.499 5.499 0 1 1-1.288 10.848l-.932.932a.749.749 0 0 1-.53.22H7v.75a.749.749 0 0 1-.22.53l-.5.5a.749.749 0 0 1-.53.22H5v.75a.749.749 0 0 1-.22.53l-.5.5a.749.749 0 0 1-.53.22h-2A1.75 1.75 0 0 1 0 14.25v-2c0-.199.079-.389.22-.53l4.932-4.932A5.5 5.5 0 0 1 10.5 0Zm0 1.5a4.002 4.002 0 0 0-3.923 4.802.75.75 0 0 1-.206.701L1.5 12.561v1.689c0 .138.112.25.25.25h1.689l.31-.31V13a.75.75 0 0 1 .75-.75h1.19l.31-.31V11a.75.75 0 0 1 .75-.75h1.19l1.371-1.371a.751.751 0 0 1 .701-.206A4 4 0 1 0 10.5 1.5Zm1 2.5a1 1 0 1 1 0 2 1 1 0 0 1 0-2Z"/></svg>
         </button>
@@ -268,6 +276,8 @@
 
   <script>document.write('<scr'+'ipt src="agent-key-modal.js?t='+Date.now()+'"></scr'+'ipt>');</script>
   <script>document.write('<scr'+'ipt src="self-update.js?t='+Date.now()+'"></scr'+'ipt>');</script>
+  <script>document.write('<scr'+'ipt src="proxy-log-modal.js?t='+Date.now()+'"></scr'+'ipt>');</script>
+  <script>document.write('<scr'+'ipt src="snapshot-modal.js?t='+Date.now()+'"></scr'+'ipt>');</script>
   <script>document.write('<scr'+'ipt src="app.js?t='+Date.now()+'"></scr'+'ipt>');</script>
 </body>
 </html>

--- a/cds/web/project-list.html
+++ b/cds/web/project-list.html
@@ -1222,6 +1222,14 @@
             #pendingImportBadge.pi-flash{animation:pi-flash 0.9s ease-out 3}
             @keyframes pi-flash{0%{box-shadow:0 0 0 0 rgba(251,191,36,0.55)}70%{box-shadow:0 0 0 10px rgba(251,191,36,0)}100%{box-shadow:0 0 0 0 rgba(251,191,36,0)}}
           </style>
+          <button class="icon-btn" id="proxyLogBtn" onclick="window.openProxyLogModal && window.openProxyLogModal()" title="查看转发日志（代理 502/未命中路由等）"
+            style="width:32px;height:32px;border-radius:8px;border:1px solid var(--card-border);background:var(--bg-card);cursor:pointer;display:inline-flex;align-items:center;justify-content:center;color:var(--text-secondary)">
+            <svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z"/></svg>
+          </button>
+          <button class="icon-btn" id="historyBtn" onclick="window.openHistoryModal && window.openHistoryModal()" title="历史版本 & 紧急还原"
+            style="width:32px;height:32px;border-radius:8px;border:1px solid var(--card-border);background:var(--bg-card);cursor:pointer;display:inline-flex;align-items:center;justify-content:center;color:var(--text-secondary)">
+            <svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M1.643 3.143 .427 1.927A.25.25 0 0 0 0 2.104V5.75a.25.25 0 0 0 .25.25h3.646a.25.25 0 0 0 .177-.427L2.715 4.215a6.5 6.5 0 1 1-1.18 4.458.75.75 0 1 0-1.493.154 8.001 8.001 0 1 0 1.6-5.684zM7.75 4a.75.75 0 0 1 .75.75v2.992l2.028.812a.75.75 0 0 1-.557 1.392l-2.5-1A.751.751 0 0 1 7 8.25v-3.5A.75.75 0 0 1 7.75 4z"/></svg>
+          </button>
           <button id="themeToggleBtn" class="icon-btn" onclick="toggleTheme(event)" title="切换主题"
             style="width:32px;height:32px;border-radius:8px;border:1px solid var(--card-border);background:var(--bg-card);cursor:pointer;display:inline-flex;align-items:center;justify-content:center;color:var(--text-secondary)">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="4.22" x2="19.78" y2="5.64"/></svg>
@@ -1475,5 +1483,7 @@ export CDS_SECRET_KEY="$(openssl rand -hex 32)"          # 可选,加密 token
   <script>document.write('<scr'+'ipt src="agent-key-modal.js?t='+Date.now()+'"><\/scr'+'ipt>');</script>
   <script>document.write('<scr'+'ipt src="self-update.js?t='+Date.now()+'"><\/scr'+'ipt>');</script>
   <script>document.write('<scr'+'ipt src="projects.js?t='+Date.now()+'"><\/scr'+'ipt>');</script>
+  <script>document.write('<scr'+'ipt src="proxy-log-modal.js?t='+Date.now()+'"><\/scr'+'ipt>');</script>
+  <script>document.write('<scr'+'ipt src="snapshot-modal.js?t='+Date.now()+'"><\/scr'+'ipt>');</script>
 </body>
 </html>

--- a/cds/web/project-list.html
+++ b/cds/web/project-list.html
@@ -1230,6 +1230,10 @@
             style="width:32px;height:32px;border-radius:8px;border:1px solid var(--card-border);background:var(--bg-card);cursor:pointer;display:inline-flex;align-items:center;justify-content:center;color:var(--text-secondary)">
             <svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M1.643 3.143 .427 1.927A.25.25 0 0 0 0 2.104V5.75a.25.25 0 0 0 .25.25h3.646a.25.25 0 0 0 .177-.427L2.715 4.215a6.5 6.5 0 1 1-1.18 4.458.75.75 0 1 0-1.493.154 8.001 8.001 0 1 0 1.6-5.684zM7.75 4a.75.75 0 0 1 .75.75v2.992l2.028.812a.75.75 0 0 1-.557 1.392l-2.5-1A.751.751 0 0 1 7 8.25v-3.5A.75.75 0 0 1 7.75 4z"/></svg>
           </button>
+          <button class="icon-btn" id="globalCmdBtn" onclick="window.openGlobalBuildCommandPanel && window.openGlobalBuildCommandPanel()" title="全局构建命令（一次定义批量覆盖所有 profile）"
+            style="width:32px;height:32px;border-radius:8px;border:1px solid var(--card-border);background:var(--bg-card);cursor:pointer;display:inline-flex;align-items:center;justify-content:center;color:var(--text-secondary)">
+            <svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M9.06 2.358a4.5 4.5 0 0 1 5.852 5.852L9.06 14.06l-1.06-1.06 5.66-5.66a3 3 0 1 0-4.24-4.24L3.76 8.762l-1.06-1.06 5.36-5.343z"/></svg>
+          </button>
           <button id="themeToggleBtn" class="icon-btn" onclick="toggleTheme(event)" title="切换主题"
             style="width:32px;height:32px;border-radius:8px;border:1px solid var(--card-border);background:var(--bg-card);cursor:pointer;display:inline-flex;align-items:center;justify-content:center;color:var(--text-secondary)">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="4.22" x2="19.78" y2="5.64"/></svg>
@@ -1485,5 +1489,6 @@ export CDS_SECRET_KEY="$(openssl rand -hex 32)"          # 可选,加密 token
   <script>document.write('<scr'+'ipt src="projects.js?t='+Date.now()+'"><\/scr'+'ipt>');</script>
   <script>document.write('<scr'+'ipt src="proxy-log-modal.js?t='+Date.now()+'"><\/scr'+'ipt>');</script>
   <script>document.write('<scr'+'ipt src="snapshot-modal.js?t='+Date.now()+'"><\/scr'+'ipt>');</script>
+  <script>document.write('<scr'+'ipt src="global-cmd-modal.js?t='+Date.now()+'"><\/scr'+'ipt>');</script>
 </body>
 </html>

--- a/cds/web/projects.js
+++ b/cds/web/projects.js
@@ -1099,6 +1099,48 @@ window.cdsDoLogout = cdsDoLogout;
         var projects = (data && data.projects) || [];
         if (projectCountEl) projectCountEl.textContent = projects.length;
 
+        // 2026-04-22 遗留 default 项目迁移提醒
+        fetch('/api/legacy-cleanup/status', { credentials: 'same-origin' })
+          .then(function (r) { return r.json(); })
+          .then(function (st) {
+            var banner = document.getElementById('legacyBanner');
+            if (!st.legacyInUse) { if (banner) banner.remove(); return; }
+            if (banner) return;
+            var el = document.createElement('div');
+            el.id = 'legacyBanner';
+            el.style.cssText = 'margin:16px 0;padding:12px 16px;background:rgba(245,158,11,0.08);border:1px solid rgba(245,158,11,0.45);border-radius:8px;display:flex;gap:12px;align-items:center;font-size:13px';
+            el.innerHTML =
+              '<div style="font-size:20px">⚠</div>' +
+              '<div style="flex:1"><strong>检测到遗留 "default" 项目</strong><br>' +
+                '<span style="color:var(--text-muted);font-size:12px">' +
+                  st.counts.branches + ' 分支 / ' + st.counts.buildProfiles + ' profile / ' + st.counts.infraServices + ' infra。' +
+                  'default 是升级兼容占位，建议给它改成真实项目名以获得完整权限隔离。' +
+                '</span>' +
+              '</div>' +
+              '<button id="legacyMigrateBtn" class="btn-primary-solid">迁移 →</button>';
+            var container = document.querySelector('.project-list-container') || document.body;
+            container.prepend(el);
+            document.getElementById('legacyMigrateBtn').onclick = function () {
+              var newId = prompt('为 "default" 项目起个新 id（小写字母、数字、短横线，如 prd-agent）：');
+              if (!newId) return;
+              var newName = prompt('为项目起个中文显示名（可选）：') || undefined;
+              fetch('/api/legacy-cleanup/rename-default', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                credentials: 'same-origin',
+                body: JSON.stringify({ newId: newId.trim(), newName: newName }),
+              })
+                .then(function (r) { return r.json().then(function (b) { return { ok: r.ok, body: b }; }); })
+                .then(function (r) {
+                  if (!r.ok) throw new Error(r.body.error || '迁移失败');
+                  alert(r.body.message || '迁移完成');
+                  location.reload();
+                })
+                .catch(function (err) { alert('迁移失败：' + err.message); });
+            };
+          })
+          .catch(function () { /* legacy-cleanup 接口缺失就静默 */ });
+
         // Cache by id so the pending-import drawer can look up the
         // human-readable project name without its own /api/projects
         // round trip. Refreshed on every loadProjects() call.

--- a/cds/web/proxy-log-modal.js
+++ b/cds/web/proxy-log-modal.js
@@ -1,0 +1,189 @@
+/**
+ * 全局转发日志面板
+ *
+ * 场景：用户看到「接口 502，但 CDS / 服务器日志都没东西」，分不清是
+ * "请求没命中"、"命中但上游没起来"、还是"上游崩了"。本面板是 worker
+ * port 的代理层日志，区别于 Activity Monitor 的 /api/* Dashboard 调用。
+ *
+ * 使用：顶部 🔍 按钮打开 → 弹窗显示最近 500 条，SSE 实时更新。
+ */
+(function () {
+  var modal = null;
+  var sse = null;
+  var filter = 'all'; // all | errors | upstream-error | no-branch-match
+
+  function escapeHtml(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+
+  function outcomeTag(evt) {
+    var map = {
+      'ok': { label: 'OK', bg: 'rgba(34,197,94,0.15)', fg: '#22c55e' },
+      'client-error': { label: '客户端', bg: 'rgba(251,146,60,0.18)', fg: '#fb923c' },
+      'upstream-error': { label: '上游错误', bg: 'rgba(239,68,68,0.18)', fg: '#ef4444' },
+      'no-branch-match': { label: '未命中路由', bg: 'rgba(168,85,247,0.18)', fg: '#a855f7' },
+      'branch-not-running': { label: '分支未运行', bg: 'rgba(245,158,11,0.18)', fg: '#f59e0b' },
+      'timeout': { label: '超时', bg: 'rgba(239,68,68,0.18)', fg: '#ef4444' },
+    };
+    var m = map[evt.outcome] || { label: evt.outcome, bg: 'rgba(120,120,120,0.18)', fg: '#999' };
+    return '<span style="display:inline-block;padding:1px 8px;border-radius:4px;background:' + m.bg + ';color:' + m.fg + ';font-size:11px;font-weight:600">' + m.label + '</span>';
+  }
+
+  function methodTag(m) {
+    var colors = { GET: '#22c55e', POST: '#3b82f6', PUT: '#f59e0b', DELETE: '#ef4444', PATCH: '#a855f7' };
+    var c = colors[m] || '#999';
+    return '<span style="font-family:var(--font-mono, monospace);font-weight:600;color:' + c + ';font-size:11px">' + escapeHtml(m) + '</span>';
+  }
+
+  function rowHtml(evt) {
+    var t = new Date(evt.ts);
+    var tStr = t.toLocaleTimeString() + '.' + String(t.getMilliseconds()).padStart(3, '0');
+    var passFilter = (
+      filter === 'all' ||
+      (filter === 'errors' && (evt.outcome === 'upstream-error' || evt.outcome === 'no-branch-match' || evt.outcome === 'branch-not-running' || evt.outcome === 'timeout' || evt.outcome === 'client-error')) ||
+      filter === evt.outcome
+    );
+    if (!passFilter) return '';
+
+    var detail = '';
+    if (evt.errorCode) {
+      detail += '<div style="font-family:var(--font-mono, monospace);font-size:11px;color:#ef4444;margin-top:4px">' +
+        '<strong>' + escapeHtml(evt.errorCode) + '</strong>: ' + escapeHtml(evt.errorMessage || '') +
+      '</div>';
+    }
+    if (evt.hint) {
+      detail += '<div style="font-size:12px;color:var(--text-muted);margin-top:3px">💡 ' + escapeHtml(evt.hint) + '</div>';
+    }
+
+    return '<div class="proxy-log-row" style="padding:8px 12px;border-bottom:1px solid var(--border-subtle);font-size:12px">' +
+      '<div style="display:flex;gap:10px;align-items:center;flex-wrap:wrap">' +
+        '<span style="color:var(--text-muted);font-family:var(--font-mono, monospace);font-size:11px">' + escapeHtml(tStr) + '</span>' +
+        outcomeTag(evt) +
+        methodTag(evt.method) +
+        '<span style="color:var(--text-muted)">' + evt.status + '</span>' +
+        '<span style="color:var(--text-muted)">' + evt.durationMs + 'ms</span>' +
+        (evt.branchSlug ? '<span style="padding:1px 6px;background:var(--bg-card);border:1px solid var(--border-subtle);border-radius:3px;font-family:var(--font-mono, monospace);font-size:11px">' + escapeHtml(evt.branchSlug) + (evt.profileId ? ':' + escapeHtml(evt.profileId) : '') + '</span>' : '') +
+      '</div>' +
+      '<div style="margin-top:4px;font-family:var(--font-mono, monospace);font-size:12px;word-break:break-all">' +
+        '<span style="color:var(--text-muted)">' + escapeHtml(evt.host || '-') + '</span>' +
+        '<span style="color:var(--text-primary)">' + escapeHtml(evt.url) + '</span>' +
+        (evt.upstream ? '<span style="color:var(--text-muted)"> → ' + escapeHtml(evt.upstream) + '</span>' : '') +
+      '</div>' +
+      detail +
+    '</div>';
+  }
+
+  function renderList(container, events) {
+    if (events.length === 0) {
+      container.innerHTML = '<div style="padding:40px;text-align:center;color:var(--text-muted)">暂无转发日志。尝试刷新某个预览分支，这里会实时记录。</div>';
+      return;
+    }
+    // 最新在上
+    var html = events.slice().reverse().map(rowHtml).join('');
+    if (!html.trim()) {
+      container.innerHTML = '<div style="padding:40px;text-align:center;color:var(--text-muted)">当前过滤下无匹配记录。</div>';
+      return;
+    }
+    container.innerHTML = html;
+  }
+
+  function openModal() {
+    if (modal) return; // already open
+
+    modal = document.createElement('div');
+    modal.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,0.6);z-index:10000;display:flex;align-items:center;justify-content:center;padding:20px';
+    modal.onclick = function (e) { if (e.target === modal) closeModal(); };
+
+    var box = document.createElement('div');
+    box.style.cssText = 'background:var(--bg-card);color:var(--text-primary);border:1px solid var(--border-subtle);border-radius:10px;width:min(100%, 980px);height:min(100%, 720px);display:flex;flex-direction:column;min-height:0';
+    box.onclick = function (e) { e.stopPropagation(); };
+
+    box.innerHTML =
+      '<div style="padding:14px 18px;border-bottom:1px solid var(--border-subtle);display:flex;align-items:center;gap:12px;flex-shrink:0">' +
+        '<div style="flex:1">' +
+          '<div style="font-weight:600;font-size:14px">🔍 全局转发日志</div>' +
+          '<div style="color:var(--text-muted);font-size:11px;margin-top:2px">CDS worker port 每一次请求都会在这里留痕 · 用于排查「接口 502 但服务器日志为空」</div>' +
+        '</div>' +
+        '<select id="proxyLogFilter" style="padding:6px 10px;background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border-subtle);border-radius:5px;font-size:12px">' +
+          '<option value="all">全部</option>' +
+          '<option value="errors">仅错误</option>' +
+          '<option value="upstream-error">上游错误</option>' +
+          '<option value="no-branch-match">未命中路由</option>' +
+          '<option value="branch-not-running">分支未运行</option>' +
+        '</select>' +
+        '<button id="proxyLogClearBtn" class="icon-btn sm" title="清空列表">清空</button>' +
+        '<button id="proxyLogCloseBtn" class="icon-btn sm" title="关闭">✕</button>' +
+      '</div>' +
+      '<div id="proxyLogBody" style="flex:1;min-height:0;overflow-y:auto" data-testid="proxy-log-body"></div>' +
+      '<div style="padding:8px 18px;border-top:1px solid var(--border-subtle);color:var(--text-muted);font-size:11px;flex-shrink:0">' +
+        '<span id="proxyLogCount">0</span> 条记录 · 实时更新（SSE）· 环形缓冲最多 500 条' +
+      '</div>';
+
+    modal.appendChild(box);
+    document.body.appendChild(modal);
+
+    var body = box.querySelector('#proxyLogBody');
+    var filterEl = box.querySelector('#proxyLogFilter');
+    var countEl = box.querySelector('#proxyLogCount');
+
+    var events = [];
+
+    function update() {
+      renderList(body, events);
+      countEl.textContent = events.length;
+    }
+
+    filterEl.onchange = function () { filter = filterEl.value; update(); };
+    box.querySelector('#proxyLogClearBtn').onclick = function () { events = []; update(); };
+    box.querySelector('#proxyLogCloseBtn').onclick = closeModal;
+
+    // 初始拉一次 + 开 SSE 持续订阅
+    fetch('/api/proxy-log', { credentials: 'same-origin' })
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        events = data.events || [];
+        update();
+        startSse(data.maxId || 0);
+      })
+      .catch(function (err) {
+        body.innerHTML = '<div style="padding:20px;color:#ef4444">加载日志失败：' + escapeHtml(err.message) + '</div>';
+      });
+
+    function startSse(afterSeq) {
+      try {
+        sse = new EventSource('/api/proxy-log/stream?afterSeq=' + afterSeq);
+        sse.onmessage = function (e) {
+          try {
+            var evt = JSON.parse(e.data);
+            if (!evt || !evt.id) return;
+            events.push(evt);
+            if (events.length > 500) events.shift();
+            update();
+          } catch { /* ignore parse error */ }
+        };
+        sse.onerror = function () { /* browser auto-reconnects; we swallow errors */ };
+      } catch (err) {
+        // SSE not supported — degrade to manual refresh
+      }
+    }
+
+    // ESC 关
+    document.addEventListener('keydown', onKeydown);
+  }
+
+  function onKeydown(e) {
+    if (e.key === 'Escape') closeModal();
+  }
+
+  function closeModal() {
+    if (sse) { try { sse.close(); } catch { /* ignore */ } sse = null; }
+    if (modal && modal.parentNode) modal.parentNode.removeChild(modal);
+    modal = null;
+    document.removeEventListener('keydown', onKeydown);
+  }
+
+  window.openProxyLogModal = openModal;
+  window.closeProxyLogModal = closeModal;
+})();

--- a/cds/web/settings.html
+++ b/cds/web/settings.html
@@ -387,6 +387,7 @@
   <script src="settings.js?t=0"></script>
   <script>document.write('<scr'+'ipt src="proxy-log-modal.js?t='+Date.now()+'"><\/scr'+'ipt>');</script>
   <script>document.write('<scr'+'ipt src="snapshot-modal.js?t='+Date.now()+'"><\/scr'+'ipt>');</script>
+  <script>document.write('<scr'+'ipt src="global-cmd-modal.js?t='+Date.now()+'"><\/scr'+'ipt>');</script>
   <script>
     document.currentScript.previousElementSibling.src = 'settings.js?t=' + Date.now();
   </script>

--- a/cds/web/settings.html
+++ b/cds/web/settings.html
@@ -359,6 +359,10 @@
             <span class="icon"><svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></span>
             GitHub
           </button>
+          <button type="button" class="settings-subnav-item" data-tab="cache" onclick="switchSettingsTab('cache')">
+            <span class="icon"><svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 1.79 0 4v8c0 2.21 3.59 4 8 4s8-1.79 8-4V4c0-2.21-3.58-4-8-4zm0 1c3.87 0 7 1.34 7 3s-3.13 3-7 3-7-1.34-7-3 3.13-3 7-3zm0 14c-3.87 0-7-1.34-7-3v-2.32c1.42 1.04 3.94 1.79 7 1.79s5.58-.75 7-1.79V12c0 1.66-3.13 3-7 3zm0-3c-3.87 0-7-1.34-7-3V6.68C2.42 7.72 4.94 8.47 8 8.47s5.58-.75 7-1.79V9c0 1.66-3.13 3-7 3z"/></svg></span>
+            缓存诊断
+          </button>
           <button type="button" class="settings-subnav-item" data-tab="comment-template" onclick="switchSettingsTab('comment-template')">
             <span class="icon"><svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M1.75 1h8.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0110.25 10H7.061l-2.574 2.573A1.458 1.458 0 012 11.543V10h-.25A1.75 1.75 0 010 8.25v-5.5C0 1.784.784 1 1.75 1zM1.5 2.75v5.5c0 .138.112.25.25.25h1a.75.75 0 01.75.75v1.543l2.21-2.209a.75.75 0 01.53-.22h4.01a.25.25 0 00.25-.25v-5.5a.25.25 0 00-.25-.25h-8.5a.25.25 0 00-.25.25zm13 2a.25.25 0 00-.25-.25h-.5a.75.75 0 110-1.5h.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0114.25 12H14v1.543a1.458 1.458 0 01-2.487 1.03L9.22 12.28a.75.75 0 111.06-1.06l2.22 2.22v-1.69a.75.75 0 01.75-.75h1a.25.25 0 00.25-.25v-5.5z"/></svg></span>
             评论模板
@@ -381,6 +385,8 @@
   <div id="toast" class="toast hidden"></div>
 
   <script src="settings.js?t=0"></script>
+  <script>document.write('<scr'+'ipt src="proxy-log-modal.js?t='+Date.now()+'"><\/scr'+'ipt>');</script>
+  <script>document.write('<scr'+'ipt src="snapshot-modal.js?t='+Date.now()+'"><\/scr'+'ipt>');</script>
   <script>
     document.currentScript.previousElementSibling.src = 'settings.js?t=' + Date.now();
   </script>

--- a/cds/web/settings.js
+++ b/cds/web/settings.js
@@ -96,6 +96,8 @@
       renderGithubTab();
     } else if (currentTab === 'comment-template') {
       renderCommentTemplateTab();
+    } else if (currentTab === 'cache') {
+      renderCacheTab();
     } else {
       // P4 Part 18 cleanup: unknown tab → fall back to General,
       // not a stale "coming soon" placeholder. Dead subnav items
@@ -1509,6 +1511,160 @@
   if (topologyLink) topologyLink.href = '/branch-panel?project=' + encodeURIComponent(CURRENT_PROJECT_ID);
   var logsLink = document.getElementById('leftnavLogs');
   if (logsLink) logsLink.href = '/branch-list?project=' + encodeURIComponent(CURRENT_PROJECT_ID);
+
+  // ── Cache diagnostic tab ──
+  function humanBytes(n) {
+    if (n == null) return '—';
+    if (n < 1024) return n + ' B';
+    if (n < 1024 * 1024) return (n / 1024).toFixed(1) + ' KB';
+    if (n < 1024 * 1024 * 1024) return (n / 1024 / 1024).toFixed(1) + ' MB';
+    return (n / 1024 / 1024 / 1024).toFixed(2) + ' GB';
+  }
+
+  function renderCacheTab() {
+    contentEl.innerHTML =
+      '<div class="settings-section">' +
+        '<div class="settings-section-title">缓存诊断</div>' +
+        '<div class="settings-section-desc">' +
+          '展示所有 BuildProfile 的 cacheMount 目录状态，诊断「挂载失效」「缓存被清」等导致 <code>dotnet restore</code> / <code>pnpm install</code> 重复下载的问题。' +
+          '<br>若发现 <strong>目录空</strong> 或 <strong>引用不存在</strong> 的告警，点「修复挂载」一键补齐。' +
+        '</div>' +
+        '<div id="cacheDiagBody" class="settings-placeholder">加载缓存状态…</div>' +
+      '</div>';
+
+    fetch('/api/cache/status', { credentials: 'same-origin' })
+      .then(function (res) { return res.json().then(function (b) { return { ok: res.ok, body: b }; }); })
+      .then(function (r) {
+        if (!r.ok) throw new Error((r.body && r.body.error) || '加载失败');
+        var body = r.body;
+        var html = '';
+
+        html += '<div style="display:flex;gap:12px;flex-wrap:wrap;margin-bottom:16px;padding:12px;background:var(--bg-card);border:1px solid var(--border-subtle);border-radius:8px">' +
+          '<div><div style="color:var(--text-muted);font-size:11px">项目 slug</div><div class="mono" style="font-weight:600">' + escapeHtml(body.projectSlug) + '</div></div>' +
+          '<div><div style="color:var(--text-muted);font-size:11px">缓存根目录</div><div class="mono" style="font-weight:600">' + escapeHtml(body.cacheBase) + '</div></div>' +
+          '<div><div style="color:var(--text-muted);font-size:11px">总占用</div><div style="font-weight:600">' + escapeHtml(body.totalBytesHuman) + '</div></div>' +
+        '</div>';
+
+        if (body.warnings && body.warnings.length) {
+          html += '<div style="margin-bottom:16px;padding:12px;border:1px solid #f59e0b;background:rgba(245,158,11,0.08);border-radius:8px">' +
+            '<div style="font-weight:600;margin-bottom:6px;color:#f59e0b">⚠ 发现 ' + body.warnings.length + ' 条告警</div>' +
+            '<ul style="margin:0;padding-left:20px;font-size:13px">' +
+              body.warnings.map(function (w) { return '<li style="margin:2px 0">' + escapeHtml(w) + '</li>'; }).join('') +
+            '</ul>' +
+          '</div>';
+        }
+
+        html += '<div style="display:flex;gap:8px;margin-bottom:12px">' +
+          '<button id="cacheRepairBtn" class="settings-btn settings-btn-primary">🔧 修复缓存挂载</button>' +
+          '<button id="cacheRefreshBtn" class="settings-btn">🔄 刷新</button>' +
+        '</div>';
+
+        html += '<table style="width:100%;border-collapse:collapse;font-size:13px">' +
+          '<thead><tr style="border-bottom:1px solid var(--border-subtle);color:var(--text-muted);font-size:11px">' +
+            '<th style="text-align:left;padding:8px 6px">名称</th>' +
+            '<th style="text-align:left;padding:8px 6px">宿主机路径</th>' +
+            '<th style="text-align:left;padding:8px 6px">容器内</th>' +
+            '<th style="text-align:right;padding:8px 6px">大小</th>' +
+            '<th style="text-align:right;padding:8px 6px">文件数</th>' +
+            '<th style="text-align:left;padding:8px 6px">最近写入</th>' +
+            '<th style="text-align:left;padding:8px 6px">使用者</th>' +
+            '<th style="text-align:right;padding:8px 6px">操作</th>' +
+          '</tr></thead><tbody>';
+        var allCaches = (body.caches || []).concat((body.orphans || []).map(function (o) { o._orphan = true; return o; }));
+        if (allCaches.length === 0) {
+          html += '<tr><td colspan="8" style="text-align:center;padding:24px;color:var(--text-muted)">暂无缓存挂载</td></tr>';
+        } else {
+          allCaches.forEach(function (c) {
+            var statusDot = c.exists
+              ? (c.sizeBytes === 0 ? '<span style="color:#f59e0b">●</span>' : '<span style="color:#22c55e">●</span>')
+              : '<span style="color:#ef4444">●</span>';
+            html += '<tr style="border-bottom:1px solid var(--border-subtle)' + (c._orphan ? ';opacity:0.7' : '') + '">' +
+              '<td style="padding:8px 6px">' + statusDot + ' <strong>' + escapeHtml(c.name) + '</strong>' + (c._orphan ? ' <span style="color:var(--text-muted);font-size:11px">(孤儿)</span>' : '') + '</td>' +
+              '<td style="padding:8px 6px" class="mono" title="' + escapeHtml(c.hostPath) + '">' + escapeHtml(c.hostPath) + '</td>' +
+              '<td style="padding:8px 6px" class="mono">' + escapeHtml(c.containerPath) + '</td>' +
+              '<td style="padding:8px 6px;text-align:right">' + escapeHtml(c.sizeBytes != null ? humanBytes(c.sizeBytes) : '—') + '</td>' +
+              '<td style="padding:8px 6px;text-align:right">' + (c.fileCount != null ? c.fileCount.toLocaleString() : '—') + '</td>' +
+              '<td style="padding:8px 6px">' + (c.lastModified ? escapeHtml(new Date(c.lastModified).toLocaleString()) : '—') + '</td>' +
+              '<td style="padding:8px 6px">' + escapeHtml((c.usedByProfiles || []).join(', ') || '—') + '</td>' +
+              '<td style="padding:8px 6px;text-align:right;white-space:nowrap">' +
+                '<button class="settings-btn settings-btn-sm" onclick="window._cacheExport(\'' + escapeHtml(c.name) + '\')">导出</button> ' +
+                '<button class="settings-btn settings-btn-sm" onclick="window._cachePurge(\'' + escapeHtml(c.name) + '\')">清空</button>' +
+              '</td>' +
+            '</tr>';
+          });
+        }
+        html += '</tbody></table>';
+
+        html += '<div style="margin-top:20px;padding:12px;background:var(--bg-card);border:1px solid var(--border-subtle);border-radius:8px">' +
+          '<div style="font-weight:600;margin-bottom:6px">从其他 CDS 服务器导入缓存</div>' +
+          '<div style="color:var(--text-muted);font-size:12px;margin-bottom:8px">' +
+            '迁移服务器时：在老机器点「导出」下载 tar.gz，在新机器这里上传，可跳过首次冷下载的 35 秒等待。' +
+          '</div>' +
+          '<div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">' +
+            '<label style="font-size:12px;color:var(--text-muted)">名称：</label>' +
+            '<input id="cacheImportName" type="text" placeholder="如 nuget / pnpm" class="settings-input mono" style="width:150px">' +
+            '<input id="cacheImportFile" type="file" accept=".tar.gz,.tgz,application/gzip">' +
+            '<button id="cacheImportBtn" class="settings-btn">⬆ 导入</button>' +
+          '</div>' +
+          '<div id="cacheImportStatus" style="margin-top:8px;font-size:12px"></div>' +
+        '</div>';
+
+        document.getElementById('cacheDiagBody').outerHTML = html;
+        document.getElementById('cacheRefreshBtn').onclick = renderCacheTab;
+        document.getElementById('cacheRepairBtn').onclick = function () {
+          if (!confirm('这会按镜像类型补齐所有 BuildProfile 缺失的 cacheMount（幂等操作，不会删数据）。继续？')) return;
+          fetch('/api/cache/repair', { method: 'POST', credentials: 'same-origin' })
+            .then(function (r) { return r.json().then(function (b) { return { ok: r.ok, body: b }; }); })
+            .then(function (r) {
+              if (!r.ok) throw new Error(r.body.error || '修复失败');
+              showToast(r.body.message || '修复完成');
+              setTimeout(renderCacheTab, 400);
+            })
+            .catch(function (err) { showToast('修复失败：' + err.message); });
+        };
+        document.getElementById('cacheImportBtn').onclick = function () {
+          var nameEl = document.getElementById('cacheImportName');
+          var fileEl = document.getElementById('cacheImportFile');
+          var statusEl = document.getElementById('cacheImportStatus');
+          var name = (nameEl.value || '').trim();
+          if (!name) { showToast('请先填缓存名称'); return; }
+          if (!fileEl.files[0]) { showToast('请选 tar.gz 文件'); return; }
+          statusEl.textContent = '上传中…';
+          fetch('/api/cache/import?name=' + encodeURIComponent(name), {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/gzip' },
+            body: fileEl.files[0],
+          })
+            .then(function (r) { return r.json().then(function (b) { return { ok: r.ok, body: b }; }); })
+            .then(function (r) {
+              if (!r.ok) throw new Error(r.body.error || '导入失败');
+              statusEl.textContent = '✓ ' + r.body.message + '（' + r.body.sizeBytesHuman + ', ' + r.body.fileCount + ' 文件）';
+              setTimeout(renderCacheTab, 600);
+            })
+            .catch(function (err) { statusEl.textContent = '✗ ' + err.message; });
+        };
+      })
+      .catch(function (err) {
+        var el = document.getElementById('cacheDiagBody');
+        if (el) el.innerHTML = '<div style="color:var(--red)">加载失败：' + escapeHtml(err.message) + '</div>';
+      });
+  }
+
+  window._cacheExport = function (name) {
+    window.location.href = '/api/cache/export?name=' + encodeURIComponent(name);
+  };
+  window._cachePurge = function (name) {
+    if (!confirm('清空缓存 "' + name + '"？下次 restore / install 会从头下载。此操作不可撤销。')) return;
+    fetch('/api/cache/purge?name=' + encodeURIComponent(name), { method: 'POST', credentials: 'same-origin' })
+      .then(function (r) { return r.json().then(function (b) { return { ok: r.ok, body: b }; }); })
+      .then(function (r) {
+        if (!r.ok) throw new Error(r.body.error || '清空失败');
+        showToast(r.body.message || '已清空');
+        setTimeout(renderCacheTab, 400);
+      })
+      .catch(function (err) { showToast('清空失败：' + err.message); });
+  };
 
   // ── Init ──
   loadProject()

--- a/cds/web/snapshot-modal.js
+++ b/cds/web/snapshot-modal.js
@@ -1,0 +1,296 @@
+/**
+ * 历史版本 & 紧急还原面板
+ *
+ * 一个 modal 两个 tab：
+ *   - 配置历史：列出 ConfigSnapshot，每条带「回滚」按钮
+ *   - 最近操作：列出 DestructiveOperationLog，30 分钟内可「撤销」
+ *
+ * 用户故事：用户导入了污染配置 → 打开面板 → 看到"导入前"快照 → 点回滚 → 秒复原。
+ *          用户不小心点了 replace-all 导入 → 打开面板 → 看到"最近操作" → 点撤销。
+ */
+(function () {
+  var modal = null;
+  var currentTab = 'snapshots';
+
+  function escapeHtml(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+
+  function humanSize(b) {
+    if (b == null) return '—';
+    if (b < 1024) return b + ' B';
+    if (b < 1024 * 1024) return (b / 1024).toFixed(1) + ' KB';
+    return (b / 1024 / 1024).toFixed(1) + ' MB';
+  }
+
+  function triggerLabel(t) {
+    return {
+      'pre-import': '导入前',
+      'pre-destructive': '破坏性操作前',
+      'manual': '手动保存',
+      'scheduled': '定时备份',
+    }[t] || t;
+  }
+
+  function triggerColor(t) {
+    return {
+      'pre-import': '#3b82f6',
+      'pre-destructive': '#ef4444',
+      'manual': '#22c55e',
+      'scheduled': '#a855f7',
+    }[t] || '#999';
+  }
+
+  function opTypeLabel(t) {
+    return {
+      'import-replace-all': 'replace-all 导入',
+      'factory-reset': '恢复出厂',
+      'delete-project': '删除项目',
+      'purge-branch': '清空分支',
+      'purge-database': '清空数据库',
+      'other': '其他',
+    }[t] || t;
+  }
+
+  function renderSnapshots(body) {
+    body.innerHTML = '<div style="padding:40px;text-align:center;color:var(--text-muted)">加载中…</div>';
+    fetch('/api/config-snapshots', { credentials: 'same-origin' })
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        var list = data.snapshots || [];
+        if (list.length === 0) {
+          body.innerHTML = '<div style="padding:40px;text-align:center;color:var(--text-muted)">' +
+            '<div style="font-size:40px;margin-bottom:10px">📦</div>' +
+            '还没有配置快照。<br>下次 <code>POST /import-config</code> 时会自动拍一份，' +
+            '也可以 <button id="snapshotManualBtn" class="settings-btn settings-btn-sm" style="margin-top:8px">手动保存当前配置</button>' +
+          '</div>';
+          var btn = document.getElementById('snapshotManualBtn');
+          if (btn) btn.onclick = manualSave;
+          return;
+        }
+        var html = '<div style="padding:12px 16px;display:flex;justify-content:space-between;align-items:center;border-bottom:1px solid var(--border-subtle)">' +
+          '<span style="color:var(--text-muted);font-size:12px">' + list.length + ' 条 · 保留最近 ' + (data.limit || 30) + ' 条</span>' +
+          '<button id="snapshotManualBtn" class="settings-btn settings-btn-sm">💾 手动保存当前配置</button>' +
+        '</div>';
+        list.forEach(function (s) {
+          var color = triggerColor(s.trigger);
+          html += '<div style="padding:12px 16px;border-bottom:1px solid var(--border-subtle);display:flex;gap:12px;align-items:flex-start">' +
+            '<div style="flex:1;min-width:0">' +
+              '<div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:4px">' +
+                '<span style="padding:2px 8px;background:' + color + '22;color:' + color + ';font-size:11px;border-radius:4px;font-weight:600">' + triggerLabel(s.trigger) + '</span>' +
+                '<span style="font-weight:600">' + escapeHtml(s.label) + '</span>' +
+              '</div>' +
+              '<div style="color:var(--text-muted);font-size:12px">' +
+                escapeHtml(new Date(s.createdAt).toLocaleString('zh-CN')) + ' · ' +
+                humanSize(s.sizeBytes) + ' · ' +
+                s.counts.buildProfiles + ' profile · ' +
+                s.counts.infraServices + ' infra · ' +
+                s.counts.routingRules + ' 规则 · ' +
+                s.counts.envVarScopes + ' env scope' +
+              '</div>' +
+            '</div>' +
+            '<div style="display:flex;gap:6px;flex-shrink:0">' +
+              '<button class="settings-btn settings-btn-sm" onclick="window._snapshotView(\'' + escapeHtml(s.id) + '\')">查看</button>' +
+              '<button class="settings-btn settings-btn-sm" onclick="window._snapshotRollback(\'' + escapeHtml(s.id) + '\', \'' + escapeHtml(s.label.replace(/\\/g, '\\\\').replace(/'/g, "\\'")) + '\')" style="color:#3b82f6">↩ 回滚</button>' +
+              '<button class="settings-btn settings-btn-sm" onclick="window._snapshotDelete(\'' + escapeHtml(s.id) + '\')" style="color:#ef4444">✕</button>' +
+            '</div>' +
+          '</div>';
+        });
+        body.innerHTML = html;
+        var mbtn = document.getElementById('snapshotManualBtn');
+        if (mbtn) mbtn.onclick = manualSave;
+      })
+      .catch(function (err) {
+        body.innerHTML = '<div style="padding:20px;color:#ef4444">加载快照列表失败：' + escapeHtml(err.message) + '</div>';
+      });
+  }
+
+  function renderDestructiveOps(body) {
+    body.innerHTML = '<div style="padding:40px;text-align:center;color:var(--text-muted)">加载中…</div>';
+    fetch('/api/destructive-ops', { credentials: 'same-origin' })
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        var ops = data.ops || [];
+        if (ops.length === 0) {
+          body.innerHTML = '<div style="padding:40px;text-align:center;color:var(--text-muted)">' +
+            '<div style="font-size:40px;margin-bottom:10px">🛡</div>' +
+            '暂无破坏性操作记录。<br>这里会出现：replace-all 导入、清空分支、清空数据库、恢复出厂、删除项目等操作。' +
+          '</div>';
+          return;
+        }
+        var html = '<div style="padding:12px 16px;color:var(--text-muted);font-size:12px;border-bottom:1px solid var(--border-subtle)">' +
+          ops.length + ' 条 · 30 分钟内可撤销' +
+        '</div>';
+        ops.forEach(function (op) {
+          var age = Date.now() - new Date(op.at).getTime();
+          var ageMin = Math.floor(age / 60000);
+          var ageStr = ageMin < 1 ? '刚刚' : (ageMin < 60 ? ageMin + ' 分钟前' : Math.floor(ageMin / 60) + ' 小时前');
+          var done = op.undoneAt ? ' (已撤销)' : '';
+          html += '<div style="padding:12px 16px;border-bottom:1px solid var(--border-subtle);display:flex;gap:12px;align-items:flex-start' + (op.undoneAt ? ';opacity:0.5' : '') + '">' +
+            '<div style="flex:1;min-width:0">' +
+              '<div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:4px">' +
+                '<span style="padding:2px 8px;background:#ef444422;color:#ef4444;font-size:11px;border-radius:4px;font-weight:600">' + opTypeLabel(op.type) + '</span>' +
+                '<span style="font-weight:600">' + escapeHtml(op.summary) + escapeHtml(done) + '</span>' +
+              '</div>' +
+              '<div style="color:var(--text-muted);font-size:12px">' +
+                escapeHtml(ageStr) + ' · ' + escapeHtml(new Date(op.at).toLocaleString('zh-CN')) +
+                (op.triggeredBy ? ' · by ' + escapeHtml(op.triggeredBy) : '') +
+                (op.snapshotId ? ' · 📦 已关联快照' : ' · <span style="color:#f59e0b">⚠ 无快照</span>') +
+              '</div>' +
+            '</div>' +
+            '<div style="flex-shrink:0">' +
+              (op.canUndo
+                ? '<button class="settings-btn settings-btn-sm" onclick="window._opUndo(\'' + escapeHtml(op.id) + '\')" style="color:#3b82f6">↩ 撤销</button>'
+                : '<span style="color:var(--text-muted);font-size:11px">已过期</span>'
+              ) +
+            '</div>' +
+          '</div>';
+        });
+        body.innerHTML = html;
+      })
+      .catch(function (err) {
+        body.innerHTML = '<div style="padding:20px;color:#ef4444">加载失败：' + escapeHtml(err.message) + '</div>';
+      });
+  }
+
+  function manualSave() {
+    var label = prompt('给这份快照起个名字（可选）：', '手动保存 · ' + new Date().toLocaleString('zh-CN'));
+    if (label === null) return;
+    fetch('/api/config-snapshots', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin',
+      body: JSON.stringify({ label: label.trim() || undefined }),
+    })
+      .then(function (r) { return r.json().then(function (b) { return { ok: r.ok, body: b }; }); })
+      .then(function (r) {
+        if (!r.ok) throw new Error(r.body.error || '保存失败');
+        renderActive();
+      })
+      .catch(function (err) { alert('保存失败：' + err.message); });
+  }
+
+  window._snapshotView = function (id) {
+    fetch('/api/config-snapshots/' + encodeURIComponent(id), { credentials: 'same-origin' })
+      .then(function (r) { return r.json(); })
+      .then(function (s) {
+        var w = window.open('', '_blank');
+        w.document.write('<pre style="padding:20px;font-family:monospace;white-space:pre-wrap;word-break:break-all">' +
+          escapeHtml(JSON.stringify(s, null, 2)) + '</pre>');
+      });
+  };
+
+  window._snapshotRollback = function (id, label) {
+    if (!confirm('回滚到「' + label + '」？\n\n这会用该快照覆盖当前的 buildProfiles / envVars / infraServices / routingRules。\n回滚前会自动再拍一份当前状态，便于再改回来。\n\n分支和数据库不会被触碰。')) return;
+    fetch('/api/config-snapshots/' + encodeURIComponent(id) + '/rollback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin',
+      body: '{}',
+    })
+      .then(function (r) { return r.json().then(function (b) { return { ok: r.ok, body: b }; }); })
+      .then(function (r) {
+        if (!r.ok) throw new Error(r.body.error || '回滚失败');
+        alert(r.body.message || '回滚完成');
+        renderActive();
+      })
+      .catch(function (err) { alert('回滚失败：' + err.message); });
+  };
+
+  window._snapshotDelete = function (id) {
+    if (!confirm('删除这份快照？此操作不可撤销。')) return;
+    fetch('/api/config-snapshots/' + encodeURIComponent(id), {
+      method: 'DELETE',
+      credentials: 'same-origin',
+    })
+      .then(function (r) { return r.json().then(function (b) { return { ok: r.ok, body: b }; }); })
+      .then(function (r) {
+        if (!r.ok) throw new Error(r.body.error || '删除失败');
+        renderActive();
+      })
+      .catch(function (err) { alert('删除失败：' + err.message); });
+  };
+
+  window._opUndo = function (id) {
+    if (!confirm('撤销这次破坏性操作？\n\n会通过回滚对应快照把配置恢复到操作前的状态。')) return;
+    fetch('/api/destructive-ops/' + encodeURIComponent(id) + '/undo', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin',
+      body: '{}',
+    })
+      .then(function (r) { return r.json().then(function (b) { return { ok: r.ok, body: b }; }); })
+      .then(function (r) {
+        if (!r.ok) throw new Error(r.body.error || '撤销失败');
+        alert(r.body.message || '撤销成功');
+        renderActive();
+      })
+      .catch(function (err) { alert('撤销失败：' + err.message); });
+  };
+
+  function renderActive() {
+    if (!modal) return;
+    var body = modal.querySelector('#historyBody');
+    if (!body) return;
+    if (currentTab === 'snapshots') renderSnapshots(body);
+    else renderDestructiveOps(body);
+  }
+
+  function setTab(tab) {
+    currentTab = tab;
+    if (!modal) return;
+    modal.querySelectorAll('.history-tab').forEach(function (el) {
+      var on = el.dataset.tab === tab;
+      el.style.borderBottomColor = on ? 'var(--accent, #3b82f6)' : 'transparent';
+      el.style.color = on ? 'var(--text-primary)' : 'var(--text-muted)';
+    });
+    renderActive();
+  }
+
+  function openModal() {
+    if (modal) return;
+    modal = document.createElement('div');
+    modal.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,0.6);z-index:10000;display:flex;align-items:center;justify-content:center;padding:20px';
+    modal.onclick = function (e) { if (e.target === modal) closeModal(); };
+
+    var box = document.createElement('div');
+    box.style.cssText = 'background:var(--bg-card);color:var(--text-primary);border:1px solid var(--border-subtle);border-radius:10px;width:min(100%, 880px);height:min(100%, 680px);display:flex;flex-direction:column;min-height:0';
+    box.onclick = function (e) { e.stopPropagation(); };
+
+    box.innerHTML =
+      '<div style="padding:12px 18px;border-bottom:1px solid var(--border-subtle);display:flex;gap:16px;align-items:center;flex-shrink:0">' +
+        '<div style="font-weight:600;font-size:14px">🕐 历史版本 & 紧急还原</div>' +
+        '<button class="history-tab" data-tab="snapshots" style="background:none;border:none;border-bottom:2px solid transparent;padding:8px 4px;cursor:pointer;color:var(--text-primary);font-size:13px">配置历史</button>' +
+        '<button class="history-tab" data-tab="ops" style="background:none;border:none;border-bottom:2px solid transparent;padding:8px 4px;cursor:pointer;color:var(--text-muted);font-size:13px">最近破坏性操作</button>' +
+        '<div style="flex:1"></div>' +
+        '<button id="historyCloseBtn" class="icon-btn sm" title="关闭">✕</button>' +
+      '</div>' +
+      '<div id="historyBody" style="flex:1;min-height:0;overflow-y:auto"></div>';
+
+    modal.appendChild(box);
+    document.body.appendChild(modal);
+
+    box.querySelector('#historyCloseBtn').onclick = closeModal;
+    modal.querySelectorAll('.history-tab').forEach(function (el) {
+      el.onclick = function () { setTab(el.dataset.tab); };
+    });
+
+    setTab(currentTab);
+    document.addEventListener('keydown', onKeydown);
+  }
+
+  function onKeydown(e) { if (e.key === 'Escape') closeModal(); }
+
+  function closeModal() {
+    if (modal && modal.parentNode) modal.parentNode.removeChild(modal);
+    modal = null;
+    document.removeEventListener('keydown', onKeydown);
+  }
+
+  window.openHistoryModal = openModal;
+  window.closeHistoryModal = closeModal;
+  // 顶部菜单 "历史/撤销" 直接切到 ops tab
+  window.openHistoryModalOnOps = function () { currentTab = 'ops'; openModal(); };
+})();

--- a/cds/web/style.css
+++ b/cds/web/style.css
@@ -2132,6 +2132,47 @@ a.branch-name:hover { color: var(--accent); }
 .deploy-menu-item-danger { color: var(--red); }
 .deploy-menu-item-danger:hover { background: var(--red-bg); }
 
+/* 2026-04-22 二级菜单（某服务 hover 展开部署/清理/核验/编辑命令） */
+.deploy-submenu-anchor {
+  display: flex; align-items: center; gap: 6px; position: relative;
+}
+.deploy-submenu {
+  position: absolute;
+  left: 100%; top: -6px;
+  min-width: 240px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 8px 30px rgba(0,0,0,0.35);
+  padding: 4px 0;
+  display: none;
+  z-index: 10001;
+  margin-left: 4px;
+}
+.deploy-submenu-anchor:hover > .deploy-submenu,
+.deploy-submenu-anchor:focus-within > .deploy-submenu { display: block; }
+.deploy-submenu-header {
+  padding: 6px 10px; font-size: 10px; color: var(--text-muted);
+  font-weight: 600; letter-spacing: 0.04em;
+}
+.deploy-submenu-item {
+  padding: 8px 10px; font-size: 12px; cursor: pointer;
+  color: var(--text-primary);
+  display: flex; align-items: center; gap: 6px;
+  transition: background var(--transition);
+}
+.deploy-submenu-item:hover { background: var(--bg-hover); }
+.deploy-submenu-divider { height: 1px; background: var(--border); margin: 4px 0; }
+/* 屏幕太窄时降级：子菜单翻到左侧（避免右侧被裁） */
+@media (max-width: 820px) {
+  .deploy-submenu { left: auto; right: 100%; margin-left: 0; margin-right: 4px; }
+}
+/* 触屏：没 hover → 改用 .open 类（由 JS tap 触发） */
+@media (hover: none) {
+  .deploy-submenu-anchor:hover > .deploy-submenu { display: none; }
+  .deploy-submenu-anchor.open > .deploy-submenu { display: block; }
+}
+
 /* ── Settings dropdown menu ── */
 .settings-menu {
   position: fixed;

--- a/changelogs/2026-04-22_cds-2level-menu-custom-cmd.md
+++ b/changelogs/2026-04-22_cds-2level-menu-custom-cmd.md
@@ -1,0 +1,3 @@
+| feat | cds | 新增 dotnet-run 热更新模式（增量+快）作 .NET 默认；dotnet-restart 降为疑难兜底 |
+| feat | cds | deploy 下拉改二级菜单：按服务分组 + 每服务 hover 展开（部署/清理/核验/编辑命令） |
+| feat | cds | 新增「⚙ 构建命令」编辑面板：用户自定义每个 profile 的多个 deployMode 命令，带预设模板（dotnet run / publish / pnpm dev） |

--- a/changelogs/2026-04-22_cds-backup-cache-hotreload.md
+++ b/changelogs/2026-04-22_cds-backup-cache-hotreload.md
@@ -1,0 +1,11 @@
+| feat | prd-api | Dockerfile 改用 BuildKit cache mount（NuGet + pnpm），restore 换服务器后也能秒级复用 |
+| feat | cds | 新增缓存诊断/修复/跨服务器迁移（Settings → 缓存诊断） |
+| fix | cds | migrateCacheMounts 现在合并缺失的 NuGet/pnpm 挂载（老的 skip-if-any 逻辑会让混合 profile 永远拿不到 nuget） |
+| feat | cds | 顶部新增 🔍 全局转发日志面板，专门排查「页面正常但 API 502 没日志」 |
+| feat | cds | 新增配置快照系统 —— 每次 import-config 前自动拍 + 手动拍 + 一键回滚 |
+| feat | cds | 新增破坏性操作审计 + 30 分钟内撤销窗口（顶部 🕐 按钮） |
+| feat | cds | /api/import-config 新增 cleanMode (merge/replace-all) + branchPolicy (keep/restart-all/clean) |
+| feat | cds | 数据库一键备份下载 + 上传恢复（mongodump / redis BGSAVE / tar） |
+| feat | cds | BuildProfile.hotReload：容器里跑 dotnet watch / pnpm dev，改代码自动重编译不重启 |
+| feat | cds | 遗留 default 项目迁移：banner 提醒 + /api/legacy-cleanup/rename-default |
+| fix | cds | 新建项目禁止使用 id='default'（保留给迁移占位） |

--- a/changelogs/2026-04-22_cds-dotnet-restart-diag.md
+++ b/changelogs/2026-04-22_cds-dotnet-restart-diag.md
@@ -1,0 +1,4 @@
+| feat | cds | 热更新新增 dotnet-restart 模式：kill+clean+no-incremental+重跑，对付 MSBuild 增量误判 |
+| fix | cds | .NET profile 启用热更新默认用 dotnet-restart（watch 改为「不推荐」可选项） |
+| feat | cds | 新增「💥 强制干净重建」：停容器 + rm -rf bin/obj，破除文件系统缓存 |
+| feat | cds | 新增「🔍 运行时字节码核验」：比对源码/DLL/进程启动时间，诊断是否在跑老字节码 |

--- a/changelogs/2026-04-22_cds-end-ai-global-cmd.md
+++ b/changelogs/2026-04-22_cds-end-ai-global-cmd.md
@@ -1,0 +1,3 @@
+| feat | cds | AI 操控指示器加「✕ 结束」按钮，一点即调 /api/bridge/end-session 结束 Bridge session |
+| feat | cds | 新增「🔧 全局构建命令」面板：按镜像类型(.NET/Node/Python/手选)批量覆盖所有 profile 的 deployModes |
+| feat | cds | POST /api/build-profiles/bulk-set-modes 后端：merge/replace 策略 + 自动拍 ConfigSnapshot 便于回滚 |

--- a/prd-api/Dockerfile
+++ b/prd-api/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.4
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 # 安装 Node.js 20 + pnpm + 系统 Chromium（供 Remotion 分镜预览渲染用）
 # 系统 Chromium 可避免 Remotion 在 read-only 容器内自行下载 Chromium 时因写不进
@@ -15,21 +16,28 @@ EXPOSE 80
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
+COPY ["PrdAgent.sln", "./"]
 COPY ["src/PrdAgent.Api/PrdAgent.Api.csproj", "src/PrdAgent.Api/"]
 COPY ["src/PrdAgent.Core/PrdAgent.Core.csproj", "src/PrdAgent.Core/"]
 COPY ["src/PrdAgent.Infrastructure/PrdAgent.Infrastructure.csproj", "src/PrdAgent.Infrastructure/"]
-RUN dotnet restore "src/PrdAgent.Api/PrdAgent.Api.csproj"
+COPY ["tests/PrdAgent.Api.Tests/PrdAgent.Api.Tests.csproj", "tests/PrdAgent.Api.Tests/"]
+# BuildKit cache mount：NuGet 包跨 build 复用，避免换服务器 / 清 docker layer 后重新下载全量包
+RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
+    dotnet restore PrdAgent.sln
 COPY . .
 WORKDIR "/src/src/PrdAgent.Api"
 # publish 会自动 build：避免 build + publish 双编译；并复用上一步 restore 的缓存
-RUN dotnet publish "PrdAgent.Api.csproj" -c Release -o /app/publish /p:UseAppHost=false --no-restore
+RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
+    dotnet publish "PrdAgent.Api.csproj" -c Release -o /app/publish /p:UseAppHost=false --no-restore
 
 # 安装 prd-video 依赖（独立 stage；通过 --build-context video=./prd-video 注入，不污染 dotnet 缓存）
 FROM node:20-slim AS video-deps
 WORKDIR /prd-video
 # "video" 是构建时通过 --build-context video=./prd-video 传入的命名上下文
 COPY --from=video package.json pnpm-lock.yaml ./
-RUN npm install -g pnpm && pnpm install --frozen-lockfile
+# BuildKit cache mount：pnpm store 跨 build 复用
+RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
+    npm install -g pnpm && pnpm install --frozen-lockfile
 
 FROM base AS final
 WORKDIR /app

--- a/prd-api/Dockerfile.build
+++ b/prd-api/Dockerfile.build
@@ -1,7 +1,8 @@
 # 专门用于编译后台代码的 Docker 镜像
 # 使用方式：
-#   docker build -f Dockerfile.build -t prdagent-build --target build --output ./output .
+#   DOCKER_BUILDKIT=1 docker build -f Dockerfile.build -t prdagent-build --target build --output ./output .
 #   产物将输出到 ./output 目录
+# syntax=docker/dockerfile:1.4
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
 WORKDIR /src
@@ -11,25 +12,23 @@ COPY ["PrdAgent.sln", "."]
 COPY ["src/PrdAgent.Api/PrdAgent.Api.csproj", "src/PrdAgent.Api/"]
 COPY ["src/PrdAgent.Core/PrdAgent.Core.csproj", "src/PrdAgent.Core/"]
 COPY ["src/PrdAgent.Infrastructure/PrdAgent.Infrastructure.csproj", "src/PrdAgent.Infrastructure/"]
+COPY ["tests/PrdAgent.Api.Tests/PrdAgent.Api.Tests.csproj", "tests/PrdAgent.Api.Tests/"]
 
-# 如果有测试项目，也拷贝
-COPY ["tests/PrdAgent.Tests/PrdAgent.Tests.csproj", "tests/PrdAgent.Tests/"] 2>/dev/null || true
-
-# 恢复依赖（利用缓存）
-RUN dotnet restore PrdAgent.sln
+# 恢复依赖：使用 BuildKit cache mount，NuGet 包跨 build 复用（换服务器只首次冷下载一次）
+RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
+    dotnet restore PrdAgent.sln
 
 # 拷贝所有源码
 COPY . .
 
-# 编译解决方案
-RUN dotnet build PrdAgent.sln -c Release --no-restore
-
-# 运行测试（可选）
-# RUN dotnet test PrdAgent.sln -c Release --no-build --verbosity normal
+# 编译解决方案（复用 restore 缓存）
+RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
+    dotnet build PrdAgent.sln -c Release --no-restore
 
 # 发布 API 项目
 WORKDIR "/src/src/PrdAgent.Api"
-RUN dotnet publish "PrdAgent.Api.csproj" -c Release -o /app/publish /p:UseAppHost=false --no-restore
+RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
+    dotnet publish "PrdAgent.Api.csproj" -c Release -o /app/publish /p:UseAppHost=false --no-restore
 
 # 编译产物在 /app/publish 目录中
 # 使用 --output 参数将产物导出到宿主机

--- a/scripts/build-server-docker.sh
+++ b/scripts/build-server-docker.sh
@@ -17,8 +17,8 @@ echo "Output directory: $OUTPUT_DIR"
 # 清理旧的输出目录
 rm -rf "$OUTPUT_DIR"
 
-# 使用 Docker 构建并输出产物
-docker build \
+# 使用 Docker 构建并输出产物（BuildKit 必须启用，否则 Dockerfile 里的 cache mount 不生效 → NuGet 每次重下）
+DOCKER_BUILDKIT=1 docker build \
   -f Dockerfile.build \
   -t prdagent-build:local \
   --target build \


### PR DESCRIPTION
## Summary

This PR introduces comprehensive infrastructure improvements for CDS, focusing on cache management, configuration snapshots with rollback, hot-reload support for development, and bulk command configuration. These changes address user pain points around cache invalidation, accidental configuration pollution, and repetitive per-profile command setup.

## Key Changes

### Cache Management & Diagnostics
- **New cache router** (`cds/src/routes/cache.ts`): Provides `/api/cache/status` for diagnosing cache mount issues, `/api/cache/repair` for fixing missing mounts, and `/api/cache/export`/`import` for migrating pre-warmed caches between servers
- **Cache settings tab** (`cds/web/settings.js`): UI for viewing cache directory sizes, file counts, and last-modified timestamps; identifies orphaned cache directories
- **Improved cache mount migration** (`cds/src/services/state.ts`): Changed from skip-if-exists to merge semantics—now supplements missing cache types (nuget/pnpm) even if profile already has some mounts

### Configuration Snapshots & Rollback
- **New snapshots router** (`cds/src/routes/snapshots.ts`): Implements ConfigSnapshot and DestructiveOperationLog endpoints for listing, creating, and rolling back configuration states
- **Snapshot modal UI** (`cds/web/snapshot-modal.js`): Two-tab interface showing configuration history with rollback buttons and recent destructive operations with undo capability (30-minute window)
- **Auto-snapshot on destructive ops**: Bulk imports and dangerous operations automatically create snapshots before execution

### Hot-Reload Development Mode
- **HotReloadConfig type** (`cds/src/types.ts`): New configuration structure with three modes:
  - `dotnet-run`: Fast path using MSBuild incremental compilation (new default for .NET)
  - `dotnet-restart`: Reliable fallback with clean + no-incremental + process restart
  - `dotnet-watch`: Legacy mode (no longer recommended)
- **Hot-reload command resolution** (`cds/src/services/container.ts`): Generates appropriate watcher commands (dotnet watch, pnpm dev, vite, etc.) based on profile type and mode
- **Hot-reload endpoint** (`cds/src/routes/branches.ts`): POST `/api/build-profiles/:id/hot-reload` for toggling and configuring hot-reload per profile

### Bulk Command Management
- **Global command panel** (`cds/web/global-cmd-modal.js`): New UI for batch-setting deploy modes across profiles filtered by image type (all/.NET/Node/Python/custom regex)
- **Bulk set modes endpoint** (`cds/src/routes/branches.ts`): POST `/api/build-profiles/bulk-set-modes` with replace/merge strategies; auto-snapshots before applying
- **Two-level deploy menu** (`cds/web/app.js`): Restructured deploy dropdown from flat list to hierarchical: services as primary items with hover-expanded submenus showing modes, cleanup, verify, and edit commands

### Infrastructure Backup & Recovery
- **Infra backup router** (`cds/src/routes/infra-backup.ts`): Endpoints for backing up MongoDB (mongodump), Redis (BGSAVE), and generic services (tar); streaming download support
- **Infra restore endpoint**: Upload and restore from backup files with automatic container restart

### Legacy Project Migration
- **Legacy cleanup router** (`cds/src/routes/legacy-cleanup.ts`): Provides status check and controlled migration of the historical `default` project to user-specified ID, updating all references across branches, profiles, infra services, and worktree directories

### Proxy Logging
- **ProxyLogEvent interface** (`cds/src/services/proxy.ts`): Ring buffer of 500 recent proxy events with detailed diagnostics (outcome classification, error codes, upstream URLs)
- **Proxy log modal UI** (`cds/web/proxy-log-modal.js`): Real-time SSE-based viewer for debugging 502 errors and routing issues

### UI/UX Enhancements
- **Settings tabs**: Added cache diagnostics tab to project settings
- **

https://claude.ai/code/session_01Bmt9zkDbQP9qkRdX8WAoMv

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it adds multiple new admin APIs and mutates persisted state (`configSnapshots`, `destructiveOps`, `replace-all` imports) plus introduces database restore and container-affecting actions (stop/cleanup/rebuild), any of which can cause data/config loss or service disruption if misused or buggy.
> 
> **Overview**
> Adds several new operational/admin capabilities to CDS: **cache diagnostics/repair and cache export/import**, **configuration snapshots with rollback plus a 30‑minute destructive-op undo log**, **proxy-level request logging with SSE**, **infra data backup/restore** (Mongo/Redis/generic), and **legacy `default` project migration**.
> 
> Build/deploy tooling is expanded with **bulk deploy-mode updates across build profiles** (merge/replace with auto-snapshot), a **reworked two-level deploy menu**, and **per-profile hot-reload** (new `HotReloadConfig` and container command resolution), plus new branch tools to **force clean rebuild** (wipe `bin/obj`) and **verify runtime bytecode freshness**. The `import-config` endpoint now supports `cleanMode` (`merge`/`replace-all`) and records snapshots/audit info, and project creation now blocks `slug='default'`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b06c3ceb47032f29abf5ae209bca9d5a3dc60514. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->