### PR TITLE
Add TikTok/Douyin creator subscription workflow with homepage poster publishing

### DIFF
--- a/changelogs/2026-05-05_tiktok-creator-to-homepage.md
+++ b/changelogs/2026-05-05_tiktok-creator-to-homepage.md
@@ -1,3 +1,4 @@
 | feat | prd-api | 工作流新增 tiktok-creator-fetch 胶囊（调 TikHub 拉博主视频列表，输出标准化 items 数组 + firstItem 快捷字段）
 | feat | prd-api | 工作流新增 homepage-publisher 胶囊（下载媒体并写入 HomepageAsset，slot/objectKey 规则与 HomepageAssetsController 对齐）
 | feat | prd-admin | 工作流模板新增「TikTok 博主订阅 → 首页海报」：填 secUid + API 密钥 → 抓最新视频 → 直发首页槽位
+| refactor | prd-admin | TikTok 博主订阅模板瘦身：必填项从 5 项砍到 2 项（API 密钥 + secUid，secUid 默认填 TikHub 官方示例），默认发封面图到 card.showcase 槽位避开 tt_chain_token 复杂度

--- a/changelogs/2026-05-05_tiktok-creator-to-homepage.md
+++ b/changelogs/2026-05-05_tiktok-creator-to-homepage.md
@@ -15,3 +15,4 @@
 | feat | prd-admin | 海报弹窗新增 ad-4-3 展示模式：4:3 比例 + 全 bleed cover/video + 中央 Play 按钮 + 用户主动点击播放（借鉴 Apple 产品视频弹窗 / Netflix 预告 modal / Twitch 视频卡片，autoplay 容易吓跑用户）。修改 WeeklyPosterModal.tsx 根据 presentationMode 切换 aspectRatio 和 PageView 组件
 | feat | prd-api | weekly-poster-publisher 暴露 presentationMode 配置（默认 ad-4-3）；视频 URL 时同步把 cover 写到 SecondaryImageUrl 作为 video poster 海报，pause 状态显示静图，点击后切到真视频
 | refactor | prd-admin | TikTok / 抖音订阅模板默认 presentationMode='ad-4-3'，CTA 文案随平台切换（"去 TikTok 看完整视频" / "去抖音看完整视频"）
+| fix | prd-admin | 修复 ad-4-3 弹窗左上角破图占位符：cover 改用独立 <img> 层渲染（带 onError 静默隐藏 + accentColor 渐变兜底），<video> 元素仅在用户点 Play 后才挂载并 autoplay。彻底避开 <video poster=动图webp> 在部分浏览器渲染破图的问题

--- a/changelogs/2026-05-05_tiktok-creator-to-homepage.md
+++ b/changelogs/2026-05-05_tiktok-creator-to-homepage.md
@@ -4,3 +4,6 @@
 | refactor | prd-admin | TikTok 博主订阅模板瘦身：必填项从 5 项砍到 2 项（API 密钥 + secUid，secUid 默认填 TikHub 官方示例），默认发封面图到 card.showcase 槽位避开 tt_chain_token 复杂度
 | fix | prd-api | TikTok 端点改用 app/v3（/api/v1/tiktok/app/v3/fetch_user_post_videos），web 端点上游 TikTok 实测 400（连官方示例 secUid 也失败）。app/v3 稳定可用，响应结构 data.aweme_list 与抖音对齐
 | fix | prd-api | TikTok coverUrl 改优先取 video.dynamic_cover（WebP）。TikTok 默认的 video.cover/origin_cover 实际返回 HEIC，浏览器无法直接显示
+| feat | prd-api | 工作流新增 weekly-poster-publisher 胶囊：把上游条目数组写入 WeeklyPoster 集合并发布，登录后首页轮播弹窗即时显示。每条 item 对应海报一页（title/body/imageUrl），imageUrl 前端自动识别视频/图片
+| feat | prd-api | tiktok-creator-fetch 标准化输出新增 shareUrl 字段（拼 https://www.tiktok.com/@unique_id/video/aweme_id），便于海报 CTA 直跳 TikTok
+| refactor | prd-admin | TikTok 模板改名「订阅 → 首页弹窗海报」，发布节点改用 weekly-poster-publisher，count 默认 4（弹窗 4 页轮播），CTA 自动跳到 TikTok 视频页

--- a/changelogs/2026-05-05_tiktok-creator-to-homepage.md
+++ b/changelogs/2026-05-05_tiktok-creator-to-homepage.md
@@ -16,3 +16,6 @@
 | feat | prd-api | weekly-poster-publisher 暴露 presentationMode 配置（默认 ad-4-3）；视频 URL 时同步把 cover 写到 SecondaryImageUrl 作为 video poster 海报，pause 状态显示静图，点击后切到真视频
 | refactor | prd-admin | TikTok / 抖音订阅模板默认 presentationMode='ad-4-3'，CTA 文案随平台切换（"去 TikTok 看完整视频" / "去抖音看完整视频"）
 | fix | prd-admin | 修复 ad-4-3 弹窗左上角破图占位符：cover 改用独立 <img> 层渲染（带 onError 静默隐藏 + accentColor 渐变兜底），<video> 元素仅在用户点 Play 后才挂载并 autoplay。彻底避开 <video poster=动图webp> 在部分浏览器渲染破图的问题
+| fix | prd-admin | 收紧 isVideoUrl 检测：去除 host-only 匹配（tiktokcdn 等主机同时服务 cover 静图与 video，不应仅按 host 判定），仅认路径模式 /video/tos/ 与 /aweme/v{N}/play/。修复 weekly-poster-publisher fallback 到 coverUrl 时被误判为视频 → 渲染破图问题（Codex P2 / Bugbot Medium）
+| fix | prd-api | homepage-publisher MIME 残留 octet-stream 问题：CDN 返回 application/octet-stream 时用 ext 反推真实 mime（image/png / video/mp4 等），避免 COS 上对象 mime 错误导致前端拒绝渲染（Bugbot Medium）
+| docs | doc | 新增 plan.emergence-1-tiktok-douyin-poster.md：交接文档给下一智能体接 Phase 2（视频转文字 + 图文混排海报版式），含完整 Phase 1 教程、踩坑记录、Phase 2 子任务分解、关联文件

--- a/changelogs/2026-05-05_tiktok-creator-to-homepage.md
+++ b/changelogs/2026-05-05_tiktok-creator-to-homepage.md
@@ -7,3 +7,4 @@
 | feat | prd-api | 工作流新增 weekly-poster-publisher 胶囊：把上游条目数组写入 WeeklyPoster 集合并发布，登录后首页轮播弹窗即时显示。每条 item 对应海报一页（title/body/imageUrl），imageUrl 前端自动识别视频/图片
 | feat | prd-api | tiktok-creator-fetch 标准化输出新增 shareUrl 字段（拼 https://www.tiktok.com/@unique_id/video/aweme_id），便于海报 CTA 直跳 TikTok
 | refactor | prd-admin | TikTok 模板改名「订阅 → 首页弹窗海报」，发布节点改用 weekly-poster-publisher，count 默认 4（弹窗 4 页轮播），CTA 自动跳到 TikTok 视频页
+| fix | prd-api | WeeklyPosterController 补 [Authorize] 装饰器，AI Access Key 等 non-cookie 认证才能正常通过（之前缺这个标记，AdminPermissionMiddleware 直接拦在未登录分支返回 401）

--- a/changelogs/2026-05-05_tiktok-creator-to-homepage.md
+++ b/changelogs/2026-05-05_tiktok-creator-to-homepage.md
@@ -12,3 +12,6 @@
 | feat | prd-admin | isVideoUrl 扩展识别 TikTok / 抖音 CDN URL（路径含 /video/tos/ 或 host 含 tiktokcdn 等），无 .mp4 扩展名也能命中，被识别后走 <video autoplay loop> 自动播放
 | refactor | prd-api | weekly-poster-publisher 优先取 videoUrl（真实 mp4，前端直接 <video> 播放），fallback 到 coverUrl。海报弹窗由"模糊静图"升级为"自动播放视频"
 | feat | prd-admin | TikTok 订阅模板新增 platform 二选项（TikTok / 抖音），选抖音时走 sec_user_id + douyin web 端点
+| feat | prd-admin | 海报弹窗新增 ad-4-3 展示模式：4:3 比例 + 全 bleed cover/video + 中央 Play 按钮 + 用户主动点击播放（借鉴 Apple 产品视频弹窗 / Netflix 预告 modal / Twitch 视频卡片，autoplay 容易吓跑用户）。修改 WeeklyPosterModal.tsx 根据 presentationMode 切换 aspectRatio 和 PageView 组件
+| feat | prd-api | weekly-poster-publisher 暴露 presentationMode 配置（默认 ad-4-3）；视频 URL 时同步把 cover 写到 SecondaryImageUrl 作为 video poster 海报，pause 状态显示静图，点击后切到真视频
+| refactor | prd-admin | TikTok / 抖音订阅模板默认 presentationMode='ad-4-3'，CTA 文案随平台切换（"去 TikTok 看完整视频" / "去抖音看完整视频"）

--- a/changelogs/2026-05-05_tiktok-creator-to-homepage.md
+++ b/changelogs/2026-05-05_tiktok-creator-to-homepage.md
@@ -2,3 +2,4 @@
 | feat | prd-api | 工作流新增 homepage-publisher 胶囊（下载媒体并写入 HomepageAsset，slot/objectKey 规则与 HomepageAssetsController 对齐）
 | feat | prd-admin | 工作流模板新增「TikTok 博主订阅 → 首页海报」：填 secUid + API 密钥 → 抓最新视频 → 直发首页槽位
 | refactor | prd-admin | TikTok 博主订阅模板瘦身：必填项从 5 项砍到 2 项（API 密钥 + secUid，secUid 默认填 TikHub 官方示例），默认发封面图到 card.showcase 槽位避开 tt_chain_token 复杂度
+| fix | prd-api | TikTok 端点改用 app/v3（/api/v1/tiktok/app/v3/fetch_user_post_videos），web 端点上游 TikTok 实测 400（连官方示例 secUid 也失败）。app/v3 稳定可用，响应结构 data.aweme_list 与抖音对齐

--- a/changelogs/2026-05-05_tiktok-creator-to-homepage.md
+++ b/changelogs/2026-05-05_tiktok-creator-to-homepage.md
@@ -1,0 +1,3 @@
+| feat | prd-api | 工作流新增 tiktok-creator-fetch 胶囊（调 TikHub 拉博主视频列表，输出标准化 items 数组 + firstItem 快捷字段）
+| feat | prd-api | 工作流新增 homepage-publisher 胶囊（下载媒体并写入 HomepageAsset，slot/objectKey 规则与 HomepageAssetsController 对齐）
+| feat | prd-admin | 工作流模板新增「TikTok 博主订阅 → 首页海报」：填 secUid + API 密钥 → 抓最新视频 → 直发首页槽位

--- a/changelogs/2026-05-05_tiktok-creator-to-homepage.md
+++ b/changelogs/2026-05-05_tiktok-creator-to-homepage.md
@@ -3,3 +3,4 @@
 | feat | prd-admin | 工作流模板新增「TikTok 博主订阅 → 首页海报」：填 secUid + API 密钥 → 抓最新视频 → 直发首页槽位
 | refactor | prd-admin | TikTok 博主订阅模板瘦身：必填项从 5 项砍到 2 项（API 密钥 + secUid，secUid 默认填 TikHub 官方示例），默认发封面图到 card.showcase 槽位避开 tt_chain_token 复杂度
 | fix | prd-api | TikTok 端点改用 app/v3（/api/v1/tiktok/app/v3/fetch_user_post_videos），web 端点上游 TikTok 实测 400（连官方示例 secUid 也失败）。app/v3 稳定可用，响应结构 data.aweme_list 与抖音对齐
+| fix | prd-api | TikTok coverUrl 改优先取 video.dynamic_cover（WebP）。TikTok 默认的 video.cover/origin_cover 实际返回 HEIC，浏览器无法直接显示

--- a/changelogs/2026-05-05_tiktok-creator-to-homepage.md
+++ b/changelogs/2026-05-05_tiktok-creator-to-homepage.md
@@ -8,3 +8,7 @@
 | feat | prd-api | tiktok-creator-fetch 标准化输出新增 shareUrl 字段（拼 https://www.tiktok.com/@unique_id/video/aweme_id），便于海报 CTA 直跳 TikTok
 | refactor | prd-admin | TikTok 模板改名「订阅 → 首页弹窗海报」，发布节点改用 weekly-poster-publisher，count 默认 4（弹窗 4 页轮播），CTA 自动跳到 TikTok 视频页
 | fix | prd-api | WeeklyPosterController 补 [Authorize] 装饰器，AI Access Key 等 non-cookie 认证才能正常通过（之前缺这个标记，AdminPermissionMiddleware 直接拦在未登录分支返回 401）
+| fix | prd-admin | 移除 WeeklyPosterModal 用户端误传的 metaLabel="1200 × 628 · 发布"（编辑器调试残留），用户登录看到的弹窗右下角不再有这条提示
+| feat | prd-admin | isVideoUrl 扩展识别 TikTok / 抖音 CDN URL（路径含 /video/tos/ 或 host 含 tiktokcdn 等），无 .mp4 扩展名也能命中，被识别后走 <video autoplay loop> 自动播放
+| refactor | prd-api | weekly-poster-publisher 优先取 videoUrl（真实 mp4，前端直接 <video> 播放），fallback 到 coverUrl。海报弹窗由"模糊静图"升级为"自动播放视频"
+| feat | prd-admin | TikTok 订阅模板新增 platform 二选项（TikTok / 抖音），选抖音时走 sec_user_id + douyin web 端点

