### PR TITLE
Fix document store preview starvation issue

### DIFF
--- a/changelogs/2026-04-27_document-store-recent-entries-starvation.md
+++ b/changelogs/2026-04-27_document-store-recent-entries-starvation.md
@@ -1,0 +1,1 @@
+| fix | prd-api | 修复知识库卡片"暂无内容"与 documentCount 不一致：recentEntries 改为按 store 维度独立查询，避免单次全局 sort+limit 导致活跃度低的 store 被抢占额度 |

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/DocumentStoreController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/DocumentStoreController.cs
@@ -1239,24 +1239,7 @@ public class DocumentStoreController : ControllerBase
 
         // 批量获取每个空间的最近 3 个文档（用于卡片预览）
         var storeIds = stores.Select(s => s.Id).ToList();
-        var recentEntries = await _db.DocumentEntries
-            .Find(Builders<DocumentEntry>.Filter.And(
-                Builders<DocumentEntry>.Filter.In(e => e.StoreId, storeIds),
-                Builders<DocumentEntry>.Filter.Eq(e => e.IsFolder, false),
-                Builders<DocumentEntry>.Filter.Ne(e => e.SourceType, DocumentSourceType.GithubDirectory)))
-            .SortByDescending(e => e.UpdatedAt)
-            .Limit(storeIds.Count * 3) // 最多取 N*3 条
-            .ToListAsync();
-
-        var entriesByStore = recentEntries
-            .GroupBy(e => e.StoreId)
-            .ToDictionary(g => g.Key, g => g.Take(3).Select(e => new
-            {
-                id = e.Id,
-                title = e.Title,
-                updatedAt = e.UpdatedAt,
-                contentType = e.ContentType,
-            }).ToList());
+        var entriesByStore = await LoadRecentEntriesByStoreAsync(storeIds);
 
         var items = stores.Select(s => new
         {
@@ -1943,6 +1926,38 @@ public class DocumentStoreController : ControllerBase
     }
 
     /// <summary>
+    /// 批量获取每个 store 的最近 N 个文档预览。
+    /// 必须按 store 维度独立查询：单次全局 sort+limit 会导致活跃度低的 store 被活跃度高的 store 抢占额度，渲染出 "知识库暂无内容" 但 documentCount 非 0 的不一致。
+    /// </summary>
+    private async Task<Dictionary<string, List<object>>> LoadRecentEntriesByStoreAsync(IReadOnlyList<string> storeIds, int perStore = 3)
+    {
+        if (storeIds.Count == 0) return new Dictionary<string, List<object>>();
+
+        var tasks = storeIds.Select(async sid =>
+        {
+            var entries = await _db.DocumentEntries
+                .Find(Builders<DocumentEntry>.Filter.And(
+                    Builders<DocumentEntry>.Filter.Eq(e => e.StoreId, sid),
+                    Builders<DocumentEntry>.Filter.Eq(e => e.IsFolder, false),
+                    Builders<DocumentEntry>.Filter.Ne(e => e.SourceType, DocumentSourceType.GithubDirectory)))
+                .SortByDescending(e => e.UpdatedAt)
+                .Limit(perStore)
+                .ToListAsync();
+            var list = entries.Select(e => (object)new
+            {
+                id = e.Id,
+                title = e.Title,
+                updatedAt = e.UpdatedAt,
+                contentType = e.ContentType,
+            }).ToList();
+            return (sid, list);
+        }).ToList();
+
+        var results = await Task.WhenAll(tasks);
+        return results.ToDictionary(r => r.sid, r => r.list);
+    }
+
+    /// <summary>
     /// 为我的收藏/点赞列表构造卡片数据：按传入 storeId 顺序保留 + 附加最近 3 个文档 + 店主信息。
     /// 不存在的 store（已被删除）会被静默跳过。
     /// </summary>
@@ -1954,24 +1969,7 @@ public class DocumentStoreController : ControllerBase
         var storeMap = stores.ToDictionary(s => s.Id, s => s);
 
         // 最近 3 个文档预览（每个空间）
-        var recentEntries = await _db.DocumentEntries
-            .Find(Builders<DocumentEntry>.Filter.And(
-                Builders<DocumentEntry>.Filter.In(e => e.StoreId, storeIds),
-                Builders<DocumentEntry>.Filter.Eq(e => e.IsFolder, false),
-                Builders<DocumentEntry>.Filter.Ne(e => e.SourceType, DocumentSourceType.GithubDirectory)))
-            .SortByDescending(e => e.UpdatedAt)
-            .Limit(storeIds.Count * 3)
-            .ToListAsync();
-
-        var entriesByStore = recentEntries
-            .GroupBy(e => e.StoreId)
-            .ToDictionary(g => g.Key, g => g.Take(3).Select(e => new
-            {
-                id = e.Id,
-                title = e.Title,
-                updatedAt = e.UpdatedAt,
-                contentType = e.ContentType,
-            }).ToList());
+        var entriesByStore = await LoadRecentEntriesByStoreAsync(storeIds);
 
         // 店主信息
         var ownerIds = stores.Select(s => s.OwnerId).Distinct().ToList();

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/DocumentStoreController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/DocumentStoreController.cs
@@ -1905,7 +1905,9 @@ public class DocumentStoreController : ControllerBase
             .SortByDescending(f => f.CreatedAt)
             .ToListAsync();
 
-        var storeIds = favs.Select(f => f.StoreId).ToList();
+        // Distinct: 旧 like/favorite 集合无 (UserId, StoreId) 唯一索引，并发请求或重复点击可能产生重复记录；
+        // 不去重会让卡片列表出现重复，并使下游按 storeId 建字典时抛 ArgumentException。
+        var storeIds = favs.Select(f => f.StoreId).Distinct().ToList();
         var items = await BuildInteractionStoreCardsAsync(storeIds, userId);
         return Ok(ApiResponse<object>.Ok(new { items }));
     }
