### PR TITLE
Event-driven self-status + shared infra protection + env bootstrap fix

### DIFF
--- a/cds/exec_cds.sh
+++ b/cds/exec_cds.sh
@@ -2686,7 +2686,17 @@ case "$CMD" in
     load_env
     cd "$SCRIPT_DIR" || { err "无法 cd 到 $SCRIPT_DIR"; exit 1; }
     info "[master-run] pnpm install --frozen-lockfile --prefer-offline"
-    pnpm install --frozen-lockfile --prefer-offline
+    # ⚠ Bugbot 982b38ca (Medium):必须显式 fail-fast。pnpm install 失败可能由
+    # lockfile 与 package.json 漂移、pnpm store 损坏、磁盘满 等原因触发,
+    # 静默继续会让 node 启动时遭遇 stale / 不完整 node_modules,运行时崩溃。
+    # systemd Restart=always 会无限重启,污染日志且永远起不来。
+    # 显式 exit 78(EX_CONFIG)告诉 systemd 这是配置/依赖问题,operator 看 status
+    # 一眼区分"代码 bug 崩"vs"依赖装不上",对应不同 runbook。
+    if ! pnpm install --frozen-lockfile --prefer-offline; then
+      err "[master-run] pnpm install 失败 — 中止启动,避免 node 用陈旧 node_modules"
+      err "[master-run] 排查: (a) pnpm-lock.yaml 是否与 package.json 同步 (b) ~/.pnpm-store 是否健康 (c) 磁盘空间"
+      exit 78  # EX_CONFIG — operator 友好的 systemd 退出码
+    fi
     info "[master-run] exec node dist/index.js"
     exec node dist/index.js
     ;;

--- a/cds/exec_cds.sh
+++ b/cds/exec_cds.sh
@@ -2674,6 +2674,22 @@ case "$CMD" in
     # longer have to hand-edit /etc/systemd/system/cds-master.service.
     install_systemd_cmd
     ;;
+  master-run)
+    # 用户反馈 2026-05-06:每次改 pnpm install / node 启动参数都要 sudo cp
+    # 重装 systemd unit 太蠢。把"master 进程怎么启动"这件事从 systemd unit
+    # 搬到这里,unit 文件只负责"在哪个目录跑哪个命令、Restart=always、
+    # MemoryMax",真正的启动细节随 self-update 自动更新,sudo 一次即可。
+    #
+    # systemd ExecStart 调用本子命令:
+    #   ExecStart=/opt/prd_agent/cds/exec_cds.sh master-run
+    # 之后改 pnpm 标志、node flag 都改这里,不动 unit。
+    load_env
+    cd "$SCRIPT_DIR" || { err "无法 cd 到 $SCRIPT_DIR"; exit 1; }
+    info "[master-run] pnpm install --frozen-lockfile --prefer-offline"
+    pnpm install --frozen-lockfile --prefer-offline
+    info "[master-run] exec node dist/index.js"
+    exec node dist/index.js
+    ;;
   migrate-env|migrate)
     # 2026-04-27: 把杂乱的环境源（.cds.env、./.env、~/.bashrc、当前 shell）
     # 按"CDS canonical / CDS legacy / 项目级"三类分流。详细行为见

--- a/cds/package.json
+++ b/cds/package.json
@@ -23,6 +23,7 @@
     "@types/express": "^4.17.21",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.0.0",
+    "esbuild": "^0.21.5",
     "tsx": "^4.19.0",
     "typescript": "^5.6.0",
     "vitest": "^2.1.0"

--- a/cds/pnpm-lock.yaml
+++ b/cds/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.11
+      esbuild:
+        specifier: ^0.21.5
+        version: 0.21.5
       tsx:
         specifier: ^4.19.0
         version: 4.21.0

--- a/cds/scripts/build-dist-esbuild.mjs
+++ b/cds/scripts/build-dist-esbuild.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+/**
+ * build-dist-esbuild.mjs — 用 esbuild 替代 `tsc --outDir` 做 emit。
+ *
+ * 用户反馈 2026-05-06:self-update 慢,tsc 编译 cds/dist 占 30-50s。
+ * esbuild 同等转译只要 ~2s(纯 syntax 转换,不做类型检查)。
+ *
+ * **类型检查由并行的 `tsc --noEmit` 兜底**(不在本脚本范围内,在 self-update
+ * 流程里 esbuild + tsc --noEmit 并行跑;两者都过才算 build 成功)。
+ *
+ * 用法:OUT_DIR=dist.next node scripts/build-dist-esbuild.mjs
+ *
+ * 设计取舍:
+ * - bundle: false  纯 1:1 转译,保留模块边界,生成的 dist/ 跟 tsc emit 形状一致
+ * - format: esm    匹配 cds/package.json 的 type: "module"
+ * - target: node20 匹配 engines.node >=20
+ * - outbase: src   保留 src/ 下的子目录结构(否则全平铺)
+ *
+ * 注意:本脚本同步实现,失败 process.exit(1)。调用方 (self-force-sync)
+ * 检查退出码区分成功/失败。
+ */
+
+import { build } from 'esbuild';
+import { readdir } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const cdsRoot = path.resolve(__dirname, '..');
+const srcDir = path.join(cdsRoot, 'src');
+const outDir = process.env.OUT_DIR
+  ? path.resolve(cdsRoot, process.env.OUT_DIR)
+  : path.join(cdsRoot, 'dist');
+
+async function findTsFiles(dir) {
+  const out = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...await findTsFiles(full));
+    } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const startedAt = Date.now();
+const entries = await findTsFiles(srcDir);
+console.log(`[build-dist-esbuild] 编译 ${entries.length} 个 .ts 文件 → ${path.relative(cdsRoot, outDir)}`);
+
+await build({
+  entryPoints: entries,
+  outdir: outDir,
+  outbase: srcDir,
+  format: 'esm',
+  platform: 'node',
+  target: 'node20',
+  bundle: false,
+  sourcemap: false,
+  // tsc emit 一致的行为:source TS 已经在 import 语句写了 .js 后缀
+  // (ESM module resolution 要求),esbuild 保持原样不动
+  logLevel: 'info',
+});
+
+const elapsed = ((Date.now() - startedAt) / 1000).toFixed(2);
+console.log(`[build-dist-esbuild] 完成,耗时 ${elapsed}s`);

--- a/cds/src/config.ts
+++ b/cds/src/config.ts
@@ -2,6 +2,12 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { CdsConfig, CdsMode, GitHubAppConfig } from './types.js';
 
+// ⚠️ side-effect import：必须在 DEFAULT_CONFIG 求值之前把 .cds.env 注入 process.env。
+// ES module 顶层导入会先评估被导入模块的 top-level 代码，所以这一行保证 env
+// 在下方 `DEFAULT_CONFIG.githubApp = resolveGitHubApp()` 之前就位。
+// 缺这行 → GitHub App config 永远 undefined → webhook 拒收 503。详见 load-env.ts 注释。
+import './load-env.js';
+
 function parseCsv(value: string | undefined): string[] | undefined {
   if (!value) return undefined;
   const items = value.split(',').map(v => v.trim()).filter(Boolean);

--- a/cds/src/config.ts
+++ b/cds/src/config.ts
@@ -121,14 +121,43 @@ const DEFAULT_CONFIG: CdsConfig = {
   // GitHub App credentials for the Railway-style check-run integration.
   // Absent when any of CDS_GITHUB_APP_ID / _PRIVATE_KEY / _WEBHOOK_SECRET
   // is unset — the webhook route returns 503 not_configured in that case.
-  githubApp: resolveGitHubApp(),
-  // Public-facing base URL used for GitHub check-run `details_url` and the
-  // GitHub App install redirect. Falls back to http://localhost:<masterPort>
-  // at call-sites when unset so local-dev setups still function.
-  publicBaseUrl: process.env.CDS_PUBLIC_BASE_URL?.trim() || undefined,
+  // ⚠️ 在 loadConfig() 函数体里 lazy 求值，不要放这里！原版本是
+  //   `githubApp: resolveGitHubApp()` 直接 module-level 调用，
+  // 但 ES module 顶层求值时机和 self-loader (load-env.ts) 完成时机
+  // 不能 100% 保证有先后关系（受 import 拓扑顺序、tsc-incremental
+  // 缓存、循环依赖影响），导致 process.env 还没注入就读完了。改成
+  // 在 loadConfig() 里读，那一刻 self-loader 必定已跑完。
+  githubApp: undefined,
+  // Public-facing base URL — 同样 lazy 化，规避 module-level 求值陷阱
+  publicBaseUrl: undefined,
 };
 
 export function loadConfig(configPath?: string): CdsConfig {
+  // ⚠️ Lazy env reads —— 这里 (loadConfig 调用时) self-loader (load-env.ts)
+  // 一定已跑完，process.env 已注入磁盘 .cds.env。
+  // 历史教训：原版本是 module-level `DEFAULT_CONFIG.githubApp =
+  // resolveGitHubApp()`，但 ES module 顶层求值时机受 import 拓扑顺序
+  // / tsc-incremental 缓存影响，可能在 self-loader 之前 evaluate，
+  // 导致 GitHub App config 永远 undefined → webhook 拒收 503。
+  const liveDefaults: CdsConfig = {
+    ...DEFAULT_CONFIG,
+    githubApp: resolveGitHubApp(),
+    publicBaseUrl: process.env.CDS_PUBLIC_BASE_URL?.trim() || undefined,
+  };
+
+  if (liveDefaults.githubApp) {
+    console.log(`[config] GitHub App configured (appId=${liveDefaults.githubApp.appId})`);
+  } else {
+    const appId = process.env.CDS_GITHUB_APP_ID?.trim();
+    const key = process.env.CDS_GITHUB_APP_PRIVATE_KEY?.trim();
+    const secret = process.env.CDS_GITHUB_WEBHOOK_SECRET?.trim();
+    console.log(
+      `[config] GitHub App NOT configured — appId=${appId ? 'set' : 'EMPTY'} ` +
+      `privateKey=${key ? 'len=' + key.length : 'EMPTY'} ` +
+      `webhookSecret=${secret ? 'set' : 'EMPTY'}`,
+    );
+  }
+
   const candidates = [
     configPath,
     path.resolve(process.cwd(), 'cds.config.json'),
@@ -139,12 +168,12 @@ export function loadConfig(configPath?: string): CdsConfig {
       const raw = fs.readFileSync(candidate, 'utf-8');
       const override = JSON.parse(raw) as Partial<CdsConfig>;
       console.log(`  Config loaded from: ${candidate}`);
-      return deepMerge(DEFAULT_CONFIG, override);
+      return deepMerge(liveDefaults, override);
     }
   }
 
   console.log('  Config: using defaults (no cds.config.json found)');
-  return { ...DEFAULT_CONFIG };
+  return { ...liveDefaults };
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/cds/src/config.ts
+++ b/cds/src/config.ts
@@ -7,12 +7,7 @@ import type { CdsConfig, CdsMode, GitHubAppConfig } from './types.js';
 // 在下方 `DEFAULT_CONFIG.githubApp = resolveGitHubApp()` 之前就位。
 // 缺这行 → GitHub App config 永远 undefined → webhook 拒收 503。详见 load-env.ts 注释。
 import './load-env.js';
-
-function parseCsv(value: string | undefined): string[] | undefined {
-  if (!value) return undefined;
-  const items = value.split(',').map(v => v.trim()).filter(Boolean);
-  return items.length > 0 ? items : undefined;
-}
+import { parseCsv } from './util/parse-csv.js';
 
 function resolveMode(): CdsMode {
   const env = (process.env.CDS_MODE || '').toLowerCase();

--- a/cds/src/config.ts
+++ b/cds/src/config.ts
@@ -121,43 +121,42 @@ const DEFAULT_CONFIG: CdsConfig = {
   // GitHub App credentials for the Railway-style check-run integration.
   // Absent when any of CDS_GITHUB_APP_ID / _PRIVATE_KEY / _WEBHOOK_SECRET
   // is unset — the webhook route returns 503 not_configured in that case.
-  // ⚠️ 在 loadConfig() 函数体里 lazy 求值，不要放这里！原版本是
-  //   `githubApp: resolveGitHubApp()` 直接 module-level 调用，
-  // 但 ES module 顶层求值时机和 self-loader (load-env.ts) 完成时机
-  // 不能 100% 保证有先后关系（受 import 拓扑顺序、tsc-incremental
-  // 缓存、循环依赖影响），导致 process.env 还没注入就读完了。改成
-  // 在 loadConfig() 里读，那一刻 self-loader 必定已跑完。
-  githubApp: undefined,
-  // Public-facing base URL — 同样 lazy 化，规避 module-level 求值陷阱
-  publicBaseUrl: undefined,
+  //
+  // 跟 rootDomains / switchDomain / jwt.secret / bootstrapToken 等其它
+  // env-dependent 字段一样 module-level eager 求值。文件顶部的
+  // `import './load-env.js'` side-effect import 按 ES module spec 保证
+  // load-env.ts 的 .cds.env 注入在本模块 top-level 代码评估之前完成,
+  // 所以这里读到的 process.env 永远是已注入磁盘值的状态。
+  //
+  // 历史背景(2026-05-05):曾经误以为 ES module 求值时机有边界 case 把
+  // 这两个字段改成在 loadConfig() 里 lazy 求值。Bugbot Review 2026-05-06
+  // 指出这违背 spec 也制造了与其它字段的不一致(参见 d2e4ebeb-6dca)。
+  // 真实根因是当时 self-force-sync 留下了 stale dist —— 现在已被
+  // atomic dist swap (commit b3a7aef) 修掉,本字段回归 eager,与全文一致。
+  githubApp: resolveGitHubApp(),
+  // Public-facing base URL used for GitHub check-run `details_url` and the
+  // GitHub App install redirect. Falls back to http://localhost:<masterPort>
+  // at call-sites when unset so local-dev setups still function.
+  publicBaseUrl: process.env.CDS_PUBLIC_BASE_URL?.trim() || undefined,
 };
 
+// 启动诊断:打印一次 GitHub App 命中状态(redacted),便于运维确认
+// .cds.env 是否被正确读取。失败时附 EMPTY/set 字段对照,直接定位是哪
+// 一个 env 没注入。
+if (DEFAULT_CONFIG.githubApp) {
+  console.log(`[config] GitHub App configured (appId=${DEFAULT_CONFIG.githubApp.appId})`);
+} else {
+  const appId = process.env.CDS_GITHUB_APP_ID?.trim();
+  const key = process.env.CDS_GITHUB_APP_PRIVATE_KEY?.trim();
+  const secret = process.env.CDS_GITHUB_WEBHOOK_SECRET?.trim();
+  console.log(
+    `[config] GitHub App NOT configured — appId=${appId ? 'set' : 'EMPTY'} ` +
+    `privateKey=${key ? 'len=' + key.length : 'EMPTY'} ` +
+    `webhookSecret=${secret ? 'set' : 'EMPTY'}`,
+  );
+}
+
 export function loadConfig(configPath?: string): CdsConfig {
-  // ⚠️ Lazy env reads —— 这里 (loadConfig 调用时) self-loader (load-env.ts)
-  // 一定已跑完，process.env 已注入磁盘 .cds.env。
-  // 历史教训：原版本是 module-level `DEFAULT_CONFIG.githubApp =
-  // resolveGitHubApp()`，但 ES module 顶层求值时机受 import 拓扑顺序
-  // / tsc-incremental 缓存影响，可能在 self-loader 之前 evaluate，
-  // 导致 GitHub App config 永远 undefined → webhook 拒收 503。
-  const liveDefaults: CdsConfig = {
-    ...DEFAULT_CONFIG,
-    githubApp: resolveGitHubApp(),
-    publicBaseUrl: process.env.CDS_PUBLIC_BASE_URL?.trim() || undefined,
-  };
-
-  if (liveDefaults.githubApp) {
-    console.log(`[config] GitHub App configured (appId=${liveDefaults.githubApp.appId})`);
-  } else {
-    const appId = process.env.CDS_GITHUB_APP_ID?.trim();
-    const key = process.env.CDS_GITHUB_APP_PRIVATE_KEY?.trim();
-    const secret = process.env.CDS_GITHUB_WEBHOOK_SECRET?.trim();
-    console.log(
-      `[config] GitHub App NOT configured — appId=${appId ? 'set' : 'EMPTY'} ` +
-      `privateKey=${key ? 'len=' + key.length : 'EMPTY'} ` +
-      `webhookSecret=${secret ? 'set' : 'EMPTY'}`,
-    );
-  }
-
   const candidates = [
     configPath,
     path.resolve(process.cwd(), 'cds.config.json'),
@@ -168,12 +167,12 @@ export function loadConfig(configPath?: string): CdsConfig {
       const raw = fs.readFileSync(candidate, 'utf-8');
       const override = JSON.parse(raw) as Partial<CdsConfig>;
       console.log(`  Config loaded from: ${candidate}`);
-      return deepMerge(liveDefaults, override);
+      return deepMerge(DEFAULT_CONFIG, override);
     }
   }
 
   console.log('  Config: using defaults (no cds.config.json found)');
-  return { ...liveDefaults };
+  return { ...DEFAULT_CONFIG };
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/cds/src/index.ts
+++ b/cds/src/index.ts
@@ -31,12 +31,7 @@ import { getCdsAiAccessKey } from './config/known-env-keys.js';
 // side-effect import。这里保留 side-effect import 是为了即便有人未来调整
 // import 顺序、把 config 的 import 挪走，env loading 也仍然先于业务模块求值。
 import './load-env.js';
-
-function parseCsv(value: string | undefined): string[] | undefined {
-  if (!value) return undefined;
-  const items = value.split(',').map(v => v.trim()).filter(Boolean);
-  return items.length > 0 ? items : undefined;
-}
+import { parseCsv } from './util/parse-csv.js';
 
 const configPath = process.argv[2] || undefined;
 const config = loadConfig(configPath);

--- a/cds/src/index.ts
+++ b/cds/src/index.ts
@@ -25,77 +25,12 @@ import { ExecutorRegistry } from './scheduler/executor-registry.js';
 import { createSchedulerRouter } from './scheduler/routes.js';
 import { createClusterRouter } from './routes/cluster.js';
 import { updateEnvFile, defaultEnvFilePath } from './services/env-file.js';
-import { warnLegacyCdsEnvKeys, getCdsAiAccessKey } from './config/known-env-keys.js';
+import { getCdsAiAccessKey } from './config/known-env-keys.js';
 
-/**
- * 2026-04-18 bug fix — .cds.env self-loader.
- *
- * 历史行为：依赖 exec_cds.sh 的 load_env() 在 bash 层 source .cds.env，
- * 再 exec node。但 systemd-managed 部署（cds-master.service 的
- * `ExecStart=/usr/bin/node dist/index.js`）会直接 exec node，绕过
- * exec_cds.sh，于是 `.cds.env` 里的 `export CDS_MONGO_URI=...` 永远
- * 不会进入 process.env。生产侧诊断发现：
- *   切 Mongo → persisted=true → systemd 重启 → mode=json（URI 没读到）
- *
- * 修复策略：node 启动一开始自己解析 .cds.env，与 shell 无关。
- * 已经在 process.env 里的变量（systemd Environment= 或 shell export）
- * **不覆盖**，保证运维显式设置仍然有最高优先级。
- *
- * 支持语法：`export KEY="value"` 和 `KEY="value"`，值里 bash 双引号
- * 转义（\\ \" \$）反向 unescape。忽略 `#` 注释行和空行。
- *
- * 位置：必须在 loadConfig() 之前调用，否则 config 里引用的
- * repoRoot / rootDomains 等还是从未配置的 env 读。
- */
-function loadCdsEnvFile(): void {
-  const candidates = [
-    path.resolve(process.cwd(), '.cds.env'),
-    path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '.cds.env'),
-  ];
-  for (const envPath of candidates) {
-    try {
-      if (!fs.existsSync(envPath)) continue;
-      const content = fs.readFileSync(envPath, 'utf-8');
-      const lineRe = /^\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)=(?:"((?:[^"\\]|\\.)*)"|'([^']*)'|(\S*))\s*$/;
-      let loaded = 0;
-      const loadedKeys: string[] = [];
-      for (const line of content.split('\n')) {
-        if (!line || /^\s*#/.test(line)) continue;
-        const m = line.match(lineRe);
-        if (!m) continue;
-        const key = m[1];
-        const raw = m[2] ?? m[3] ?? m[4] ?? '';
-        // Unescape bash double-quoted: \" \\ \$ → " \ $
-        const value = (m[2] !== undefined)
-          ? raw.replace(/\\(.)/g, '$1')
-          : raw;
-        // process.env 已有值（systemd/shell 显式设置）优先
-        if (process.env[key] === undefined) {
-          process.env[key] = value;
-          loaded++;
-        }
-        // 不管覆盖与否，都把出现在 .cds.env 里的 key 收集起来用于
-        // 分类警告 —— 即使 systemd 已经显式注入同名变量，也说明用户
-        // 在 .cds.env 里写了这个 key，需要按名字判断它是否合规。
-        loadedKeys.push(key);
-      }
-      if (loaded > 0) {
-        // 用 console.log 而不是 logger，这一步比 logger 早
-        console.log(`[cds-env-loader] 从 ${envPath} 加载 ${loaded} 个变量到 process.env`);
-      }
-      // 对 .cds.env 里出现的旧名 CDS 变量打 deprecation warning。
-      // 不会对 GITHUB_PAT/R2_*/ROOT_ACCESS_* 这类项目级变量出声 ——
-      // migrate-env 子命令会负责这块迁移。
-      warnLegacyCdsEnvKeys(loadedKeys, envPath);
-      return; // 只读第一个找到的
-    } catch (err) {
-      console.warn(`[cds-env-loader] 跳过 ${envPath}: ${(err as Error).message}`);
-    }
-  }
-}
-
-// 必须在 loadConfig 之前调用
-loadCdsEnvFile();
+// .cds.env 注入 process.env 的逻辑搬到 ./load-env.js，并被 ./config.js 顶部
+// side-effect import。这里保留 side-effect import 是为了即便有人未来调整
+// import 顺序、把 config 的 import 挪走，env loading 也仍然先于业务模块求值。
+import './load-env.js';
 
 function parseCsv(value: string | undefined): string[] | undefined {
   if (!value) return undefined;

--- a/cds/src/load-env.ts
+++ b/cds/src/load-env.ts
@@ -1,0 +1,81 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { warnLegacyCdsEnvKeys } from './config/known-env-keys.js';
+
+/**
+ * `.cds.env` self-loader —— 在 Node 启动最早期把磁盘上的 env 注入 process.env。
+ *
+ * ⚠️ 必须放在独立 module 里，让任何 import 它的 module（如 `config.ts`）在
+ * top-level 评估自己的 module-scope 常量之前，先经过这里 side-effect。
+ *
+ * 历史教训（2026-05-05 确诊的两个 bug 同时显形）：
+ *
+ *   Bug 1（ES module 导入顺序）：原版本 `loadCdsEnvFile()` 写在 `index.ts:98`
+ *   函数体里调用，但 `index.ts` 顶部的 `import { loadConfig } from './config.js'`
+ *   会**先**触发 `config.ts` 的模块顶层求值——`DEFAULT_CONFIG.githubApp =
+ *   resolveGitHubApp()` 在那一刻就读 `process.env`，但此时 self-loader 还
+ *   没跑！结果 GitHub App config 永远 undefined，`/api/github/app` 一直
+ *   报 `configured: false`，webhook 永远拒收 503，即便磁盘 .cds.env 配
+ *   得好好的。把这一坨抽到独立 module + 在 `config.ts` 顶部 side-effect
+ *   import 它，能确保 env 在 DEFAULT_CONFIG 求值之前就位。
+ *
+ *   Bug 2（self-update spawn 透传 stale env）：`branches.ts` 的 self-update /
+ *   self-force-sync 端点 spawn 子进程时用 `env: { ...process.env }`。如果
+ *   父进程 env 里某 key 是空字符串（曾经被 init 写过空值，或被 unset 后
+ *   又被某个工具回填空），子进程继承到的也是空字符串。原 self-loader
+ *   语义是「process.env[key] === undefined 才覆盖」——空字符串不算
+ *   undefined，于是空值被保留下来。改成「只要假值（空串/undefined）就用
+ *   磁盘最新值覆盖」可同时解决这条路径的 stale。
+ *
+ * 不变式：systemd `Environment=KEY=non-empty` / shell `export KEY=non-empty`
+ * 显式注入的非空值仍然有最高优先级，self-loader 不动它们。
+ */
+
+function loadCdsEnvFile(): void {
+  const candidates = [
+    path.resolve(process.cwd(), '.cds.env'),
+    path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '.cds.env'),
+  ];
+  for (const envPath of candidates) {
+    try {
+      if (!fs.existsSync(envPath)) continue;
+      const content = fs.readFileSync(envPath, 'utf-8');
+      const lineRe = /^\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)=(?:"((?:[^"\\]|\\.)*)"|'([^']*)'|(\S*))\s*$/;
+      let loaded = 0;
+      let overwrote = 0;
+      const loadedKeys: string[] = [];
+      for (const line of content.split('\n')) {
+        if (!line || /^\s*#/.test(line)) continue;
+        const m = line.match(lineRe);
+        if (!m) continue;
+        const key = m[1];
+        const raw = m[2] ?? m[3] ?? m[4] ?? '';
+        const value = (m[2] !== undefined)
+          ? raw.replace(/\\(.)/g, '$1')
+          : raw;
+        const existing = process.env[key];
+        // 空字符串视同未配置——透过 spawn 透传过来的 stale 空值要被磁盘最新值覆盖。
+        // 非空值 = 运维或上层显式注入，保留它们的最高优先级。
+        if (existing === undefined || existing === '') {
+          if (existing === '' && value !== '') overwrote++;
+          process.env[key] = value;
+          loaded++;
+        }
+        loadedKeys.push(key);
+      }
+      if (loaded > 0) {
+        // logger 还没起来，先用 console.log 打到 cds.log
+        const overwroteSuffix = overwrote > 0 ? ` (覆盖 ${overwrote} 个空字符串占位)` : '';
+        console.log(`[cds-env-loader] 从 ${envPath} 加载 ${loaded} 个变量到 process.env${overwroteSuffix}`);
+      }
+      warnLegacyCdsEnvKeys(loadedKeys, envPath);
+      return;
+    } catch (err) {
+      console.warn(`[cds-env-loader] 跳过 ${envPath}: ${(err as Error).message}`);
+    }
+  }
+}
+
+// 模块加载时自动执行——任何 `import './load-env.js'` 都触发一次。
+// 重复 import 不会重复执行（ES module 缓存），所以幂等。
+loadCdsEnvFile();

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -861,7 +861,13 @@ export function createBranchRouter(deps: RouterDeps): Router {
         try { res.write(finalChunk); } catch { /* client gone */ }
         buffer += finalChunk;
       }
-      if (buffer.trim()) ingestFrame(buffer);
+      // ⚠ Bugbot 2026-05-06 6927c312:之前直接 ingestFrame(buffer) 把"多个完整
+      // 帧 + 一个尾巴"当作单帧解析,后面 event: 把前面 event: 覆盖,data: 行混到
+      // 一起 → opLog 里出现合并/错位事件。改:对 buffer 跑一次 parseSseFrames,
+      // 完整帧逐个 ingest,只有真正不完整的尾巴才整体 ingest。
+      const drained = parseSseFrames(buffer);
+      for (const frame of drained.frames) ingestFrame(frame);
+      if (drained.tail.trim()) ingestFrame(drained.tail);
 
       // Master-side state is best-effort — the executor has the source of
       // truth via its next heartbeat, which will reconcile status.

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -9094,31 +9094,26 @@ cdscli project list --human
         ...({ updateMode: hotEligible ? 'hot-reload' : 'restart' } as Record<string, unknown>),
       });
 
-      // ★ 2026-05-06 热路径出口:hotEligible 时**不**触发 systemd restart。
-      // node --watch=dist 已在 systemd ExecStart 里启动,dist/ 文件 mtime 变化
-      // 自己平滑重启,~2s 完成,期间老进程优雅退出 + 新进程接管。
-      if (hotEligible) {
-        send('hot-reload', 'done',
-          `热重载完成: dist 已更新到 ${newHead},node --watch 自动重启进程(~2s)。` +
-          `本次改动 ${impact.hotReloadablePaths.length} 个应用文件全部热路径安全。`,
-        );
-        sendSSE(res, 'done', {
-          message: `热重载已生效, HEAD=${newHead}(应用代码改动,无需重启 systemd unit)`,
-          commitHash: newHead,
-          mode: 'hot-reload',
-          hotReloadFiles: impact.hotReloadablePaths.length,
-        });
-        res.end();
-        return;
-      }
-
-      // Step 6 (cold path): restart via exec_cds.sh daemon spawn, exit after 1s.
-      send('restart', 'running', '正在重启 CDS(冷路径)…');
+      // ★ 2026-05-06 双模式 self-update 出口:
+      // 不论 hot 还是 cold,都通过 process.exit + systemd Restart 重启进程。
+      // ⚠ Bugbot bb81f978 + 8af6751a 教训:之前以为 `node --watch=dist` 能热重载,
+      // 但 (a) --watch 语法错了 (b) atomic rename 让 inode 变化 inotify 失效,
+      // 即使写对了也不工作。**唯一物理可行的 hot path 优化是跳过 validate,
+      // 仍然要走 systemd 重启**。
+      // 区别仍然有意义记录(updateMode):
+      //   - hot-reload: 跳过 validate,~15-25s 总耗时
+      //   - restart: 走完整 validate,~70-95s 总耗时
+      const exitMessage = hotEligible
+        ? `热路径完成: dist 已更新到 ${newHead},systemd 软重启(~5-10s,跳过了 validate)。改动 ${impact.hotReloadablePaths.length} 个应用文件。`
+        : `完整重启: HEAD=${newHead}${impact.restartTriggers.length > 0 ? `(${impact.restartTriggers.length} 处改动需重启)` : ''}。`;
+      send('restart', 'running', exitMessage);
       sendSSE(res, 'done', {
-        message: `CDS 即将重启, HEAD=${newHead}(${impact.restartTriggers.length > 0 ? '改动需重启' : '默认重启'})`,
+        message: exitMessage,
         commitHash: newHead,
-        mode: 'restart',
-        restartReasons: impact.restartTriggers.slice(0, 5).map((t) => t.reason),
+        mode: hotEligible ? 'hot-reload' : 'restart',
+        ...(hotEligible
+          ? { hotReloadFiles: impact.hotReloadablePaths.length }
+          : { restartReasons: impact.restartTriggers.slice(0, 5).map((t) => t.reason) }),
       });
       res.end();
 

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -693,6 +693,18 @@ export function createBranchRouter(deps: RouterDeps): Router {
     };
     res.write(`event: step\ndata: ${JSON.stringify(preamble)}\n\n`);
 
+    // 用户反馈 2026-05-06 (#3):远程执行器部署的 log 一直没回流到 master,
+    // GET /api/branches/:id/logs 永远空 → "部署" tab 显示 "还没有构建记录"。
+    // 这里 mirror 本地部署的 OperationLog,边 pipe SSE 边累积 events,
+    // proxy 结束(成功/失败)再 appendLog 到 stateService,与本地路径对齐。
+    const opLog: OperationLog = {
+      type: 'build',
+      startedAt: new Date().toISOString(),
+      status: 'running',
+      events: [{ step: preamble.step, status: preamble.status, title: preamble.title, timestamp: preamble.timestamp }],
+    };
+    let proxyHasError = false;
+
     // Prepare the payload the remote's /exec/deploy expects. The remote has
     // its own worktree + state, so we pass branch metadata + profiles + the
     // merged env var map and let it handle the rest.
@@ -736,6 +748,8 @@ export function createBranchRouter(deps: RouterDeps): Router {
         res.write(`event: error\ndata: ${JSON.stringify(errEvent)}\n\n`);
         entry.status = 'error';
         entry.errorMessage = errEvent.message;
+        proxyHasError = true;
+        opLog.events.push({ step: 'error', status: 'error', title: errEvent.message, timestamp: new Date().toISOString() });
         stateService.save();
         return;
       }
@@ -743,14 +757,54 @@ export function createBranchRouter(deps: RouterDeps): Router {
       // Pipe the executor's SSE bytes directly to the client. Chunks may
       // contain partial events but SSE framing is newline-delimited so the
       // browser's EventSource parser handles boundaries correctly.
+      // 同时增量解析 SSE frame 写入 opLog.events,远端执行器结束后 master
+      // 的 GET /api/branches/:id/logs 也能取到完整构建历史(用户反馈 #3)。
       const reader = upstream.body.getReader();
       const decoder = new TextDecoder('utf-8');
       let buffer = '';
+      // SSE 帧边界 = 双换行;parseSseFrames 取出完整帧、保留尾部不完整片段。
+      const parseSseFrames = (text: string): { frames: string[]; tail: string } => {
+        const out: string[] = [];
+        let rest = text;
+        while (true) {
+          const idx = rest.indexOf('\n\n');
+          if (idx === -1) break;
+          out.push(rest.slice(0, idx));
+          rest = rest.slice(idx + 2);
+        }
+        return { frames: out, tail: rest };
+      };
+      const ingestFrame = (frame: string): void => {
+        if (!frame.trim()) return;
+        let eventName = 'message';
+        const dataLines: string[] = [];
+        for (const line of frame.split('\n')) {
+          if (line.startsWith('event:')) eventName = line.slice(6).trim();
+          else if (line.startsWith('data:')) dataLines.push(line.slice(5).trim());
+        }
+        if (dataLines.length === 0) return;
+        const dataStr = dataLines.join('\n');
+        let parsed: Record<string, unknown> = {};
+        try { parsed = JSON.parse(dataStr) as Record<string, unknown>; }
+        catch { /* 非 JSON 数据降级为 raw chunk */ opLog.events.push({ step: eventName, status: 'log', chunk: dataStr.slice(0, 500), timestamp: new Date().toISOString() }); return; }
+        if (eventName === 'error') proxyHasError = true;
+        opLog.events.push({
+          step: typeof parsed.step === 'string' ? parsed.step : eventName,
+          status: typeof parsed.status === 'string' ? parsed.status : eventName,
+          title: typeof parsed.title === 'string' ? parsed.title : (typeof parsed.message === 'string' ? parsed.message : undefined),
+          detail: parsed,
+          timestamp: typeof parsed.timestamp === 'string' ? parsed.timestamp : new Date().toISOString(),
+        });
+      };
+
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;
         const chunk = decoder.decode(value, { stream: true });
         buffer += chunk;
+        const { frames, tail } = parseSseFrames(buffer);
+        buffer = tail;
+        for (const frame of frames) ingestFrame(frame);
         // Flush every complete SSE frame (terminated by blank line) so the
         // client sees updates promptly rather than waiting for the full
         // upstream response to arrive.
@@ -763,8 +817,11 @@ export function createBranchRouter(deps: RouterDeps): Router {
         }
       }
       // If the upstream ended mid-event (rare), drain the final bytes.
-      if (buffer.length > 0) {
-        try { res.write(decoder.decode()); } catch { /* client gone */ }
+      const finalChunk = decoder.decode();
+      if (finalChunk) buffer += finalChunk;
+      if (buffer.trim()) {
+        ingestFrame(buffer);
+        try { res.write(finalChunk); } catch { /* client gone */ }
       }
 
       // Master-side state is best-effort — the executor has the source of
@@ -777,8 +834,14 @@ export function createBranchRouter(deps: RouterDeps): Router {
       try { res.write(`event: error\ndata: ${JSON.stringify(errEvent)}\n\n`); } catch { /* ignore */ }
       entry.status = 'error';
       entry.errorMessage = errEvent.message;
+      proxyHasError = true;
+      opLog.events.push({ step: 'error', status: 'error', title: errEvent.message, timestamp: new Date().toISOString() });
       stateService.save();
     } finally {
+      // 收尾:remote 部署的 OperationLog 落库,与本地部署 (line 2724) 对齐
+      opLog.finishedAt = new Date().toISOString();
+      opLog.status = proxyHasError ? 'error' : 'completed';
+      try { stateService.appendLog(entry.id, opLog); } catch { /* tolerate */ }
       try { res.end(); } catch { /* ignore */ }
     }
   }

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -31,6 +31,7 @@ import { computePreviewSlug } from '../services/preview-slug.js';
 import { maskSecrets as maskSecretsText, shouldMask } from '../services/secret-masker.js';
 import { fetchWithLockRetry } from '../services/git-fetch-retry.js';
 import { nodeModulesVolumePrefix } from '../util/node-modules-volume.js';
+import { analyzeChangeImpact } from '../services/change-impact-analyzer.js';
 
 // ── Self-status SSE 模块级状态 ────────────────────────────────────────
 // 为什么放模块级而不是闭包内:
@@ -93,7 +94,13 @@ export async function broadcastSelfStatus(): Promise<void> {
       } catch (err) {
         // eslint-disable-next-line no-console
         console.warn('[self-status] broadcast 重新计算失败:', (err as Error).message);
-        if (loops >= MAX_LOOPS) break;
+        if (loops >= MAX_LOOPS) {
+          // ⚠ Bugbot 2026-05-06 bd579e3d:错误退出时 broadcastQueued 残留 true
+          // 不会被消费,与 coalesce 心智模型不一致(下次 fresh call 会复位但
+          // 留状态残影)。显式复位以便 finally 后调用方看到干净状态。
+          broadcastQueued = false;
+          break;
+        }
         // 失败后给事件循环让出 1s,避免持续故障下的 hot loop
         await new Promise((r) => setTimeout(r, 1_000));
         continue;
@@ -8879,18 +8886,54 @@ cdscli project list --human
         return;
       }
 
+      // ★ 2026-05-06 新增 — 改动影响分析,决定走"热重载"还是"完整重启"。
+      // 用户反馈:让两种模式同时生效,自动判断。RESTART_PATTERNS(依赖/Docker/
+      // tsconfig/vite.config/.env/路由 schema)命中任一即冷重启;否则走热重载。
+      // 热路径跳过 validate(节省 ~50s),直接 incremental emit + atomic swap +
+      // 写 .build-sha,然后**不**触发 systemd restart。systemd unit 的 ExecStart
+      // 已经改成 `node --watch=dist`,node 自己感知 dist/ 变化平滑重启 ~2s。
+      let changedPaths: string[] = [];
+      try {
+        const diffRes = await shell.exec(
+          `git diff --name-only ${fromSha || 'HEAD~1'}..HEAD`,
+          { cwd: repoRoot, timeout: 15_000 },
+        );
+        if (diffRes.exitCode === 0) {
+          changedPaths = diffRes.stdout.split('\n').map((s) => s.trim()).filter(Boolean);
+        }
+      } catch { /* tolerate — fall through to cold restart */ }
+      const impact = analyzeChangeImpact(changedPaths);
+      if (impact.needsRestart) {
+        const sample = impact.restartTriggers.slice(0, 3).map((t) => `${t.path}(${t.reason})`).join('; ');
+        send('analyze', 'done', `${impact.restartTriggers.length} 处改动需重启:${sample}${impact.restartTriggers.length > 3 ? '…' : ''}`);
+      } else {
+        send('analyze', 'done', `本次改动 ${changedPaths.length} 文件全部热重载安全(应用代码 ${impact.hotReloadablePaths.length} + 文档 ${impact.irrelevantPaths.length})— 走热重载快路径`);
+      }
+      const hotEligible = !impact.needsRestart && changedPaths.length > 0;
+
       // Step 4: validate new code compiles BEFORE touching dist.
       //
-      // ★ 2026-05-05 顺序修正（用户实测 4 次 abort 留空 dist）：
-      // 历史顺序是 cache → validate，validate 失败时 dist 已经清空 →
+      // ★ 2026-05-05 顺序修正(用户实测 4 次 abort 留空 dist):
+      // 历史顺序是 cache → validate,validate 失败时 dist 已经清空 →
       // systemd 重启 cds-master 就找不到 dist/index.js → CDS 起不来 →
       // 用户必须 SSH 手动 npx tsc 救场。
       //
-      // 现改成 validate 先做（tsc --noEmit 不输出文件，无副作用），
-      // 通过才清 dist + tsbuildinfo + 重建。fail-safe：validate 失败时
-      // dist 完好，cds 继续跑老版本，不需要人工介入。
+      // 现改成 validate 先做(tsc --noEmit 不输出文件,无副作用),
+      // 通过才清 dist + tsbuildinfo + 重建。fail-safe:validate 失败时
+      // dist 完好,cds 继续跑老版本,不需要人工介入。
+      //
+      // ★ 2026-05-06 热路径优化:hotEligible 时跳过 validate(50s)。理由:
+      //   - tsc emit 步骤本身就会捕获类型错误(失败 → dist.next 删除,旧 dist 保留)
+      //   - hot-eligible 已排除 package.json/lockfile 变更,无需 pnpm install
+      // 风险:web tsc 错误不再阻断,改成 emit 阶段 vite build 失败 → web bundleStale
+      // 徽章亮(原行为)。
+      let validation: Awaited<ReturnType<typeof validateBuildReadiness>>;
+      if (hotEligible) {
+        send('validate', 'done', '热路径:跳过 validate(改动只涉及应用代码,tsc emit 会捕获错误)');
+        validation = { ok: true, summary: 'skipped via hot-path' };
+      } else {
       send('validate', 'running', '预检: pnpm install + tsc --noEmit…');
-      const validation = await validateBuildReadiness(shell, cdsDir);
+      validation = await validateBuildReadiness(shell, cdsDir);
       if (!validation.ok) {
         send('validate', 'error', `预检失败: ${validation.error.slice(0, 300)}`);
         sendSSE(res, 'error', {
@@ -8916,6 +8959,7 @@ cdscli project list --human
       if (validation.webWarning) {
         send('web-warning', 'warning', validation.webWarning.slice(0, 400));
       }
+      } // end of cold-path validate
 
       // Step 5+6: Atomic 重建 dist —— 编译到 dist.next/，验证后才 swap。
       //
@@ -9046,11 +9090,36 @@ cdscli project list --human
         status: 'success',
         durationMs: Date.now() - startedAt,
         actor,
+        // 把热路径决策记到流水里,UI 历史可分辨"重启 / 热重载 / no-op"
+        ...({ updateMode: hotEligible ? 'hot-reload' : 'restart' } as Record<string, unknown>),
       });
 
-      // Step 6: restart via exec_cds.sh daemon spawn, exit after 1s.
-      send('restart', 'running', '正在重启 CDS…');
-      sendSSE(res, 'done', { message: `CDS 即将重启, HEAD=${newHead}`, commitHash: newHead });
+      // ★ 2026-05-06 热路径出口:hotEligible 时**不**触发 systemd restart。
+      // node --watch=dist 已在 systemd ExecStart 里启动,dist/ 文件 mtime 变化
+      // 自己平滑重启,~2s 完成,期间老进程优雅退出 + 新进程接管。
+      if (hotEligible) {
+        send('hot-reload', 'done',
+          `热重载完成: dist 已更新到 ${newHead},node --watch 自动重启进程(~2s)。` +
+          `本次改动 ${impact.hotReloadablePaths.length} 个应用文件全部热路径安全。`,
+        );
+        sendSSE(res, 'done', {
+          message: `热重载已生效, HEAD=${newHead}(应用代码改动,无需重启 systemd unit)`,
+          commitHash: newHead,
+          mode: 'hot-reload',
+          hotReloadFiles: impact.hotReloadablePaths.length,
+        });
+        res.end();
+        return;
+      }
+
+      // Step 6 (cold path): restart via exec_cds.sh daemon spawn, exit after 1s.
+      send('restart', 'running', '正在重启 CDS(冷路径)…');
+      sendSSE(res, 'done', {
+        message: `CDS 即将重启, HEAD=${newHead}(${impact.restartTriggers.length > 0 ? '改动需重启' : '默认重启'})`,
+        commitHash: newHead,
+        mode: 'restart',
+        restartReasons: impact.restartTriggers.slice(0, 5).map((t) => t.reason),
+      });
       res.end();
 
       // Same restart technique as /api/self-update — spawn a detached bash

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -8653,12 +8653,46 @@ cdscli project list --human
       const newHead = (await shell.exec('git rev-parse --short HEAD', { cwd: repoRoot })).stdout.trim();
       send('reset', 'done', `HEAD = ${newHead}`, { commitHash: newHead });
 
-      // Step 4: drop dist build cache so next start recompiles.
+      // Step 4: validate new code compiles BEFORE touching dist.
       //
-      // 2026-05-05: 仅删 .build-sha 还不够，TypeScript incremental 缓存
-      // (.tsbuildinfo) 让 systemd ExecStartPre 的 `npx tsc` 跳过编译，
-      // 导致代码已切但 dist/ 仍是 stale。所以同步删 .tsbuildinfo（项目根
-      // 和 cds/ 各一份）+ 删整个 dist/ 让 tsc 必须从头编译。
+      // ★ 2026-05-05 顺序修正（用户实测 4 次 abort 留空 dist）：
+      // 历史顺序是 cache → validate，validate 失败时 dist 已经清空 →
+      // systemd 重启 cds-master 就找不到 dist/index.js → CDS 起不来 →
+      // 用户必须 SSH 手动 npx tsc 救场。
+      //
+      // 现改成 validate 先做（tsc --noEmit 不输出文件，无副作用），
+      // 通过才清 dist + tsbuildinfo + 重建。fail-safe：validate 失败时
+      // dist 完好，cds 继续跑老版本，不需要人工介入。
+      send('validate', 'running', '预检: pnpm install + tsc --noEmit…');
+      const validation = await validateBuildReadiness(shell, cdsDir);
+      if (!validation.ok) {
+        send('validate', 'error', `预检失败: ${validation.error.slice(0, 300)}`);
+        sendSSE(res, 'error', {
+          message: `force-sync 已中止 — ${target} 的代码没过预检: ${validation.error}`,
+        });
+        res.end();
+        // 流水标 'aborted' 同 self-update 处理 — 安全中止,不是真正的故障。
+        // dist 完好，cds 继续跑老版本，下次重启 systemd ExecStartPre 用现有 dist。
+        stateService.recordSelfUpdate({
+          ts: new Date().toISOString(),
+          branch: branch || target || '',
+          fromSha,
+          toSha: fromSha,
+          trigger: 'force-sync',
+          status: 'aborted',
+          durationMs: Date.now() - startedAt,
+          error: `预检失败 (${validation.stage}): ${(validation.error || '').slice(0, 1500)}`,
+          actor,
+        });
+        return;
+      }
+      send('validate', 'done', validation.summary);
+      if (validation.webWarning) {
+        send('web-warning', 'warning', validation.webWarning.slice(0, 400));
+      }
+
+      // Step 5: validate 通过，安全清空 backend 编译缓存，下次启动重新编译。
+      // 此时即便 cache 操作失败，dist 也还在原地，cds 仍可运行。
       send('cache', 'running', '清除 dist/ + tsc 增量缓存…');
       const cacheTargets = [
         path.join(cdsDir, 'dist', '.build-sha'),
@@ -8687,33 +8721,36 @@ cdscli project list --human
       }
       send('cache', 'done', removed.length > 0 ? `已清: ${removed.join(', ')}` : '无缓存可清');
 
-      // Step 5: validate new code compiles before restart.
-      send('validate', 'running', '预检: pnpm install + tsc --noEmit…');
-      const validation = await validateBuildReadiness(shell, cdsDir);
-      if (!validation.ok) {
-        send('validate', 'error', `预检失败: ${validation.error.slice(0, 300)}`);
-        sendSSE(res, 'error', {
-          message: `force-sync 已中止 — ${target} 的代码没过预检: ${validation.error}`,
-        });
+      // Step 6: 主动 in-process rebuild dist（不依赖 systemd ExecStartPre）。
+      //
+      // 为什么自己跑：systemd ExecStartPre 的 npx tsc 在生产环境观测到偶尔
+      // 静默 skip 不重建 dist（tsc incremental cache 边界 case / cwd 解析
+      // 问题），导致清 dist 后 cds-master 重启找不到 dist/index.js。这里
+      // 主动跑一次 tsc 让 dist 立刻就位，systemd 重启时 ExecStartPre 是
+      // incremental no-op，cds 立刻能起。
+      send('build-backend', 'running', '主动重建 cds/dist …');
+      const tscRes = await shell.exec(
+        'npx tsc',
+        { cwd: cdsDir, timeout: 240_000, env: { NODE_OPTIONS: '--max-old-space-size=4096' } },
+      );
+      if (tscRes.exitCode !== 0) {
+        const errMsg = combinedOutput(tscRes).slice(0, 1500);
+        send('build-backend', 'error', `tsc 编译失败: ${errMsg.slice(0, 300)}`);
+        sendSSE(res, 'error', { message: `cds/dist 编译失败 — cds 继续跑老版本，请检查代码：\n${errMsg.slice(0, 800)}` });
         res.end();
-        // 流水标 'aborted' 同 self-update 处理 — 安全中止,不是真正的故障。
-        stateService.recordSelfUpdate({
-          ts: new Date().toISOString(),
-          branch: branch || target || '',
-          fromSha,
-          toSha: fromSha,
-          trigger: 'force-sync',
-          status: 'aborted',
-          durationMs: Date.now() - startedAt,
-          error: `预检失败 (${validation.stage}): ${(validation.error || '').slice(0, 250)}`,
-          actor,
-        });
+        recordFailure(`tsc 编译失败: ${errMsg.slice(0, 300)}`);
         return;
       }
-      send('validate', 'done', validation.summary);
-      if (validation.webWarning) {
-        send('web-warning', 'warning', validation.webWarning.slice(0, 400));
+      // 验证 dist 真生成了关键文件（tsc 偶发 exit=0 但 outDir 为空）
+      const distEntry = path.join(cdsDir, 'dist', 'index.js');
+      if (!fs.existsSync(distEntry)) {
+        send('build-backend', 'error', 'tsc 报成功但 dist/index.js 不存在');
+        sendSSE(res, 'error', { message: 'tsc 编译报成功但 dist/index.js 缺失，已中止重启避免 cds 起不来' });
+        res.end();
+        recordFailure('tsc exit=0 but dist/index.js missing');
+        return;
       }
+      send('build-backend', 'done', `dist/ 已就位（${(await shell.exec('ls dist | wc -l', { cwd: cdsDir })).stdout.trim()} 个文件）`);
 
       // In-process 重建 cds/web/dist —— Bugbot PR #524 第九轮反馈:之前
       // self-force-sync 走 daemon build_web(实测 production 不可靠),会复现

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -30,6 +30,7 @@ import { buildPreviewUrl } from '../services/comment-template.js';
 import { computePreviewSlug } from '../services/preview-slug.js';
 import { maskSecrets as maskSecretsText, shouldMask } from '../services/secret-masker.js';
 import { fetchWithLockRetry } from '../services/git-fetch-retry.js';
+import { nodeModulesVolumePrefix } from '../util/node-modules-volume.js';
 
 // ── Self-status SSE 模块级状态 ────────────────────────────────────────
 // 为什么放模块级而不是闭包内:
@@ -2183,8 +2184,8 @@ export function createBranchRouter(deps: RouterDeps): Router {
       // create/delete 分支会留下数百 MB × N 个孤儿。这里 docker volume ls
       // 过滤前缀 + docker volume rm,失败容忍(volume 还被某个容器引用)。
       try {
-        const sanitize = (s: string): string => s.replace(/[^a-zA-Z0-9_.-]/g, '-').slice(0, 60);
-        const prefix = `cds-nm-${sanitize(entry.id)}-`;
+        // SSOT: util/node-modules-volume.ts(Bugbot 3e19da66 — 防 sanitize 漂移)
+        const prefix = nodeModulesVolumePrefix(entry.id);
         const list = await shell.exec(`docker volume ls --format='{{.Name}}' --filter name=^${prefix}`);
         if (list.exitCode === 0) {
           const names = list.stdout.split('\n').map((s) => s.trim()).filter((n) => n.startsWith(prefix));
@@ -8282,13 +8283,25 @@ cdscli project list --human
     }
     selfStatusClients.add(res);
 
-    // ⚠ Bugbot 2026-05-06 d7db4dba:snapshot 用 skipFetch=true(避免连接被 git fetch 阻塞),
-    // 所以它的 fetchOk=false / remoteAheadCount 走 cached refs(可能 stale)。
-    // 后续如果没有 webhook push,客户端永远看不到真实远端状态。在 add(res) 之后
-    // 异步 fire-and-forget 一次 broadcastSelfStatus()(走 skipFetch=false 真 fetch),
-    // 几秒内推一条 update 给所有 client(包括刚连上的这个)消除盲点。
-    // broadcastSelfStatus 本身有 coalesce,多个并发新连接不会引发 fetch 风暴。
-    void broadcastSelfStatus().catch(() => { /* 已在内部记 warn */ });
+    // ⚠ Bugbot 2026-05-06 d7db4dba + d19e3cf1:snapshot 用 skipFetch=true 避免
+    // 连接被 git fetch 阻塞,代价是 fetchOk=false / remoteAheadCount 走 cached refs
+    // (可能 stale)。原方案 broadcastSelfStatus() 会把 update 推给**所有**客户端
+    // → 多 tab 时每开一个新 tab,旧 tab 都收到一条冗余 update + git fetch 也跑一次。
+    // 改成只给**当前新连接**真 fetch 一次推 update,不打扰别的 client。
+    void (async () => {
+      try {
+        const payload = await computeSelfStatusPayload(
+          { repoRoot: config.repoRoot, shell, stateService },
+          { skipFetch: false },
+        );
+        // 期间客户端可能断开 / 主动关
+        if (req.destroyed || !selfStatusClients.has(res)) return;
+        res.write(`event: update\ndata: ${JSON.stringify(payload)}\n\n`);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn('[self-status/stream] 首屏 fresh fetch 失败,下一条 webhook update 会兜底:', (err as Error).message);
+      }
+    })();
 
     // 3) 25s keepalive,防 nginx/中间代理 60s 闲置超时 cut 连接
     const keepalive = setInterval(() => {

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -122,6 +122,44 @@ export async function broadcastSelfStatus(): Promise<void> {
 }
 
 /**
+ * 检测 cds/systemd/cds-master.service(repo)与 /etc/systemd/system/cds-master.service
+ * (installed)是否漂移。归一化 install-path 后做 sha1 比对,命中就返 hash 对让
+ * MaintenanceTab 的 drift banner 显示一行 sudo 修复命令。
+ *
+ * 抽成顶层 helper 是为了 /api/self-status 的 catch fallback(Bugbot 50e705cf)
+ * 也能带回这个字段:git fetch 偶发失败时 banner 不应消失。
+ */
+type SystemdUnitDrift = { repoHash: string; installedHash: string; installedAt?: string };
+function detectSystemdUnitDrift(repoRoot: string): SystemdUnitDrift | null {
+  const repoUnit = path.resolve(repoRoot, 'cds', 'systemd', 'cds-master.service');
+  const installedUnit = '/etc/systemd/system/cds-master.service';
+  if (!fs.existsSync(repoUnit) || !fs.existsSync(installedUnit)) return null;
+  const repoText = fs.readFileSync(repoUnit, 'utf8');
+  const installedText = fs.readFileSync(installedUnit, 'utf8');
+  // install_systemd_cmd 会替换 ExecStart 的 /opt/prd_agent/... 路径,
+  // 比较时归一化:把两边的 /opt/prd_agent/... 路径全部抹掉,只看其他字段。
+  // 否则 development 装在 /home/user/ 永远 drift 误报。
+  const normalize = (s: string): string =>
+    s
+      .replace(/^WorkingDirectory=.*/m, 'WorkingDirectory=<install-path>')
+      .replace(/^Environment=PATH=.*/m, 'Environment=PATH=<resolved>')
+      .replace(/^Environment=CDS_REPO_ROOT=.*/m, 'Environment=CDS_REPO_ROOT=<install-path>')
+      .replace(/^ExecStart=.*master-run.*/m, 'ExecStart=<install-path>/exec_cds.sh master-run')
+      .replace(/^ExecStartPre=\S+/gm, 'ExecStartPre=<resolved-bin>')
+      .replace(/^ReadWritePaths=.*/m, 'ReadWritePaths=<resolved>');
+  if (normalize(repoText) === normalize(installedText)) return null;
+  const hash = (s: string): string => createHash('sha1').update(s).digest('hex').slice(0, 8);
+  const drift: SystemdUnitDrift = {
+    repoHash: hash(normalize(repoText)),
+    installedHash: hash(normalize(installedText)),
+  };
+  try {
+    drift.installedAt = fs.statSync(installedUnit).mtime.toISOString();
+  } catch { /* tolerate */ }
+  return drift;
+}
+
+/**
  * 纯计算 self-status payload。
  * 与 GET /api/self-status handler 共享同一份逻辑,避免双份维护。
  *
@@ -257,36 +295,11 @@ async function computeSelfStatusPayload(
   // 用户反馈 2026-05-06:每次改 unit 都要 sudo 重装太蠢。重构后 unit 文件
   // 极少改,但确实改时 operator 不知道 → 默默用旧 unit。这里检测 drift,
   // 命中就在 self-status payload 里曝光,UI 提示 operator 用一行命令重装。
-  let systemdUnitDrift: { repoHash: string; installedHash: string; installedAt?: string } | null = null;
+  // ⚠ Bugbot 50e705cf:抽到顶层 helper detectSystemdUnitDrift,/api/self-status
+  // catch fallback 也要带回这个字段,否则 git fetch 偶发失败时 drift banner 消失。
+  let systemdUnitDrift: SystemdUnitDrift | null = null;
   try {
-    const repoUnit = path.resolve(repoRoot, 'cds', 'systemd', 'cds-master.service');
-    const installedUnit = '/etc/systemd/system/cds-master.service';
-    if (fs.existsSync(repoUnit) && fs.existsSync(installedUnit)) {
-      const repoText = fs.readFileSync(repoUnit, 'utf8');
-      const installedText = fs.readFileSync(installedUnit, 'utf8');
-      // install_systemd_cmd 会替换 ExecStart 的 /opt/prd_agent/... 路径,
-      // 比较时归一化:把两边的 /opt/prd_agent/... 路径全部抹掉,只看其他字段。
-      // 否则 development 装在 /home/user/ 永远 drift 误报。
-      const normalize = (s: string): string =>
-        s
-          .replace(/^WorkingDirectory=.*/m, 'WorkingDirectory=<install-path>')
-          .replace(/^Environment=PATH=.*/m, 'Environment=PATH=<resolved>')
-          .replace(/^Environment=CDS_REPO_ROOT=.*/m, 'Environment=CDS_REPO_ROOT=<install-path>')
-          .replace(/^ExecStart=.*master-run.*/m, 'ExecStart=<install-path>/exec_cds.sh master-run')
-          .replace(/^ExecStartPre=\S+/gm, 'ExecStartPre=<resolved-bin>')
-          .replace(/^ReadWritePaths=.*/m, 'ReadWritePaths=<resolved>');
-      if (normalize(repoText) !== normalize(installedText)) {
-        const hash = (s: string): string => createHash('sha1').update(s).digest('hex').slice(0, 8);
-        systemdUnitDrift = {
-          repoHash: hash(normalize(repoText)),
-          installedHash: hash(normalize(installedText)),
-        };
-        try {
-          const stat = fs.statSync(installedUnit);
-          systemdUnitDrift.installedAt = stat.mtime.toISOString();
-        } catch { /* tolerate */ }
-      }
-    }
+    systemdUnitDrift = detectSystemdUnitDrift(repoRoot);
   } catch (err) {
     degradedReasons.push(`unitDrift: ${(err as Error).message}`);
   }
@@ -8264,6 +8277,13 @@ cdscli project list --human
     } catch (err) {
       // computeSelfStatusPayload 自身已尽量不抛;真抛了也返 200 + degraded
       // 保证前端不会看到红色 banner。
+      // ⚠ Bugbot 50e705cf:把 activeSelfUpdate / systemdUnitDrift 也带回去 —
+      // 即使 git fetch 等数据组装失败,这两个 in-memory / fs-only 字段仍可读,
+      // 缺了就让 MaintenanceTab 跨 tab 同步 + drift banner 都失效。
+      let degradedActive: import('../types.js').ActiveSelfUpdate | null = null;
+      let degradedDrift: SystemdUnitDrift | null = null;
+      try { degradedActive = stateService.getActiveSelfUpdate(); } catch { /* tolerate */ }
+      try { degradedDrift = detectSystemdUnitDrift(config.repoRoot); } catch { /* tolerate */ }
       res.json({
         currentBranch: '',
         headSha: '',
@@ -8278,6 +8298,8 @@ cdscli project list --human
         webBuildSha: '',
         webBuildError: '',
         bundleStale: false,
+        activeSelfUpdate: degradedActive,
+        systemdUnitDrift: degradedDrift,
         degraded: { reasons: [(err as Error).message] },
         cachedAt: new Date().toISOString(),
       });
@@ -9161,27 +9183,37 @@ cdscli project list --human
       send('cache', 'done', removed.length > 0 ? `已清: ${removed.join(', ')}` : '无缓存可清');
 
       // 编译到 dist.next/,旧 dist/ 全程不动。
-      // 用户反馈 2026-05-06:tsc 30-50s 太慢,改 esbuild + 并行 tsc --noEmit:
+      // 用户反馈 2026-05-06:tsc 30-50s 太慢,改 esbuild + 按需并行 tsc --noEmit:
       //   - esbuild emit JS:~1s(纯 syntax 转译,无类型检查)
       //   - tsc --noEmit:5-30s(增量;有 .tsbuildinfo 命中可秒级)
-      //   两者并行,wall-clock = max(1s, tsc) ≈ tsc 时间。
-      //   类型错误由 tsc 兜底:失败 → abort,旧 dist 保留(fail-safe)。
       //
-      // hot-eligible 时 validate 阶段已跳过 tsc --noEmit,这里再跑一次保证类型
-      // 安全。即便如此,从串行 tsc emit 30s + 30s validate → 并行 max 各 10-20s,
-      // 总收益依然显著。
-      send('build-backend', 'running', '编译 cds/dist.next/(esbuild + tsc --noEmit 并行)…');
+      // ⚠ Bugbot 858bca04 (Medium):**只**在 hotEligible 时并行跑 tsc。
+      // cold path 的 validateBuildReadiness(line ~9089)已经跑过 tsc --noEmit
+      // 通过了,这里再跑一次纯属重复(浪费 5-30s)。
+      // hot path 的 validate 设了 skipTsc=true,所以这里必须补一次 tsc 兜底。
+      const skipTscInBuild = !hotEligible;
+      send(
+        'build-backend',
+        'running',
+        skipTscInBuild
+          ? '编译 cds/dist.next/(esbuild — cold path validate 已跑过 tsc)…'
+          : '编译 cds/dist.next/(esbuild + tsc --noEmit 并行)…',
+      );
       const buildStartedAt = Date.now();
-      const [esbuildRes, tscCheckRes] = await Promise.all([
+      const tasks: Array<Promise<Awaited<ReturnType<typeof shell.exec>>>> = [
         shell.exec(
           'node scripts/build-dist-esbuild.mjs',
           { cwd: cdsDir, timeout: 60_000, env: { OUT_DIR: 'dist.next' } },
         ),
-        shell.exec(
-          'npx tsc --noEmit',
-          { cwd: cdsDir, timeout: 120_000 },
-        ),
-      ]);
+      ];
+      if (!skipTscInBuild) {
+        tasks.push(
+          shell.exec('npx tsc --noEmit', { cwd: cdsDir, timeout: 120_000 }),
+        );
+      }
+      const buildResults = await Promise.all(tasks);
+      const esbuildRes = buildResults[0];
+      const tscCheckRes = skipTscInBuild ? null : buildResults[1];
       const buildElapsed = ((Date.now() - buildStartedAt) / 1000).toFixed(1);
       if (esbuildRes.exitCode !== 0) {
         const errMsg = combinedOutput(esbuildRes).slice(0, 1500);
@@ -9192,7 +9224,7 @@ cdscli project list --human
         recordFailure(`esbuild 编译失败: ${errMsg.slice(0, 300)}`);
         return;
       }
-      if (tscCheckRes.exitCode !== 0) {
+      if (tscCheckRes && tscCheckRes.exitCode !== 0) {
         const errMsg = combinedOutput(tscCheckRes).slice(0, 1500);
         try { fs.rmSync(path.join(cdsDir, 'dist.next'), { recursive: true, force: true }); } catch { /* ignore */ }
         send('build-backend', 'error', `tsc 类型检查失败(旧 dist 保留): ${errMsg.slice(0, 300)}`);
@@ -9201,7 +9233,13 @@ cdscli project list --human
         recordFailure(`tsc 类型检查失败: ${errMsg.slice(0, 300)}`);
         return;
       }
-      send('build-backend', 'done', `编译完成 (${buildElapsed}s) — esbuild emit + tsc --noEmit 并行通过`);
+      send(
+        'build-backend',
+        'done',
+        skipTscInBuild
+          ? `编译完成 (${buildElapsed}s) — esbuild emit(tsc 已在 validate 阶段过)`
+          : `编译完成 (${buildElapsed}s) — esbuild emit + tsc --noEmit 并行通过`,
+      );
       const nextEntry = path.join(cdsDir, 'dist.next', 'index.js');
       if (!fs.existsSync(nextEntry)) {
         try { fs.rmSync(path.join(cdsDir, 'dist.next'), { recursive: true, force: true }); } catch { /* ignore */ }

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -302,6 +302,7 @@ async function computeSelfStatusPayload(
     remoteAheadSubjects,
     lastSelfUpdate: history[0] || null,
     selfUpdateHistory: history,
+    activeSelfUpdate: stateService.getActiveSelfUpdate(),
     webBuildSha,
     webBuildError,
     systemdUnitDrift,
@@ -8387,6 +8388,15 @@ cdscli project list --human
     const { branch } = req.body as { branch?: string };
 
     initSSE(res);
+    // 2026-05-06 用户反馈:中间面板不知道别 session 触发的 self-update。
+    // 标记 in-progress,/api/self-status 把这个状态带回所有 tab,违反
+    // server-authority 不再发生。
+    stateService.markSelfUpdateActive({
+      startedAt: new Date().toISOString(),
+      branch: branch || '',
+      trigger: 'manual',
+      actor: (req as { username?: string }).username || 'unknown',
+    });
     const send = (step: string, status: string, title: string) => {
       sendSSE(res, 'step', { step, status, title, timestamp: new Date().toISOString() });
     };
@@ -8781,8 +8791,17 @@ cdscli project list --human
     const { branch } = (req.body || {}) as { branch?: string };
 
     initSSE(res);
+    stateService.markSelfUpdateActive({
+      startedAt: new Date().toISOString(),
+      branch: branch || '',
+      trigger: 'force-sync',
+      actor: (req as { username?: string }).username || 'unknown',
+    });
     const send = (step: string, status: string, title: string, extra?: Record<string, unknown>) => {
       sendSSE(res, 'step', { step, status, title, timestamp: new Date().toISOString(), ...(extra || {}) });
+      // 把当前阶段塞回 active marker,/api/self-status 能看到 step="validate" 等
+      const cur = stateService.getActiveSelfUpdate();
+      if (cur) stateService.markSelfUpdateActive({ ...cur, step });
     };
 
     // 流水记录(2026-05-04):同 /api/self-update,trigger='force-sync',

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -2185,8 +2185,12 @@ export function createBranchRouter(deps: RouterDeps): Router {
       // 过滤前缀 + docker volume rm,失败容忍(volume 还被某个容器引用)。
       try {
         // SSOT: util/node-modules-volume.ts(Bugbot 3e19da66 — 防 sanitize 漂移)
+        // ⚠ Bugbot 2c7c4ad2:docker `--filter name=` 是 substring 匹配,**不是** regex,
+        // `^` 被当字面量 → 永远 0 命中,cleanup 静默失败,孤儿照样累积。
+        // 改为子串过滤(name=prefix)粗筛 + JS startsWith 精确兜底,前缀里的 hyphen
+        // 已足够独特,不会误吞其他名字。
         const prefix = nodeModulesVolumePrefix(entry.id);
-        const list = await shell.exec(`docker volume ls --format='{{.Name}}' --filter name=^${prefix}`);
+        const list = await shell.exec(`docker volume ls --format='{{.Name}}' --filter name=${prefix}`);
         if (list.exitCode === 0) {
           const names = list.stdout.split('\n').map((s) => s.trim()).filter((n) => n.startsWith(prefix));
           for (const name of names) {

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -29,6 +29,7 @@ import { isSafeGitRef } from '../services/github-webhook-dispatcher.js';
 import { buildPreviewUrl } from '../services/comment-template.js';
 import { computePreviewSlug } from '../services/preview-slug.js';
 import { maskSecrets as maskSecretsText, shouldMask } from '../services/secret-masker.js';
+import { fetchWithLockRetry } from '../services/git-fetch-retry.js';
 
 // ── Self-status SSE 模块级状态 ────────────────────────────────────────
 // 为什么放模块级而不是闭包内:
@@ -125,30 +126,20 @@ async function computeSelfStatusPayload(
     fetchOk = false;
     fetchError = 'skipped (snapshot uses cached refs)';
   } else if (branchIsSafe) {
-    // ⚠ Bugbot Review 2026-05-06 930c5f98: broadcastSelfStatus 在 webhook 风暴
-    // 期间会和 deploy worker 的 git fetch 抢同一个 .git/refs/remotes/.../<branch>.lock,
-    // 单次 exec 直接退非 0,前端拿到 fetchOk=false + 计数空。WorktreeService.fetchWithLockRetry
-    // 已有同样 retry 逻辑;这里 inline 一份(模块级 free function 不便复用 class private)。
-    // maxAttempts=3 与 worktree 一致;退避 2s/4s 累计 ≤ 6s,在 SSE 推送可接受范围内。
+    // ⚠ Bugbot Review 2026-05-06 930c5f98 + e0f66dce: broadcastSelfStatus 在
+    // webhook 风暴期间会和 deploy worker 的 git fetch 抢同一个
+    // .git/refs/remotes/.../<branch>.lock。共享 fetchWithLockRetry(SSOT 在
+    // services/git-fetch-retry.ts),与 WorktreeService 同语义,改一处生效全局。
     try {
-      const maxAttempts = 3;
-      let lastResult: Awaited<ReturnType<typeof shell.exec>> | null = null;
-      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-        lastResult = await shell.exec(
-          `git fetch origin ${currentBranch}`,
-          { cwd: repoRoot, timeout: 5_000 },
-        );
-        if (lastResult.exitCode === 0) break;
-        const errOut = ((lastResult.stderr || '') + (lastResult.stdout || ''));
-        const isLockErr = /cannot lock ref|unable to create.*lock/i.test(errOut);
-        if (!isLockErr || attempt === maxAttempts) break;
-        await new Promise((r) => setTimeout(r, 2_000 * attempt));
-      }
-      if (!lastResult || lastResult.exitCode !== 0) {
+      const fetchResult = await fetchWithLockRetry(
+        shell,
+        repoRoot,
+        currentBranch,
+        { timeoutMs: 5_000 },
+      );
+      if (fetchResult.exitCode !== 0) {
         fetchOk = false;
-        fetchError = lastResult
-          ? (lastResult.stderr || lastResult.stdout || '').trim().slice(0, 500)
-          : 'fetch returned no result';
+        fetchError = (fetchResult.stderr || fetchResult.stdout || '').trim().slice(0, 500);
       }
     } catch (err) {
       fetchOk = false;

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -817,12 +817,17 @@ export function createBranchRouter(deps: RouterDeps): Router {
         }
       }
       // If the upstream ended mid-event (rare), drain the final bytes.
+      // ⚠ Bugbot 2026-05-06 047481b8: 区分两种 leftover,语义不同 —
+      //   1. finalChunk = decoder 内部 multi-byte 续 buf,**还没**写过客户端 → 必须 res.write
+      //   2. buffer = SSE 解析器尾部不完整帧(loop 内 chunk 早就写过客户端了) → 仅需 ingestFrame 入 opLog
+      // 之前用 if (buffer.trim()) 同时管两件事,finalChunk 为空但 buffer 有
+      // 残留时,res.write(finalChunk) 等于 res.write('') 没意义 — 拆成两个独立 guard。
       const finalChunk = decoder.decode();
-      if (finalChunk) buffer += finalChunk;
-      if (buffer.trim()) {
-        ingestFrame(buffer);
+      if (finalChunk) {
         try { res.write(finalChunk); } catch { /* client gone */ }
+        buffer += finalChunk;
       }
+      if (buffer.trim()) ingestFrame(buffer);
 
       // Master-side state is best-effort — the executor has the source of
       // truth via its next heartbeat, which will reconcile status.

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -30,6 +30,190 @@ import { buildPreviewUrl } from '../services/comment-template.js';
 import { computePreviewSlug } from '../services/preview-slug.js';
 import { maskSecrets as maskSecretsText, shouldMask } from '../services/secret-masker.js';
 
+// ── Self-status SSE 模块级状态 ────────────────────────────────────────
+// 为什么放模块级而不是闭包内:
+//   - GET /api/self-status/stream 客户端池需要被 broadcastSelfStatus()
+//     从模块外(github-webhook.ts)触达。
+//   - selfStatusContext 由 createBranchRouter() 在启动时填充,提供给
+//     broadcastSelfStatus() 重新计算 payload 所需的依赖(repoRoot/shell/state)。
+// 注意:CDS 单进程单实例,Set 不需要并发锁。
+let selfStatusContext: {
+  repoRoot: string;
+  shell: IShellExecutor;
+  stateService: StateService;
+} | null = null;
+const selfStatusClients = new Set<import('express').Response>();
+
+/**
+ * 重新计算 self-status payload 并向所有 SSE 客户端推送 update 事件。
+ *
+ * 由 GitHub push webhook(当前 CDS 跑的分支收到新 commit 时)调用。
+ * 也保留给后续 self-update 完成钩子复用。
+ *
+ * 实现要点:
+ *   - 这次允许触发 git fetch(带 5s 超时),否则前端拿到的 ahead 计数还是旧的
+ *   - 远端不可达 → 用 fetchOk=false + cached refs 兜底,不阻塞推送
+ *   - 写失败的 client 从池里清除(对端已断开)
+ */
+export async function broadcastSelfStatus(): Promise<void> {
+  if (!selfStatusContext) return;
+  if (selfStatusClients.size === 0) return;
+  let payload: unknown;
+  try {
+    payload = await computeSelfStatusPayload(selfStatusContext, { skipFetch: false });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn('[self-status] broadcast 重新计算失败:', (err as Error).message);
+    return;
+  }
+  const line = `event: update\ndata: ${JSON.stringify(payload)}\n\n`;
+  for (const client of Array.from(selfStatusClients)) {
+    try {
+      client.write(line);
+    } catch {
+      selfStatusClients.delete(client);
+    }
+  }
+}
+
+/**
+ * 纯计算 self-status payload。
+ * 与 GET /api/self-status handler 共享同一份逻辑,避免双份维护。
+ *
+ * skipFetch=true → SSE 首屏 snapshot 用本地 cached refs(不发网络)
+ * skipFetch=false → 真实查询(走 git fetch,带超时)
+ */
+async function computeSelfStatusPayload(
+  ctx: { repoRoot: string; shell: IShellExecutor; stateService: StateService },
+  opts: { skipFetch: boolean },
+): Promise<Record<string, unknown>> {
+  const { repoRoot, shell, stateService } = ctx;
+  const degradedReasons: string[] = [];
+  const safeExec = async (
+    cmd: string,
+    execOpts: { cwd: string; timeout?: number } = { cwd: repoRoot },
+    fallback = '',
+  ): Promise<string> => {
+    try {
+      const r = await shell.exec(cmd, execOpts);
+      if (r.exitCode !== 0) {
+        degradedReasons.push(`${cmd.slice(0, 40)}... exit=${r.exitCode}`);
+        return fallback;
+      }
+      return r.stdout.trim();
+    } catch (err) {
+      degradedReasons.push(`${cmd.slice(0, 40)}... ${(err as Error).message}`);
+      return fallback;
+    }
+  };
+
+  const currentBranch = await safeExec('git rev-parse --abbrev-ref HEAD');
+  const headSha = await safeExec('git rev-parse --short HEAD');
+  const headIso = await safeExec('git log -1 --format=%cI HEAD');
+
+  let fetchOk = true;
+  let fetchError = '';
+  if (opts.skipFetch) {
+    fetchOk = false;
+    fetchError = 'skipped (snapshot uses cached refs)';
+  } else if (currentBranch) {
+    try {
+      const fetchResult = await shell.exec(
+        `git fetch origin ${currentBranch}`,
+        { cwd: repoRoot, timeout: 5_000 },
+      );
+      if (fetchResult.exitCode !== 0) {
+        fetchOk = false;
+        fetchError = (fetchResult.stderr || fetchResult.stdout || '').trim().slice(0, 500);
+      }
+    } catch (err) {
+      fetchOk = false;
+      fetchError = (err as Error).message;
+    }
+  } else {
+    fetchOk = false;
+    fetchError = 'currentBranch unknown — skipped fetch';
+  }
+
+  let remoteAheadCount = 0;
+  let localAheadCount = 0;
+  const remoteAheadSubjects: Array<{ sha: string; subject: string; date: string }> = [];
+  if (currentBranch) {
+    const counts = await safeExec(
+      `git rev-list --left-right --count HEAD...origin/${currentBranch}`,
+      { cwd: repoRoot, timeout: 5_000 },
+    );
+    if (counts) {
+      const parts = counts.split(/\s+/);
+      localAheadCount = parseInt(parts[0] || '0', 10) || 0;
+      remoteAheadCount = parseInt(parts[1] || '0', 10) || 0;
+    }
+    if (remoteAheadCount > 0) {
+      const log = await safeExec(
+        `git log --format='%h%x1f%cI%x1f%s' -n 5 HEAD..origin/${currentBranch}`,
+        { cwd: repoRoot, timeout: 5_000 },
+      );
+      if (log) {
+        for (const line of log.split('\n')) {
+          if (!line.trim()) continue;
+          const [sha, date, subject] = line.split('\x1f');
+          if (sha && subject) {
+            remoteAheadSubjects.push({
+              sha: sha.trim(),
+              date: (date || '').trim(),
+              subject: subject.trim(),
+            });
+          }
+        }
+      }
+    }
+  }
+
+  let history: ReturnType<typeof stateService.getSelfUpdateHistory> = [];
+  try {
+    history = stateService.getSelfUpdateHistory(20);
+  } catch (err) {
+    degradedReasons.push(`getSelfUpdateHistory: ${(err as Error).message}`);
+  }
+
+  let webBuildSha = '';
+  let webBuildError = '';
+  try {
+    const shaFile = path.resolve(repoRoot, 'cds', 'web', 'dist', '.build-sha');
+    if (fs.existsSync(shaFile)) {
+      webBuildSha = fs.readFileSync(shaFile, 'utf8').trim().slice(0, 40);
+    }
+    const errFile = path.resolve(repoRoot, 'cds', 'web', 'dist', '.build-error');
+    if (fs.existsSync(errFile)) {
+      webBuildError = fs.readFileSync(errFile, 'utf8').trim().slice(0, 2000);
+    }
+  } catch (err) {
+    degradedReasons.push(`webBuildSha: ${(err as Error).message}`);
+  }
+
+  return {
+    currentBranch,
+    headSha,
+    headIso,
+    fetchOk,
+    fetchError,
+    remoteAheadCount,
+    localAheadCount,
+    remoteAheadSubjects,
+    lastSelfUpdate: history[0] || null,
+    selfUpdateHistory: history,
+    webBuildSha,
+    webBuildError,
+    bundleStale: Boolean(
+      (headSha && webBuildSha && !(
+        webBuildSha.startsWith(headSha) || headSha.startsWith(webBuildSha)
+      )) || webBuildError,
+    ),
+    degraded: degradedReasons.length > 0 ? { reasons: degradedReasons } : null,
+    cachedAt: new Date().toISOString(),
+  };
+}
+
 /**
  * P4 Part 18 (hardening): pre-restart sanity check for self-update.
  *
@@ -7835,173 +8019,113 @@ cdscli project list --human
   // 注意:`git fetch` 会真的发网络请求,带 10s 超时;远端不可达时优雅降级
   // 到 cached(用 `--cached` 不会触发 fetch)。
   //
-  // 2026-05-05 性能修复(P1):前端 GlobalUpdateBadge 反复轮询 ?probe=remote,
-  // 每次都触发 git fetch → 单次 5~10s,导致页面整体卡（用户反馈"打开什么都卡"）。
-  // 加 60s in-process 缓存：同一查询参数组合在 60s 内复用上次结果，零网络。
-  // 用户明确点"刷新"时前端可以加 ?force=1 跳过缓存（如未实现，refresh 重启进程
-  // 也能清缓存）。
-  let selfStatusCache: { key: string; payload: unknown; expiresAt: number } | null = null;
-  router.get('/self-status', async (req, res) => {
-    const probeMode = (req.query.probe as string | undefined) || 'local';
-    const force = req.query.force === '1' || req.query.force === 'true';
-    const cacheKey = `probe=${probeMode}`;
-    const now = Date.now();
-    if (!force && selfStatusCache && selfStatusCache.key === cacheKey && selfStatusCache.expiresAt > now) {
-      res.json(selfStatusCache.payload);
-      return;
-    }
+  // 2026-05-05 改造(事件驱动):去掉 60s in-process 缓存,改为
+  //   - 每次 ?probe=remote 诚实查询(GlobalUpdateBadge 不再轮询,只在
+  //     SSE 断开等少数 case 才会主动调本端点)
+  //   - 新增 GET /api/self-status/stream SSE 长连接,把 push webhook
+  //     触发的状态变化主动推给前端
+  // 把 selfStatusContext 注册到模块级,broadcastSelfStatus() 才能用同一份
+  // 闭包重新计算 payload。
+  selfStatusContext = {
+    repoRoot: config.repoRoot,
+    shell,
+    stateService,
+  };
+  router.get('/self-status', async (_req, res) => {
     // 2026-05-04 v2(用户反馈"GET /api/self-status → 400"):
-    // 之前是单一 outer try/catch + 多个 await 串联,任何一个 git 命令失败 / 上游
-    // 中间件意外都会导致整个端点挂掉(返 500/4xx)。改为**逐个 try/catch + 永远返 200**,
-    // 哪怕所有 git 命令全失败,也返结构完整的 JSON(各字段填默认/空值)+ 一个
-    // `degraded: { reason }` 字段告诉前端 "数据有缺,但接口活着"。
+    // computeSelfStatusPayload 内部用 safeExec 逐条吞错,永远返结构完整的 JSON
+    // (各字段填默认/空值)+ 一个 `degraded: { reasons }` 字段告诉前端 "数据
+    // 有缺,但接口活着"。这样即使 CDS host 上 git 抽风、网络断、ref 损坏,
+    // UI 也不会显示 "读取自更新状态失败" 红色 banner,而是显示能读到的部分
+    // + 安全降级。
     //
-    // 这样即使 CDS host 上 git 抽风、网络断、ref 损坏,UI 也不会显示
-    // "读取自更新状态失败" 红色 banner,而是显示能读到的部分 + 安全降级。
-    const repoRoot = config.repoRoot;
-    const degradedReasons: string[] = [];
-
-    // 工具:跑一条 shell 命令,任何异常 / 非零退出都吞掉返 fallback。
-    const safeExec = async (
-      cmd: string,
-      opts: { cwd: string; timeout?: number } = { cwd: repoRoot },
-      fallback = '',
-    ): Promise<string> => {
-      try {
-        const r = await shell.exec(cmd, opts);
-        if (r.exitCode !== 0) {
-          degradedReasons.push(`${cmd.slice(0, 40)}... exit=${r.exitCode}`);
-          return fallback;
-        }
-        return r.stdout.trim();
-      } catch (err) {
-        degradedReasons.push(`${cmd.slice(0, 40)}... ${(err as Error).message}`);
-        return fallback;
-      }
-    };
-
-    // 1. 当前分支 + HEAD short SHA + 最近 commit 时间
-    const currentBranch = await safeExec('git rev-parse --abbrev-ref HEAD');
-    const headSha = await safeExec('git rev-parse --short HEAD');
-    const headIso = await safeExec('git log -1 --format=%cI HEAD');
-
-    // 2. fetch 当前分支(允许失败 — 远端可能不可达 / 凭据过期)
-    let fetchOk = true;
-    let fetchError = '';
-    if (currentBranch) {
-      try {
-        const fetchResult = await shell.exec(
-          `git fetch origin ${currentBranch}`,
-          { cwd: repoRoot, timeout: 10_000 },
-        );
-        if (fetchResult.exitCode !== 0) {
-          fetchOk = false;
-          fetchError = (fetchResult.stderr || fetchResult.stdout || '').trim().slice(0, 500);
-        }
-      } catch (err) {
-        fetchOk = false;
-        fetchError = (err as Error).message;
-      }
-    } else {
-      fetchOk = false;
-      fetchError = 'currentBranch unknown — skipped fetch';
-    }
-
-    // 3. ahead/behind 对比
-    let remoteAheadCount = 0;
-    let localAheadCount = 0;
-    let remoteAheadSubjects: Array<{ sha: string; subject: string; date: string }> = [];
-    if (currentBranch) {
-      const counts = await safeExec(
-        `git rev-list --left-right --count HEAD...origin/${currentBranch}`,
-        { cwd: repoRoot, timeout: 5_000 },
+    // 2026-05-05 改造(事件驱动):去掉 60s in-process 缓存,前端 GlobalUpdateBadge
+    // 改为订阅 /self-status/stream SSE,不再频繁轮询本端点。
+    try {
+      const payload = await computeSelfStatusPayload(
+        { repoRoot: config.repoRoot, shell, stateService },
+        { skipFetch: false },
       );
-      if (counts) {
-        const parts = counts.split(/\s+/);
-        localAheadCount = parseInt(parts[0] || '0', 10) || 0;
-        remoteAheadCount = parseInt(parts[1] || '0', 10) || 0;
-      }
-      if (remoteAheadCount > 0) {
-        const log = await safeExec(
-          `git log --format='%h%x1f%cI%x1f%s' -n 5 HEAD..origin/${currentBranch}`,
-          { cwd: repoRoot, timeout: 5_000 },
-        );
-        if (log) {
-          for (const line of log.split('\n')) {
-            if (!line.trim()) continue;
-            const [sha, date, subject] = line.split('\x1f');
-            if (sha && subject) {
-              remoteAheadSubjects.push({
-                sha: sha.trim(),
-                date: (date || '').trim(),
-                subject: subject.trim(),
-              });
-            }
-          }
-        }
-      }
-    }
-
-    // 4. 自更新历史(从 state — 不可能失败,直接读)
-    let history: ReturnType<typeof stateService.getSelfUpdateHistory> = [];
-    try {
-      history = stateService.getSelfUpdateHistory(20);
+      res.json(payload);
     } catch (err) {
-      degradedReasons.push(`getSelfUpdateHistory: ${(err as Error).message}`);
+      // computeSelfStatusPayload 自身已尽量不抛;真抛了也返 200 + degraded
+      // 保证前端不会看到红色 banner。
+      res.json({
+        currentBranch: '',
+        headSha: '',
+        headIso: '',
+        fetchOk: false,
+        fetchError: (err as Error).message,
+        remoteAheadCount: 0,
+        localAheadCount: 0,
+        remoteAheadSubjects: [],
+        lastSelfUpdate: null,
+        selfUpdateHistory: [],
+        webBuildSha: '',
+        webBuildError: '',
+        bundleStale: false,
+        degraded: { reasons: [(err as Error).message] },
+        cachedAt: new Date().toISOString(),
+      });
+    }
+  });
+
+  // GET /api/self-status/stream — SSE 长连接,事件驱动推送 self-status
+  //
+  // 2026-05-05:取代 GlobalUpdateBadge 的 30s 轮询(每次都触发 git fetch
+  // → 5-10s 慢操作 → 页面卡)。客户端连上后:
+  //   1. 立即收到 `event: snapshot` 首屏数据(用本地 cached refs,不发网络)
+  //   2. 后续 GitHub push webhook 命中本机当前分支时,服务端主动推
+  //      `event: update`(那时才走真实 git fetch)
+  //   3. 每 25s 一条 `event: keepalive` 防 nginx 60s 超时把连接断掉
+  //
+  // 鉴权沿用 router 上的 auth middleware(本路由器的所有 GET 都已过 auth)。
+  router.get('/self-status/stream', async (req, res) => {
+    // SSE 标准头部(同 initSSE,但显式写一遍以贴近 SSE 契约)
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    });
+    // 立刻 flush 头(部分代理需要)
+    if (typeof (res as { flushHeaders?: () => void }).flushHeaders === 'function') {
+      (res as { flushHeaders: () => void }).flushHeaders();
     }
 
-    // 5. 前端 bundle SHA(2026-05-04 fix — 用户反馈"已更新但页面不对")
-    //
-    // exec_cds.sh 的 build_web 在成功后会写 cds/web/dist/.build-sha = git HEAD。
-    // 如果 build_web 静默失败,这个文件是旧的。前端可以对比 headSha vs webBuildSha
-    // 显示 "前端比后端旧" 警告,提示用户检查 ./exec_cds.sh logs。
-    let webBuildSha = '';
-    let webBuildError = ''; // build_web 失败时 exec_cds.sh 会写 .build-error 标记
+    // 加入客户端池
+    selfStatusClients.add(res);
+
+    // 1) 首屏 snapshot:用本地 cached refs(不触发 git fetch,首屏要快)。
+    //    只是初始数据;后续靠 webhook 触发的 update 事件保持新鲜。
     try {
-      const shaFile = path.resolve(repoRoot, 'cds', 'web', 'dist', '.build-sha');
-      if (fs.existsSync(shaFile)) {
-        webBuildSha = fs.readFileSync(shaFile, 'utf8').trim().slice(0, 40);
-      }
-      const errFile = path.resolve(repoRoot, 'cds', 'web', 'dist', '.build-error');
-      if (fs.existsSync(errFile)) {
-        webBuildError = fs.readFileSync(errFile, 'utf8').trim().slice(0, 2000);
-      }
+      const snapshot = await computeSelfStatusPayload(
+        { repoRoot: config.repoRoot, shell, stateService },
+        { skipFetch: true },
+      );
+      res.write(`event: snapshot\ndata: ${JSON.stringify(snapshot)}\n\n`);
     } catch (err) {
-      degradedReasons.push(`webBuildSha: ${(err as Error).message}`);
+      // snapshot 失败也不挂断 — 客户端会等下一个 update/keepalive
+      // eslint-disable-next-line no-console
+      console.warn('[self-status/stream] snapshot 失败:', (err as Error).message);
     }
 
-    const payload = {
-      currentBranch,
-      headSha,
-      headIso,
-      fetchOk,
-      fetchError,
-      remoteAheadCount,
-      localAheadCount,
-      remoteAheadSubjects,
-      lastSelfUpdate: history[0] || null,
-      selfUpdateHistory: history,
-      // 前端 bundle 的 git HEAD,用于 detect 后端/前端 SHA 不一致(build_web 静默失败)
-      webBuildSha,
-      // build_web 失败标记内容(exec_cds.sh 写的 .build-error 文件,前端可展示)
-      webBuildError,
-      // bundle 不一致 OR build 报错时前端显示 "前端比后端旧" 警告。
-      // Bugbot PR #524 反馈:轻量版(server.ts)同时检 webBuildError,这里要保持一致,
-      // 否则 GlobalUpdateBadge 切到 ?probe=remote 后 build 失败时角标不会亮。
-      // 第十一轮:用双向 startsWith 兼容 short/full SHA 任意组合(详见 server.ts
-      // 同名注释)。
-      bundleStale: Boolean(
-        (headSha && webBuildSha && !(
-          webBuildSha.startsWith(headSha) || headSha.startsWith(webBuildSha)
-        )) || webBuildError,
-      ),
-      // 给前端一个明确信号:数据是不是降级了 + 哪步降级。
-      degraded: degradedReasons.length > 0 ? { reasons: degradedReasons } : null,
-      cachedAt: new Date().toISOString(),
-    };
-    // 进 cache 60 秒（前端反复轮询不再每次都 git fetch）
-    selfStatusCache = { key: cacheKey, payload, expiresAt: Date.now() + 60_000 };
-    res.json(payload);
+    // 2) 25s keepalive,防 nginx/中间代理 60s 闲置超时 cut 连接
+    const keepalive = setInterval(() => {
+      try {
+        res.write(`event: keepalive\ndata: ${JSON.stringify({ ts: new Date().toISOString() })}\n\n`);
+      } catch {
+        clearInterval(keepalive);
+        selfStatusClients.delete(res);
+      }
+    }, 25_000);
+
+    // 3) 客户端断开时清池(server-authority.md:断开只清池,不取消任何
+    //    git/db 操作 — 本路由也没启动任何长任务,纯被动等推送)
+    req.on('close', () => {
+      clearInterval(keepalive);
+      selfStatusClients.delete(res);
+    });
   });
 
   // POST /api/self-update — switch branch + pull + restart CDS (SSE progress)

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -2093,12 +2093,38 @@ export function createBranchRouter(deps: RouterDeps): Router {
       // infra up before resolving app service env, matching Railway-style
       // service references instead of asking users to copy ports manually.
       //
-      // Phase 2.5 (2026-05-01):决策逻辑抽到 computeRequiredInfra 纯函数,
-      // 便于跨项目同名 / stale state vs docker 等场景单测。详见
-      // services/deploy-infra-resolver.ts 注释 + tests/services/deploy-infra-resolver.test.ts。
-      const projectInfra = stateService.getInfraServicesForProject(entry.projectId || 'default');
-      const actualInfraState = await containerService.discoverInfraContainers();
-      const requiredInfraIds = computeRequiredInfra(profiles, projectInfra, actualInfraState);
+      // ★ 2026-05-05 重大语义修正（用户反馈"数据库不需要构建"）：
+      // infra 默认是 shared 模式 —— init 时一次性建好的 long-lived 资源，
+      // 所有分支共用一份 mongo/redis。**deploy 流程不应触碰它**：不重启、
+      // 不删除、不健康检查阻塞。touch infra 是 init / admin 的事。
+      //
+      // 历史 bug：原版本无脑 computeRequiredInfra → 兜底逻辑把"docker 实际未
+      // running 的 infra"全部加进 required，触发 startInfraService → docker
+      // rm -f → 杀掉用户正在共享使用的 mongo 容器（连接断、SSE 中断、所有
+      // 页面 502），还偶发 race condition 报"container name already in use"
+      // 让 deploy 整体 fail。
+      //
+      // 修法：仅当 project.infraIsolation === 'per-branch' 才走原启动链路。
+      // 默认 / 缺省 / 'shared' 模式 → 整段 skip。
+      const projectMeta = stateService.getProject(entry.projectId || 'default');
+      const perBranchInfra = projectMeta?.infraIsolation === 'per-branch';
+      const projectInfra = perBranchInfra
+        ? stateService.getInfraServicesForProject(entry.projectId || 'default')
+        : [];
+      const actualInfraState = perBranchInfra
+        ? await containerService.discoverInfraContainers()
+        : new Map<string, { running: boolean; containerName: string; serviceId: string }>();
+      const requiredInfraIds = perBranchInfra
+        ? computeRequiredInfra(profiles, projectInfra, actualInfraState)
+        : new Set<string>();
+      if (!perBranchInfra) {
+        logEvent({
+          step: 'infra-shared',
+          status: 'done',
+          title: '基础设施为共享模式 —— deploy 跳过 infra 启动（如需独立 infra 请在项目设置切换为 per-branch）',
+          timestamp: new Date().toISOString(),
+        });
+      }
       for (const infraId of requiredInfraIds) {
         const infra = stateService.getInfraServiceForProjectAndId(entry.projectId || 'default', infraId);
         // Phase 2 fix:不再用 infra.status === 'running' 跳过 — requiredInfraIds 已经
@@ -2146,8 +2172,13 @@ export function createBranchRouter(deps: RouterDeps): Router {
       // 修法:起完 infra 后、起 app 前,对每个有 healthcheck 配置的 infra
       // 轮询 docker inspect health,直到 healthy 或 60s 超时。无 healthcheck
       // 的 infra 跳过(不阻塞)。
-      const infraToWait = stateService.getInfraServicesForProject(entry.projectId || 'default')
-        .filter(s => s.status === 'running' && s.healthCheck);
+      //
+      // ★ 2026-05-05：共享模式（默认）下 infra 是 long-lived 的，已经
+      // healthy；deploy 不需要重新等。仅 per-branch 独占模式才走这段。
+      const infraToWait = perBranchInfra
+        ? stateService.getInfraServicesForProject(entry.projectId || 'default')
+            .filter(s => s.status === 'running' && s.healthCheck)
+        : [];
       for (const infra of infraToWait) {
         const stepId = `infra-${infra.id}-healthy`;
         logEvent({

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -56,24 +56,46 @@ const selfStatusClients = new Set<import('express').Response>();
  *   - 远端不可达 → 用 fetchOk=false + cached refs 兜底,不阻塞推送
  *   - 写失败的 client 从池里清除(对端已断开)
  */
+// ⚠ Bugbot 2026-05-06 7433fb85: webhook fire-and-forget 会触发并发的
+// computeSelfStatusPayload(都做 git fetch,撞 .git/refs/.../<branch>.lock),
+// 引发 fetchWithLockRetry × 3 次回退,N 个 webhook 放大成 O(N×3) fetch + N
+// 个 SSE update。coalesce:正在跑就排队 1 次,跑完检查 pending 再跑一次。
+// 多个 webhook 突发只会造成最多 2 轮(当前 + 一次合并),git fetch 串行,
+// 客户端只收到 ≤2 条 update,不再风暴。
+let broadcastInFlight = false;
+let broadcastQueued = false;
+
 export async function broadcastSelfStatus(): Promise<void> {
   if (!selfStatusContext) return;
   if (selfStatusClients.size === 0) return;
-  let payload: unknown;
-  try {
-    payload = await computeSelfStatusPayload(selfStatusContext, { skipFetch: false });
-  } catch (err) {
-    // eslint-disable-next-line no-console
-    console.warn('[self-status] broadcast 重新计算失败:', (err as Error).message);
+  if (broadcastInFlight) {
+    broadcastQueued = true;
     return;
   }
-  const line = `event: update\ndata: ${JSON.stringify(payload)}\n\n`;
-  for (const client of Array.from(selfStatusClients)) {
-    try {
-      client.write(line);
-    } catch {
-      selfStatusClients.delete(client);
-    }
+  broadcastInFlight = true;
+  try {
+    do {
+      broadcastQueued = false;
+      let payload: unknown;
+      try {
+        payload = await computeSelfStatusPayload(selfStatusContext, { skipFetch: false });
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn('[self-status] broadcast 重新计算失败:', (err as Error).message);
+        continue;
+      }
+      if (!selfStatusContext) return;
+      const line = `event: update\ndata: ${JSON.stringify(payload)}\n\n`;
+      for (const client of Array.from(selfStatusClients)) {
+        try {
+          client.write(line);
+        } catch {
+          selfStatusClients.delete(client);
+        }
+      }
+    } while (broadcastQueued);
+  } finally {
+    broadcastInFlight = false;
   }
 }
 

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -8105,11 +8105,13 @@ cdscli project list --human
       (res as { flushHeaders: () => void }).flushHeaders();
     }
 
-    // 加入客户端池
-    selfStatusClients.add(res);
-
     // 1) 首屏 snapshot:用本地 cached refs(不触发 git fetch,首屏要快)。
     //    只是初始数据;后续靠 webhook 触发的 update 事件保持新鲜。
+    //
+    // ⚠ Bugbot Review 2026-05-06: snapshot 必须**先于** add(res) 写入,否则
+    // 在 computeSelfStatusPayload 异步期间如果发生 broadcastSelfStatus()
+    // (push webhook 触发),client 会先收到 update 再收到 snapshot,违反
+    // SSE 协议契约 (snapshot = "Initial cached state on connection")。
     try {
       const snapshot = await computeSelfStatusPayload(
         { repoRoot: config.repoRoot, shell, stateService },
@@ -8121,6 +8123,9 @@ cdscli project list --human
       // eslint-disable-next-line no-console
       console.warn('[self-status/stream] snapshot 失败:', (err as Error).message);
     }
+
+    // 2) snapshot 写完才加进客户端池,确保事件顺序 snapshot → update → keepalive
+    selfStatusClients.add(res);
 
     // 2) 25s keepalive,防 nginx/中间代理 60s 闲置超时 cut 连接
     const keepalive = setInterval(() => {

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -125,14 +125,30 @@ async function computeSelfStatusPayload(
     fetchOk = false;
     fetchError = 'skipped (snapshot uses cached refs)';
   } else if (branchIsSafe) {
+    // ⚠ Bugbot Review 2026-05-06 930c5f98: broadcastSelfStatus 在 webhook 风暴
+    // 期间会和 deploy worker 的 git fetch 抢同一个 .git/refs/remotes/.../<branch>.lock,
+    // 单次 exec 直接退非 0,前端拿到 fetchOk=false + 计数空。WorktreeService.fetchWithLockRetry
+    // 已有同样 retry 逻辑;这里 inline 一份(模块级 free function 不便复用 class private)。
+    // maxAttempts=3 与 worktree 一致;退避 2s/4s 累计 ≤ 6s,在 SSE 推送可接受范围内。
     try {
-      const fetchResult = await shell.exec(
-        `git fetch origin ${currentBranch}`,
-        { cwd: repoRoot, timeout: 5_000 },
-      );
-      if (fetchResult.exitCode !== 0) {
+      const maxAttempts = 3;
+      let lastResult: Awaited<ReturnType<typeof shell.exec>> | null = null;
+      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        lastResult = await shell.exec(
+          `git fetch origin ${currentBranch}`,
+          { cwd: repoRoot, timeout: 5_000 },
+        );
+        if (lastResult.exitCode === 0) break;
+        const errOut = ((lastResult.stderr || '') + (lastResult.stdout || ''));
+        const isLockErr = /cannot lock ref|unable to create.*lock/i.test(errOut);
+        if (!isLockErr || attempt === maxAttempts) break;
+        await new Promise((r) => setTimeout(r, 2_000 * attempt));
+      }
+      if (!lastResult || lastResult.exitCode !== 0) {
         fetchOk = false;
-        fetchError = (fetchResult.stderr || fetchResult.stdout || '').trim().slice(0, 500);
+        fetchError = lastResult
+          ? (lastResult.stderr || lastResult.stdout || '').trim().slice(0, 500)
+          : 'fetch returned no result';
       }
     } catch (err) {
       fetchOk = false;
@@ -8125,9 +8141,18 @@ cdscli project list --human
     }
 
     // 2) snapshot 写完才加进客户端池,确保事件顺序 snapshot → update → keepalive
+    //
+    // ⚠ Bugbot Review 2026-05-06 a105ae91: 客户端在 await 期间断开时
+    // req.on('close') 已经触发但 selfStatusClients 还没包含 res, delete
+    // 形同 no-op。await 完后再 add(res) 把死客户端加进池, 启动的
+    // setInterval 会一直 keepalive 直到第一次 res.write 失败 (~25s) 才清。
+    // 加 req.destroyed 守卫立刻 return, 避免给死客户端起 keepalive。
+    if (req.destroyed) {
+      return;
+    }
     selfStatusClients.add(res);
 
-    // 2) 25s keepalive,防 nginx/中间代理 60s 闲置超时 cut 连接
+    // 3) 25s keepalive,防 nginx/中间代理 60s 闲置超时 cut 连接
     const keepalive = setInterval(() => {
       try {
         res.write(`event: keepalive\ndata: ${JSON.stringify({ ts: new Date().toISOString() })}\n\n`);
@@ -8137,7 +8162,7 @@ cdscli project list --human
       }
     }, 25_000);
 
-    // 3) 客户端断开时清池(server-authority.md:断开只清池,不取消任何
+    // 4) 客户端断开时清池(server-authority.md:断开只清池,不取消任何
     //    git/db 操作 — 本路由也没启动任何长任务,纯被动等推送)
     req.on('close', () => {
       clearInterval(keepalive);

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -8932,12 +8932,13 @@ cdscli project list --human
       //       3) 删 dist.old.<ts>          （清理）
       //   - 第 2 步失败（罕见）会回滚把 dist.old.<ts> 改回 dist。
       // 任何一步失败，cds 永远有可启动的 dist，不再需要人工介入。
-      send('cache', 'running', '清除 tsc 增量缓存（保留 dist/ 不动）…');
-      const tsbCleanTargets = [
-        path.join(cdsDir, '.tsbuildinfo'),
-        path.join(cdsDir, 'tsconfig.tsbuildinfo'),
-        path.join(cdsDir, 'dist', '.tsbuildinfo'),
-        path.join(cdsDir, 'dist.next', '.tsbuildinfo'),
+      // 用户反馈 2026-05-06:之前清 dist/.tsbuildinfo 让重 build 走全量(慢
+      // 30-50s)。incremental cache 本身就是为"代码改了重 build 也要快"准备的,
+      // 主动清等于自废武功。**不**清 .tsbuildinfo,只清 dist.next/(上一次失败
+      // 的孤儿)+ dist.old.*(rmSync 失败的孤儿)。
+      send('cache', 'running', '清理孤儿目录(保留 .tsbuildinfo 让 tsc 走增量)…');
+      const tsbCleanTargets: string[] = [
+        // .tsbuildinfo 一概保留 — incremental 命中是 30s vs 60s 的差距
       ];
       const removed: string[] = [];
       for (const f of tsbCleanTargets) {
@@ -9021,6 +9022,13 @@ cdscli project list --human
         }
         // 清理备份（保不保都不影响 cds 运行，rmSync 失败也忽略）
         try { fs.rmSync(distOldPath, { recursive: true, force: true }); } catch { /* ignore */ }
+        // ⚠ Bugbot 2026-05-06 0c17e470:之前没人写 dist/.build-sha,
+        // self-force-sync 顶部的 fast-path no-op 检测永远 false → 死代码。
+        // swap 成功后**显式写**当前 commit 的 full SHA,下次同 commit 触发
+        // self-force-sync 即可秒级 return。
+        try {
+          fs.writeFileSync(path.join(distPath, '.build-sha'), newHeadFull);
+        } catch { /* tolerate — fast-path 失效但功能不受影响 */ }
       } catch (swapErr) {
         send('build-backend', 'error', `dist 原子替换失败: ${(swapErr as Error).message}`);
         sendSSE(res, 'error', { message: `dist 原子替换失败,已尝试回滚: ${(swapErr as Error).message}` });

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -82,6 +82,9 @@ export async function broadcastSelfStatus(): Promise<void> {
     const MAX_LOOPS = 4;
     let loops = 0;
     do {
+      // ⚠ Bugbot 2026-05-06 93db4981:loops 必须在循环顶部统一 +1,否则
+      // success / failure 路径分别 +1 会让有效上限随交错变化(off-by-one)。
+      loops += 1;
       broadcastQueued = false;
       let payload: unknown;
       try {
@@ -89,7 +92,6 @@ export async function broadcastSelfStatus(): Promise<void> {
       } catch (err) {
         // eslint-disable-next-line no-console
         console.warn('[self-status] broadcast 重新计算失败:', (err as Error).message);
-        loops += 1;
         if (loops >= MAX_LOOPS) break;
         // 失败后给事件循环让出 1s,避免持续故障下的 hot loop
         await new Promise((r) => setTimeout(r, 1_000));
@@ -104,7 +106,6 @@ export async function broadcastSelfStatus(): Promise<void> {
           selfStatusClients.delete(client);
         }
       }
-      loops += 1;
     } while (broadcastQueued && loops < MAX_LOOPS);
   } finally {
     broadcastInFlight = false;
@@ -8247,6 +8248,9 @@ cdscli project list --human
     // setInterval 会一直 keepalive 直到第一次 res.write 失败 (~25s) 才清。
     // 加 req.destroyed 守卫立刻 return, 避免给死客户端起 keepalive。
     if (req.destroyed) {
+      // ⚠ Bugbot 2026-05-06 a9793a4a:res.writeHead 已写头,半开响应应显式 end()
+      // 兜底,即使底层 socket 已 destroy,Express 内部状态也干净下来。
+      try { res.end(); } catch { /* ignore */ }
       return;
     }
     selfStatusClients.add(res);

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -9026,7 +9026,7 @@ cdscli project list --human
       } else if (impact.needsRestart) {
         const sample = impact.restartTriggers.slice(0, 3).map((t) => `${t.path}(${t.reason})`).join('; ');
         send('analyze', 'done', `${impact.restartTriggers.length} 处改动需重启:${sample}${impact.restartTriggers.length > 3 ? '…' : ''}`);
-      } else if (impact.hotReloadablePaths.length === 0) {
+      } else if (impact.hotReloadablePaths.length === 0 && impact.irrelevantPaths.length > 0) {
         // ⚠ Bugbot 7749d6f8 (Medium) — 之前这里只 send 了一句 analyze 日志,然后
         // hotEligible=false 让流程继续走完整冷路径(validate + esbuild + tsc + atomic
         // swap + restart),~70-95s 全部白跑。文档/changelogs 改动既不影响 dist
@@ -9034,6 +9034,11 @@ cdscli project list --human
         // 与前面 line 8970 fast-path 区别:那个要求两个 .build-sha 已是 newHead;
         // 这里是首次切到 newHead 时,虽然 .build-sha 不同但改动全是 docs,可以直接
         // 把现有 dist + web bundle 标记为"已是 newHead 产物"(它们的字节实际不变)。
+        //
+        // ⚠ Bugbot da715c3c (Medium) — 必须同时要求 irrelevantPaths > 0,
+        // 否则 changedPaths 为空(fromSha == newHead 但 .build-sha 缺失/不匹配)也会命中,
+        // 导致写一个伪 .build-sha 让"陈旧 dist"被永久标记为 current,后续永远不重 build。
+        // 空 diff 下落到下面的 else,走冷路径重新 build 兜底。
         send('analyze', 'done', `本次改动 ${impact.irrelevantPaths.length} 个纯文档文件,无应用代码改动 — 跳过 build/restart`);
         try { fs.writeFileSync(distShaPath, newHeadFull); } catch { /* tolerate — fast-path 失效但功能不受影响 */ }
         try { fs.writeFileSync(webShaPath, newHeadFull); } catch { /* tolerate */ }
@@ -9057,6 +9062,11 @@ cdscli project list --human
           ...({ updateMode: 'doc-only' } as Record<string, unknown>),
         });
         return;
+      } else if (impact.hotReloadablePaths.length === 0) {
+        // 走到这里 = changedPaths 为空(fromSha == newHead 但前面 fast-path no-op
+        // 没命中,说明 dist/.build-sha 缺失或不匹配)。**不能**写假 .build-sha 标记当前
+        // 为最新,必须走冷路径重新 build 把 dist 真正同步到 newHead。
+        send('analyze', 'done', `git diff 显示无文件变更,但 dist/.build-sha 不匹配 — 走冷路径重 build 兜底`);
       } else {
         send('analyze', 'done', `本次改动 ${changedPaths.length} 文件全部热重载安全(应用代码 ${impact.hotReloadablePaths.length} + 文档 ${impact.irrelevantPaths.length})— 走热路径`);
       }

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -2191,8 +2191,16 @@ export function createBranchRouter(deps: RouterDeps): Router {
         // 已足够独特,不会误吞其他名字。
         const prefix = nodeModulesVolumePrefix(entry.id);
         const list = await shell.exec(`docker volume ls --format='{{.Name}}' --filter name=${prefix}`);
+        // ⚠ Bugbot 2026-05-06 8469603b:虽然我们生成的 volume 名是定长 hex,但
+        // docker volume ls 输出来自 docker daemon,理论上可被外部命令污染。
+        // shell.exec 走 child_process.exec(整串 shell 解释),恶意 volume 名
+        // 含 metacharacter 时 docker volume rm 就成了命令注入。docker volume
+        // 名规范是 `[a-zA-Z0-9][a-zA-Z0-9_.-]+`,严格 regex 守门。
+        const isSafeVolumeName = (n: string): boolean => /^[a-zA-Z0-9][a-zA-Z0-9_.-]{1,254}$/.test(n);
         if (list.exitCode === 0) {
-          const names = list.stdout.split('\n').map((s) => s.trim()).filter((n) => n.startsWith(prefix));
+          const names = list.stdout.split('\n').map((s) => s.trim()).filter((n) =>
+            n.startsWith(prefix) && isSafeVolumeName(n),
+          );
           for (const name of names) {
             await shell.exec(`docker volume rm ${name}`).catch(() => { /* tolerate */ });
           }

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -2177,6 +2177,26 @@ export function createBranchRouter(deps: RouterDeps): Router {
       } catch { /* ok */ }
       sendSSE(res, 'step', { step: 'worktree', status: 'done', title: '工作树已删除' });
 
+      // ⚠ Bugbot 2026-05-06 ea633e03:删除 per-(branch, profile) 的
+      // node_modules docker named volume(container.ts 里给 pnpm 项目挂的
+      // cds-nm-{branchId}-{profileId})。volume 不会随容器删除自动清,长期
+      // create/delete 分支会留下数百 MB × N 个孤儿。这里 docker volume ls
+      // 过滤前缀 + docker volume rm,失败容忍(volume 还被某个容器引用)。
+      try {
+        const sanitize = (s: string): string => s.replace(/[^a-zA-Z0-9_.-]/g, '-').slice(0, 60);
+        const prefix = `cds-nm-${sanitize(entry.id)}-`;
+        const list = await shell.exec(`docker volume ls --format='{{.Name}}' --filter name=^${prefix}`);
+        if (list.exitCode === 0) {
+          const names = list.stdout.split('\n').map((s) => s.trim()).filter((n) => n.startsWith(prefix));
+          for (const name of names) {
+            await shell.exec(`docker volume rm ${name}`).catch(() => { /* tolerate */ });
+          }
+          if (names.length > 0) {
+            sendSSE(res, 'step', { step: 'volume-cleanup', status: 'done', title: `已清理 ${names.length} 个 node_modules volume` });
+          }
+        }
+      } catch { /* ok — volume cleanup 是 best-effort */ }
+
       stateService.removeLogs(id);
       stateService.removeBranch(id);
       stateService.save();
@@ -8885,6 +8905,21 @@ cdscli project list --human
         if (fs.existsSync(next)) {
           fs.rmSync(next, { recursive: true, force: true });
           removed.push('dist.next/ (stale)');
+        }
+      } catch { /* tolerate */ }
+      // ⚠ Bugbot 2026-05-06 238e81a5:atomic swap 第 3 步 rmSync(dist.old.<ts>) 偶尔
+      // 静默失败(disk pressure / 文件正被 inotify 监听等),孤儿 dist.old.* 累积。
+      // 每次 self-force-sync 启动前扫一遍,一并清掉旧的 dist.old.* (每个都是 full
+      // 编译产物,几十到几百 MB)。失败容忍,本来就是兜底清理。
+      try {
+        const entries = fs.readdirSync(cdsDir);
+        for (const name of entries) {
+          if (name.startsWith('dist.old.')) {
+            try {
+              fs.rmSync(path.join(cdsDir, name), { recursive: true, force: true });
+              removed.push(`${name} (orphan)`);
+            } catch { /* tolerate */ }
+          }
         }
       } catch { /* tolerate */ }
       send('cache', 'done', removed.length > 0 ? `已清: ${removed.join(', ')}` : '无缓存可清');

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -316,10 +316,10 @@ export async function validateBuildReadiness(
 
   // Round 1: pnpm install --frozen-lockfile (cds + cds/web 并行)
   const installPromises: Array<Promise<Awaited<ReturnType<typeof shell.exec>>>> = [
-    shell.exec('pnpm install --frozen-lockfile', { cwd: cdsDir, timeout: 300_000 }),
+    shell.exec('pnpm install --frozen-lockfile --prefer-offline', { cwd: cdsDir, timeout: 300_000 }),
   ];
   if (webExists) {
-    installPromises.push(shell.exec('pnpm install --frozen-lockfile', { cwd: webDir, timeout: 300_000 }));
+    installPromises.push(shell.exec('pnpm install --frozen-lockfile --prefer-offline', { cwd: webDir, timeout: 300_000 }));
   }
   const [installResult, webInstallResult] = await Promise.all(installPromises);
 
@@ -1767,7 +1767,7 @@ export function createBranchRouter(deps: RouterDeps): Router {
       }, 5_000);
       try {
         const wInstall = await shell.exec(
-          'pnpm install --frozen-lockfile',
+          'pnpm install --frozen-lockfile --prefer-offline',
           { cwd: webDir, timeout: 300_000 },
         );
         if (wInstall.exitCode !== 0) {
@@ -9007,27 +9007,48 @@ cdscli project list --human
       } catch { /* tolerate */ }
       send('cache', 'done', removed.length > 0 ? `已清: ${removed.join(', ')}` : '无缓存可清');
 
-      // 编译到 dist.next/，旧 dist/ 全程不动
-      // ⚠ Bugbot Review 2026-05-06 daab0916: tsconfig.json 把 tsBuildInfoFile
-      // 硬编码到 dist/.tsbuildinfo,只覆盖 --outDir 不够 —— tsc 仍会把
-      // .tsbuildinfo 写到旧 dist/,失败时该文件指向不存在的 dist.next/ 编译产物,
-      // 污染下次 systemd ExecStartPre 的增量缓存。同时覆盖 --tsBuildInfoFile
-      // 让两边的输出都在 dist.next/ 内,失败时一起 rm 即可。
-      send('build-backend', 'running', '主动重建 cds/dist.next/(旧 dist 保留为兜底)…');
-      const tscRes = await shell.exec(
-        'npx tsc --outDir dist.next --tsBuildInfoFile dist.next/.tsbuildinfo',
-        { cwd: cdsDir, timeout: 240_000 },
-      );
-      if (tscRes.exitCode !== 0) {
-        const errMsg = combinedOutput(tscRes).slice(0, 1500);
-        // 清掉半成品 dist.next，不动旧 dist
+      // 编译到 dist.next/,旧 dist/ 全程不动。
+      // 用户反馈 2026-05-06:tsc 30-50s 太慢,改 esbuild + 并行 tsc --noEmit:
+      //   - esbuild emit JS:~1s(纯 syntax 转译,无类型检查)
+      //   - tsc --noEmit:5-30s(增量;有 .tsbuildinfo 命中可秒级)
+      //   两者并行,wall-clock = max(1s, tsc) ≈ tsc 时间。
+      //   类型错误由 tsc 兜底:失败 → abort,旧 dist 保留(fail-safe)。
+      //
+      // hot-eligible 时 validate 阶段已跳过 tsc --noEmit,这里再跑一次保证类型
+      // 安全。即便如此,从串行 tsc emit 30s + 30s validate → 并行 max 各 10-20s,
+      // 总收益依然显著。
+      send('build-backend', 'running', '编译 cds/dist.next/(esbuild + tsc --noEmit 并行)…');
+      const buildStartedAt = Date.now();
+      const [esbuildRes, tscCheckRes] = await Promise.all([
+        shell.exec(
+          'node scripts/build-dist-esbuild.mjs',
+          { cwd: cdsDir, timeout: 60_000, env: { OUT_DIR: 'dist.next' } },
+        ),
+        shell.exec(
+          'npx tsc --noEmit',
+          { cwd: cdsDir, timeout: 120_000 },
+        ),
+      ]);
+      const buildElapsed = ((Date.now() - buildStartedAt) / 1000).toFixed(1);
+      if (esbuildRes.exitCode !== 0) {
+        const errMsg = combinedOutput(esbuildRes).slice(0, 1500);
         try { fs.rmSync(path.join(cdsDir, 'dist.next'), { recursive: true, force: true }); } catch { /* ignore */ }
-        send('build-backend', 'error', `tsc 编译失败（旧 dist 保留）: ${errMsg.slice(0, 300)}`);
-        sendSSE(res, 'error', { message: `cds/dist.next 编译失败 — cds 继续跑老版本，请检查代码：\n${errMsg.slice(0, 800)}` });
+        send('build-backend', 'error', `esbuild 编译失败(旧 dist 保留): ${errMsg.slice(0, 300)}`);
+        sendSSE(res, 'error', { message: `cds/dist.next 编译失败 — cds 继续跑老版本,请检查代码:\n${errMsg.slice(0, 800)}` });
         res.end();
-        recordFailure(`tsc 编译失败: ${errMsg.slice(0, 300)}`);
+        recordFailure(`esbuild 编译失败: ${errMsg.slice(0, 300)}`);
         return;
       }
+      if (tscCheckRes.exitCode !== 0) {
+        const errMsg = combinedOutput(tscCheckRes).slice(0, 1500);
+        try { fs.rmSync(path.join(cdsDir, 'dist.next'), { recursive: true, force: true }); } catch { /* ignore */ }
+        send('build-backend', 'error', `tsc 类型检查失败(旧 dist 保留): ${errMsg.slice(0, 300)}`);
+        sendSSE(res, 'error', { message: `cds/ 类型检查失败 — cds 继续跑老版本,请检查代码:\n${errMsg.slice(0, 800)}` });
+        res.end();
+        recordFailure(`tsc 类型检查失败: ${errMsg.slice(0, 300)}`);
+        return;
+      }
+      send('build-backend', 'done', `编译完成 (${buildElapsed}s) — esbuild emit + tsc --noEmit 并行通过`);
       const nextEntry = path.join(cdsDir, 'dist.next', 'index.js');
       if (!fs.existsSync(nextEntry)) {
         try { fs.rmSync(path.join(cdsDir, 'dist.next'), { recursive: true, force: true }); } catch { /* ignore */ }

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -111,12 +111,20 @@ async function computeSelfStatusPayload(
   const headSha = await safeExec('git rev-parse --short HEAD');
   const headIso = await safeExec('git log -1 --format=%cI HEAD');
 
+  // Codex Review 2026-05-06 P2: shell injection 防御。currentBranch 来自
+  // `git rev-parse --abbrev-ref HEAD`,git 自己应该已经拒绝含 shell
+  // metacharacters 的分支名,但 defense-in-depth —— 万一 detached HEAD /
+  // 损坏 ref / 老 git 版本边界 case 漏网,后续 `git fetch origin ${branch}`
+  // 等命令会通过 child_process.exec 让 metacharacter 改变命令行为。
+  // self-update / self-force-sync 路径已用 isSafeGitRef 守门,这里补齐。
+  const branchIsSafe = currentBranch && isSafeGitRef(currentBranch);
+
   let fetchOk = true;
   let fetchError = '';
   if (opts.skipFetch) {
     fetchOk = false;
     fetchError = 'skipped (snapshot uses cached refs)';
-  } else if (currentBranch) {
+  } else if (branchIsSafe) {
     try {
       const fetchResult = await shell.exec(
         `git fetch origin ${currentBranch}`,
@@ -130,15 +138,19 @@ async function computeSelfStatusPayload(
       fetchOk = false;
       fetchError = (err as Error).message;
     }
-  } else {
+  } else if (!currentBranch) {
     fetchOk = false;
     fetchError = 'currentBranch unknown — skipped fetch';
+  } else {
+    fetchOk = false;
+    fetchError = `currentBranch ${JSON.stringify(currentBranch).slice(0, 80)} 含不安全字符,跳过 git fetch`;
+    degradedReasons.push('currentBranch unsafe — fetch/diff skipped');
   }
 
   let remoteAheadCount = 0;
   let localAheadCount = 0;
   const remoteAheadSubjects: Array<{ sha: string; subject: string; date: string }> = [];
-  if (currentBranch) {
+  if (branchIsSafe) {
     const counts = await safeExec(
       `git rev-list --left-right --count HEAD...origin/${currentBranch}`,
       { cwd: repoRoot, timeout: 5_000 },
@@ -8691,66 +8703,98 @@ cdscli project list --human
         send('web-warning', 'warning', validation.webWarning.slice(0, 400));
       }
 
-      // Step 5: validate 通过，安全清空 backend 编译缓存，下次启动重新编译。
-      // 此时即便 cache 操作失败，dist 也还在原地，cds 仍可运行。
-      send('cache', 'running', '清除 dist/ + tsc 增量缓存…');
-      const cacheTargets = [
-        path.join(cdsDir, 'dist', '.build-sha'),
+      // Step 5+6: Atomic 重建 dist —— 编译到 dist.next/，验证后才 swap。
+      //
+      // ★ Codex Review 2026-05-06 P2 修复（"Preserve old dist until rebuild
+      // succeeds"）：原版本先 `rm -rf dist` 再跑 npx tsc，如果 tsc 中途
+      // 因 ENOSPC / cgroup OOM / 权限错被 kill，handler return 后 host 上
+      // 没 dist/index.js，下一次 systemd 重启就起不来 —— 必须 SSH 救场。
+      //
+      // 修法：tsc --outDir 到独立的 dist.next/，全程不动旧 dist。
+      //   - 编译失败 → 删 dist.next，旧 dist 保留，cds 继续跑
+      //   - 编译成功 + dist.next/index.js 存在 → 原子三步 swap：
+      //       1) 旧 dist → dist.old.<ts>  （备份）
+      //       2) dist.next → dist          （上线新版）
+      //       3) 删 dist.old.<ts>          （清理）
+      //   - 第 2 步失败（罕见）会回滚把 dist.old.<ts> 改回 dist。
+      // 任何一步失败，cds 永远有可启动的 dist，不再需要人工介入。
+      send('cache', 'running', '清除 tsc 增量缓存（保留 dist/ 不动）…');
+      const tsbCleanTargets = [
         path.join(cdsDir, '.tsbuildinfo'),
         path.join(cdsDir, 'tsconfig.tsbuildinfo'),
         path.join(cdsDir, 'dist', '.tsbuildinfo'),
+        path.join(cdsDir, 'dist.next', '.tsbuildinfo'),
       ];
       const removed: string[] = [];
-      for (const f of cacheTargets) {
+      for (const f of tsbCleanTargets) {
         try {
-          if (fs.existsSync(f)) {
-            fs.unlinkSync(f);
-            removed.push(path.basename(f));
-          }
-        } catch { /* tolerate per-file errors */ }
+          if (fs.existsSync(f)) { fs.unlinkSync(f); removed.push(path.basename(f)); }
+        } catch { /* tolerate */ }
       }
-      // 整个 dist/ 也清掉 — 强制 tsc 从空目录全量编译，杜绝任何 stale 文件
+      // dist.next 残留（上次失败留下的）也清掉
       try {
-        const distDir = path.join(cdsDir, 'dist');
-        if (fs.existsSync(distDir)) {
-          fs.rmSync(distDir, { recursive: true, force: true });
-          removed.push('dist/');
+        const next = path.join(cdsDir, 'dist.next');
+        if (fs.existsSync(next)) {
+          fs.rmSync(next, { recursive: true, force: true });
+          removed.push('dist.next/ (stale)');
         }
-      } catch (err) {
-        send('cache', 'warning', '删除 dist/ 失败: ' + (err as Error).message);
-      }
+      } catch { /* tolerate */ }
       send('cache', 'done', removed.length > 0 ? `已清: ${removed.join(', ')}` : '无缓存可清');
 
-      // Step 6: 主动 in-process rebuild dist（不依赖 systemd ExecStartPre）。
-      //
-      // 为什么自己跑：systemd ExecStartPre 的 npx tsc 在生产环境观测到偶尔
-      // 静默 skip 不重建 dist（tsc incremental cache 边界 case / cwd 解析
-      // 问题），导致清 dist 后 cds-master 重启找不到 dist/index.js。这里
-      // 主动跑一次 tsc 让 dist 立刻就位，systemd 重启时 ExecStartPre 是
-      // incremental no-op，cds 立刻能起。
-      send('build-backend', 'running', '主动重建 cds/dist …');
+      // 编译到 dist.next/，旧 dist/ 全程不动
+      send('build-backend', 'running', '主动重建 cds/dist.next/（旧 dist 保留为兜底）…');
       const tscRes = await shell.exec(
-        'npx tsc',
+        'npx tsc --outDir dist.next',
         { cwd: cdsDir, timeout: 240_000, env: { NODE_OPTIONS: '--max-old-space-size=4096' } },
       );
       if (tscRes.exitCode !== 0) {
         const errMsg = combinedOutput(tscRes).slice(0, 1500);
-        send('build-backend', 'error', `tsc 编译失败: ${errMsg.slice(0, 300)}`);
-        sendSSE(res, 'error', { message: `cds/dist 编译失败 — cds 继续跑老版本，请检查代码：\n${errMsg.slice(0, 800)}` });
+        // 清掉半成品 dist.next，不动旧 dist
+        try { fs.rmSync(path.join(cdsDir, 'dist.next'), { recursive: true, force: true }); } catch { /* ignore */ }
+        send('build-backend', 'error', `tsc 编译失败（旧 dist 保留）: ${errMsg.slice(0, 300)}`);
+        sendSSE(res, 'error', { message: `cds/dist.next 编译失败 — cds 继续跑老版本，请检查代码：\n${errMsg.slice(0, 800)}` });
         res.end();
         recordFailure(`tsc 编译失败: ${errMsg.slice(0, 300)}`);
         return;
       }
-      // 验证 dist 真生成了关键文件（tsc 偶发 exit=0 但 outDir 为空）
-      const distEntry = path.join(cdsDir, 'dist', 'index.js');
-      if (!fs.existsSync(distEntry)) {
-        send('build-backend', 'error', 'tsc 报成功但 dist/index.js 不存在');
-        sendSSE(res, 'error', { message: 'tsc 编译报成功但 dist/index.js 缺失，已中止重启避免 cds 起不来' });
+      const nextEntry = path.join(cdsDir, 'dist.next', 'index.js');
+      if (!fs.existsSync(nextEntry)) {
+        try { fs.rmSync(path.join(cdsDir, 'dist.next'), { recursive: true, force: true }); } catch { /* ignore */ }
+        send('build-backend', 'error', 'tsc 报成功但 dist.next/index.js 不存在（旧 dist 保留）');
+        sendSSE(res, 'error', { message: 'tsc 编译报成功但 dist.next/index.js 缺失，已中止重启避免 cds 起不来' });
         res.end();
-        recordFailure('tsc exit=0 but dist/index.js missing');
+        recordFailure('tsc exit=0 but dist.next/index.js missing');
         return;
       }
-      send('build-backend', 'done', `dist/ 已就位（${(await shell.exec('ls dist | wc -l', { cwd: cdsDir })).stdout.trim()} 个文件）`);
+
+      // Atomic swap: dist → dist.old.<ts> → dist.next → dist
+      const swapTs = Date.now();
+      const distPath = path.join(cdsDir, 'dist');
+      const distOldPath = path.join(cdsDir, `dist.old.${swapTs}`);
+      const distNextPath = path.join(cdsDir, 'dist.next');
+      try {
+        if (fs.existsSync(distPath)) {
+          fs.renameSync(distPath, distOldPath);
+        }
+        try {
+          fs.renameSync(distNextPath, distPath);
+        } catch (renameErr) {
+          // 极罕见的中间失败 —— 把备份恢复回去保证 dist 始终存在
+          if (fs.existsSync(distOldPath)) {
+            try { fs.renameSync(distOldPath, distPath); } catch { /* ignore — already broken */ }
+          }
+          throw renameErr;
+        }
+        // 清理备份（保不保都不影响 cds 运行，rmSync 失败也忽略）
+        try { fs.rmSync(distOldPath, { recursive: true, force: true }); } catch { /* ignore */ }
+      } catch (swapErr) {
+        send('build-backend', 'error', `dist 原子替换失败: ${(swapErr as Error).message}`);
+        sendSSE(res, 'error', { message: `dist 原子替换失败,已尝试回滚: ${(swapErr as Error).message}` });
+        res.end();
+        recordFailure(`dist atomic swap failed: ${(swapErr as Error).message}`);
+        return;
+      }
+      send('build-backend', 'done', 'dist/ 已原子替换（旧版已删除）');
 
       // In-process 重建 cds/web/dist —— Bugbot PR #524 第九轮反馈:之前
       // self-force-sync 走 daemon build_web(实测 production 不可靠),会复现

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -8399,6 +8399,10 @@ cdscli project list --human
     });
     const send = (step: string, status: string, title: string) => {
       sendSSE(res, 'step', { step, status, title, timestamp: new Date().toISOString() });
+      // Bugbot b6cf7d4a — 跟 self-force-sync 的 send 保持一致,同步 step 字段
+      // 到 activeSelfUpdate,让别 tab 通过 /api/self-status 看到当前阶段。
+      const cur = stateService.getActiveSelfUpdate();
+      if (cur) stateService.markSelfUpdateActive({ ...cur, step });
     };
 
     // 2026-05-04 流水记录:从开头捕获 fromSha + start time,所有 abort 路径

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -325,8 +325,8 @@ export async function validateBuildReadiness(
   //     用户感受是"UI 没变" → GlobalUpdateBadge 显示 bundleStale 红徽章 →
   //     用户主动来排查
   //
-  // 加 NODE_OPTIONS=--max-old-space-size=4096 防 vite tsc -b 在小内存机器
-  // 上 OOM(实测 production 1G 机器跑 tsc -b 会爆)。
+  // 2026-05-06 用户授权:不再下发 NODE_OPTIONS=--max-old-space-size,V8 自适应
+  // 主机 RAM(避免人为压低,也不刻意放大 — 不放 -Xmx 这种"占满 1 万 G"的反模式)。
   // 失败只 collect 到 webWarning 字段,SSE 流照常 send 'done',self-update 继续。
   const webDir = path.join(cdsDir, 'web');
   let webWarning: string | undefined;
@@ -349,7 +349,7 @@ export async function validateBuildReadiness(
             timeout: 180_000,
             // Bugbot PR #524 第五轮:shell-executor 已 merge process.env,调用方
             // 只需传需要 override 的部分,不要再 spread。
-            env: { NODE_OPTIONS: '--max-old-space-size=4096' },
+            env: { /* 不限制 V8 堆,用户授权 build 阶段尽情释放内存 */ },
           },
         );
         if (webTsc.exitCode !== 0) {
@@ -1763,14 +1763,17 @@ export function createBranchRouter(deps: RouterDeps): Router {
     try {
       try { fs.unlinkSync(webShaFile); } catch { /* ignore */ }
       const buildStartedAt = Date.now();
+      // 用户反馈 2026-05-06:"network error 用时 2m12s" — 中间层(浏览器/nginx)
+      // 切了 SSE 长连接。15s 一次的 tick 在 vite 子进程长时间无 stdout 时仍可能
+      // 触发某些代理的 idle 超时。改 5s 一次,密度高 5 倍,代理几乎不会判 idle。
       const heartbeat = setInterval(() => {
         const elapsed = Math.floor((Date.now() - buildStartedAt) / 1000);
         sendSSE(res, 'web-build-tick', { elapsed, message: `web build 进行中 ${elapsed}s` });
-      }, 15_000);
+      }, 5_000);
       try {
         const wInstall = await shell.exec(
           'pnpm install --frozen-lockfile',
-          { cwd: webDir, timeout: 300_000, env: { NODE_OPTIONS: '--max-old-space-size=4096' } },
+          { cwd: webDir, timeout: 300_000, env: { /* 不限制 V8 堆,用户授权 build 阶段尽情释放内存 */ } },
         );
         if (wInstall.exitCode !== 0) {
           clearInterval(heartbeat);
@@ -1793,7 +1796,7 @@ export function createBranchRouter(deps: RouterDeps): Router {
         } else {
           const wBuild = await shell.exec(
             'pnpm build',
-            { cwd: webDir, timeout: 300_000, env: { NODE_OPTIONS: '--max-old-space-size=4096' } },
+            { cwd: webDir, timeout: 300_000, env: { /* 不限制 V8 堆,用户授权 build 阶段尽情释放内存 */ } },
           );
           clearInterval(heartbeat);
           if (wBuild.exitCode === 0) {
@@ -8883,7 +8886,7 @@ cdscli project list --human
       send('build-backend', 'running', '主动重建 cds/dist.next/(旧 dist 保留为兜底)…');
       const tscRes = await shell.exec(
         'npx tsc --outDir dist.next --tsBuildInfoFile dist.next/.tsbuildinfo',
-        { cwd: cdsDir, timeout: 240_000, env: { NODE_OPTIONS: '--max-old-space-size=4096' } },
+        { cwd: cdsDir, timeout: 240_000, env: { /* 不限制 V8 堆,用户授权 build 阶段尽情释放内存 */ } },
       );
       if (tscRes.exitCode !== 0) {
         const errMsg = combinedOutput(tscRes).slice(0, 1500);

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -8530,18 +8530,38 @@ cdscli project list --human
       send('reset', 'done', `HEAD = ${newHead}`, { commitHash: newHead });
 
       // Step 4: drop dist build cache so next start recompiles.
-      send('cache', 'running', '清除 dist/.build-sha 编译缓存…');
-      const shaFile = path.join(cdsDir, 'dist', '.build-sha');
+      //
+      // 2026-05-05: 仅删 .build-sha 还不够，TypeScript incremental 缓存
+      // (.tsbuildinfo) 让 systemd ExecStartPre 的 `npx tsc` 跳过编译，
+      // 导致代码已切但 dist/ 仍是 stale。所以同步删 .tsbuildinfo（项目根
+      // 和 cds/ 各一份）+ 删整个 dist/ 让 tsc 必须从头编译。
+      send('cache', 'running', '清除 dist/ + tsc 增量缓存…');
+      const cacheTargets = [
+        path.join(cdsDir, 'dist', '.build-sha'),
+        path.join(cdsDir, '.tsbuildinfo'),
+        path.join(cdsDir, 'tsconfig.tsbuildinfo'),
+        path.join(cdsDir, 'dist', '.tsbuildinfo'),
+      ];
+      const removed: string[] = [];
+      for (const f of cacheTargets) {
+        try {
+          if (fs.existsSync(f)) {
+            fs.unlinkSync(f);
+            removed.push(path.basename(f));
+          }
+        } catch { /* tolerate per-file errors */ }
+      }
+      // 整个 dist/ 也清掉 — 强制 tsc 从空目录全量编译，杜绝任何 stale 文件
       try {
-        if (fs.existsSync(shaFile)) {
-          fs.unlinkSync(shaFile);
-          send('cache', 'done', '已删除 .build-sha');
-        } else {
-          send('cache', 'done', '.build-sha 不存在, 跳过');
+        const distDir = path.join(cdsDir, 'dist');
+        if (fs.existsSync(distDir)) {
+          fs.rmSync(distDir, { recursive: true, force: true });
+          removed.push('dist/');
         }
       } catch (err) {
-        send('cache', 'warning', '删除 .build-sha 失败: ' + (err as Error).message);
+        send('cache', 'warning', '删除 dist/ 失败: ' + (err as Error).message);
       }
+      send('cache', 'done', removed.length > 0 ? `已清: ${removed.join(', ')}` : '无缓存可清');
 
       // Step 5: validate new code compiles before restart.
       send('validate', 'running', '预检: pnpm install + tsc --noEmit…');

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -74,6 +74,13 @@ export async function broadcastSelfStatus(): Promise<void> {
   }
   broadcastInFlight = true;
   try {
+    // ⚠ Bugbot 2026-05-06 97af6861:do/while 在 compute 持续抛 + webhook
+    // 持续到来时形成 tight loop(catch 后 continue 不 sleep,broadcastQueued
+    // 又被新 webhook 立刻置 true → 立刻再尝试)。给两道护栏:
+    //   - 最多 4 轮(初始 + 3 次合并),超出就放弃当前 burst,下个 webhook 重启
+    //   - 失败后 sleep 1s 再循环,避免 CPU/git fetch 风暴
+    const MAX_LOOPS = 4;
+    let loops = 0;
     do {
       broadcastQueued = false;
       let payload: unknown;
@@ -82,6 +89,10 @@ export async function broadcastSelfStatus(): Promise<void> {
       } catch (err) {
         // eslint-disable-next-line no-console
         console.warn('[self-status] broadcast 重新计算失败:', (err as Error).message);
+        loops += 1;
+        if (loops >= MAX_LOOPS) break;
+        // 失败后给事件循环让出 1s,避免持续故障下的 hot loop
+        await new Promise((r) => setTimeout(r, 1_000));
         continue;
       }
       if (!selfStatusContext) return;
@@ -93,7 +104,8 @@ export async function broadcastSelfStatus(): Promise<void> {
           selfStatusClients.delete(client);
         }
       }
-    } while (broadcastQueued);
+      loops += 1;
+    } while (broadcastQueued && loops < MAX_LOOPS);
   } finally {
     broadcastInFlight = false;
   }

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -866,9 +866,13 @@ export function createBranchRouter(deps: RouterDeps): Router {
       // 帧 + 一个尾巴"当作单帧解析,后面 event: 把前面 event: 覆盖,data: 行混到
       // 一起 → opLog 里出现合并/错位事件。改:对 buffer 跑一次 parseSseFrames,
       // 完整帧逐个 ingest,只有真正不完整的尾巴才整体 ingest。
-      const drained = parseSseFrames(buffer);
-      for (const frame of drained.frames) ingestFrame(frame);
-      if (drained.tail.trim()) ingestFrame(drained.tail);
+      // ⚠ Bugbot 2026-05-06 18514cde:buffer 为空时跳过整个 drain,避免无谓的
+      // parseSseFrames('') / ingestFrame('') 调用(虽然各自是 no-op)。
+      if (buffer.length > 0) {
+        const drained = parseSseFrames(buffer);
+        for (const frame of drained.frames) ingestFrame(frame);
+        if (drained.tail.trim()) ingestFrame(drained.tail);
+      }
 
       // Master-side state is best-effort — the executor has the source of
       // truth via its next heartbeat, which will reconcile status.
@@ -8257,6 +8261,14 @@ cdscli project list --human
       return;
     }
     selfStatusClients.add(res);
+
+    // ⚠ Bugbot 2026-05-06 d7db4dba:snapshot 用 skipFetch=true(避免连接被 git fetch 阻塞),
+    // 所以它的 fetchOk=false / remoteAheadCount 走 cached refs(可能 stale)。
+    // 后续如果没有 webhook push,客户端永远看不到真实远端状态。在 add(res) 之后
+    // 异步 fire-and-forget 一次 broadcastSelfStatus()(走 skipFetch=false 真 fetch),
+    // 几秒内推一条 update 给所有 client(包括刚连上的这个)消除盲点。
+    // broadcastSelfStatus 本身有 coalesce,多个并发新连接不会引发 fetch 风暴。
+    void broadcastSelfStatus().catch(() => { /* 已在内部记 warn */ });
 
     // 3) 25s keepalive,防 nginx/中间代理 60s 闲置超时 cut 连接
     const keepalive = setInterval(() => {

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -3,6 +3,7 @@ import https from 'node:https';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { createHash } from 'node:crypto';
 import { execSync, spawn } from 'node:child_process';
 import { createGzip } from 'node:zlib';
 import { Router, type Request } from 'express';
@@ -253,6 +254,43 @@ async function computeSelfStatusPayload(
     degradedReasons.push(`webBuildSha: ${(err as Error).message}`);
   }
 
+  // 用户反馈 2026-05-06:每次改 unit 都要 sudo 重装太蠢。重构后 unit 文件
+  // 极少改,但确实改时 operator 不知道 → 默默用旧 unit。这里检测 drift,
+  // 命中就在 self-status payload 里曝光,UI 提示 operator 用一行命令重装。
+  let systemdUnitDrift: { repoHash: string; installedHash: string; installedAt?: string } | null = null;
+  try {
+    const repoUnit = path.resolve(repoRoot, 'cds', 'systemd', 'cds-master.service');
+    const installedUnit = '/etc/systemd/system/cds-master.service';
+    if (fs.existsSync(repoUnit) && fs.existsSync(installedUnit)) {
+      const repoText = fs.readFileSync(repoUnit, 'utf8');
+      const installedText = fs.readFileSync(installedUnit, 'utf8');
+      // install_systemd_cmd 会替换 ExecStart 的 /opt/prd_agent/... 路径,
+      // 比较时归一化:把两边的 /opt/prd_agent/... 路径全部抹掉,只看其他字段。
+      // 否则 development 装在 /home/user/ 永远 drift 误报。
+      const normalize = (s: string): string =>
+        s
+          .replace(/^WorkingDirectory=.*/m, 'WorkingDirectory=<install-path>')
+          .replace(/^Environment=PATH=.*/m, 'Environment=PATH=<resolved>')
+          .replace(/^Environment=CDS_REPO_ROOT=.*/m, 'Environment=CDS_REPO_ROOT=<install-path>')
+          .replace(/^ExecStart=.*master-run.*/m, 'ExecStart=<install-path>/exec_cds.sh master-run')
+          .replace(/^ExecStartPre=\S+/gm, 'ExecStartPre=<resolved-bin>')
+          .replace(/^ReadWritePaths=.*/m, 'ReadWritePaths=<resolved>');
+      if (normalize(repoText) !== normalize(installedText)) {
+        const hash = (s: string): string => createHash('sha1').update(s).digest('hex').slice(0, 8);
+        systemdUnitDrift = {
+          repoHash: hash(normalize(repoText)),
+          installedHash: hash(normalize(installedText)),
+        };
+        try {
+          const stat = fs.statSync(installedUnit);
+          systemdUnitDrift.installedAt = stat.mtime.toISOString();
+        } catch { /* tolerate */ }
+      }
+    }
+  } catch (err) {
+    degradedReasons.push(`unitDrift: ${(err as Error).message}`);
+  }
+
   return {
     currentBranch,
     headSha,
@@ -266,6 +304,7 @@ async function computeSelfStatusPayload(
     selfUpdateHistory: history,
     webBuildSha,
     webBuildError,
+    systemdUnitDrift,
     bundleStale: Boolean(
       (headSha && webBuildSha && !(
         webBuildSha.startsWith(headSha) || headSha.startsWith(webBuildSha)

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -341,6 +341,7 @@ async function computeSelfStatusPayload(
 export async function validateBuildReadiness(
   shell: IShellExecutor,
   cdsDir: string,
+  options: { skipTsc?: boolean } = {},
 ): Promise<
   | { ok: true; summary: string; webWarning?: string }
   | { ok: false; stage: 'install' | 'tsc'; error: string }
@@ -370,6 +371,21 @@ export async function validateBuildReadiness(
   let webWarning: string | undefined;
   if (webInstallResult && webInstallResult.exitCode !== 0) {
     webWarning = 'web pnpm install 失败 — web build 大概率会跟着失败,继续 self-update 但前端可能不更新';
+  }
+
+  // ⚠ Bugbot 9095dfbb + 1f4db209:hot path 调用方传 skipTsc=true,因为
+  // self-force-sync 下游会跑 esbuild + tsc --noEmit 并行(line 9020-),那一步等
+  // 价于这里的 tsc round。**仍然要跑 pnpm install** — 新 .ts 文件 import 一个
+  // 已声明但没装的 dep 时 esbuild 会失败,`pnpm install --frozen-lockfile`
+  // 是 5s 的 no-op(快路径,lockfile 一致时只校验)修复 node_modules 残缺。
+  if (options.skipTsc) {
+    return {
+      ok: true,
+      summary: webWarning
+        ? `pnpm install 通过 — ⚠ web install 失败(self-update 继续)`
+        : 'pnpm install 通过(hot path,tsc 由后续 esbuild + tsc --noEmit 并行兜底)',
+      webWarning,
+    };
   }
 
   // Round 2: tsc --noEmit (cds + cds/web 并行,后者仅在 web install 通过时跑)
@@ -8330,13 +8346,17 @@ cdscli project list --human
     // → 多 tab 时每开一个新 tab,旧 tab 都收到一条冗余 update + git fetch 也跑一次。
     // 改成只给**当前新连接**真 fetch 一次推 update,不打扰别的 client。
     void (async () => {
+      // ⚠ Bugbot 2026-05-06 9514bd0b:正在 broadcast 时本 client 跳过 per-client
+      // update — broadcast 会推到整个 selfStatusClients 池(本 res 已在池里),
+      // 避免 snapshot → broadcast update → per-client update 的三连闪烁。
+      if (broadcastInFlight) return;
       try {
         const payload = await computeSelfStatusPayload(
           { repoRoot: config.repoRoot, shell, stateService },
           { skipFetch: false },
         );
-        // 期间客户端可能断开 / 主动关
-        if (req.destroyed || !selfStatusClients.has(res)) return;
+        // 期间客户端可能断开 / 主动关 / broadcast 抢先了
+        if (req.destroyed || !selfStatusClients.has(res) || broadcastInFlight) return;
         res.write(`event: update\ndata: ${JSON.stringify(payload)}\n\n`);
       } catch (err) {
         // eslint-disable-next-line no-console
@@ -8931,24 +8951,40 @@ cdscli project list --human
       // 热路径跳过 validate(节省 ~50s),直接 incremental emit + atomic swap +
       // 写 .build-sha,然后**不**触发 systemd restart。systemd unit 的 ExecStart
       // 已经改成 `node --watch=dist`,node 自己感知 dist/ 变化平滑重启 ~2s。
+      // ⚠ Bugbot 0ab88deb + fbdfe6ce:fromSha 来自 `git rev-parse --short HEAD`
+      // 通常是 7 位 hex,但允许为空(line 8744 容忍),且即使非空也应过 isSafeGitRef
+      // defense-in-depth。空 / 不合法 → 没法可靠 diff → 保守走冷路径。
       let changedPaths: string[] = [];
-      try {
-        const diffRes = await shell.exec(
-          `git diff --name-only ${fromSha || 'HEAD~1'}..HEAD`,
-          { cwd: repoRoot, timeout: 15_000 },
-        );
-        if (diffRes.exitCode === 0) {
-          changedPaths = diffRes.stdout.split('\n').map((s) => s.trim()).filter(Boolean);
-        }
-      } catch { /* tolerate — fall through to cold restart */ }
+      let diffOk = false;
+      if (fromSha && isSafeGitRef(fromSha)) {
+        try {
+          const diffRes = await shell.exec(
+            `git diff --name-only ${fromSha}..HEAD`,
+            { cwd: repoRoot, timeout: 15_000 },
+          );
+          if (diffRes.exitCode === 0) {
+            changedPaths = diffRes.stdout.split('\n').map((s) => s.trim()).filter(Boolean);
+            diffOk = true;
+          }
+        } catch { /* tolerate */ }
+      }
       const impact = analyzeChangeImpact(changedPaths);
-      if (impact.needsRestart) {
+      if (!diffOk) {
+        send('analyze', 'done', `git diff 不可用(fromSha 为空或 shallow repo)— 保守走完整重启`);
+      } else if (impact.needsRestart) {
         const sample = impact.restartTriggers.slice(0, 3).map((t) => `${t.path}(${t.reason})`).join('; ');
         send('analyze', 'done', `${impact.restartTriggers.length} 处改动需重启:${sample}${impact.restartTriggers.length > 3 ? '…' : ''}`);
+      } else if (impact.hotReloadablePaths.length === 0) {
+        // ⚠ Bugbot 3ec7d7ab:全部都是 irrelevant(纯文档/changelogs)的话 hot path 都没必要走,
+        // 直接 fast-path no-op 在前面 8870 行已处理(.build-sha 一致时)。
+        // 这里走到说明 .build-sha 不同(SHA 真换了,但只动了 doc)— 仍是 noOp 语义。
+        send('analyze', 'done', `本次改动 ${impact.irrelevantPaths.length} 个纯文档文件,无应用代码改动 — 仅打 commit tag,不重 build`);
       } else {
-        send('analyze', 'done', `本次改动 ${changedPaths.length} 文件全部热重载安全(应用代码 ${impact.hotReloadablePaths.length} + 文档 ${impact.irrelevantPaths.length})— 走热重载快路径`);
+        send('analyze', 'done', `本次改动 ${changedPaths.length} 文件全部热重载安全(应用代码 ${impact.hotReloadablePaths.length} + 文档 ${impact.irrelevantPaths.length})— 走热路径`);
       }
-      const hotEligible = !impact.needsRestart && changedPaths.length > 0;
+      // ⚠ Bugbot 0ab88deb + 3ec7d7ab:hotEligible 必须 (a) diff 可信 (b) 至少有一个应用代码改动。
+      // 缺任一都退回冷路径(保守) — 走冷路径的成本是慢点,走错路径的成本是 silent stale code。
+      const hotEligible = diffOk && !impact.needsRestart && impact.hotReloadablePaths.length > 0;
 
       // Step 4: validate new code compiles BEFORE touching dist.
       //
@@ -8968,8 +9004,29 @@ cdscli project list --human
       // 徽章亮(原行为)。
       let validation: Awaited<ReturnType<typeof validateBuildReadiness>>;
       if (hotEligible) {
-        send('validate', 'done', '热路径:跳过 validate(改动只涉及应用代码,tsc emit 会捕获错误)');
-        validation = { ok: true, summary: 'skipped via hot-path' };
+        // ⚠ Bugbot 9095dfbb + 1f4db209:即使 hot path 也要跑 pnpm install
+        // (~5s no-op,修复 node_modules 残缺;新 .ts 加 import 一个已声明但
+        // 没装的 dep 时 esbuild 会失败)。**只**跳过 tsc --noEmit。
+        send('validate', 'running', '热路径预检: pnpm install --prefer-offline (skipTsc)…');
+        validation = await validateBuildReadiness(shell, cdsDir, { skipTsc: true });
+        if (!validation.ok) {
+          send('validate', 'error', `pnpm install 失败: ${validation.error.slice(0, 300)}`);
+          sendSSE(res, 'error', { message: `force-sync 已中止 — pnpm install 失败: ${validation.error}` });
+          res.end();
+          stateService.recordSelfUpdate({
+            ts: new Date().toISOString(),
+            branch: branch || target || '',
+            fromSha,
+            toSha: fromSha,
+            trigger: 'force-sync',
+            status: 'aborted',
+            durationMs: Date.now() - startedAt,
+            error: `pnpm install 失败: ${(validation.error || '').slice(0, 1500)}`,
+            actor,
+          });
+          return;
+        }
+        send('validate', 'done', validation.summary);
       } else {
       send('validate', 'running', '预检: pnpm install + tsc --noEmit…');
       validation = await validateBuildReadiness(shell, cdsDir);

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -7803,7 +7803,22 @@ cdscli project list --human
   //
   // 注意:`git fetch` 会真的发网络请求,带 10s 超时;远端不可达时优雅降级
   // 到 cached(用 `--cached` 不会触发 fetch)。
-  router.get('/self-status', async (_req, res) => {
+  //
+  // 2026-05-05 性能修复(P1):前端 GlobalUpdateBadge 反复轮询 ?probe=remote,
+  // 每次都触发 git fetch → 单次 5~10s,导致页面整体卡（用户反馈"打开什么都卡"）。
+  // 加 60s in-process 缓存：同一查询参数组合在 60s 内复用上次结果，零网络。
+  // 用户明确点"刷新"时前端可以加 ?force=1 跳过缓存（如未实现，refresh 重启进程
+  // 也能清缓存）。
+  let selfStatusCache: { key: string; payload: unknown; expiresAt: number } | null = null;
+  router.get('/self-status', async (req, res) => {
+    const probeMode = (req.query.probe as string | undefined) || 'local';
+    const force = req.query.force === '1' || req.query.force === 'true';
+    const cacheKey = `probe=${probeMode}`;
+    const now = Date.now();
+    if (!force && selfStatusCache && selfStatusCache.key === cacheKey && selfStatusCache.expiresAt > now) {
+      res.json(selfStatusCache.payload);
+      return;
+    }
     // 2026-05-04 v2(用户反馈"GET /api/self-status → 400"):
     // 之前是单一 outer try/catch + 多个 await 串联,任何一个 git 命令失败 / 上游
     // 中间件意外都会导致整个端点挂掉(返 500/4xx)。改为**逐个 try/catch + 永远返 200**,
@@ -7924,7 +7939,7 @@ cdscli project list --human
       degradedReasons.push(`webBuildSha: ${(err as Error).message}`);
     }
 
-    res.json({
+    const payload = {
       currentBranch,
       headSha,
       headIso,
@@ -7951,7 +7966,11 @@ cdscli project list --human
       ),
       // 给前端一个明确信号:数据是不是降级了 + 哪步降级。
       degraded: degradedReasons.length > 0 ? { reasons: degradedReasons } : null,
-    });
+      cachedAt: new Date().toISOString(),
+    };
+    // 进 cache 60 秒（前端反复轮询不再每次都 git fetch）
+    selfStatusCache = { key: cacheKey, payload, expiresAt: Date.now() + 60_000 };
+    res.json(payload);
   });
 
   // POST /api/self-update — switch branch + pull + restart CDS (SSE progress)

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -8763,9 +8763,14 @@ cdscli project list --human
       send('cache', 'done', removed.length > 0 ? `已清: ${removed.join(', ')}` : '无缓存可清');
 
       // 编译到 dist.next/，旧 dist/ 全程不动
-      send('build-backend', 'running', '主动重建 cds/dist.next/（旧 dist 保留为兜底）…');
+      // ⚠ Bugbot Review 2026-05-06 daab0916: tsconfig.json 把 tsBuildInfoFile
+      // 硬编码到 dist/.tsbuildinfo,只覆盖 --outDir 不够 —— tsc 仍会把
+      // .tsbuildinfo 写到旧 dist/,失败时该文件指向不存在的 dist.next/ 编译产物,
+      // 污染下次 systemd ExecStartPre 的增量缓存。同时覆盖 --tsBuildInfoFile
+      // 让两边的输出都在 dist.next/ 内,失败时一起 rm 即可。
+      send('build-backend', 'running', '主动重建 cds/dist.next/(旧 dist 保留为兜底)…');
       const tscRes = await shell.exec(
-        'npx tsc --outDir dist.next',
+        'npx tsc --outDir dist.next --tsBuildInfoFile dist.next/.tsbuildinfo',
         { cwd: cdsDir, timeout: 240_000, env: { NODE_OPTIONS: '--max-old-space-size=4096' } },
       );
       if (tscRes.exitCode !== 0) {

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -8937,16 +8937,8 @@ cdscli project list --human
       // 主动清等于自废武功。**不**清 .tsbuildinfo,只清 dist.next/(上一次失败
       // 的孤儿)+ dist.old.*(rmSync 失败的孤儿)。
       send('cache', 'running', '清理孤儿目录(保留 .tsbuildinfo 让 tsc 走增量)…');
-      const tsbCleanTargets: string[] = [
-        // .tsbuildinfo 一概保留 — incremental 命中是 30s vs 60s 的差距
-      ];
       const removed: string[] = [];
-      for (const f of tsbCleanTargets) {
-        try {
-          if (fs.existsSync(f)) { fs.unlinkSync(f); removed.push(path.basename(f)); }
-        } catch { /* tolerate */ }
-      }
-      // dist.next 残留（上次失败留下的）也清掉
+      // dist.next 残留(上次失败留下的)
       try {
         const next = path.join(cdsDir, 'dist.next');
         if (fs.existsSync(next)) {

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -8727,6 +8727,13 @@ cdscli project list --human
       sendSSE(res, 'error', { message: (err as Error).message });
       res.end();
       recordFailure(`更新失败(异常): ${(err as Error).message}`);
+    } finally {
+      // Bugbot 31da8d97 (HIGH):兜底清 in-progress 标记。
+      // recordSelfUpdate 已经在 success/aborted/failed 三种正常路径上清掉,
+      // 但若 catch handler 自身抛(send / sendSSE / res.end 在异常态下),
+      // marker 会卡住 — 所有 tab 看到"自更新进行中"幽灵。idempotent 清空,
+      // 二次清不影响已 record 的历史。
+      stateService.clearSelfUpdateActive();
     }
   });
 
@@ -8998,15 +9005,42 @@ cdscli project list --human
         const sample = impact.restartTriggers.slice(0, 3).map((t) => `${t.path}(${t.reason})`).join('; ');
         send('analyze', 'done', `${impact.restartTriggers.length} 处改动需重启:${sample}${impact.restartTriggers.length > 3 ? '…' : ''}`);
       } else if (impact.hotReloadablePaths.length === 0) {
-        // ⚠ Bugbot 3ec7d7ab:全部都是 irrelevant(纯文档/changelogs)的话 hot path 都没必要走,
-        // 直接 fast-path no-op 在前面 8870 行已处理(.build-sha 一致时)。
-        // 这里走到说明 .build-sha 不同(SHA 真换了,但只动了 doc)— 仍是 noOp 语义。
-        send('analyze', 'done', `本次改动 ${impact.irrelevantPaths.length} 个纯文档文件,无应用代码改动 — 仅打 commit tag,不重 build`);
+        // ⚠ Bugbot 7749d6f8 (Medium) — 之前这里只 send 了一句 analyze 日志,然后
+        // hotEligible=false 让流程继续走完整冷路径(validate + esbuild + tsc + atomic
+        // swap + restart),~70-95s 全部白跑。文档/changelogs 改动既不影响 dist
+        // 也不影响 web bundle,正确做法是直接 fast-path 写新 .build-sha 后 return。
+        // 与前面 line 8970 fast-path 区别:那个要求两个 .build-sha 已是 newHead;
+        // 这里是首次切到 newHead 时,虽然 .build-sha 不同但改动全是 docs,可以直接
+        // 把现有 dist + web bundle 标记为"已是 newHead 产物"(它们的字节实际不变)。
+        send('analyze', 'done', `本次改动 ${impact.irrelevantPaths.length} 个纯文档文件,无应用代码改动 — 跳过 build/restart`);
+        try { fs.writeFileSync(distShaPath, newHeadFull); } catch { /* tolerate — fast-path 失效但功能不受影响 */ }
+        try { fs.writeFileSync(webShaPath, newHeadFull); } catch { /* tolerate */ }
+        send('doc-only', 'done', `dist/.build-sha 与 web/dist/.build-sha 已标记为 ${newHead}`);
+        sendSSE(res, 'done', {
+          message: `已对齐到 ${newHead},仅改动 ${impact.irrelevantPaths.length} 个文档文件 — 无需 rebuild/restart`,
+          commitHash: newHead,
+          mode: 'doc-only',
+          docOnlyFiles: impact.irrelevantPaths.length,
+        });
+        res.end();
+        stateService.recordSelfUpdate({
+          ts: new Date().toISOString(),
+          branch: branch || target || '',
+          fromSha,
+          toSha: newHead,
+          trigger: 'force-sync',
+          status: 'success',
+          durationMs: Date.now() - startedAt,
+          actor,
+          ...({ updateMode: 'doc-only' } as Record<string, unknown>),
+        });
+        return;
       } else {
         send('analyze', 'done', `本次改动 ${changedPaths.length} 文件全部热重载安全(应用代码 ${impact.hotReloadablePaths.length} + 文档 ${impact.irrelevantPaths.length})— 走热路径`);
       }
       // ⚠ Bugbot 0ab88deb + 3ec7d7ab:hotEligible 必须 (a) diff 可信 (b) 至少有一个应用代码改动。
       // 缺任一都退回冷路径(保守) — 走冷路径的成本是慢点,走错路径的成本是 silent stale code。
+      // (doc-only 路径已在上面 return,这里走到时 hotReloadablePaths.length > 0 必然成立。)
       const hotEligible = diffOk && !impact.needsRestart && impact.hotReloadablePaths.length > 0;
 
       // Step 4: validate new code compiles BEFORE touching dist.
@@ -9293,6 +9327,9 @@ cdscli project list --human
       sendSSE(res, 'error', { message: (err as Error).message });
       try { res.end(); } catch { /* already ended */ }
       recordFailure(`force-sync 异常: ${(err as Error).message}`);
+    } finally {
+      // Bugbot 31da8d97 (HIGH):同 /self-update,兜底清 marker。
+      stateService.clearSelfUpdateActive();
     }
   });
 

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -299,68 +299,51 @@ export async function validateBuildReadiness(
   | { ok: true; summary: string; webWarning?: string }
   | { ok: false; stage: 'install' | 'tsc'; error: string }
 > {
-  // Stage 1: pnpm install --frozen-lockfile (后端 cds/)
-  const installResult = await shell.exec(
-    'pnpm install --frozen-lockfile',
-    { cwd: cdsDir, timeout: 300_000 },
-  );
+  // 用户反馈 2026-05-06:验证 75-95s 太慢。原因:cds + cds/web 各跑 pnpm install
+  // + tsc --noEmit 共 4 步串行。改成 Promise.all 两两并行 → 期望 50% 缩减。
+  // - 后端 tsc 失败 → node 起不来 → CDS 死翘 → 必须 abort
+  // - 前端 tsc 失败 → web build 也会失败 → 老 dist/ 继续 serve → bundleStale 徽章
+  //   只算 webWarning,self-update 继续。
+  const webDir = path.join(cdsDir, 'web');
+  const webExists = fs.existsSync(path.join(webDir, 'package.json'));
+
+  // Round 1: pnpm install --frozen-lockfile (cds + cds/web 并行)
+  const installPromises: Array<Promise<Awaited<ReturnType<typeof shell.exec>>>> = [
+    shell.exec('pnpm install --frozen-lockfile', { cwd: cdsDir, timeout: 300_000 }),
+  ];
+  if (webExists) {
+    installPromises.push(shell.exec('pnpm install --frozen-lockfile', { cwd: webDir, timeout: 300_000 }));
+  }
+  const [installResult, webInstallResult] = await Promise.all(installPromises);
+
   if (installResult.exitCode !== 0) {
     const err = (combinedOutput(installResult) || 'pnpm install 失败').slice(0, 500);
     return { ok: false, stage: 'install', error: err };
   }
 
-  // Stage 2: tsc --noEmit (后端 cds/) — 这步失败必 abort,因为新代码起不来
-  const tscResult = await shell.exec(
-    'npx tsc --noEmit',
-    { cwd: cdsDir, timeout: 120_000 },
-  );
+  let webWarning: string | undefined;
+  if (webInstallResult && webInstallResult.exitCode !== 0) {
+    webWarning = 'web pnpm install 失败 — web build 大概率会跟着失败,继续 self-update 但前端可能不更新';
+  }
+
+  // Round 2: tsc --noEmit (cds + cds/web 并行,后者仅在 web install 通过时跑)
+  const tscPromises: Array<Promise<Awaited<ReturnType<typeof shell.exec>>>> = [
+    shell.exec('npx tsc --noEmit', { cwd: cdsDir, timeout: 120_000 }),
+  ];
+  const runWebTsc = webExists && webInstallResult && webInstallResult.exitCode === 0;
+  if (runWebTsc) {
+    tscPromises.push(shell.exec('npx tsc --noEmit', { cwd: webDir, timeout: 180_000 }));
+  }
+  const [tscResult, webTscResult] = await Promise.all(tscPromises);
+
   if (tscResult.exitCode !== 0) {
     const err = (combinedOutput(tscResult) || 'tsc --noEmit 失败').slice(0, 800);
     return { ok: false, stage: 'tsc', error: err };
   }
 
-  // Stage 3: 前端 tsc(2026-05-04 v2 — production OOM 教训)
-  // 前端 tsc 失败**不**阻断 self-update。理由:
-  //   - 后端 tsc 失败 → node 起不来 → CDS 死翘 → 必须 abort
-  //   - 前端 tsc 失败 → web build 也会失败 → 老 dist/ 继续 serve →
-  //     用户感受是"UI 没变" → GlobalUpdateBadge 显示 bundleStale 红徽章 →
-  //     用户主动来排查
-  //
-  // 2026-05-06 用户授权:不再下发 NODE_OPTIONS=--max-old-space-size,V8 自适应
-  // 主机 RAM(避免人为压低,也不刻意放大 — 不放 -Xmx 这种"占满 1 万 G"的反模式)。
-  // 失败只 collect 到 webWarning 字段,SSE 流照常 send 'done',self-update 继续。
-  const webDir = path.join(cdsDir, 'web');
-  let webWarning: string | undefined;
-  try {
-    const webExists = fs.existsSync(path.join(webDir, 'package.json'));
-    if (webExists) {
-      const webInstall = await shell.exec(
-        'pnpm install --frozen-lockfile',
-        { cwd: webDir, timeout: 300_000 },
-      );
-      if (webInstall.exitCode !== 0) {
-        webWarning = 'web pnpm install 失败 — web build 大概率会跟着失败,继续 self-update 但前端可能不更新';
-      } else {
-        // tsc -b 比直接 tsc --noEmit 多用 2-3x 内存,改用后者(单 tsconfig 编译)。
-        // NODE_OPTIONS 提到 4G,绝大多数 vite 项目够用。
-        const webTsc = await shell.exec(
-          'npx tsc --noEmit',
-          {
-            cwd: webDir,
-            timeout: 180_000,
-            // 2026-05-06 起不下发 NODE_OPTIONS=--max-old-space-size,V8 自适应主机 RAM。
-            // ⚠ Bugbot 501afd51:不写 env 字段比写 env: {} 干净 — 后者仍会让
-            // shell-executor 走 merge 分支 spread 一份 process.env 副本,无意义。
-          },
-        );
-        if (webTsc.exitCode !== 0) {
-          const tail = (combinedOutput(webTsc) || '').slice(-800);
-          webWarning = `前端 tsc 失败(self-update 继续,但前端 bundle 不会更新): ${tail}`;
-        }
-      }
-    }
-  } catch (err) {
-    webWarning = `前端 tsc 异常(已忽略,self-update 继续): ${(err as Error).message}`;
+  if (runWebTsc && webTscResult && webTscResult.exitCode !== 0) {
+    const tail = (combinedOutput(webTscResult) || '').slice(-800);
+    webWarning = `前端 tsc 失败(self-update 继续,但前端 bundle 不会更新): ${tail}`;
   }
 
   return {
@@ -8856,7 +8839,45 @@ cdscli project list --human
         return;
       }
       const newHead = (await shell.exec('git rev-parse --short HEAD', { cwd: repoRoot })).stdout.trim();
+      const newHeadFull = (await shell.exec('git rev-parse HEAD', { cwd: repoRoot })).stdout.trim();
       send('reset', 'done', `HEAD = ${newHead}`, { commitHash: newHead });
+
+      // ── Fast-path: 当前 dist + web bundle 已经是 newHead 编译产物时直接跳过
+      // ── 用户反馈 2026-05-06:更新流程 215s 太慢。如果 force-sync 后 HEAD
+      //    没真正变化(reset 是个 no-op),整个 validate + 重 build + restart 就
+      //    100% 浪费。先看 dist/.build-sha 和 web/dist/.build-sha:两者都匹配
+      //    newHead → 整个 self-force-sync 在 ~3s 内 return,不走 validate / 重启。
+      const distShaPath = path.join(cdsDir, 'dist', '.build-sha');
+      const webShaPath = path.join(cdsDir, 'web', 'dist', '.build-sha');
+      let distSha = '';
+      let webSha = '';
+      try { if (fs.existsSync(distShaPath)) distSha = fs.readFileSync(distShaPath, 'utf8').trim(); } catch { /* ignore */ }
+      try { if (fs.existsSync(webShaPath)) webSha = fs.readFileSync(webShaPath, 'utf8').trim(); } catch { /* ignore */ }
+      const shaMatches = (a: string, b: string): boolean =>
+        !!a && !!b && (a === b || (a.length >= 7 && b.startsWith(a)) || (b.length >= 7 && a.startsWith(b)));
+      const distMatches = shaMatches(distSha, newHeadFull);
+      const webMatches = shaMatches(webSha, newHeadFull);
+      const distErrFile = path.join(cdsDir, 'dist', '.build-error');
+      const webErrFile = path.join(cdsDir, 'web', 'dist', '.build-error');
+      const noBuildErrors = !fs.existsSync(distErrFile) && !fs.existsSync(webErrFile);
+      if (distMatches && webMatches && noBuildErrors) {
+        send('no-op', 'done', `dist + web bundle 都已是 ${newHead} — 跳过 validate / 重 build / 重启`);
+        sendSSE(res, 'done', { message: `force-sync 已无操作(HEAD ${newHead} 与现行 dist 完全一致)` });
+        res.end();
+        stateService.recordSelfUpdate({
+          ts: new Date().toISOString(),
+          branch: branch || target || '',
+          fromSha,
+          toSha: newHead,
+          trigger: 'force-sync',
+          status: 'success',
+          durationMs: Date.now() - startedAt,
+          actor,
+          // 标记 noOp 让 UI 历史区分"真重启"和"已是最新走快路径"
+          ...({ noOp: true } as Record<string, unknown>),
+        });
+        return;
+      }
 
       // Step 4: validate new code compiles BEFORE touching dist.
       //

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -347,9 +347,9 @@ export async function validateBuildReadiness(
           {
             cwd: webDir,
             timeout: 180_000,
-            // Bugbot PR #524 第五轮:shell-executor 已 merge process.env,调用方
-            // 只需传需要 override 的部分,不要再 spread。
-            env: { /* 不限制 V8 堆,用户授权 build 阶段尽情释放内存 */ },
+            // 2026-05-06 起不下发 NODE_OPTIONS=--max-old-space-size,V8 自适应主机 RAM。
+            // ⚠ Bugbot 501afd51:不写 env 字段比写 env: {} 干净 — 后者仍会让
+            // shell-executor 走 merge 分支 spread 一份 process.env 副本,无意义。
           },
         );
         if (webTsc.exitCode !== 0) {
@@ -1777,7 +1777,7 @@ export function createBranchRouter(deps: RouterDeps): Router {
       try {
         const wInstall = await shell.exec(
           'pnpm install --frozen-lockfile',
-          { cwd: webDir, timeout: 300_000, env: { /* 不限制 V8 堆,用户授权 build 阶段尽情释放内存 */ } },
+          { cwd: webDir, timeout: 300_000 },
         );
         if (wInstall.exitCode !== 0) {
           clearInterval(heartbeat);
@@ -1800,7 +1800,7 @@ export function createBranchRouter(deps: RouterDeps): Router {
         } else {
           const wBuild = await shell.exec(
             'pnpm build',
-            { cwd: webDir, timeout: 300_000, env: { /* 不限制 V8 堆,用户授权 build 阶段尽情释放内存 */ } },
+            { cwd: webDir, timeout: 300_000 },
           );
           clearInterval(heartbeat);
           if (wBuild.exitCode === 0) {
@@ -8898,7 +8898,7 @@ cdscli project list --human
       send('build-backend', 'running', '主动重建 cds/dist.next/(旧 dist 保留为兜底)…');
       const tscRes = await shell.exec(
         'npx tsc --outDir dist.next --tsBuildInfoFile dist.next/.tsbuildinfo',
-        { cwd: cdsDir, timeout: 240_000, env: { /* 不限制 V8 堆,用户授权 build 阶段尽情释放内存 */ } },
+        { cwd: cdsDir, timeout: 240_000 },
       );
       if (tscRes.exitCode !== 0) {
         const errMsg = combinedOutput(tscRes).slice(0, 1500);

--- a/cds/src/routes/github-webhook.ts
+++ b/cds/src/routes/github-webhook.ts
@@ -48,6 +48,7 @@ import {
   buildTemplateVariables,
   renderTemplate,
 } from '../services/comment-template.js';
+import { broadcastSelfStatus } from './branches.js';
 
 export interface GitHubWebhookRouterDeps {
   stateService: StateService;
@@ -125,6 +126,38 @@ function shouldSkipDuplicateDispatch(branchId: string, commitSha: string): boole
 /** Test-only: reset dedup state between cases so they don't leak. */
 export function __resetWebhookDedupForTests(): void {
   recentDeployDispatches.clear();
+  cdsHostBranchCache = null;
+}
+
+/**
+ * CDS 进程当前 checkout 的分支(用于判断 push 事件是否影响"我"的 self-status)。
+ *
+ * 启动后基本不变(self-update 切分支会重启进程),所以只在第一次 push 时探测,
+ * 之后命中内存缓存。失败 → null,broadcast 简单跳过(对 GlobalUpdateBadge 无副作用,
+ * 用户最多看到角标稍微滞后一点)。
+ */
+let cdsHostBranchCache: string | null = null;
+async function getCdsHostBranch(
+  shell: IShellExecutor,
+  repoRoot: string,
+): Promise<string | null> {
+  if (cdsHostBranchCache !== null) return cdsHostBranchCache;
+  try {
+    const r = await shell.exec('git rev-parse --abbrev-ref HEAD', {
+      cwd: repoRoot,
+      timeout: 5_000,
+    });
+    if (r.exitCode === 0) {
+      const branch = r.stdout.trim();
+      if (branch) {
+        cdsHostBranchCache = branch;
+        return branch;
+      }
+    }
+  } catch {
+    /* 探测失败容忍 — 见函数 doc */
+  }
+  return null;
 }
 
 export function createGithubWebhookRouter(deps: GitHubWebhookRouterDeps): Router {
@@ -333,6 +366,33 @@ export function createGithubWebhookRouter(deps: GitHubWebhookRouterDeps): Router
     // events that actually moved state.
     if (result.action === 'ignored-event' || result.action === 'ignored-ping') {
       res.setHeader('X-CDS-Suppress-Activity', '1');
+    }
+
+    // 2026-05-05:push 命中 CDS 自身当前分支 → 主动 broadcast self-status
+    // 给所有 GlobalUpdateBadge SSE 客户端,前端无需轮询即可感知"有新 commit"。
+    //
+    // 仅当 push 事件 且 ref 解析出的分支等于 CDS 当前分支时才 broadcast,
+    // 避免任意分支 push 都触发(无意义的网络/git fetch)。fire-and-forget,
+    // 失败不阻塞 webhook 200 返回(GitHub 在意的是 10s 内 ack)。
+    if (eventName === 'push') {
+      const pushRef = (payload as { ref?: string })?.ref || '';
+      const pushedBranch = pushRef.startsWith('refs/heads/')
+        ? pushRef.slice('refs/heads/'.length)
+        : '';
+      if (pushedBranch) {
+        void getCdsHostBranch(shell, config.repoRoot).then((hostBranch) => {
+          if (hostBranch && hostBranch === pushedBranch) {
+            return broadcastSelfStatus();
+          }
+          return undefined;
+        }).catch((err) => {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[webhook] broadcastSelfStatus 失败 (push branch=${pushedBranch}):`,
+            (err as Error).message,
+          );
+        });
+      }
     }
 
     res.json({

--- a/cds/src/server.ts
+++ b/cds/src/server.ts
@@ -262,6 +262,7 @@ export function resolveApiLabel(method: string, path: string): string {
     'POST /import-and-init': '导入并初始化',
     'GET /self-branches': '获取自身分支',
     'GET /self-status': '获取自更新状态',
+    'GET /self-status/stream': '订阅自更新状态',
     'POST /self-update': '自我更新',
     'POST /login': '用户登录',
     'POST /logout': '用户登出',

--- a/cds/src/services/change-impact-analyzer.ts
+++ b/cds/src/services/change-impact-analyzer.ts
@@ -1,0 +1,122 @@
+/**
+ * change-impact-analyzer — 判断 git diff 涉及的改动是否需要重启 CDS 进程。
+ *
+ * 默认策略:**保守判定**(`needsRestart=true` 是默认),只有所有改动文件都明确
+ * 落入"热重载安全"白名单,才返回 `needsRestart=false`。
+ *
+ * 这个保守取舍是为了避免"看着像热重载场景实际不安全"的情况(比如 import
+ * 了新模块、初始化期副作用代码改了、数据库 schema 变更等)— 误判热重载
+ * 路径会让旧逻辑继续跑,用户感知到的是"我已经更新但行为没变",debug 极困
+ * 难。误判重启路径只是慢一点,可接受。
+ *
+ * 用户反馈 2026-05-06 让 self-update 同时支持热重载 + 重启,这个模块是
+ * 决策入口。
+ */
+
+export interface ChangeImpactResult {
+  /** true = 必须走完整重启流程;false = 可以走热重载快路径 */
+  needsRestart: boolean;
+  /** 触发"必须重启"的具体文件 + 原因。为空时 needsRestart 必为 false */
+  restartTriggers: Array<{ path: string; reason: string }>;
+  /** 即使热重载也建议重新编译的文件(应用代码 .ts/.tsx) */
+  hotReloadablePaths: string[];
+  /** 完全无影响的文件(纯文档、changelogs) */
+  irrelevantPaths: string[];
+}
+
+/**
+ * 必须重启的硬规则。命中任一即 needsRestart=true。
+ * 顺序无关,使用 `some()` 短路。
+ */
+const RESTART_PATTERNS: Array<{ pattern: RegExp; reason: string }> = [
+  // 依赖
+  { pattern: /(?:^|\/)package\.json$/, reason: '依赖清单变更' },
+  { pattern: /(?:^|\/)pnpm-lock\.yaml$/, reason: 'pnpm lockfile 变更' },
+  { pattern: /(?:^|\/)package-lock\.json$/, reason: 'npm lockfile 变更' },
+  { pattern: /(?:^|\/)yarn\.lock$/, reason: 'yarn lockfile 变更' },
+  // 容器/镜像
+  { pattern: /(?:^|\/)Dockerfile(\.|$)/, reason: 'Dockerfile 变更需要重建镜像' },
+  { pattern: /(?:^|\/)docker-compose[\w.-]*\.ya?ml$/, reason: 'compose 文件变更' },
+  { pattern: /(?:^|\/)\.dockerignore$/, reason: 'docker 上下文变更' },
+  // 编译/打包配置
+  { pattern: /(?:^|\/)tsconfig[\w.-]*\.json$/, reason: 'TypeScript 配置变更' },
+  { pattern: /(?:^|\/)vite\.config\.[jt]s$/, reason: 'Vite 配置变更' },
+  { pattern: /(?:^|\/)tsup\.config\.[jt]s$/, reason: 'tsup 配置变更' },
+  { pattern: /(?:^|\/)esbuild\.config\.[jt]s$/, reason: 'esbuild 配置变更' },
+  // 环境变量
+  { pattern: /(?:^|\/)\.env(\.[\w-]+)?$/, reason: '环境变量文件变更' },
+  { pattern: /(?:^|\/)\.cds\.env$/, reason: 'CDS 环境变量变更' },
+  // systemd / 启动脚本
+  { pattern: /\.service$/, reason: 'systemd unit 变更' },
+  { pattern: /(?:^|\/)exec_cds\.sh$/, reason: 'CDS 启动脚本变更' },
+  // CDS 关键路由/初始化代码 — 这些变化即使 hot-reload 也不能正确生效
+  // 因为 Express 路由表已挂载,新 router 不会被重新注册
+  { pattern: /^cds\/src\/server\.ts$/, reason: 'CDS server bootstrap 变更' },
+  { pattern: /^cds\/src\/index\.ts$/, reason: 'CDS 入口变更' },
+  { pattern: /^cds\/src\/types\.ts$/, reason: '核心类型 schema 变更' },
+  { pattern: /^cds\/src\/config\.ts$/, reason: 'CDS 配置加载逻辑变更' },
+  { pattern: /^cds\/src\/load-env\.ts$/, reason: 'env 加载逻辑变更' },
+  // 数据库 schema / migration
+  { pattern: /(?:^|\/)migrations?\//, reason: '数据库迁移' },
+  // 二进制 / native 模块
+  { pattern: /\.(?:so|dll|dylib|node)$/, reason: 'native 模块变更' },
+];
+
+/**
+ * 完全无影响的文件(纯文档/元数据)。命中即 irrelevantPaths,
+ * 不参与任何判定。
+ */
+const IRRELEVANT_PATTERNS: RegExp[] = [
+  /\.md$/i,
+  /\.txt$/i,
+  /(?:^|\/)CHANGELOG[\w.-]*$/,
+  /(?:^|\/)changelogs\//,
+  /(?:^|\/)doc\//,
+  /(?:^|\/)\.claude\//,
+  /(?:^|\/)\.github\//,
+  /(?:^|\/)LICENSE$/i,
+  /(?:^|\/)\.gitignore$/,
+  /(?:^|\/)\.editorconfig$/,
+];
+
+/**
+ * 热重载安全的应用代码 — 进 cds/src 或 cds/web/src 的 .ts/.tsx,
+ * 但不在 RESTART_PATTERNS 里。
+ */
+function isHotReloadable(p: string): boolean {
+  return /^cds\/(?:src|web\/src)\/.+\.(?:ts|tsx|js|jsx|css|html|svg)$/.test(p);
+}
+
+export function analyzeChangeImpact(changedPaths: string[]): ChangeImpactResult {
+  const restartTriggers: Array<{ path: string; reason: string }> = [];
+  const hotReloadablePaths: string[] = [];
+  const irrelevantPaths: string[] = [];
+
+  for (const p of changedPaths) {
+    // 1) 完全无影响优先短路
+    if (IRRELEVANT_PATTERNS.some((re) => re.test(p))) {
+      irrelevantPaths.push(p);
+      continue;
+    }
+    // 2) 必须重启的硬规则
+    const trigger = RESTART_PATTERNS.find((r) => r.pattern.test(p));
+    if (trigger) {
+      restartTriggers.push({ path: p, reason: trigger.reason });
+      continue;
+    }
+    // 3) 应用代码 → 热重载安全
+    if (isHotReloadable(p)) {
+      hotReloadablePaths.push(p);
+      continue;
+    }
+    // 4) 落到这里:未知文件,保守起见标"必须重启"
+    restartTriggers.push({ path: p, reason: '未知改动,保守判定为重启' });
+  }
+
+  return {
+    needsRestart: restartTriggers.length > 0,
+    restartTriggers,
+    hotReloadablePaths,
+    irrelevantPaths,
+  };
+}

--- a/cds/src/services/container.ts
+++ b/cds/src/services/container.ts
@@ -933,8 +933,39 @@ export class ContainerService {
     const network = this.getNetworkForProject(service.projectId);
     await this.ensureNetwork(network);
 
-    // Remove any existing container with the same name
-    await this.shell.exec(`docker rm -f ${service.containerName}`);
+    // ★ 幂等启动（2026-05-05 修 P0 bug）
+    //
+    // 历史行为：直接 `docker rm -f ${name}` 然后 `docker run` 重建。这条路径
+    // 在 deploy 流程触发时会**杀掉用户正在共享使用的 mongo / redis 等
+    // long-lived infra 容器**——所有连接被 kill、SSE/WebSocket 断、用户在
+    // 用的页面瞬间 502。同时还会偶发 race-condition：rm 完成前 docker run
+    // 已经发起 → "container name already in use" → deploy 整体 fail。
+    //
+    // 修法：分三档处理已存在的同名容器：
+    //   - running    → noop 复用（共享语义。不删不停不重建，连接不断）
+    //   - stopped    → docker start 唤醒（保留 volume / 端口绑定 / 网络配置）
+    //   - 不存在     → docker run 创建（首次启动）
+    //   - 唤醒失败   → fallback rm-f + run（image 升级或 cmdline 改变时）
+    //
+    // 配合用户的设计意图："默认共享数据库"——deploy 跑到这里时，如果共享
+    // mongo 已经在跑，本函数立刻返回，零副作用。
+    const inspect = await this.shell.exec(
+      `docker inspect --format='{{.State.Status}}' ${service.containerName}`,
+    );
+    if (inspect.exitCode === 0) {
+      const dockerStatus = inspect.stdout.trim();
+      if (dockerStatus === 'running') {
+        // 已经在跑 —— 共享复用，不动它
+        return;
+      }
+      // 存在但 stopped/exited/created —— 用 docker start 唤醒
+      const startResult = await this.shell.exec(`docker start ${service.containerName}`);
+      if (startResult.exitCode === 0) {
+        return;
+      }
+      // 唤醒失败（image 升级 / 命令行变了）—— fallback：删了重建
+      await this.shell.exec(`docker rm -f ${service.containerName}`);
+    }
 
     // Build volume flags (named volumes + bind mounts)
     const volumeFlags = service.volumes.map(v => {

--- a/cds/src/services/container.ts
+++ b/cds/src/services/container.ts
@@ -8,6 +8,7 @@ import type { IShellExecutor, CdsConfig, BuildProfile, BranchEntry, ServiceState
 import { combinedOutput } from '../types.js';
 import { resolveEnvTemplates } from './compose-parser.js';
 import { applyPerBranchDbIsolation } from './db-scope-isolation.js';
+import { nodeModulesVolumeName } from '../util/node-modules-volume.js';
 
 /**
  * 项目级 docker network 解析器接口。
@@ -433,9 +434,8 @@ export class ContainerService {
     // 收紧到 command 含 pnpm 的场景才挂 volume,其它场景仍走 worktree 的
     // bind mount(慢但语义安全)。
     if (isNodeContainer && !skipSrcMount && /\bpnpm\b/.test(profile.command || '')) {
-      const sanitize = (s: string): string => s.replace(/[^a-zA-Z0-9_.-]/g, '-').slice(0, 60);
-      const nodeModulesVolume = `cds-nm-${sanitize(entry.id)}-${sanitize(profile.id)}`;
-      volumeFlags.push(`-v "${nodeModulesVolume}":"${containerWorkDir}/node_modules"`);
+      // SSOT: util/node-modules-volume.ts(Bugbot 3e19da66 — 防 sanitize 漂移)
+      volumeFlags.push(`-v "${nodeModulesVolumeName(entry.id, profile.id)}":"${containerWorkDir}/node_modules"`);
     }
 
     if (profile.cacheMounts) {

--- a/cds/src/services/container.ts
+++ b/cds/src/services/container.ts
@@ -949,6 +949,24 @@ export class ContainerService {
     //
     // 配合用户的设计意图："默认共享数据库"——deploy 跑到这里时，如果共享
     // mongo 已经在跑，本函数立刻返回，零副作用。
+    //
+    // ⚠️ 关于配置漂移（Bugbot Review 2026-05-06 Medium 8cf58fe4 提出）
+    //
+    // docker start 用的是容器**创建时**的 image / env / port / volume / health。
+    // 如果运维通过 admin UI 改了 InfraService 定义（升级 image，改 env，
+    // 加 volume），这里的 idempotent reuse 路径**不会**应用新定义 —— 这是
+    // 故意的，符合"共享 infra 是 long-lived，配置变更走专门动作"的语义。
+    //
+    // 让配置变更生效的正确姿势：
+    //   POST /api/infra/:id/restart 或 stopInfraService + startInfraService
+    //   组合 —— 前者会 `docker stop && docker rm`，下次 startInfraService 看不
+    //   到容器走 docker run 新 config 重建。
+    //
+    // 如果未来要做"自动检测 config drift 触发 rebuild"，建议方案：
+    //   - 创建容器时打 label `cds.config.fingerprint=<sha256(image+ports+volumes)>`
+    //   - 这里 inspect labels 比对 fingerprint，不一致 → rm + run；一致 → start
+    //   - env 不进 fingerprint（频繁变 + 用户不期待杀连接）
+    // 暂未实现 —— 当前共享 mongo/redis 实战中 image 几乎不变，drift 风险低。
     const inspect = await this.shell.exec(
       `docker inspect --format='{{.State.Status}}' ${service.containerName}`,
     );

--- a/cds/src/services/container.ts
+++ b/cds/src/services/container.ts
@@ -426,8 +426,13 @@ export class ContainerService {
     // 即:首次部署装满 volume,后续部署 volume 持久化,跳过重链。worktree
     // 重置不影响这个 volume(代价是 stale node_modules,但 pnpm 用 lockfile
     // diff 自我修正,只补差量)。
-    // 适用范围:仅 Node.js 容器 + 非 prebuiltImage 模式。
-    if (isNodeContainer && !skipSrcMount) {
+    //
+    // ⚠ Bugbot 2026-05-06 bf11290f:此优化只在 pnpm 自我修正语义下安全
+    // (worktree 重置 / 切 commit 时 stale modules 由 lockfile diff 收敛)。
+    // npm / yarn 不保证差量校验,启用 volume 反而可能装入旧版本依赖。
+    // 收紧到 command 含 pnpm 的场景才挂 volume,其它场景仍走 worktree 的
+    // bind mount(慢但语义安全)。
+    if (isNodeContainer && !skipSrcMount && /\bpnpm\b/.test(profile.command || '')) {
       const sanitize = (s: string): string => s.replace(/[^a-zA-Z0-9_.-]/g, '-').slice(0, 60);
       const nodeModulesVolume = `cds-nm-${sanitize(entry.id)}-${sanitize(profile.id)}`;
       volumeFlags.push(`-v "${nodeModulesVolume}":"${containerWorkDir}/node_modules"`);
@@ -983,6 +988,13 @@ export class ContainerService {
     //   - 这里 inspect labels 比对 fingerprint，不一致 → rm + run；一致 → start
     //   - env 不进 fingerprint（频繁变 + 用户不期待杀连接）
     // 暂未实现 —— 当前共享 mongo/redis 实战中 image 几乎不变，drift 风险低。
+    // ⚠ Bugbot 2026-05-06 cd577195:service.containerName 直接拼进
+    // child_process.exec 会让 shell metacharacters 改变命令行为。
+    // Docker 容器名规范是 [a-zA-Z0-9][a-zA-Z0-9_.-]+,完全 alnum/dot/dash,
+    // 这里加 defense-in-depth 守门拒绝异常值。
+    if (!/^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/.test(service.containerName)) {
+      throw new Error(`Infra service container name 含非法字符: ${JSON.stringify(service.containerName).slice(0, 80)}`);
+    }
     const inspect = await this.shell.exec(
       `docker inspect --format='{{.State.Status}}' ${service.containerName}`,
     );

--- a/cds/src/services/container.ts
+++ b/cds/src/services/container.ts
@@ -417,6 +417,22 @@ export class ContainerService {
       onOutput?.(`── 预构建镜像模式: 跳过 source mount(image 已含应用文件)──\n`);
     }
 
+    // 用户反馈 2026-05-06 (#4):部署有时 19s(命中)有时 57s(重链 669 个包)。
+    // 根因:srcMount 是 host 上的 worktree 目录,worktree 重置 / 首次创建时
+    // node_modules 是空,pnpm 要从 /pnpm/store(host bind mount,内容齐全)
+    // 重新 hardlink/copy 到 /app/node_modules,O(N=669) 文件操作 ≈ 30-40s。
+    // 加一个 per-(branch, profile) 的 docker named volume 挂在
+    // /app/node_modules 上,**Docker 让 volume 覆盖 bind mount 的子路径**,
+    // 即:首次部署装满 volume,后续部署 volume 持久化,跳过重链。worktree
+    // 重置不影响这个 volume(代价是 stale node_modules,但 pnpm 用 lockfile
+    // diff 自我修正,只补差量)。
+    // 适用范围:仅 Node.js 容器 + 非 prebuiltImage 模式。
+    if (isNodeContainer && !skipSrcMount) {
+      const sanitize = (s: string): string => s.replace(/[^a-zA-Z0-9_.-]/g, '-').slice(0, 60);
+      const nodeModulesVolume = `cds-nm-${sanitize(entry.id)}-${sanitize(profile.id)}`;
+      volumeFlags.push(`-v "${nodeModulesVolume}":"${containerWorkDir}/node_modules"`);
+    }
+
     if (profile.cacheMounts) {
       for (const cm of profile.cacheMounts) {
         // Ensure host path exists
@@ -455,8 +471,8 @@ export class ContainerService {
       }
 
       onOutput?.(`── 运行: ${command} ──\n`);
-      if (isNodeContainer) {
-        onOutput?.(`── Node.js 容器: node_modules 已隔离到 Docker volume ──\n`);
+      if (isNodeContainer && !skipSrcMount) {
+        onOutput?.(`── Node.js 容器: node_modules 走 docker volume(跨部署持久化,首次会装满,后续秒过)──\n`);
       }
 
       // Phase 2 resilience: enforce per-container cgroup limits when configured.

--- a/cds/src/services/container.ts
+++ b/cds/src/services/container.ts
@@ -476,18 +476,20 @@ export class ContainerService {
       }
 
       onOutput?.(`── 运行: ${command} ──\n`);
-      if (isNodeContainer && !skipSrcMount) {
+      // ⚠ Bugbot 2026-05-06 1f32c1da:之前 log 的条件是 isNodeContainer && !skipSrcMount,
+      // 比真正挂 volume 的条件(还要 /\bpnpm\b/.test(command))宽,npm/yarn 项目会
+      // 看到"走 docker volume"的误导日志。改为与真实 mount 条件完全一致。
+      if (isNodeContainer && !skipSrcMount && /\bpnpm\b/.test(command)) {
         onOutput?.(`── Node.js 容器: node_modules 走 docker volume(跨部署持久化,首次会装满,后续秒过)──\n`);
       }
 
       // Phase 2 resilience: enforce per-container cgroup limits when configured.
-      // Unset = legacy behavior (no limits). See doc/design.cds-resilience.md Phase 2.
+      //
+      // 用户反馈 2026-05-06:"每一个容器都不限制内存,尽情释放"。
+      // 不再下发 --memory / --memory-swap;profile.resources.memoryMB 仅作
+      // capacity 调度规划的提示(见 capacityMessage),不再硬限制运行时。
+      // CPU 限制保留 — 它是配额不是 OOM,语义不同。
       const resourceFlags: string[] = [];
-      if (profile.resources?.memoryMB && profile.resources.memoryMB > 0) {
-        resourceFlags.push(`--memory ${profile.resources.memoryMB}m`);
-        // Match memory-swap to memory so we don't leak into swap under pressure.
-        resourceFlags.push(`--memory-swap ${profile.resources.memoryMB}m`);
-      }
       if (profile.resources?.cpus && profile.resources.cpus > 0) {
         resourceFlags.push(`--cpus ${profile.resources.cpus}`);
       }

--- a/cds/src/services/git-fetch-retry.ts
+++ b/cds/src/services/git-fetch-retry.ts
@@ -32,6 +32,16 @@ export async function fetchWithLockRetry(
     };
   }
   const maxAttempts = options.maxAttempts ?? 3;
+  // ⚠ Bugbot 2026-05-06 b66fb1c3:maxAttempts=0 时下面的 for 循环不进,lastResult
+  // 永远 undefined,return lastResult! 撒谎(类型说是 ShellExecResult,实际 undefined)。
+  // 调用方很难想得到这个边角,直接返回合成的失败结果保护类型契约。
+  if (maxAttempts <= 0) {
+    return {
+      exitCode: 128,
+      stdout: '',
+      stderr: `fetchWithLockRetry: maxAttempts=${maxAttempts} 不合法(必须 ≥1)`,
+    };
+  }
   const execOpts: { cwd: string; timeout?: number } = { cwd };
   if (options.timeoutMs !== undefined) execOpts.timeout = options.timeoutMs;
   let lastResult: Awaited<ReturnType<IShellExecutor['exec']>> | undefined;

--- a/cds/src/services/git-fetch-retry.ts
+++ b/cds/src/services/git-fetch-retry.ts
@@ -1,0 +1,35 @@
+import type { IShellExecutor } from '../types.js';
+
+/**
+ * git fetch with lock-aware retry —— 同一 repo 短时间内并发 fetch 时
+ * (webhook 多 push 撞上 / 多分支 deploy 同时跑 / SSE broadcast 撞 deploy worker)
+ * git 会报 `cannot lock ref 'refs/remotes/origin/xxx': is at YYY but expected ZZZ`
+ * 这类 ref-lock 冲突。这是瞬时错误,等几秒就好。
+ *
+ * 重试策略:最多 3 次,间隔 2s / 4s(线性退避);非 lock 错误立即返回不重试
+ * (避免掩盖真实问题如网络断 / 凭据失效)。
+ *
+ * SSOT 提示:WorktreeService.create / branches.ts computeSelfStatusPayload 都走这一份。
+ * 修退避或 lock 正则时只动这里,不要再 inline。
+ */
+export async function fetchWithLockRetry(
+  shell: IShellExecutor,
+  cwd: string,
+  branch: string,
+  options: { maxAttempts?: number; timeoutMs?: number } = {},
+): Promise<Awaited<ReturnType<IShellExecutor['exec']>>> {
+  const maxAttempts = options.maxAttempts ?? 3;
+  const execOpts: { cwd: string; timeout?: number } = { cwd };
+  if (options.timeoutMs !== undefined) execOpts.timeout = options.timeoutMs;
+  let lastResult: Awaited<ReturnType<IShellExecutor['exec']>> | undefined;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const result = await shell.exec(`git fetch origin ${branch}`, execOpts);
+    if (result.exitCode === 0) return result;
+    lastResult = result;
+    const stderr = (result.stderr || '') + (result.stdout || '');
+    const isLockErr = /cannot lock ref|unable to create.*lock/i.test(stderr);
+    if (!isLockErr || attempt === maxAttempts) return result;
+    await new Promise((r) => setTimeout(r, 2_000 * attempt));
+  }
+  return lastResult!;
+}

--- a/cds/src/services/git-fetch-retry.ts
+++ b/cds/src/services/git-fetch-retry.ts
@@ -1,4 +1,5 @@
 import type { IShellExecutor } from '../types.js';
+import { isSafeGitRef } from './github-webhook-dispatcher.js';
 
 /**
  * git fetch with lock-aware retry —— 同一 repo 短时间内并发 fetch 时
@@ -11,6 +12,11 @@ import type { IShellExecutor } from '../types.js';
  *
  * SSOT 提示:WorktreeService.create / branches.ts computeSelfStatusPayload 都走这一份。
  * 修退避或 lock 正则时只动这里,不要再 inline。
+ *
+ * 安全性:branch 来自远端 webhook / git rev-parse 输出,可能含 shell metacharacters。
+ * shell.exec 走 child_process.exec(整串 shell 解释),所以本函数内做 isSafeGitRef 守门
+ * 作为 defense-in-depth —— 即使新 caller 忘了在外层 sanitize,这里也兜得住,返回
+ * 退非 0 的合成结果让上游统一走错误分支。
  */
 export async function fetchWithLockRetry(
   shell: IShellExecutor,
@@ -18,6 +24,13 @@ export async function fetchWithLockRetry(
   branch: string,
   options: { maxAttempts?: number; timeoutMs?: number } = {},
 ): Promise<Awaited<ReturnType<IShellExecutor['exec']>>> {
+  if (!isSafeGitRef(branch)) {
+    return {
+      exitCode: 128,
+      stdout: '',
+      stderr: `fetchWithLockRetry: refusing unsafe branch ref ${JSON.stringify(branch).slice(0, 80)}`,
+    };
+  }
   const maxAttempts = options.maxAttempts ?? 3;
   const execOpts: { cwd: string; timeout?: number } = { cwd };
   if (options.timeoutMs !== undefined) execOpts.timeout = options.timeoutMs;

--- a/cds/src/services/shell-executor.ts
+++ b/cds/src/services/shell-executor.ts
@@ -10,9 +10,9 @@ export class ShellExecutor implements IShellExecutor {
           cwd: options?.cwd,
           timeout: options?.timeout,
           maxBuffer: 10 * 1024 * 1024,
-          // 2026-05-04:支持调用方覆盖部分 env 变量(典型用途:tsc/vite 加
-          // NODE_OPTIONS=--max-old-space-size=4096 防 OOM)。提供 env 时与
+          // 2026-05-04:支持调用方覆盖部分 env 变量。提供 env 时与
           // process.env 合并,本字段后写覆盖。不提供时沿用 process.env(默认行为)。
+          // 2026-05-06 起 self-update / web build 不再下发 NODE_OPTIONS 上限,V8 自适应主机 RAM。
           ...(options?.env ? { env: { ...process.env, ...options.env } } : {}),
         },
         (error, stdout, stderr) => {

--- a/cds/src/services/state.ts
+++ b/cds/src/services/state.ts
@@ -2017,6 +2017,8 @@ export class StateService {
       // 写盘失败不影响 self-update 主链路 — 顶多丢这条历史,记错误日志即可。
       console.warn('[state] recordSelfUpdate save failed:', (err as Error).message);
     }
+    // 记录进 history 等同于"流程结束",清掉 in-progress 标记
+    this.activeSelfUpdate = null;
   }
 
   getSelfUpdateHistory(limit = 10): import('../types.js').SelfUpdateRecord[] {
@@ -2024,6 +2026,22 @@ export class StateService {
     // 倒序(最近在前)
     const desc = [...list].reverse();
     return desc.slice(0, limit);
+  }
+
+  // ── 用户反馈 2026-05-06:中间面板不知道别 session / webhook 触发的 self-update,
+  // 显示"尚未执行更新"但其实在跑,违反 server-authority。in-memory 标记
+  // (CDS 重启后丢,但重启意味着 self-update 已结束,无需持久化)。
+  // self-update / self-force-sync 路由开始时调 markSelfUpdateActive,
+  // 走完(成功/失败/中止)调 recordSelfUpdate 自动清除。
+  // ──
+  private activeSelfUpdate: import('../types.js').ActiveSelfUpdate | null = null;
+
+  markSelfUpdateActive(rec: import('../types.js').ActiveSelfUpdate): void {
+    this.activeSelfUpdate = rec;
+  }
+
+  getActiveSelfUpdate(): import('../types.js').ActiveSelfUpdate | null {
+    return this.activeSelfUpdate;
   }
 
   // ── P5: per-project getters (project value > legacy state value) ──

--- a/cds/src/services/state.ts
+++ b/cds/src/services/state.ts
@@ -2040,6 +2040,16 @@ export class StateService {
     this.activeSelfUpdate = rec;
   }
 
+  // ── Bugbot 31da8d97 (HIGH):top-level finally 兜底清 marker。
+  // recordSelfUpdate 已经在 success/aborted 时自动清,但若有未处理异常
+  // 直接逃出 try/catch(e.g. recordFailure 自身抛错、send() 失败),
+  // marker 会永远卡住,所有 tab 看到"自更新进行中"幽灵态。
+  // 调用方在路由顶层 try { ... } finally { clearSelfUpdateActive() } 兜底,
+  // 与 markSelfUpdateActive 的 idempotent 清空语义一致。
+  clearSelfUpdateActive(): void {
+    this.activeSelfUpdate = null;
+  }
+
   getActiveSelfUpdate(): import('../types.js').ActiveSelfUpdate | null {
     return this.activeSelfUpdate;
   }

--- a/cds/src/services/worktree.ts
+++ b/cds/src/services/worktree.ts
@@ -4,6 +4,7 @@ import type { IShellExecutor } from '../types.js';
 import { combinedOutput } from '../types.js';
 import { StateService } from './state.js';
 import { computePreviewSlug, slugifyForPreview } from './preview-slug.js';
+import { fetchWithLockRetry } from './git-fetch-retry.js';
 
 /**
  * Current worktree layout version. See `CdsState.worktreeLayoutVersion`
@@ -217,34 +218,19 @@ export class WorktreeService {
   }
 
   /**
-   * git fetch with lock-aware retry —— 同一 repo 短时间内有多次并发 fetch
-   * 时（webhook 多个 push 撞上 / 多分支 deploy 同时跑），git 会报
-   * `cannot lock ref 'refs/remotes/origin/xxx': is at YYY but expected ZZZ`
-   * 这类 ref-lock 冲突。这是瞬时错误，等几秒就好。
+   * git fetch with lock-aware retry —— 实现见 ./git-fetch-retry.ts。
    *
    * 实测背景（2026-05-06）：PR #526 push 触发 webhook deploy 接连两次
-   * 撞 lock。增加退避重试后 race 消失。
-   *
-   * 重试策略：最多 3 次，间隔 2s / 4s（线性退避）；非 lock 错误立即返回
-   * 不重试（避免掩盖真实问题如网络断 / 凭据失效）。
+   * 撞 lock。增加退避重试后 race 消失。Bugbot 2026-05-06 e0f66dce 反馈
+   * SSE broadcast 路径也要同样语义,故抽出共享 helper,这里只是 thin wrapper
+   * 保留方法名兼容旧 call site。
    */
   private async fetchWithLockRetry(
     cwd: string,
     branch: string,
     maxAttempts = 3,
   ): Promise<Awaited<ReturnType<IShellExecutor['exec']>>> {
-    let lastResult: Awaited<ReturnType<IShellExecutor['exec']>> | undefined;
-    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-      const result = await this.shell.exec(`git fetch origin ${branch}`, { cwd });
-      if (result.exitCode === 0) return result;
-      lastResult = result;
-      const stderr = (result.stderr || '') + (result.stdout || '');
-      const isLockErr = /cannot lock ref|unable to create.*lock/i.test(stderr);
-      if (!isLockErr || attempt === maxAttempts) return result;
-      // 线性退避：2s, 4s
-      await new Promise((r) => setTimeout(r, 2_000 * attempt));
-    }
-    return lastResult!;
+    return fetchWithLockRetry(this.shell, cwd, branch, { maxAttempts });
   }
 
   async create(repoRoot: string, branch: string, targetDir: string): Promise<void> {

--- a/cds/src/services/worktree.ts
+++ b/cds/src/services/worktree.ts
@@ -216,11 +216,39 @@ export class WorktreeService {
     return migratedSlugs.length;
   }
 
+  /**
+   * git fetch with lock-aware retry —— 同一 repo 短时间内有多次并发 fetch
+   * 时（webhook 多个 push 撞上 / 多分支 deploy 同时跑），git 会报
+   * `cannot lock ref 'refs/remotes/origin/xxx': is at YYY but expected ZZZ`
+   * 这类 ref-lock 冲突。这是瞬时错误，等几秒就好。
+   *
+   * 实测背景（2026-05-06）：PR #526 push 触发 webhook deploy 接连两次
+   * 撞 lock。增加退避重试后 race 消失。
+   *
+   * 重试策略：最多 3 次，间隔 2s / 4s（线性退避）；非 lock 错误立即返回
+   * 不重试（避免掩盖真实问题如网络断 / 凭据失效）。
+   */
+  private async fetchWithLockRetry(
+    cwd: string,
+    branch: string,
+    maxAttempts = 3,
+  ): Promise<Awaited<ReturnType<IShellExecutor['exec']>>> {
+    let lastResult: Awaited<ReturnType<IShellExecutor['exec']>> | undefined;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      const result = await this.shell.exec(`git fetch origin ${branch}`, { cwd });
+      if (result.exitCode === 0) return result;
+      lastResult = result;
+      const stderr = (result.stderr || '') + (result.stdout || '');
+      const isLockErr = /cannot lock ref|unable to create.*lock/i.test(stderr);
+      if (!isLockErr || attempt === maxAttempts) return result;
+      // 线性退避：2s, 4s
+      await new Promise((r) => setTimeout(r, 2_000 * attempt));
+    }
+    return lastResult!;
+  }
+
   async create(repoRoot: string, branch: string, targetDir: string): Promise<void> {
-    const fetchResult = await this.shell.exec(
-      `git fetch origin ${branch}`,
-      { cwd: repoRoot },
-    );
+    const fetchResult = await this.fetchWithLockRetry(repoRoot, branch);
     if (fetchResult.exitCode !== 0) {
       throw new Error(`拉取分支 "${branch}" 失败:\n${combinedOutput(fetchResult)}`);
     }
@@ -259,11 +287,8 @@ export class WorktreeService {
     );
     const before = beforeResult.stdout.trim();
 
-    // Fetch latest from remote
-    const fetchResult = await this.shell.exec(
-      `git fetch origin ${branch}`,
-      { cwd: targetDir },
-    );
+    // Fetch latest from remote (lock-aware retry, 见 fetchWithLockRetry 注释)
+    const fetchResult = await this.fetchWithLockRetry(targetDir, branch);
     if (fetchResult.exitCode !== 0) {
       throw new Error(`拉取失败:\n${combinedOutput(fetchResult)}`);
     }

--- a/cds/src/types.ts
+++ b/cds/src/types.ts
@@ -382,7 +382,13 @@ export interface CacheMount {
  * See `doc/design.cds-resilience.md` Phase 2.
  */
 export interface ResourceLimits {
-  /** Max memory in MB. Docker flag: --memory <N>m */
+  /**
+   * Max memory in MB.
+   *
+   * 2026-05-06 起仅作 capacity 调度规划提示(见 capacityMessage),
+   * **不再**下发为 --memory / --memory-swap docker 运行时硬限制。
+   * 用户明确"每个容器都不限制内存,尽情释放"。
+   */
   memoryMB?: number;
   /** Max CPU cores (fractional allowed, e.g. 1.5). Docker flag: --cpus <N> */
   cpus?: number;
@@ -1714,7 +1720,7 @@ export interface ExecOptions {
   timeout?: number;
   onData?: (chunk: string) => void;
   /** 环境变量覆盖。提供时与 process.env 合并(本字段后写覆盖)。
-   *  典型用途:tsc/vite 加 NODE_OPTIONS=--max-old-space-size=4096 防 OOM。 */
+   *  2026-05-06 起 self-update / web build 不再下发 NODE_OPTIONS 上限,V8 自适应主机 RAM。 */
   env?: Record<string, string>;
 }
 

--- a/cds/src/types.ts
+++ b/cds/src/types.ts
@@ -787,6 +787,20 @@ export interface CdsState {
  * 这两件事配合看就能完整复盘:历史告诉你「曾经发生过更新」,healthz 告诉你
  * 「现在能不能用」。
  */
+/**
+ * In-progress self-update marker(in-memory only,CDS 重启后丢)。
+ * 用户反馈 2026-05-06:中间面板不知道别 session / webhook 触发的 self-update。
+ * /api/self-status 携带此字段,前端任何 tab 都能立刻显示"正在重启"语义。
+ */
+export interface ActiveSelfUpdate {
+  startedAt: string;
+  branch: string;
+  trigger: 'manual' | 'force-sync' | 'auto-poll' | 'webhook';
+  actor?: string;
+  /** 当前阶段标签(validate / build-backend / web-build / restart 等) */
+  step?: string;
+}
+
 export interface SelfUpdateRecord {
   /** ISO timestamp 当事件被记录(预检通过 / 出错时) */
   ts: string;

--- a/cds/src/types.ts
+++ b/cds/src/types.ts
@@ -1013,6 +1013,26 @@ export interface Project {
   /** Optional one-line description shown under the name. */
   description?: string;
   /**
+   * Infrastructure 隔离模式（mongo / redis 等基础设施容器与分支的关系）。
+   *
+   * - 'shared'（默认 / 缺省）：infra 是 init 时一次性创建的 long-lived 资源，
+   *   所有分支**共享**同一个 mongo / redis 容器。容器隔离 ≠ infra 隔离。
+   *   分支的 deploy 流程**不应触碰** infra（不重启、不删除、不健康检查阻塞）—
+   *   touch infra 是 init / admin 的事，不是 branch deploy 的事。
+   *
+   * - 'per-branch'：每分支自己的 infra 容器（容器名带 branchSlug 后缀）。
+   *   适合需要数据完全隔离的场景（如灰度数据演练）。deploy 流程会触发
+   *   computeRequiredInfra → startInfraService 走完整启动链路。
+   *
+   *   ⚠️ 'per-branch' 当前是 placeholder，containerName 还没真正按
+   *   branch 区分（cds/src/services/infra-name.ts TODO）。在那块 land
+   *   之前，project.infraIsolation 别填 'per-branch'，否则会落回
+   *   shared 行为但触发额外重启循环。
+   *
+   * 字段缺省时（老 project / fresh install）按 'shared' 处理。
+   */
+  infraIsolation?: 'shared' | 'per-branch';
+  /**
    * Project kind. 'git' is the only value Part 1 creates; 'manual'
    * lands in P6 when users can upload their own compose.
    */

--- a/cds/src/util/node-modules-volume.ts
+++ b/cds/src/util/node-modules-volume.ts
@@ -4,33 +4,37 @@
  *
  * Both creation (cds/src/services/container.ts) and cleanup
  * (cds/src/routes/branches.ts DELETE handler) MUST use these helpers,
- * otherwise drift between the two sanitize regex / length cap silently
- * orphans volumes (Bugbot 2026-05-06 3e19da66).
+ * otherwise drift between the two encoding 实现 silently orphans volumes
+ * (Bugbot 2026-05-06 3e19da66).
+ *
+ * 设计取舍(Bugbot 65a383bb 之后):
+ * 之前用 `cds-nm-{sanitize(branchId)}-{sanitize(profileId)}` 把斜杠等替换成
+ * `-` 再 join,导致 ("foo/bar","baz") 和 ("foo","bar-baz") 都生成
+ * `cds-nm-foo-bar-baz` —— 创建期就共用同一 volume,node_modules 串了。
+ * 改用**两段固定长度 sha1 前缀**,join 边界绝对明确:
+ *   `cds-nm-{branchHash8}-{profileHash8}` (总长 24 chars)
+ * 两段分别 hash,只要原文不同,hash 不同(2^32 空间冲突可忽略)。
+ *
+ * ⚠ 升级影响:旧格式 (`cds-nm-{sanitize}-{sanitize}`) 的 volume 不会被新格式
+ * 命名命中。下次部署相当于全新 volume → 第一次 pnpm install 会慢一回,后续
+ * 复用快路径。可选一次性清理:`docker volume ls -q -f name=cds-nm- | xargs docker volume rm 2>/dev/null`。
  */
 
 import { createHash } from 'node:crypto';
 
 const NODE_MODULES_VOLUME_PREFIX = 'cds-nm-';
-const SANITIZE_RE = /[^a-zA-Z0-9_.-]/g;
-const SANITIZE_MAX_LEN = 60;
-const HASH_LEN = 8; // 8-hex char suffix(2^32 collision space,够分支级别用)
+const HASH_LEN = 8; // 8-hex char(2^32 空间够分支 × profile 量级用)
 
-function sanitizeForDockerVolume(s: string): string {
-  const replaced = s.replace(SANITIZE_RE, '-');
-  if (replaced.length <= SANITIZE_MAX_LEN) return replaced;
-  // ⚠ Bugbot 2026-05-06 b952e898:纯 slice 截断会让两个仅在 60 位之后差异的
-  // branch ID 共用同一前缀,删一个会误吞另一个的 volume。截断时拼上 sha1
-  // 前 8 位作 disambiguator,保证 SANITIZE_MAX_LEN+1+HASH_LEN 长度内一一对应。
-  const hash = createHash('sha1').update(s).digest('hex').slice(0, HASH_LEN);
-  return `${replaced.slice(0, SANITIZE_MAX_LEN - HASH_LEN - 1)}-${hash}`;
+function shortHash(s: string): string {
+  return createHash('sha1').update(s).digest('hex').slice(0, HASH_LEN);
 }
 
 /** 单个 (branch, profile) 的完整 volume 名,用于 `-v {name}:/app/node_modules`。 */
 export function nodeModulesVolumeName(branchId: string, profileId: string): string {
-  return `${NODE_MODULES_VOLUME_PREFIX}${sanitizeForDockerVolume(branchId)}-${sanitizeForDockerVolume(profileId)}`;
+  return `${NODE_MODULES_VOLUME_PREFIX}${shortHash(branchId)}-${shortHash(profileId)}`;
 }
 
-/** 单个分支所有 profile 的 volume 共享前缀,用于 `docker volume ls --filter name=^{prefix}`。 */
+/** 单个分支所有 profile 的 volume 共享前缀,用于 `docker volume ls --filter name={prefix}`。 */
 export function nodeModulesVolumePrefix(branchId: string): string {
-  return `${NODE_MODULES_VOLUME_PREFIX}${sanitizeForDockerVolume(branchId)}-`;
+  return `${NODE_MODULES_VOLUME_PREFIX}${shortHash(branchId)}-`;
 }

--- a/cds/src/util/node-modules-volume.ts
+++ b/cds/src/util/node-modules-volume.ts
@@ -1,0 +1,27 @@
+/**
+ * SSOT for the per-(branch, profile) docker named volume that holds
+ * `node_modules` for pnpm projects (cross-deploy persistence).
+ *
+ * Both creation (cds/src/services/container.ts) and cleanup
+ * (cds/src/routes/branches.ts DELETE handler) MUST use these helpers,
+ * otherwise drift between the two sanitize regex / length cap silently
+ * orphans volumes (Bugbot 2026-05-06 3e19da66).
+ */
+
+const NODE_MODULES_VOLUME_PREFIX = 'cds-nm-';
+const SANITIZE_RE = /[^a-zA-Z0-9_.-]/g;
+const SANITIZE_MAX_LEN = 60;
+
+function sanitizeForDockerVolume(s: string): string {
+  return s.replace(SANITIZE_RE, '-').slice(0, SANITIZE_MAX_LEN);
+}
+
+/** 单个 (branch, profile) 的完整 volume 名,用于 `-v {name}:/app/node_modules`。 */
+export function nodeModulesVolumeName(branchId: string, profileId: string): string {
+  return `${NODE_MODULES_VOLUME_PREFIX}${sanitizeForDockerVolume(branchId)}-${sanitizeForDockerVolume(profileId)}`;
+}
+
+/** 单个分支所有 profile 的 volume 共享前缀,用于 `docker volume ls --filter name=^{prefix}`。 */
+export function nodeModulesVolumePrefix(branchId: string): string {
+  return `${NODE_MODULES_VOLUME_PREFIX}${sanitizeForDockerVolume(branchId)}-`;
+}

--- a/cds/src/util/node-modules-volume.ts
+++ b/cds/src/util/node-modules-volume.ts
@@ -8,12 +8,21 @@
  * orphans volumes (Bugbot 2026-05-06 3e19da66).
  */
 
+import { createHash } from 'node:crypto';
+
 const NODE_MODULES_VOLUME_PREFIX = 'cds-nm-';
 const SANITIZE_RE = /[^a-zA-Z0-9_.-]/g;
 const SANITIZE_MAX_LEN = 60;
+const HASH_LEN = 8; // 8-hex char suffix(2^32 collision space,够分支级别用)
 
 function sanitizeForDockerVolume(s: string): string {
-  return s.replace(SANITIZE_RE, '-').slice(0, SANITIZE_MAX_LEN);
+  const replaced = s.replace(SANITIZE_RE, '-');
+  if (replaced.length <= SANITIZE_MAX_LEN) return replaced;
+  // ⚠ Bugbot 2026-05-06 b952e898:纯 slice 截断会让两个仅在 60 位之后差异的
+  // branch ID 共用同一前缀,删一个会误吞另一个的 volume。截断时拼上 sha1
+  // 前 8 位作 disambiguator,保证 SANITIZE_MAX_LEN+1+HASH_LEN 长度内一一对应。
+  const hash = createHash('sha1').update(s).digest('hex').slice(0, HASH_LEN);
+  return `${replaced.slice(0, SANITIZE_MAX_LEN - HASH_LEN - 1)}-${hash}`;
 }
 
 /** 单个 (branch, profile) 的完整 volume 名,用于 `-v {name}:/app/node_modules`。 */

--- a/cds/src/util/parse-csv.ts
+++ b/cds/src/util/parse-csv.ts
@@ -1,0 +1,12 @@
+/**
+ * parseCsv — 把逗号分隔的字符串拆成 string[]。`undefined`/空串返回 undefined,
+ * 让调用方走默认值分支(`?? defaults`)而不是覆盖成空数组。
+ *
+ * 之前 cds/src/config.ts + cds/src/index.ts 各有一份完全相同的实现,
+ * Bugbot 2026-05-06 66483e29 指出维护风险 → 抽到本文件作 SSOT。
+ */
+export function parseCsv(value: string | undefined): string[] | undefined {
+  if (!value) return undefined;
+  const items = value.split(',').map(v => v.trim()).filter(Boolean);
+  return items.length > 0 ? items : undefined;
+}

--- a/cds/systemd/cds-master.service
+++ b/cds/systemd/cds-master.service
@@ -83,6 +83,11 @@ ExecStart=/usr/bin/node dist/index.js
 Restart=always
 RestartSec=3s
 
+# 启动超时：默认 90s 不够 —— self-update / self-force-sync 会清空 dist/，
+# 下次 systemd ExecStartPre 全量 `pnpm install + npx tsc` 冷启动可能要
+# 2-3 分钟。给 5 分钟兜底，避免"删了 dist 重启就启动超时"的事故。
+TimeoutStartSec=300
+
 # Standard output goes to the journal
 StandardOutput=journal
 StandardError=journal

--- a/cds/systemd/cds-master.service
+++ b/cds/systemd/cds-master.service
@@ -75,12 +75,13 @@ EnvironmentFile=-/etc/cds/env
 # ──────────────────────────────────────────────────────────────
 ExecStartPre=/usr/bin/pnpm install --frozen-lockfile
 
-# 用户反馈 2026-05-06:CDS 自更新支持热重载。
-# `--watch=dist` 让 node 监听 dist/ 目录,self-force-sync 走"热路径"时
-# 只 emit 新 dist,无需 process.exit,node 自己平滑重启。冷路径(改了
-# 依赖/配置/路由 schema 等)仍 process.exit + systemd restart,跟以前一样。
-# Node 22 起 --watch 是 stable,Restart=always 仍作 watch crash 时的兜底。
-ExecStart=/usr/bin/node --watch=dist dist/index.js
+# 2026-05-06 Bugbot bb81f978 + 8af6751a 双 HIGH:
+# 之前试图用 `node --watch=dist` 实现热重载,但语法错了(应该是 --watch-path=dist),
+# 而且即使语法对,fs.renameSync 原子换 dist 目录会让 inode 变化,Linux inotify
+# 监听旧 inode → 新 dist 不被监听 → 热重载不工作。
+# 放弃 --watch 路径,回归 ExecStart=node dist/index.js,所有 self-update 路径
+# 走 systemd Restart=always 软重启(~5-10s),依靠刚移除的 tsc ExecStartPre 节省 30s。
+ExecStart=/usr/bin/node dist/index.js
 
 # Restart policy — the whole point of this unit file.
 # (The matching StartLimitIntervalSec / StartLimitBurst rate-limit

--- a/cds/systemd/cds-master.service
+++ b/cds/systemd/cds-master.service
@@ -94,8 +94,17 @@ StandardError=journal
 SyslogIdentifier=cds-master
 
 # Resource accounting (requires cgroup v2)
-# Prevents the Master process from consuming more than it should
-MemoryMax=512M
+#
+# 2026-05-06 Bugbot be8dc4f5 / 2c22c57a 反馈 + 用户授权:
+# 之前 MemoryMax=512M 是 master 自身 + 它 spawn 的所有 child(tsc / vite / pnpm)
+# 共享的 cgroup 上限。我们已经移除了 NODE_OPTIONS=--max-old-space-size,V8 默认
+# 会按主机 RAM 自适应,但 V8 看不到 cgroup 限制 → 跑大型 tsc/vite 时会被
+# SIGKILL(uncatchable,无 graceful 错误)。
+#
+# 用户明确策略:"每个容器都不限制内存,尽情释放" + "不要刻意放大"。
+# MemoryMax 解除(infinity = 无限制),让 master + child 跟随主机 RAM。
+# CPUQuota 保留作为防爆 host 的兜底。
+MemoryMax=infinity
 CPUQuota=100%
 
 # Security hardening — soft, compatible with docker CLI usage

--- a/cds/systemd/cds-master.service
+++ b/cds/systemd/cds-master.service
@@ -73,7 +73,7 @@ EnvironmentFile=-/etc/cds/env
 # 帮你救场"的代价低 30-50s/次,且大多数路径不会失败(self-update 自带
 # 预检 + 原子 swap)。
 # ──────────────────────────────────────────────────────────────
-ExecStartPre=/usr/bin/pnpm install --frozen-lockfile
+ExecStartPre=/usr/bin/pnpm install --frozen-lockfile --prefer-offline
 
 # 2026-05-06 Bugbot bb81f978 + 8af6751a 双 HIGH:
 # 之前试图用 `node --watch=dist` 实现热重载,但语法错了(应该是 --watch-path=dist),

--- a/cds/systemd/cds-master.service
+++ b/cds/systemd/cds-master.service
@@ -56,24 +56,24 @@ Environment=CDS_REPO_ROOT=/opt/prd_agent
 EnvironmentFile=-/etc/cds/env
 
 # ──────────────────────────────────────────────────────────────
-# P4 Part 18 hardening — ExecStartPre self-heal.
+# P4 Part 18 hardening — ExecStartPre self-heal(2026-05-06 减负版)。
 #
-# Runs dependency + compile check BEFORE ExecStart so systemd
-# restarts don't keep relaunching a broken build in a loop.
+# 用户实测 self-update 215s,定位发现 ~50s 来自 systemd restart 时
+# **再跑一次** `npx tsc`(emit 到 dist),与 self-update 流程已经做的
+# tsc 完全冗余。self-force-sync 还会清 dist/.tsbuildinfo,导致 systemd
+# 这次 tsc 走全量冷启动 30-50s。
 #
-#   pnpm install  — idempotent; picks up new deps after branch switch
-#   tsc           — produces dist/ when missing or stale
+# 现行策略:
+#   - pnpm install --frozen-lockfile:保留(快路径 ~5s,自动拉新依赖)
+#   - npx tsc:**删除**(self-update 路径自己负责 dist,systemd 不再编译)
 #
-# If either fails, systemd marks the unit as failed and RestartSec
-# backs off naturally. Operators see the failure in `journalctl` and
-# can fix the branch before the next restart tick.
-#
-# Total overhead on a healthy install: ~1-2s (pnpm install is a
-# no-op when node_modules matches the lockfile, and tsc skips when
-# dist/ is newer than src/).
+# Fail-safe(self-update 失败 / 误删 dist):node 启动会报
+# "Cannot find module dist/index.js",systemd 标 failed,operator 在
+# journalctl 看到错误后用 /api/self-force-sync 重新构建。比之前"systemd
+# 帮你救场"的代价低 30-50s/次,且大多数路径不会失败(self-update 自带
+# 预检 + 原子 swap)。
 # ──────────────────────────────────────────────────────────────
 ExecStartPre=/usr/bin/pnpm install --frozen-lockfile
-ExecStartPre=/usr/bin/npx tsc
 
 ExecStart=/usr/bin/node dist/index.js
 

--- a/cds/systemd/cds-master.service
+++ b/cds/systemd/cds-master.service
@@ -56,32 +56,19 @@ Environment=CDS_REPO_ROOT=/opt/prd_agent
 EnvironmentFile=-/etc/cds/env
 
 # ──────────────────────────────────────────────────────────────
-# P4 Part 18 hardening — ExecStartPre self-heal(2026-05-06 减负版)。
+# 2026-05-06 重构(用户反馈"为什么每次都要手动 sudo 重装 unit"):
+# 把"启动 master 进程要做什么"全部委托给 exec_cds.sh 的 master-run 子命令。
+# 本 unit 文件只声明**框架**(在哪儿跑、Restart 策略、资源限制),所有
+# 易变的启动细节(pnpm 标志、node 启动参数、ExecStartPre 步骤)随
+# self-update 自动更新到 exec_cds.sh,operator 不用每次都 sudo cp。
 #
-# 用户实测 self-update 215s,定位发现 ~50s 来自 systemd restart 时
-# **再跑一次** `npx tsc`(emit 到 dist),与 self-update 流程已经做的
-# tsc 完全冗余。self-force-sync 还会清 dist/.tsbuildinfo,导致 systemd
-# 这次 tsc 走全量冷启动 30-50s。
-#
-# 现行策略:
-#   - pnpm install --frozen-lockfile:保留(快路径 ~5s,自动拉新依赖)
-#   - npx tsc:**删除**(self-update 路径自己负责 dist,systemd 不再编译)
-#
-# Fail-safe(self-update 失败 / 误删 dist):node 启动会报
-# "Cannot find module dist/index.js",systemd 标 failed,operator 在
-# journalctl 看到错误后用 /api/self-force-sync 重新构建。比之前"systemd
-# 帮你救场"的代价低 30-50s/次,且大多数路径不会失败(self-update 自带
-# 预检 + 原子 swap)。
+# unit 文件改动**只**在以下情况发生(应该极少):
+#   - 改 systemd 行为本身(Restart 策略、MemoryMax、TimeoutStartSec)
+#   - 改 WorkingDirectory(install 位置变了)
+# 其它启动细节去 cds/exec_cds.sh 的 `master-run` case 改即可。
 # ──────────────────────────────────────────────────────────────
-ExecStartPre=/usr/bin/pnpm install --frozen-lockfile --prefer-offline
-
-# 2026-05-06 Bugbot bb81f978 + 8af6751a 双 HIGH:
-# 之前试图用 `node --watch=dist` 实现热重载,但语法错了(应该是 --watch-path=dist),
-# 而且即使语法对,fs.renameSync 原子换 dist 目录会让 inode 变化,Linux inotify
-# 监听旧 inode → 新 dist 不被监听 → 热重载不工作。
-# 放弃 --watch 路径,回归 ExecStart=node dist/index.js,所有 self-update 路径
-# 走 systemd Restart=always 软重启(~5-10s),依靠刚移除的 tsc ExecStartPre 节省 30s。
-ExecStart=/usr/bin/node dist/index.js
+# install-systemd 时会把这条路径替换为实际安装位置 + 实际用户家目录的 PATH
+ExecStart=/opt/prd_agent/cds/exec_cds.sh master-run
 
 # Restart policy — the whole point of this unit file.
 # (The matching StartLimitIntervalSec / StartLimitBurst rate-limit

--- a/cds/systemd/cds-master.service
+++ b/cds/systemd/cds-master.service
@@ -75,7 +75,12 @@ EnvironmentFile=-/etc/cds/env
 # ──────────────────────────────────────────────────────────────
 ExecStartPre=/usr/bin/pnpm install --frozen-lockfile
 
-ExecStart=/usr/bin/node dist/index.js
+# 用户反馈 2026-05-06:CDS 自更新支持热重载。
+# `--watch=dist` 让 node 监听 dist/ 目录,self-force-sync 走"热路径"时
+# 只 emit 新 dist,无需 process.exit,node 自己平滑重启。冷路径(改了
+# 依赖/配置/路由 schema 等)仍 process.exit + systemd restart,跟以前一样。
+# Node 22 起 --watch 是 stable,Restart=always 仍作 watch crash 时的兜底。
+ExecStart=/usr/bin/node --watch=dist dist/index.js
 
 # Restart policy — the whole point of this unit file.
 # (The matching StartLimitIntervalSec / StartLimitBurst rate-limit

--- a/cds/tests/services/change-impact-analyzer.test.ts
+++ b/cds/tests/services/change-impact-analyzer.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { analyzeChangeImpact } from '../../src/services/change-impact-analyzer.js';
+
+describe('analyzeChangeImpact', () => {
+  it('全部应用代码 → 热重载', () => {
+    const r = analyzeChangeImpact([
+      'cds/src/routes/branches.ts',
+      'cds/src/services/foo.ts',
+      'cds/web/src/pages/BranchListPage.tsx',
+    ]);
+    expect(r.needsRestart).toBe(false);
+    expect(r.hotReloadablePaths.length).toBe(3);
+    expect(r.restartTriggers).toHaveLength(0);
+  });
+
+  it('package.json 变更 → 必须重启', () => {
+    const r = analyzeChangeImpact(['cds/package.json', 'cds/src/foo.ts']);
+    expect(r.needsRestart).toBe(true);
+    expect(r.restartTriggers[0].reason).toMatch(/依赖清单/);
+  });
+
+  it('lockfile 变更 → 必须重启', () => {
+    const r = analyzeChangeImpact(['cds/pnpm-lock.yaml']);
+    expect(r.needsRestart).toBe(true);
+    expect(r.restartTriggers[0].reason).toMatch(/lockfile/);
+  });
+
+  it('Dockerfile / compose / .env → 必须重启', () => {
+    expect(analyzeChangeImpact(['cds/Dockerfile']).needsRestart).toBe(true);
+    expect(analyzeChangeImpact(['docker-compose.dev.yml']).needsRestart).toBe(true);
+    expect(analyzeChangeImpact(['cds/.cds.env']).needsRestart).toBe(true);
+    expect(analyzeChangeImpact(['prd-api/appsettings.json']).needsRestart).toBe(true); // unknown 文件保守
+  });
+
+  it('tsconfig / vite.config 变更 → 必须重启', () => {
+    expect(analyzeChangeImpact(['cds/tsconfig.json']).needsRestart).toBe(true);
+    expect(analyzeChangeImpact(['cds/web/tsconfig.json']).needsRestart).toBe(true);
+    expect(analyzeChangeImpact(['cds/web/vite.config.ts']).needsRestart).toBe(true);
+  });
+
+  it('CDS 关键 schema 文件 → 必须重启', () => {
+    expect(analyzeChangeImpact(['cds/src/server.ts']).needsRestart).toBe(true);
+    expect(analyzeChangeImpact(['cds/src/index.ts']).needsRestart).toBe(true);
+    expect(analyzeChangeImpact(['cds/src/types.ts']).needsRestart).toBe(true);
+    expect(analyzeChangeImpact(['cds/src/config.ts']).needsRestart).toBe(true);
+  });
+
+  it('systemd unit 变更 → 必须重启', () => {
+    expect(analyzeChangeImpact(['cds/systemd/cds-master.service']).needsRestart).toBe(true);
+  });
+
+  it('纯文档/changelogs → 全部 irrelevant', () => {
+    const r = analyzeChangeImpact([
+      'README.md',
+      'CHANGELOG.md',
+      'doc/design.foo.md',
+      'changelogs/2026-05-06_x.md',
+      '.claude/rules/x.md',
+    ]);
+    expect(r.needsRestart).toBe(false);
+    expect(r.hotReloadablePaths).toHaveLength(0);
+    expect(r.irrelevantPaths).toHaveLength(5);
+  });
+
+  it('混合改动:应用代码 + 文档 → 仍是热重载', () => {
+    const r = analyzeChangeImpact([
+      'cds/src/services/foo.ts',
+      'README.md',
+      'doc/x.md',
+    ]);
+    expect(r.needsRestart).toBe(false);
+    expect(r.hotReloadablePaths).toHaveLength(1);
+    expect(r.irrelevantPaths).toHaveLength(2);
+  });
+
+  it('未知文件类型 → 保守判定为重启', () => {
+    const r = analyzeChangeImpact(['some/unknown.bin']);
+    expect(r.needsRestart).toBe(true);
+    expect(r.restartTriggers[0].reason).toMatch(/未知改动/);
+  });
+
+  it('空 diff → 视为无变更(不需要重启)', () => {
+    const r = analyzeChangeImpact([]);
+    expect(r.needsRestart).toBe(false);
+    expect(r.hotReloadablePaths).toHaveLength(0);
+  });
+});

--- a/cds/tests/services/container.test.ts
+++ b/cds/tests/services/container.test.ts
@@ -135,7 +135,10 @@ describe('ContainerService', () => {
 
     // ── Phase 2 cgroup resource limits ──
 
-    it('should apply --memory and --memory-swap when memoryMB is set', async () => {
+    // 2026-05-06 用户授权"每个容器都不限制内存,尽情释放" — 不再下发
+    // --memory / --memory-swap docker 运行时硬限。memoryMB 字段保留作
+    // capacity 调度规划提示(capacityMessage 用),但不进 docker run。
+    it('should NOT apply --memory / --memory-swap even when memoryMB is set (no-mem-limit policy)', async () => {
       mock.addResponsePattern(/docker network inspect/, () => ({ stdout: '', stderr: '', exitCode: 0 }));
       mock.addResponsePattern(/docker rm -f/, () => ({ stdout: '', stderr: '', exitCode: 0 }));
       mock.addResponsePattern(/docker run/, () => ({ stdout: 'ok', stderr: '', exitCode: 0 }));
@@ -147,9 +150,8 @@ describe('ContainerService', () => {
       await service.runService(makeEntry(), profile, makeService());
 
       const runCmd = mock.commands.find(c => c.includes('docker run -d'))!;
-      expect(runCmd).toContain('--memory 512m');
-      // Match memory-swap to memory to avoid swap leakage under pressure
-      expect(runCmd).toContain('--memory-swap 512m');
+      expect(runCmd).not.toContain('--memory');
+      expect(runCmd).not.toContain('--memory-swap');
     });
 
     it('should apply --cpus when cpus is set', async () => {
@@ -167,7 +169,7 @@ describe('ContainerService', () => {
       expect(runCmd).toContain('--cpus 1.5');
     });
 
-    it('should combine memory and cpu limits', async () => {
+    it('should keep --cpus but drop --memory when both are set (no-mem-limit policy)', async () => {
       mock.addResponsePattern(/docker network inspect/, () => ({ stdout: '', stderr: '', exitCode: 0 }));
       mock.addResponsePattern(/docker rm -f/, () => ({ stdout: '', stderr: '', exitCode: 0 }));
       mock.addResponsePattern(/docker run/, () => ({ stdout: 'ok', stderr: '', exitCode: 0 }));
@@ -179,7 +181,7 @@ describe('ContainerService', () => {
       await service.runService(makeEntry(), profile, makeService());
 
       const runCmd = mock.commands.find(c => c.includes('docker run -d'))!;
-      expect(runCmd).toContain('--memory 1024m');
+      expect(runCmd).not.toContain('--memory');
       expect(runCmd).toContain('--cpus 2');
     });
 

--- a/cds/tests/util/node-modules-volume.test.ts
+++ b/cds/tests/util/node-modules-volume.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { nodeModulesVolumeName, nodeModulesVolumePrefix } from '../../src/util/node-modules-volume.js';
+
+describe('nodeModulesVolumeName / Prefix', () => {
+  it('短输入直接 sanitize,不加 hash', () => {
+    expect(nodeModulesVolumeName('br', 'api')).toBe('cds-nm-br-api');
+  });
+
+  it('斜杠 / 大写 / 下划线被替换或保留', () => {
+    expect(nodeModulesVolumeName('claude/feat_1', 'API')).toBe('cds-nm-claude-feat_1-API');
+  });
+
+  it('截断的输入加 sha1 短 hash 防碰撞', () => {
+    const longA = 'prd-agent-claude-very-long-branch-name-with-lots-of-chars-AAAA';
+    const longB = 'prd-agent-claude-very-long-branch-name-with-lots-of-chars-BBBB';
+    const a = nodeModulesVolumeName(longA, 'api');
+    const b = nodeModulesVolumeName(longB, 'api');
+    // Bugbot b952e898:截断后必须不一致(否则删 A 会误吞 B 的 volume)
+    expect(a).not.toBe(b);
+  });
+
+  it('prefix === volumeName 去掉 -profileId 后缀', () => {
+    const name = nodeModulesVolumeName('br', 'api');
+    const prefix = nodeModulesVolumePrefix('br');
+    expect(name.startsWith(prefix)).toBe(true);
+  });
+
+  it('同一 branch 不同 profile 共享 prefix', () => {
+    const a = nodeModulesVolumeName('br', 'api');
+    const b = nodeModulesVolumeName('br', 'admin');
+    const prefix = nodeModulesVolumePrefix('br');
+    expect(a.startsWith(prefix)).toBe(true);
+    expect(b.startsWith(prefix)).toBe(true);
+    expect(a).not.toBe(b);
+  });
+});

--- a/cds/tests/util/node-modules-volume.test.ts
+++ b/cds/tests/util/node-modules-volume.test.ts
@@ -2,35 +2,49 @@ import { describe, it, expect } from 'vitest';
 import { nodeModulesVolumeName, nodeModulesVolumePrefix } from '../../src/util/node-modules-volume.js';
 
 describe('nodeModulesVolumeName / Prefix', () => {
-  it('短输入直接 sanitize,不加 hash', () => {
-    expect(nodeModulesVolumeName('br', 'api')).toBe('cds-nm-br-api');
+  it('两段定长 hash 编码,边界绝对明确', () => {
+    const name = nodeModulesVolumeName('br', 'api');
+    // 7 + 8 + 1 + 8 = 24
+    expect(name).toMatch(/^cds-nm-[0-9a-f]{8}-[0-9a-f]{8}$/);
+    expect(name.length).toBe(24);
   });
 
-  it('斜杠 / 大写 / 下划线被替换或保留', () => {
-    expect(nodeModulesVolumeName('claude/feat_1', 'API')).toBe('cds-nm-claude-feat_1-API');
-  });
-
-  it('截断的输入加 sha1 短 hash 防碰撞', () => {
-    const longA = 'prd-agent-claude-very-long-branch-name-with-lots-of-chars-AAAA';
-    const longB = 'prd-agent-claude-very-long-branch-name-with-lots-of-chars-BBBB';
-    const a = nodeModulesVolumeName(longA, 'api');
-    const b = nodeModulesVolumeName(longB, 'api');
-    // Bugbot b952e898:截断后必须不一致(否则删 A 会误吞 B 的 volume)
+  it('Bugbot 65a383bb 回归:join 边界歧义不再存在', () => {
+    // 老编码下 ("foo/bar","baz") 和 ("foo","bar-baz") 都生成 cds-nm-foo-bar-baz
+    // 新编码下两段独立 hash,必然不同
+    const a = nodeModulesVolumeName('foo/bar', 'baz');
+    const b = nodeModulesVolumeName('foo', 'bar-baz');
     expect(a).not.toBe(b);
   });
 
-  it('prefix === volumeName 去掉 -profileId 后缀', () => {
-    const name = nodeModulesVolumeName('br', 'api');
+  it('Bugbot b952e898 回归:超长输入两段 hash 仍然 1:1 区分', () => {
+    const longA = 'prd-agent-claude-very-long-branch-name-with-lots-of-chars-AAAA';
+    const longB = 'prd-agent-claude-very-long-branch-name-with-lots-of-chars-BBBB';
+    expect(nodeModulesVolumeName(longA, 'api')).not.toBe(nodeModulesVolumeName(longB, 'api'));
+  });
+
+  it('prefix 是 volumeName 的真前缀,长度固定 16', () => {
     const prefix = nodeModulesVolumePrefix('br');
-    expect(name.startsWith(prefix)).toBe(true);
+    expect(prefix).toMatch(/^cds-nm-[0-9a-f]{8}-$/);
+    expect(prefix.length).toBe(16);
+    expect(nodeModulesVolumeName('br', 'api').startsWith(prefix)).toBe(true);
   });
 
   it('同一 branch 不同 profile 共享 prefix', () => {
-    const a = nodeModulesVolumeName('br', 'api');
-    const b = nodeModulesVolumeName('br', 'admin');
     const prefix = nodeModulesVolumePrefix('br');
-    expect(a.startsWith(prefix)).toBe(true);
-    expect(b.startsWith(prefix)).toBe(true);
-    expect(a).not.toBe(b);
+    expect(nodeModulesVolumeName('br', 'api').startsWith(prefix)).toBe(true);
+    expect(nodeModulesVolumeName('br', 'admin').startsWith(prefix)).toBe(true);
+    expect(nodeModulesVolumeName('br', 'api')).not.toBe(nodeModulesVolumeName('br', 'admin'));
+  });
+
+  it('确定性:同输入永远同输出', () => {
+    expect(nodeModulesVolumeName('claude/feat', 'api')).toBe(nodeModulesVolumeName('claude/feat', 'api'));
+  });
+
+  it('docker volume name 字符集合规(只 [a-z0-9-])', () => {
+    const samples = ['br', 'claude/feat-1', 'main', 'CamelCase/With_Special.Chars'];
+    for (const s of samples) {
+      expect(nodeModulesVolumeName(s, 'api')).toMatch(/^[a-zA-Z0-9_.-]+$/);
+    }
   });
 });

--- a/cds/web/src/components/GlobalUpdateBadge.tsx
+++ b/cds/web/src/components/GlobalUpdateBadge.tsx
@@ -232,10 +232,15 @@ export function GlobalUpdateBadge(): JSX.Element | null {
         // 每 FALLBACK_POLLS_PER_SSE_RETRY 次成功 poll 后,试着重连 SSE。失败
         // 会触发 onerror,达到阈值后 onerror 内会再调 startFallbackPolling()
         // 把 fallback 重新拉起来 — 形成"polling ↔ SSE"自愈循环。
+        //
+        // ⚠ Bugbot 2026-05-06 50a97d6e:之前 fallbackActive=false + 不再
+        // schedule 下一轮 tick + 直接 connect()。如果 SSE 静默挂着不触发
+        // onerror(没达到 3 次/30s 阈值),polling 这边已停,SSE 那边不来数据,
+        // 出现长达 ~33s 的 "无源" 区间。改为:**保留 polling 继续滚**,
+        // 只 connect() 试 SSE。SSE 真活了 → onopen 里关 polling;真死了 →
+        // 原先的 polling 已经在那转,无缝兜底。
         if (fallbackSuccessCount >= FALLBACK_POLLS_PER_SSE_RETRY) {
           fallbackSuccessCount = 0;
-          fallbackActive = false;
-          fallbackTimer = null;
           // ⚠ Bugbot Review 2026-05-06 7eefcba6: 不重置 consecutiveErrors /
           // firstErrorAt 时,新 EventSource 的第一个 onerror 会用旧的(分钟级)
           // firstErrorAt 算 elapsed,瞬间超阈值 → 立刻又回 fallback,升级永远
@@ -243,9 +248,10 @@ export function GlobalUpdateBadge(): JSX.Element | null {
           consecutiveErrors = 0;
           firstErrorAt = 0;
           // eslint-disable-next-line no-console
-          console.info('[GlobalUpdateBadge] 尝试升级回 SSE 长连接');
+          console.info('[GlobalUpdateBadge] 尝试升级回 SSE 长连接(polling 继续滚作为兜底)');
           connect();
-          return;
+          // 注意:这里**不**清 fallbackTimer,polling 继续作为兜底,
+          // SSE 的 onopen 里才真正关掉 polling。
         }
         fallbackTimer = window.setTimeout(() => { void tick(); }, FALLBACK_POLL_INTERVAL_MS);
       };
@@ -266,6 +272,18 @@ export function GlobalUpdateBadge(): JSX.Element | null {
         // 连上了:重置失败计数,清掉 restarting(若有)
         consecutiveErrors = 0;
         firstErrorAt = 0;
+        // ⚠ Bugbot 2026-05-06 50a97d6e:fallback 升级路径让 polling 继续滚
+        // 作为兜底,SSE 真连上了才在这里关 polling — 升级期间无缝衔接,
+        // 不会出现"polling 已停 / SSE 静默"的真空期。
+        if (fallbackActive) {
+          fallbackActive = false;
+          if (fallbackTimer !== null) {
+            window.clearTimeout(fallbackTimer);
+            fallbackTimer = null;
+          }
+          // eslint-disable-next-line no-console
+          console.info('[GlobalUpdateBadge] SSE 升级成功,关掉 fallback polling');
+        }
         // 不直接清掉 state — 让 snapshot 事件来填充。这里只在恢复后给个 hint:
         // 若当前是 restarting,等下一条 snapshot/update 事件即可。
       };

--- a/cds/web/src/components/GlobalUpdateBadge.tsx
+++ b/cds/web/src/components/GlobalUpdateBadge.tsx
@@ -55,6 +55,11 @@ export function GlobalUpdateBadge(): JSX.Element | null {
   const [state, setState] = useState<BadgeState>({ kind: 'idle' });
   const [expanded, setExpanded] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
+  // 同步 ref guard：防 rapid double-click 触发两次 fetch（React setState 是
+  // batched，闭包里 `if (refreshing) return` 看到的是上一帧的值，第二次
+  // click 进来时 setRefreshing(true) 还没生效，guard 形同虚设。useRef 是
+  // mutable 即时生效的，不受 batching 影响。Bugbot Review 2026-05-06 bb22baea。
+  const refreshingRef = useRef(false);
   const initialShaRef = useRef<string>('');
   const lastSuccessRef = useRef<SelfStatusLite | null>(null);
 
@@ -129,7 +134,10 @@ export function GlobalUpdateBadge(): JSX.Element | null {
 
   // 手动刷新按钮:走老的 /api/self-status?probe=remote&force=1 当作一次 update 事件处理。
   const triggerManualRefresh = useCallback(async (): Promise<void> => {
-    if (refreshing) return;
+    // ref guard 即时生效,先于 React batch；setRefreshing 只为驱动 UI 状态
+    // (disabled / spin 动画),并发防护看 ref 不看 state。
+    if (refreshingRef.current) return;
+    refreshingRef.current = true;
     setRefreshing(true);
     try {
       const ctrl = new AbortController();
@@ -150,9 +158,11 @@ export function GlobalUpdateBadge(): JSX.Element | null {
     } catch {
       setState({ kind: 'restarting', sinceMs: Date.now() });
     } finally {
+      refreshingRef.current = false;
       setRefreshing(false);
     }
-  }, [refreshing, applyPayload]);
+    // 不再依赖 refreshing state（避免 stale closure 让 guard 失效）
+  }, [applyPayload]);
 
   // SSE 订阅 + 失败降级到轮询。
   useEffect(() => {

--- a/cds/web/src/components/GlobalUpdateBadge.tsx
+++ b/cds/web/src/components/GlobalUpdateBadge.tsx
@@ -53,7 +53,10 @@ const SSE_FAIL_THRESHOLD_MS = 30_000;
 
 export function GlobalUpdateBadge(): JSX.Element | null {
   const [state, setState] = useState<BadgeState>({ kind: 'idle' });
-  const [expanded, setExpanded] = useState(false);
+  // 2026-05-06 用户反馈"我要的是常开":徽章默认就展开显示完整状态,鼠标移开
+  // 也不主动收。要让它收只能点 X 关闭(dismiss 1h)。Pin 按钮变成"自动收起切换"
+  // (点击切到 hover-intent 模式,鼠标移开 280ms 收)。默认 pinned=true 实现常开。
+  const [expanded, setExpanded] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   // 同步 ref guard：防 rapid double-click 触发两次 fetch（React setState 是
   // batched，闭包里 `if (refreshing) return` 看到的是上一帧的值，第二次
@@ -70,7 +73,9 @@ export function GlobalUpdateBadge(): JSX.Element | null {
   // ⚠ Bugbot 2026-05-06 286deafc(High):这几个 hook **必须在** if (state.kind=='idle') return null
   // **之前**声明,否则 idle ↔ 非 idle 切换时 hook 调用顺序变化,React 直接 crash。
   const collapseTimerRef = useRef<number | null>(null);
-  const [pinned, setPinned] = useState(false);
+  // 默认 pinned=true 实现"常开"。Pin 按钮点击切换:pinned=false → 进入 hover-intent
+  // 模式(鼠标移开 280ms 收);再点又切回常开。
+  const [pinned, setPinned] = useState(true);
   const handleEnter = useCallback(() => {
     if (collapseTimerRef.current) {
       window.clearTimeout(collapseTimerRef.current);
@@ -89,12 +94,9 @@ export function GlobalUpdateBadge(): JSX.Element | null {
   useEffect(() => () => {
     if (collapseTimerRef.current) window.clearTimeout(collapseTimerRef.current);
   }, []);
-  // 2026-05-06 用户反馈"常开":state.kind 切换时(restart→idle / updated→restart 等)
-  // 强制 unpin + collapse,避免某 kind 偶然钉住后被另一 kind 继承。
-  useEffect(() => {
-    setPinned(false);
-    setExpanded(false);
-  }, [state.kind]);
+  // 2026-05-06 用户反馈"我要常开":state.kind 切换时**保持** pinned + expanded,
+  // 不再强制收。新出现的 kind(restart→idle→updateAvailable 等)继续可见,
+  // 用户主动点 X 才 dismiss。
 
   // dismiss 短期:用户主动关掉徽章 → 接下来 1 小时不再显示(各 kind 独立,
   // 真发生新事件会再覆盖)。存 sessionStorage 标签关了就丢。
@@ -500,10 +502,10 @@ export function GlobalUpdateBadge(): JSX.Element | null {
             <RefreshCw className={`h-3.5 w-3.5 ${refreshing ? 'animate-spin' : ''}`} />
           </button>
         ) : null}
-        {/* 用户反馈 2026-05-06"常开":restarting 是瞬态(SSE 重连即消失),
-            钉住没意义反而误操作风险。仅在 updateAvailable / bundleStale / updated
-            这种"用户需要决定"的稳定态显示 Pin。restart 永远走 hover-intent 自动收。 */}
-        {expanded && state.kind !== 'restarting' ? (
+        {/* 2026-05-06 用户反馈"我要常开":Pin 按钮始终显示(包括 restart 状态),
+            默认常开(pinned=true)。点 Pin 切到 hover-intent 模式(鼠标移开自动收)。
+            再点切回常开。 */}
+        {expanded ? (
           <button
             type="button"
             onClick={(e) => {
@@ -511,10 +513,10 @@ export function GlobalUpdateBadge(): JSX.Element | null {
               setPinned((p) => !p);
             }}
             className={`flex shrink-0 items-center justify-center px-2 ${visual.textClass} ${pinned ? 'opacity-100' : 'opacity-60'} transition-opacity hover:opacity-100`}
-            aria-label={pinned ? '取消钉住' : '钉住面板'}
-            title={pinned ? '取消钉住(点击,鼠标移开会自动收起)' : '钉住面板(点击,鼠标移开也不收起)'}
+            aria-label={pinned ? '取消钉住(切换到鼠标移开自动收起)' : '钉住面板(始终展开)'}
+            title={pinned ? '已钉住 — 点击切换到自动收起模式(鼠标移开 280ms 收)' : '已自动收起模式 — 点击切回常开'}
           >
-            {pinned ? <PinOff className="h-3.5 w-3.5" /> : <Pin className="h-3.5 w-3.5" />}
+            {pinned ? <Pin className="h-3.5 w-3.5" /> : <PinOff className="h-3.5 w-3.5" />}
           </button>
         ) : null}
         {expanded ? (

--- a/cds/web/src/components/GlobalUpdateBadge.tsx
+++ b/cds/web/src/components/GlobalUpdateBadge.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { AlertTriangle, ArrowUpCircle, CheckCircle2, Loader2, Sparkles, X } from 'lucide-react';
+import { AlertTriangle, ArrowUpCircle, CheckCircle2, Loader2, RefreshCw, Sparkles, X } from 'lucide-react';
 
 /*
  * GlobalUpdateBadge — 浮在屏幕左下角的全局 CDS 更新状态徽章。
@@ -7,14 +7,17 @@ import { AlertTriangle, ArrowUpCircle, CheckCircle2, Loader2, Sparkles, X } from
  * 用户反馈(2026-05-04):「点更新后看不出真的更新了没」「希望有活动部件告诉我
  * 更新中/完成/失败」「订阅了分支,该分支更新了在任何页面左下角弹出可以点击更新」。
  *
- * 这个组件挂在 AppShell,所有页面共享。30s 一次轮询 /api/self-status,
- * 根据返回数据 + 与"页面打开时快照"对比,推出 4 种状态:
+ * 这个组件挂在 AppShell,所有页面共享。原来 30s 一次轮询 /api/self-status 太重
+ * (server 端 git fetch 卡顿)。改为事件驱动:订阅 SSE /api/self-status/stream,
+ * 后端有事件主动推送;前端只在用户手动点刷新或 SSE 不可用降级时才发请求。
+ *
+ * 状态机仍是原来的 5 种:
  *
  *   1. ✓ idle       — 正常,徽章隐藏(不打扰)
  *   2. ↑ updateAvail — 该分支 GitHub 远端有 N 个新 commit(订阅意义)
  *                      点击 → 跳 /cds-settings → 维护
- *   3. ⌛ restarting — 轮询失败 / CDS 在重启
- *                      显示 spinner,等 30s 后自动验证
+ *   3. ⌛ restarting — SSE 断开 / CDS 在重启
+ *                      显示 spinner,等 onopen 自动恢复
  *   4. ✓ updated     — headSha 与页面打开时不同(后端真换版本了)
  *                      点击 → 强制 reload 页面加载新 bundle
  *   5. ⚠ bundleStale — 后端 SHA != web bundle SHA(build_web 静默失败的征兆)
@@ -41,16 +44,18 @@ type BadgeState =
   | { kind: 'restarting'; sinceMs: number }
   | { kind: 'bundleStale'; backendSha: string; bundleSha: string };
 
-const POLL_INTERVAL_NORMAL_MS = 30_000;
-const POLL_INTERVAL_FAST_MS = 5_000; // 在 restarting / 检测到变化后的短窗口
-const FAST_POLL_DURATION_MS = 90_000;
 const DISMISS_KEY = 'cds:global-update-badge:dismissed-until';
+// SSE 不可用时的降级轮询间隔。比原来的 30s 更长 — 已经是兜底方案,主路径走 SSE。
+const FALLBACK_POLL_INTERVAL_MS = 60_000;
+// 连续 N 次 onerror 且累积超过 30s 仍未 onopen,判定 SSE 不可用,启动降级。
+const SSE_FAIL_THRESHOLD_COUNT = 3;
+const SSE_FAIL_THRESHOLD_MS = 30_000;
 
 export function GlobalUpdateBadge(): JSX.Element | null {
   const [state, setState] = useState<BadgeState>({ kind: 'idle' });
   const [expanded, setExpanded] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
   const initialShaRef = useRef<string>('');
-  const fastPollUntilRef = useRef<number>(0);
   const lastSuccessRef = useRef<SelfStatusLite | null>(null);
 
   // dismiss 短期:用户主动关掉徽章 → 接下来 1 小时不再显示(各 kind 独立,
@@ -77,99 +82,188 @@ export function GlobalUpdateBadge(): JSX.Element | null {
     setState({ kind: 'idle' });
   }, []);
 
-  const poll = useCallback(async (): Promise<void> => {
+  // 把 self-status payload 转成 BadgeState 的统一逻辑。
+  // 三个调用方:SSE snapshot 事件 / SSE update 事件 / 手动刷新按钮。
+  // 状态机优先级(高 → 低):
+  //   1. SHA 变了 = 后端真换版本(updated)
+  //   2. bundleStale = 前端比后端旧(build_web 静默失败)
+  //   3. ahead > 0 = 远端有新 commit 可拉
+  //   4. else idle
+  const applyPayload = useCallback((payload: SelfStatusLite, source: 'snapshot' | 'update' | 'manual'): void => {
+    lastSuccessRef.current = payload;
+
+    // 第一次成功(snapshot 或 manual 首次):记录初始 SHA,作为"页面打开后是否换版本"的基线
+    if (!initialShaRef.current && payload.headSha) {
+      initialShaRef.current = payload.headSha;
+    }
+
+    if (initialShaRef.current && payload.headSha && payload.headSha !== initialShaRef.current) {
+      setState({
+        kind: 'updated',
+        fromSha: initialShaRef.current,
+        toSha: payload.headSha,
+      });
+      return;
+    }
+    if (payload.bundleStale && payload.headSha && payload.webBuildSha) {
+      setState({
+        kind: 'bundleStale',
+        backendSha: payload.headSha,
+        bundleSha: payload.webBuildSha.slice(0, 7),
+      });
+      return;
+    }
+    if ((payload.remoteAheadCount || 0) > 0) {
+      setState({
+        kind: 'updateAvailable',
+        count: payload.remoteAheadCount || 0,
+        firstSubject: payload.remoteAheadSubjects?.[0]?.subject,
+      });
+      return;
+    }
+    // 手动刷新得到 idle 时不要把已有的 restarting 等异常态盖掉 — 这里直接置 idle 即可,
+    // 因为能拿到 200 payload 说明后端是活的。snapshot/update 同理。
+    setState({ kind: 'idle' });
+    void source; // 当前不需要按 source 分支处理,保留参数以便日后埋点
+  }, []);
+
+  // 手动刷新按钮:走老的 /api/self-status?probe=remote&force=1 当作一次 update 事件处理。
+  const triggerManualRefresh = useCallback(async (): Promise<void> => {
+    if (refreshing) return;
+    setRefreshing(true);
     try {
       const ctrl = new AbortController();
-      const timeoutId = setTimeout(() => ctrl.abort(), 5000);
-      // probe=remote 走 branches.ts 完整版,做 git fetch + 算 ahead 数。
-      // 顶层轻量版不调 fetch,永远返 remoteAheadCount=0,角标永远不亮。
-      // 单用户 dashboard 30s 一次 git fetch(本地 origin)~200-500ms,可接受。
-      const r = await fetch('/api/self-status?probe=remote', {
+      const timeoutId = window.setTimeout(() => ctrl.abort(), 10_000);
+      const r = await fetch('/api/self-status?probe=remote&force=1', {
         credentials: 'include',
         cache: 'no-store',
         signal: ctrl.signal,
       });
-      clearTimeout(timeoutId);
+      window.clearTimeout(timeoutId);
       if (!r.ok) {
-        // 任何 4xx/5xx 都先按 restarting 处理 — 用户感知是"CDS 不太对"
-        const since = Date.now();
-        fastPollUntilRef.current = Math.max(fastPollUntilRef.current, since + FAST_POLL_DURATION_MS);
-        setState({ kind: 'restarting', sinceMs: since });
+        // 主动刷新失败 → 视为 restarting,让用户感知 CDS 不太行
+        setState({ kind: 'restarting', sinceMs: Date.now() });
         return;
       }
       const data = (await r.json()) as SelfStatusLite;
-      lastSuccessRef.current = data;
-
-      // 第一次成功:记录初始 SHA,用作"页面打开后是否换版本"的基线
-      if (!initialShaRef.current && data.headSha) {
-        initialShaRef.current = data.headSha;
-      }
-
-      // 优先级判定(高 → 低):
-      //   1. SHA 变了 = 后端真换版本(updated)
-      //   2. bundleStale = 前端比后端旧(build_web 静默失败)
-      //   3. ahead > 0 = 远端有新 commit 可拉
-      //   4. else idle
-      if (initialShaRef.current && data.headSha && data.headSha !== initialShaRef.current) {
-        setState({
-          kind: 'updated',
-          fromSha: initialShaRef.current,
-          toSha: data.headSha,
-        });
-        return;
-      }
-      if (data.bundleStale && data.headSha && data.webBuildSha) {
-        setState({
-          kind: 'bundleStale',
-          backendSha: data.headSha,
-          bundleSha: data.webBuildSha.slice(0, 7),
-        });
-        return;
-      }
-      if ((data.remoteAheadCount || 0) > 0) {
-        setState({
-          kind: 'updateAvailable',
-          count: data.remoteAheadCount || 0,
-          firstSubject: data.remoteAheadSubjects?.[0]?.subject,
-        });
-        return;
-      }
-      setState({ kind: 'idle' });
+      applyPayload(data, 'manual');
     } catch {
-      // 网络错误 / abort → 视为 restarting,触发 fast poll
-      const since = Date.now();
-      fastPollUntilRef.current = Math.max(fastPollUntilRef.current, since + FAST_POLL_DURATION_MS);
-      setState({ kind: 'restarting', sinceMs: since });
+      setState({ kind: 'restarting', sinceMs: Date.now() });
+    } finally {
+      setRefreshing(false);
     }
-  }, []);
+  }, [refreshing, applyPayload]);
 
+  // SSE 订阅 + 失败降级到轮询。
   useEffect(() => {
-    void poll();
     let cancelled = false;
-    const tick = (): void => {
-      if (cancelled) return;
-      const interval = Date.now() < fastPollUntilRef.current
-        ? POLL_INTERVAL_FAST_MS
-        : POLL_INTERVAL_NORMAL_MS;
-      const timer = window.setTimeout(async () => {
-        await poll();
-        tick();
-      }, interval);
-      // store on closure for cleanup
-      cleanupRef.current = () => window.clearTimeout(timer);
+    let es: EventSource | null = null;
+    let fallbackTimer: number | null = null;
+    let firstErrorAt = 0;
+    let consecutiveErrors = 0;
+    let fallbackActive = false;
+
+    const startFallbackPolling = (): void => {
+      if (fallbackActive || cancelled) return;
+      fallbackActive = true;
+      // eslint-disable-next-line no-console
+      console.warn('[GlobalUpdateBadge] SSE 不可用,降级到 60s 轮询');
+      const tick = async (): Promise<void> => {
+        if (cancelled) return;
+        try {
+          const r = await fetch('/api/self-status?probe=remote', {
+            credentials: 'include',
+            cache: 'no-store',
+          });
+          if (r.ok) {
+            const data = (await r.json()) as SelfStatusLite;
+            if (!cancelled) applyPayload(data, 'update');
+          } else if (!cancelled) {
+            setState({ kind: 'restarting', sinceMs: Date.now() });
+          }
+        } catch {
+          if (!cancelled) setState({ kind: 'restarting', sinceMs: Date.now() });
+        }
+        if (!cancelled) {
+          fallbackTimer = window.setTimeout(() => { void tick(); }, FALLBACK_POLL_INTERVAL_MS);
+        }
+      };
+      void tick();
     };
-    const cleanupRef = { current: () => {} };
-    tick();
+
+    const connect = (): void => {
+      if (cancelled) return;
+      try {
+        es = new EventSource('/api/self-status/stream', { withCredentials: true });
+      } catch {
+        // 浏览器不支持 EventSource(极老 IE 等)→ 直接降级
+        startFallbackPolling();
+        return;
+      }
+
+      es.onopen = (): void => {
+        // 连上了:重置失败计数,清掉 restarting(若有)
+        consecutiveErrors = 0;
+        firstErrorAt = 0;
+        // 不直接清掉 state — 让 snapshot 事件来填充。这里只在恢复后给个 hint:
+        // 若当前是 restarting,等下一条 snapshot/update 事件即可。
+      };
+
+      es.addEventListener('snapshot', (ev: MessageEvent) => {
+        try {
+          const data = JSON.parse(ev.data) as SelfStatusLite;
+          applyPayload(data, 'snapshot');
+        } catch {
+          /* malformed payload, ignore */
+        }
+      });
+
+      es.addEventListener('update', (ev: MessageEvent) => {
+        try {
+          const data = JSON.parse(ev.data) as SelfStatusLite;
+          applyPayload(data, 'update');
+        } catch {
+          /* malformed payload, ignore */
+        }
+      });
+
+      es.addEventListener('keepalive', () => {
+        // 心跳:无 payload 价值,丢弃。本身能进 handler 就说明连接还活着。
+      });
+
+      es.onerror = (): void => {
+        // EventSource 断开 — 浏览器内置 3s 重试,不需要我们手动 reconnect。
+        // 但要把 UI 切到 restarting,并累计失败次数判断是否需要降级。
+        if (cancelled) return;
+        const now = Date.now();
+        if (consecutiveErrors === 0) firstErrorAt = now;
+        consecutiveErrors += 1;
+        setState({ kind: 'restarting', sinceMs: firstErrorAt || now });
+
+        const elapsed = now - firstErrorAt;
+        if (consecutiveErrors >= SSE_FAIL_THRESHOLD_COUNT && elapsed > SSE_FAIL_THRESHOLD_MS) {
+          // 判定 SSE 不可用 — 关掉 EventSource,降级轮询
+          if (es) {
+            es.close();
+            es = null;
+          }
+          startFallbackPolling();
+        }
+      };
+    };
+
+    connect();
+
     return () => {
       cancelled = true;
-      cleanupRef.current();
+      if (es) es.close();
+      if (fallbackTimer !== null) window.clearTimeout(fallbackTimer);
     };
-  }, [poll]);
+  }, [applyPayload]);
 
   // restarting 状态下 1s 定时刷新让 "CDS 不可达 Ns" 计时秒数跳动。
-  // Bugbot PR #524 反馈:elapsed 在 visualForState 里 render 时计算一次,
-  // 组件只在 5s 一次 poll 响应或 state 变化时才 re-render —— 用户盯着等恢复时
-  // 看到秒数 5s 跳一次,会以为系统卡死。这里 1s 一次轻量 setState 强制重渲染。
+  // elapsed 在 visualForState 里 render 时计算一次,组件本身不会因时间流逝
+  // 自动 re-render — 这里 1s 一次轻量 setState 强制重渲染。
   const [, forceTick] = useState(0);
   useEffect(() => {
     if (state.kind !== 'restarting') return;
@@ -179,13 +273,6 @@ export function GlobalUpdateBadge(): JSX.Element | null {
 
   // 立即更新(2026-05-04 UX 优化):updateAvailable 状态下角标 hover 直接给
   // "立即更新"按钮,POST /api/self-update 后 Badge 切到 restarting 状态。
-  // 之前要跳 /cds-settings 再点一次,多一步,行业(VS Code / Vercel CLI / Linear)
-  // 都是 inline。
-  //
-  // Bugbot PR #524 第七轮反馈:/api/self-update 是 SSE 端点,initSSE 会**先**
-  // 写 200 头再开始干活,所以 fetch().ok 总是 true 即使后续步骤失败。需要
-  // 主动读流第一个事件块来确认是否被接受 + 处理 error 事件。读完第一块就
-  // abort,免得 SSE 流被挂 30+ 秒占着连接(进度由 30s 角标轮询接管显示)。
   const [triggering, setTriggering] = useState(false);
   const triggerSelfUpdate = useCallback(async () => {
     if (triggering) return;
@@ -234,13 +321,9 @@ export function GlobalUpdateBadge(): JSX.Element | null {
               return;
             }
             // 第一个非 error event(typically 'step' status:'running')→ 触发已接受。
-            // Bugbot PR #524 第八轮反馈:之前只 abort 流就 return,Badge 仍显示
-            // "GitHub 有新 commit",最长要等 30s 下次轮询才切到 restarting。
-            // 这里立刻把 state → restarting + 拉满 fastPoll 窗,让用户当场看到
-            // "CDS 不可达 Ns" 的 spinner 反馈,不用怀疑"按钮按了没用"。
-            const since = Date.now();
-            fastPollUntilRef.current = Math.max(fastPollUntilRef.current, since + FAST_POLL_DURATION_MS);
-            setState({ kind: 'restarting', sinceMs: since });
+            // 立刻把 state → restarting,让用户当场看到 spinner,SSE 后续会推 update
+            // 把状态切回正常。
+            setState({ kind: 'restarting', sinceMs: Date.now() });
             ctrl.abort();
             return;
           }
@@ -303,6 +386,21 @@ export function GlobalUpdateBadge(): JSX.Element | null {
             type="button"
             onClick={(e) => {
               e.stopPropagation();
+              void triggerManualRefresh();
+            }}
+            disabled={refreshing}
+            className={`flex shrink-0 items-center justify-center px-2 ${visual.textClass} opacity-60 transition-opacity hover:opacity-100 disabled:opacity-40`}
+            aria-label="立即检查远端更新"
+            title="立即检查远端更新"
+          >
+            <RefreshCw className={`h-3.5 w-3.5 ${refreshing ? 'animate-spin' : ''}`} />
+          </button>
+        ) : null}
+        {expanded ? (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
               dismiss(state.kind);
             }}
             className={`flex shrink-0 items-center justify-center px-2 ${visual.textClass} opacity-60 transition-opacity hover:opacity-100`}
@@ -358,7 +456,7 @@ function visualForState(state: Exclude<BadgeState, { kind: 'idle' }>): {
       return {
         icon: <Loader2 className="h-4 w-4 animate-spin" />,
         label: `CDS 不可达 ${elapsed}s · 可能正在重启…`,
-        title: 'self-status 请求失败。CDS 可能在重启,自动 5 秒一次重连。',
+        title: 'self-status 流断开。CDS 可能在重启,EventSource 自动 3 秒一次重连。',
         bgClass: 'bg-blue-50 dark:bg-blue-950/30',
         borderClass: 'border-blue-500/40',
         textClass: 'text-blue-700 dark:text-blue-300',

--- a/cds/web/src/components/GlobalUpdateBadge.tsx
+++ b/cds/web/src/components/GlobalUpdateBadge.tsx
@@ -241,12 +241,9 @@ export function GlobalUpdateBadge(): JSX.Element | null {
         // 原先的 polling 已经在那转,无缝兜底。
         if (fallbackSuccessCount >= FALLBACK_POLLS_PER_SSE_RETRY) {
           fallbackSuccessCount = 0;
-          // ⚠ Bugbot Review 2026-05-06 7eefcba6: 不重置 consecutiveErrors /
-          // firstErrorAt 时,新 EventSource 的第一个 onerror 会用旧的(分钟级)
-          // firstErrorAt 算 elapsed,瞬间超阈值 → 立刻又回 fallback,升级永远
-          // 无效。这里清零让新 SSE 拿到完整的 30s × 3 次试错窗口。
-          consecutiveErrors = 0;
-          firstErrorAt = 0;
+          // ⚠ Bugbot 2026-05-06 d8a072be + d8a80ffd:counter reset 移到 connect()
+          // 内部、关旧 ES **之后**做。在外面先 reset 后 close 会留一个微任务窗口
+          // 让旧 ES 已 queue 的 onerror 把 0 又改成 1,污染新 ES 的阈值判断。
           // eslint-disable-next-line no-console
           console.info('[GlobalUpdateBadge] 尝试升级回 SSE 长连接(polling 继续滚作为兜底)');
           connect();
@@ -272,6 +269,11 @@ export function GlobalUpdateBadge(): JSX.Element | null {
         try { es.close(); } catch { /* ignore */ }
         es = null;
       }
+      // ⚠ Bugbot 7eefcba6 + d8a072be + d8a80ffd:counter reset 必须**在关旧 ES 之后**
+      // 立刻做,中间不留微任务窗口。否则旧 ES 已 queue 的 onerror 会把 0 又改成 1,
+      // 新 EventSource 的第一个 onerror 立刻达到阈值 → 升级永远失败。
+      consecutiveErrors = 0;
+      firstErrorAt = 0;
       try {
         es = new EventSource('/api/self-status/stream', { withCredentials: true });
       } catch {

--- a/cds/web/src/components/GlobalUpdateBadge.tsx
+++ b/cds/web/src/components/GlobalUpdateBadge.tsx
@@ -35,6 +35,16 @@ interface SelfStatusLite {
   bundleStale?: boolean;
   webBuildSha?: string;
   lastSelfUpdate?: { ts: string; status: string; toSha?: string } | null;
+  /** 后端 in-memory 标记:别 session/webhook 触发的 self-update 进行中。
+   *  SSE 透传到这里后,window dispatch 'cds:active-self-update' 让 MaintenanceTab
+   *  实时跨 tab 同步,不再依赖 30s 轮询(Bugbot 59568cb0)。 */
+  activeSelfUpdate?: {
+    startedAt: string;
+    branch: string;
+    trigger: 'manual' | 'force-sync' | 'auto-poll' | 'webhook';
+    actor?: string;
+    step?: string;
+  } | null;
 }
 
 type BadgeState =
@@ -131,6 +141,16 @@ export function GlobalUpdateBadge(): JSX.Element | null {
   //   4. else idle
   const applyPayload = useCallback((payload: SelfStatusLite, source: 'snapshot' | 'update' | 'manual'): void => {
     lastSuccessRef.current = payload;
+
+    // ⚠ Bugbot 59568cb0:把 activeSelfUpdate 通过 window CustomEvent 广播,
+    // MaintenanceTab 监听后立刻同步显示"正在重启",不再等 30s 轮询。
+    // SSE 30s ack 不够 — webhook 触发的 self-update 平均 70s 跑完,30s 轮询
+    // 只能看到 "正在结束" 那一帧,完全错过中间进度。
+    try {
+      window.dispatchEvent(new CustomEvent('cds:active-self-update', {
+        detail: payload.activeSelfUpdate ?? null,
+      }));
+    } catch { /* tolerate — older browsers */ }
 
     // 第一次成功(snapshot 或 manual 首次):记录初始 SHA,作为"页面打开后是否换版本"的基线
     if (!initialShaRef.current && payload.headSha) {

--- a/cds/web/src/components/GlobalUpdateBadge.tsx
+++ b/cds/web/src/components/GlobalUpdateBadge.tsx
@@ -209,6 +209,12 @@ export function GlobalUpdateBadge(): JSX.Element | null {
           fallbackSuccessCount = 0;
           fallbackActive = false;
           fallbackTimer = null;
+          // ⚠ Bugbot Review 2026-05-06 7eefcba6: 不重置 consecutiveErrors /
+          // firstErrorAt 时,新 EventSource 的第一个 onerror 会用旧的(分钟级)
+          // firstErrorAt 算 elapsed,瞬间超阈值 → 立刻又回 fallback,升级永远
+          // 无效。这里清零让新 SSE 拿到完整的 30s × 3 次试错窗口。
+          consecutiveErrors = 0;
+          firstErrorAt = 0;
           // eslint-disable-next-line no-console
           console.info('[GlobalUpdateBadge] 尝试升级回 SSE 长连接');
           connect();

--- a/cds/web/src/components/GlobalUpdateBadge.tsx
+++ b/cds/web/src/components/GlobalUpdateBadge.tsx
@@ -172,10 +172,16 @@ export function GlobalUpdateBadge(): JSX.Element | null {
     let firstErrorAt = 0;
     let consecutiveErrors = 0;
     let fallbackActive = false;
+    let fallbackSuccessCount = 0;
+    // ⚠ Bugbot Review 2026-05-06 0005a515: fallback polling 启动后永远不再尝
+    // 试 SSE,即使是临时网络/代理问题恢复了也只能等用户刷新页面。每 N 次成
+    // 功 poll 后试着重连一次 SSE;失败会被 onerror 重新拉回 polling。
+    const FALLBACK_POLLS_PER_SSE_RETRY = 5; // 5 * 60s = 5min 一次升级尝试
 
     const startFallbackPolling = (): void => {
       if (fallbackActive || cancelled) return;
       fallbackActive = true;
+      fallbackSuccessCount = 0;
       // eslint-disable-next-line no-console
       console.warn('[GlobalUpdateBadge] SSE 不可用,降级到 60s 轮询');
       const tick = async (): Promise<void> => {
@@ -188,15 +194,27 @@ export function GlobalUpdateBadge(): JSX.Element | null {
           if (r.ok) {
             const data = (await r.json()) as SelfStatusLite;
             if (!cancelled) applyPayload(data, 'update');
+            fallbackSuccessCount += 1;
           } else if (!cancelled) {
             setState({ kind: 'restarting', sinceMs: Date.now() });
           }
         } catch {
           if (!cancelled) setState({ kind: 'restarting', sinceMs: Date.now() });
         }
-        if (!cancelled) {
-          fallbackTimer = window.setTimeout(() => { void tick(); }, FALLBACK_POLL_INTERVAL_MS);
+        if (cancelled) return;
+        // 每 FALLBACK_POLLS_PER_SSE_RETRY 次成功 poll 后,试着重连 SSE。失败
+        // 会触发 onerror,达到阈值后 onerror 内会再调 startFallbackPolling()
+        // 把 fallback 重新拉起来 — 形成"polling ↔ SSE"自愈循环。
+        if (fallbackSuccessCount >= FALLBACK_POLLS_PER_SSE_RETRY) {
+          fallbackSuccessCount = 0;
+          fallbackActive = false;
+          fallbackTimer = null;
+          // eslint-disable-next-line no-console
+          console.info('[GlobalUpdateBadge] 尝试升级回 SSE 长连接');
+          connect();
+          return;
         }
+        fallbackTimer = window.setTimeout(() => { void tick(); }, FALLBACK_POLL_INTERVAL_MS);
       };
       void tick();
     };
@@ -238,7 +256,12 @@ export function GlobalUpdateBadge(): JSX.Element | null {
       });
 
       es.addEventListener('keepalive', () => {
-        // 心跳:无 payload 价值,丢弃。本身能进 handler 就说明连接还活着。
+        // ⚠ Bugbot Review 2026-05-06 fda43466: keepalive 到达本身证明连接活着,
+        // 必须用来"反证"restarting。否则当服务端 computeSelfStatusPayload 异常
+        // 被 try/catch 吞掉时,snapshot 事件永远不到,徽章会卡在 "CDS 不可达 Ns"。
+        consecutiveErrors = 0;
+        firstErrorAt = 0;
+        setState((prev) => (prev.kind === 'restarting' ? { kind: 'idle' } : prev));
       });
 
       es.onerror = (): void => {

--- a/cds/web/src/components/GlobalUpdateBadge.tsx
+++ b/cds/web/src/components/GlobalUpdateBadge.tsx
@@ -89,6 +89,12 @@ export function GlobalUpdateBadge(): JSX.Element | null {
   useEffect(() => () => {
     if (collapseTimerRef.current) window.clearTimeout(collapseTimerRef.current);
   }, []);
+  // 2026-05-06 用户反馈"常开":state.kind 切换时(restart→idle / updated→restart 等)
+  // 强制 unpin + collapse,避免某 kind 偶然钉住后被另一 kind 继承。
+  useEffect(() => {
+    setPinned(false);
+    setExpanded(false);
+  }, [state.kind]);
 
   // dismiss 短期:用户主动关掉徽章 → 接下来 1 小时不再显示(各 kind 独立,
   // 真发生新事件会再覆盖)。存 sessionStorage 标签关了就丢。
@@ -494,7 +500,10 @@ export function GlobalUpdateBadge(): JSX.Element | null {
             <RefreshCw className={`h-3.5 w-3.5 ${refreshing ? 'animate-spin' : ''}`} />
           </button>
         ) : null}
-        {expanded ? (
+        {/* 用户反馈 2026-05-06"常开":restarting 是瞬态(SSE 重连即消失),
+            钉住没意义反而误操作风险。仅在 updateAvailable / bundleStale / updated
+            这种"用户需要决定"的稳定态显示 Pin。restart 永远走 hover-intent 自动收。 */}
+        {expanded && state.kind !== 'restarting' ? (
           <button
             type="button"
             onClick={(e) => {

--- a/cds/web/src/components/GlobalUpdateBadge.tsx
+++ b/cds/web/src/components/GlobalUpdateBadge.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { AlertTriangle, ArrowUpCircle, CheckCircle2, Loader2, RefreshCw, Sparkles, X } from 'lucide-react';
+import { AlertTriangle, ArrowUpCircle, CheckCircle2, Loader2, Pin, PinOff, RefreshCw, Sparkles, X } from 'lucide-react';
 
 /*
  * GlobalUpdateBadge — 浮在屏幕左下角的全局 CDS 更新状态徽章。
@@ -384,15 +384,42 @@ export function GlobalUpdateBadge(): JSX.Element | null {
 
   const visual = visualForState(state);
 
+  // 用户反馈 2026-05-06:hover 离开瞬间徽章就收起,鼠标根本来不及划到
+  // "立即更新" / "刷新" / "关闭" 这几个按钮 — 像走钢丝。改 hover-intent:
+  // - 进入立即展开
+  // - 离开延迟 280ms 才收起,中途再 enter 取消
+  // - 已展开 + 点击 chip 主体 = 钉住(pinned),不再受 mouseLeave 影响
+  //   (再点一次 unpin)
+  const collapseTimerRef = useRef<number | null>(null);
+  const [pinned, setPinned] = useState(false);
+  const handleEnter = useCallback(() => {
+    if (collapseTimerRef.current) {
+      window.clearTimeout(collapseTimerRef.current);
+      collapseTimerRef.current = null;
+    }
+    setExpanded(true);
+  }, []);
+  const handleLeave = useCallback(() => {
+    if (pinned) return;
+    if (collapseTimerRef.current) window.clearTimeout(collapseTimerRef.current);
+    collapseTimerRef.current = window.setTimeout(() => {
+      setExpanded(false);
+      collapseTimerRef.current = null;
+    }, 280);
+  }, [pinned]);
+  useEffect(() => () => {
+    if (collapseTimerRef.current) window.clearTimeout(collapseTimerRef.current);
+  }, []);
+
   return (
     <div
       className="fixed bottom-4 left-4 z-[200] select-none"
       style={{ pointerEvents: 'auto' }}
     >
       <div
-        className={`flex items-stretch gap-0 overflow-hidden rounded-full border shadow-2xl transition-all duration-200 ${visual.borderClass} ${visual.bgClass}`}
-        onMouseEnter={() => setExpanded(true)}
-        onMouseLeave={() => setExpanded(false)}
+        className={`flex items-stretch gap-0 overflow-hidden rounded-full border shadow-2xl transition-all duration-200 ${visual.borderClass} ${visual.bgClass} ${pinned ? 'ring-2 ring-amber-400/40' : ''}`}
+        onMouseEnter={handleEnter}
+        onMouseLeave={handleLeave}
       >
         <button
           type="button"
@@ -433,6 +460,20 @@ export function GlobalUpdateBadge(): JSX.Element | null {
             title="立即检查远端更新"
           >
             <RefreshCw className={`h-3.5 w-3.5 ${refreshing ? 'animate-spin' : ''}`} />
+          </button>
+        ) : null}
+        {expanded ? (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              setPinned((p) => !p);
+            }}
+            className={`flex shrink-0 items-center justify-center px-2 ${visual.textClass} ${pinned ? 'opacity-100' : 'opacity-60'} transition-opacity hover:opacity-100`}
+            aria-label={pinned ? '取消钉住' : '钉住面板'}
+            title={pinned ? '取消钉住(点击,鼠标移开会自动收起)' : '钉住面板(点击,鼠标移开也不收起)'}
+          >
+            {pinned ? <PinOff className="h-3.5 w-3.5" /> : <Pin className="h-3.5 w-3.5" />}
           </button>
         ) : null}
         {expanded ? (

--- a/cds/web/src/components/GlobalUpdateBadge.tsx
+++ b/cds/web/src/components/GlobalUpdateBadge.tsx
@@ -62,6 +62,33 @@ export function GlobalUpdateBadge(): JSX.Element | null {
   const refreshingRef = useRef(false);
   const initialShaRef = useRef<string>('');
   const lastSuccessRef = useRef<SelfStatusLite | null>(null);
+  // 用户反馈 2026-05-06:hover 离开瞬间徽章就收起,鼠标根本来不及划到
+  // "立即更新" / "刷新" / "关闭" 这几个按钮 — 像走钢丝。改 hover-intent:
+  // - 进入立即展开
+  // - 离开延迟 280ms 才收起,中途再 enter 取消
+  // - 钉住按钮(Pin/PinOff):pinned 时鼠标移开也不收
+  // ⚠ Bugbot 2026-05-06 286deafc(High):这几个 hook **必须在** if (state.kind=='idle') return null
+  // **之前**声明,否则 idle ↔ 非 idle 切换时 hook 调用顺序变化,React 直接 crash。
+  const collapseTimerRef = useRef<number | null>(null);
+  const [pinned, setPinned] = useState(false);
+  const handleEnter = useCallback(() => {
+    if (collapseTimerRef.current) {
+      window.clearTimeout(collapseTimerRef.current);
+      collapseTimerRef.current = null;
+    }
+    setExpanded(true);
+  }, []);
+  const handleLeave = useCallback(() => {
+    if (pinned) return;
+    if (collapseTimerRef.current) window.clearTimeout(collapseTimerRef.current);
+    collapseTimerRef.current = window.setTimeout(() => {
+      setExpanded(false);
+      collapseTimerRef.current = null;
+    }, 280);
+  }, [pinned]);
+  useEffect(() => () => {
+    if (collapseTimerRef.current) window.clearTimeout(collapseTimerRef.current);
+  }, []);
 
   // dismiss 短期:用户主动关掉徽章 → 接下来 1 小时不再显示(各 kind 独立,
   // 真发生新事件会再覆盖)。存 sessionStorage 标签关了就丢。
@@ -383,33 +410,6 @@ export function GlobalUpdateBadge(): JSX.Element | null {
   if (state.kind === 'idle' || isDismissed(state.kind)) return null;
 
   const visual = visualForState(state);
-
-  // 用户反馈 2026-05-06:hover 离开瞬间徽章就收起,鼠标根本来不及划到
-  // "立即更新" / "刷新" / "关闭" 这几个按钮 — 像走钢丝。改 hover-intent:
-  // - 进入立即展开
-  // - 离开延迟 280ms 才收起,中途再 enter 取消
-  // - 已展开 + 点击 chip 主体 = 钉住(pinned),不再受 mouseLeave 影响
-  //   (再点一次 unpin)
-  const collapseTimerRef = useRef<number | null>(null);
-  const [pinned, setPinned] = useState(false);
-  const handleEnter = useCallback(() => {
-    if (collapseTimerRef.current) {
-      window.clearTimeout(collapseTimerRef.current);
-      collapseTimerRef.current = null;
-    }
-    setExpanded(true);
-  }, []);
-  const handleLeave = useCallback(() => {
-    if (pinned) return;
-    if (collapseTimerRef.current) window.clearTimeout(collapseTimerRef.current);
-    collapseTimerRef.current = window.setTimeout(() => {
-      setExpanded(false);
-      collapseTimerRef.current = null;
-    }, 280);
-  }, [pinned]);
-  useEffect(() => () => {
-    if (collapseTimerRef.current) window.clearTimeout(collapseTimerRef.current);
-  }, []);
 
   return (
     <div

--- a/cds/web/src/components/GlobalUpdateBadge.tsx
+++ b/cds/web/src/components/GlobalUpdateBadge.tsx
@@ -253,6 +253,11 @@ export function GlobalUpdateBadge(): JSX.Element | null {
           // 注意:这里**不**清 fallbackTimer,polling 继续作为兜底,
           // SSE 的 onopen 里才真正关掉 polling。
         }
+        // ⚠ Bugbot 2026-05-06 ed38c0a0:in-flight tick 可能在 onopen 已经把
+        // fallbackActive 翻成 false / 清完 fallbackTimer **之后**才 await 完成,
+        // 这里如果无脑 setTimeout 会再起一个 fallbackTimer,onopen 永远关不掉
+        // → polling 永远停不下来。补 active+cancelled guard。
+        if (cancelled || !fallbackActive) return;
         fallbackTimer = window.setTimeout(() => { void tick(); }, FALLBACK_POLL_INTERVAL_MS);
       };
       void tick();
@@ -260,6 +265,13 @@ export function GlobalUpdateBadge(): JSX.Element | null {
 
     const connect = (): void => {
       if (cancelled) return;
+      // ⚠ Bugbot 2026-05-06 ed38c0a0:升级路径每次 connect() 都新建 EventSource,
+      // 不关旧的 → 旧 ES 留在 selfStatusClients 里继续吃心跳 + 重复触发 applyPayload。
+      // 进 connect 先关掉旧实例兜底。
+      if (es) {
+        try { es.close(); } catch { /* ignore */ }
+        es = null;
+      }
       try {
         es = new EventSource('/api/self-status/stream', { withCredentials: true });
       } catch {

--- a/cds/web/src/index.css
+++ b/cds/web/src/index.css
@@ -147,6 +147,23 @@
   }
 
   /*
+   * BranchCard 命中高亮 — 用户在搜索框粘贴已有分支名 + 回车后触发。
+   * ReactBits 风格的呼吸边框光晕,1.6s 内三次 pulse 然后归位,提示
+   * "就是这张卡",不跳页。
+   */
+  @keyframes cds-card-pulse-glow {
+    0%   { box-shadow: 0 0 0 0 hsl(var(--primary) / 0.0), 0 0 0 0 hsl(var(--primary) / 0.0); }
+    20%  { box-shadow: 0 0 0 3px hsl(var(--primary) / 0.55), 0 0 24px 6px hsl(var(--primary) / 0.45); }
+    40%  { box-shadow: 0 0 0 1px hsl(var(--primary) / 0.25), 0 0 12px 2px hsl(var(--primary) / 0.20); }
+    60%  { box-shadow: 0 0 0 3px hsl(var(--primary) / 0.55), 0 0 24px 6px hsl(var(--primary) / 0.45); }
+    80%  { box-shadow: 0 0 0 1px hsl(var(--primary) / 0.25), 0 0 12px 2px hsl(var(--primary) / 0.20); }
+    100% { box-shadow: 0 0 0 0 hsl(var(--primary) / 0.0), 0 0 0 0 hsl(var(--primary) / 0.0); }
+  }
+  .cds-card-pulse {
+    animation: cds-card-pulse-glow 1600ms ease-out;
+  }
+
+  /*
    * AppShell — Railway-style two-column layout.
    * Left rail (56px) holds icon nav + theme toggle. Right column is the work area.
    * The shell paints surface-base; pages paint their own surface-raised cards.

--- a/cds/web/src/pages/BranchDetailPage.tsx
+++ b/cds/web/src/pages/BranchDetailPage.tsx
@@ -121,6 +121,7 @@ interface ProfileRow {
     command?: string;
     containerPort?: number;
     pathPrefixes?: string[];
+    startupSignal?: string;
   };
 }
 
@@ -915,6 +916,23 @@ export function BranchDetailPage(): JSX.Element {
     await saveProfileOverride(profile, next);
   }, [saveProfileOverride]);
 
+  // 用户反馈 2026-05-06:"启动标志"功能丢了 — 实际上后端 startupSignal 一直在,
+  // 只是前端 UI 没暴露入口。补上这个 prompt:输入 stdout 子串(如 "Listening on")
+  // 或正则,容器只要在日志里出现这串就被判为 ready,不必等 readiness HTTP 探针。
+  // 参考默认值:vite 走 "➜  Network:"(branches.ts:4922 已用此 pattern 自动检测)。
+  const editProfileStartupSignalOverride = useCallback(async (profile: ProfileRow) => {
+    const current = profile.override?.startupSignal || profile.effective?.startupSignal || '';
+    const input = window.prompt(
+      '启动信号(日志里出现这串就视为 ready,如 "Listening on" / "ready in" / "➜ Network:");留空走默认 readiness probe',
+      current,
+    );
+    if (input === null) return;
+    const next = { ...(profile.override || {}) };
+    if (input.trim()) next.startupSignal = input.trim();
+    else delete next.startupSignal;
+    await saveProfileOverride(profile, next);
+  }, [saveProfileOverride]);
+
   const editProfilePathPrefixesOverride = useCallback(async (profile: ProfileRow) => {
     const current = profile.override?.pathPrefixes || profile.effective?.pathPrefixes || [];
     const input = window.prompt('路径前缀覆写，多个用逗号分隔；留空则继承公共配置', current.join(', '));
@@ -1549,6 +1567,10 @@ export function BranchDetailPage(): JSX.Element {
                           <ExternalLink />
                           路径前缀
                         </Button>
+                        <Button size="sm" variant="outline" onClick={() => void editProfileStartupSignalOverride(selectedProfile)}>
+                          <TerminalSquare />
+                          启动信号
+                        </Button>
                         {selectedProfile.hasOverride ? (
                           <Button size="sm" variant="outline" onClick={() => void clearProfileOverride(selectedProfile)}>
                             <RefreshCw />
@@ -1559,6 +1581,10 @@ export function BranchDetailPage(): JSX.Element {
                       <Field label="镜像" value={selectedProfile.effective?.dockerImage || '未设置'} />
                       <Field label="端口" value={selectedProfile.effective?.containerPort || '未设置'} />
                       <Field label="路径前缀" value={(selectedProfile.effective?.pathPrefixes || []).join(', ') || '默认'} />
+                      <Field
+                        label="启动信号"
+                        value={selectedProfile.effective?.startupSignal || '未设置(走默认 readiness 探针)'}
+                      />
                       <div>
                         <div className="mb-1 text-xs font-semibold uppercase tracking-normal text-muted-foreground">命令</div>
                         <pre className="max-h-32 overflow-auto whitespace-pre-wrap rounded-md bg-muted p-3 font-mono text-xs leading-5">

--- a/cds/web/src/pages/BranchListPage.tsx
+++ b/cds/web/src/pages/BranchListPage.tsx
@@ -2800,28 +2800,33 @@ function BranchCard({
       }}
       aria-label={`打开 ${branch.branch} 详情`}
     >
-      {/* Header */}
-      <header className="flex min-w-0 items-start justify-between gap-4 px-5 pt-5">
-        <div className="flex min-w-0 items-start gap-3">
+      {/* Header — 用户反馈 2026-05-06:
+          - 时间和 ··· 不可挡住分支名 → 时间下沉到 chip 行右侧 / commit 行,
+            顶行只保留 dot + 分支名 + ···(右上角缩到 6×6 容器,不挤标题)
+          - 分支名给最大宽度,truncate(必要时 hover 显示完整) */}
+      <header className="flex min-w-0 items-start justify-between gap-3 px-5 pt-5">
+        <div className="flex min-w-0 flex-1 items-start gap-3">
           <span
             className={`mt-2 inline-block h-2.5 w-2.5 shrink-0 rounded-full ${statusRailClass(branch.status)} ${
               isRunning ? 'shadow-[0_0_8px_rgba(16,185,129,0.45)]' : ''
-            }`}
+            } ${isInterim ? 'animate-pulse' : ''}`}
             aria-hidden
           />
           <div className="min-w-0 flex-1">
             <div className="flex min-w-0 items-center gap-1.5">
-              <h3 className="min-w-0 truncate text-[17px] font-semibold leading-7 tracking-tight">{branch.branch}</h3>
+              <h3
+                className="min-w-0 truncate text-[17px] font-semibold leading-7 tracking-tight"
+                title={branch.branch}
+              >
+                {branch.branch}
+              </h3>
               {branch.isFavorite ? <Star className="h-3 w-3 shrink-0 fill-current text-amber-500" /> : null}
               {branch.isColorMarked ? <Lightbulb className="h-3 w-3 shrink-0 text-primary" /> : null}
             </div>
           </div>
         </div>
 
-        <div className="flex shrink-0 items-start gap-1.5" onClick={(event) => event.stopPropagation()}>
-          <span className="mt-2 whitespace-nowrap text-sm text-muted-foreground">
-            {formatRelativeTime(branch.lastDeployAt || branch.lastAccessedAt)}
-          </span>
+        <div className="flex shrink-0 items-start" onClick={(event) => event.stopPropagation()}>
           <BranchMoreMenu
             busy={busy}
             branch={branch}
@@ -2837,26 +2842,36 @@ function BranchCard({
       </header>
 
       {/* 状态/服务 chip 行 — wrap 不 nowrap,所有 port 全部显示(无 +N 折叠)。
-          未运行不再显示"未运行"chip(整卡已淡化暗示)。异常和中间态保留 chip。 */}
+          用户反馈 2026-05-06:
+          - running 时端口 chip 已带绿点,"运行中"chip 完全冗余 → 删
+          - 启动中 / 异常 时,端口 chip 色统一跟 branch 状态(以前是
+            service.status,会出现"branch 启动中蓝 / 服务 chip 绿"割裂)
+          - 时间挪到这一行最右,小号灰字,绝对不挡分支名 */}
       <div className="flex max-w-full flex-wrap items-center gap-2 px-5 pt-3">
-        {/* status chip 仅在异常/中间态显示;running 也保留(实心绿色,正向反馈) */}
-        {(isRunning || isError || isInterim) ? (
+        {/* status chip 仅在异常/中间态显示;running 删除(冗余) */}
+        {(isError || isInterim) ? (
           <span className={`inline-flex h-6 shrink-0 items-center gap-1.5 rounded-md border px-2 text-xs ${statusClass(branch.status)}`}>
             <span className={`h-1.5 w-1.5 rounded-full ${statusRailClass(branch.status)}`} aria-hidden />
             {statusLabel(branch.status)}
           </span>
         ) : null}
-        {portChips.length > 0 ? portChips.map((service) => (
-          <span
-            key={service.profileId}
-            className={`inline-flex h-6 shrink-0 items-center gap-1.5 rounded-md border px-2 font-mono text-xs ${statusClass(service.status)}`}
-            title={service.profileId}
-          >
-            <span className={`h-1.5 w-1.5 rounded-full ${statusRailClass(service.status)}`} aria-hidden />
-            <span>{compactServiceLabel(service.profileId)}</span>
-            <span>:{service.hostPort}</span>
-          </span>
-        )) : (
+        {portChips.length > 0 ? portChips.map((service) => {
+          // 端口 chip 颜色优先跟 branch 整体态:isInterim/isError 时强制对齐
+          // (端口监听了不代表流量已通,容易给用户"绿色=就绪"的错觉);
+          // running 时才用 service 自身状态做精细化区分。
+          const chipStatus = isInterim || isError ? branch.status : service.status;
+          return (
+            <span
+              key={service.profileId}
+              className={`inline-flex h-6 shrink-0 items-center gap-1.5 rounded-md border px-2 font-mono text-xs ${statusClass(chipStatus)}`}
+              title={service.profileId}
+            >
+              <span className={`h-1.5 w-1.5 rounded-full ${statusRailClass(chipStatus)}`} aria-hidden />
+              <span>{compactServiceLabel(service.profileId)}</span>
+              <span>:{service.hostPort}</span>
+            </span>
+          );
+        }) : (
           // 没有 port 时显示概览(只有当至少有 service 才显示,否则啥都不显示)
           serviceCount(branch) > 0 ? (
             <span className="inline-flex h-6 shrink-0 items-center rounded-md border border-[hsl(var(--hairline))] px-2 text-xs text-muted-foreground">
@@ -2864,6 +2879,9 @@ function BranchCard({
             </span>
           ) : null
         )}
+        <span className="ml-auto whitespace-nowrap text-xs text-muted-foreground">
+          {formatRelativeTime(branch.lastDeployAt || branch.lastAccessedAt)}
+        </span>
       </div>
 
       <BranchFailureHint branch={branch} />

--- a/cds/web/src/pages/BranchListPage.tsx
+++ b/cds/web/src/pages/BranchListPage.tsx
@@ -804,6 +804,10 @@ export function BranchListPage(): JSX.Element {
   const [state, setState] = useState<LoadState>({ status: 'loading' });
   const [selectedBranchIds, setSelectedBranchIds] = useState<string[]>([]);
   const [manualBranchName, setManualBranchName] = useState('');
+  // 用户在搜索框粘贴已有分支名/SHA + 回车时,不再跳页打开预览,而是高亮
+  // 那张卡片(ReactBits 风格的 1.6s pulse 边框光晕)。1.6s 后自动归位。
+  const [highlightedBranchId, setHighlightedBranchId] = useState<string | null>(null);
+  const highlightTimerRef = useRef<number | null>(null);
   const [toast, setToast] = useState('');
   const [actions, setActions] = useState<Record<string, BranchAction>>({});
   const [actionClock, setActionClock] = useState(Date.now());
@@ -1545,6 +1549,24 @@ export function BranchListPage(): JSX.Element {
     }
   }, [deployBranch, openPreview, projectId, refresh, setAction, state, trackedByName]);
 
+  // 触发卡片 pulse 高亮 + 滚动可视。1.6s 后自动归位以便再次触发同一张卡。
+  const flashBranchCard = useCallback((branchId: string): void => {
+    if (highlightTimerRef.current) window.clearTimeout(highlightTimerRef.current);
+    setHighlightedBranchId(branchId);
+    requestAnimationFrame(() => {
+      const el = document.querySelector<HTMLElement>(`[data-branch-card-id="${CSS.escape(branchId)}"]`);
+      if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    });
+    highlightTimerRef.current = window.setTimeout(() => {
+      setHighlightedBranchId(null);
+      highlightTimerRef.current = null;
+    }, 1600);
+  }, []);
+
+  useEffect(() => () => {
+    if (highlightTimerRef.current) window.clearTimeout(highlightTimerRef.current);
+  }, []);
+
   const previewBranchByName = useCallback(async (name: string): Promise<void> => {
     const branchName = name.trim();
     if (!branchName) {
@@ -1552,9 +1574,18 @@ export function BranchListPage(): JSX.Element {
       return;
     }
     if (!projectId || state.status !== 'ok') return;
-    const existing = trackedByName.get(branchName) || branches.find((branch) => branch.id === branchName);
+    // 命中规则:branch name(完整 / 大小写敏感)→ branch.id → commitSha 前缀。
+    // 后两个让"粘贴 commit / tag"也能落到本地已部署的卡片,不至于走创建分支兜底。
+    const lower = branchName.toLowerCase();
+    const existing =
+      trackedByName.get(branchName) ||
+      branches.find((branch) => branch.id === branchName) ||
+      branches.find((branch) => branch.commitSha && branch.commitSha.toLowerCase().startsWith(lower) && lower.length >= 7);
     if (existing) {
-      await openPreview(existing, true);
+      // 用户反馈:已有分支不要跳页,本页高亮即可。橙色 pulse 提示"就是这张"。
+      setManualBranchName('');
+      setBranchSearchOpen(false);
+      flashBranchCard(existing.id);
       return;
     }
     setAction(branchName, createAction('create', '正在创建分支'));
@@ -1573,7 +1604,7 @@ export function BranchListPage(): JSX.Element {
       setAction(branchName, finishAction(actionRef.current[branchName], 'create', message, 'error'));
       setToast(message);
     }
-  }, [branches, deployBranch, openPreview, projectId, refresh, setAction, state, trackedByName]);
+  }, [branches, deployBranch, flashBranchCard, projectId, refresh, setAction, state, trackedByName]);
 
   useEffect(() => {
     const requestedBranch = previewQueryRef.current.trim();
@@ -1955,6 +1986,7 @@ export function BranchListPage(): JSX.Element {
                     branch={branch}
                     action={actions[branch.id]}
                     projectId={projectId}
+                    highlighted={highlightedBranchId === branch.id}
                     capacityWarning={state.status === 'ok' ? capacityMessage(state.capacity, [branch]) : ''}
                     onPreview={() => void openPreview(branch, true)}
                     onDeploy={() => void deployBranch(branch, false)}
@@ -2682,6 +2714,7 @@ function BranchCard({
   branch,
   action,
   capacityWarning,
+  highlighted,
   onPreview,
   // 2026-05-04 重设计:部署按钮从卡片右下移到「分支详情抽屉 → 设置 tab」。
   // onDeploy prop 保留是为了不打断父组件 ProjectListPage / 上层 BranchListPage
@@ -2705,6 +2738,9 @@ function BranchCard({
   // callers when we later need it (e.g. cross-project routing tests).
   projectId?: string;
   selected?: boolean;
+  // 搜索框命中"已粘贴的分支名/SHA"时,父组件 set 这个 prop = true,触发
+  // 1.6s 边框 pulse + 自动滚到可视区。详见 flashBranchCard / index.css。
+  highlighted?: boolean;
   onSelect?: () => void;
   onPreview: () => void;
   onDeploy: () => void;
@@ -2745,13 +2781,14 @@ function BranchCard({
 
   return (
     <article
+      data-branch-card-id={branch.id}
       className={`group relative flex min-h-[158px] cursor-pointer flex-col overflow-hidden rounded-md border ${
         isError
           ? 'border-destructive/60 bg-destructive/5 ring-1 ring-destructive/30 shadow-[0_0_0_1px_hsl(var(--destructive)/0.25),0_4px_16px_-4px_hsl(var(--destructive)/0.35)]'
           : 'border-[hsl(var(--hairline))] bg-[hsl(var(--surface-raised))]'
       } transition-[border-color,box-shadow,transform,opacity] duration-150 hover:-translate-y-0.5 hover:border-[hsl(var(--hairline-strong))] hover:shadow-md hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 ${
         dimWholeCard ? 'opacity-60' : ''
-      }`}
+      } ${highlighted ? 'cds-card-pulse' : ''}`}
       role="button"
       tabIndex={0}
       onClick={onDetail}

--- a/cds/web/src/pages/cds-settings/tabs/MaintenanceTab.tsx
+++ b/cds/web/src/pages/cds-settings/tabs/MaintenanceTab.tsx
@@ -340,7 +340,11 @@ export function MaintenanceTab({ onToast }: { onToast: (message: string) => void
   // 不需要手动按"重试"按钮。
   const loadSelfStatus = useCallback(async () => {
     try {
-      const data = await apiRequest<SelfStatusResponse>('/api/self-status');
+      // 用户反馈 2026-05-06:面板永远显示 "fetch 失败 / 远端不可达 — top-level
+      // lightweight version"。根因:server.ts:1114 顶层 handler 抢答 /api/self-status,
+      // 默认走"轻量"分支(不调 git fetch),fetchOk 永远 false,remoteAheadCount 永远 0。
+      // 必须 ?probe=remote 才会 next() 流到 branches.ts:8116 的完整版,真实 fetch + 算 ahead。
+      const data = await apiRequest<SelfStatusResponse>('/api/self-status?probe=remote');
       setSelfStatus({ status: 'ok', data });
     } catch (err) {
       setSelfStatus((prev) => {
@@ -861,9 +865,29 @@ function SelfUpdateStatusPanel({
     data.remoteAheadCount === 0
       ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300'
       : 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300';
+  // 用户反馈 2026-05-06:"现在版本和最新版本差多少 / 差距在哪里"。
+  // 一句话总结:本地 SHA · 远端最新 SHA · 落后 N commit。chip 之上,扫一眼定位。
+  const remoteHeadSha = data.remoteAheadSubjects[0]?.sha;
+  const showVersionSummary = data.fetchOk && (data.headSha || remoteHeadSha);
 
   return (
     <div className="rounded-md border border-border bg-card px-4 py-3">
+      {showVersionSummary ? (
+        <div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm">
+          <span className="text-muted-foreground">本地</span>
+          <CodePill>{data.headSha || '-'}</CodePill>
+          <span className="text-muted-foreground">→</span>
+          <span className="text-muted-foreground">远端最新</span>
+          <CodePill>{remoteHeadSha || data.headSha || '-'}</CodePill>
+          {data.remoteAheadCount > 0 ? (
+            <span className="font-semibold text-amber-700 dark:text-amber-300">
+              落后 {data.remoteAheadCount} 个 commit
+            </span>
+          ) : (
+            <span className="font-semibold text-emerald-700 dark:text-emerald-300">已是最新</span>
+          )}
+        </div>
+      ) : null}
       <div className="flex flex-wrap items-center gap-2">
         {/* GitHub 远端状态 chip */}
         <span className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-xs ${aheadColor}`}>

--- a/cds/web/src/pages/cds-settings/tabs/MaintenanceTab.tsx
+++ b/cds/web/src/pages/cds-settings/tabs/MaintenanceTab.tsx
@@ -54,6 +54,12 @@ interface SelfUpdateRecord {
   noOp?: boolean;
 }
 
+interface SystemdUnitDrift {
+  repoHash: string;
+  installedHash: string;
+  installedAt?: string;
+}
+
 interface SelfStatusResponse {
   currentBranch: string;
   headSha: string;
@@ -63,6 +69,9 @@ interface SelfStatusResponse {
   remoteAheadCount: number;
   localAheadCount: number;
   remoteAheadSubjects: Array<{ sha: string; subject: string; date: string }>;
+  /** 仓库里的 systemd unit 文件 vs 已安装的 /etc/systemd/system/cds-master.service
+   *  归一化后比对 hash 不一致时填,提示 operator 一行命令重装。 */
+  systemdUnitDrift?: SystemdUnitDrift | null;
   lastSelfUpdate: SelfUpdateRecord | null;
   selfUpdateHistory: SelfUpdateRecord[];
 }
@@ -963,6 +972,31 @@ function SelfUpdateStatusPanel({
       {!data.fetchOk && data.fetchError ? (
         <div className="mt-2 text-xs text-muted-foreground">
           fetch 错误:{data.fetchError.slice(0, 200)}
+        </div>
+      ) : null}
+
+      {/* 用户反馈 2026-05-06 — systemd unit 漂移提示。
+          重构后 unit 文件极少改,但确实改时 operator 不知道 → 默默用旧 unit。
+          这里 backend 检测到漂移,UI 一行命令告诉怎么修。 */}
+      {data.systemdUnitDrift ? (
+        <div className="mt-3 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2.5 text-xs">
+          <div className="mb-1 flex items-center gap-2 text-amber-700 dark:text-amber-300">
+            <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+            <span className="font-medium">systemd unit 文件已更新但未重装</span>
+          </div>
+          <div className="text-muted-foreground">
+            仓库:<CodePill>{data.systemdUnitDrift.repoHash}</CodePill> · 已装:
+            <CodePill>{data.systemdUnitDrift.installedHash}</CodePill>
+            {data.systemdUnitDrift.installedAt
+              ? ` · 上次安装 ${formatRelativeTime(data.systemdUnitDrift.installedAt)}`
+              : ''}
+          </div>
+          <div className="mt-1.5 font-mono text-[11px] text-muted-foreground">
+            一次性修(SSH 到 host):<br />
+            <span className="text-foreground">
+              cd {'<repo>'}/cds && ./exec_cds.sh install-systemd && sudo cp /tmp/cds-master.service.* /etc/systemd/system/cds-master.service && sudo systemctl daemon-reload
+            </span>
+          </div>
         </div>
       ) : null}
     </div>

--- a/cds/web/src/pages/cds-settings/tabs/MaintenanceTab.tsx
+++ b/cds/web/src/pages/cds-settings/tabs/MaintenanceTab.tsx
@@ -60,6 +60,16 @@ interface SystemdUnitDrift {
   installedAt?: string;
 }
 
+/** 用户反馈 2026-05-06:中间面板不知道别 session/webhook 触发的 self-update。
+ *  backend 暴露 in-progress 标记,任何 tab 打开都能立刻显示"正在重启"。 */
+interface ActiveSelfUpdate {
+  startedAt: string;
+  branch: string;
+  trigger: 'manual' | 'force-sync' | 'auto-poll' | 'webhook';
+  actor?: string;
+  step?: string;
+}
+
 interface SelfStatusResponse {
   currentBranch: string;
   headSha: string;
@@ -69,6 +79,8 @@ interface SelfStatusResponse {
   remoteAheadCount: number;
   localAheadCount: number;
   remoteAheadSubjects: Array<{ sha: string; subject: string; date: string }>;
+  /** 非空表示后端正在跑 self-update / self-force-sync(任一 session 触发) */
+  activeSelfUpdate?: ActiveSelfUpdate | null;
   /** 仓库里的 systemd unit 文件 vs 已安装的 /etc/systemd/system/cds-master.service
    *  归一化后比对 hash 不一致时填,提示 operator 一行命令重装。 */
   systemdUnitDrift?: SystemdUnitDrift | null;
@@ -333,6 +345,34 @@ export function MaintenanceTab({ onToast }: { onToast: (message: string) => void
   // 2026-05-04 新增:CDS 自更新可见性面板状态(用户:"我不清楚是否有自动更新")
   const [selfStatus, setSelfStatus] = useState<SelfStatusState>({ status: 'loading' });
   const [historyOpen, setHistoryOpen] = useState(false);
+
+  // ⚠ 2026-05-06 用户反馈"中间没更新左下角在动" — server-authority 同步:
+  // 检测到 backend 有 in-progress self-update(可能是别 session/webhook 触发),
+  // 自动设 runState='running'。本地 click 也走这条 — useEffect 不会冲突,
+  // 因为 activeSelfUpdate 真存在时不会回退到 idle。
+  const activeSelfUpdate = selfStatus.status === 'ok' ? selfStatus.data.activeSelfUpdate : null;
+  useEffect(() => {
+    if (activeSelfUpdate && runState === 'idle') {
+      setRunState('running');
+      setRunStartedAt(Date.parse(activeSelfUpdate.startedAt) || Date.now());
+      const triggerLabel = activeSelfUpdate.trigger === 'webhook' ? 'GitHub webhook'
+        : activeSelfUpdate.trigger === 'auto-poll' ? '后台轮询'
+        : activeSelfUpdate.trigger === 'force-sync' ? '强制同步'
+        : '更新';
+      setRunTitle(`${triggerLabel} 进行中${activeSelfUpdate.step ? ` · ${activeSelfUpdate.step}` : ''}`);
+      setRunLog([`检测到后端正在跑 ${triggerLabel}(actor: ${activeSelfUpdate.actor || 'unknown'}),本 tab 同步显示进度`]);
+    } else if (activeSelfUpdate && runState === 'running' && activeSelfUpdate.step) {
+      // 阶段名变了 — 实时同步标题
+      setRunTitle((prev) => {
+        const triggerLabel = activeSelfUpdate.trigger === 'webhook' ? 'GitHub webhook'
+          : activeSelfUpdate.trigger === 'auto-poll' ? '后台轮询'
+          : activeSelfUpdate.trigger === 'force-sync' ? '强制同步'
+          : '更新';
+        const next = `${triggerLabel} 进行中 · ${activeSelfUpdate.step}`;
+        return prev === next ? prev : next;
+      });
+    }
+  }, [activeSelfUpdate, runState]);
 
   const loadBranches = useCallback(async () => {
     setBranchState({ status: 'loading' });

--- a/cds/web/src/pages/cds-settings/tabs/MaintenanceTab.tsx
+++ b/cds/web/src/pages/cds-settings/tabs/MaintenanceTab.tsx
@@ -44,8 +44,10 @@ interface SelfUpdateRecord {
   error?: string;
   actor?: string;
   /** 用户反馈 2026-05-06 — 让用户看到走了哪种更新模式。
-   *  hot-reload = node --watch 平滑重启(~3s,只 emit dist 不动 systemd)
-   *  restart    = process.exit + systemd 全量重启(~70s,改了依赖/配置/路由 schema 等)
+   *  hot-reload = 跳过 validate(节省 50s)+ systemd 软重启,~15-25s。
+   *               改动只涉及应用代码(.ts/.tsx),且未触及依赖/配置/路由 schema。
+   *  restart    = 完整 validate + systemd 重启,~70-95s。
+   *               改了依赖/Dockerfile/tsconfig/.env/路由表/types schema 等。
    *  noOp       = HEAD 已是 .build-sha 的版本,啥都没做(~3s)
    */
   updateMode?: 'hot-reload' | 'restart' | 'noOp';
@@ -1009,10 +1011,10 @@ function SelfUpdateHistoryList({ state }: { state: SelfStatusState }): JSX.Eleme
                       : '完整重启';
                 const tip =
                   mode === 'hot-reload'
-                    ? 'node --watch 平滑重启,改动只涉及应用代码'
+                    ? '应用代码改动,跳过 validate(节省 ~50s)走 systemd 软重启'
                     : mode === 'noOp'
                       ? 'HEAD 已与 dist 完全一致,啥都没做'
-                      : '改动涉及依赖/配置/路由 schema,走 systemd 完整重启';
+                      : '改动涉及依赖/配置/路由 schema,走 systemd 完整重启(含 validate)';
                 return (
                   <span
                     className={`inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-[10px] ${tone}`}

--- a/cds/web/src/pages/cds-settings/tabs/MaintenanceTab.tsx
+++ b/cds/web/src/pages/cds-settings/tabs/MaintenanceTab.tsx
@@ -43,6 +43,13 @@ interface SelfUpdateRecord {
   durationMs?: number;
   error?: string;
   actor?: string;
+  /** 用户反馈 2026-05-06 — 让用户看到走了哪种更新模式。
+   *  hot-reload = node --watch 平滑重启(~3s,只 emit dist 不动 systemd)
+   *  restart    = process.exit + systemd 全量重启(~70s,改了依赖/配置/路由 schema 等)
+   *  noOp       = HEAD 已是 .build-sha 的版本,啥都没做(~3s)
+   */
+  updateMode?: 'hot-reload' | 'restart' | 'noOp';
+  noOp?: boolean;
 }
 
 interface SelfStatusResponse {
@@ -984,6 +991,37 @@ function SelfUpdateHistoryList({ state }: { state: SelfStatusState }): JSX.Eleme
               {rec.durationMs !== undefined ? (
                 <span className="text-xs text-muted-foreground">{(rec.durationMs / 1000).toFixed(1)}s</span>
               ) : null}
+              {/* 2026-05-06:让用户一眼看出本次走的是哪条更新路径 */}
+              {(() => {
+                const mode = rec.updateMode || (rec.noOp ? 'noOp' : undefined);
+                if (!mode) return null;
+                const tone =
+                  mode === 'hot-reload'
+                    ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300'
+                    : mode === 'noOp'
+                      ? 'border-sky-500/40 bg-sky-500/10 text-sky-700 dark:text-sky-300'
+                      : 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300';
+                const label =
+                  mode === 'hot-reload'
+                    ? '热重载'
+                    : mode === 'noOp'
+                      ? '已是最新'
+                      : '完整重启';
+                const tip =
+                  mode === 'hot-reload'
+                    ? 'node --watch 平滑重启,改动只涉及应用代码'
+                    : mode === 'noOp'
+                      ? 'HEAD 已与 dist 完全一致,啥都没做'
+                      : '改动涉及依赖/配置/路由 schema,走 systemd 完整重启';
+                return (
+                  <span
+                    className={`inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-[10px] ${tone}`}
+                    title={tip}
+                  >
+                    {label}
+                  </span>
+                );
+              })()}
             </div>
             <div className="flex flex-wrap items-center gap-2 text-xs">
               <CodePill>{rec.branch || '(当前分支)'}</CodePill>

--- a/cds/web/src/pages/cds-settings/tabs/MaintenanceTab.tsx
+++ b/cds/web/src/pages/cds-settings/tabs/MaintenanceTab.tsx
@@ -436,9 +436,28 @@ export function MaintenanceTab({ onToast }: { onToast: (message: string) => void
       }, delay);
     };
     tick(30000);
+
+    // ⚠ Bugbot 59568cb0:GlobalUpdateBadge 已订阅 /api/self-status/stream,
+    // 接收 SSE snapshot/update 事件后会 dispatch 'cds:active-self-update'。
+    // 这里监听该事件,把 activeSelfUpdate 立刻 patch 进本地 selfStatus,
+    // 不再等 30s 轮询周期 — 别 tab/webhook 触发的自更新进度实时跨 tab 同步。
+    const onActive = (e: Event): void => {
+      const detail = (e as CustomEvent<ActiveSelfUpdate | null>).detail ?? null;
+      setSelfStatus((prev) => {
+        if (prev.status !== 'ok') return prev;
+        // detail 与现状相等就不触发重渲染,避免 useEffect 噪音。
+        const cur = prev.data.activeSelfUpdate ?? null;
+        const same = (cur?.startedAt === detail?.startedAt) && (cur?.step === detail?.step) && (cur?.trigger === detail?.trigger);
+        if (same) return prev;
+        return { status: 'ok', data: { ...prev.data, activeSelfUpdate: detail } };
+      });
+    };
+    window.addEventListener('cds:active-self-update', onActive);
+
     return () => {
       disposed = true;
       if (timer) clearTimeout(timer);
+      window.removeEventListener('cds:active-self-update', onActive);
     };
   }, [loadBranches, loadSelfStatus]);
 

--- a/cds/web/tsconfig.json
+++ b/cds/web/tsconfig.json
@@ -19,7 +19,9 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "incremental": true,
+    "tsBuildInfoFile": "./.tsbuildinfo"
   },
   "include": ["src", "vite.config.ts"]
 }

--- a/changelogs/2026-05-05_cds-env-bootstrap-fix.md
+++ b/changelogs/2026-05-05_cds-env-bootstrap-fix.md
@@ -1,0 +1,1 @@
+| fix | cds | 修复 GitHub App config 永远 undefined 的"幽灵 webhook 503"bug —— 抽 load-env.ts 独立模块，让 config.ts 顶部 side-effect import；self-loader 语义改为"空字符串占位也覆盖"，消除 self-update spawn 透传 stale 空值导致的二次失效 |

--- a/changelogs/2026-05-05_cds-force-sync-fail-safe.md
+++ b/changelogs/2026-05-05_cds-force-sync-fail-safe.md
@@ -1,0 +1,1 @@
+| fix | cds | self-force-sync 改 fail-safe 顺序 + 主动 in-process backend build：validate 先做（不动 dist），通过才清 dist + 跑 npx tsc 重建。consequences：validate 失败时 dist 完好 cds 继续跑；validate 通过时 dist 立刻就位无需 systemd ExecStartPre 兜底，杜绝"force-sync abort 后 cds 起不来需要 SSH 救场" |

--- a/changelogs/2026-05-05_cds-self-status-event-driven.md
+++ b/changelogs/2026-05-05_cds-self-status-event-driven.md
@@ -1,0 +1,2 @@
+| feat | cds | self-status 改事件驱动：新增 SSE 端点 /api/self-status/stream（snapshot/update/keepalive 三类事件 + 25s 心跳）+ webhook push 事件触发 broadcastSelfStatus + 删除 60s server cache，回归"诚实"查询 |
+| feat | cds | GlobalUpdateBadge 改用 EventSource 订阅 SSE，删除 30s/5s 双档自动轮询，新增"立即检查更新"手动刷新按钮（spin 动画 + 主题 token）；EventSource 不可用时回落 60s 兜底 polling |

--- a/changelogs/2026-05-05_cds-shared-infra-and-self-status-cache.md
+++ b/changelogs/2026-05-05_cds-shared-infra-and-self-status-cache.md
@@ -1,0 +1,2 @@
+| fix | cds | startInfraService 改为幂等：共享 mongo/redis 等 long-lived infra 容器在 deploy 时不再被 docker rm -f 强删（保护用户正在使用的连接），running 直接复用、stopped 改用 docker start 唤醒、不存在才创建 |
+| perf | cds | /api/self-status?probe=remote 加 60 秒 in-process 缓存，前端 GlobalUpdateBadge 反复轮询不再每次触发 git fetch（之前 5-10 秒导致页面整体卡） |

--- a/changelogs/2026-05-05_cds-shared-infra-default-skip.md
+++ b/changelogs/2026-05-05_cds-shared-infra-default-skip.md
@@ -1,0 +1,1 @@
+| fix | cds | 修正 deploy 流程对 infra 的处理：默认共享模式（init 时一次性建好，所有分支共用 mongo/redis）下，deploy 不再触碰 infra（不重启、不 health 阻塞），杜绝"共享 mongo 被强删"+"deploy 因 infra healthcheck 等待变慢"两类故障。新增 Project.infraIsolation 字段，'per-branch' 才走原启动链路 |

--- a/changelogs/2026-05-06_cds-bugbot-cold-tsc-and-status-fallback.md
+++ b/changelogs/2026-05-06_cds-bugbot-cold-tsc-and-status-fallback.md
@@ -1,0 +1,2 @@
+| perf | cds | self-force-sync cold path 不再重复跑 tsc — Bugbot 858bca04 (Medium):validateBuildReadiness 已跑过 tsc --noEmit,build-backend 阶段只跑 esbuild,节省 5-30s。hot path 仍并行 tsc(validate skipTsc=true) |
+| fix | cds | /api/self-status catch fallback 补 activeSelfUpdate + systemdUnitDrift — Bugbot 50e705cf (Low):git fetch 偶发失败时 MaintenanceTab 跨 tab 同步 + drift banner 不再消失。drift 检测抽到顶层 helper detectSystemdUnitDrift,两路共用 |

--- a/changelogs/2026-05-06_cds-bugbot-low-severity-fixes.md
+++ b/changelogs/2026-05-06_cds-bugbot-low-severity-fixes.md
@@ -1,0 +1,1 @@
+| fix | cds | 修复 Cursor Bugbot 两条 Low Severity：SSE client 加进池移到 snapshot 写入之后（保证 snapshot → update 顺序）；config.ts 的 githubApp/publicBaseUrl 回归 module-level eager（与其它 env 字段一致，import './load-env.js' 已 spec 保证求值顺序），删 lazy 路径 |

--- a/changelogs/2026-05-06_cds-bugbot-self-update-finally-doc-only.md
+++ b/changelogs/2026-05-06_cds-bugbot-self-update-finally-doc-only.md
@@ -1,0 +1,2 @@
+| fix | cds | self-update / self-force-sync 路由顶层补 finally,Bugbot 31da8d97 (HIGH):recordFailure 自身抛错时 activeSelfUpdate 标记不再卡住 — 所有 tab 不再看到永久"自更新中"幽灵态。新增 `stateService.clearSelfUpdateActive()` 幂等清空 |
+| perf | cds | self-force-sync 改动全是文档/changelogs 时改走 doc-only fast-path,Bugbot 7749d6f8 (Medium):写新 commit 的 .build-sha 后直接 return,跳过 validate + esbuild + tsc + atomic swap + restart(节省 ~70-95s) |

--- a/changelogs/2026-05-06_cds-bugbot-three-medium.md
+++ b/changelogs/2026-05-06_cds-bugbot-three-medium.md
@@ -1,0 +1,3 @@
+| fix | cds | exec_cds.sh master-run pnpm install 失败时 fail-fast(exit 78 EX_CONFIG)— Bugbot 982b38ca (Medium):lockfile 漂移 / pnpm store 损坏 / 磁盘满时不再静默继续启动 stale node_modules |
+| fix | cds | self-force-sync doc-only fast-path 必须 irrelevantPaths > 0 — Bugbot da715c3c (Medium):空 diff(fromSha == newHead 但 .build-sha 缺失/不匹配)不再误命中 fast-path 写假 SHA,改走冷路径重新 build |
+| fix | cds | self-status SSE 透传 activeSelfUpdate — Bugbot 59568cb0 (Medium):GlobalUpdateBadge 收到 SSE 后 dispatch CustomEvent,MaintenanceTab 监听后实时跨 tab 同步,不再依赖 30s 轮询 |

--- a/changelogs/2026-05-06_cds-codex-p2-fixes.md
+++ b/changelogs/2026-05-06_cds-codex-p2-fixes.md
@@ -1,0 +1,1 @@
+| fix | cds | 修复 Codex P2 review：computeSelfStatusPayload 给 currentBranch 加 isSafeGitRef shell injection 守卫；self-force-sync in-process build 改 atomic dist swap（编译到 dist.next/ → 验证 → 原子三步替换 → 清备份），任何阶段失败旧 dist 完好 |


### PR DESCRIPTION
## Summary

This PR addresses multiple critical issues in CDS self-update and infrastructure management:

1. **Event-driven self-status** — Replaces 30s polling with SSE-based push notifications
2. **Shared infrastructure protection** — Prevents accidental deletion of long-lived containers during deploy
3. **Environment bootstrap fix** — Ensures GitHub App config loads correctly on systemd startup
4. **Self-update fail-safe** — Validates code before clearing dist/ to prevent startup failures

## Key Changes

### Self-Status Event-Driven Architecture
- **New SSE endpoint** `GET /api/self-status/stream` with three event types:
  - `snapshot` — Initial cached state on connection (no git fetch)
  - `update` — Real-time updates triggered by GitHub push webhooks
  - `keepalive` — 25s heartbeat to prevent proxy timeouts
- **Webhook integration** — GitHub push events now trigger `broadcastSelfStatus()` to notify all connected clients
- **Removed polling** — Deleted 60s in-process cache; `/api/self-status` now does honest queries on demand
- **GlobalUpdateBadge refactor** — Subscribes to SSE stream instead of 30s polling; falls back to 60s polling if SSE unavailable after 3 consecutive errors over 30s

### Shared Infrastructure Protection
- **Idempotent container startup** — `startInfraService()` now checks container state:
  - `running` → reuse without touching (protects user connections)
  - `stopped` → `docker start` to wake up (preserves volumes/config)
  - missing → `docker run` to create
- **Deploy flow fix** — Shared mode (default) now skips infra startup entirely; only `per-branch` isolation mode triggers full infra lifecycle
- **New field** `Project.infraIsolation` ('shared' | 'per-branch') to control behavior

### Environment Bootstrap Fix
- **New module** `load-env.ts` — Extracted self-loader to ensure it runs before `config.ts` module evaluation
- **Side-effect import** in `config.ts` — Guarantees `.cds.env` is loaded before `DEFAULT_CONFIG.githubApp` is computed
- **Improved semantics** — Empty string values now treated as "unset" and overwritten by disk values (fixes stale env in self-update spawn)
- **Fixes "phantom 503"** — GitHub App config no longer undefined due to timing issues

### Self-Force-Sync Fail-Safe
- **Reordered validation** — `tsc --noEmit` runs before clearing dist/ (no side effects)
- **In-process rebuild** — After validation passes, actively runs `npx tsc` to rebuild dist/ immediately (doesn't rely on systemd ExecStartPre)
- **Consequence** — Validation failures leave dist/ intact; CDS continues running old version without manual intervention
- **Increased timeout** — systemd `TimeoutStartSec` raised to 5 minutes for cold builds after dist/ cleanup

### Additional Improvements
- Extracted `computeSelfStatusPayload()` as shared pure function (used by both `/api/self-status` and SSE broadcast)
- Added `safeExec()` pattern with graceful degradation — all git commands fail individually without crashing endpoint
- Improved error messages and logging for debugging
- Added `RefreshCw` icon to GlobalUpdateBadge for manual refresh button

## Implementation Details

- **Module-level state** — `selfStatusContext` and `selfStatusClients` Set stored at module scope in `branches.ts` to allow webhook access
- **Webhook integration** — `github-webhook.ts` caches current branch and calls `broadcastSelfStatus()` on push events matching CDS's branch
- **Graceful degradation** — SSE failures automatically fall back to polling; all git operations tolerate timeouts/failures
- **Idempotency** — Container startup checks actual Docker state; repeated calls are safe
- **Backward compatible** — `/api/self-status` endpoint unchanged; clients can use either polling or SSE

https://claude.ai/code/session_01SbvfGyjd1XTiLQ9xQZ9uNz

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes production-critical paths: self-update/build flow, systemd startup command/limits, deploy infra lifecycle, and long-lived SSE/webhook-triggered git operations; regressions could prevent CDS from starting or disrupt deployments.
> 
> **Overview**
> Shifts CDS self-update visibility from polling to **event-driven SSE**: adds `GET /api/self-status/stream` (snapshot/update/keepalive), coalesced `broadcastSelfStatus()` updates triggered by GitHub `push` webhooks, and refactors `/api/self-status` to share a single `computeSelfStatusPayload()` with graceful degradation; the web `GlobalUpdateBadge` is rewritten to consume SSE with fallback polling and new UX controls, and Maintenance UI gains cross-tab “active self-update” syncing plus systemd unit drift reporting.
> 
> Hardens startup/update/deploy reliability: extracts `.cds.env` loading into a dedicated `load-env.ts` side-effect import to fix config timing and stale empty env values, introduces a systemd-friendly `exec_cds.sh master-run` entrypoint (unit now calls the script and relaxes `MemoryMax`/adds `TimeoutStartSec`), and significantly reworks `self-force-sync`/validation to avoid bricking installs (atomic `dist.next` swap, faster esbuild emit with optional `tsc --noEmit`, doc-only/no-op fast paths, and explicit active-update markers with `finally` cleanup).
> 
> Protects shared infrastructure and reduces deploy churn: deploy skips infra start/health waits unless `Project.infraIsolation === 'per-branch'`, `startInfraService()` becomes idempotent (reuse/start existing containers instead of `docker rm -f`), adds pnpm-only per-(branch,profile) `node_modules` Docker volumes with cleanup on branch deletion, and removes per-container Docker memory limits (keeps CPU limits).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98851978fe8295b3ca2d212b231f1aa5efbbd616. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->