### PR TITLE
fix(cds): auto-build 路径补齐 v3/v2 预览 slug 反向解析

### DIFF
--- a/cds/src/index.ts
+++ b/cds/src/index.ts
@@ -1064,11 +1064,15 @@ proxyService.setOnAutoBuild(async (branchSlug, _req, res) => {
     const localBranch = stateService.getBranch(branchSlug);
     if (!localBranch) {
       const autoRepoRoot = config.repoRoot;
+      const projectSlugs = (stateService.getProjects?.() ?? [])
+        .filter((p) => !p.legacyFlag && p.slug)
+        .map((p) => p.slug as string);
       let foundRemote = false;
       try {
         foundRemote = await worktreeService.branchExists(autoRepoRoot, branchSlug)
           || !!(await worktreeService.findBranchBySuffix(autoRepoRoot, branchSlug))
-          || !!(await worktreeService.findBranchBySlug(autoRepoRoot, branchSlug));
+          || !!(await worktreeService.findBranchBySlug(autoRepoRoot, branchSlug))
+          || !!(await worktreeService.findBranchByPreviewSlug(autoRepoRoot, branchSlug, projectSlugs));
       } catch {
         foundRemote = false;
       }
@@ -1169,6 +1173,19 @@ proxyService.setOnAutoBuild(async (branchSlug, _req, res) => {
   // If still not found, try slug matching (e.g. slug "claude-fix-xxx" → branch "claude/fix-xxx")
   if (!resolvedBranch) {
     resolvedBranch = await worktreeService.findBranchBySlug(autoRepoRoot, branchSlug);
+  }
+
+  // Last resort: forward-match the slug as a v1 / v2 / v3 preview URL slug.
+  // Handles cases like host `audio-upload-asr-tgr1f-claude-prd-agent.miduo.org`
+  // where the slug embeds the project name plus a slash-bearing branch ref.
+  if (!resolvedBranch) {
+    const projectSlugs = (stateService.getProjects?.() ?? [])
+      .filter((p) => !p.legacyFlag && p.slug)
+      .map((p) => p.slug as string);
+    if (projectSlugs.length > 0) {
+      resolvedBranch = await worktreeService.findBranchByPreviewSlug(
+        autoRepoRoot, branchSlug, projectSlugs);
+    }
   }
 
   if (!resolvedBranch) {

--- a/cds/src/services/worktree.ts
+++ b/cds/src/services/worktree.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import type { IShellExecutor } from '../types.js';
 import { combinedOutput } from '../types.js';
 import { StateService } from './state.js';
+import { computePreviewSlug, slugifyForPreview } from './preview-slug.js';
 
 /**
  * Current worktree layout version. See `CdsState.worktreeLayoutVersion`
@@ -355,6 +356,66 @@ export class WorktreeService {
 
     const lowerSlug = slug.toLowerCase();
     return branches.find(b => StateService.slugify(b) === lowerSlug) || null;
+  }
+
+  /**
+   * Reverse-map a v1 / v2 / v3 preview-URL slug back to its remote branch name.
+   *
+   * Use case: subdomain auto-build. Browser hits
+   *   https://audio-upload-asr-tgr1f-claude-prd-agent.miduo.org/
+   * The host's leftmost label is the slug, but the actual git ref is
+   * `claude/audio-upload-asr-TGR1f` (with `/`, mixed case). Without this
+   * reverse mapping the user just sees "远程仓库中未找到分支 ..." even though
+   * the ref exists.
+   *
+   * Three-tier forward match (matches the cascade in proxy.ts resolveBranchEntry):
+   *   - v3: `${tail}-${prefix}-${projectSlug}` → computePreviewSlug(branch, p) === slug
+   *   - v2: `${projectSlug}-${slugify(branch)}` → projectSlug-prefix slugifies match
+   *   - v1: `${slugify(branch)}` → bare slugify (legacy projects)
+   *
+   * Try every (branch, projectSlug) combo. First exact match wins.
+   *
+   * Why "forward match" not "reverse parse": parsing a slug back to (prefix,
+   * tail, projectSlug) is ambiguous when projectSlug contains hyphens
+   * (e.g. `prd-agent` vs branch `audio-upload-asr-tgr1f-claude` — where does
+   * project end and branch start?). Computing the canonical slug for each
+   * known branch and comparing equality avoids the ambiguity entirely.
+   */
+  async findBranchByPreviewSlug(
+    repoRoot: string,
+    slug: string,
+    projectSlugs: string[],
+  ): Promise<string | null> {
+    const result = await this.shell.exec(
+      `git ls-remote --heads origin`,
+      { cwd: repoRoot },
+    );
+    if (result.exitCode !== 0) return null;
+
+    const branches = result.stdout.trim().split('\n')
+      .map(line => line.replace(/^.*refs\/heads\//, '').trim())
+      .filter(Boolean);
+    if (branches.length === 0) return null;
+
+    const lowerSlug = slug.toLowerCase();
+    const projectSlugsClean = projectSlugs
+      .filter(Boolean)
+      .map((p) => slugifyForPreview(p))
+      .filter(Boolean);
+
+    for (const branch of branches) {
+      // v1: bare slugify match (legacy single-project URLs)
+      if (StateService.slugify(branch) === lowerSlug) return branch;
+
+      const branchSlug = StateService.slugify(branch);
+      for (const ps of projectSlugsClean) {
+        // v3: tail-prefix-project (重要的靠前)
+        if (computePreviewSlug(branch, ps) === lowerSlug) return branch;
+        // v2: project-prefix-tail (legacy multi-project URL外发期)
+        if (`${ps}-${branchSlug}` === lowerSlug) return branch;
+      }
+    }
+    return null;
   }
 }
 

--- a/cds/tests/services/worktree.test.ts
+++ b/cds/tests/services/worktree.test.ts
@@ -258,6 +258,94 @@ describe('WorktreeService', () => {
     });
   });
 
+  // ── findBranchByPreviewSlug：v1 / v2 / v3 三档反查 ──
+  //
+  // 用例核心场景：subdomain 命中 auto-build 时，host 里的 slug 是按
+  // computePreviewSlug 算出来的（含项目身份），需要反向找到原始 git ref。
+  describe('findBranchByPreviewSlug', () => {
+    const STD_REMOTE = [
+      'abc123\trefs/heads/main',
+      'def456\trefs/heads/claude/audio-upload-asr-TGR1f',
+      'ghi789\trefs/heads/feature/login',
+    ].join('\n');
+
+    it('matches v3 slug (tail-prefix-project)', async () => {
+      mock.addResponsePattern(/git ls-remote/, () => ({
+        stdout: STD_REMOTE, stderr: '', exitCode: 0,
+      }));
+      const result = await service.findBranchByPreviewSlug(
+        REPO, 'audio-upload-asr-tgr1f-claude-prd-agent', ['prd-agent']);
+      expect(result).toBe('claude/audio-upload-asr-TGR1f');
+    });
+
+    it('matches v2 slug (project-prefix-tail)', async () => {
+      mock.addResponsePattern(/git ls-remote/, () => ({
+        stdout: STD_REMOTE, stderr: '', exitCode: 0,
+      }));
+      const result = await service.findBranchByPreviewSlug(
+        REPO, 'prd-agent-claude-audio-upload-asr-tgr1f', ['prd-agent']);
+      expect(result).toBe('claude/audio-upload-asr-TGR1f');
+    });
+
+    it('matches v1 bare slug (legacy single-project)', async () => {
+      mock.addResponsePattern(/git ls-remote/, () => ({
+        stdout: STD_REMOTE, stderr: '', exitCode: 0,
+      }));
+      const result = await service.findBranchByPreviewSlug(
+        REPO, 'claude-audio-upload-asr-tgr1f', ['prd-agent']);
+      expect(result).toBe('claude/audio-upload-asr-TGR1f');
+    });
+
+    it('matches main branch via v3 tail-only form', async () => {
+      mock.addResponsePattern(/git ls-remote/, () => ({
+        stdout: STD_REMOTE, stderr: '', exitCode: 0,
+      }));
+      const result = await service.findBranchByPreviewSlug(
+        REPO, 'main-prd-agent', ['prd-agent']);
+      expect(result).toBe('main');
+    });
+
+    it('returns null when slug matches no remote branch', async () => {
+      mock.addResponsePattern(/git ls-remote/, () => ({
+        stdout: STD_REMOTE, stderr: '', exitCode: 0,
+      }));
+      const result = await service.findBranchByPreviewSlug(
+        REPO, 'nonexistent-branch-prd-agent', ['prd-agent']);
+      expect(result).toBeNull();
+    });
+
+    it('returns null when projectSlugs is empty (no v2/v3 attempt)', async () => {
+      mock.addResponsePattern(/git ls-remote/, () => ({
+        stdout: STD_REMOTE, stderr: '', exitCode: 0,
+      }));
+      // v2/v3 needs project context; v1 bare match still works
+      const v1Result = await service.findBranchByPreviewSlug(
+        REPO, 'claude-audio-upload-asr-tgr1f', []);
+      expect(v1Result).toBe('claude/audio-upload-asr-TGR1f');
+      const v3Result = await service.findBranchByPreviewSlug(
+        REPO, 'audio-upload-asr-tgr1f-claude-prd-agent', []);
+      expect(v3Result).toBeNull();
+    });
+
+    it('tries multiple project slugs', async () => {
+      mock.addResponsePattern(/git ls-remote/, () => ({
+        stdout: STD_REMOTE, stderr: '', exitCode: 0,
+      }));
+      const result = await service.findBranchByPreviewSlug(
+        REPO, 'login-feature-prd-agent', ['demo', 'prd-agent', 'other']);
+      expect(result).toBe('feature/login');
+    });
+
+    it('returns null on git failure', async () => {
+      mock.addResponsePattern(/git ls-remote/, () => ({
+        stdout: '', stderr: 'fatal: error', exitCode: 128,
+      }));
+      const result = await service.findBranchByPreviewSlug(
+        REPO, 'anything', ['prd-agent']);
+      expect(result).toBeNull();
+    });
+  });
+
   // ── FU-04 — per-project worktree subdirectory ──
   //
   // These tests live in the WorktreeService suite (not in

--- a/changelogs/2026-05-05_cds-preview-slug-reverse.md
+++ b/changelogs/2026-05-05_cds-preview-slug-reverse.md
@@ -1,0 +1,2 @@
+| fix | cds | auto-build 路径补 v3 / v2 预览 slug 反向解析，子域名首次访问也能从 host 还原带 / 的真实分支名（如 `audio-upload-asr-tgr1f-claude-prd-agent` → `claude/audio-upload-asr-TGR1f`），不再误报"远程仓库中未找到分支" |
+| test | cds | WorktreeService.findBranchByPreviewSlug 单测覆盖 v1/v2/v3 三档 + 多项目候选 + git 失败兜底，共 7 条用例 |


### PR DESCRIPTION
子域名首次访问触发 auto-build 时，原 4 档兜底（branchExists / 常见前缀 / findBranchBySuffix / findBranchBySlug）只能反查"项目 slug 不掺合"的 v1 URL；遇到 v2 (`{project}-{prefix}-{tail}`) 和 v3 (`{tail}-{prefix}-{project}`) URL 时全部 miss，最终给用户报"远程仓库中未找到分支 ${slug}"，但分支其实
存在 —— 只是名字带 `/` 加大小写。

修法：在 WorktreeService 加一档 `findBranchByPreviewSlug(repoRoot, slug, projectSlugs)`，对所有远程 ref 做"前向匹配"——逐个调 computePreviewSlug 看 v3 是否相等，再算 v2 拼接、v1 直查 slug。三档命中谁就返回谁。这是
proxy.ts resolveBranchEntry 的对偶版本（一个查 state.branches，一个查 git ls-remote）。

为什么不"反向解析"slug：projectSlug 含连字符（如 `prd-agent`）+ 分支名 也含连字符，无法在不知道全集的情况下确定哪段是项目身份。前向匹配避免
歧义，逻辑也更短。

附 7 条 vitest 用例覆盖三档 + 主分支无 prefix 形态 + 多项目候选 + git 失败兜底。

https://claude.ai/code/session_01SbvfGyjd1XTiLQ9xQZ9uNz

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the auto-build branch resolution path to scan remote refs and map preview URL slugs back to real branch names, which could affect routing/build behavior and adds a potentially expensive `git ls-remote` fallback on misses.
> 
> **Overview**
> Fixes subdomain-triggered auto-build failures where v2/v3 preview URL slugs (including project identity) could not be resolved back to real remote branch refs (especially when refs contain `/` or mixed case), causing false "branch not found" errors.
> 
> Adds `WorktreeService.findBranchByPreviewSlug()` which forward-matches a requested slug against all remote heads using v1/v2/v3 slug formats (via `computePreviewSlug`/`slugifyForPreview`), and wires this as a final fallback in `cds/src/index.ts` both for the initial non-SSE "gone vs transit" check and the SSE resolve flow. Includes new Vitest coverage for v1/v2/v3 matching, multiple project slug candidates, and git-failure behavior, plus a changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6861f1c33b47e114fad5c468dd96d8ba21c35e7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->