@@ -1920,7 +1922,7 @@ public class DocumentStoreController : ControllerBase
             .SortByDescending(l => l.CreatedAt)
             .ToListAsync();
 
-        var storeIds = likes.Select(l => l.StoreId).ToList();
+        var storeIds = likes.Select(l => l.StoreId).Distinct().ToList();
         var items = await BuildInteractionStoreCardsAsync(storeIds, userId);
         return Ok(ApiResponse<object>.Ok(new { items }));
     }
@@ -1933,7 +1935,9 @@ public class DocumentStoreController : ControllerBase
     {
         if (storeIds.Count == 0) return new Dictionary<string, List<object>>();
 
-        var tasks = storeIds.Select(async sid =>
+        // 去重：下游 ToDictionary 不能容忍重复 key；调用方理论上已 Distinct，这里再兜一层防回归。
+        var distinctIds = storeIds.Distinct().ToList();
+        var tasks = distinctIds.Select(async sid =>
         {
             var entries = await _db.DocumentEntries
                 .Find(Builders<DocumentEntry>.Filter.And(


### PR DESCRIPTION
## Summary
Refactored the recent document entries loading logic to query per-store instead of globally, fixing an issue where knowledge bases with lower activity would show "no content" despite having documents.

## Problem
The previous implementation used a single global query with `sort + limit` across all stores:
- Fetched `storeCount * 3` entries globally sorted by `UpdatedAt`
- Grouped results by store and took top 3 per store
- This caused active stores to consume all available slots, leaving inactive stores with no preview entries
- Result: UI showed "暂无内容" (no content) but `documentCount > 0`, creating an inconsistency

## Solution
Created a new private method `LoadRecentEntriesByStoreAsync()` that:
- Queries each store independently for its 3 most recent documents
- Uses `Task.WhenAll()` for parallel execution to maintain performance
- Ensures fair distribution of preview entries across all stores regardless of activity level
- Includes comprehensive documentation explaining the rationale

## Changes
- **New method**: `LoadRecentEntriesByStoreAsync()` - Extracts per-store document preview loading logic with configurable limit (default 3)
- **Refactored**: `ListStoresWithPreview()` - Now uses the new method instead of inline global query
- **Refactored**: `BuildInteractionStoreCardsAsync()` - Now uses the new method instead of inline global query
- **Added**: Changelog entry documenting the fix

## Implementation Details
- The new method accepts `storeIds` and optional `perStore` parameter for flexibility
- Parallel queries via `Task.WhenAll()` maintain performance despite per-store approach
- Filters remain consistent: excludes folders and GitHub directory sources
- Returns `Dictionary<string, List<object>>` for easy store-based lookup

https://claude.ai/code/session_01BgFyfyPd248pXEcc1Dv7Dv

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the query strategy from one global query to multiple parallel per-store queries, which could affect MongoDB load/latency under large store counts; functional impact is otherwise localized to preview-card endpoints.
> 
> **Overview**
> Fixes a card-preview inconsistency where some document stores could render *“暂无内容”* even when `documentCount > 0` by changing `recentEntries` loading to query **per store** instead of a single global `sort + limit` that could starve less-active stores.
> 
> This refactors both `ListStoresWithPreview` and the likes/favorites card builder to reuse a new `LoadRecentEntriesByStoreAsync()` helper (parallel per-store queries), and adds `Distinct()` on liked/favorited `storeIds` to avoid duplicate cards and potential `ToDictionary` key collisions. A changelog entry documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3034e6b9e5bc54dbc4f42b759a169aa1651e66ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->