### PR TITLE
Fix Docker build failure by restoring only API project

### DIFF
--- a/changelogs/2026-04-23_dockerfile-test-copy-fix.md
+++ b/changelogs/2026-04-23_dockerfile-test-copy-fix.md
@@ -1,0 +1,1 @@
+| fix | prd-api | 修复 Docker 镜像构建失败 — Dockerfile 之前 COPY `tests/PrdAgent.Api.Tests/PrdAgent.Api.Tests.csproj` 并 restore 整个 sln，但 `.dockerignore` 排除了 `**/tests`，导致 CI `Build & Push Docker Image` 长期失败；改为仅 restore API 项目（测试不需要进生产镜像） |

--- a/prd-api/Dockerfile
+++ b/prd-api/Dockerfile
@@ -16,14 +16,13 @@ EXPOSE 80
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
-COPY ["PrdAgent.sln", "./"]
 COPY ["src/PrdAgent.Api/PrdAgent.Api.csproj", "src/PrdAgent.Api/"]
 COPY ["src/PrdAgent.Core/PrdAgent.Core.csproj", "src/PrdAgent.Core/"]
 COPY ["src/PrdAgent.Infrastructure/PrdAgent.Infrastructure.csproj", "src/PrdAgent.Infrastructure/"]
-COPY ["tests/PrdAgent.Api.Tests/PrdAgent.Api.Tests.csproj", "tests/PrdAgent.Api.Tests/"]
+# 仅 restore API 项目：测试项目被 .dockerignore 排除，不进入生产镜像
 # BuildKit cache mount：NuGet 包跨 build 复用，避免换服务器 / 清 docker layer 后重新下载全量包
 RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
-    dotnet restore PrdAgent.sln
+    dotnet restore "src/PrdAgent.Api/PrdAgent.Api.csproj"
 COPY . .
 WORKDIR "/src/src/PrdAgent.Api"
 # publish 会自动 build：避免 build + publish 双编译；并复用上一步 restore 的缓存


### PR DESCRIPTION
## Summary
Fixed a Docker build failure in the prd-api Dockerfile caused by attempting to copy and restore test projects that are excluded by `.dockerignore`.

## Key Changes
- Removed `PrdAgent.sln` from COPY statement (no longer needed for selective restore)
- Removed the COPY instruction for `tests/PrdAgent.Api.Tests/PrdAgent.Api.Tests.csproj` 
- Changed `dotnet restore` to target only `src/PrdAgent.Api/PrdAgent.Api.csproj` instead of the entire solution
- Added clarifying comment explaining that test projects are excluded and not needed in production image

## Implementation Details
The build was failing because the Dockerfile attempted to copy test project files and restore the entire solution, but `.dockerignore` was configured to exclude all `**/tests` directories. This mismatch caused the restore step to fail.

Since test projects are not needed in the production Docker image, the fix optimizes the build by:
- Restoring only the API project and its dependencies
- Avoiding unnecessary file copy operations for excluded test files
- Maintaining the BuildKit cache mount for efficient NuGet package caching across builds

https://claude.ai/code/session_011EMKt1aGPjMZb696vgh3gT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes Docker build steps to restore/publish the API project and should not affect runtime behavior, but could impact build caching or dependency restore if the API relied on solution-level restore behavior.
> 
> **Overview**
> **Fixes CI Docker build failures for `prd-api`.** The Dockerfile no longer copies `PrdAgent.sln` or the test project and switches `dotnet restore` from the full solution to `src/PrdAgent.Api/PrdAgent.Api.csproj`, aligning with tests being excluded from the Docker build context.
> 
> Adds a changelog entry documenting the root cause (`.dockerignore` excluding `**/tests`) and the production-image intent (tests not included).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1def75c729140d34957f46cef3fca64f5e4e6420. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->