--- a/doc/plan.emergence-1-tiktok-douyin-poster.md
+++ b/doc/plan.emergence-1-tiktok-douyin-poster.md
@@ -1,0 +1,220 @@
+# 涌现 1 · TikTok / 抖音博主订阅 → 首页广告海报
+
+> **系列定位**: 涌现 1（emergence-1）。本仓库的"涌现"系列指**借助平台已有砖块（工作流胶囊 + LLM Gateway + 周报海报弹窗 + COS / HomepageAsset）组合出的新功能**。本期是该系列首作。
+>
+> **状态**: Phase 1 已上线，Phase 2 待下一个智能体接手。
+>
+> **交接对象**: 下一个负责 Phase 2 的智能体（人 / Cursor / Claude Code 均可）。
+
+---
+
+## 1. Phase 1 已交付（现状速览）
+
+### 1.1 用户视角教程
+
+#### 跑一次：手动触发
+
+1. 登录预览 → 百宝箱 → 工作流 → 新建 → 选模板「TikTok / 抖音 博主订阅 → 首页广告海报」
+2. 表单填两项必填 + 两项可选：
+   - **TikHub API 密钥** (必填) — 从 https://tikhub.io 用户中心取，或填 `{{secrets.TIKHUB_API_KEY}}` 引用工作流密钥
+   - **平台** — TikTok / 抖音 二选一
+   - **博主 secUid / sec_user_id** (必填) — TikTok 默认填官方示例 `MS4wLjABAAAAv7iSuuXDJGDvJkmH_vz1qkDZYo1apxgzaxdBSeIuPiM`，可改
+   - **展示几条作品** — 默认 4 条，对应海报 4 页轮播
+3. 点击执行 → 几秒后刷新首页 → 登录弹窗就是 4:3 视频广告海报
+
+#### 切换博主 / 平台
+
+工作流编辑器里直接改「拉取博主视频列表」节点的 `secUid` / `platform` 字段，保存重跑即可。
+
+#### 切换"主动播放" → "全自动定时拉"
+
+把首节点 `manual-trigger` 删除，换成 `timer` 胶囊（cron 表达式如 `0 */6 * * *` 每 6 小时）。Cron 调度器目前在 `wip:true` 状态——具体能不能跑要看部署版本。如不可用，兜底用外部 cron 周期调 `POST /api/workflow-agent/workflows/{id}/run`。
+
+### 1.2 技术视角架构
+
+```
+[手动触发] →  [tiktok-creator-fetch]  →  [weekly-poster-publisher]  →  WeeklyPoster (DB)
+                ↓                            ↓                              ↓
+            TikHub API                   写 4 页海报                   /api/weekly-posters/current
+        app/v3 (TikTok) /              presentationMode='ad-4-3'          首页弹窗读取
+        web (Douyin)                   imageUrl=videoUrl              <PosterAdPageView>
+                                       secondaryImageUrl=coverUrl     渲染 4:3 ad 弹窗
+```
+
+### 1.3 关键文件清单
+
+| 文件 | 职责 |
+|---|---|
+| `prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs` | `ExecuteTiktokCreatorFetchAsync` (~5750-5950) + `NormalizeTiktokVideoItem` + `ExecuteHomepagePublisherAsync` + `ExecuteWeeklyPosterPublisherAsync` (~6260-6420) |
+| `prd-api/src/PrdAgent.Core/Models/WorkflowModels.cs` | `CapsuleTypes.{TiktokCreatorFetch, HomepagePublisher, WeeklyPosterPublisher}` 常量 |
+| `prd-api/src/PrdAgent.Core/Models/CapsuleTypeRegistry.cs` | 三个胶囊的 ConfigSchema / Slots 元数据 |
+| `prd-api/src/PrdAgent.Core/Models/WeeklyPosterAnnouncement.cs` | 海报 Model（`PresentationMode` 字段是路由分发的关键） |
+| `prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx` | `PosterAdPageView` 4:3 ad 视图 + `isVideoUrl` 路径级视频探测 |
+| `prd-admin/src/pages/workflow-agent/workflowTemplates.ts` | `tiktokCreatorToHomepageTemplate` 模板定义 |
+| `prd-admin/src/pages/workflow-agent/capsuleRegistry.tsx` | 三个胶囊前端图标/分类注册 |
+| `prd-admin/src/services/real/weeklyPoster.ts` | `WeeklyPosterPresentationMode` type union（含 `'ad-4-3'`） |
+
+### 1.4 三个新胶囊速查
+
+| 胶囊 | 输入 | 输出 | 关键配置 |
+|---|---|---|---|
+| `tiktok-creator-fetch` | 触发（trigger）+ 配置 | items 数组 + firstItem | `platform`, `apiKey`, `secUid`, `count` |
+| `homepage-publisher` | 媒体 URL JSON | 发布结果（slot/url/mime） | `slot` (card.* / agent.*.image / hero.*), `mediaType`, `sourceField` (JSONPath) |
+| `weekly-poster-publisher` | items 数组 | posterId / pageCount | `presentationMode` (`ad-4-3` / `static`), `templateKey`, `accentColor`, `ctaText`, `ctaUrlField` |
+
+### 1.5 重要踩坑记录（防 Phase 2 重蹈覆辙）
+
+1. **TikHub `web/fetch_user_post` 上游 400**：连官方示例 secUid 也失败（TikTok web 限流），必须走 `app/v3/fetch_user_post_videos`。Douyin 走 `web/fetch_user_post_videos` 正常
+2. **TikTok `cover` / `origin_cover` 是 HEIC**：浏览器不支持渲染。`dynamic_cover` 才是 WebP 动图，能直接用
+3. **`<video poster={animated_webp}>` 渲染破图**：HTML5 `<video poster>` 只接静态图，动图 webp 用 `<img>` 独立层渲染才稳
+4. **`tiktokcdn` host 同时服务视频和封面**：`isVideoUrl` 不能仅用 host 判定，必须用路径（`/video/tos/` 或 `/aweme/v{N}/play/`）
+5. **`WeeklyPosterController` 缺 `[Authorize]`**：导致 AI Access Key 等 non-cookie 认证一律 401
+6. **`HomepagePublisher` MIME 残留 octet-stream**：CDN 返回 `application/octet-stream` 时必须用 ext 反推 mime，否则 COS 上的对象 mime 错误，前端拒绝渲染
+
+---
+
+## 2. Phase 2 待做（下一智能体）
+
+### 2.1 总目标
+
+把 TikTok / 抖音视频从"只看封面 + 点开播放"升级到**"图文并茂的内容卡"**：
+
+- 视频自动转文字（标题 / 字幕 / 描述）→ AI 摘要 → 海报正文
+- 海报每页支持"顶部动态封面 + 中段大字 hook + 底部转写摘要"图文混排
+- 不再仅仅是 4:3 全 bleed 视频
+
+### 2.2 子任务
+
+#### 任务 A: 视频转文字胶囊（接入现有 `video-to-text`）
+
+仓库**已有** `video-to-text` 胶囊（`CapsuleExecutor.cs:ExecuteVideoToTextAsync`），目前两种模式：
+- `metadata`: 直接用 TikHub 返回的 `title/desc/字幕` 字段（**免费 / 快**）
+- `llm`: 用多模态 LLM 看封面图 + 描述（**收费 / 较慢**）
+
+Phase 2 要做：
+1. **真音频转写模式**: 加第三种 `extractMode = 'asr'`，调系统已有 ASR 模型池（参考 `prd-api/src/.../Services/Asr*` 是否已存在；不存在则借用 `transcript-agent`）。先下载 mp4 → 提取音轨（ffmpeg） → ASR 文字稿
+2. **AI 二次提炼**: 转写后再走一遍 LLM Gateway 出"标题 / 一句话 hook / 三段要点"结构化文本
+3. 输出新增 `transcript / hook / bullets` 字段进上游 JSON
+
+#### 任务 B: 新海报版式 `ad-rich-text` 图文混排
+
+现有 `presentationMode` 路由：
+- `static` — 老横幅 1200×628
+- `ad-4-3` — 全 bleed 视频广告（Phase 1 做的）
+- **`ad-rich-text` (新增)** — 图文混排
+
+`ad-rich-text` 设计建议（参考 Apple Newsroom / Instagram Story Ad / 小红书笔记三套行业范式）：
+
+```
+┌────────────────────────────────────┐  4:3 或 3:4 都可
+│  ┌──────────┐                      │
+│  │          │  hook 大字 (clamp 28-44px)
+│  │ 顶部动图  │  例: "Girl's Trip Season"
+│  │  cover   │                      │
+│  │  16:9    │  ─────────────────   │
+│  │          │  • bullet 1          │
+│  └──────────┘  • bullet 2          │
+│                • bullet 3          │
+│                                    │
+│  [✦ @TikTok · 12s ago]    [Play ▶] │ ← 小角标，点 Play 切到 ad-4-3 全屏视频
+└────────────────────────────────────┘
+```
+
+实现要点：
+- 沿用 `WeeklyPosterPage` schema：`title`=hook, `body`=bullets (markdown), `imageUrl`=cover, `secondaryImageUrl`=videoUrl（点 Play 切回 ad-4-3 全 bleed）
+- 在 `WeeklyPosterModal.tsx` 加一个 `PosterRichTextPageView` 组件，由 `presentationMode === 'ad-rich-text'` 路由
+- 模板表单加 `presentationMode` 选项让用户选 ad-4-3 / ad-rich-text
+
+#### 任务 C: 工作流模板分叉
+
+现有：`tiktokCreatorToHomepageTemplate` (3 节点 ad-4-3)
+
+Phase 2 加：`tiktokCreatorToHomepageRichTemplate` (5 节点)
+
+```
+[手动触发] → [tiktok-creator-fetch] → [video-to-text (asr)] → [llm-analyzer (摘要)] → [weekly-poster-publisher (ad-rich-text)]
+```
+
+或者：让用户在原模板表单里选 `presentationMode`，模板 build() 里根据 mode 决定是否插入 `video-to-text + llm-analyzer` 两个中间节点（参数化模板）。
+
+#### 任务 D: 抖音 OAuth 长 token + 真订阅
+
+目前是手动触发。完整订阅闭环还差：
+1. 抖音 OAuth：用户授权后拿到长效 token，存到 `external_authorizations` 集合
+2. 定时调度：cron 5 分钟查一次，新作品入库前比对去重 key（aweme_id）
+3. 通知：新作品发布时除了换海报，还可推送 station 内 admin notification
+
+### 2.3 边界 / 不要做
+
+- ❌ **不要碰 `card.* / agent.*.image / hero.*` 这些首页设计资产**——那是设计师手动维护的视觉位（CLAUDE.md 用户已明确要求）。运营内容只走 `weekly_posters` 集合
+- ❌ **不要去掉 `[Authorize]` 装饰器** — 这是 admin controller 标配，去掉 AI Access Key 立刻 401
+- ❌ **不要把 cover URL 当视频处理** — TikTok CDN host 共用，必须走路径级别检测 (`/video/tos/`)
+- ❌ **不要在 `<video poster>` 里塞动图 webp** — Chromium 渲染破图占位符
+- ❌ **不要让模板默认 `count > 4`** — 海报弹窗 5 页起翻页疲劳
+
+---
+
+## 3. 交接给下一个智能体的步骤
+
+### 3.1 第一次拉到这个任务时
+
+```bash
+# 1. 切到 Phase 1 分支看现状
+git fetch origin claude/auto-publish-tiktok-subscription-dnNKX
+git checkout claude/auto-publish-tiktok-subscription-dnNKX
+
+# 2. 跑通 Phase 1 验证你环境 OK
+# - 打开 https://auto-publish-tiktok-subscription-dnnkx-claude-prd-agent.miduo.org/
+# - 登录 → 应弹出 4:3 ad 海报，4 页 TikTok 视频，中央 Play 按钮可点
+
+# 3. 读这份文档 + 关键文件
+cat doc/plan.emergence-1-tiktok-douyin-poster.md
+# 看 1.3 节"关键文件清单"列出的所有文件
+```
+
+### 3.2 开发 Phase 2 时
+
+#### 推荐顺序
+
+1. **先做任务 B（`ad-rich-text` 视图）**——纯前端，影响最小，能直接验证视觉
+2. **然后任务 A（ASR 转写）**——后端胶囊扩展，有 LLM Gateway 现成
+3. **任务 C（模板组合）**——把 A + B 串起来
+4. **任务 D（真订阅）放最后**——抖音 OAuth 是大头，不阻塞前面
+
+#### 每个任务做完跑这套验证
+
+```bash
+# 前端
+cd prd-admin && pnpm tsc --noEmit && pnpm exec eslint src/components/weekly-poster src/pages/workflow-agent
+
+# 后端
+cd prd-api && dotnet build --no-restore 2>&1 | grep -E "error CS|warning CS"
+
+# 端到端冒烟
+/cds-deploy   # 触发部署
+# 然后 7 层冒烟（参考 plan.emergence-1 §"冷测验收"段落）
+```
+
+#### Changelog
+
+每次提交在 `changelogs/2026-XX-XX_emergence-1-phase-2-*.md` 加碎片，**不要**直接编辑 `CHANGELOG.md`（CLAUDE.md 规则 #4）。
+
+### 3.3 完成后
+
+- 把 `presentationMode` 文档移到 `doc/spec.weekly-poster-presentation-modes.md`（独立文档）
+- 把 `涌现 1` 系列下一篇（涌现 2）开新文件 `doc/plan.emergence-2-*.md`，本文件保持只读历史
+- 更新 `doc/index.yml` 与 `doc/guide.list.directory.md`
+- 通知用户验收 + `/handoff` 出交接清单
+
+---
+
+## 4. 关联文档
+
+- `.claude/rules/marketplace.md` — 海鲜市场扩展（如要把 TikTok 订阅作为可分享的工作流模板上架）
+- `.claude/rules/server-authority.md` — Run/Worker 模式（cron 调度真订阅时必读）
+- `.claude/rules/llm-gateway.md` — ASR / 摘要必经
+- `prd-admin/src/lib/homepageAssetSlots.ts` — 首页 slot 注册表（**只读**，Phase 2 不需要动）
+
+---
+
+**最后更新**: 2026-05-06 / Phase 1 完成 commit `61046085`

