### PR TITLE
fix(prd-api): 修复 Server Deploy NuGet 缓存缺包

### DIFF
--- a/changelogs/2026-04-26_server-deploy-nuget-cache.md
+++ b/changelogs/2026-04-26_server-deploy-nuget-cache.md
@@ -1,0 +1,1 @@
+| fix | prd-api | 修复 Server Deploy 镜像构建因 NuGet cache mount 缺包导致 publish 失败 |

--- a/prd-api/Dockerfile
+++ b/prd-api/Dockerfile
@@ -25,8 +25,9 @@ RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
     dotnet restore "src/PrdAgent.Api/PrdAgent.Api.csproj"
 COPY . .
 WORKDIR "/src/src/PrdAgent.Api"
-# publish 会自动 build：避免 build + publish 双编译；并复用上一步 restore 的缓存
+# publish 会自动 build：避免 build + publish 双编译；二次 restore 防止 BuildKit 复用 restore 层但 NuGet cache mount 缺包
 RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
+    dotnet restore "PrdAgent.Api.csproj" && \
     dotnet publish "PrdAgent.Api.csproj" -c Release -o /app/publish /p:UseAppHost=false --no-restore
 
 # 安装 prd-video 依赖（独立 stage；通过 --build-context video=./prd-video 注入，不污染 dotnet 缓存）

--- a/prd-api/Dockerfile.build
+++ b/prd-api/Dockerfile.build
@@ -28,6 +28,7 @@ RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
 # 发布 API 项目
 WORKDIR "/src/src/PrdAgent.Api"
 RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
+    dotnet restore "PrdAgent.Api.csproj" && \
     dotnet publish "PrdAgent.Api.csproj" -c Release -o /app/publish /p:UseAppHost=false --no-restore
 
 # 编译产物在 /app/publish 目录中


### PR DESCRIPTION
Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> 变更仅影响 Docker 构建流程：在 `publish` 前增加一次 `dotnet restore`，可能轻微增加构建时间但不改变运行时代码逻辑。风险主要在于构建缓存/层复用行为变化。
> 
> **Overview**
> 修复 Server Deploy 在使用 BuildKit `--mount=type=cache` 复用 NuGet 包时，因 cache mount 偶发缺包导致 `dotnet publish` 失败的问题。
> 
> 在 `prd-api/Dockerfile` 与 `prd-api/Dockerfile.build` 的发布阶段增加一次针对 `PrdAgent.Api.csproj` 的二次 `dotnet restore`（随后仍以 `--no-restore` 进行 `publish`），并补充对应变更日志。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf1edc7e43db3d65e282bf85798d7203cf76f57a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->