### PR TITLE
Improve cleanup error handling with detailed directory contents

### DIFF
--- a/cds/src/routes/legacy-cleanup.ts
+++ b/cds/src/routes/legacy-cleanup.ts
@@ -151,6 +151,9 @@ export function createLegacyCleanupRouter(deps: LegacyCleanupRouterDeps): Router
             error: 'dir_not_empty',
             message: `残留目录 ${legacyDir} 非空 (${entries.length} 项),拒绝自动删除。请手动检查。`,
             entries: entries.slice(0, 20),
+            // 真实总数：entries 已被 slice 到 20，前端展示需要原始 count
+            // 才能正确显示"目录里残留 N 项"和"仅显示前 20 项,共 N 项"文案
+            totalEntries: entries.length,
           });
           return;
         }

--- a/cds/web/projects.js
+++ b/cds/web/projects.js
@@ -1243,14 +1243,19 @@ window.cdsDoLogout = cdsDoLogout;
                       // 但 entries 列表已回传,这里展开给用户 + 提示如何手动排查,
                       // 避免「看到错误但不知道是哪 1 项卡住」。
                       if (r.body && r.body.error === 'dir_not_empty' && Array.isArray(r.body.entries) && r.body.entries.length > 0) {
-                        var displayEntries = r.body.entries.slice(0, 20);
+                        // 后端已 slice(0, 20)，并通过 totalEntries 字段告诉真实总数。
+                        // 老版本后端可能没 totalEntries 字段，回退到数组长度（此时 = sliced 长度）。
+                        var displayEntries = r.body.entries;
+                        var totalCount = typeof r.body.totalEntries === 'number'
+                          ? r.body.totalEntries
+                          : displayEntries.length;
                         var entryLines = displayEntries.map(function (e) { return '  - ' + e; }).join('\n');
-                        var moreSuffix = r.body.entries.length > displayEntries.length
-                          ? '\n  ...（仅显示前 ' + displayEntries.length + ' 项,共 ' + r.body.entries.length + ' 项）'
+                        var moreSuffix = totalCount > displayEntries.length
+                          ? '\n  ...（仅显示前 ' + displayEntries.length + ' 项,共 ' + totalCount + ' 项）'
                           : '';
                         alert(
                           (r.body.message || '清理失败:目录非空') + '\n\n' +
-                          '目录里残留的内容（' + r.body.entries.length + ' 项）:\n' + entryLines + moreSuffix + '\n\n' +
+                          '目录里残留的内容（' + totalCount + ' 项）:\n' + entryLines + moreSuffix + '\n\n' +
                           '排查建议:\n' +
                           '  1) 确认这些项是否还有用（某分支 worktree / symlink 残留 / 空目录等）\n' +
                           '  2) 若确认无用,SSH 到 CDS 主机执行 rm -rf 删除\n' +

--- a/cds/web/projects.js
+++ b/cds/web/projects.js
@@ -1238,7 +1238,25 @@ window.cdsDoLogout = cdsDoLogout;
                 })
                   .then(function (r) { return r.json().then(function (b) { return { ok: r.ok, body: b }; }); })
                   .then(function (r) {
-                    if (!r.ok) throw new Error(r.body.message || r.body.error || '清理失败');
+                    if (!r.ok) {
+                      // dir_not_empty 错误：后端 safe-by-design 拒绝盲删,
+                      // 但 entries 列表已回传,这里展开给用户 + 提示如何手动排查,
+                      // 避免「看到错误但不知道是哪 1 项卡住」。
+                      if (r.body && r.body.error === 'dir_not_empty' && Array.isArray(r.body.entries) && r.body.entries.length > 0) {
+                        var entryLines = r.body.entries.map(function (e) { return '  - ' + e; }).join('\n');
+                        var moreSuffix = r.body.entries.length >= 20 ? '\n  ...（仅显示前 20 项）' : '';
+                        alert(
+                          (r.body.message || '清理失败:目录非空') + '\n\n' +
+                          '目录里残留的内容（' + r.body.entries.length + ' 项）:\n' + entryLines + moreSuffix + '\n\n' +
+                          '排查建议:\n' +
+                          '  1) 确认这些项是否还有用（某分支 worktree / symlink 残留 / 空目录等）\n' +
+                          '  2) 若确认无用,SSH 到 CDS 主机执行 rm -rf 删除\n' +
+                          '  3) 然后再次点「清理残留」'
+                        );
+                        return;
+                      }
+                      throw new Error((r.body && (r.body.message || r.body.error)) || '清理失败');
+                    }
                     alert(r.body.message || '清理完成');
                     location.reload();
                   })

--- a/cds/web/projects.js
+++ b/cds/web/projects.js
@@ -1243,8 +1243,11 @@ window.cdsDoLogout = cdsDoLogout;
                       // 但 entries 列表已回传,这里展开给用户 + 提示如何手动排查,
                       // 避免「看到错误但不知道是哪 1 项卡住」。
                       if (r.body && r.body.error === 'dir_not_empty' && Array.isArray(r.body.entries) && r.body.entries.length > 0) {
-                        var entryLines = r.body.entries.map(function (e) { return '  - ' + e; }).join('\n');
-                        var moreSuffix = r.body.entries.length >= 20 ? '\n  ...（仅显示前 20 项）' : '';
+                        var displayEntries = r.body.entries.slice(0, 20);
+                        var entryLines = displayEntries.map(function (e) { return '  - ' + e; }).join('\n');
+                        var moreSuffix = r.body.entries.length > displayEntries.length
+                          ? '\n  ...（仅显示前 ' + displayEntries.length + ' 项,共 ' + r.body.entries.length + ' 项）'
+                          : '';
                         alert(
                           (r.body.message || '清理失败:目录非空') + '\n\n' +
                           '目录里残留的内容（' + r.body.entries.length + ' 项）:\n' + entryLines + moreSuffix + '\n\n' +


### PR DESCRIPTION
## Summary
Enhanced the cleanup failure error handling to provide users with detailed information about directory contents when a `dir_not_empty` error occurs, along with actionable troubleshooting steps.

## Key Changes
- Added specialized handling for `dir_not_empty` errors that displays the list of remaining entries in the directory
- Implemented a user-friendly alert message that includes:
  - The count and names of remaining items (limited to first 20 entries)
  - Clear troubleshooting steps for manual cleanup (SSH access and rm -rf)
  - Guidance on identifying problematic items (worktrees, symlinks, empty directories, etc.)
- Improved fallback error message to safely access nested error properties with proper null checks
- Prevents blind deletion by showing users exactly what's blocking the cleanup operation

## Implementation Details
- The error handler now checks for `dir_not_empty` error code and validates the presence of an `entries` array
- Entry names are formatted as a bulleted list for readability
- A truncation indicator is shown if there are 20+ entries to keep the alert manageable
- The function returns early after showing the detailed alert, preventing a generic error throw
- Maintains backward compatibility with other error types through the fallback error handling

https://claude.ai/code/session_01QoMbC8FLwArsRRwckUshnp

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an extra response field and client-side alert logic for a specific 409 error path without changing deletion behavior or data handling.
> 
> **Overview**
> Improves the UX when `cleanup-residual` refuses to delete a non-empty legacy `default` worktree directory.
> 
> The backend now returns `totalEntries` alongside the already-sliced `entries` list for `dir_not_empty` responses, and the projects page shows a detailed alert listing the blocking items (with truncation messaging) plus manual cleanup guidance instead of a generic failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33bab10e5d8694322523ad1d6386a0c3690b3367. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->