--- a/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
+++ b/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
@@ -124,7 +124,7 @@ export function PosterCarousel({
           style={{ overflow: 'hidden' }}
           key={`page-${pageIndex}`}
         >
-          <WeeklyPosterPageView page={currentPage} weekKey={poster.weekKey} metaLabel="1200 × 628 · 发布" />
+          <WeeklyPosterPageView page={currentPage} weekKey={poster.weekKey} />
         </div>
 
         <div className="pointer-events-none absolute inset-x-0 bottom-0 z-20 h-24" style={{ background: 'linear-gradient(180deg, transparent, rgba(4,8,18,0.28))' }} />
@@ -315,7 +315,13 @@ export function WeeklyPosterPageView({
 }
 
 function isVideoUrl(url: string) {
-  return /^data:video\//i.test(url) || /\.(mp4|webm|mov|m4v)(\?|#|$)/i.test(url);
+  if (!url) return false;
+  if (/^data:video\//i.test(url)) return true;
+  if (/\.(mp4|webm|mov|m4v)(\?|#|$)/i.test(url)) return true;
+  // TikTok / 抖音 CDN 视频 URL 没有扩展名（路径含 /video/tos/）但 content-type 是 video/mp4
+  if (/(tiktokcdn|tiktokv|douyinvod|aweme\.snssdk|byteimg\.com\/.*\/video)/i.test(url)) return true;
+  if (/\/video\/tos\//i.test(url)) return true;
+  return false;
 }
 
 /**

--- a/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
+++ b/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
@@ -329,9 +329,12 @@ function isVideoUrl(url: string) {
   if (!url) return false;
   if (/^data:video\//i.test(url)) return true;
   if (/\.(mp4|webm|mov|m4v)(\?|#|$)/i.test(url)) return true;
-  // TikTok / 抖音 CDN 视频 URL 没有扩展名（路径含 /video/tos/）但 content-type 是 video/mp4
-  if (/(tiktokcdn|tiktokv|douyinvod|aweme\.snssdk|byteimg\.com\/.*\/video)/i.test(url)) return true;
+  // 必须用路径级别识别（host 共用：tiktokcdn 主机同时服务 cover 静图 + video，不能仅按 host 判定）：
+  // - TikTok app/v3 + 抖音 web 视频: 路径含 /video/tos/
+  // - 抖音 web 直链: 路径含 /aweme/v{N}/play/
+  // cover 走 /tos-xxx-p-/ 路径，不会命中以上模式。
   if (/\/video\/tos\//i.test(url)) return true;
+  if (/\/aweme\/v[0-9]+\/play\//i.test(url)) return true;
   return false;
 }
 

--- a/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
+++ b/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
-import { ChevronLeft, ChevronRight, X, ArrowRight, Sparkles } from 'lucide-react';
+import { ChevronLeft, ChevronRight, X, ArrowRight, Sparkles, Play } from 'lucide-react';
 import { useWeeklyPosterStore } from '@/stores/weeklyPosterStore';
 import { MarkdownContent } from '@/components/ui/MarkdownContent';
 import type { WeeklyPoster, WeeklyPosterPage } from '@/services';
@@ -80,6 +80,13 @@ export function PosterCarousel({
     touchStartX.current = null;
   };
 
+  const isAdMode = poster.presentationMode === 'ad-4-3';
+  const aspect = isAdMode ? '4 / 3' : '1200 / 628';
+  // 4:3 适合视频广告类弹窗（横屏不太宽、能装下竖屏视频又不极端），借鉴 Apple 产品视频弹窗 / Netflix 预告模态
+  const widthCalc = isAdMode
+    ? 'min(960px, calc((100vh - 80px) * 1.333), calc(100vw - 64px))'
+    : 'min(1120px, calc((100vh - 80px) * 1.91), calc(100vw - 64px))';
+
   const modal = (
     <div
       className="fixed inset-0 z-[9999] flex items-center justify-center"
@@ -96,9 +103,9 @@ export function PosterCarousel({
         onClick={(e) => e.stopPropagation()}
         className="relative overflow-hidden"
         style={{
-          width: 'min(1120px, calc((100vh - 80px) * 1.91), calc(100vw - 64px))',
-          aspectRatio: '1200 / 628',
-          background: '#06111e',
+          width: widthCalc,
+          aspectRatio: aspect,
+          background: isAdMode ? '#000' : '#06111e',
           border: '1px solid rgba(255,255,255,0.1)',
           borderRadius: 28,
           boxShadow:
@@ -109,7 +116,7 @@ export function PosterCarousel({
           type="button"
           onClick={onDismiss}
           aria-label="关闭"
-          className="absolute top-5 right-5 z-20 w-10 h-10 rounded-full flex items-center justify-center transition-all hover:scale-110"
+          className="absolute top-5 right-5 z-30 w-10 h-10 rounded-full flex items-center justify-center transition-all hover:scale-110"
           style={{
             background: 'rgba(0,0,0,0.55)',
             border: '1px solid rgba(255,255,255,0.12)',
@@ -124,7 +131,11 @@ export function PosterCarousel({
           style={{ overflow: 'hidden' }}
           key={`page-${pageIndex}`}
         >
-          <WeeklyPosterPageView page={currentPage} weekKey={poster.weekKey} />
+          {isAdMode ? (
+            <PosterAdPageView page={currentPage} weekKey={poster.weekKey} />
+          ) : (
+            <WeeklyPosterPageView page={currentPage} weekKey={poster.weekKey} />
+          )}
         </div>
 
         <div className="pointer-events-none absolute inset-x-0 bottom-0 z-20 h-24" style={{ background: 'linear-gradient(180deg, transparent, rgba(4,8,18,0.28))' }} />
@@ -322,6 +333,160 @@ function isVideoUrl(url: string) {
   if (/(tiktokcdn|tiktokv|douyinvod|aweme\.snssdk|byteimg\.com\/.*\/video)/i.test(url)) return true;
   if (/\/video\/tos\//i.test(url)) return true;
   return false;
+}
+
+/**
+ * 广告版海报页（4:3 全 bleed + 中央 Play + 用户主动点开）。
+ * 借鉴：Apple 产品发布会视频弹窗 / Netflix 预告 modal / Twitch 视频卡片。
+ *
+ * 关键差异 vs `WeeklyPosterPageView`：
+ *   - 全屏铺满 cover/video（不是上下分屏）
+ *   - 视频不 autoplay，显示中央 Play 按钮，用户点击才播
+ *   - 播放后 cover/title 渐隐，让视频成为主角
+ *   - 原生 controls，可暂停/调音量/全屏
+ */
+export function PosterAdPageView({
+  page,
+  weekKey,
+}: {
+  page: WeeklyPosterPage | undefined;
+  weekKey?: string;
+}) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [hasPlayed, setHasPlayed] = useState(false);
+
+  if (!page) return null;
+  const isVideo = isVideoUrl(page.imageUrl ?? '');
+
+  const handlePlay = () => {
+    const v = videoRef.current;
+    if (!v) return;
+    v.play().then(() => setHasPlayed(true)).catch(() => {
+      // 自动播放被浏览器拦截时，仍标记 hasPlayed 让 controls 显示
+      setHasPlayed(true);
+    });
+  };
+
+  return (
+    <div className="relative h-full" style={{ background: '#000' }}>
+      {/* 全 bleed 媒体层 */}
+      <div className="absolute inset-0">
+        {isVideo ? (
+          <video
+            ref={videoRef}
+            src={page.imageUrl ?? ''}
+            className="w-full h-full object-contain bg-black"
+            controls={hasPlayed}
+            playsInline
+            preload="metadata"
+            poster={page.secondaryImageUrl ?? undefined}
+            onEnded={() => {
+              // 播放完不重置，保留 controls 让用户重播
+            }}
+          />
+        ) : page.imageUrl ? (
+          <img
+            src={page.imageUrl}
+            alt=""
+            className="w-full h-full object-cover"
+            draggable={false}
+          />
+        ) : (
+          <div
+            className="w-full h-full flex items-center justify-center"
+            style={{
+              background: `linear-gradient(135deg, ${page.accentColor || '#7c3aed'} 0%, #0a0a12 100%)`,
+            }}
+          >
+            <div className="text-[120px] font-black text-white/20">
+              {(page.order + 1).toString().padStart(2, '0')}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* 中央 Play 按钮（仅在视频且未播放时显示） */}
+      {isVideo && !hasPlayed && (
+        <button
+          type="button"
+          onClick={handlePlay}
+          aria-label="播放视频"
+          className="absolute inset-0 z-10 flex items-center justify-center group cursor-pointer"
+          style={{ background: 'rgba(0,0,0,0.18)' }}
+        >
+          <div
+            className="flex items-center justify-center transition-all duration-200 group-hover:scale-110"
+            style={{
+              width: 96,
+              height: 96,
+              borderRadius: '50%',
+              background: 'rgba(255,255,255,0.18)',
+              backdropFilter: 'blur(16px)',
+              WebkitBackdropFilter: 'blur(16px)',
+              border: '1.5px solid rgba(255,255,255,0.35)',
+              boxShadow: '0 12px 40px rgba(0,0,0,0.5)',
+            }}
+          >
+            <Play size={36} fill="white" strokeWidth={0} style={{ marginLeft: 4 }} />
+          </div>
+        </button>
+      )}
+
+      {/* 底部渐变遮罩 + 文案（播放后渐隐让位给视频） */}
+      <div
+        className="pointer-events-none absolute inset-x-0 bottom-0 z-10 transition-opacity duration-300"
+        style={{
+          height: '46%',
+          background:
+            'linear-gradient(180deg, transparent 0%, rgba(0,0,0,0.45) 35%, rgba(0,0,0,0.92) 100%)',
+          opacity: hasPlayed ? 0 : 1,
+        }}
+      />
+
+      {weekKey && !hasPlayed && (
+        <div
+          className="absolute left-6 top-6 z-20 inline-flex items-center gap-2 rounded-full px-3.5 py-1.5 text-[12px] font-semibold tracking-wide transition-opacity duration-300"
+          style={{
+            background: 'rgba(0,0,0,0.5)',
+            backdropFilter: 'blur(12px)',
+            WebkitBackdropFilter: 'blur(12px)',
+            border: '1px solid rgba(255,255,255,0.18)',
+            color: 'rgba(255,255,255,0.92)',
+          }}
+        >
+          <Sparkles size={12} />
+          {weekKey}
+        </div>
+      )}
+
+      {!hasPlayed && (
+        <div
+          className="absolute inset-x-0 bottom-0 z-20 px-7 pb-20 pt-8 pointer-events-none transition-opacity duration-300"
+        >
+          <h2
+            className="font-black text-white leading-tight"
+            style={{
+              fontSize: 'clamp(20px, 2.4vw, 32px)',
+              textShadow: '0 2px 12px rgba(0,0,0,0.6)',
+            }}
+          >
+            {page.title}
+          </h2>
+          {page.body && (
+            <div
+              className="mt-3 max-w-[80%] text-white/85 leading-relaxed line-clamp-2"
+              style={{
+                fontSize: 'clamp(13px, 1.3vw, 16px)',
+                textShadow: '0 1px 8px rgba(0,0,0,0.5)',
+              }}
+            >
+              <MarkdownContent content={page.body} />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
 }
 
 /**

--- a/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
+++ b/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
@@ -344,6 +344,12 @@ function isVideoUrl(url: string) {
  *   - 视频不 autoplay，显示中央 Play 按钮，用户点击才播
  *   - 播放后 cover/title 渐隐，让视频成为主角
  *   - 原生 controls，可暂停/调音量/全屏
+ *
+ * 实现策略（避坑）：
+ *   - cover 静图用独立 <img> 层渲染，**不**塞到 <video poster> 里——动图 webp 当 poster
+ *     在部分浏览器（含 Chrome 某些版本）会渲染破图占位符
+ *   - <video> 元素仅在用户点 Play 后才挂载，避开"未播放视频元素"产生的视觉噪音
+ *   - cover 加载失败也不会破图（onError 静默隐藏）
  */
 export function PosterAdPageView({
   page,
@@ -354,54 +360,78 @@ export function PosterAdPageView({
 }) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const [hasPlayed, setHasPlayed] = useState(false);
+  const [coverErrored, setCoverErrored] = useState(false);
 
   if (!page) return null;
-  const isVideo = isVideoUrl(page.imageUrl ?? '');
+  const primaryUrl = page.imageUrl ?? '';
+  const isVideo = isVideoUrl(primaryUrl);
+  // cover 来源：secondaryImageUrl 优先（capsule 写视频时会同步填这个 cover），
+  // 没有时退回 primaryUrl（仅当 primary 是图片时才能用）
+  const coverUrl = page.secondaryImageUrl || (isVideo ? null : primaryUrl);
 
   const handlePlay = () => {
-    const v = videoRef.current;
-    if (!v) return;
-    v.play().then(() => setHasPlayed(true)).catch(() => {
-      // 自动播放被浏览器拦截时，仍标记 hasPlayed 让 controls 显示
-      setHasPlayed(true);
-    });
+    setHasPlayed(true);
+    // 等 React 把 <video> 挂上 DOM 后再调 play()
+    setTimeout(() => {
+      videoRef.current?.play().catch(() => {
+        /* 浏览器可能拦截编程式播放，用户可手点原生 play */
+      });
+    }, 30);
   };
+
+  const accent = page.accentColor || '#7c3aed';
+  const showCover = !hasPlayed && !!coverUrl && !coverErrored;
+  const showFallbackBg = !hasPlayed && (!coverUrl || coverErrored);
 
   return (
     <div className="relative h-full" style={{ background: '#000' }}>
-      {/* 全 bleed 媒体层 */}
+      {/* 媒体层 */}
       <div className="absolute inset-0">
-        {isVideo ? (
-          <video
-            ref={videoRef}
-            src={page.imageUrl ?? ''}
-            className="w-full h-full object-contain bg-black"
-            controls={hasPlayed}
-            playsInline
-            preload="metadata"
-            poster={page.secondaryImageUrl ?? undefined}
-            onEnded={() => {
-              // 播放完不重置，保留 controls 让用户重播
-            }}
-          />
-        ) : page.imageUrl ? (
+        {/* Cover 静图层（仅播放前） */}
+        {showCover && (
           <img
-            src={page.imageUrl}
+            src={coverUrl as string}
             alt=""
-            className="w-full h-full object-cover"
+            className="absolute inset-0 w-full h-full object-cover"
             draggable={false}
+            onError={() => setCoverErrored(true)}
           />
-        ) : (
+        )}
+
+        {/* 无 cover 兜底渐变 */}
+        {showFallbackBg && (
           <div
-            className="w-full h-full flex items-center justify-center"
+            className="absolute inset-0 flex items-center justify-center"
             style={{
-              background: `linear-gradient(135deg, ${page.accentColor || '#7c3aed'} 0%, #0a0a12 100%)`,
+              background: `linear-gradient(135deg, ${accent} 0%, #0a0a12 100%)`,
             }}
           >
-            <div className="text-[120px] font-black text-white/20">
+            <div className="text-[120px] font-black text-white/15 select-none">
               {(page.order + 1).toString().padStart(2, '0')}
             </div>
           </div>
+        )}
+
+        {/* 静图直显（页面就是图片，不是视频） */}
+        {!isVideo && primaryUrl && (
+          <img
+            src={primaryUrl}
+            alt=""
+            className="absolute inset-0 w-full h-full object-cover"
+            draggable={false}
+          />
+        )}
+
+        {/* 视频层（仅用户点击 Play 后才挂载，避开未播放元素的视觉噪音） */}
+        {isVideo && hasPlayed && (
+          <video
+            ref={videoRef}
+            src={primaryUrl}
+            className="absolute inset-0 w-full h-full object-contain bg-black"
+            controls
+            playsInline
+            autoPlay
+          />
         )}
       </div>
 

--- a/prd-admin/src/pages/workflow-agent/capsuleRegistry.tsx
+++ b/prd-admin/src/pages/workflow-agent/capsuleRegistry.tsx
@@ -3,7 +3,7 @@ import {
   Database, Globe, Brain, Code2, Filter, Merge, Repeat, BarChart3,
   Clock, GitBranch,
   FileText, Download, Send, Bell, Box, AppWindow, GlobeLock, Mail,
-  Video, PenTool, Terminal,
+  Video, PenTool, Terminal, Image,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 
@@ -198,6 +198,26 @@ export const CAPSULE_TYPE_REGISTRY: Record<string, CapsuleTypeDef> = {
   },
 
   // ──────── 短视频工作流类 ────────
+  'tiktok-creator-fetch': {
+    typeKey: 'tiktok-creator-fetch',
+    name: 'TikTok 博主视频列表',
+    description: '调用 TikHub API 拉取指定博主最新视频列表，输出标准化条目数组',
+    Icon: Video,
+    emoji: 'TT',
+    category: 'processor',
+    accentHue: 340,
+    testable: true,
+  },
+  'homepage-publisher': {
+    typeKey: 'homepage-publisher',
+    name: '发布到首页海报',
+    description: '把上游图片/视频 URL 下载并写入「首页资源」槽位，登录后首页快捷卡 / Agent 封面即时更新',
+    Icon: Image,
+    emoji: 'HP',
+    category: 'output',
+    accentHue: 200,
+    testable: true,
+  },
   'douyin-parser': {
     typeKey: 'douyin-parser',
     name: '短视频解析',

--- a/prd-admin/src/pages/workflow-agent/capsuleRegistry.tsx
+++ b/prd-admin/src/pages/workflow-agent/capsuleRegistry.tsx
@@ -210,12 +210,22 @@ export const CAPSULE_TYPE_REGISTRY: Record<string, CapsuleTypeDef> = {
   },
   'homepage-publisher': {
     typeKey: 'homepage-publisher',
-    name: '发布到首页海报',
+    name: '发布到首页快捷卡',
     description: '把上游图片/视频 URL 下载并写入「首页资源」槽位，登录后首页快捷卡 / Agent 封面即时更新',
     Icon: Image,
     emoji: 'HP',
     category: 'output',
     accentHue: 200,
+    testable: true,
+  },
+  'weekly-poster-publisher': {
+    typeKey: 'weekly-poster-publisher',
+    name: '发布到首页弹窗海报',
+    description: '把上游内容（含图片/视频 URL + 文案）作为「周报小报」发布——登录后首页轮播弹窗即时显示',
+    Icon: Image,
+    emoji: 'WP',
+    category: 'output',
+    accentHue: 320,
     testable: true,
   },
   'douyin-parser': {

--- a/prd-admin/src/pages/workflow-agent/workflowTemplates.ts
+++ b/prd-admin/src/pages/workflow-agent/workflowTemplates.ts
@@ -1447,81 +1447,65 @@ result = {
 // 拓扑图：
 //   👆 手动触发（确认参数）
 //     ↓
-//   📺 拉取博主最新视频列表（TikHub）
+//   📺 拉取博主最新视频列表（TikHub /api/v1/tiktok/web/fetch_user_post）
 //     ↓
-//   🖼️ 发布到首页海报（slot 写入 HomepageAsset）
+//   🖼️ 发布到首页海报（默认写 card.showcase 的封面图）
 //
-// 设计要点：
-//   - 仅发一条视频做首试。把 count 设为 1，capsule 输出的 firstItem.videoUrl 直通发布
-//   - slot 默认 agent.video-agent.video（首页 Video Agent 卡片的封面视频会自动刷新）
-//   - 后续可改为 timer 定时触发 + dedupe 实现真正订阅，本模板先跑通最小闭环
+// 设计要点（严格按 TikHub 指引 + 参数最少化）：
+//   - TikHub 官方此端点唯一必填参数是 secUid，所以模板只暴露 2 个必填：
+//     API 密钥 + 博主 secUid（且 secUid 默认填 TikHub 官方示例账号便于首试）
+//   - 默认抓 1 条最新视频，发它的封面图（不下载视频本体），
+//     避开 TikHub "视频 CDN URL 需要 tt_chain_token" 的复杂度
+//   - 默认 slot=card.showcase，登录后首页四张快捷卡之一即时刷新
 //
 
 const tiktokCreatorToHomepageTemplate: WorkflowTemplate = {
   id: 'tiktok-creator-to-homepage',
   name: 'TikTok 博主订阅 → 首页海报',
-  description: '输入 TikHub 博主 secUid + API 密钥 → 自动拉取最新视频 → 直接发布到首页海报槽位（默认 agent.video-agent.video）。先发一条视频做首试',
+  description: '只填 TikHub API 密钥 + 博主 secUid，自动抓博主最新一条视频，把封面图发到首页 card.showcase 槽位。完整闭环，登录后首页立即可见',
   icon: 'TT',
-  tags: ['tiktok', 'douyin', 'tikhub', 'homepage', 'subscription'],
+  tags: ['tiktok', 'tikhub', 'homepage', 'subscription'],
   requiredInputs: [
     {
       key: 'tikHubApiKey',
       label: 'TikHub API 密钥',
       type: 'password',
       placeholder: 'Bearer xxx 或直接粘贴 API Key',
-      helpTip: '从 https://tikhub.io 获取的 API 密钥（用户中心 → API Key）。也可使用 {{secrets.TIKHUB_API_KEY}}',
+      helpTip: '从 https://tikhub.io 用户中心获取的 API Key。也可填 {{secrets.TIKHUB_API_KEY}}',
       required: true,
-    },
-    {
-      key: 'platform',
-      label: '平台',
-      type: 'select',
-      required: true,
-      defaultValue: 'tiktok',
-      options: [
-        { value: 'tiktok', label: 'TikTok（海外，使用 secUid）' },
-        { value: 'douyin', label: '抖音（国内，使用 sec_user_id）' },
-      ],
-      helpTip: '从 TikHub 文档 / 博主主页 URL 获取对应平台的用户标识',
     },
     {
       key: 'secUid',
-      label: '博主 secUid / sec_user_id',
+      label: 'TikTok 博主 secUid',
       type: 'text',
+      defaultValue: 'MS4wLjABAAAAv7iSuuXDJGDvJkmH_vz1qkDZYo1apxgzaxdBSeIuPiM',
       placeholder: 'MS4wLjABAAAA...',
-      helpTip: 'TikTok 用 secUid（博主主页 URL 中或调用 TikHub 用户搜索接口取得）；抖音填 sec_user_id',
+      helpTip: '默认填的是 TikHub 官方示例账号，可直接保留试通；后续换成你想订阅的真实博主 secUid（从 TikHub 用户搜索接口或博主主页 URL 取得）',
       required: true,
     },
     {
       key: 'slot',
-      label: '首页槽位 (slot)',
-      type: 'text',
-      defaultValue: 'agent.video-agent.video',
-      helpTip: '默认 agent.video-agent.video（首页 Video Agent 卡片封面视频）；也可填 card.{id} / hero.{id} / agent.{key}.image',
-      required: true,
-    },
-    {
-      key: 'count',
-      label: '拉取数量',
+      label: '首页槽位（高级）',
       type: 'select',
       required: false,
-      defaultValue: '1',
+      defaultValue: 'card.showcase',
       options: [
-        { value: '1', label: '1 条（首试推荐）' },
-        { value: '5', label: '5 条' },
-        { value: '10', label: '10 条' },
+        { value: 'card.showcase', label: '首页 - 案例卡（推荐）' },
+        { value: 'card.marketplace', label: '首页 - 市场卡' },
+        { value: 'card.library', label: '首页 - 图书馆卡' },
+        { value: 'card.updates', label: '首页 - 更新卡' },
+        { value: 'agent.video-agent.image', label: 'Video Agent 封面图' },
+        { value: 'hero.landing', label: '首页顶部 banner' },
       ],
-      helpTip: '本次最多拉取多少条视频。首次测试建议 1 条，跑通后再放宽',
+      helpTip: '默认写 card.showcase（首页四张快捷卡之一）。需要其他位置可改',
     },
   ],
   build: (inputs) => {
     _edgeIdx = 0;
 
     const tikHubApiKey = inputs.tikHubApiKey || '';
-    const platform = inputs.platform || 'tiktok';
-    const secUid = inputs.secUid || '';
-    const slot = inputs.slot || 'agent.video-agent.video';
-    const count = inputs.count || '1';
+    const secUid = inputs.secUid || 'MS4wLjABAAAAv7iSuuXDJGDvJkmH_vz1qkDZYo1apxgzaxdBSeIuPiM';
+    const slot = inputs.slot || 'card.showcase';
 
     const nodes: WorkflowNode[] = [
       // ─── 触发 ───
@@ -1529,7 +1513,7 @@ const tiktokCreatorToHomepageTemplate: WorkflowTemplate = {
         nodeId: 'n-trigger',
         name: '开始抓取',
         nodeType: 'manual-trigger',
-        config: { inputPrompt: '点击执行将拉取该博主最新视频并发布到首页' },
+        config: { inputPrompt: '点击执行 → 抓博主最新视频 → 把封面图发到首页' },
         inputSlots: [],
         outputSlots: [{ slotId: 'manual-out', name: 'input', dataType: 'json', required: true }],
         position: { x: 80, y: 240 },
@@ -1540,27 +1524,27 @@ const tiktokCreatorToHomepageTemplate: WorkflowTemplate = {
         name: '拉取博主视频列表',
         nodeType: 'tiktok-creator-fetch',
         config: {
-          platform,
+          platform: 'tiktok',
           apiBaseUrl: 'https://api.tikhub.io',
           apiKey: tikHubApiKey,
           secUid,
-          count,
+          count: '1',
           cursor: '0',
         },
         inputSlots: [{ slotId: 'tcf-in', name: 'trigger', dataType: 'json', required: false }],
         outputSlots: [{ slotId: 'tcf-out', name: 'videos', dataType: 'json', required: true }],
         position: { x: 380, y: 240 },
       },
-      // ─── 发布到首页海报 ───
+      // ─── 发布到首页海报（封面图）───
       {
         nodeId: 'n-publish',
         name: '发布到首页海报',
         nodeType: 'homepage-publisher',
         config: {
           slot,
-          mediaType: 'video',
-          sourceField: 'firstItem.videoUrl',
-          timeoutSeconds: '120',
+          mediaType: 'image',
+          sourceField: 'firstItem.coverUrl',
+          timeoutSeconds: '60',
         },
         inputSlots: [{ slotId: 'hp-in', name: 'media', dataType: 'json', required: true }],
         outputSlots: [{ slotId: 'hp-out', name: 'result', dataType: 'json', required: true }],

--- a/prd-admin/src/pages/workflow-agent/workflowTemplates.ts
+++ b/prd-admin/src/pages/workflow-agent/workflowTemplates.ts
@@ -1441,25 +1441,26 @@ result = {
 };
 
 // ═══════════════════════════════════════════════════════════════
-// 模板 6: TikTok 博主订阅 → 首页弹窗海报
+// 模板 6: TikTok / 抖音 博主订阅 → 首页广告海报弹窗
 // ═══════════════════════════════════════════════════════════════
 //
 // 拓扑图：
 //   👆 手动触发
 //     ↓
-//   📺 拉取博主最新作品列表（TikHub app/v3，默认 4 条 = 海报 4 页）
+//   📺 拉取博主最新作品列表（TikHub app/v3 或抖音 web，默认 4 条 = 海报 4 页）
 //     ↓
-//   🪟 发布到首页弹窗海报（每条 item 一页，含 cover/title/author/CTA）
+//   🪟 发布到首页广告海报弹窗（4:3 ad-mode，全 bleed 视频 + 中央 Play）
 //
-// 用户登录后立刻看到全屏轮播海报弹窗，每页是博主一条视频（封面动图 + 文案 + 跳 TikTok 链接）。
+// 用户登录后看到借鉴 Apple 产品发布会 / Netflix 预告的视频广告弹窗，
+// 中央 Play 按钮主动点击播放，不打扰用户（autoplay 容易吓跑）。
 //
 
 const tiktokCreatorToHomepageTemplate: WorkflowTemplate = {
   id: 'tiktok-creator-to-homepage',
-  name: 'TikTok 博主订阅 → 首页弹窗海报',
-  description: '只填 TikHub API 密钥 + 博主 secUid，自动抓博主最新 N 条视频，作为首页登录弹窗海报多页轮播显示。每页一条视频（封面动图 + 标题 + 作者）',
+  name: 'TikTok / 抖音 博主订阅 → 首页广告海报',
+  description: '抓博主最新 N 条视频 → 作为首页登录弹窗海报（4:3 ad 样式，借鉴 Apple/Netflix 视频广告 modal：全 bleed 封面 + 中央 Play 按钮，点击才播）',
   icon: 'TT',
-  tags: ['tiktok', 'tikhub', 'weekly-poster', 'subscription'],
+  tags: ['tiktok', 'douyin', 'tikhub', 'video-ad', 'subscription'],
   requiredInputs: [
     {
       key: 'tikHubApiKey',
@@ -1541,16 +1542,17 @@ const tiktokCreatorToHomepageTemplate: WorkflowTemplate = {
         outputSlots: [{ slotId: 'tcf-out', name: 'videos', dataType: 'json', required: true }],
         position: { x: 380, y: 240 },
       },
-      // ─── 发布到首页弹窗海报 ───
+      // ─── 发布到首页广告海报弹窗 ───
       {
         nodeId: 'n-publish',
-        name: '发布到首页弹窗海报',
+        name: '发布到首页广告海报',
         nodeType: 'weekly-poster-publisher',
         config: {
           itemsField: 'items',
           templateKey: 'promo',
+          presentationMode: 'ad-4-3',
           accentColor: '#ff0050',
-          ctaText: '去 TikTok 看完整视频',
+          ctaText: platform === 'douyin' ? '去抖音看完整视频' : '去 TikTok 看完整视频',
           ctaUrlField: 'firstItem.shareUrl',
           publish: 'true',
         },

--- a/prd-admin/src/pages/workflow-agent/workflowTemplates.ts
+++ b/prd-admin/src/pages/workflow-agent/workflowTemplates.ts
@@ -1466,16 +1466,28 @@ const tiktokCreatorToHomepageTemplate: WorkflowTemplate = {
       label: 'TikHub API 密钥',
       type: 'password',
       placeholder: 'Bearer xxx 或直接粘贴 API Key',
-      helpTip: '从 https://tikhub.io 用户中心获取的 API Key。也可填 {{secrets.TIKHUB_API_KEY}}',
+      helpTip: '从 https://tikhub.io 用户中心获取。也可填 {{secrets.TIKHUB_API_KEY}}',
       required: true,
     },
     {
+      key: 'platform',
+      label: '平台',
+      type: 'select',
+      required: true,
+      defaultValue: 'tiktok',
+      options: [
+        { value: 'tiktok', label: 'TikTok（海外，secUid）' },
+        { value: 'douyin', label: '抖音（国内，sec_user_id）' },
+      ],
+      helpTip: '选 TikTok 用 secUid，选抖音用 sec_user_id',
+    },
+    {
       key: 'secUid',
-      label: 'TikTok 博主 secUid',
+      label: '博主 secUid / sec_user_id',
       type: 'text',
       defaultValue: 'MS4wLjABAAAAv7iSuuXDJGDvJkmH_vz1qkDZYo1apxgzaxdBSeIuPiM',
       placeholder: 'MS4wLjABAAAA...',
-      helpTip: '默认是 TikHub 官方示例账号，可直接保留首试；换成你想订阅的真实博主即可',
+      helpTip: 'TikTok 默认填 TikHub 官方示例；抖音换成抖音 sec_user_id（参考 TikHub 文档）',
       required: true,
     },
     {
@@ -1497,6 +1509,7 @@ const tiktokCreatorToHomepageTemplate: WorkflowTemplate = {
     _edgeIdx = 0;
 
     const tikHubApiKey = inputs.tikHubApiKey || '';
+    const platform = inputs.platform || 'tiktok';
     const secUid = inputs.secUid || 'MS4wLjABAAAAv7iSuuXDJGDvJkmH_vz1qkDZYo1apxgzaxdBSeIuPiM';
     const count = inputs.count || '4';
 
@@ -1517,7 +1530,7 @@ const tiktokCreatorToHomepageTemplate: WorkflowTemplate = {
         name: '拉取博主视频列表',
         nodeType: 'tiktok-creator-fetch',
         config: {
-          platform: 'tiktok',
+          platform,
           apiBaseUrl: 'https://api.tikhub.io',
           apiKey: tikHubApiKey,
           secUid,

--- a/prd-admin/src/pages/workflow-agent/workflowTemplates.ts
+++ b/prd-admin/src/pages/workflow-agent/workflowTemplates.ts
@@ -1441,6 +1441,143 @@ result = {
 };
 
 // ═══════════════════════════════════════════════════════════════
+// 模板 6: TikTok 博主订阅 → 首页海报
+// ═══════════════════════════════════════════════════════════════
+//
+// 拓扑图：
+//   👆 手动触发（确认参数）
+//     ↓
+//   📺 拉取博主最新视频列表（TikHub）
+//     ↓
+//   🖼️ 发布到首页海报（slot 写入 HomepageAsset）
+//
+// 设计要点：
+//   - 仅发一条视频做首试。把 count 设为 1，capsule 输出的 firstItem.videoUrl 直通发布
+//   - slot 默认 agent.video-agent.video（首页 Video Agent 卡片的封面视频会自动刷新）
+//   - 后续可改为 timer 定时触发 + dedupe 实现真正订阅，本模板先跑通最小闭环
+//
+
+const tiktokCreatorToHomepageTemplate: WorkflowTemplate = {
+  id: 'tiktok-creator-to-homepage',
+  name: 'TikTok 博主订阅 → 首页海报',
+  description: '输入 TikHub 博主 secUid + API 密钥 → 自动拉取最新视频 → 直接发布到首页海报槽位（默认 agent.video-agent.video）。先发一条视频做首试',
+  icon: 'TT',
+  tags: ['tiktok', 'douyin', 'tikhub', 'homepage', 'subscription'],
+  requiredInputs: [
+    {
+      key: 'tikHubApiKey',
+      label: 'TikHub API 密钥',
+      type: 'password',
+      placeholder: 'Bearer xxx 或直接粘贴 API Key',
+      helpTip: '从 https://tikhub.io 获取的 API 密钥（用户中心 → API Key）。也可使用 {{secrets.TIKHUB_API_KEY}}',
+      required: true,
+    },
+    {
+      key: 'platform',
+      label: '平台',
+      type: 'select',
+      required: true,
+      defaultValue: 'tiktok',
+      options: [
+        { value: 'tiktok', label: 'TikTok（海外，使用 secUid）' },
+        { value: 'douyin', label: '抖音（国内，使用 sec_user_id）' },
+      ],
+      helpTip: '从 TikHub 文档 / 博主主页 URL 获取对应平台的用户标识',
+    },
+    {
+      key: 'secUid',
+      label: '博主 secUid / sec_user_id',
+      type: 'text',
+      placeholder: 'MS4wLjABAAAA...',
+      helpTip: 'TikTok 用 secUid（博主主页 URL 中或调用 TikHub 用户搜索接口取得）；抖音填 sec_user_id',
+      required: true,
+    },
+    {
+      key: 'slot',
+      label: '首页槽位 (slot)',
+      type: 'text',
+      defaultValue: 'agent.video-agent.video',
+      helpTip: '默认 agent.video-agent.video（首页 Video Agent 卡片封面视频）；也可填 card.{id} / hero.{id} / agent.{key}.image',
+      required: true,
+    },
+    {
+      key: 'count',
+      label: '拉取数量',
+      type: 'select',
+      required: false,
+      defaultValue: '1',
+      options: [
+        { value: '1', label: '1 条（首试推荐）' },
+        { value: '5', label: '5 条' },
+        { value: '10', label: '10 条' },
+      ],
+      helpTip: '本次最多拉取多少条视频。首次测试建议 1 条，跑通后再放宽',
+    },
+  ],
+  build: (inputs) => {
+    _edgeIdx = 0;
+
+    const tikHubApiKey = inputs.tikHubApiKey || '';
+    const platform = inputs.platform || 'tiktok';
+    const secUid = inputs.secUid || '';
+    const slot = inputs.slot || 'agent.video-agent.video';
+    const count = inputs.count || '1';
+
+    const nodes: WorkflowNode[] = [
+      // ─── 触发 ───
+      {
+        nodeId: 'n-trigger',
+        name: '开始抓取',
+        nodeType: 'manual-trigger',
+        config: { inputPrompt: '点击执行将拉取该博主最新视频并发布到首页' },
+        inputSlots: [],
+        outputSlots: [{ slotId: 'manual-out', name: 'input', dataType: 'json', required: true }],
+        position: { x: 80, y: 240 },
+      },
+      // ─── 拉取博主视频列表 ───
+      {
+        nodeId: 'n-fetch',
+        name: '拉取博主视频列表',
+        nodeType: 'tiktok-creator-fetch',
+        config: {
+          platform,
+          apiBaseUrl: 'https://api.tikhub.io',
+          apiKey: tikHubApiKey,
+          secUid,
+          count,
+          cursor: '0',
+        },
+        inputSlots: [{ slotId: 'tcf-in', name: 'trigger', dataType: 'json', required: false }],
+        outputSlots: [{ slotId: 'tcf-out', name: 'videos', dataType: 'json', required: true }],
+        position: { x: 380, y: 240 },
+      },
+      // ─── 发布到首页海报 ───
+      {
+        nodeId: 'n-publish',
+        name: '发布到首页海报',
+        nodeType: 'homepage-publisher',
+        config: {
+          slot,
+          mediaType: 'video',
+          sourceField: 'firstItem.videoUrl',
+          timeoutSeconds: '120',
+        },
+        inputSlots: [{ slotId: 'hp-in', name: 'media', dataType: 'json', required: true }],
+        outputSlots: [{ slotId: 'hp-out', name: 'result', dataType: 'json', required: true }],
+        position: { x: 720, y: 240 },
+      },
+    ];
+
+    const edges: WorkflowEdge[] = [
+      edge('n-trigger', 'manual-out', 'n-fetch', 'tcf-in'),
+      edge('n-fetch', 'tcf-out', 'n-publish', 'hp-in'),
+    ];
+
+    return { nodes, edges, variables: [] };
+  },
+};
+
+// ═══════════════════════════════════════════════════════════════
 // 模板: 产品专业委员会月报（4 章节合一）
 // ═══════════════════════════════════════════════════════════════
 //
@@ -1941,4 +2078,5 @@ export const WORKFLOW_TEMPLATES: WorkflowTemplate[] = [
   smartHttpAcceptanceTemplate,
   apiReviewWorkflowTemplate,
   videoWorkflowTemplate,
+  tiktokCreatorToHomepageTemplate,
 ];

--- a/prd-admin/src/pages/workflow-agent/workflowTemplates.ts
+++ b/prd-admin/src/pages/workflow-agent/workflowTemplates.ts
@@ -1441,30 +1441,25 @@ result = {
 };
 
 // ═══════════════════════════════════════════════════════════════
-// 模板 6: TikTok 博主订阅 → 首页海报
+// 模板 6: TikTok 博主订阅 → 首页弹窗海报
 // ═══════════════════════════════════════════════════════════════
 //
 // 拓扑图：
-//   👆 手动触发（确认参数）
+//   👆 手动触发
 //     ↓
-//   📺 拉取博主最新视频列表（TikHub /api/v1/tiktok/web/fetch_user_post）
+//   📺 拉取博主最新作品列表（TikHub app/v3，默认 4 条 = 海报 4 页）
 //     ↓
-//   🖼️ 发布到首页海报（默认写 card.showcase 的封面图）
+//   🪟 发布到首页弹窗海报（每条 item 一页，含 cover/title/author/CTA）
 //
-// 设计要点（严格按 TikHub 指引 + 参数最少化）：
-//   - TikHub 官方此端点唯一必填参数是 secUid，所以模板只暴露 2 个必填：
-//     API 密钥 + 博主 secUid（且 secUid 默认填 TikHub 官方示例账号便于首试）
-//   - 默认抓 1 条最新视频，发它的封面图（不下载视频本体），
-//     避开 TikHub "视频 CDN URL 需要 tt_chain_token" 的复杂度
-//   - 默认 slot=card.showcase，登录后首页四张快捷卡之一即时刷新
+// 用户登录后立刻看到全屏轮播海报弹窗，每页是博主一条视频（封面动图 + 文案 + 跳 TikTok 链接）。
 //
 
 const tiktokCreatorToHomepageTemplate: WorkflowTemplate = {
   id: 'tiktok-creator-to-homepage',
-  name: 'TikTok 博主订阅 → 首页海报',
-  description: '只填 TikHub API 密钥 + 博主 secUid，自动抓博主最新一条视频，把封面图发到首页 card.showcase 槽位。完整闭环，登录后首页立即可见',
+  name: 'TikTok 博主订阅 → 首页弹窗海报',
+  description: '只填 TikHub API 密钥 + 博主 secUid，自动抓博主最新 N 条视频，作为首页登录弹窗海报多页轮播显示。每页一条视频（封面动图 + 标题 + 作者）',
   icon: 'TT',
-  tags: ['tiktok', 'tikhub', 'homepage', 'subscription'],
+  tags: ['tiktok', 'tikhub', 'weekly-poster', 'subscription'],
   requiredInputs: [
     {
       key: 'tikHubApiKey',
@@ -1480,24 +1475,22 @@ const tiktokCreatorToHomepageTemplate: WorkflowTemplate = {
       type: 'text',
       defaultValue: 'MS4wLjABAAAAv7iSuuXDJGDvJkmH_vz1qkDZYo1apxgzaxdBSeIuPiM',
       placeholder: 'MS4wLjABAAAA...',
-      helpTip: '默认填的是 TikHub 官方示例账号，可直接保留试通；后续换成你想订阅的真实博主 secUid（从 TikHub 用户搜索接口或博主主页 URL 取得）',
+      helpTip: '默认是 TikHub 官方示例账号，可直接保留首试；换成你想订阅的真实博主即可',
       required: true,
     },
     {
-      key: 'slot',
-      label: '首页槽位（高级）',
+      key: 'count',
+      label: '展示几条作品（= 海报页数）',
       type: 'select',
       required: false,
-      defaultValue: 'card.showcase',
+      defaultValue: '4',
       options: [
-        { value: 'card.showcase', label: '首页 - 案例卡（推荐）' },
-        { value: 'card.marketplace', label: '首页 - 市场卡' },
-        { value: 'card.library', label: '首页 - 图书馆卡' },
-        { value: 'card.updates', label: '首页 - 更新卡' },
-        { value: 'agent.video-agent.image', label: 'Video Agent 封面图' },
-        { value: 'hero.landing', label: '首页顶部 banner' },
+        { value: '1', label: '1 条（单页海报）' },
+        { value: '4', label: '4 条（推荐，4 页轮播）' },
+        { value: '6', label: '6 条' },
+        { value: '10', label: '10 条' },
       ],
-      helpTip: '默认写 card.showcase（首页四张快捷卡之一）。需要其他位置可改',
+      helpTip: '一条 item 对应海报一页，弹窗会自动轮播',
     },
   ],
   build: (inputs) => {
@@ -1505,7 +1498,7 @@ const tiktokCreatorToHomepageTemplate: WorkflowTemplate = {
 
     const tikHubApiKey = inputs.tikHubApiKey || '';
     const secUid = inputs.secUid || 'MS4wLjABAAAAv7iSuuXDJGDvJkmH_vz1qkDZYo1apxgzaxdBSeIuPiM';
-    const slot = inputs.slot || 'card.showcase';
+    const count = inputs.count || '4';
 
     const nodes: WorkflowNode[] = [
       // ─── 触发 ───
@@ -1513,7 +1506,7 @@ const tiktokCreatorToHomepageTemplate: WorkflowTemplate = {
         nodeId: 'n-trigger',
         name: '开始抓取',
         nodeType: 'manual-trigger',
-        config: { inputPrompt: '点击执行 → 抓博主最新视频 → 把封面图发到首页' },
+        config: { inputPrompt: '点击执行 → 抓博主最新作品 → 作为首页弹窗海报发布' },
         inputSlots: [],
         outputSlots: [{ slotId: 'manual-out', name: 'input', dataType: 'json', required: true }],
         position: { x: 80, y: 240 },
@@ -1528,33 +1521,35 @@ const tiktokCreatorToHomepageTemplate: WorkflowTemplate = {
           apiBaseUrl: 'https://api.tikhub.io',
           apiKey: tikHubApiKey,
           secUid,
-          count: '1',
+          count,
           cursor: '0',
         },
         inputSlots: [{ slotId: 'tcf-in', name: 'trigger', dataType: 'json', required: false }],
         outputSlots: [{ slotId: 'tcf-out', name: 'videos', dataType: 'json', required: true }],
         position: { x: 380, y: 240 },
       },
-      // ─── 发布到首页海报（封面图）───
+      // ─── 发布到首页弹窗海报 ───
       {
         nodeId: 'n-publish',
-        name: '发布到首页海报',
-        nodeType: 'homepage-publisher',
+        name: '发布到首页弹窗海报',
+        nodeType: 'weekly-poster-publisher',
         config: {
-          slot,
-          mediaType: 'image',
-          sourceField: 'firstItem.coverUrl',
-          timeoutSeconds: '60',
+          itemsField: 'items',
+          templateKey: 'promo',
+          accentColor: '#ff0050',
+          ctaText: '去 TikTok 看完整视频',
+          ctaUrlField: 'firstItem.shareUrl',
+          publish: 'true',
         },
-        inputSlots: [{ slotId: 'hp-in', name: 'media', dataType: 'json', required: true }],
-        outputSlots: [{ slotId: 'hp-out', name: 'result', dataType: 'json', required: true }],
+        inputSlots: [{ slotId: 'wp-in', name: 'items', dataType: 'json', required: true }],
+        outputSlots: [{ slotId: 'wp-out', name: 'result', dataType: 'json', required: true }],
         position: { x: 720, y: 240 },
       },
     ];
 
     const edges: WorkflowEdge[] = [
       edge('n-trigger', 'manual-out', 'n-fetch', 'tcf-in'),
-      edge('n-fetch', 'tcf-out', 'n-publish', 'hp-in'),
+      edge('n-fetch', 'tcf-out', 'n-publish', 'wp-in'),
     ];
 
     return { nodes, edges, variables: [] };

--- a/prd-admin/src/services/real/weeklyPoster.ts
+++ b/prd-admin/src/services/real/weeklyPoster.ts
@@ -5,7 +5,7 @@ import { apiRequest } from '@/services/real/apiClient';
 export type WeeklyPosterStatus = 'draft' | 'published' | 'archived';
 
 export type WeeklyPosterTemplateKey = 'release' | 'hotfix' | 'promo' | 'sale';
-export type WeeklyPosterPresentationMode = 'static' | 'fullscreen' | 'interactive';
+export type WeeklyPosterPresentationMode = 'static' | 'fullscreen' | 'interactive' | 'ad-4-3';
 export type WeeklyPosterSourceType =
   | 'changelog-current-week'
   | 'github-commits'

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/WeeklyPosterController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/WeeklyPosterController.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using MongoDB.Driver;
 using PrdAgent.Api.Extensions;
@@ -21,6 +22,7 @@ namespace PrdAgent.Api.Controllers.Api;
 /// </summary>
 [ApiController]
 [Route("api/weekly-posters")]
+[Authorize]
 [AdminController(
     "report-agent",
     AdminPermissionCatalog.Access,

--- a/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
+++ b/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
@@ -5772,10 +5772,12 @@ function safeChart(canvasId, config) {
         if (!int.TryParse(countStr, out var count) || count <= 0) count = 10;
         if (count > 50) count = 50;
 
-        // TikHub 端点路径（参考 https://api.tikhub.io 文档；可被 apiBaseUrl 覆盖）
+        // TikHub 端点路径（参考 https://api.tikhub.io/openapi.json）
+        // TikTok web: /api/v1/tiktok/web/fetch_user_post（注意没有 _videos 后缀，这点容易踩坑）
+        // Douyin web: /api/v1/douyin/web/fetch_user_post_videos
         var requestUrl = platform == "douyin"
             ? $"{apiBaseUrl}/api/v1/douyin/web/fetch_user_post_videos?sec_user_id={Uri.EscapeDataString(secUid)}&max_cursor={Uri.EscapeDataString(cursor)}&count={count}"
-            : $"{apiBaseUrl}/api/v1/tiktok/web/fetch_user_post_videos?secUid={Uri.EscapeDataString(secUid)}&count={count}&cursor={Uri.EscapeDataString(cursor)}";
+            : $"{apiBaseUrl}/api/v1/tiktok/web/fetch_user_post?secUid={Uri.EscapeDataString(secUid)}&count={count}&cursor={Uri.EscapeDataString(cursor)}";
 
         sb.AppendLine($"[TiktokCreatorFetch] 平台: {platform}");
         sb.AppendLine($"[TiktokCreatorFetch] 博主: {secUid}");

--- a/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
+++ b/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
@@ -6234,6 +6234,7 @@ function safeChart(canvasId, config) {
             var titleConfig = ReplaceVariables(GetConfigString(node, "title") ?? "", variables).Trim();
             var subtitle = ReplaceVariables(GetConfigString(node, "subtitle") ?? "", variables).Trim();
             var templateKey = (GetConfigString(node, "templateKey") ?? "promo").Trim();
+            var presentationMode = (GetConfigString(node, "presentationMode") ?? "ad-4-3").Trim();
             var accentColor = (GetConfigString(node, "accentColor") ?? "#ff0050").Trim();
             var ctaText = ReplaceVariables(GetConfigString(node, "ctaText") ?? "去看完整视频", variables).Trim();
             var ctaUrlDirect = ReplaceVariables(GetConfigString(node, "ctaUrl") ?? "", variables).Trim();
@@ -6279,13 +6280,15 @@ function safeChart(canvasId, config) {
                 }
                 var body = string.Join("\n\n", bodyParts);
 
-                // 优先真实视频 URL（前端 modal 会用 <video autoplay loop> 播放，比静态 cover 好得多）。
-                // TikTok play_addr / 抖音 download_addr 的 URL 已包含签名 query，直链可访问，
-                // 浏览器原生播放无需额外 header（实测 content-type=video/mp4，HTTP 200）。
-                // 失败时退回 coverUrl（动图 webp）。
-                var imageUrl = TryGetJsonString(item, "videoUrl", "video_url", "playUrl", "play_url");
+                // 优先真实视频 URL（前端 modal 会 <video> 播放）。失败时退回 coverUrl 静图。
+                // ad-4-3 模式下视频不 autoplay，需要用户点中央 Play 按钮，所以 coverUrl 同时填到
+                // SecondaryImageUrl 里作为视频 poster（pause 状态显示静图，播放后切到真视频）。
+                var videoUrl = TryGetJsonString(item, "videoUrl", "video_url", "playUrl", "play_url");
+                var coverUrl = TryGetJsonString(item, "coverUrl", "cover_url");
+                var imageUrl = string.IsNullOrWhiteSpace(videoUrl) ? coverUrl : videoUrl;
                 if (string.IsNullOrWhiteSpace(imageUrl))
-                    imageUrl = TryGetJsonString(item, "coverUrl", "cover_url", "url");
+                    imageUrl = TryGetJsonString(item, "url");
+                var posterUrl = string.IsNullOrWhiteSpace(videoUrl) ? null : (string.IsNullOrWhiteSpace(coverUrl) ? null : coverUrl);
 
                 pages.Add(new WeeklyPosterPage
                 {
@@ -6294,6 +6297,7 @@ function safeChart(canvasId, config) {
                     Body = body,
                     ImagePrompt = "",
                     ImageUrl = string.IsNullOrWhiteSpace(imageUrl) ? null : imageUrl,
+                    SecondaryImageUrl = posterUrl,
                     AccentColor = string.IsNullOrWhiteSpace(accentColor) ? null : accentColor,
                 });
             }
@@ -6359,7 +6363,7 @@ function safeChart(canvasId, config) {
                 Subtitle = string.IsNullOrWhiteSpace(subtitle) ? null : subtitle,
                 Status = status,
                 TemplateKey = templateKey,
-                PresentationMode = "static",
+                PresentationMode = presentationMode,
                 SourceType = "workflow-tiktok",
                 SourceRef = node.NodeId,
                 Pages = pages,

--- a/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
+++ b/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
@@ -5773,11 +5773,13 @@ function safeChart(canvasId, config) {
         if (count > 50) count = 50;
 
         // TikHub 端点路径（参考 https://api.tikhub.io/openapi.json）
-        // TikTok web: /api/v1/tiktok/web/fetch_user_post（注意没有 _videos 后缀，这点容易踩坑）
-        // Douyin web: /api/v1/douyin/web/fetch_user_post_videos
+        // TikTok：用 app/v3 端点（/api/v1/tiktok/app/v3/fetch_user_post_videos），param=sec_user_id；
+        //   web 端点（/api/v1/tiktok/web/fetch_user_post）2026-05 实测连官方示例 secUid 都返回 400，
+        //   猜测上游 TikTok web 限流。app/v3 稳定可用，输出 data.aweme_list 结构和抖音对齐。
+        // Douyin：/api/v1/douyin/web/fetch_user_post_videos，param=sec_user_id。
         var requestUrl = platform == "douyin"
             ? $"{apiBaseUrl}/api/v1/douyin/web/fetch_user_post_videos?sec_user_id={Uri.EscapeDataString(secUid)}&max_cursor={Uri.EscapeDataString(cursor)}&count={count}"
-            : $"{apiBaseUrl}/api/v1/tiktok/web/fetch_user_post?secUid={Uri.EscapeDataString(secUid)}&count={count}&cursor={Uri.EscapeDataString(cursor)}";
+            : $"{apiBaseUrl}/api/v1/tiktok/app/v3/fetch_user_post_videos?sec_user_id={Uri.EscapeDataString(secUid)}&max_cursor={Uri.EscapeDataString(cursor)}&count={count}";
 
         sb.AppendLine($"[TiktokCreatorFetch] 平台: {platform}");
         sb.AppendLine($"[TiktokCreatorFetch] 博主: {secUid}");

--- a/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
+++ b/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
@@ -6279,9 +6279,13 @@ function safeChart(canvasId, config) {
                 }
                 var body = string.Join("\n\n", bodyParts);
 
-                // 优先视频 URL（video.coverUrl 是 webp 动图，但若有真视频更好）；fallback 到 coverUrl
-                // 但 TikTok 视频 URL 需 tt_chain_token，浏览器直链可能 403；先用 coverUrl（动图 webp）保证可用
-                var imageUrl = TryGetJsonString(item, "coverUrl", "cover_url", "videoUrl", "video_url", "url");
+                // 优先真实视频 URL（前端 modal 会用 <video autoplay loop> 播放，比静态 cover 好得多）。
+                // TikTok play_addr / 抖音 download_addr 的 URL 已包含签名 query，直链可访问，
+                // 浏览器原生播放无需额外 header（实测 content-type=video/mp4，HTTP 200）。
+                // 失败时退回 coverUrl（动图 webp）。
+                var imageUrl = TryGetJsonString(item, "videoUrl", "video_url", "playUrl", "play_url");
+                if (string.IsNullOrWhiteSpace(imageUrl))
+                    imageUrl = TryGetJsonString(item, "coverUrl", "cover_url", "url");
 
                 pages.Add(new WeeklyPosterPage
                 {

--- a/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
+++ b/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
@@ -5,6 +5,7 @@ using System.Text.Json.Nodes;
 using Jint;
 using Jint.Runtime;
 using Microsoft.Extensions.Logging;
+using MongoDB.Driver;
 using PrdAgent.Core.Models;
 
 namespace PrdAgent.Api.Services;
@@ -87,6 +88,8 @@ public static class CapsuleExecutor
             CapsuleTypes.VideoDownloader => await ExecuteVideoDownloaderAsync(sp, node, variables, inputArtifacts),
             CapsuleTypes.VideoToText => await ExecuteVideoToTextAsync(sp, node, variables, inputArtifacts, emitEvent),
             CapsuleTypes.TextToCopywriting => await ExecuteTextToCopywritingAsync(sp, node, variables, inputArtifacts, emitEvent),
+            CapsuleTypes.TiktokCreatorFetch => await ExecuteTiktokCreatorFetchAsync(sp, node, variables, inputArtifacts),
+            CapsuleTypes.HomepagePublisher => await ExecuteHomepagePublisherAsync(sp, node, variables, inputArtifacts),
 
             // ── CLI Agent 执行器 ──
             CapsuleTypes.CliAgentExecutor => await ExecuteCliAgentAsync(sp, node, variables, inputArtifacts, emitEvent),
@@ -5719,5 +5722,452 @@ function safeChart(canvasId, config) {
         return new CapsuleResult(
             new List<ExecutionArtifact> { MakeTextArtifact(node, "vg-out", "视频生成结果", output) },
             sb.ToString());
+    }
+
+    // ── TikTok 博主订阅 ──────────────────────────────────────────
+
+    /// <summary>
+    /// TikTok 博主视频列表：调用 TikHub API 拉取指定博主的最新视频，输出标准化条目数组。
+    /// 支持 TikTok（secUid）与抖音（sec_user_id）两种平台。
+    /// </summary>
+    public static async Task<CapsuleResult> ExecuteTiktokCreatorFetchAsync(
+        IServiceProvider sp,
+        WorkflowNode node,
+        Dictionary<string, string> variables,
+        List<ExecutionArtifact> inputArtifacts)
+    {
+        var sb = new StringBuilder();
+
+        var platform = (ReplaceVariables(GetConfigString(node, "platform") ?? "tiktok", variables).Trim().ToLowerInvariant()) switch
+        {
+            "douyin" => "douyin",
+            _ => "tiktok",
+        };
+        var apiBaseUrl = ReplaceVariables(GetConfigString(node, "apiBaseUrl") ?? "https://api.tikhub.io", variables).TrimEnd('/');
+        var apiKey = ReplaceVariables(GetConfigString(node, "apiKey") ?? "", variables).Trim();
+        var secUid = ReplaceVariables(GetConfigString(node, "secUid") ?? "", variables).Trim();
+        var countStr = ReplaceVariables(GetConfigString(node, "count") ?? "10", variables).Trim();
+        var cursor = ReplaceVariables(GetConfigString(node, "cursor") ?? "0", variables).Trim();
+
+        // 上游 trigger 输入也允许覆盖 secUid
+        if (string.IsNullOrWhiteSpace(secUid))
+        {
+            var inputContent = inputArtifacts.FirstOrDefault(a => a.SlotId == "tcf-in")?.InlineContent
+                ?? inputArtifacts.FirstOrDefault()?.InlineContent;
+            if (!string.IsNullOrWhiteSpace(inputContent))
+            {
+                try
+                {
+                    using var doc = JsonDocument.Parse(inputContent);
+                    secUid = TryGetJsonString(doc.RootElement, "secUid", "sec_user_id", "secUserId");
+                }
+                catch { /* not json */ }
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(apiKey))
+            throw new InvalidOperationException("TikHub API 密钥未配置（apiKey）");
+        if (string.IsNullOrWhiteSpace(secUid))
+            throw new InvalidOperationException("博主 secUid / sec_user_id 未配置");
+        if (!int.TryParse(countStr, out var count) || count <= 0) count = 10;
+        if (count > 50) count = 50;
+
+        // TikHub 端点路径（参考 https://api.tikhub.io 文档；可被 apiBaseUrl 覆盖）
+        var requestUrl = platform == "douyin"
+            ? $"{apiBaseUrl}/api/v1/douyin/web/fetch_user_post_videos?sec_user_id={Uri.EscapeDataString(secUid)}&max_cursor={Uri.EscapeDataString(cursor)}&count={count}"
+            : $"{apiBaseUrl}/api/v1/tiktok/web/fetch_user_post_videos?secUid={Uri.EscapeDataString(secUid)}&count={count}&cursor={Uri.EscapeDataString(cursor)}";
+
+        sb.AppendLine($"[TiktokCreatorFetch] 平台: {platform}");
+        sb.AppendLine($"[TiktokCreatorFetch] 博主: {secUid}");
+        sb.AppendLine($"[TiktokCreatorFetch] 请求: GET {requestUrl}");
+
+        var factory = sp.GetRequiredService<IHttpClientFactory>();
+        using var client = factory.CreateClient();
+        client.Timeout = TimeSpan.FromSeconds(30);
+        if (apiKey.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+            client.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", apiKey);
+        else
+            client.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", $"Bearer {apiKey}");
+
+        var response = await client.GetAsync(requestUrl, CancellationToken.None);
+        var responseBody = await response.Content.ReadAsStringAsync(CancellationToken.None);
+        sb.AppendLine($"[TiktokCreatorFetch] 状态: {(int)response.StatusCode}");
+
+        if (!response.IsSuccessStatusCode)
+        {
+            sb.AppendLine($"[TiktokCreatorFetch] 错误响应: {responseBody[..Math.Min(500, responseBody.Length)]}");
+            throw new InvalidOperationException($"TikHub API 请求失败 (HTTP {(int)response.StatusCode}): {responseBody[..Math.Min(200, responseBody.Length)]}");
+        }
+
+        // 解析响应：兼容 TikTok web (data.itemList) / 抖音 web (data.aweme_list) / 其他变体
+        using var respDoc = JsonDocument.Parse(responseBody);
+        var root = respDoc.RootElement;
+        var dataElem = root.TryGetProperty("data", out var d) && d.ValueKind == JsonValueKind.Object ? d : root;
+
+        JsonElement listElem = default;
+        var listFound = false;
+        foreach (var key in new[] { "itemList", "aweme_list", "items", "videos", "list" })
+        {
+            if (dataElem.TryGetProperty(key, out var arr) && arr.ValueKind == JsonValueKind.Array)
+            {
+                listElem = arr;
+                listFound = true;
+                sb.AppendLine($"[TiktokCreatorFetch] 数据数组路径: data.{key}");
+                break;
+            }
+        }
+
+        var items = new List<object>();
+        if (listFound)
+        {
+            foreach (var v in listElem.EnumerateArray())
+            {
+                items.Add(NormalizeTiktokVideoItem(v, platform));
+            }
+        }
+
+        sb.AppendLine($"[TiktokCreatorFetch] 抓到 {items.Count} 条视频");
+
+        var firstItem = items.FirstOrDefault();
+        var output = new
+        {
+            platform,
+            secUid,
+            count = items.Count,
+            items,
+            firstItem,
+            rawResponse = responseBody.Length > 8000 ? responseBody[..8000] + "...(truncated)" : responseBody,
+        };
+
+        var outputJson = JsonSerializer.Serialize(output, JsonPretty);
+        var artifact = MakeTextArtifact(node, "tcf-out", $"博主视频列表 ({items.Count} 条)", outputJson, "application/json");
+        return new CapsuleResult(new List<ExecutionArtifact> { artifact }, sb.ToString());
+    }
+
+    /// <summary>
+    /// 把 TikHub 返回的 video item 标准化成 { awemeId, title, videoUrl, coverUrl, author, ... }
+    /// </summary>
+    private static object NormalizeTiktokVideoItem(JsonElement item, string platform)
+    {
+        // 视频地址：TikTok 是 video.play_addr.url_list[0]；抖音类似但字段名可能不同
+        string videoUrl = "";
+        if (item.TryGetProperty("video", out var videoNode) && videoNode.ValueKind == JsonValueKind.Object)
+        {
+            // play_addr / playAddr
+            foreach (var addrKey in new[] { "play_addr", "playAddr", "play_addr_h264", "play_addr_lowbr" })
+            {
+                if (videoNode.TryGetProperty(addrKey, out var addr))
+                {
+                    if (addr.ValueKind == JsonValueKind.Object && addr.TryGetProperty("url_list", out var urlList) && urlList.ValueKind == JsonValueKind.Array)
+                    {
+                        foreach (var u in urlList.EnumerateArray())
+                        {
+                            if (u.ValueKind == JsonValueKind.String) { videoUrl = u.GetString() ?? ""; break; }
+                        }
+                    }
+                    else if (addr.ValueKind == JsonValueKind.String)
+                    {
+                        videoUrl = addr.GetString() ?? "";
+                    }
+                    if (!string.IsNullOrWhiteSpace(videoUrl)) break;
+                }
+            }
+            // 兜底：直接 video.url / video.download_addr
+            if (string.IsNullOrWhiteSpace(videoUrl))
+            {
+                videoUrl = TryGetJsonString(videoNode, "url", "playUrl", "downloadUrl");
+            }
+        }
+        if (string.IsNullOrWhiteSpace(videoUrl))
+        {
+            videoUrl = TryGetJsonString(item, "video_url", "play_url", "nwm_video_url", "playUrl", "videoUrl");
+        }
+
+        // 封面
+        string coverUrl = "";
+        if (item.TryGetProperty("video", out var vNode2) && vNode2.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var coverKey in new[] { "cover", "origin_cover", "dynamic_cover", "originCover" })
+            {
+                if (vNode2.TryGetProperty(coverKey, out var cover))
+                {
+                    if (cover.ValueKind == JsonValueKind.Object && cover.TryGetProperty("url_list", out var coverList) && coverList.ValueKind == JsonValueKind.Array)
+                    {
+                        foreach (var u in coverList.EnumerateArray())
+                        {
+                            if (u.ValueKind == JsonValueKind.String) { coverUrl = u.GetString() ?? ""; break; }
+                        }
+                    }
+                    else if (cover.ValueKind == JsonValueKind.String)
+                    {
+                        coverUrl = cover.GetString() ?? "";
+                    }
+                    if (!string.IsNullOrWhiteSpace(coverUrl)) break;
+                }
+            }
+        }
+        if (string.IsNullOrWhiteSpace(coverUrl))
+        {
+            coverUrl = TryGetJsonString(item, "cover_url", "coverUrl", "thumb");
+        }
+
+        var awemeId = TryGetJsonString(item, "id", "aweme_id", "awemeId", "itemId");
+        var title = TryGetJsonString(item, "desc", "description", "title");
+        var author = "";
+        if (item.TryGetProperty("author", out var authorNode) && authorNode.ValueKind == JsonValueKind.Object)
+        {
+            author = TryGetJsonString(authorNode, "nickname", "unique_id", "uniqueId", "name");
+        }
+        var createTime = TryGetJsonString(item, "create_time", "createTime", "createdAt");
+
+        return new
+        {
+            awemeId,
+            title,
+            videoUrl,
+            coverUrl,
+            author,
+            createTime,
+            platform,
+        };
+    }
+
+    // ── 发布到首页海报 ──────────────────────────────────────────
+
+    private static readonly System.Text.RegularExpressions.Regex HomepageSlotRegex =
+        new(@"^[a-z0-9][a-z0-9._\-]{0,127}$", System.Text.RegularExpressions.RegexOptions.Compiled);
+    private static readonly System.Text.RegularExpressions.Regex HomepageAgentImageSlotRegex =
+        new(@"^agent\.(.+)\.image$", System.Text.RegularExpressions.RegexOptions.Compiled);
+    private static readonly System.Text.RegularExpressions.Regex HomepageAgentVideoSlotRegex =
+        new(@"^agent\.(.+)\.video$", System.Text.RegularExpressions.RegexOptions.Compiled);
+    private static readonly System.Text.RegularExpressions.Regex HomepageHeroSlotRegex =
+        new(@"^hero\.(.+)$", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+    /// <summary>
+    /// 发布到首页海报：下载上游 URL 指向的媒体文件，写入 HomepageAsset（按 slot 唯一覆盖）。
+    /// 与 HomepageAssetsController.Upload 保持完全相同的 slot/路径规则。
+    /// </summary>
+    public static async Task<CapsuleResult> ExecuteHomepagePublisherAsync(
+        IServiceProvider sp,
+        WorkflowNode node,
+        Dictionary<string, string> variables,
+        List<ExecutionArtifact> inputArtifacts)
+    {
+        var sb = new StringBuilder();
+
+        var slot = ReplaceVariables(GetConfigString(node, "slot") ?? "", variables).Trim().ToLowerInvariant();
+        if (string.IsNullOrWhiteSpace(slot))
+            throw new InvalidOperationException("slot 不能为空（如 agent.video-agent.video / card.tiktok-feed）");
+        if (slot.Length > 128) throw new InvalidOperationException("slot 不能超过 128 字符");
+        if (slot.Contains('/') || slot.Contains('\\')) throw new InvalidOperationException("slot 不允许包含 / 或 \\");
+        if (slot.Contains("..", StringComparison.Ordinal)) throw new InvalidOperationException("slot 不允许包含 ..");
+        if (!HomepageSlotRegex.IsMatch(slot)) throw new InvalidOperationException("slot 仅允许小写字母/数字/点/下划线/中划线，且需以字母或数字开头");
+        if (slot.StartsWith('.') || slot.EndsWith('.')) throw new InvalidOperationException("slot 不允许以 . 开头或结尾");
+
+        var mediaType = ReplaceVariables(GetConfigString(node, "mediaType") ?? "video", variables).Trim().ToLowerInvariant();
+        if (mediaType != "video" && mediaType != "image") mediaType = "video";
+
+        // 决定源 URL：直接 sourceUrl 优先 → 否则 sourceField 从上游 JSON 取
+        var sourceUrl = ReplaceVariables(GetConfigString(node, "sourceUrl") ?? "", variables).Trim();
+        var sourceField = (GetConfigString(node, "sourceField") ?? "videoUrl").Trim();
+        if (string.IsNullOrWhiteSpace(sourceUrl))
+        {
+            var inputContent = inputArtifacts.FirstOrDefault(a => a.SlotId == "hp-in")?.InlineContent
+                ?? inputArtifacts.FirstOrDefault()?.InlineContent;
+            if (!string.IsNullOrWhiteSpace(inputContent))
+            {
+                try
+                {
+                    using var doc = JsonDocument.Parse(inputContent);
+                    sourceUrl = ResolveJsonPath(doc.RootElement, sourceField);
+                    // 兜底候选：常见字段
+                    if (string.IsNullOrWhiteSpace(sourceUrl))
+                        sourceUrl = TryGetJsonString(doc.RootElement, "videoUrl", "video_url", "cosUrl", "url", "coverUrl", "cover_url");
+                    // 如果上游有 firstItem，再钻一层
+                    if (string.IsNullOrWhiteSpace(sourceUrl) && doc.RootElement.TryGetProperty("firstItem", out var first) && first.ValueKind == JsonValueKind.Object)
+                    {
+                        sourceUrl = TryGetJsonString(first, "videoUrl", "video_url", "coverUrl", "cover_url", "url");
+                    }
+                }
+                catch
+                {
+                    if (inputContent.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+                        sourceUrl = inputContent.Trim();
+                }
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(sourceUrl))
+            throw new InvalidOperationException($"未能从上游或配置获取下载 URL（sourceField='{sourceField}'）");
+
+        var timeoutSeconds = int.TryParse(GetConfigString(node, "timeoutSeconds"), out var ts) ? ts : 120;
+
+        sb.AppendLine($"[HomepagePublisher] slot: {slot}");
+        sb.AppendLine($"[HomepagePublisher] mediaType: {mediaType}");
+        sb.AppendLine($"[HomepagePublisher] 下载: {sourceUrl}");
+
+        // 下载媒体
+        var factory = sp.GetRequiredService<IHttpClientFactory>();
+        using var client = factory.CreateClient();
+        client.Timeout = TimeSpan.FromSeconds(timeoutSeconds);
+        client.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", "Mozilla/5.0 (compatible; PrdAgentWorkflow/1.0)");
+
+        byte[] mediaBytes;
+        string contentType;
+        try
+        {
+            var resp = await client.GetAsync(sourceUrl, CancellationToken.None);
+            resp.EnsureSuccessStatusCode();
+            mediaBytes = await resp.Content.ReadAsByteArrayAsync(CancellationToken.None);
+            contentType = resp.Content.Headers.ContentType?.MediaType ?? (mediaType == "video" ? "video/mp4" : "image/png");
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"下载失败: {ex.Message}");
+        }
+
+        if (mediaBytes.Length == 0)
+            throw new InvalidOperationException("下载结果为空字节");
+        if (mediaBytes.Length > 20 * 1024 * 1024)
+            throw new InvalidOperationException($"文件过大 {mediaBytes.Length / 1024 / 1024}MB，首页资源上限 20MB");
+
+        // 按 contentType 与 mediaType 决定扩展名
+        var ext = GuessHomepageExt(contentType, mediaType);
+        var mime = string.IsNullOrWhiteSpace(contentType) ? GuessHomepageMime(ext) : contentType;
+
+        // slot 与媒体类型校验：agent.X.image 不应配 video，反之亦然
+        if (HomepageAgentImageSlotRegex.IsMatch(slot) && mediaType != "image")
+            throw new InvalidOperationException($"slot '{slot}' 是图片槽位，但 mediaType='{mediaType}'");
+        if (HomepageAgentVideoSlotRegex.IsMatch(slot) && mediaType != "video")
+            throw new InvalidOperationException($"slot '{slot}' 是视频槽位，但 mediaType='{mediaType}'");
+
+        var objectKey = BuildHomepageObjectKey(slot, ext);
+        sb.AppendLine($"[HomepagePublisher] objectKey: {objectKey}");
+
+        var assetStorage = sp.GetRequiredService<PrdAgent.Infrastructure.Services.AssetStorage.IAssetStorage>();
+        await assetStorage.UploadToKeyAsync(objectKey, mediaBytes, mime, CancellationToken.None);
+        var url = assetStorage.BuildUrlForKey(objectKey);
+        sb.AppendLine($"[HomepagePublisher] ✅ COS 上传成功: {url}");
+
+        // upsert HomepageAsset
+        var dbContext = sp.GetRequiredService<PrdAgent.Infrastructure.Database.MongoDbContext>();
+        var triggeredBy = variables.GetValueOrDefault("__triggeredBy");
+        var now = DateTime.UtcNow;
+
+        var existing = await dbContext.HomepageAssets
+            .Find(x => x.Slot == slot)
+            .Limit(1)
+            .FirstOrDefaultAsync(CancellationToken.None);
+
+        if (existing == null)
+        {
+            var rec = new PrdAgent.Core.Models.HomepageAsset
+            {
+                Id = Guid.NewGuid().ToString("N"),
+                Slot = slot,
+                RelativePath = objectKey,
+                Url = url,
+                Mime = mime,
+                SizeBytes = mediaBytes.LongLength,
+                CreatedByAdminId = triggeredBy,
+                CreatedAt = now,
+                UpdatedAt = now,
+            };
+            await dbContext.HomepageAssets.InsertOneAsync(rec, cancellationToken: CancellationToken.None);
+            sb.AppendLine("[HomepagePublisher] 新建 HomepageAsset 记录");
+        }
+        else
+        {
+            // 旧扩展名变了：尝试清理旧 COS 对象
+            if (!string.Equals(existing.RelativePath, objectKey, StringComparison.Ordinal))
+            {
+                try { await assetStorage.DeleteByKeyAsync(existing.RelativePath, CancellationToken.None); }
+                catch (Exception ex) { sb.AppendLine($"[HomepagePublisher] 清理旧对象失败（忽略）: {ex.Message}"); }
+            }
+            await dbContext.HomepageAssets.UpdateOneAsync(
+                x => x.Id == existing.Id,
+                MongoDB.Driver.Builders<PrdAgent.Core.Models.HomepageAsset>.Update
+                    .Set(x => x.RelativePath, objectKey)
+                    .Set(x => x.Url, url)
+                    .Set(x => x.Mime, mime)
+                    .Set(x => x.SizeBytes, mediaBytes.LongLength)
+                    .Set(x => x.UpdatedAt, now),
+                cancellationToken: CancellationToken.None);
+            sb.AppendLine("[HomepagePublisher] 覆盖更新 HomepageAsset 记录");
+        }
+
+        var output = JsonSerializer.Serialize(new
+        {
+            slot,
+            url,
+            mime,
+            sizeBytes = mediaBytes.LongLength,
+            objectKey,
+            sourceUrl,
+        }, JsonPretty);
+
+        var artifact = MakeTextArtifact(node, "hp-out", "首页发布结果", output, "application/json");
+        return new CapsuleResult(new List<ExecutionArtifact> { artifact }, sb.ToString());
+    }
+
+    /// <summary>
+    /// 解析点号路径（如 firstItem.videoUrl）取嵌套字符串。
+    /// </summary>
+    private static string ResolveJsonPath(JsonElement root, string path)
+    {
+        if (string.IsNullOrWhiteSpace(path)) return "";
+        var parts = path.Split('.', StringSplitOptions.RemoveEmptyEntries);
+        var cur = root;
+        foreach (var p in parts)
+        {
+            if (cur.ValueKind != JsonValueKind.Object) return "";
+            if (!cur.TryGetProperty(p, out var next)) return "";
+            cur = next;
+        }
+        return cur.ValueKind == JsonValueKind.String ? (cur.GetString() ?? "") :
+               cur.ValueKind != JsonValueKind.Null && cur.ValueKind != JsonValueKind.Undefined ? cur.GetRawText() : "";
+    }
+
+    private static string GuessHomepageExt(string mime, string mediaType)
+    {
+        var m = (mime ?? "").Trim().ToLowerInvariant();
+        if (m.Contains("gif")) return "gif";
+        if (m.Contains("png")) return "png";
+        if (m.Contains("webp")) return "webp";
+        if (m.Contains("svg")) return "svg";
+        if (m.Contains("jpeg") || m.Contains("jpg")) return "jpg";
+        if (m.Contains("mp4")) return "mp4";
+        if (m.Contains("webm")) return "webm";
+        if (m.Contains("quicktime") || m.Contains("mov")) return "mov";
+        return mediaType == "video" ? "mp4" : "png";
+    }
+
+    private static string GuessHomepageMime(string ext)
+    {
+        var e = (ext ?? "").Trim().ToLowerInvariant().TrimStart('.');
+        return e switch
+        {
+            "png" => "image/png",
+            "jpg" or "jpeg" => "image/jpeg",
+            "webp" => "image/webp",
+            "gif" => "image/gif",
+            "svg" => "image/svg+xml",
+            "mp4" => "video/mp4",
+            "webm" => "video/webm",
+            "mov" => "video/quicktime",
+            _ => "application/octet-stream"
+        };
+    }
+
+    private static string BuildHomepageObjectKey(string slot, string ext)
+    {
+        var imgM = HomepageAgentImageSlotRegex.Match(slot);
+        if (imgM.Success) return $"icon/backups/agent/{imgM.Groups[1].Value}.{ext}";
+        var vidM = HomepageAgentVideoSlotRegex.Match(slot);
+        if (vidM.Success) return $"icon/backups/agent/{vidM.Groups[1].Value}.{ext}";
+        var heroM = HomepageHeroSlotRegex.Match(slot);
+        if (heroM.Success) return $"icon/title/{heroM.Groups[1].Value}.{ext}";
+        var path = slot.Replace('.', '/');
+        return $"icon/homepage/{path}.{ext}";
     }
 }

--- a/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
+++ b/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
@@ -90,6 +90,7 @@ public static class CapsuleExecutor
             CapsuleTypes.TextToCopywriting => await ExecuteTextToCopywritingAsync(sp, node, variables, inputArtifacts, emitEvent),
             CapsuleTypes.TiktokCreatorFetch => await ExecuteTiktokCreatorFetchAsync(sp, node, variables, inputArtifacts),
             CapsuleTypes.HomepagePublisher => await ExecuteHomepagePublisherAsync(sp, node, variables, inputArtifacts),
+            CapsuleTypes.WeeklyPosterPublisher => await ExecuteWeeklyPosterPublisherAsync(sp, node, variables, inputArtifacts),
 
             // ── CLI Agent 执行器 ──
             CapsuleTypes.CliAgentExecutor => await ExecuteCliAgentAsync(sp, node, variables, inputArtifacts, emitEvent),
@@ -5919,11 +5920,26 @@ function safeChart(canvasId, config) {
         var awemeId = TryGetJsonString(item, "id", "aweme_id", "awemeId", "itemId");
         var title = TryGetJsonString(item, "desc", "description", "title");
         var author = "";
+        var authorUniqueId = "";
         if (item.TryGetProperty("author", out var authorNode) && authorNode.ValueKind == JsonValueKind.Object)
         {
-            author = TryGetJsonString(authorNode, "nickname", "unique_id", "uniqueId", "name");
+            author = TryGetJsonString(authorNode, "nickname", "name");
+            authorUniqueId = TryGetJsonString(authorNode, "unique_id", "uniqueId");
         }
         var createTime = TryGetJsonString(item, "create_time", "createTime", "createdAt");
+
+        // 公开播放页 URL：TikTok 是 https://www.tiktok.com/@{unique_id}/video/{aweme_id}
+        // 抖音是 https://www.douyin.com/video/{aweme_id}
+        var shareUrl = "";
+        if (!string.IsNullOrWhiteSpace(awemeId))
+        {
+            if (platform == "douyin")
+                shareUrl = $"https://www.douyin.com/video/{awemeId}";
+            else if (!string.IsNullOrWhiteSpace(authorUniqueId))
+                shareUrl = $"https://www.tiktok.com/@{authorUniqueId}/video/{awemeId}";
+            else
+                shareUrl = $"https://www.tiktok.com/video/{awemeId}";
+        }
 
         return new
         {
@@ -5932,7 +5948,9 @@ function safeChart(canvasId, config) {
             videoUrl,
             coverUrl,
             author,
+            authorUniqueId,
             createTime,
+            shareUrl,
             platform,
         };
     }
@@ -6174,5 +6192,220 @@ function safeChart(canvasId, config) {
         if (heroM.Success) return $"icon/title/{heroM.Groups[1].Value}.{ext}";
         var path = slot.Replace('.', '/');
         return $"icon/homepage/{path}.{ext}";
+    }
+
+    // ── 发布到首页弹窗海报（Weekly Poster）─────────────────────
+
+    /// <summary>
+    /// 把上游条目数组写入 WeeklyPoster 集合并发布——登录后首页轮播弹窗即时显示。
+    /// 每条 item 对应海报的一页：title/body/imageUrl，imageUrl 前端会自动识别视频/图片。
+    /// </summary>
+    public static async Task<CapsuleResult> ExecuteWeeklyPosterPublisherAsync(
+        IServiceProvider sp,
+        WorkflowNode node,
+        Dictionary<string, string> variables,
+        List<ExecutionArtifact> inputArtifacts)
+    {
+        var sb = new StringBuilder();
+
+        var inputContent = inputArtifacts.FirstOrDefault(a => a.SlotId == "wp-in")?.InlineContent
+            ?? inputArtifacts.FirstOrDefault()?.InlineContent
+            ?? "";
+
+        if (string.IsNullOrWhiteSpace(inputContent))
+            throw new InvalidOperationException("上游输入为空，无法构建海报");
+
+        JsonElement inputRoot;
+        JsonDocument? inputDoc = null;
+        try
+        {
+            inputDoc = JsonDocument.Parse(inputContent);
+            inputRoot = inputDoc.RootElement;
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"上游输入不是合法 JSON: {ex.Message}");
+        }
+
+        try
+        {
+            var itemsField = (GetConfigString(node, "itemsField") ?? "items").Trim();
+            var weekKey = ReplaceVariables(GetConfigString(node, "weekKey") ?? "", variables).Trim();
+            var titleConfig = ReplaceVariables(GetConfigString(node, "title") ?? "", variables).Trim();
+            var subtitle = ReplaceVariables(GetConfigString(node, "subtitle") ?? "", variables).Trim();
+            var templateKey = (GetConfigString(node, "templateKey") ?? "promo").Trim();
+            var accentColor = (GetConfigString(node, "accentColor") ?? "#ff0050").Trim();
+            var ctaText = ReplaceVariables(GetConfigString(node, "ctaText") ?? "去看完整视频", variables).Trim();
+            var ctaUrlDirect = ReplaceVariables(GetConfigString(node, "ctaUrl") ?? "", variables).Trim();
+            var ctaUrlField = (GetConfigString(node, "ctaUrlField") ?? "firstItem.shareUrl").Trim();
+            var publishFlag = (GetConfigString(node, "publish") ?? "true").Trim().ToLowerInvariant() != "false";
+
+            // 取 items 数组
+            JsonElement itemsElem = ResolveJsonElement(inputRoot, itemsField);
+            if (itemsElem.ValueKind != JsonValueKind.Array)
+            {
+                // 兜底：如果上游就是数组本身
+                if (inputRoot.ValueKind == JsonValueKind.Array) itemsElem = inputRoot;
+                // 兜底：取 firstItem 包装成单元素数组（适配 tiktok-creator-fetch 的简化输出）
+                else if (inputRoot.TryGetProperty("firstItem", out var fi) && fi.ValueKind == JsonValueKind.Object)
+                {
+                    var single = JsonDocument.Parse("[" + fi.GetRawText() + "]");
+                    itemsElem = single.RootElement;
+                }
+                else
+                    throw new InvalidOperationException($"上游 JSON 中找不到数组字段「{itemsField}」（也没有 items / firstItem 兜底）");
+            }
+
+            var pages = new List<WeeklyPosterPage>();
+            int order = 0;
+            foreach (var item in itemsElem.EnumerateArray())
+            {
+                var pageTitle = TryGetJsonString(item, "title", "desc", "description", "name");
+                if (string.IsNullOrWhiteSpace(pageTitle)) pageTitle = $"作品 #{order + 1}";
+                if (pageTitle.Length > 80) pageTitle = pageTitle[..80] + "…";
+
+                var author = TryGetJsonString(item, "author", "nickname");
+                var createTime = TryGetJsonString(item, "createTime", "create_time");
+                var awemeId = TryGetJsonString(item, "awemeId", "aweme_id", "id");
+                var fullDesc = TryGetJsonString(item, "title", "desc", "description");
+
+                var bodyParts = new List<string>();
+                if (!string.IsNullOrWhiteSpace(author)) bodyParts.Add($"@{author}");
+                if (!string.IsNullOrWhiteSpace(awemeId)) bodyParts.Add($"#{awemeId}");
+                if (!string.IsNullOrWhiteSpace(fullDesc) && fullDesc != pageTitle)
+                {
+                    var truncated = fullDesc.Length > 200 ? fullDesc[..200] + "…" : fullDesc;
+                    bodyParts.Add(truncated);
+                }
+                var body = string.Join("\n\n", bodyParts);
+
+                // 优先视频 URL（video.coverUrl 是 webp 动图，但若有真视频更好）；fallback 到 coverUrl
+                // 但 TikTok 视频 URL 需 tt_chain_token，浏览器直链可能 403；先用 coverUrl（动图 webp）保证可用
+                var imageUrl = TryGetJsonString(item, "coverUrl", "cover_url", "videoUrl", "video_url", "url");
+
+                pages.Add(new WeeklyPosterPage
+                {
+                    Order = order++,
+                    Title = pageTitle,
+                    Body = body,
+                    ImagePrompt = "",
+                    ImageUrl = string.IsNullOrWhiteSpace(imageUrl) ? null : imageUrl,
+                    AccentColor = string.IsNullOrWhiteSpace(accentColor) ? null : accentColor,
+                });
+            }
+
+            if (pages.Count == 0)
+                throw new InvalidOperationException("没有任何条目可以构建海报页");
+
+            sb.AppendLine($"[WeeklyPosterPublisher] 构建 {pages.Count} 页");
+
+            // 自动 weekKey
+            if (string.IsNullOrWhiteSpace(weekKey))
+            {
+                var now = DateTime.UtcNow;
+                var iso = System.Globalization.ISOWeek.GetWeekOfYear(now);
+                var year = System.Globalization.ISOWeek.GetYear(now);
+                weekKey = $"{year}-W{iso:D2}";
+            }
+
+            // 自动 title
+            if (string.IsNullOrWhiteSpace(titleConfig))
+            {
+                var firstAuthor = "";
+                foreach (var item in itemsElem.EnumerateArray()) { firstAuthor = TryGetJsonString(item, "author", "nickname"); break; }
+                titleConfig = string.IsNullOrWhiteSpace(firstAuthor) ? "TikTok 最新作品" : $"TikTok @{firstAuthor} 最新作品";
+            }
+
+            // CTA URL 解析
+            var ctaUrl = "/changelog";
+            if (!string.IsNullOrWhiteSpace(ctaUrlDirect)) ctaUrl = ctaUrlDirect;
+            else if (!string.IsNullOrWhiteSpace(ctaUrlField))
+            {
+                var resolved = ResolveJsonPath(inputRoot, ctaUrlField);
+                if (!string.IsNullOrWhiteSpace(resolved)) ctaUrl = resolved;
+            }
+
+            sb.AppendLine($"[WeeklyPosterPublisher] weekKey={weekKey} title={titleConfig} cta={ctaUrl}");
+
+            var dbContext = sp.GetRequiredService<PrdAgent.Infrastructure.Database.MongoDbContext>();
+            var triggeredBy = variables.GetValueOrDefault("__triggeredBy") ?? "workflow-system";
+
+            var status = publishFlag ? WeeklyPosterStatus.Published : WeeklyPosterStatus.Draft;
+            var nowUtc = DateTime.UtcNow;
+
+            // 同 weekKey 旧 published 归档
+            if (publishFlag)
+            {
+                await dbContext.WeeklyPosters.UpdateManyAsync(
+                    Builders<WeeklyPosterAnnouncement>.Filter.And(
+                        Builders<WeeklyPosterAnnouncement>.Filter.Eq(x => x.WeekKey, weekKey),
+                        Builders<WeeklyPosterAnnouncement>.Filter.Eq(x => x.Status, WeeklyPosterStatus.Published)),
+                    Builders<WeeklyPosterAnnouncement>.Update
+                        .Set(x => x.Status, WeeklyPosterStatus.Archived)
+                        .Set(x => x.UpdatedAt, nowUtc),
+                    cancellationToken: CancellationToken.None);
+                sb.AppendLine($"[WeeklyPosterPublisher] 同 weekKey 旧 published 已归档");
+            }
+
+            var poster = new WeeklyPosterAnnouncement
+            {
+                Id = Guid.NewGuid().ToString("N"),
+                WeekKey = weekKey,
+                Title = titleConfig,
+                Subtitle = string.IsNullOrWhiteSpace(subtitle) ? null : subtitle,
+                Status = status,
+                TemplateKey = templateKey,
+                PresentationMode = "static",
+                SourceType = "workflow-tiktok",
+                SourceRef = node.NodeId,
+                Pages = pages,
+                CtaText = ctaText,
+                CtaUrl = ctaUrl,
+                CreatedBy = triggeredBy,
+                CreatedAt = nowUtc,
+                UpdatedAt = nowUtc,
+                PublishedAt = publishFlag ? nowUtc : null,
+                PublishedBy = publishFlag ? triggeredBy : null,
+            };
+
+            await dbContext.WeeklyPosters.InsertOneAsync(poster, cancellationToken: CancellationToken.None);
+            sb.AppendLine($"[WeeklyPosterPublisher] {(publishFlag ? "已发布" : "保存草稿")}: id={poster.Id}");
+
+            var output = JsonSerializer.Serialize(new
+            {
+                posterId = poster.Id,
+                weekKey,
+                status,
+                title = titleConfig,
+                pageCount = pages.Count,
+                pages = pages.Select(p => new { p.Order, p.Title, p.ImageUrl }),
+                ctaUrl,
+                publishedAt = poster.PublishedAt,
+            }, JsonPretty);
+
+            var artifact = MakeTextArtifact(node, "wp-out", "海报发布结果", output, "application/json");
+            return new CapsuleResult(new List<ExecutionArtifact> { artifact }, sb.ToString());
+        }
+        finally
+        {
+            inputDoc?.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// 解析点号路径取 JsonElement 引用（保留类型信息）。
+    /// </summary>
+    private static JsonElement ResolveJsonElement(JsonElement root, string path)
+    {
+        if (string.IsNullOrWhiteSpace(path)) return default;
+        var parts = path.Split('.', StringSplitOptions.RemoveEmptyEntries);
+        var cur = root;
+        foreach (var p in parts)
+        {
+            if (cur.ValueKind != JsonValueKind.Object) return default;
+            if (!cur.TryGetProperty(p, out var next)) return default;
+            cur = next;
+        }
+        return cur;
     }
 }

--- a/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
+++ b/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
@@ -5887,11 +5887,12 @@ function safeChart(canvasId, config) {
             videoUrl = TryGetJsonString(item, "video_url", "play_url", "nwm_video_url", "playUrl", "videoUrl");
         }
 
-        // 封面
+        // 封面：优先 dynamic_cover（WebP，浏览器全兼容），TikTok 的 cover/origin_cover 实际是 HEIC，
+        //   浏览器原生不支持显示。dynamic_cover 是动态 webp（动图），ai_dynamic_cover 是 ai 生成的封面。
         string coverUrl = "";
         if (item.TryGetProperty("video", out var vNode2) && vNode2.ValueKind == JsonValueKind.Object)
         {
-            foreach (var coverKey in new[] { "cover", "origin_cover", "dynamic_cover", "originCover" })
+            foreach (var coverKey in new[] { "dynamic_cover", "ai_dynamic_cover", "cover", "origin_cover", "originCover" })
             {
                 if (vNode2.TryGetProperty(coverKey, out var cover))
                 {

--- a/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
+++ b/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
@@ -6054,9 +6054,14 @@ function safeChart(canvasId, config) {
         if (mediaBytes.Length > 20 * 1024 * 1024)
             throw new InvalidOperationException($"文件过大 {mediaBytes.Length / 1024 / 1024}MB，首页资源上限 20MB");
 
-        // 按 contentType 与 mediaType 决定扩展名
+        // 按 contentType 与 mediaType 决定扩展名 + 兜底 mime
+        // 当 CDN 返回通用 application/octet-stream 时，必须用扩展名推回真实 mime——否则
+        // COS 上的对象会以 octet-stream 落库，前端 <video>/<img> 拒绝识别该 mime 导致播不出来
         var ext = GuessHomepageExt(contentType, mediaType);
-        var mime = string.IsNullOrWhiteSpace(contentType) ? GuessHomepageMime(ext) : contentType;
+        var isGenericMime = string.IsNullOrWhiteSpace(contentType)
+            || string.Equals(contentType, "application/octet-stream", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(contentType, "binary/octet-stream", StringComparison.OrdinalIgnoreCase);
+        var mime = isGenericMime ? GuessHomepageMime(ext) : contentType;
 
         // slot 与媒体类型校验：agent.X.image 不应配 video，反之亦然
         if (HomepageAgentImageSlotRegex.IsMatch(slot) && mediaType != "image")

--- a/prd-api/src/PrdAgent.Core/Models/CapsuleTypeRegistry.cs
+++ b/prd-api/src/PrdAgent.Core/Models/CapsuleTypeRegistry.cs
@@ -812,6 +812,67 @@ public static class CapsuleTypeRegistry
 
     // ──────────── 短视频工作流类 ────────────
 
+    public static readonly CapsuleTypeMeta TiktokCreatorFetch = new()
+    {
+        TypeKey = CapsuleTypes.TiktokCreatorFetch,
+        Name = "TikTok 博主视频列表",
+        Description = "调用 TikHub API 拉取指定 TikTok / 抖音博主的最新视频列表。输出标准化的视频条目数组（含 videoUrl / coverUrl / title / awemeId），可作为「博主订阅」工作流的源头",
+        Icon = "video",
+        Category = CapsuleCategory.Processor,
+        AccentHue = 340,
+        ConfigSchema = new()
+        {
+            new() { Key = "platform", Label = "平台", FieldType = "select", Required = true, DefaultValue = "tiktok", Options = new()
+            {
+                new() { Value = "tiktok", Label = "TikTok（海外，使用 secUid）" },
+                new() { Value = "douyin", Label = "抖音（国内，使用 sec_user_id）" },
+            }, HelpTip = "选择目标平台。TikTok 用 secUid，抖音用 sec_user_id（参考 tikhub.io 文档获取）" },
+            new() { Key = "apiBaseUrl", Label = "TikHub API 地址", FieldType = "text", Required = false, DefaultValue = "https://api.tikhub.io", HelpTip = "TikHub API 基础地址，留空走默认 https://api.tikhub.io" },
+            new() { Key = "apiKey", Label = "API 密钥", FieldType = "password", Required = true, Placeholder = "Bearer xxx", HelpTip = "TikHub API 认证密钥，可使用 {{secrets.TIKHUB_API_KEY}} 引用工作流密钥" },
+            new() { Key = "secUid", Label = "博主 secUid / sec_user_id", FieldType = "text", Required = true, Placeholder = "MS4wLjABAAAA...", HelpTip = "TikTok 博主 secUid（从博主主页 URL 或 TikHub 用户搜索接口取得），抖音填 sec_user_id" },
+            new() { Key = "count", Label = "拉取数量", FieldType = "number", Required = false, DefaultValue = "10", HelpTip = "本次最多拉取多少条视频，建议 1-30。首次测试可设为 1" },
+            new() { Key = "cursor", Label = "起始游标", FieldType = "text", Required = false, DefaultValue = "0", HelpTip = "翻页游标，留空或 0 从最新开始" },
+        },
+        DefaultInputSlots = new()
+        {
+            new() { SlotId = "tcf-in", Name = "trigger", DataType = "json", Required = false, Description = "上游触发上下文（可选，可覆盖 secUid）" },
+        },
+        DefaultOutputSlots = new()
+        {
+            new() { SlotId = "tcf-out", Name = "videos", DataType = "json", Required = true, Description = "标准化视频列表（items 数组 + firstItem 快捷字段，每项含 videoUrl / coverUrl / title / awemeId）" },
+        },
+    };
+
+    public static readonly CapsuleTypeMeta HomepagePublisher = new()
+    {
+        TypeKey = CapsuleTypes.HomepagePublisher,
+        Name = "发布到首页海报",
+        Description = "把上游的图片或视频 URL 下载并写入「首页资源」槽位（slot），登录后首页快捷卡 / Agent 封面即时更新。slot 命名遵循 card.* / agent.{key}.image / agent.{key}.video / hero.* 约定",
+        Icon = "image",
+        Category = CapsuleCategory.Output,
+        AccentHue = 200,
+        ConfigSchema = new()
+        {
+            new() { Key = "slot", Label = "首页槽位 (slot)", FieldType = "text", Required = true, Placeholder = "agent.video-agent.video", HelpTip = "首页资源 slot：card.{id}（卡片背景）/ agent.{key}.image（Agent 封面图）/ agent.{key}.video（Agent 封面视频）/ hero.{id}（顶部 banner）" },
+            new() { Key = "mediaType", Label = "媒体类型", FieldType = "select", Required = true, DefaultValue = "video", Options = new()
+            {
+                new() { Value = "video", Label = "视频（mp4/webm/mov）" },
+                new() { Value = "image", Label = "图片（png/jpg/webp/gif）" },
+            }, HelpTip = "决定 slot 写入的扩展名与 MIME 类型；与 slot 后缀（.image / .video）必须匹配" },
+            new() { Key = "sourceField", Label = "上游字段名", FieldType = "text", Required = false, DefaultValue = "videoUrl", HelpTip = "从上游 JSON 中取哪个字段作为下载 URL。常用：videoUrl / coverUrl / cosUrl / url。也支持 firstItem.videoUrl 这样的点号路径" },
+            new() { Key = "sourceUrl", Label = "直接源 URL（可选）", FieldType = "text", Required = false, Placeholder = "https://...", HelpTip = "如果不从上游取，直接填一个完整 URL；填了优先于 sourceField" },
+            new() { Key = "timeoutSeconds", Label = "下载超时（秒）", FieldType = "number", Required = false, DefaultValue = "120" },
+        },
+        DefaultInputSlots = new()
+        {
+            new() { SlotId = "hp-in", Name = "media", DataType = "json", Required = false, Description = "上游媒体信息（含 videoUrl / coverUrl / cosUrl 等字段）" },
+        },
+        DefaultOutputSlots = new()
+        {
+            new() { SlotId = "hp-out", Name = "result", DataType = "json", Required = true, Description = "发布结果（含 slot / url / mime / sizeBytes）" },
+        },
+    };
+
     public static readonly CapsuleTypeMeta DouyinParser = new()
     {
         TypeKey = CapsuleTypes.DouyinParser,
@@ -1028,7 +1089,7 @@ public static class CapsuleTypeRegistry
         // CLI Agent 执行器
         CliAgentExecutor,
         // 短视频工作流类
-        DouyinParser, VideoDownloader, VideoToText, TextToCopywriting,
+        DouyinParser, VideoDownloader, VideoToText, TextToCopywriting, TiktokCreatorFetch, HomepagePublisher,
     };
 
     /// <summary>按 TypeKey 查找</summary>

--- a/prd-api/src/PrdAgent.Core/Models/CapsuleTypeRegistry.cs
+++ b/prd-api/src/PrdAgent.Core/Models/CapsuleTypeRegistry.cs
@@ -863,6 +863,11 @@ public static class CapsuleTypeRegistry
                 new() { Value = "promo", Label = "promo（推广，TikTok 推荐用）" },
                 new() { Value = "sale", Label = "sale（活动）" },
             } },
+            new() { Key = "presentationMode", Label = "展示样式", FieldType = "select", Required = false, DefaultValue = "ad-4-3", Options = new()
+            {
+                new() { Value = "ad-4-3", Label = "ad-4-3（4:3 视频广告样式，中央 Play 按钮，推荐）" },
+                new() { Value = "static", Label = "static（1200×628 横幅样式，自动播放）" },
+            }, HelpTip = "ad-4-3：借鉴 Apple 产品视频弹窗，全 bleed 封面 + 中央 Play 按钮，用户主动点击才播。static：传统横幅 48% 上图 52% 下文" },
             new() { Key = "accentColor", Label = "强调色", FieldType = "text", Required = false, DefaultValue = "#ff0050", HelpTip = "页面主色调（hex），TikTok 粉默认 #ff0050" },
             new() { Key = "ctaText", Label = "末页按钮文案", FieldType = "text", Required = false, DefaultValue = "去看完整视频" },
             new() { Key = "ctaUrlField", Label = "CTA 链接字段", FieldType = "text", Required = false, DefaultValue = "firstItem.shareUrl", HelpTip = "从上游 JSON 取哪个字段做 CTA 链接（点号路径），留空时退回到 #" },

--- a/prd-api/src/PrdAgent.Core/Models/CapsuleTypeRegistry.cs
+++ b/prd-api/src/PrdAgent.Core/Models/CapsuleTypeRegistry.cs
@@ -843,6 +843,47 @@ public static class CapsuleTypeRegistry
         },
     };
 
+    public static readonly CapsuleTypeMeta WeeklyPosterPublisher = new()
+    {
+        TypeKey = CapsuleTypes.WeeklyPosterPublisher,
+        Name = "发布到首页弹窗海报",
+        Description = "把上游内容（含图片/视频 URL + 文案）作为「周报小报」发布——登录后首页的轮播弹窗会立刻显示。每条上游 item 对应海报的一页（title/body/imageUrl），imageUrl 前端自动识别视频还是图片",
+        Icon = "image",
+        Category = CapsuleCategory.Output,
+        AccentHue = 320,
+        ConfigSchema = new()
+        {
+            new() { Key = "weekKey", Label = "周标识", FieldType = "text", Required = false, Placeholder = "2026-W18", HelpTip = "ISO 周标识，留空自动取当前周。同一 weekKey 多次发布旧版本自动归档" },
+            new() { Key = "title", Label = "海报主标题", FieldType = "text", Required = false, Placeholder = "TikTok @author 最新作品", HelpTip = "海报顶部主标题。留空时自动用「TikTok @{firstItem.author} 最新作品」" },
+            new() { Key = "subtitle", Label = "副标题", FieldType = "text", Required = false, Placeholder = "本周精选" },
+            new() { Key = "templateKey", Label = "模板", FieldType = "select", Required = false, DefaultValue = "promo", Options = new()
+            {
+                new() { Value = "release", Label = "release（更新公告）" },
+                new() { Value = "hotfix", Label = "hotfix（紧急修复）" },
+                new() { Value = "promo", Label = "promo（推广，TikTok 推荐用）" },
+                new() { Value = "sale", Label = "sale（活动）" },
+            } },
+            new() { Key = "accentColor", Label = "强调色", FieldType = "text", Required = false, DefaultValue = "#ff0050", HelpTip = "页面主色调（hex），TikTok 粉默认 #ff0050" },
+            new() { Key = "ctaText", Label = "末页按钮文案", FieldType = "text", Required = false, DefaultValue = "去看完整视频" },
+            new() { Key = "ctaUrlField", Label = "CTA 链接字段", FieldType = "text", Required = false, DefaultValue = "firstItem.shareUrl", HelpTip = "从上游 JSON 取哪个字段做 CTA 链接（点号路径），留空时退回到 #" },
+            new() { Key = "ctaUrl", Label = "CTA 链接（直填）", FieldType = "text", Required = false, Placeholder = "https://www.tiktok.com/@author/video/xxx", HelpTip = "直接填一个完整 URL，优先级高于 ctaUrlField" },
+            new() { Key = "itemsField", Label = "上游条目字段", FieldType = "text", Required = false, DefaultValue = "items", HelpTip = "从上游 JSON 取哪个字段作为海报页数组（默认 items）" },
+            new() { Key = "publish", Label = "立即发布", FieldType = "select", Required = false, DefaultValue = "true", Options = new()
+            {
+                new() { Value = "true", Label = "立即发布（用户登录可见）" },
+                new() { Value = "false", Label = "保存为草稿" },
+            } },
+        },
+        DefaultInputSlots = new()
+        {
+            new() { SlotId = "wp-in", Name = "items", DataType = "json", Required = true, Description = "上游条目数组（如 tiktok-creator-fetch 的 items 字段）" },
+        },
+        DefaultOutputSlots = new()
+        {
+            new() { SlotId = "wp-out", Name = "result", DataType = "json", Required = true, Description = "发布结果（含 posterId / weekKey / status / pageCount）" },
+        },
+    };
+
     public static readonly CapsuleTypeMeta HomepagePublisher = new()
     {
         TypeKey = CapsuleTypes.HomepagePublisher,
@@ -1089,7 +1130,7 @@ public static class CapsuleTypeRegistry
         // CLI Agent 执行器
         CliAgentExecutor,
         // 短视频工作流类
-        DouyinParser, VideoDownloader, VideoToText, TextToCopywriting, TiktokCreatorFetch, HomepagePublisher,
+        DouyinParser, VideoDownloader, VideoToText, TextToCopywriting, TiktokCreatorFetch, HomepagePublisher, WeeklyPosterPublisher,
     };
 
     /// <summary>按 TypeKey 查找</summary>

--- a/prd-api/src/PrdAgent.Core/Models/WorkflowModels.cs
+++ b/prd-api/src/PrdAgent.Core/Models/WorkflowModels.cs
@@ -467,6 +467,7 @@ public static class CapsuleTypes
     public const string TextToCopywriting = "text-to-copywriting";
     public const string TiktokCreatorFetch = "tiktok-creator-fetch";
     public const string HomepagePublisher = "homepage-publisher";
+    public const string WeeklyPosterPublisher = "weekly-poster-publisher";
 
     // 兼容旧类型映射
     public const string DataCollectorLegacy = "data-collector";
@@ -482,7 +483,7 @@ public static class CapsuleTypes
         // 流程控制类
         Delay, Condition,
         // 输出类
-        ReportGenerator, WebpageGenerator, FileExporter, WebhookSender, NotificationSender, VideoGeneration, SitePublisher, EmailSender, HomepagePublisher,
+        ReportGenerator, WebpageGenerator, FileExporter, WebhookSender, NotificationSender, VideoGeneration, SitePublisher, EmailSender, HomepagePublisher, WeeklyPosterPublisher,
         // CLI Agent 执行器
         CliAgentExecutor,
         // 短视频工作流类

--- a/prd-api/src/PrdAgent.Core/Models/WorkflowModels.cs
+++ b/prd-api/src/PrdAgent.Core/Models/WorkflowModels.cs
@@ -465,6 +465,8 @@ public static class CapsuleTypes
     public const string VideoDownloader = "video-downloader";
     public const string VideoToText = "video-to-text";
     public const string TextToCopywriting = "text-to-copywriting";
+    public const string TiktokCreatorFetch = "tiktok-creator-fetch";
+    public const string HomepagePublisher = "homepage-publisher";
 
     // 兼容旧类型映射
     public const string DataCollectorLegacy = "data-collector";
@@ -480,11 +482,11 @@ public static class CapsuleTypes
         // 流程控制类
         Delay, Condition,
         // 输出类
-        ReportGenerator, WebpageGenerator, FileExporter, WebhookSender, NotificationSender, VideoGeneration, SitePublisher, EmailSender,
+        ReportGenerator, WebpageGenerator, FileExporter, WebhookSender, NotificationSender, VideoGeneration, SitePublisher, EmailSender, HomepagePublisher,
         // CLI Agent 执行器
         CliAgentExecutor,
         // 短视频工作流类
-        DouyinParser, VideoDownloader, VideoToText, TextToCopywriting,
+        DouyinParser, VideoDownloader, VideoToText, TextToCopywriting, TiktokCreatorFetch,
         // 旧类型兼容
         DataCollectorLegacy, LlmCodeExecutorLegacy, RendererLegacy,
     };


### PR DESCRIPTION
## Summary

This PR introduces a complete workflow for subscribing to TikTok/Douyin creators and publishing their latest videos as homepage advertisement posters. It adds three new workflow capsule types and a pre-built template, enabling users to automatically fetch creator videos via TikHub API and display them as engaging modal popups on the homepage.

## Key Changes

### Backend (prd-api)

- **New Capsule: `tiktok-creator-fetch`** - Fetches latest videos from TikTok/Douyin creators via TikHub API
  - Supports both TikTok (secUid) and Douyin (sec_user_id) platforms
  - Uses TikTok app/v3 endpoint (more stable than web endpoint)
  - Normalizes video items with standardized fields: `awemeId`, `title`, `videoUrl`, `coverUrl`, `author`, `shareUrl`
  - Handles multiple response formats (itemList, aweme_list, items, videos, list)
  - Intelligently extracts video URLs from nested structures and prefers dynamic_cover (WebP) over HEIC formats

- **New Capsule: `homepage-publisher`** - Downloads media and publishes to homepage asset slots
  - Downloads media from upstream URLs with configurable timeout
  - Validates slot naming and media type consistency
  - Stores assets in COS with proper MIME type detection
  - Upserts HomepageAsset records with automatic cleanup of old versions
  - Supports both image and video media types

- **New Capsule: `weekly-poster-publisher`** - Publishes content as homepage carousel posters
  - Converts upstream items into poster pages with title, body, and media
  - Supports two presentation modes: `ad-4-3` (video ad style with Play button) and `static` (traditional 1200×628 banner)
  - Handles both video and image URLs with intelligent format detection
  - Generates shareable URLs for TikTok/Douyin videos
  - Manages poster lifecycle (draft → published → archived)

### Frontend (prd-admin)

- **New Workflow Template: "TikTok/Douyin Creator Subscription → Homepage Poster"**
  - Simplified user inputs: API key + secUid (with TikHub official example as default)
  - Configurable video count (1, 4, 6, or 10 items)
  - Auto-generates poster pages from creator videos

- **Enhanced `PosterAdPageView` Component** - New ad-mode poster presentation
  - Full-bleed media layout (4:3 aspect ratio)
  - Central Play button for videos (inspired by Apple/Netflix modals)
  - Lazy video mounting to avoid visual noise
  - Separate cover image layer (avoids WebP poster rendering issues in some browsers)
  - Gradient fallback background with accent color
  - Smooth transitions between cover and video playback

- **Improved Video URL Detection** - Enhanced `isVideoUrl()` function
  - Recognizes TikTok/Douyin CDN URLs without file extensions
  - Detects `/video/tos/` path patterns
  - Handles data: URIs and common video extensions

- **Updated Capsule Registry** - Added three new capsule type definitions with proper icons and metadata

## Notable Implementation Details

- **TikHub API Integration**: Uses Bearer token authentication, configurable base URL, supports pagination via cursor
- **Media Normalization**: Robust JSON path resolution with fallback chains for different API response formats
- **Asset Storage**: Integrates with existing AssetStorage service for COS uploads with automatic MIME type detection
- **Database Operations**: Uses MongoDB upsert pattern for HomepageAsset records with proper timestamp management
- **Video Format Handling**: Intelligently selects between video playback and image display based on URL patterns and content type
- **Slot Validation**: Enforces strict naming rules (lowercase alphanumeric + dots/underscores/hyphens) with regex validation
- **Responsive Design**: Modal sizing adapts to viewport with proper aspect ratio constraints for both ad and static modes

## Files Modified

- `prd-api/src/PrdAgent.Api/Services/CapsuleExecut

https://claude.ai/code/session_01YNVENTybaBMYH5CpFafJem

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new workflow capsules that call external TikHub APIs, upload media to COS, and write/modify MongoDB records for `WeeklyPoster`/`HomepageAsset`, plus changes homepage modal rendering; mistakes could affect homepage content or publishing/auth flows.
> 
> **Overview**
> Enables a new end-to-end workflow to **fetch TikTok/抖音 creator posts and publish them as homepage login posters**. This adds three new capsule types: `tiktok-creator-fetch` (TikHub app/v3 for TikTok + web for Douyin, normalized `items/firstItem` incl. `shareUrl` and WebP `dynamic_cover`), `weekly-poster-publisher` (turns items into `WeeklyPosterAnnouncement` pages, supports `presentationMode` and prefers `videoUrl` with `SecondaryImageUrl` as poster), and `homepage-publisher` (downloads media, validates slot naming, uploads to COS with MIME fallback when upstream returns `octet-stream`, and upserts `HomepageAsset`).
> 
> Updates admin UI to register these capsules and ships a new workflow template `tiktok-creator-to-homepage` (API key + platform + secUid/sec_user_id + count) that publishes via `weekly-poster-publisher` with platform-specific CTA. The homepage poster modal now routes on `presentationMode='ad-4-3'` to a new 4:3 ad view with click-to-play video, tightened `isVideoUrl` path-based detection, and removal of a stray `metaLabel`. Also locks down `WeeklyPosterController` by adding `[Authorize]`, and adds Phase-1/2 handoff docs and a changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddd27fa42d9bab7f1f74375fdac913713689248c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->