### PR TITLE
feat(emergence-1): 多平台博主订阅 → 首页 feed-card 海报（Phase 2 + 3 全量）

### DIFF
--- a/changelogs/2026-05-06_emergence-1-phase-2-rich-text-poster.md
+++ b/changelogs/2026-05-06_emergence-1-phase-2-rich-text-poster.md
@@ -1,3 +1,5 @@
 | feat | prd-admin | 周报海报新增 ad-rich-text 版式（左侧 9:16 动态封面 + 右侧 hook 大字 + bullets，点 Play 切回全屏视频） |
 | feat | prd-api | weekly-poster-publisher 胶囊 presentationMode 选项追加 ad-rich-text |
 | docs | prd-api | WeeklyPosterAnnouncement.PresentationMode 注释同步实际支持的三种模式 |
+| feat | prd-api | video-to-text 胶囊新增 asr 模式：下载视频 → ffmpeg 抽音 → 豆包流式 ASR → 可选 LLM 提炼 hook + bullets，输出兼容数组/单对象 |
+| feat | prd-api | AppCallerRegistry 新增 video-agent.video-to-text::asr 入口供 ASR 模型池绑定 |

--- a/changelogs/2026-05-06_emergence-1-phase-2-rich-text-poster.md
+++ b/changelogs/2026-05-06_emergence-1-phase-2-rich-text-poster.md
@@ -1,0 +1,3 @@
+| feat | prd-admin | 周报海报新增 ad-rich-text 版式（左侧 9:16 动态封面 + 右侧 hook 大字 + bullets，点 Play 切回全屏视频） |
+| feat | prd-api | weekly-poster-publisher 胶囊 presentationMode 选项追加 ad-rich-text |
+| docs | prd-api | WeeklyPosterAnnouncement.PresentationMode 注释同步实际支持的三种模式 |

--- a/changelogs/2026-05-06_emergence-1-phase-2-rich-text-poster.md
+++ b/changelogs/2026-05-06_emergence-1-phase-2-rich-text-poster.md
@@ -3,3 +3,5 @@
 | docs | prd-api | WeeklyPosterAnnouncement.PresentationMode 注释同步实际支持的三种模式 |
 | feat | prd-api | video-to-text 胶囊新增 asr 模式：下载视频 → ffmpeg 抽音 → 豆包流式 ASR → 可选 LLM 提炼 hook + bullets，输出兼容数组/单对象 |
 | feat | prd-api | AppCallerRegistry 新增 video-agent.video-to-text::asr 入口供 ASR 模型池绑定 |
+| feat | prd-api | weekly-poster-publisher 渲染 page 时优先使用上游 item.hook / item.body 字段，未提供时走原 @author+#aweme+desc 兜底 |
+| feat | prd-admin | 新增模板「TikTok / 抖音 博主订阅 → 首页图文混排海报 (ASR)」，4 节点串联手动触发 / 拉视频 / ASR + hook / 发布 ad-rich-text |

--- a/changelogs/2026-05-07_emergence-1-phase-3-feed-card.md
+++ b/changelogs/2026-05-07_emergence-1-phase-3-feed-card.md
@@ -1,0 +1,13 @@
+| feat | prd-api | 博主作品订阅胶囊扩展支持 5 平台（TikTok / 抖音 / B 站 / 小红书 / YouTube），按 platform 分发到 5 个 normalizer 输出统一 schema |
+| feat | prd-api | 新增 media-rehost 胶囊，items 数组里的视频/封面/头像 URL 下载到 COS 替换为稳定直链，绕开 CDN 防盗链 403 |
+| feat | prd-api | weekly-poster-publisher 新增 feed-card 版式（presentationMode），并把 page schema 扩到 7 个新字段：authorName / avatar / platform / durationSec / hashtags / stats / transcriptCues |
+| feat | prd-api | video-to-text asr 模式从豆包 ASR utterances 抽取毫秒级时间戳写入 item.transcriptCues，给前端字幕浮层用 |
+| feat | prd-api | 5 个 normalizer 全部透出 author / avatar / duration / stats / hashtags 字段（TikTok statistics、B 站 length 字符串、小红书 interact_info 等）|
+| feat | prd-admin | PosterFeedCardView 组件实现抖音/小红书风格 9 信息单元布局：头像 + @ 用户 + 平台 chip + 时长 + 视频 + 互动 chip + 字幕浮层 + 标题 + 标签 |
+| feat | prd-admin | feed-card 模态视频比例自适应：检测 videoWidth/Height 三档切换 9:16 (460px) / 4:3 (760px) / 16:9 (920px) |
+| feat | prd-admin | 海报弹窗 X 按钮重定义为「收起到右下角胶囊」，胶囊上的 ✕ 才彻底 dismiss。仿 Slack PiP / 抖音 reminder 模式 |
+| feat | prd-admin | feed-card 视频播放时挂 timeupdate listener，二分查找 currentTime 命中的 cue，渲染半透明字幕浮层 |
+| feat | prd-admin | 多平台模板加 PLATFORM_OPTIONS / PLATFORM_CTA_LABELS / PLATFORM_ID_HELP 共享常量，两个工作流模板都自动支持 5 平台下拉切换 |
+| feat | prd-admin | 工作流模板默认插入 media-rehost 节点（fetch → rehost → publish），rich-text 模板里 rehost 在 ASR 之前防止短期签名 URL 二次过期 |
+| fix | prd-api | WeeklyPosterPageDto 同步透出 7 个新字段 + TranscriptCues，否则 GET /api/weekly-posters/* 永远返回 null |
+| docs | doc/ | 新增 guide.poster-feed-card 用户教程；plan.emergence-1 加 §3 Phase 3 已交付段；debt.workflow-agent 升 v2.0：Phase 2 留尾 7 项 paid + 5 项 Phase 3 新债 |

--- a/doc/debt.workflow-agent.md
+++ b/doc/debt.workflow-agent.md
@@ -1,0 +1,126 @@
+# 工作流 Agent · 债务台账
+
+> **版本**：v1.0 | **日期**：2026-05-06 | **状态**：维护中
+
+## 总览
+
+| 指标 | 当前值 |
+|------|--------|
+| open | 7 |
+| in-progress | 0 |
+| paid | 0 |
+
+模块范围：`prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs`、`prd-admin/src/pages/workflow-agent/`、所有 `CapsuleTypes.*` 胶囊执行链路。本文件只覆盖工作流胶囊侧的债务；视频生成（OpenRouter 直出）的债务见 `debt.video-agent.md`。
+
+---
+
+## open 债务（按风险倒序）
+
+### 1. video-to-text asr 模式：模型池绑定是手动一次性配置
+
+**触发场景**：用户首次创建 ASR 工作流执行时。
+
+**当前行为**：胶囊执行抛 `InvalidOperationException("ASR 模型调度失败: ... 请去模型池配置 video-agent.video-to-text::asr")`。错误信息明确，但用户得自己理解去管理后台「模型池」页绑定一个 `doubao-asr-stream` 模型才能继续。
+
+**理想行为**：
+- 选项 A：模板首次执行时 fallback 到 `video-agent.v2d.transcribe::asr`（已有 ASR 资源），而非直接抛错
+- 选项 B：模板表单里加一个「使用现有 ASR 池」开关，让用户自选 caller code
+- 选项 C：管理后台增加「未配置 caller 自动复用同分类 caller」开关
+
+**估时**：1-2h（选项 A 最简单，加 try/fallback 即可）
+
+**关联**：`prd-api/Services/CapsuleExecutor.cs ExecuteVideoToTextAsrAsync`、`AppCallerRegistry.VideoAgent.VideoToText.Asr`。
+
+### 2. video-to-text asr 模式：maxItems 默认 4 是硬编码
+
+**当前行为**：超出 maxItems 的条目原样透传不做转写，但用户可能期望全部转写。模板里 count 选项最大 6，如果用户在画布里手动改 count 到 10，maxItems 仍是 4 → 后 6 条没 transcript，海报内容缺失但不报错。
+
+**理想行为**：
+- 模板 build 时把 maxItems = count，但用户在画布编辑器里修改 count 后无自动同步
+- 或者 maxItems 留空时自动等于 input 数组长度
+- 或者前端在 itemsField 与 maxItems 不一致时给出黄色 warning chip
+
+**估时**：30min（前端 warning chip 最简单）
+
+**关联**：`prd-admin/src/pages/workflow-agent/workflowTemplates.ts` `tiktokCreatorToHomepageRichTemplate`。
+
+### 3. video-to-text asr 模式：LLM hook 提炼无 LlmRequestContext
+
+**当前行为**：沿用现有 video-to-text 旧规约，未走 `BeginScope`。`UserId` 由 workflow 执行时的 `__triggeredBy` 变量提供（自动化触发时是 `workflow-system`）。
+
+**与规则的差异**：`.claude/rules/llm-gateway.md` 强制要求 LLM 调用前 `using var _ = ctx.BeginScope(...)` 设置 UserId。当前代码若引入用户级配额/告警会失效。
+
+**风险等级**：低（workflow capsule 上下文已无强用户绑定，且现有 video-to-text/llm 模式也没设置）。
+
+**估时**：30min（加 ILLMRequestContextAccessor 注入 + BeginScope 即可）
+
+**关联**：`CapsuleExecutor.cs` 所有 `gateway.SendAsync` 调用点。
+
+### 4. video-to-text asr 模式：转写失败兜底为空 transcript 透传
+
+**当前行为**：视频不可达 / ffmpeg 失败 / ASR 失败时，item 仍保留原结构，仅 `transcript=""`。下游 weekly-poster-publisher 渲染 `ad-rich-text` 海报时会因 body 为空展示空白。
+
+**理想行为**：
+- 选项 A：失败的 item 跳过不入海报，logs 里记录跳过原因
+- 选项 B：失败的 item 在 ad-rich-text 视图里降级到 ad-4-3 风格（cover 全 bleed + Play 按钮）
+- 选项 C：在 PosterRichTextPageView 检测 body 为空时切到 PosterAdPageView 渲染
+
+**估时**：1h（选项 C 最优，前端单文件改动）
+
+**关联**：`prd-admin/components/weekly-poster/WeeklyPosterModal.tsx` `PosterRichTextPageView`。
+
+### 5. video-to-text asr 模式：ffmpeg 依赖未检测
+
+**当前行为**：CDS 容器有 ffmpeg，但本地 dev 镜像可能没有。`ExtractAudioWithFfmpegAsync` 启动失败抛 `InvalidOperationException("ffmpeg 启动失败")`，用户可能误以为是 ASR 模型问题。
+
+**理想行为**：
+- 胶囊执行前先 `which ffmpeg` 探测，缺失时给出明确错误「环境缺 ffmpeg，CDS 容器请重建，本地请 apt install ffmpeg」
+- 或者 Dockerfile 显式声明 ffmpeg 是必需依赖
+
+**估时**：30min
+
+**关联**：`CapsuleExecutor.cs ExtractAudioWithFfmpegAsync`、`prd-api/Dockerfile`。
+
+### 6. ad-rich-text 海报：用户点 Play 后无法回到 rich-text 视图
+
+**当前行为**：`hasPlayed` 状态进入全屏视频后，用户必须翻页或关闭弹窗才能重置。无「返回」按钮。
+
+**理想行为**：
+- 选项 A：在全屏视频右上角加「< 返回详情」按钮
+- 选项 B：视频播放结束后自动回到 rich-text 视图
+
+**估时**：30min
+
+**关联**：`WeeklyPosterModal.tsx PosterRichTextPageView`。
+
+### 7. weekly-poster-publisher：count 与 maxItems 在多模板间不一致
+
+**当前行为**：模板 build 时 `maxItems: count`，但用户在画布里改 count 不会自动同步 maxItems（两个字段独立维护）。
+
+**理想行为**：
+- 选项 A：在前端工作流编辑器加跨节点联动逻辑（count 改了同步到下游 video-to-text.maxItems）
+- 选项 B：去掉 maxItems，video-to-text 默认处理所有 items（适配 N 条）
+
+**估时**：1h（选项 A 复杂；选项 B 最简单但失去保护）
+
+**关联**：`prd-admin/src/pages/workflow-agent/`（编辑器联动）、`CapsuleExecutor.cs ExecuteVideoToTextAsrAsync`。
+
+---
+
+## 待落地（Phase 2 任务 D 上线后追加）
+
+任务 D（抖音 OAuth + cron 真订阅）落地后，预计会引入新债务：
+- aweme_id 去重表的索引策略（按 user/account 分桶 vs 全局）
+- OAuth token 续期失败的降级策略
+- cron 漂移对 5 分钟轮询粒度的影响
+
+待真正落地后再补本节。
+
+---
+
+## 相关文档
+
+- `doc/plan.emergence-1-tiktok-douyin-poster.md`：涌现 1 主计划文档（Phase 1 + Phase 2 任务 A/B/C 已完成）
+- `doc/debt.video-agent.md`：视频生成 Agent 债务（Remotion 已废弃路径）
+- `.claude/rules/llm-gateway.md`：LlmRequestContext 强制要求（本文件 §3 关联）
+- `.claude/rules/server-authority.md`：CancellationToken.None + Run/Worker 模式

--- a/doc/debt.workflow-agent.md
+++ b/doc/debt.workflow-agent.md
@@ -1,113 +1,111 @@
 # 工作流 Agent · 债务台账
 
-> **版本**：v1.0 | **日期**：2026-05-06 | **状态**：维护中
+> **版本**：v2.0 | **日期**：2026-05-07 | **状态**：维护中
 
 ## 总览
 
 | 指标 | 当前值 |
 |------|--------|
-| open | 7 |
+| open | 5 |
 | in-progress | 0 |
-| paid | 0 |
+| paid | 7（Phase 2 留尾全部偿还） |
 
 模块范围：`prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs`、`prd-admin/src/pages/workflow-agent/`、所有 `CapsuleTypes.*` 胶囊执行链路。本文件只覆盖工作流胶囊侧的债务；视频生成（OpenRouter 直出）的债务见 `debt.video-agent.md`。
 
 ---
 
-## open 债务（按风险倒序）
+## paid 债务（Phase 2 7 项已还，2026-05-06 commit `0d3ca22`）
 
-### 1. video-to-text asr 模式：模型池绑定是手动一次性配置
-
-**触发场景**：用户首次创建 ASR 工作流执行时。
-
-**当前行为**：胶囊执行抛 `InvalidOperationException("ASR 模型调度失败: ... 请去模型池配置 video-agent.video-to-text::asr")`。错误信息明确，但用户得自己理解去管理后台「模型池」页绑定一个 `doubao-asr-stream` 模型才能继续。
-
-**理想行为**：
-- 选项 A：模板首次执行时 fallback 到 `video-agent.v2d.transcribe::asr`（已有 ASR 资源），而非直接抛错
-- 选项 B：模板表单里加一个「使用现有 ASR 池」开关，让用户自选 caller code
-- 选项 C：管理后台增加「未配置 caller 自动复用同分类 caller」开关
-
-**估时**：1-2h（选项 A 最简单，加 try/fallback 即可）
-
-**关联**：`prd-api/Services/CapsuleExecutor.cs ExecuteVideoToTextAsrAsync`、`AppCallerRegistry.VideoAgent.VideoToText.Asr`。
-
-### 2. video-to-text asr 模式：maxItems 默认 4 是硬编码
-
-**当前行为**：超出 maxItems 的条目原样透传不做转写，但用户可能期望全部转写。模板里 count 选项最大 6，如果用户在画布里手动改 count 到 10，maxItems 仍是 4 → 后 6 条没 transcript，海报内容缺失但不报错。
-
-**理想行为**：
-- 模板 build 时把 maxItems = count，但用户在画布编辑器里修改 count 后无自动同步
-- 或者 maxItems 留空时自动等于 input 数组长度
-- 或者前端在 itemsField 与 maxItems 不一致时给出黄色 warning chip
-
-**估时**：30min（前端 warning chip 最简单）
-
-**关联**：`prd-admin/src/pages/workflow-agent/workflowTemplates.ts` `tiktokCreatorToHomepageRichTemplate`。
-
-### 3. video-to-text asr 模式：LLM hook 提炼无 LlmRequestContext
-
-**当前行为**：沿用现有 video-to-text 旧规约，未走 `BeginScope`。`UserId` 由 workflow 执行时的 `__triggeredBy` 变量提供（自动化触发时是 `workflow-system`）。
-
-**与规则的差异**：`.claude/rules/llm-gateway.md` 强制要求 LLM 调用前 `using var _ = ctx.BeginScope(...)` 设置 UserId。当前代码若引入用户级配额/告警会失效。
-
-**风险等级**：低（workflow capsule 上下文已无强用户绑定，且现有 video-to-text/llm 模式也没设置）。
-
-**估时**：30min（加 ILLMRequestContextAccessor 注入 + BeginScope 即可）
-
-**关联**：`CapsuleExecutor.cs` 所有 `gateway.SendAsync` 调用点。
-
-### 4. video-to-text asr 模式：转写失败兜底为空 transcript 透传
-
-**当前行为**：视频不可达 / ffmpeg 失败 / ASR 失败时，item 仍保留原结构，仅 `transcript=""`。下游 weekly-poster-publisher 渲染 `ad-rich-text` 海报时会因 body 为空展示空白。
-
-**理想行为**：
-- 选项 A：失败的 item 跳过不入海报，logs 里记录跳过原因
-- 选项 B：失败的 item 在 ad-rich-text 视图里降级到 ad-4-3 风格（cover 全 bleed + Play 按钮）
-- 选项 C：在 PosterRichTextPageView 检测 body 为空时切到 PosterAdPageView 渲染
-
-**估时**：1h（选项 C 最优，前端单文件改动）
-
-**关联**：`prd-admin/components/weekly-poster/WeeklyPosterModal.tsx` `PosterRichTextPageView`。
-
-### 5. video-to-text asr 模式：ffmpeg 依赖未检测
-
-**当前行为**：CDS 容器有 ffmpeg，但本地 dev 镜像可能没有。`ExtractAudioWithFfmpegAsync` 启动失败抛 `InvalidOperationException("ffmpeg 启动失败")`，用户可能误以为是 ASR 模型问题。
-
-**理想行为**：
-- 胶囊执行前先 `which ffmpeg` 探测，缺失时给出明确错误「环境缺 ffmpeg，CDS 容器请重建，本地请 apt install ffmpeg」
-- 或者 Dockerfile 显式声明 ffmpeg 是必需依赖
-
-**估时**：30min
-
-**关联**：`CapsuleExecutor.cs ExtractAudioWithFfmpegAsync`、`prd-api/Dockerfile`。
-
-### 6. ad-rich-text 海报：用户点 Play 后无法回到 rich-text 视图
-
-**当前行为**：`hasPlayed` 状态进入全屏视频后，用户必须翻页或关闭弹窗才能重置。无「返回」按钮。
-
-**理想行为**：
-- 选项 A：在全屏视频右上角加「< 返回详情」按钮
-- 选项 B：视频播放结束后自动回到 rich-text 视图
-
-**估时**：30min
-
-**关联**：`WeeklyPosterModal.tsx PosterRichTextPageView`。
-
-### 7. weekly-poster-publisher：count 与 maxItems 在多模板间不一致
-
-**当前行为**：模板 build 时 `maxItems: count`，但用户在画布里改 count 不会自动同步 maxItems（两个字段独立维护）。
-
-**理想行为**：
-- 选项 A：在前端工作流编辑器加跨节点联动逻辑（count 改了同步到下游 video-to-text.maxItems）
-- 选项 B：去掉 maxItems，video-to-text 默认处理所有 items（适配 N 条）
-
-**估时**：1h（选项 A 复杂；选项 B 最简单但失去保护）
-
-**关联**：`prd-admin/src/pages/workflow-agent/`（编辑器联动）、`CapsuleExecutor.cs ExecuteVideoToTextAsrAsync`。
+| 编号 | 债务 | 修复方式 | 验证 |
+|---|---|---|---|
+| #1-old | ASR 模型池绑定手动 | caller fallback 链：`video-agent.video-to-text::asr` → `video-agent.v2d.transcribe::asr` → `document-store.subtitle::asr`，任一绑定 doubao-asr-stream 即可 | 错误信息明确列三个 caller 诊断 |
+| #2-old | maxItems 默认 4 硬编码 / 与 count 不联动 | 默认空 = 处理全部上游条目，模板移除 maxItems 配置 | iter 2 实测处理 5 条全转写 |
+| #3-old | 缺 LlmRequestContext | hook 提炼前 `BeginScope`，UserId 从 `__triggeredBy` 取 | rule.llm-gateway.md 合规 |
+| #4-old | rich-text body 空白破图 | body 为空时降级渲染 `PosterAdPageView` 全 bleed 视图 | feed-card 也复用此 fallback 模式 |
+| #5-old | ffmpeg 缺失被误判 | `EnsureFfmpegAvailableAsync` 入口探测 + 平台特定安装指引 | 错误信息含 apt/brew/choco 三种方式 |
+| #6-old | Play 后无返回 | 全屏视频左上角「返回详情」按钮重置 hasPlayed | rich-text 视图体验闭环 |
+| #7-old | count 与 maxItems 跨节点未联动 | 同 #2-old：maxItems 默认空 → 自动跟随 count | 用户改 count 无需同步两处 |
 
 ---
 
-## 待落地（Phase 2 任务 D 上线后追加）
+## open 债务（按风险倒序，Phase 3 引入）
+
+### 1. CDS dev 模式 hot-reload 卡进程
+
+**触发场景**：CDS 上 api 服务以默认 `dev` 模式（dotnet watch run）部署时，遇到 rude edit（switch 加 case / 新增 method / 新增 class / 改 enum）。
+
+**当前行为**：`dotnet watch` 检测到 rude edit 应该 fallback 到完整重启 .NET 进程，但**实测会卡住跑旧 IL**。表现为：
+- workflow execute 一直命中"未知舱类型 'media-rehost'，已跳过"等
+- stack trace 里源文件行号停在几个 commit 前的版本
+- 部分请求又能命中新代码（IL 加载半新半旧）
+
+**根因证据**：在分支 `claude/review-emergence-plan-Y8pOR` 上推完 `f349074` 后 8 小时，stack trace 仍报 `CapsuleExecutor.cs:line 6262` —— 这是 `cbef04c` 时期的行号，相差 24 小时。
+
+**当前规避**：用户在 CDS dashboard 把 api 服务**部署模式从 dev 切到 static**（dotnet publish + Production），强制完整构建 + 重启。`cds-compose.yml` 的 `x-cds-deploy-modes.api.static` 已经定义此模式。
+
+**理想行为**：
+- 选项 A：`cds-compose.yml` api 服务默认就用 static 模式，dev 模式只手动切（推荐：本仓库这种规模的代码改动 dev 模式负担太大）
+- 选项 B：CDS 后端检测 git push 时强制 `docker restart` 容器，绕过 dotnet watch 的不可靠 fallback
+
+**估时**：30min（选项 A 改 cds-compose.yml 一行）
+
+**关联**：`cds-compose.yml`、CDS 部署模式机制。
+
+### 2. B 站 / YouTube 无 mp4 直链
+
+**触发场景**：用户在 ad-4-3 / feed-card 模板里选 B 站或 YouTube，点 Play 按钮无视频可播。
+
+**当前行为**：`NormalizeBilibiliVideoItem` / `NormalizeYoutubeVideoItem` 输出 `videoUrl=""`。weekly-poster-publisher 把 coverUrl 当 imageUrl 写进 page，前端 isVideoUrl 判定为图片，不显示 Play 按钮，正常展示静图卡片。CTA 跳转 bilibili.com / youtube.com。
+
+**理想行为**：
+- 选项 A：在 NormalizeBilibiliVideoItem 内追加 `fetch_video_playurl` 二次调用，拿真实 mp4 URL（B 站需 wbi 签名，复杂）
+- 选项 B：feed-card 视图检测 videoUrl 为空时，Play 按钮变成「跳转原平台 ↗」
+
+**估时**：B 选项 30min；A 选项 2-3h（wbi 签名实现）
+
+**关联**：`CapsuleExecutor.cs` `NormalizeBilibiliVideoItem` / `NormalizeYoutubeVideoItem`、`PosterFeedCardView`。
+
+### 3. 小红书图文笔记无视频
+
+**触发场景**：小红书博主作品里的图文笔记（type=normal）。
+
+**当前行为**：videoUrl 为空，coverUrl 取 cover.url_default 或 image_list[0].url。feed-card 视图正常展示首张图。但海报只展示一张图，没有翻多图（小红书原生支持图集）。
+
+**理想行为**：feed-card 视图检测 image_list 长度 > 1 时，在视频区域加图片轮播（左右切换 vs 翻页箭头共用）。
+
+**估时**：1.5h
+
+**关联**：`PosterFeedCardView`、`NormalizeXiaohongshuItem` 输出 image_list 字段。
+
+### 4. CDN avatar URL 也防盗链
+
+**触发场景**：feed-card 海报顶部条头像在浏览器加载时。
+
+**当前行为**：抖音 / B 站 / 小红书的 avatar URL 都防盗链。已在 `tiktokCreatorToHomepageTemplate` 模板里把 `authorAvatarUrl` 加入 `rehostFields` 默认值（`videoUrl,coverUrl,authorAvatarUrl`），通过 media-rehost 落到 cfi.miduo.org。但**用户手动改 rehostFields 配置时容易漏掉头像字段**。
+
+**理想行为**：media-rehost 胶囊把头像字段做成必选（不可去掉），或者 PosterFeedCardView 检测到 avatar 是抖音 CDN host 时显示渐变兜底（已实现 onError 兜底，但仍发出 403 请求）。
+
+**估时**：30min
+
+**关联**：`tiktokCreatorToHomepageTemplate / tiktokCreatorToHomepageRichTemplate`、`PosterFeedCardView`。
+
+### 5. TranscriptCues 仅 ASR 模式可得
+
+**触发场景**：metadata / llm 模式不调 ASR，无 cues。feed-card 视图遇到 null 字段不渲染浮层。
+
+**当前行为**：向下兼容 OK，但用户用 metadata 模式时看不到字幕。
+
+**理想行为**：
+- 选项 A：metadata 模式从上游 `subtitles` 字段（如果有）解析时间戳生成 cues
+- 选项 B：UI 提示「此视频无字幕轨道」+ 引导切到 ASR 模板
+
+**估时**：选项 A 视上游 subtitle 数据格式而定（30min-2h）；B 选项 15min
+
+**关联**：`CapsuleExecutor.cs` `ExecuteVideoToTextAsync` metadata 分支、`PosterFeedCardView`。
+
+---
+
+## 待落地（任务 D 上线后追加）
 
 任务 D（抖音 OAuth + cron 真订阅）落地后，预计会引入新债务：
 - aweme_id 去重表的索引策略（按 user/account 分桶 vs 全局）
@@ -120,7 +118,9 @@
 
 ## 相关文档
 
-- `doc/plan.emergence-1-tiktok-douyin-poster.md`：涌现 1 主计划文档（Phase 1 + Phase 2 任务 A/B/C 已完成）
+- `doc/plan.emergence-1-tiktok-douyin-poster.md`：涌现 1 主计划文档（Phase 1 + 2 + 3 已完成）
+- `doc/guide.poster-feed-card.md`：用户教程（多平台博主订阅 → 首页海报）
 - `doc/debt.video-agent.md`：视频生成 Agent 债务（Remotion 已废弃路径）
-- `.claude/rules/llm-gateway.md`：LlmRequestContext 强制要求（本文件 §3 关联）
+- `.claude/rules/llm-gateway.md`：LlmRequestContext 强制要求
 - `.claude/rules/server-authority.md`：CancellationToken.None + Run/Worker 模式
+- `cds-compose.yml`：api 服务部署模式定义（dev / static）

--- a/doc/guide.list.directory.md
+++ b/doc/guide.list.directory.md
@@ -405,6 +405,9 @@
 - [视频生成 Agent · 债务台账](debt.video-agent) `debt.video-agent`
   > 4 条 open：OpenRouter CDN 7 天过期、混合渲染 ffmpeg normalize、直出心跳文案分级、成本预估 tooltip
 
+- [工作流 Agent · 债务台账](debt.workflow-agent) `debt.workflow-agent`
+  > 7 条 open：video-to-text asr 模式 ASR 池绑定 / maxItems 硬编码 / LlmRequestContext / 转写失败兜底 / ffmpeg 检测 / Play 后无返回 / count 与 maxItems 联动
+
 ### 七、周报
 
 - [周报 2026-W16 (04-13 ~ 04-19)](report.2026-W16) `report.2026-W16`
@@ -461,6 +464,8 @@
 
 | 日期 | 操作 | 文件名 | 中文标题 |
 | :--- | :--- | :--- | :--- |
+| 2026-05-06 | 🟢 新增 | `debt.workflow-agent` | 工作流 Agent · 债务台账（涌现 1 Phase 2 任务 A/B/C 留尾 7 项） |
+| 2026-05-06 | 🔧 调整 | `plan.emergence-1-tiktok-douyin-poster` | Phase 2 任务 A/B/C 已交付，新增 §2 完整交付总览 + §2.6 已知边界 |
 | 2026-04-26 | 🟢 新增 | `debt.video-agent` | 视频生成 Agent · 债务台账（首个 debt.* 文件，落地方案 A） |
 | 2026-04-26 | 🔧 调整 | `rule.doc-naming` | 文档命名规则 v3.1：新增 `debt.*` 类型前缀 + 专项约定 |
 | 2026-04-21 | 🟢 新增 | `plan.daily-tips-remaining-work` | 每日小贴士功能 — 剩余工作交接文档 |

--- a/doc/guide.list.directory.md
+++ b/doc/guide.list.directory.md
@@ -250,6 +250,9 @@
 - [周报功能完整操作指南](guide.weekly-report) `guide.weekly-report`
   > 周报功能端到端操作指南
 
+- [多平台博主订阅 → 首页海报弹窗](guide.poster-feed-card) `guide.poster-feed-card`
+  > 涌现 1 系列：TikTok / 抖音 / B 站 / 小红书 / YouTube 任一博主作品自动拉到首页海报弹窗。含 4 种版式（feed-card / ad-4-3 / ad-rich-text / static）+ media-rehost 防盗链 + ASR 字幕浮层
+
 - [CDS 环境变量配置指南](guide.cds-env) `guide.cds-env`
   > CDS 环境变量的配置与使用说明
 
@@ -464,6 +467,9 @@
 
 | 日期 | 操作 | 文件名 | 中文标题 |
 | :--- | :--- | :--- | :--- |
+| 2026-05-07 | 🟢 新增 | `guide.poster-feed-card` | 多平台博主订阅 → 首页海报弹窗（涌现 1 Phase 3 用户教程：5 平台 + 4 版式 + ASR 字幕） |
+| 2026-05-07 | 🔧 调整 | `plan.emergence-1-tiktok-douyin-poster` | Phase 3 已交付，新增 §3 多平台 / media-rehost / feed-card / ASR 字幕 + §3.7 关键文件 + §3.8 已知边界 |
+| 2026-05-07 | 🔧 调整 | `debt.workflow-agent` | v2.0：Phase 2 留尾 7 项全部 paid，新增 5 项 open（CDS dev 模式 hot-reload / B站 YouTube 无 mp4 / 小红书图集 / avatar 防盗链 / cues 仅 ASR 模式） |
 | 2026-05-06 | 🟢 新增 | `debt.workflow-agent` | 工作流 Agent · 债务台账（涌现 1 Phase 2 任务 A/B/C 留尾 7 项） |
 | 2026-05-06 | 🔧 调整 | `plan.emergence-1-tiktok-douyin-poster` | Phase 2 任务 A/B/C 已交付，新增 §2 完整交付总览 + §2.6 已知边界 |
 | 2026-04-26 | 🟢 新增 | `debt.video-agent` | 视频生成 Agent · 债务台账（首个 debt.* 文件，落地方案 A） |

--- a/doc/guide.poster-feed-card.md
+++ b/doc/guide.poster-feed-card.md
@@ -1,0 +1,223 @@
+# 多平台博主订阅 → 首页海报弹窗 · 指南
+
+> **版本**：v1.0 | **日期**：2026-05-07 | **状态**：已落地
+
+把 TikTok / 抖音 / B 站 / 小红书 / YouTube 任一博主的最新 N 条作品，自动拉过来 + 媒体迁移到 COS + 落到首页登录弹窗海报。**不需要写代码**，工作流编辑器拖几步就搭出来。
+
+本文档面向：第一次使用此功能的运营 / 管理员 / 开发同事。
+
+---
+
+## 1. 这套东西做了什么
+
+```
+[手动触发 / cron]
+    ↓
+[博主作品订阅 (TikHub)]   ← 一个 API key 五个平台
+    ↓ items[]
+[媒体迁移到 COS]          ← 解决抖音/B 站防盗链 403
+    ↓ items[] (COS URLs)
+[(可选) 音频转写 + AI 提炼]  ← rich-text 模板才有
+    ↓ items[] (+ hook / bullets / 字幕时间戳)
+[发布到首页弹窗海报]
+    ↓
+weekly_posters 集合 → 登录后所有用户首页弹窗
+```
+
+完成后用户登录就能看到一张轮播海报，每页对应博主的一条作品。
+
+---
+
+## 2. 前置条件
+
+### 2.1 必备
+
+| 项 | 说明 |
+|---|---|
+| TikHub API Key | https://tikhub.io 用户中心免费申请。一个 key 通五个平台 |
+| 管理员账号 | 需要 `workflow-agent.use` 权限创建工作流 |
+
+### 2.2 仅 ASR 模板需要（rich-text + 字幕版式）
+
+如果只用 `ad-4-3` / `feed-card` / `static` 三种版式，不需要。如果要走 `ad-rich-text` 或想要字幕浮层，必须确认管理后台「模型池」里**至少有一个 ASR caller 绑了 doubao-asr-stream 模型**。三个 caller 任一即可，胶囊会按以下顺序 fallback：
+
+1. `video-agent.video-to-text::asr`（推荐为本功能新建一个独立池）
+2. `video-agent.v2d.transcribe::asr`（视频转文档已用）
+3. `document-store.subtitle::asr`（知识库字幕已用）
+
+如果你之前用过「视频转文档」或「知识库字幕生成」功能，**大概率不需要新建**——胶囊会自动 fallback 到现有池。
+
+---
+
+## 3. 选模板创建工作流
+
+工作流编辑器目前提供 2 个开箱即用模板：
+
+| 模板名 | 节点数 | 适用 | 总耗时 |
+|---|---|---|---|
+| **多平台博主订阅 → 首页广告海报 (TikHub)** | 4 | 快速发布。轻量、不需要 ASR 模型池 | 30s ~ 2min |
+| **多平台博主订阅 → 首页图文混排海报 (ASR)** | 5 | 想要 hook 大字 + bullets + 字幕浮层 | 2 ~ 8min（每条作品 ASR 10-60s） |
+
+### 3.1 操作步骤
+
+1. 登录管理端，左侧菜单进「**工作流**」
+2. 右上角「**新建工作流**」
+3. 选模板（任选一个）
+4. 表单填 4 项必填：
+
+| 字段 | 填什么 | 示例 |
+|---|---|---|
+| **TikHub API Key** | 你的 key 或 `{{secrets.TIKHUB_API_KEY}}` | `gr1eUZ4r...` |
+| **平台** | 下拉五选一 | 抖音 |
+| **博主 ID** | 按平台不同，见下表 | `MS4wLjAB...` |
+| **拉取数量** | 1-10 条 | 4 |
+
+### 3.2 各平台「博主 ID」怎么取
+
+| 平台 | 字段类型 | 怎么找 | 示例 |
+|---|---|---|---|
+| TikTok | secUid | 博主主页 URL 或 TikHub user search 接口 | `MS4wLjABAAAAv7iSuuXDJGDvJkmH_vz1qkDZYo1apxgzaxdBSeIuPiM` |
+| 抖音 | sec_user_id | web 版抖音博主主页 URL `?sec_uid=` 后那段 | 同上格式（MS4wLjAB 开头）|
+| B 站 | mid（数字） | UP 主主页 `space.bilibili.com/{mid}` 里的数字 | `208259`（哔哩哔哩官号）|
+| 小红书 | user_id（24 位 hex） | 博主主页 URL `xiaohongshu.com/user/profile/{user_id}` 末段 | `5f8a9b2c000000000100abcd` |
+| YouTube | channelId（UCxxxxx）| 频道页「关于」标签里看 channelId | `UCBR8-60-B28hp2BmDPdntcQ` |
+
+⚠ **B 站常见错误**：填 BV 号（`BV1xx...`）—— 不对，要填 mid 数字
+⚠ **YouTube 常见错误**：填 `@username` 或频道 URL slug —— 不对，要填 `UCxxxxx` 的 channelId
+
+5. 点「**执行**」按钮
+6. 看节点逐个变绿。失败节点会标红，点开看 logs
+
+---
+
+## 4. 验收：去首页看效果
+
+执行完毕后，最后一个节点 logs 末尾会输出 posterId。打开任意账号登录预览域名，**首页应该弹出海报**。
+
+预览域名公式（v3）：
+```
+https://{tail}-{prefix}-{projectSlug}.miduo.org/
+```
+- 当前分支 `claude/review-emergence-plan-Y8pOR` → tail=`review-emergence-plan-y8por`，prefix=`claude`，projectSlug=`prd-agent`
+- 即 https://review-emergence-plan-y8por-claude-prd-agent.miduo.org/
+
+如果首页没弹窗，可能原因：
+- 该用户已经 dismiss 过这周的海报（同 weekKey 已读不重弹）
+- 当前周已经有更新的 published 海报（同 weekKey 旧版自动归档）
+- 直接点首页右下角「再看」胶囊（如果之前 minimize 过）
+
+---
+
+## 5. 四种海报版式怎么选
+
+| presentationMode | 视觉 | 适合 | 必备字段 |
+|---|---|---|---|
+| **`feed-card`**（**推荐**）| 抖音 / 小红书播放页风格：头像 + @ 用户 + 平台 chip + 时长 + 视频 + 互动 chip + 字幕浮层 + 标题 + 标签 | 短视频博主订阅、内容信息密度高 | 必有视频；建议跑 ASR 模板有字幕 |
+| `ad-4-3` | 4:3 全 bleed 视频广告 + 中央 Play | 强调视频本身、信息少 | 视频 URL（COS）|
+| `ad-rich-text` | 4:3 左动图 + 右 hook 大字 + 三条 bullet | 摘要型呈现、重点突出 | 必须 ASR + LLM 提炼有 hook + bullets |
+| `static` | 1200×628 横幅 上图 48% / 下文 52% | 兼容老周报海报 | 任意图片 |
+
+### feed-card 视频比例自适应
+
+`feed-card` 模式自动检测视频原生宽高比：
+- 竖屏（短视频原生 9:16）→ 模态 460px 宽
+- 方屏（4:3 中间档）→ 760px 宽
+- 横屏（16:9 横屏视频）→ 920px 宽
+
+不需要手动指定。
+
+---
+
+## 6. 关闭 / 收起 / 再看
+
+海报弹窗右上角的 **X 按钮 = 收起到右下角胶囊**（不是直接关闭）。胶囊上有：
+- 缩略图 + 标题 + 页码 → 点击重新展开（pageIndex 不丢）
+- ✕ 红色按钮（hover 高亮）→ 这才是真的彻底关闭，dismiss 写到本地存储
+
+设计意图：仿照抖音 PiP / Slack reminder，让用户即使误点也能找回海报。
+
+---
+
+## 7. 自动化（cron / 定时订阅）
+
+当前模板默认是 `manual-trigger`（手动触发）。要改成定时订阅：
+
+1. 编辑工作流
+2. 删除 `manual-trigger` 节点
+3. 拖一个 `timer` 节点替换上去
+4. 配置 cron 表达式（如 `0 */6 * * *` 每 6 小时）
+
+⚠ `timer` 胶囊目前在 `wip:true` 状态。如本部署版本 cron 不可用，备选方案：
+- 走外部 cron（如 GitHub Actions 定时）调 `POST /api/workflow-agent/workflows/{id}/execute`
+- 或等任务 D（抖音 OAuth + 真订阅闭环）正式落地
+
+去重逻辑（防止同一作品重复发海报）暂未做，**当前每次执行都会归档同 weekKey 的旧 published 并新建一个**。任务 D 会落地 aweme_id 去重表。
+
+---
+
+## 8. 媒体迁移（media-rehost）：为什么海报不再 403
+
+之前直接把 TikTok CDN 的临时签名 URL 写进海报，前端浏览器跨域拉视频被防盗链 403 → 视频白屏。
+
+新增 `media-rehost` 胶囊插在 `tiktok-creator-fetch` 与 `weekly-poster-publisher` 之间：
+- 输入：items 数组
+- 行为：对每个 item 的 `videoUrl / coverUrl / authorAvatarUrl` 三个字段，下载到本平台 COS，URL 替换为稳定 `cfi.miduo.org` 直链
+- 路径约定：`workflow/media-rehost/{yyyy-MM}/{guid}.{ext}`
+- 并发 4 / 单文件 50MB 上限 / 失败保留原 URL 不阻塞流水线
+
+模板默认已经在工作流里插好这个节点。**不要删除它**，否则海报会回到 403 状态。
+
+如果上游视频 > 50MB（如 B 站长视频 154MB），rehost 会跳过保留原 URL；前端 isVideoUrl 检测到 B 站 CDN 域名，仍能尝试播放，但同样可能 403。**长视频建议设置 `maxBytesMb=200` 或更高**。
+
+---
+
+## 9. ASR 字幕浮层（feed-card / ad-rich-text 才有）
+
+走 `ad-rich-text` 或 `feed-card` 模板 + `video-to-text` extractMode=asr 时：
+1. 胶囊下载视频 → ffmpeg 抽 16kHz mono wav → 流式 ASR 转写
+2. 从豆包 ASR 返回的 utterances 抽 `start_time / end_time / text`（毫秒精度）
+3. 写到 `WeeklyPosterPage.transcriptCues`
+4. 前端 `<video>` 监听 `timeupdate` → 二分查当前时间命中的 cue → 渲染半透明黑底 + 白字浮层在视频中下部
+
+效果：播放抖音视频时实时同步显示当前句字幕。比抖音 web 还省一步开关字幕。
+
+---
+
+## 10. 常见问题
+
+### Q1：执行节点显示「未知舱类型 'xxx'，已跳过」
+
+CDS 部署模式问题。dev 模式下 dotnet watch hot-reload 遇到 rude edit 不能完整重启进程，跑旧 IL。
+
+**解法**：CDS dashboard → 当前分支 → api 服务 → 部署模式切到「**静态部署 (publish)**」。详情见 `doc/debt.workflow-agent.md` 第 1 项。
+
+### Q2：海报视频白屏点 Play 没反应
+
+CDN 防盗链。检查工作流里有没有 `media-rehost` 节点 + 确认 imageUrl 是 `cfi.miduo.org` 域名。
+
+如果是 B 站 / YouTube：list endpoint 不给 mp4 直链，海报上视频本来就播不了，CTA 跳转原平台。
+
+### Q3：feed-card 海报上没头像 / 头像 403
+
+抖音 / B 站 / 小红书的 avatar URL 也防盗链。确认 `media-rehost` 节点的 `rehostFields` 配置包含 `authorAvatarUrl`：
+
+```
+videoUrl,coverUrl,authorAvatarUrl
+```
+
+### Q4：ASR 模板报「ASR 模型调度失败：尝试了三个 caller，无一绑定...」
+
+需要在管理后台「模型池」给 `video-agent.video-to-text::asr` / `video-agent.v2d.transcribe::asr` / `document-store.subtitle::asr` 三个 caller 中任一个绑定 `doubao-asr-stream` 模型。
+
+### Q5：B 站填了 mid 还是拉不到
+
+确认填的是数字 mid（如 `208259`）。不是 BV 号、不是 UID 加密版（`UID` 字段在某些 API 是加密的）。
+
+---
+
+## 关联文档
+
+- `doc/plan.emergence-1-tiktok-douyin-poster.md`：本功能完整设计与三阶段交付历史
+- `doc/debt.workflow-agent.md`：本功能已知边界与未还债务（含 dotnet watch 卡进程根因）
+- `.claude/rules/marketplace.md`：把工作流模板分享到海鲜市场
+- `.claude/rules/server-authority.md`：Run/Worker 模式（cron 调度真订阅时必读）

--- a/doc/index.yml
+++ b/doc/index.yml
@@ -167,6 +167,7 @@ docs:
   # ── 六、技术债务台账（按模块）──
   # 已知边界 / 后续可补 / 留尾风险，命名规范见 rule.doc-naming.md「debt.* 专项约定」
   debt.video-agent: 视频生成 Agent · 债务台账
+  debt.workflow-agent: 工作流 Agent · 债务台账
 
   # ── 七、周报（降序：最新在前）──
   report.2026-W16: 周报 2026-W16 (04-13 ~ 04-19)

--- a/doc/index.yml
+++ b/doc/index.yml
@@ -107,6 +107,7 @@ docs:
   guide.marketplace: 海鲜市场（配置市场）使用教程
   guide.workflow-canvas: 工作流画布操作手册
   guide.weekly-report: 周报功能完整操作指南
+  guide.poster-feed-card: 多平台博主订阅 → 首页海报弹窗（涌现 1，TikTok/抖音/B站/小红书/YouTube）
   guide.ai-toolbox-ops: AI 百宝箱运维指南
   guide.cds-env: CDS 环境变量配置指南
   guide.troubleshooting: 疑难杂症排查手册

--- a/doc/plan.emergence-1-tiktok-douyin-poster.md
+++ b/doc/plan.emergence-1-tiktok-douyin-poster.md
@@ -2,9 +2,9 @@
 
 > **系列定位**: 涌现 1（emergence-1）。本仓库的"涌现"系列指**借助平台已有砖块（工作流胶囊 + LLM Gateway + 周报海报弹窗 + COS / HomepageAsset）组合出的新功能**。本期是该系列首作。
 >
-> **状态**: Phase 1 已上线，Phase 2 待下一个智能体接手。
+> **状态**: Phase 1 已上线，Phase 2 任务 A/B/C 已落地（branch `claude/review-emergence-plan-Y8pOR`），任务 D（抖音 OAuth + cron 真订阅）待下一个智能体接手。
 >
-> **交接对象**: 下一个负责 Phase 2 的智能体（人 / Cursor / Claude Code 均可）。
+> **交接对象**: 下一个负责 Phase 2 任务 D（真订阅闭环）的智能体（人 / Cursor / Claude Code 均可）。
 
 ---
 
@@ -73,113 +73,185 @@
 
 ---
 
-## 2. Phase 2 待做（下一智能体）
+## 2. Phase 2 已交付（任务 A / B / C，2026-05-06）
 
-### 2.1 总目标
+### 2.1 交付总览
 
-把 TikTok / 抖音视频从"只看封面 + 点开播放"升级到**"图文并茂的内容卡"**：
+把 TikTok / 抖音视频从"只看封面 + 点开播放"升级到**"图文并茂的内容卡"**：视频先走真音频转写 + AI 提炼 hook & bullets，再渲染成左右双栏的图文混排海报，点 Play 才切回原 4:3 全 bleed 视频。Phase 1 的 `ad-4-3` 模板继续可用，零向下兼容破坏。
 
-- 视频自动转文字（标题 / 字幕 / 描述）→ AI 摘要 → 海报正文
-- 海报每页支持"顶部动态封面 + 中段大字 hook + 底部转写摘要"图文混排
-- 不再仅仅是 4:3 全 bleed 视频
+### 2.2 任务 A — `video-to-text` 胶囊新增 `asr` 模式
 
-### 2.2 子任务
+#### 入口与配置
 
-#### 任务 A: 视频转文字胶囊（接入现有 `video-to-text`）
+`CapsuleExecutor.cs` 在 `ExecuteVideoToTextAsync` 主入口检测到 `extractMode == 'asr'` 时，分发到新增的 `ExecuteVideoToTextAsrAsync` 方法。新方法做四件事：
+1. 检测输入形态（裸数组 / `{items: [...]}` / 单对象），统一规范成 `List<JsonElement> rawItems`
+2. 解析 ASR 模型池一次（`AppCallerCode = video-agent.video-to-text::asr`，仅支持 `doubao-asr-stream` 转换器）
+3. 对每个 item：HttpClient 下载视频 → ffmpeg 抽 16kHz mono wav 音轨 → `DoubaoStreamAsrService.TranscribeWithCallbackAsync` 流式转写
+4. 若 `enableHookExtraction=true`，把转写文本和原标题再喂给 LLM Gateway（chat 模型，`AppCallerCode = video-agent.video-to-text::chat`），输出 JSON `{hook, bullets[3]}`，并拼成 markdown bullets `- xxx\n- xxx\n- xxx` 写到 `item.body`
 
-仓库**已有** `video-to-text` 胶囊（`CapsuleExecutor.cs:ExecuteVideoToTextAsync`），目前两种模式：
-- `metadata`: 直接用 TikHub 返回的 `title/desc/字幕` 字段（**免费 / 快**）
-- `llm`: 用多模态 LLM 看封面图 + 描述（**收费 / 较慢**）
+新增 ConfigSchema 字段（`CapsuleTypeRegistry.VideoToText`）：
 
-Phase 2 要做：
-1. **真音频转写模式**: 加第三种 `extractMode = 'asr'`，调系统已有 ASR 模型池（参考 `prd-api/src/.../Services/Asr*` 是否已存在；不存在则借用 `transcript-agent`）。先下载 mp4 → 提取音轨（ffmpeg） → ASR 文字稿
-2. **AI 二次提炼**: 转写后再走一遍 LLM Gateway 出"标题 / 一句话 hook / 三段要点"结构化文本
-3. 输出新增 `transcript / hook / bullets` 字段进上游 JSON
+| Key | 默认 | 说明 |
+|---|---|---|
+| `extractMode` | `metadata` | 新增 `asr` 选项 |
+| `videoUrlField` | `videoUrl` | 上游 item 取哪个字段做下载 URL（点号路径） |
+| `itemsField` | `items` | 上游 JSON 哪个字段是数组（自动兜底单对象 / 裸数组） |
+| `maxItems` | `4` | ASR 上限 1-20，防止单次工作流跑爆配额 |
+| `enableHookExtraction` | `true` | 关闭后只输出原始转写不调 LLM |
+| `hookSystemPrompt` | (空) | 留空走默认提示词；自定义时输出必须为严格 JSON |
 
-#### 任务 B: 新海报版式 `ad-rich-text` 图文混排
+#### 输出格式
 
-现有 `presentationMode` 路由：
-- `static` — 老横幅 1200×628
-- `ad-4-3` — 全 bleed 视频广告（Phase 1 做的）
-- **`ad-rich-text` (新增)** — 图文混排
+数组输入 → `{items: [enriched...], firstItem: {...}, count, asrProcessed}`。每个 enriched item 在原字段基础上追加：
+- `transcript` — ASR 全文（可能为空字符串，视频不可达时降级）
+- `hook` — LLM 一句话钩子（≤ 14 字）
+- `bullets` — string[] 三条要点（每条 ≤ 25 字）
+- `body` — markdown bullets，可直接喂 ad-rich-text 海报
 
-`ad-rich-text` 设计建议（参考 Apple Newsroom / Instagram Story Ad / 小红书笔记三套行业范式）：
+单对象输入 → 单个 enriched 对象（不包 items）。
+
+#### 关键依赖（前置条件）
+
+- 管理员需在模型池为 `AppCallerCode = video-agent.video-to-text::asr` 绑定一个 doubao-asr-stream 模型（复用 `DoubaoStreamAsrService` + `IModelResolver` 同款配置规约）
+- 容器 host 需有 `ffmpeg` 二进制（CDS 容器已预装，本地 dev 需 `apt install ffmpeg`）
+
+新增 `AppCallerRegistry.VideoAgent.VideoToText.Asr` 常量供管理后台模型池 picker 自动列出。
+
+### 2.3 任务 B — 新海报版式 `ad-rich-text`
+
+`prd-admin/components/weekly-poster/WeeklyPosterModal.tsx` 新增 `PosterRichTextPageView` 组件 + `PosterCarousel` 路由扩为三分支（`ad-4-3` / `ad-rich-text` / `static`）。
+
+#### 视觉设计
+
+4:3 弹窗骨架（与 `ad-4-3` 共享同款宽度公式 `min(960px, calc((100vh - 80px) * 1.333), calc(100vw - 64px))`）。内部布局：
 
 ```
-┌────────────────────────────────────┐  4:3 或 3:4 都可
+┌────────────────────────────────────┐
+│  [⭡ weekKey 角标]                  │
 │  ┌──────────┐                      │
-│  │          │  hook 大字 (clamp 28-44px)
-│  │ 顶部动图  │  例: "Girl's Trip Season"
-│  │  cover   │                      │
-│  │  16:9    │  ─────────────────   │
-│  │          │  • bullet 1          │
-│  └──────────┘  • bullet 2          │
-│                • bullet 3          │
-│                                    │
-│  [✦ @TikTok · 12s ago]    [Play ▶] │ ← 小角标，点 Play 切到 ad-4-3 全屏视频
+│  │ 9:16     │  Hook 大字           │
+│  │ 动态封面  │  ──── (accent 分割) │
+│  │ ＋ Play   │  • bullet 1          │
+│  │ hover 浮层│  • bullet 2          │
+│  │          │  • bullet 3          │
+│  └──────────┘                      │
 └────────────────────────────────────┘
 ```
 
-实现要点：
-- 沿用 `WeeklyPosterPage` schema：`title`=hook, `body`=bullets (markdown), `imageUrl`=cover, `secondaryImageUrl`=videoUrl（点 Play 切回 ad-4-3 全 bleed）
-- 在 `WeeklyPosterModal.tsx` 加一个 `PosterRichTextPageView` 组件，由 `presentationMode === 'ad-rich-text'` 路由
-- 模板表单加 `presentationMode` 选项让用户选 ad-4-3 / ad-rich-text
+- 左侧 44% 宽，竖屏 9:16 cover（适配 TikTok / 抖音 原生比例）
+- 右侧 56%：weekKey 角标 + Hook h2（clamp 22-38px）+ accent 色分割条 + bullets markdown（descendant selector `[&_ul]:list-disc` 给 ReactMarkdown 加 list 样式）
+- Cover 上 hover 浮层有 64px Play 按钮（仅有视频源时渲染）
+- 点击 Play → `hasPlayed=true` → 切到与 `PosterAdPageView` 播放后视觉一致的全 bleed `<video controls autoplay>`
 
-#### 任务 C: 工作流模板分叉
+#### 字段映射（沿用 `ad-4-3` 约定，零 schema 变更）
 
-现有：`tiktokCreatorToHomepageTemplate` (3 节点 ad-4-3)
+| WeeklyPosterPage 字段 | 在 ad-rich-text 里的角色 |
+|---|---|
+| `imageUrl` | 视频 URL（点 Play 才播） |
+| `secondaryImageUrl` | cover 静图/动图（左侧主体） |
+| `title` | hook 大字（任务 A 写入 `item.hook`，发布器映射到这里） |
+| `body` | bullets markdown（任务 A 写入 `item.body`，发布器透传） |
+| `accentColor` | 分割条 + 角标色调 |
 
-Phase 2 加：`tiktokCreatorToHomepageRichTemplate` (5 节点)
+`weeklyPoster.ts` 类型联合追加 `'ad-rich-text'`。`WeeklyPosterAnnouncement.cs` 注释同步实际支持的三种模式。
+
+### 2.4 任务 C — 串联 4 节点新模板
+
+`prd-admin/pages/workflow-agent/workflowTemplates.ts` 新增 `tiktokCreatorToHomepageRichTemplate`：
 
 ```
-[手动触发] → [tiktok-creator-fetch] → [video-to-text (asr)] → [llm-analyzer (摘要)] → [weekly-poster-publisher (ad-rich-text)]
+手动触发
+  ↓
+tiktok-creator-fetch
+  ↓ (items 数组)
+video-to-text (extractMode=asr, maxItems=count, enableHookExtraction=true)
+  ↓ ({items: [enriched], firstItem})
+weekly-poster-publisher (presentationMode=ad-rich-text, accentColor=#ff0050)
 ```
 
-或者：让用户在原模板表单里选 `presentationMode`，模板 build() 里根据 mode 决定是否插入 `video-to-text + llm-analyzer` 两个中间节点（参数化模板）。
+`weekly-poster-publisher` 渲染 page 时新增 `item.hook` / `item.body` 优先通道（`CapsuleExecutor.cs ExecuteWeeklyPosterPublisherAsync`）：
+- pageTitle ← `item.hook` > `item.title/desc/description/name` > `作品 #N`
+- body ← `item.body` > `@author + #aweme + 截断 desc` 兜底
 
-#### 任务 D: 抖音 OAuth 长 token + 真订阅
+未提供 hook/body 字段时走原 Phase 1 兜底，`ad-4-3` 模板零回归。
 
-目前是手动触发。完整订阅闭环还差：
-1. 抖音 OAuth：用户授权后拿到长效 token，存到 `external_authorizations` 集合
-2. 定时调度：cron 5 分钟查一次，新作品入库前比对去重 key（aweme_id）
-3. 通知：新作品发布时除了换海报，还可推送 station 内 admin notification
+模板表单提供 5 个输入字段（apiKey / platform / secUid / count / enableHook），count 选项里给出预估耗时（4 条约 2-3 分钟）。
 
-### 2.3 边界 / 不要做
+### 2.5 关键文件改动
+
+| 文件 | Phase 2 改动 |
+|---|---|
+| `prd-api/PrdAgent.Api/Services/CapsuleExecutor.cs` | `ExecuteVideoToTextAsync` 加 asr 分发；新增 `ExecuteVideoToTextAsrAsync` + `TryExtractJsonObject` + `ExtractAudioWithFfmpegAsync`；`ExecuteWeeklyPosterPublisherAsync` 加 hook/body 优先通道 |
+| `prd-api/PrdAgent.Core/Models/AppCallerRegistry.cs` | 新增 `VideoAgent.VideoToText.Asr` 常量 |
+| `prd-api/PrdAgent.Core/Models/CapsuleTypeRegistry.cs` | `VideoToText` 加 5 项 ASR 配置；`WeeklyPosterPublisher` 加 `ad-rich-text` 选项 |
+| `prd-api/PrdAgent.Core/Models/WeeklyPosterAnnouncement.cs` | `PresentationMode` 注释同步实际三种模式 |
+| `prd-admin/services/real/weeklyPoster.ts` | `WeeklyPosterPresentationMode` 联合追加 `'ad-rich-text'` |
+| `prd-admin/components/weekly-poster/WeeklyPosterModal.tsx` | 新增 `PosterRichTextPageView`；`PosterCarousel` 扩为三分支路由 |
+| `prd-admin/pages/workflow-agent/workflowTemplates.ts` | 新增 `tiktokCreatorToHomepageRichTemplate` 模板 |
+| `changelogs/2026-05-06_emergence-1-phase-2-rich-text-poster.md` | Phase 2 完整变更碎片 |
+
+### 2.6 已知边界 / 工程债务（待补）
+
+落到 `doc/debt.video-agent.md`（如未来更通用，则该文件应改名）。当前 Phase 2 留尾：
+
+1. **ASR 模型池绑定是手动**：用户首次跑 ASR 模板前必须去管理后台为 `video-agent.video-to-text::asr` 绑定 `doubao-asr-stream` 模型。绑定缺失时胶囊抛 `InvalidOperationException` 带明确指引（不会无声失败，但用户得自己看错误信息去配置）。可后续做"首次执行向导"或允许 fallback 到 `video-agent.v2d.transcribe::asr`
+2. **maxItems 默认 4 是硬编码**：未对接配额计费，超出 4 条会截断不报错。生产化时需对接计费监控
+3. **LLM hook 提炼无 LlmRequestContext**：沿用现有 video-to-text/llm 模式的旧规约，与 `.claude/rules/llm-gateway.md` 严格读法不一致（workflow capsule 上下文里 UserId 来自 `__triggeredBy` 变量，未走 `BeginScope`）。后续若引入用户级配额需要补
+4. **ASR 失败兜底为空 transcript 透传**：可能导致 ad-rich-text 页面右侧 bullets 区域空白。已加日志，但前端无 fallback UI。可在 `PosterRichTextPageView` 里检测 `body` 为空时降级到 ad-4-3 风格
+5. **ffmpeg 依赖未检测**：CDS 容器有 ffmpeg，本地 dev 镜像可能没有。`ExtractAudioWithFfmpegAsync` 启动失败抛异常，但用户可能误以为是 ASR 模型问题
+6. **count 与 maxItems 分裂**：模板 build 时把 maxItems 设为 count，但用户在画布里改 count 不会自动改 maxItems（两个字段独立维护）
+7. **rich-text 视图无切换返回**：用户点 Play 进入全屏视频后无法回到 rich-text 视图（必须关闭弹窗或翻页才能重置 `hasPlayed` 状态）
+
+---
+
+## 3. Phase 2 待做：任务 D — 抖音 OAuth 长 token + 真订阅
+
+目前所有模板都靠手动触发。完整订阅闭环还差：
+
+1. **抖音 OAuth 接入**：用户授权后拿到长效 token，存到 `external_authorizations` 集合（已有结构，可借用）
+2. **定时调度**：cron 5 分钟查一次，新作品入库前比对去重 key（aweme_id）。当前 `timer` 胶囊在 `wip:true` 状态——具体能不能跑要看部署版本，否则需走外部 cron 调 `POST /api/workflow-agent/workflows/{id}/run`
+3. **通知**：新作品发布时除了换海报，还可推送 station 内 admin notification
+4. **去重表**：新增 `tiktok_creator_seen_aweme_ids` 集合或在工作流执行历史里做幂等检查
+
+任务 D 是最大块（OAuth 单独就是 1-2 天工作量），独立性最强，不阻塞 Phase 2 任务 A/B/C 落地。
+
+### 3.1 边界 / 不要做（Phase 2 沿用 Phase 1 红线）
 
 - ❌ **不要碰 `card.* / agent.*.image / hero.*` 这些首页设计资产**——那是设计师手动维护的视觉位（CLAUDE.md 用户已明确要求）。运营内容只走 `weekly_posters` 集合
 - ❌ **不要去掉 `[Authorize]` 装饰器** — 这是 admin controller 标配，去掉 AI Access Key 立刻 401
 - ❌ **不要把 cover URL 当视频处理** — TikTok CDN host 共用，必须走路径级别检测 (`/video/tos/`)
 - ❌ **不要在 `<video poster>` 里塞动图 webp** — Chromium 渲染破图占位符
-- ❌ **不要让模板默认 `count > 4`** — 海报弹窗 5 页起翻页疲劳
+- ❌ **不要让模板默认 `count > 4`**（rich-text 模板因 ASR 慢更要克制）
 
 ---
 
-## 3. 交接给下一个智能体的步骤
+## 4. 交接给下一个智能体的步骤（含 Phase 2 验收）
 
-### 3.1 第一次拉到这个任务时
+### 4.1 第一次拉到这个任务时
 
 ```bash
-# 1. 切到 Phase 1 分支看现状
-git fetch origin claude/auto-publish-tiktok-subscription-dnNKX
-git checkout claude/auto-publish-tiktok-subscription-dnNKX
+# 1. 切到 Phase 2 分支看现状
+git fetch origin claude/review-emergence-plan-Y8pOR
+git checkout claude/review-emergence-plan-Y8pOR
 
-# 2. 跑通 Phase 1 验证你环境 OK
-# - 打开 https://auto-publish-tiktok-subscription-dnnkx-claude-prd-agent.miduo.org/
-# - 登录 → 应弹出 4:3 ad 海报，4 页 TikTok 视频，中央 Play 按钮可点
+# 2. 跑通 Phase 2 任务 A/B/C 验证你环境 OK
+# - 打开 https://review-emergence-plan-y8por-claude-prd-agent.miduo.org/
+# - 登录 → 工作流 → 新建 → 选「TikTok / 抖音 博主订阅 → 首页图文混排海报 (ASR)」
+# - 填 TikHub key + 默认 secUid → 执行 → 等 2-3 分钟看节点逐步绿
+# - 完成后登录主页应弹出图文混排海报，左动图 + 右 hook + bullets
 
 # 3. 读这份文档 + 关键文件
 cat doc/plan.emergence-1-tiktok-douyin-poster.md
-# 看 1.3 节"关键文件清单"列出的所有文件
+# 看 §1.3（Phase 1）+ §2.5（Phase 2）"关键文件清单"
 ```
 
-### 3.2 开发 Phase 2 时
+### 4.2 接 Phase 2 任务 D 时
 
 #### 推荐顺序
 
-1. **先做任务 B（`ad-rich-text` 视图）**——纯前端，影响最小，能直接验证视觉
-2. **然后任务 A（ASR 转写）**——后端胶囊扩展，有 LLM Gateway 现成
-3. **任务 C（模板组合）**——把 A + B 串起来
-4. **任务 D（真订阅）放最后**——抖音 OAuth 是大头，不阻塞前面
+1. **先做 OAuth 设备授权流（design.* + Controller）**——独立可测，不阻塞 cron
+2. **再做去重表 + 幂等检查**——保证重复执行不会刷屏首页弹窗
+3. **最后串 cron 调度**——优先排查 `timer` 胶囊 wip 状态，必要时走外部 cron + workflow run API
 
 #### 每个任务做完跑这套验证
 
@@ -192,18 +264,19 @@ cd prd-api && dotnet build --no-restore 2>&1 | grep -E "error CS|warning CS"
 
 # 端到端冒烟
 /cds-deploy   # 触发部署
-# 然后 7 层冒烟（参考 plan.emergence-1 §"冷测验收"段落）
+# CDS 链路绿后真人去预览域名验收（参考 §4.1）
 ```
 
 #### Changelog
 
 每次提交在 `changelogs/2026-XX-XX_emergence-1-phase-2-*.md` 加碎片，**不要**直接编辑 `CHANGELOG.md`（CLAUDE.md 规则 #4）。
 
-### 3.3 完成后
+### 4.3 完成后
 
-- 把 `presentationMode` 文档移到 `doc/spec.weekly-poster-presentation-modes.md`（独立文档）
+- 把 `presentationMode` 文档单独移到 `doc/spec.weekly-poster-presentation-modes.md`（独立文档），列出 static / ad-4-3 / ad-rich-text / fullscreen / interactive 五种状态与字段约定
 - 把 `涌现 1` 系列下一篇（涌现 2）开新文件 `doc/plan.emergence-2-*.md`，本文件保持只读历史
 - 更新 `doc/index.yml` 与 `doc/guide.list.directory.md`
+- 把 §2.6 已知边界里仍然存在的项移入 `doc/debt.video-agent.md`
 - 通知用户验收 + `/handoff` 出交接清单
 
 ---
@@ -217,4 +290,4 @@ cd prd-api && dotnet build --no-restore 2>&1 | grep -E "error CS|warning CS"
 
 ---
 
-**最后更新**: 2026-05-06 / Phase 1 完成 commit `61046085`
+**最后更新**: 2026-05-06 / Phase 2 任务 A/B/C 完成（commits `cbef04c` `1d87b8a` `1604c15` 在分支 `claude/review-emergence-plan-Y8pOR` 上）/ Phase 1 完成 commit `61046085`

--- a/doc/plan.emergence-1-tiktok-douyin-poster.md
+++ b/doc/plan.emergence-1-tiktok-douyin-poster.md
@@ -2,9 +2,11 @@
 
 > **系列定位**: 涌现 1（emergence-1）。本仓库的"涌现"系列指**借助平台已有砖块（工作流胶囊 + LLM Gateway + 周报海报弹窗 + COS / HomepageAsset）组合出的新功能**。本期是该系列首作。
 >
-> **状态**: Phase 1 已上线，Phase 2 任务 A/B/C 已落地（branch `claude/review-emergence-plan-Y8pOR`），任务 D（抖音 OAuth + cron 真订阅）待下一个智能体接手。
+> **状态**: Phase 1 / 2 / 3 已全部上线（branch `claude/review-emergence-plan-Y8pOR`，待提 PR）。任务 D（抖音 OAuth + cron 真订阅）待下一个智能体接手。
 >
-> **交接对象**: 下一个负责 Phase 2 任务 D（真订阅闭环）的智能体（人 / Cursor / Claude Code 均可）。
+> **用户教程（必读）**: `doc/guide.poster-feed-card.md`
+>
+> **交接对象**: 下一个负责任务 D（真订阅闭环）的智能体（人 / Cursor / Claude Code 均可）。
 
 ---
 
@@ -204,7 +206,93 @@ weekly-poster-publisher (presentationMode=ad-rich-text, accentColor=#ff0050)
 
 ---
 
-## 3. Phase 2 待做：任务 D — 抖音 OAuth 长 token + 真订阅
+## 3. Phase 3 已交付（多平台 + media-rehost + feed-card + ASR 字幕，2026-05-07）
+
+### 3.1 交付总览
+
+把"博主订阅 → 海报"从原 TikTok/抖音 两平台升级到**5 平台 + 抖音/小红书播放页风格的内容卡 + 实时 ASR 字幕**。新增 1 个胶囊（`media-rehost`）解决 CDN 防盗链 403 问题。
+
+### 3.2 多平台扩展（B 站 / 小红书 / YouTube）
+
+`tiktok-creator-fetch` 胶囊改名为「**博主作品订阅 (TikHub)**」，平台下拉从 2 个扩到 5 个：
+
+| 平台 | TikHub endpoint | 用户填的 ID |
+|---|---|---|
+| TikTok | `/api/v1/tiktok/app/v3/fetch_user_post_videos` | secUid (`MS4wLjAB...`) |
+| 抖音 | `/api/v1/douyin/web/fetch_user_post_videos` | sec_user_id (`MS4wLjAB...`) |
+| B 站 | `/api/v1/bilibili/web/fetch_user_post_videos` | mid 数字（如 208259）|
+| 小红书 | `/api/v1/xiaohongshu/web/get_user_notes` | user_id（24 位 hex）|
+| YouTube | `/api/v1/youtube/web/get_channel_videos_v2` | channelId (`UCxxxxx`)|
+
+`NormalizeCreatorVideoItem` 按 platform 分发到 5 个 normalizer，所有规范化器输出同一 schema：`{awemeId, title, videoUrl, coverUrl, author, authorUniqueId, authorAvatarUrl, durationSec, hashtags, stats, createTime, shareUrl, platform}`。下游胶囊无需为每个平台特化。
+
+### 3.3 media-rehost 胶囊：解决 CDN 防盗链 403
+
+**根因**：weekly-poster-publisher 直接把 TikTok / 抖音 / B 站 / 小红书 CDN 的临时签名 URL 写到 `weekly_posters.pages[].imageUrl`。前端浏览器从这些域名拉视频/图被 hot-link protection 返 403。
+
+**新胶囊**：`media-rehost` 输入 items 数组，对每个 item 的 `videoUrl / coverUrl / authorAvatarUrl` 字段下载到本平台 COS（路径 `workflow/media-rehost/{yyyy-MM}/{guid}.{ext}`），URL 替换成稳定 `cfi.miduo.org` 直链。并发 4，单文件 50MB 上限，失败保留原 URL 不阻塞。
+
+工作流插法：`tiktok-creator-fetch → media-rehost → weekly-poster-publisher`。rich-text 模板里 rehost 还需放在 ASR **之前**——避免 ASR 阶段 TikHub 短期签名 URL 二次过期。
+
+### 3.4 feed-card 海报版式：9 信息单元
+
+新增 `presentationMode = 'feed-card'`，借鉴抖音 / 小红书播放页布局，9 个信息单元一次塞满：
+
+```
+┌─────────────────────────────────────────┐
+│ [头像] @作者 · 平台 chip · 时长          │ ← 顶部条
+├─────────────────────────────────┬───────┤
+│                                 │❤️ 5961│
+│         视频 + Play 浮层          │💬 141 │
+│  ─ ASR 时间戳字幕（同步）─        │⭐ 3378│
+│                                 │🔗 717 │
+├─────────────────────────────────┴───────┤
+│ # 标题 hook                              │
+│ #标签1 #标签2 #标签3                     │
+└──────────────────────────────────────────┘
+```
+
+`WeeklyPosterPage` 加 6 个可选字段：`AuthorName / AuthorAvatarUrl / Platform / DurationSec / Hashtags[] / Stats{Likes/Comments/Shares/Collects/Plays}`。`PosterFeedCardView` 组件实现：
+- 模态尺寸**视频比例自适应**：检测 `<img onLoad>` `naturalWidth/Height` 或 `<video onLoadedMetadata>` `videoWidth/Height` → 9:16 (460px) / 4:3 (760px) / 16:9 (920px) 三档
+- 互动指标 chip 数字自动缩写（5961→5.9k, 14.8w）
+- 头像加载失败兜底：渐变色圆形 + 用户名首字母
+
+### 3.5 ASR 时间戳字幕浮层
+
+`WeeklyPosterPage` 加 `TranscriptCues: List<TranscriptCue>` 字段。`video-to-text` asr 模式从 `DoubaoStreamAsrService` 返回的 raw responses 抽 utterances 时间戳（毫秒精度），写入 `item.transcriptCues`，publisher 落库。
+
+前端 `PosterFeedCardView` 监听 `<video> timeupdate`，二分查找当前 currentTime 命中的 cue（找不到精确区间时取最近一句保持显示），渲染半透明黑底 + 白字浮层在视频中下部。播放抖音视频时实时同步显示当前句字幕——比抖音 web 版还省一步开关。
+
+### 3.6 最小化到右下角胶囊
+
+模态右上角的 X 按钮**不再彻底关闭**，改为收起到右下角胶囊（缩略图 + 标题 + 页码 + 真正的 `✕ 不再显示` 按钮）。状态保留：再次展开后 `pageIndex / hasPlayed` 不丢失。仿照 Slack PiP / 抖音 reminder 心智，避免误关后再也找不到。
+
+### 3.7 关键文件改动（Phase 3）
+
+| 文件 | 改动 |
+|---|---|
+| `prd-api/Models/WorkflowModels.cs` | 新增 `CapsuleTypes.MediaRehost` 常量 |
+| `prd-api/Models/CapsuleTypeRegistry.cs` | TiktokCreatorFetch 平台扩到 5 个 + 新增 MediaRehost meta + WeeklyPosterPublisher 加 feed-card 选项 |
+| `prd-api/Models/WeeklyPosterAnnouncement.cs` | WeeklyPosterPage 加 7 个可选字段 + 新增 PosterPageStats / TranscriptCue 类 |
+| `prd-api/Services/CapsuleExecutor.cs` | 5 平台 URL 构造器 + 4 个新规范化器 + ExecuteMediaRehostAsync + ExecuteVideoToTextAsrAsync 增加 cue 提取 + ExecuteWeeklyPosterPublisherAsync 写入新字段 |
+| `prd-api/Controllers/Api/WeeklyPosterController.cs` | WeeklyPosterPageDto 同步透出 7 个新字段 |
+| `prd-admin/services/real/weeklyPoster.ts` | 类型联合追加 'feed-card' + 新增 PosterPageStats / TranscriptCue interface |
+| `prd-admin/components/weekly-poster/WeeklyPosterModal.tsx` | 新增 PosterFeedCardView 组件 + 视频比例自适应 + minimize 折叠态 + cue 浮层 timeupdate 同步 |
+| `prd-admin/pages/workflow-agent/workflowTemplates.ts` | 两个模板插入 media-rehost 节点 + PLATFORM_OPTIONS 共享常量 |
+| `prd-admin/pages/workflow-agent/capsuleRegistry.tsx` | media-rehost 胶囊注册 CloudUpload 图标 |
+
+### 3.8 已知边界 / 工程债务（已固化到 `doc/debt.workflow-agent.md`）
+
+Phase 2 留尾的 7 项已**全部偿还**。Phase 3 引入新债务：
+1. **dotnet watch hot-reload 卡住**：CDS dev 模式遇到 rude edit（新 case/method/class）应该 fallback 到完整重启，但实测会卡住跑旧 IL。**根本解法是切到 static 部署模式**（CDS dashboard 操作）
+2. **B 站 / YouTube 无 mp4 直链**：list endpoint 不给播放地址，需二次调 fetch_video_playurl。海报上视频会播不了，只能跳转原平台
+3. **小红书图文笔记无视频**：noteType=normal 的笔记 ASR 跳过，feed-card 视图自动只展示 cover
+4. **CDN avatar URL 也防盗链**：B 站 / 抖音头像必须走 media-rehost 才能在浏览器里加载（已默认加到 `rehostFields`）
+5. **TranscriptCues 仅 ASR 模式可得**：metadata / llm 模式不调 ASR，无 cues。feed-card 视图遇到 null 字段不渲染浮层（向下兼容 OK）
+
+---
+
+## 4. Phase 2 待做：任务 D — 抖音 OAuth 长 token + 真订阅
 
 目前所有模板都靠手动触发。完整订阅闭环还差：
 
@@ -225,7 +313,7 @@ weekly-poster-publisher (presentationMode=ad-rich-text, accentColor=#ff0050)
 
 ---
 
-## 4. 交接给下一个智能体的步骤（含 Phase 2 验收）
+## 5. 交接给下一个智能体的步骤（含 Phase 2 / 3 验收）
 
 ### 4.1 第一次拉到这个任务时
 
@@ -290,4 +378,4 @@ cd prd-api && dotnet build --no-restore 2>&1 | grep -E "error CS|warning CS"
 
 ---
 
-**最后更新**: 2026-05-06 / Phase 2 任务 A/B/C 完成（commits `cbef04c` `1d87b8a` `1604c15` 在分支 `claude/review-emergence-plan-Y8pOR` 上）/ Phase 1 完成 commit `61046085`
+**最后更新**: 2026-05-07 / Phase 3 完成（多平台 / media-rehost / feed-card / ASR 字幕 / minimize，commits `01e7d72` ~ `c6be806` 在分支 `claude/review-emergence-plan-Y8pOR` 上待提 PR）/ Phase 2 完成 `cbef04c` ~ `1604c15` / Phase 1 完成 `61046085`

--- a/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
+++ b/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
@@ -554,6 +554,14 @@ export function PosterRichTextPageView({
   const [coverErrored, setCoverErrored] = useState(false);
 
   if (!page) return null;
+
+  // body 为空时降级到 ad-4-3 全 bleed 视图（ASR 失败 / 旧投稿无 LLM 提炼 / 字段缺失）
+  // 避免右侧 bullets 区域空白，仍能看视频广告
+  const bodyHasContent = !!(page.body && page.body.trim().length > 0);
+  if (!bodyHasContent) {
+    return <PosterAdPageView page={page} weekKey={weekKey} />;
+  }
+
   const primaryUrl = page.imageUrl ?? '';
   const isVideo = isVideoUrl(primaryUrl);
   // cover 优先用 secondaryImageUrl（capsule 输出 video 时会同步填这个 cover），
@@ -570,6 +578,7 @@ export function PosterRichTextPageView({
   };
 
   // 已点击 Play → 切换为 ad-4-3 风格的全 bleed 视频（与 PosterAdPageView 播放后视觉一致）
+  // 左上角加返回按钮，让用户能回到 rich-text 详情视图
   if (hasPlayed && isVideo) {
     return (
       <div className="relative h-full" style={{ background: '#000' }}>
@@ -583,6 +592,22 @@ export function PosterRichTextPageView({
             autoPlay
           />
         </div>
+        <button
+          type="button"
+          onClick={() => setHasPlayed(false)}
+          aria-label="返回详情"
+          className="absolute top-5 left-5 z-30 inline-flex items-center gap-1.5 px-3 h-9 rounded-full text-[12px] font-medium transition-all hover:bg-white/15"
+          style={{
+            background: 'rgba(0,0,0,0.5)',
+            backdropFilter: 'blur(12px)',
+            WebkitBackdropFilter: 'blur(12px)',
+            border: '1px solid rgba(255,255,255,0.18)',
+            color: 'rgba(255,255,255,0.92)',
+          }}
+        >
+          <ChevronLeft size={14} />
+          返回详情
+        </button>
       </div>
     );
   }

--- a/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
+++ b/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
@@ -81,9 +81,12 @@ export function PosterCarousel({
   };
 
   const isAdMode = poster.presentationMode === 'ad-4-3';
-  const aspect = isAdMode ? '4 / 3' : '1200 / 628';
+  const isRichText = poster.presentationMode === 'ad-rich-text';
+  // ad-4-3 与 ad-rich-text 共享 4:3 弹窗骨架，只是内部页面布局不同
+  const isWideMode = isAdMode || isRichText;
+  const aspect = isWideMode ? '4 / 3' : '1200 / 628';
   // 4:3 适合视频广告类弹窗（横屏不太宽、能装下竖屏视频又不极端），借鉴 Apple 产品视频弹窗 / Netflix 预告模态
-  const widthCalc = isAdMode
+  const widthCalc = isWideMode
     ? 'min(960px, calc((100vh - 80px) * 1.333), calc(100vw - 64px))'
     : 'min(1120px, calc((100vh - 80px) * 1.91), calc(100vw - 64px))';
 
@@ -105,7 +108,7 @@ export function PosterCarousel({
         style={{
           width: widthCalc,
           aspectRatio: aspect,
-          background: isAdMode ? '#000' : '#06111e',
+          background: isWideMode ? '#000' : '#06111e',
           border: '1px solid rgba(255,255,255,0.1)',
           borderRadius: 28,
           boxShadow:
@@ -133,6 +136,8 @@ export function PosterCarousel({
         >
           {isAdMode ? (
             <PosterAdPageView page={currentPage} weekKey={poster.weekKey} />
+          ) : isRichText ? (
+            <PosterRichTextPageView page={currentPage} weekKey={poster.weekKey} />
           ) : (
             <WeeklyPosterPageView page={currentPage} weekKey={poster.weekKey} />
           )}
@@ -518,6 +523,210 @@ export function PosterAdPageView({
           )}
         </div>
       )}
+    </div>
+  );
+}
+
+/**
+ * 图文混排海报页（4:3，左侧动态 cover + 右侧 hook & bullets，底部 Play 切回全屏视频）。
+ * 借鉴：Instagram Story Ad / Apple Newsroom 卡片 / 小红书笔记 三套行业范式。
+ *
+ * 字段约定（沿用 ad-4-3）：
+ *   - imageUrl           = 视频 URL（点 Play 才会播放，无视频时仅展示图文）
+ *   - secondaryImageUrl  = cover 静图/动图 URL（左侧主体），无值时退回到 imageUrl 或渐变兜底
+ *   - title              = hook 大字
+ *   - body               = bullets markdown（- bullet1 / - bullet2 ...）
+ *   - accentColor        = 分隔线 / 角标色调
+ *
+ * 状态：
+ *   - 默认渲染图文双栏；用户点 Play 后切到 ad-4-3 风格的全 bleed 视频播放器。
+ *   - 没有视频源时不渲染 Play 按钮，纯图文广告。
+ */
+export function PosterRichTextPageView({
+  page,
+  weekKey,
+}: {
+  page: WeeklyPosterPage | undefined;
+  weekKey?: string;
+}) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [hasPlayed, setHasPlayed] = useState(false);
+  const [coverErrored, setCoverErrored] = useState(false);
+
+  if (!page) return null;
+  const primaryUrl = page.imageUrl ?? '';
+  const isVideo = isVideoUrl(primaryUrl);
+  // cover 优先用 secondaryImageUrl（capsule 输出 video 时会同步填这个 cover），
+  // 没有时退回 primaryUrl（仅当 primary 是图片时才能用）
+  const coverUrl = page.secondaryImageUrl || (isVideo ? null : primaryUrl);
+  const accent = page.accentColor || '#7c3aed';
+
+  const handlePlay = () => {
+    if (!isVideo) return;
+    setHasPlayed(true);
+    setTimeout(() => {
+      videoRef.current?.play().catch(() => {});
+    }, 30);
+  };
+
+  // 已点击 Play → 切换为 ad-4-3 风格的全 bleed 视频（与 PosterAdPageView 播放后视觉一致）
+  if (hasPlayed && isVideo) {
+    return (
+      <div className="relative h-full" style={{ background: '#000' }}>
+        <div className="absolute inset-0">
+          <video
+            ref={videoRef}
+            src={primaryUrl}
+            className="absolute inset-0 w-full h-full object-contain bg-black"
+            controls
+            playsInline
+            autoPlay
+          />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="relative h-full flex"
+      style={{
+        background: `linear-gradient(135deg, #0b0b14 0%, #15101a 60%, #0a0a12 100%)`,
+        color: 'rgba(255,255,255,0.92)',
+      }}
+    >
+      {/* 左侧 cover 区（约 44% 宽，动态/静态封面 + 中央 Play hover） */}
+      <div
+        className="relative shrink-0 flex items-center justify-center"
+        style={{
+          width: '44%',
+          padding: '5.6% 0 5.6% 5.6%',
+        }}
+      >
+        <div
+          className="relative w-full overflow-hidden"
+          style={{
+            aspectRatio: '9 / 16',
+            borderRadius: 18,
+            background: '#0a0a12',
+            border: '1px solid rgba(255,255,255,0.08)',
+            boxShadow: '0 24px 60px -16px rgba(0,0,0,0.65), inset 0 1px 0 rgba(255,255,255,0.06)',
+          }}
+        >
+          {coverUrl && !coverErrored ? (
+            <img
+              src={coverUrl}
+              alt=""
+              className="absolute inset-0 w-full h-full object-cover"
+              draggable={false}
+              onError={() => setCoverErrored(true)}
+            />
+          ) : !isVideo && primaryUrl ? (
+            <img
+              src={primaryUrl}
+              alt=""
+              className="absolute inset-0 w-full h-full object-cover"
+              draggable={false}
+            />
+          ) : (
+            <div
+              className="absolute inset-0 flex items-center justify-center"
+              style={{
+                background: `linear-gradient(135deg, ${accent} 0%, #0a0a12 100%)`,
+              }}
+            >
+              <div className="text-[80px] font-black text-white/15 select-none">
+                {(page.order + 1).toString().padStart(2, '0')}
+              </div>
+            </div>
+          )}
+          {/* hover Play 浮层（仅有视频时） */}
+          {isVideo && (
+            <button
+              type="button"
+              onClick={handlePlay}
+              aria-label="播放视频"
+              className="absolute inset-0 flex items-center justify-center group cursor-pointer transition-colors"
+              style={{ background: 'rgba(0,0,0,0.18)' }}
+            >
+              <div
+                className="flex items-center justify-center transition-all duration-200 group-hover:scale-110"
+                style={{
+                  width: 64,
+                  height: 64,
+                  borderRadius: '50%',
+                  background: 'rgba(255,255,255,0.18)',
+                  backdropFilter: 'blur(16px)',
+                  WebkitBackdropFilter: 'blur(16px)',
+                  border: '1.5px solid rgba(255,255,255,0.35)',
+                  boxShadow: '0 12px 28px rgba(0,0,0,0.5)',
+                }}
+              >
+                <Play size={24} fill="white" strokeWidth={0} style={{ marginLeft: 3 }} />
+              </div>
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* 右侧文案区（hook 大字 + 分割线 + bullets） */}
+      <div
+        className="relative flex-1 flex flex-col justify-center"
+        style={{
+          padding: '5.6% 5.6% 5.6% 4%',
+          minWidth: 0,
+        }}
+      >
+        {weekKey && (
+          <div
+            className="inline-flex items-center gap-2 self-start rounded-full px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.18em]"
+            style={{
+              background: 'rgba(255,255,255,0.06)',
+              border: '1px solid rgba(255,255,255,0.14)',
+              color: 'rgba(255,255,255,0.7)',
+              marginBottom: '4%',
+            }}
+          >
+            <Sparkles size={11} />
+            {weekKey}
+          </div>
+        )}
+
+        <h2
+          className="font-black tracking-tight"
+          style={{
+            color: '#fff',
+            fontSize: 'clamp(22px, 2.8vw, 38px)',
+            lineHeight: 1.14,
+            marginBottom: '3.2%',
+          }}
+        >
+          {page.title}
+        </h2>
+
+        <div
+          className="shrink-0"
+          style={{
+            width: 56,
+            height: 3,
+            borderRadius: 2,
+            background: accent,
+            marginBottom: '3.6%',
+          }}
+        />
+
+        {page.body && (
+          <div
+            className="text-white/82 leading-relaxed overflow-hidden [&_ul]:list-disc [&_ul]:pl-5 [&_ol]:list-decimal [&_ol]:pl-5 [&_li]:my-1.5 [&_p]:my-1.5 [&_strong]:text-white"
+            style={{
+              fontSize: 'clamp(13px, 1.35vw, 17px)',
+              maxHeight: '52%',
+            }}
+          >
+            <MarkdownContent content={page.body} />
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
+++ b/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
-import { ChevronLeft, ChevronRight, X, ArrowRight, Sparkles, Play } from 'lucide-react';
+import { ChevronLeft, ChevronRight, X, ArrowRight, Sparkles, Play, Heart, MessageCircle, Bookmark, Share2, Eye, Clock } from 'lucide-react';
 import { useWeeklyPosterStore } from '@/stores/weeklyPosterStore';
 import { MarkdownContent } from '@/components/ui/MarkdownContent';
 import type { WeeklyPoster, WeeklyPosterPage } from '@/services';
@@ -82,13 +82,17 @@ export function PosterCarousel({
 
   const isAdMode = poster.presentationMode === 'ad-4-3';
   const isRichText = poster.presentationMode === 'ad-rich-text';
-  // ad-4-3 与 ad-rich-text 共享 4:3 弹窗骨架，只是内部页面布局不同
+  const isFeedCard = poster.presentationMode === 'feed-card';
+  // ad-4-3 / ad-rich-text 走 4:3 横屏；feed-card 走 9:16 竖屏（短视频原生比例）；其它走 1200:628 横幅
   const isWideMode = isAdMode || isRichText;
-  const aspect = isWideMode ? '4 / 3' : '1200 / 628';
+  const aspect = isFeedCard ? '9 / 16' : (isWideMode ? '4 / 3' : '1200 / 628');
   // 4:3 适合视频广告类弹窗（横屏不太宽、能装下竖屏视频又不极端），借鉴 Apple 产品视频弹窗 / Netflix 预告模态
-  const widthCalc = isWideMode
-    ? 'min(960px, calc((100vh - 80px) * 1.333), calc(100vw - 64px))'
-    : 'min(1120px, calc((100vh - 80px) * 1.91), calc(100vw - 64px))';
+  // 9:16 是抖音 / 小红书原生比例，feed-card 模式下整个弹窗是竖屏播放器
+  const widthCalc = isFeedCard
+    ? 'min(420px, calc((100vh - 80px) * 0.5625), calc(100vw - 32px))'
+    : isWideMode
+      ? 'min(960px, calc((100vh - 80px) * 1.333), calc(100vw - 64px))'
+      : 'min(1120px, calc((100vh - 80px) * 1.91), calc(100vw - 64px))';
 
   const modal = (
     <div
@@ -108,7 +112,7 @@ export function PosterCarousel({
         style={{
           width: widthCalc,
           aspectRatio: aspect,
-          background: isWideMode ? '#000' : '#06111e',
+          background: isFeedCard || isWideMode ? '#000' : '#06111e',
           border: '1px solid rgba(255,255,255,0.1)',
           borderRadius: 28,
           boxShadow:
@@ -134,7 +138,9 @@ export function PosterCarousel({
           style={{ overflow: 'hidden' }}
           key={`page-${pageIndex}`}
         >
-          {isAdMode ? (
+          {isFeedCard ? (
+            <PosterFeedCardView page={currentPage} />
+          ) : isAdMode ? (
             <PosterAdPageView page={currentPage} weekKey={poster.weekKey} />
           ) : isRichText ? (
             <PosterRichTextPageView page={currentPage} weekKey={poster.weekKey} />
@@ -754,6 +760,286 @@ export function PosterRichTextPageView({
       </div>
     </div>
   );
+}
+
+/**
+ * 短视频内容卡（9:16 竖屏，借鉴抖音/小红书播放页布局）。
+ * 把 9 个信息单元一起装进海报：
+ *   ① 顶部：作者头像 + @用户名 + 平台 chip + 时长
+ *   ② 中央：视频本体 + cover poster + 中央 Play
+ *   ③ 右栏（半透明浮层）：❤️ 点赞 / 💬 评论 / ⭐ 收藏 / 🔗 分享
+ *   ④ 底部：标题 hook + 标签 chip 列表 + 完整视频 CTA（外层 PosterCarousel 的 CTA 按钮已覆盖）
+ *
+ * 字段约定：沿用 ad-4-3（imageUrl=video, secondaryImageUrl=cover），新增字段全部走可选 fallback。
+ *
+ * 设计妥协（9:16 太窄）：
+ *   - 标签 chip 行最多展示 3 个，多余折叠到 +N
+ *   - 互动数字大于 1k 简写为 1.2k / 5.9k
+ *   - 没有头像时用渐变色圆形带首字母
+ */
+export function PosterFeedCardView({ page }: { page: WeeklyPosterPage | undefined }) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [hasPlayed, setHasPlayed] = useState(false);
+  const [coverErrored, setCoverErrored] = useState(false);
+  const [avatarErrored, setAvatarErrored] = useState(false);
+
+  if (!page) return null;
+  const primaryUrl = page.imageUrl ?? '';
+  const isVideo = isVideoUrl(primaryUrl);
+  const coverUrl = page.secondaryImageUrl || (isVideo ? null : primaryUrl);
+  const accent = page.accentColor || '#ff0050';
+  const author = page.authorName || '';
+  const platform = page.platform || '';
+  const stats = page.stats;
+  const tags = (page.hashtags || []).slice(0, 3);
+  const tagOverflow = (page.hashtags?.length || 0) - tags.length;
+
+  const handlePlay = () => {
+    if (!isVideo) return;
+    setHasPlayed(true);
+    setTimeout(() => {
+      videoRef.current?.play().catch(() => {});
+    }, 30);
+  };
+
+  const platformLabel = ({
+    tiktok: 'TikTok',
+    douyin: '抖音',
+    bilibili: 'B 站',
+    xiaohongshu: '小红书',
+    youtube: 'YouTube',
+  } as Record<string, string>)[platform] || platform;
+
+  return (
+    <div className="relative h-full" style={{ background: '#000' }}>
+      {/* 媒体层：视频或封面铺满 */}
+      <div className="absolute inset-0">
+        {coverUrl && !coverErrored && !hasPlayed && (
+          <img
+            src={coverUrl}
+            alt=""
+            className="absolute inset-0 w-full h-full object-cover"
+            draggable={false}
+            onError={() => setCoverErrored(true)}
+          />
+        )}
+        {!hasPlayed && (!coverUrl || coverErrored) && (
+          <div
+            className="absolute inset-0"
+            style={{ background: `linear-gradient(135deg, ${accent} 0%, #0a0a12 100%)` }}
+          />
+        )}
+        {!isVideo && primaryUrl && (
+          <img
+            src={primaryUrl}
+            alt=""
+            className="absolute inset-0 w-full h-full object-cover"
+            draggable={false}
+          />
+        )}
+        {isVideo && hasPlayed && (
+          <video
+            ref={videoRef}
+            src={primaryUrl}
+            poster={coverUrl ?? undefined}
+            className="absolute inset-0 w-full h-full object-cover bg-black"
+            controls
+            playsInline
+            autoPlay
+          />
+        )}
+      </div>
+
+      {/* 中央 Play 按钮（仅视频未播放时） */}
+      {isVideo && !hasPlayed && (
+        <button
+          type="button"
+          onClick={handlePlay}
+          aria-label="播放视频"
+          className="absolute inset-0 z-10 flex items-center justify-center group cursor-pointer"
+          style={{ background: 'rgba(0,0,0,0.18)' }}
+        >
+          <div
+            className="flex items-center justify-center transition-all duration-200 group-hover:scale-110"
+            style={{
+              width: 80, height: 80, borderRadius: '50%',
+              background: 'rgba(255,255,255,0.18)',
+              backdropFilter: 'blur(16px)',
+              WebkitBackdropFilter: 'blur(16px)',
+              border: '1.5px solid rgba(255,255,255,0.35)',
+              boxShadow: '0 12px 32px rgba(0,0,0,0.5)',
+            }}
+          >
+            <Play size={30} fill="white" strokeWidth={0} style={{ marginLeft: 3 }} />
+          </div>
+        </button>
+      )}
+
+      {/* 顶部条：作者头像 + @用户名 + 平台 + 时长（fade out on play） */}
+      <div
+        className="absolute inset-x-0 top-0 z-20 px-4 pt-4 pointer-events-none transition-opacity duration-300"
+        style={{
+          background: 'linear-gradient(180deg, rgba(0,0,0,0.75) 0%, rgba(0,0,0,0.4) 60%, transparent 100%)',
+          paddingBottom: 32,
+          opacity: hasPlayed ? 0 : 1,
+        }}
+      >
+        <div className="flex items-center gap-2.5">
+          {/* 头像 */}
+          <div
+            className="shrink-0 rounded-full overflow-hidden flex items-center justify-center"
+            style={{
+              width: 36, height: 36,
+              background: `linear-gradient(135deg, ${accent}, #0a0a12)`,
+              border: '1.5px solid rgba(255,255,255,0.4)',
+            }}
+          >
+            {page.authorAvatarUrl && !avatarErrored ? (
+              <img
+                src={page.authorAvatarUrl}
+                alt=""
+                className="w-full h-full object-cover"
+                draggable={false}
+                onError={() => setAvatarErrored(true)}
+              />
+            ) : (
+              <span className="text-white text-[14px] font-bold">
+                {(author || 'U').charAt(0).toUpperCase()}
+              </span>
+            )}
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-1.5 text-white text-[13px] font-semibold">
+              <span className="truncate">{author ? `@${author}` : '匿名作者'}</span>
+              {platformLabel && (
+                <span
+                  className="shrink-0 inline-flex items-center px-1.5 rounded text-[10px] font-medium"
+                  style={{
+                    background: 'rgba(255,255,255,0.22)',
+                    color: 'rgba(255,255,255,0.92)',
+                    height: 16,
+                  }}
+                >
+                  {platformLabel}
+                </span>
+              )}
+            </div>
+            {typeof page.durationSec === 'number' && page.durationSec > 0 && (
+              <div className="inline-flex items-center gap-1 text-white/72 text-[11px] mt-0.5">
+                <Clock size={11} />
+                <span>{formatDuration(page.durationSec)}</span>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* 右栏：互动指标（fade out on play 让出视频画面） */}
+      {stats && !hasPlayed && (
+        <div
+          className="absolute right-3 z-20 flex flex-col items-center gap-3 transition-opacity duration-300"
+          style={{ bottom: 110, opacity: hasPlayed ? 0 : 1 }}
+        >
+          {typeof stats.likes === 'number' && stats.likes > 0 && (
+            <FeedStatChip icon={<Heart size={20} fill="white" strokeWidth={0} />} value={stats.likes} accent="#ff2d55" />
+          )}
+          {typeof stats.comments === 'number' && stats.comments > 0 && (
+            <FeedStatChip icon={<MessageCircle size={20} fill="white" strokeWidth={0} />} value={stats.comments} />
+          )}
+          {typeof stats.collects === 'number' && stats.collects > 0 && (
+            <FeedStatChip icon={<Bookmark size={20} fill="white" strokeWidth={0} />} value={stats.collects} accent="#ffcc00" />
+          )}
+          {typeof stats.shares === 'number' && stats.shares > 0 && (
+            <FeedStatChip icon={<Share2 size={20} />} value={stats.shares} />
+          )}
+          {(stats.likes == null || stats.likes === 0) && typeof stats.plays === 'number' && stats.plays > 0 && (
+            <FeedStatChip icon={<Eye size={20} />} value={stats.plays} />
+          )}
+        </div>
+      )}
+
+      {/* 底部信息：标题 hook + 标签 chip + 渐变背景 */}
+      <div
+        className="absolute inset-x-0 bottom-0 z-20 px-4 pb-20 pt-8 pointer-events-none transition-opacity duration-300"
+        style={{
+          background: 'linear-gradient(180deg, transparent 0%, rgba(0,0,0,0.5) 35%, rgba(0,0,0,0.92) 100%)',
+          opacity: hasPlayed ? 0 : 1,
+        }}
+      >
+        <h2
+          className="font-bold text-white leading-snug line-clamp-2"
+          style={{
+            fontSize: 'clamp(15px, 1.5vw, 18px)',
+            textShadow: '0 2px 12px rgba(0,0,0,0.6)',
+          }}
+        >
+          {page.title}
+        </h2>
+        {tags.length > 0 && (
+          <div className="mt-2.5 flex flex-wrap items-center gap-1.5">
+            {tags.map((t) => (
+              <span
+                key={t}
+                className="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium"
+                style={{
+                  background: 'rgba(255,255,255,0.16)',
+                  color: 'rgba(255,255,255,0.95)',
+                  border: '1px solid rgba(255,255,255,0.18)',
+                }}
+              >
+                #{t}
+              </span>
+            ))}
+            {tagOverflow > 0 && (
+              <span className="text-white/60 text-[11px]">+{tagOverflow}</span>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** 互动数字 chip（垂直栈，图标 + 缩写数字） */
+function FeedStatChip({ icon, value, accent }: { icon: React.ReactNode; value: number; accent?: string }) {
+  return (
+    <div className="flex flex-col items-center gap-0.5 pointer-events-none">
+      <div
+        className="w-11 h-11 rounded-full flex items-center justify-center"
+        style={{
+          background: 'rgba(0,0,0,0.42)',
+          backdropFilter: 'blur(12px)',
+          WebkitBackdropFilter: 'blur(12px)',
+          color: accent || '#fff',
+          border: '1px solid rgba(255,255,255,0.14)',
+        }}
+      >
+        {icon}
+      </div>
+      <span
+        className="text-white text-[11px] font-semibold"
+        style={{ textShadow: '0 1px 4px rgba(0,0,0,0.7)' }}
+      >
+        {formatStatNumber(value)}
+      </span>
+    </div>
+  );
+}
+
+function formatStatNumber(n: number): string {
+  if (n < 1000) return String(n);
+  if (n < 10000) return `${(n / 1000).toFixed(1).replace(/\.0$/, '')}k`;
+  if (n < 1000000) return `${(n / 10000).toFixed(1).replace(/\.0$/, '')}w`;
+  return `${(n / 1000000).toFixed(1).replace(/\.0$/, '')}M`;
+}
+
+function formatDuration(sec: number): string {
+  if (sec < 60) return `${sec}s`;
+  const m = Math.floor(sec / 60);
+  const s = sec % 60;
+  if (sec < 3600) return `${m}:${s.toString().padStart(2, '0')}`;
+  const h = Math.floor(sec / 3600);
+  return `${h}:${(m % 60).toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
 }
 
 /**

--- a/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
+++ b/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
@@ -941,41 +941,54 @@ export function PosterFeedCardView({ page, onMediaAspectDetected }: {
 
   return (
     <div className="relative h-full" style={{ background: '#000' }}>
-      {/* 媒体层：视频或封面铺满。封面/视频加载后向父级上报真实宽高比，用于动态切横/竖/方屏 */}
+      {/* 媒体层：视频 / 封面 / 静图三选一互斥渲染。
+            播放后只显示 video；未播放时按优先级单层渲染：
+              静图主体 (非视频且有 primaryUrl) → cover (有 secondaryImageUrl) → 兜底渐变
+            避免之前 cover 与 primary 同时铺底导致双层叠图 + onMediaAspectDetected 双触发 */}
       <div className="absolute inset-0">
-        {coverUrl && !coverErrored && !hasPlayed && (
-          <img
-            src={coverUrl}
-            alt=""
-            className="absolute inset-0 w-full h-full object-cover"
-            draggable={false}
-            onLoad={(e) => {
-              const t = e.currentTarget;
-              if (t.naturalWidth > 0 && t.naturalHeight > 0)
-                onMediaAspectDetected?.(t.naturalWidth / t.naturalHeight);
-            }}
-            onError={() => setCoverErrored(true)}
-          />
-        )}
-        {!hasPlayed && (!coverUrl || coverErrored) && (
-          <div
-            className="absolute inset-0"
-            style={{ background: `linear-gradient(135deg, ${accent} 0%, #0a0a12 100%)` }}
-          />
-        )}
-        {!isVideo && primaryUrl && (
-          <img
-            src={primaryUrl}
-            alt=""
-            className="absolute inset-0 w-full h-full object-cover"
-            draggable={false}
-            onLoad={(e) => {
-              const t = e.currentTarget;
-              if (t.naturalWidth > 0 && t.naturalHeight > 0)
-                onMediaAspectDetected?.(t.naturalWidth / t.naturalHeight);
-            }}
-          />
-        )}
+        {(() => {
+          if (hasPlayed) return null;
+          // 优先级 1：静图 page（非视频 page，imageUrl 是图片）— 单层 primaryUrl
+          if (!isVideo && primaryUrl) {
+            return (
+              <img
+                src={primaryUrl}
+                alt=""
+                className="absolute inset-0 w-full h-full object-cover"
+                draggable={false}
+                onLoad={(e) => {
+                  const t = e.currentTarget;
+                  if (t.naturalWidth > 0 && t.naturalHeight > 0)
+                    onMediaAspectDetected?.(t.naturalWidth / t.naturalHeight);
+                }}
+              />
+            );
+          }
+          // 优先级 2：视频 page 未播放，渲染 cover（如果有）
+          if (coverUrl && !coverErrored) {
+            return (
+              <img
+                src={coverUrl}
+                alt=""
+                className="absolute inset-0 w-full h-full object-cover"
+                draggable={false}
+                onLoad={(e) => {
+                  const t = e.currentTarget;
+                  if (t.naturalWidth > 0 && t.naturalHeight > 0)
+                    onMediaAspectDetected?.(t.naturalWidth / t.naturalHeight);
+                }}
+                onError={() => setCoverErrored(true)}
+              />
+            );
+          }
+          // 优先级 3：啥都没有 → 兜底渐变
+          return (
+            <div
+              className="absolute inset-0"
+              style={{ background: `linear-gradient(135deg, ${accent} 0%, #0a0a12 100%)` }}
+            />
+          );
+        })()}
         {isVideo && hasPlayed && (
           <video
             ref={videoRef}

--- a/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
+++ b/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
@@ -44,21 +44,25 @@ export function PosterCarousel({
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onDismiss();
+      // Escape 与右上角 X 一致：收起到右下角胶囊，不彻底 dismiss
+      // （胶囊上的红色 ✕ 才走 onDismiss）
+      if (e.key === 'Escape') setMinimized(true);
       else if (e.key === 'ArrowLeft') setPageIndex((i) => Math.max(0, i - 1));
       else if (e.key === 'ArrowRight') setPageIndex((i) => Math.min(totalPages - 1, i + 1));
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [totalPages, onDismiss]);
+  }, [totalPages]);
 
+  // body overflow 锁定仅在「主模态展开」状态下生效；收起到胶囊时解锁让用户能滚页
   useEffect(() => {
+    if (minimized) return;
     const prev = document.body.style.overflow;
     document.body.style.overflow = 'hidden';
     return () => {
       document.body.style.overflow = prev;
     };
-  }, []);
+  }, [minimized]);
 
   const handleCta = () => {
     if (navigateOnCta) {
@@ -174,7 +178,8 @@ export function PosterCarousel({
         backdropFilter: 'blur(12px)',
         WebkitBackdropFilter: 'blur(12px)',
       }}
-      onClick={onDismiss}
+      // 点击 backdrop 与 X 按钮一致：收起到右下角胶囊（不彻底 dismiss）
+      onClick={() => setMinimized(true)}
       onTouchStart={handleTouchStart}
       onTouchEnd={handleTouchEnd}
     >

--- a/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
+++ b/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
@@ -862,6 +862,41 @@ export function PosterFeedCardView({ page, onMediaAspectDetected }: {
   const [hasPlayed, setHasPlayed] = useState(false);
   const [coverErrored, setCoverErrored] = useState(false);
   const [avatarErrored, setAvatarErrored] = useState(false);
+  // 当前播放时间对应的字幕 cue index（-1 表示无）
+  const [activeCueIdx, setActiveCueIdx] = useState(-1);
+
+  // 监听 video timeupdate 切到对应 cue。useEffect 依赖 page 切换时重置
+  useEffect(() => {
+    setActiveCueIdx(-1);
+  }, [page?.imageUrl]);
+
+  useEffect(() => {
+    if (!hasPlayed) return;
+    const v = videoRef.current;
+    if (!v) return;
+    const cues = page?.transcriptCues;
+    if (!cues || cues.length === 0) return;
+    const onTime = () => {
+      const t = v.currentTime;
+      // 二分查找当前时间所在 cue
+      let lo = 0, hi = cues.length - 1, found = -1;
+      while (lo <= hi) {
+        const mid = (lo + hi) >> 1;
+        if (cues[mid].startSec <= t && t <= cues[mid].endSec) { found = mid; break; }
+        if (t < cues[mid].startSec) hi = mid - 1; else lo = mid + 1;
+      }
+      // 没命中精确区间时，取距离当前时间最近的 cue（视频播放到字幕间隙时让最近一句保持显示）
+      if (found < 0 && cues.length > 0) {
+        // 找 startSec <= t 的最大那条
+        for (let i = cues.length - 1; i >= 0; i--) {
+          if (cues[i].startSec <= t) { found = i; break; }
+        }
+      }
+      setActiveCueIdx(found);
+    };
+    v.addEventListener('timeupdate', onTime);
+    return () => v.removeEventListener('timeupdate', onTime);
+  }, [hasPlayed, page?.transcriptCues]);
 
   if (!page) return null;
   const primaryUrl = page.imageUrl ?? '';
@@ -944,6 +979,31 @@ export function PosterFeedCardView({ page, onMediaAspectDetected }: {
           />
         )}
       </div>
+
+      {/* 字幕浮层（仅播放后 + 有 transcriptCues 时显示）。位置在视频中下部，上限避开右栏与底部信息 */}
+      {hasPlayed && activeCueIdx >= 0 && page.transcriptCues && page.transcriptCues[activeCueIdx] && (
+        <div
+          className="absolute z-20 pointer-events-none flex justify-center"
+          style={{ left: 12, right: 70, bottom: '24%' }}
+        >
+          <div
+            className="px-3 py-1.5 rounded-md max-w-full text-center"
+            style={{
+              background: 'rgba(0,0,0,0.62)',
+              backdropFilter: 'blur(6px)',
+              WebkitBackdropFilter: 'blur(6px)',
+              color: '#fff',
+              fontSize: 'clamp(13px, 1.4vw, 16px)',
+              fontWeight: 600,
+              lineHeight: 1.35,
+              textShadow: '0 1px 2px rgba(0,0,0,0.7)',
+              border: '1px solid rgba(255,255,255,0.08)',
+            }}
+          >
+            {page.transcriptCues[activeCueIdx].text}
+          </div>
+        </div>
+      )}
 
       {/* 中央 Play 按钮（仅视频未播放时） */}
       {isVideo && !hasPlayed && (

--- a/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
+++ b/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
-import { ChevronLeft, ChevronRight, X, ArrowRight, Sparkles, Play, Heart, MessageCircle, Bookmark, Share2, Eye, Clock } from 'lucide-react';
+import { ChevronLeft, ChevronRight, X, ArrowRight, Sparkles, Play, Heart, MessageCircle, Bookmark, Share2, Eye, Clock, Minus, Maximize2 } from 'lucide-react';
 import { useWeeklyPosterStore } from '@/stores/weeklyPosterStore';
 import { MarkdownContent } from '@/components/ui/MarkdownContent';
 import type { WeeklyPoster, WeeklyPosterPage } from '@/services';
@@ -26,6 +26,9 @@ export function PosterCarousel({
 }) {
   const navigate = useNavigate();
   const [pageIndex, setPageIndex] = useState(0);
+  const [minimized, setMinimized] = useState(false);
+  // feed-card 模式下，由当前页媒体（cover / video）的真实宽高比驱动 modal aspect
+  const [feedCardMediaAspect, setFeedCardMediaAspect] = useState<number | null>(null);
   const touchStartX = useRef<number | null>(null);
 
   const pages = useMemo(
@@ -35,6 +38,9 @@ export function PosterCarousel({
   const totalPages = pages.length;
   const isLastPage = pageIndex === totalPages - 1;
   const currentPage = pages[Math.min(pageIndex, totalPages - 1)];
+
+  // 切页时重置媒体比例（不同页可能横/竖屏不同）
+  useEffect(() => { setFeedCardMediaAspect(null); }, [pageIndex]);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -83,16 +89,80 @@ export function PosterCarousel({
   const isAdMode = poster.presentationMode === 'ad-4-3';
   const isRichText = poster.presentationMode === 'ad-rich-text';
   const isFeedCard = poster.presentationMode === 'feed-card';
-  // ad-4-3 / ad-rich-text 走 4:3 横屏；feed-card 走 9:16 竖屏（短视频原生比例）；其它走 1200:628 横幅
+  // ad-4-3 / ad-rich-text 走 4:3 横屏；feed-card 默认 9:16 竖屏，但若检测到当前页视频是
+  // 横屏（aspect>1.2）则切到 16:9，方屏（0.85~1.2）切到 4:3
   const isWideMode = isAdMode || isRichText;
-  const aspect = isFeedCard ? '9 / 16' : (isWideMode ? '4 / 3' : '1200 / 628');
-  // 4:3 适合视频广告类弹窗（横屏不太宽、能装下竖屏视频又不极端），借鉴 Apple 产品视频弹窗 / Netflix 预告模态
-  // 9:16 是抖音 / 小红书原生比例，feed-card 模式下整个弹窗是竖屏播放器
+  let feedCardAspect: '9 / 16' | '16 / 9' | '4 / 3' = '9 / 16';
+  if (isFeedCard && feedCardMediaAspect) {
+    if (feedCardMediaAspect > 1.2) feedCardAspect = '16 / 9';
+    else if (feedCardMediaAspect > 0.85) feedCardAspect = '4 / 3';
+  }
+  const aspect = isFeedCard ? feedCardAspect : (isWideMode ? '4 / 3' : '1200 / 628');
+  // 9:16 竖屏宽度 420px；横屏 16:9 给 720px；方屏 4:3 给 600px。所有都受视口高度约束
   const widthCalc = isFeedCard
-    ? 'min(420px, calc((100vh - 80px) * 0.5625), calc(100vw - 32px))'
+    ? (feedCardAspect === '16 / 9'
+        ? 'min(720px, calc((100vh - 80px) * 1.778), calc(100vw - 32px))'
+        : feedCardAspect === '4 / 3'
+          ? 'min(600px, calc((100vh - 80px) * 1.333), calc(100vw - 32px))'
+          : 'min(420px, calc((100vh - 80px) * 0.5625), calc(100vw - 32px))')
     : isWideMode
       ? 'min(960px, calc((100vh - 80px) * 1.333), calc(100vw - 64px))'
       : 'min(1120px, calc((100vh - 80px) * 1.91), calc(100vw - 64px))';
+
+  // 最小化态：右下角胶囊浮层（缩略图 + 标题 + 展开/关闭）。不会卸载主模态状态，pageIndex/hasPlayed 全部保留
+  const minimizedCoverUrl = currentPage?.secondaryImageUrl
+    || (currentPage?.imageUrl && !isVideoUrl(currentPage.imageUrl) ? currentPage.imageUrl : null);
+  const minimizedTitle = currentPage?.title || poster.title || '';
+  if (minimized) {
+    return createPortal(
+      <div
+        className="fixed bottom-6 right-6 z-[9999] flex items-center gap-2 px-2 py-2 rounded-2xl"
+        style={{
+          background: 'rgba(11,11,16,0.92)',
+          backdropFilter: 'blur(16px)',
+          WebkitBackdropFilter: 'blur(16px)',
+          border: '1px solid rgba(255,255,255,0.14)',
+          boxShadow: '0 16px 40px -8px rgba(0,0,0,0.55), 0 0 32px rgba(124,58,237,0.18)',
+          maxWidth: 280,
+        }}
+      >
+        <button
+          type="button"
+          onClick={() => setMinimized(false)}
+          aria-label="展开海报"
+          className="flex items-center gap-2 flex-1 min-w-0 cursor-pointer text-left rounded-xl px-1 py-1 hover:bg-white/5 transition-colors"
+        >
+          <div
+            className="shrink-0 rounded-lg overflow-hidden flex items-center justify-center"
+            style={{ width: 44, height: 44, background: '#000', border: '1px solid rgba(255,255,255,0.1)' }}
+          >
+            {minimizedCoverUrl ? (
+              <img src={minimizedCoverUrl} alt="" className="w-full h-full object-cover" draggable={false} />
+            ) : (
+              <Sparkles size={18} className="text-white/60" />
+            )}
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="text-[12px] font-semibold text-white truncate">{minimizedTitle}</div>
+            <div className="inline-flex items-center gap-1 text-[10px] text-white/55 mt-0.5">
+              <Maximize2 size={10} />
+              <span>{totalPages > 1 ? `${pageIndex + 1}/${totalPages} · 点击展开` : '点击展开'}</span>
+            </div>
+          </div>
+        </button>
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="关闭海报"
+          title="关闭海报"
+          className="shrink-0 w-7 h-7 rounded-full flex items-center justify-center transition-all hover:bg-white/10 text-white/70"
+        >
+          <X size={14} />
+        </button>
+      </div>,
+      document.body,
+    );
+  }
 
   const modal = (
     <div
@@ -121,6 +191,20 @@ export function PosterCarousel({
       >
         <button
           type="button"
+          onClick={() => setMinimized(true)}
+          aria-label="最小化到右下角"
+          title="最小化到右下角"
+          className="absolute top-5 right-[68px] z-30 w-10 h-10 rounded-full flex items-center justify-center transition-all hover:scale-110"
+          style={{
+            background: 'rgba(0,0,0,0.55)',
+            border: '1px solid rgba(255,255,255,0.12)',
+            color: 'rgba(255,255,255,0.85)',
+          }}
+        >
+          <Minus size={16} />
+        </button>
+        <button
+          type="button"
           onClick={onDismiss}
           aria-label="关闭"
           className="absolute top-5 right-5 z-30 w-10 h-10 rounded-full flex items-center justify-center transition-all hover:scale-110"
@@ -139,7 +223,10 @@ export function PosterCarousel({
           key={`page-${pageIndex}`}
         >
           {isFeedCard ? (
-            <PosterFeedCardView page={currentPage} />
+            <PosterFeedCardView
+              page={currentPage}
+              onMediaAspectDetected={setFeedCardMediaAspect}
+            />
           ) : isAdMode ? (
             <PosterAdPageView page={currentPage} weekKey={poster.weekKey} />
           ) : isRichText ? (
@@ -777,7 +864,10 @@ export function PosterRichTextPageView({
  *   - 互动数字大于 1k 简写为 1.2k / 5.9k
  *   - 没有头像时用渐变色圆形带首字母
  */
-export function PosterFeedCardView({ page }: { page: WeeklyPosterPage | undefined }) {
+export function PosterFeedCardView({ page, onMediaAspectDetected }: {
+  page: WeeklyPosterPage | undefined;
+  onMediaAspectDetected?: (aspect: number) => void;
+}) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const [hasPlayed, setHasPlayed] = useState(false);
   const [coverErrored, setCoverErrored] = useState(false);
@@ -812,7 +902,7 @@ export function PosterFeedCardView({ page }: { page: WeeklyPosterPage | undefine
 
   return (
     <div className="relative h-full" style={{ background: '#000' }}>
-      {/* 媒体层：视频或封面铺满 */}
+      {/* 媒体层：视频或封面铺满。封面/视频加载后向父级上报真实宽高比，用于动态切横/竖/方屏 */}
       <div className="absolute inset-0">
         {coverUrl && !coverErrored && !hasPlayed && (
           <img
@@ -820,6 +910,11 @@ export function PosterFeedCardView({ page }: { page: WeeklyPosterPage | undefine
             alt=""
             className="absolute inset-0 w-full h-full object-cover"
             draggable={false}
+            onLoad={(e) => {
+              const t = e.currentTarget;
+              if (t.naturalWidth > 0 && t.naturalHeight > 0)
+                onMediaAspectDetected?.(t.naturalWidth / t.naturalHeight);
+            }}
             onError={() => setCoverErrored(true)}
           />
         )}
@@ -835,6 +930,11 @@ export function PosterFeedCardView({ page }: { page: WeeklyPosterPage | undefine
             alt=""
             className="absolute inset-0 w-full h-full object-cover"
             draggable={false}
+            onLoad={(e) => {
+              const t = e.currentTarget;
+              if (t.naturalWidth > 0 && t.naturalHeight > 0)
+                onMediaAspectDetected?.(t.naturalWidth / t.naturalHeight);
+            }}
           />
         )}
         {isVideo && hasPlayed && (
@@ -846,6 +946,11 @@ export function PosterFeedCardView({ page }: { page: WeeklyPosterPage | undefine
             controls
             playsInline
             autoPlay
+            onLoadedMetadata={(e) => {
+              const v = e.currentTarget;
+              if (v.videoWidth > 0 && v.videoHeight > 0)
+                onMediaAspectDetected?.(v.videoWidth / v.videoHeight);
+            }}
           />
         )}
       </div>
@@ -934,11 +1039,11 @@ export function PosterFeedCardView({ page }: { page: WeeklyPosterPage | undefine
         </div>
       </div>
 
-      {/* 右栏：互动指标（fade out on play 让出视频画面） */}
-      {stats && !hasPlayed && (
+      {/* 右栏：互动指标（播放后半透明常驻，避免完全遮蔽视频但仍让用户看到数据） */}
+      {stats && (
         <div
           className="absolute right-3 z-20 flex flex-col items-center gap-3 transition-opacity duration-300"
-          style={{ bottom: 110, opacity: hasPlayed ? 0 : 1 }}
+          style={{ bottom: 110, opacity: hasPlayed ? 0.6 : 1 }}
         >
           {typeof stats.likes === 'number' && stats.likes > 0 && (
             <FeedStatChip icon={<Heart size={20} fill="white" strokeWidth={0} />} value={stats.likes} accent="#ff2d55" />

--- a/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
+++ b/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
-import { ChevronLeft, ChevronRight, X, ArrowRight, Sparkles, Play, Heart, MessageCircle, Bookmark, Share2, Eye, Clock, Minus, Maximize2 } from 'lucide-react';
+import { ChevronLeft, ChevronRight, X, ArrowRight, Sparkles, Play, Heart, MessageCircle, Bookmark, Share2, Eye, Clock, Maximize2 } from 'lucide-react';
 import { useWeeklyPosterStore } from '@/stores/weeklyPosterStore';
 import { MarkdownContent } from '@/components/ui/MarkdownContent';
 import type { WeeklyPoster, WeeklyPosterPage } from '@/services';
@@ -98,13 +98,15 @@ export function PosterCarousel({
     else if (feedCardMediaAspect > 0.85) feedCardAspect = '4 / 3';
   }
   const aspect = isFeedCard ? feedCardAspect : (isWideMode ? '4 / 3' : '1200 / 628');
-  // 9:16 竖屏宽度 420px；横屏 16:9 给 720px；方屏 4:3 给 600px。所有都受视口高度约束
+  // 三档尺寸（用户反馈横屏太小，全部加大）：
+  //   9:16 竖屏 460px / 4:3 方屏 760px / 16:9 横屏 920px
+  // 受视口高度约束防止超出屏幕
   const widthCalc = isFeedCard
     ? (feedCardAspect === '16 / 9'
-        ? 'min(720px, calc((100vh - 80px) * 1.778), calc(100vw - 32px))'
+        ? 'min(920px, calc((100vh - 80px) * 1.778), calc(100vw - 32px))'
         : feedCardAspect === '4 / 3'
-          ? 'min(600px, calc((100vh - 80px) * 1.333), calc(100vw - 32px))'
-          : 'min(420px, calc((100vh - 80px) * 0.5625), calc(100vw - 32px))')
+          ? 'min(760px, calc((100vh - 80px) * 1.333), calc(100vw - 32px))'
+          : 'min(460px, calc((100vh - 80px) * 0.5625), calc(100vw - 32px))')
     : isWideMode
       ? 'min(960px, calc((100vh - 80px) * 1.333), calc(100vw - 64px))'
       : 'min(1120px, calc((100vh - 80px) * 1.91), calc(100vw - 64px))';
@@ -153,9 +155,9 @@ export function PosterCarousel({
         <button
           type="button"
           onClick={onDismiss}
-          aria-label="关闭海报"
-          title="关闭海报"
-          className="shrink-0 w-7 h-7 rounded-full flex items-center justify-center transition-all hover:bg-white/10 text-white/70"
+          aria-label="不再显示"
+          title="不再显示（彻底关闭）"
+          className="shrink-0 w-7 h-7 rounded-full flex items-center justify-center transition-all hover:bg-red-500/40 text-white/70 hover:text-white"
         >
           <X size={14} />
         </button>
@@ -189,24 +191,12 @@ export function PosterCarousel({
             '0 40px 80px -20px rgba(0,0,0,0.6), 0 0 120px rgba(124,58,237,0.18), inset 0 1px 0 rgba(255,255,255,0.08)',
         }}
       >
+        {/* 右上角只保留一个按钮：收起到右下角胶囊。彻底 dismiss 在胶囊上的 ✕ 触发 */}
         <button
           type="button"
           onClick={() => setMinimized(true)}
-          aria-label="最小化到右下角"
-          title="最小化到右下角"
-          className="absolute top-5 right-[68px] z-30 w-10 h-10 rounded-full flex items-center justify-center transition-all hover:scale-110"
-          style={{
-            background: 'rgba(0,0,0,0.55)',
-            border: '1px solid rgba(255,255,255,0.12)',
-            color: 'rgba(255,255,255,0.85)',
-          }}
-        >
-          <Minus size={16} />
-        </button>
-        <button
-          type="button"
-          onClick={onDismiss}
-          aria-label="关闭"
+          aria-label="收起到右下角"
+          title="收起到右下角（仍可在右下角胶囊找到）"
           className="absolute top-5 right-5 z-30 w-10 h-10 rounded-full flex items-center justify-center transition-all hover:scale-110"
           style={{
             background: 'rgba(0,0,0,0.55)',

--- a/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
+++ b/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
@@ -115,65 +115,66 @@ export function PosterCarousel({
       ? 'min(960px, calc((100vh - 80px) * 1.333), calc(100vw - 64px))'
       : 'min(1120px, calc((100vh - 80px) * 1.91), calc(100vw - 64px))';
 
-  // 最小化态：右下角胶囊浮层（缩略图 + 标题 + 展开/关闭）。不会卸载主模态状态，pageIndex/hasPlayed 全部保留
+  // 最小化态：右下角胶囊浮层（缩略图 + 标题 + 展开/关闭）。
+  // 主模态在 minimized 时 display:none 不卸载子组件 → PosterFeedCardView 的
+  // hasPlayed / activeCueIdx / video.currentTime 全部保留。展开后 video 接续播
   const minimizedCoverUrl = currentPage?.secondaryImageUrl
     || (currentPage?.imageUrl && !isVideoUrl(currentPage.imageUrl) ? currentPage.imageUrl : null);
   const minimizedTitle = currentPage?.title || poster.title || '';
-  if (minimized) {
-    return createPortal(
-      <div
-        className="fixed bottom-6 right-6 z-[9999] flex items-center gap-2 px-2 py-2 rounded-2xl"
-        style={{
-          background: 'rgba(11,11,16,0.92)',
-          backdropFilter: 'blur(16px)',
-          WebkitBackdropFilter: 'blur(16px)',
-          border: '1px solid rgba(255,255,255,0.14)',
-          boxShadow: '0 16px 40px -8px rgba(0,0,0,0.55), 0 0 32px rgba(124,58,237,0.18)',
-          maxWidth: 280,
-        }}
+  const capsuleNode = minimized ? (
+    <div
+      className="fixed bottom-6 right-6 z-[9999] flex items-center gap-2 px-2 py-2 rounded-2xl"
+      style={{
+        background: 'rgba(11,11,16,0.92)',
+        backdropFilter: 'blur(16px)',
+        WebkitBackdropFilter: 'blur(16px)',
+        border: '1px solid rgba(255,255,255,0.14)',
+        boxShadow: '0 16px 40px -8px rgba(0,0,0,0.55), 0 0 32px rgba(124,58,237,0.18)',
+        maxWidth: 280,
+      }}
+    >
+      <button
+        type="button"
+        onClick={() => setMinimized(false)}
+        aria-label="展开海报"
+        className="flex items-center gap-2 flex-1 min-w-0 cursor-pointer text-left rounded-xl px-1 py-1 hover:bg-white/5 transition-colors"
       >
-        <button
-          type="button"
-          onClick={() => setMinimized(false)}
-          aria-label="展开海报"
-          className="flex items-center gap-2 flex-1 min-w-0 cursor-pointer text-left rounded-xl px-1 py-1 hover:bg-white/5 transition-colors"
+        <div
+          className="shrink-0 rounded-lg overflow-hidden flex items-center justify-center"
+          style={{ width: 44, height: 44, background: '#000', border: '1px solid rgba(255,255,255,0.1)' }}
         >
-          <div
-            className="shrink-0 rounded-lg overflow-hidden flex items-center justify-center"
-            style={{ width: 44, height: 44, background: '#000', border: '1px solid rgba(255,255,255,0.1)' }}
-          >
-            {minimizedCoverUrl ? (
-              <img src={minimizedCoverUrl} alt="" className="w-full h-full object-cover" draggable={false} />
-            ) : (
-              <Sparkles size={18} className="text-white/60" />
-            )}
+          {minimizedCoverUrl ? (
+            <img src={minimizedCoverUrl} alt="" className="w-full h-full object-cover" draggable={false} />
+          ) : (
+            <Sparkles size={18} className="text-white/60" />
+          )}
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="text-[12px] font-semibold text-white truncate">{minimizedTitle}</div>
+          <div className="inline-flex items-center gap-1 text-[10px] text-white/55 mt-0.5">
+            <Maximize2 size={10} />
+            <span>{totalPages > 1 ? `${pageIndex + 1}/${totalPages} · 点击展开` : '点击展开'}</span>
           </div>
-          <div className="flex-1 min-w-0">
-            <div className="text-[12px] font-semibold text-white truncate">{minimizedTitle}</div>
-            <div className="inline-flex items-center gap-1 text-[10px] text-white/55 mt-0.5">
-              <Maximize2 size={10} />
-              <span>{totalPages > 1 ? `${pageIndex + 1}/${totalPages} · 点击展开` : '点击展开'}</span>
-            </div>
-          </div>
-        </button>
-        <button
-          type="button"
-          onClick={onDismiss}
-          aria-label="不再显示"
-          title="不再显示（彻底关闭）"
-          className="shrink-0 w-7 h-7 rounded-full flex items-center justify-center transition-all hover:bg-red-500/40 text-white/70 hover:text-white"
-        >
-          <X size={14} />
-        </button>
-      </div>,
-      document.body,
-    );
-  }
+        </div>
+      </button>
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="不再显示"
+        title="不再显示（彻底关闭）"
+        className="shrink-0 w-7 h-7 rounded-full flex items-center justify-center transition-all hover:bg-red-500/40 text-white/70 hover:text-white"
+      >
+        <X size={14} />
+      </button>
+    </div>
+  ) : null;
 
   const modal = (
     <div
-      className="fixed inset-0 z-[9999] flex items-center justify-center"
+      className="fixed inset-0 z-[9999] items-center justify-center"
       style={{
+        // minimized 时 display:none 隐藏，但子组件不卸载 — 视频继续保留 currentTime / hasPlayed 等内部状态
+        display: minimized ? 'none' : 'flex',
         background: 'rgba(3,3,6,0.78)',
         backdropFilter: 'blur(12px)',
         WebkitBackdropFilter: 'blur(12px)',
@@ -304,7 +305,15 @@ export function PosterCarousel({
     </div>
   );
 
-  return createPortal(modal, document.body);
+  // modal 与 capsule 同时存在于 portal：minimized 时 modal display:none 但保留子组件挂载，
+  // 视频不会被卸载，再次展开时 hasPlayed / currentTime / activeCueIdx 全部接续
+  return createPortal(
+    <>
+      {modal}
+      {capsuleNode}
+    </>,
+    document.body,
+  );
 }
 
 export function WeeklyPosterPageView({

--- a/prd-admin/src/pages/workflow-agent/capsuleRegistry.tsx
+++ b/prd-admin/src/pages/workflow-agent/capsuleRegistry.tsx
@@ -3,7 +3,7 @@ import {
   Database, Globe, Brain, Code2, Filter, Merge, Repeat, BarChart3,
   Clock, GitBranch,
   FileText, Download, Send, Bell, Box, AppWindow, GlobeLock, Mail,
-  Video, PenTool, Terminal, Image,
+  Video, PenTool, Terminal, Image, CloudUpload,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 
@@ -206,6 +206,16 @@ export const CAPSULE_TYPE_REGISTRY: Record<string, CapsuleTypeDef> = {
     emoji: 'TT',
     category: 'processor',
     accentHue: 340,
+    testable: true,
+  },
+  'media-rehost': {
+    typeKey: 'media-rehost',
+    name: '媒体迁移到 COS',
+    description: '把上游 items 数组里每条记录的视频 / 封面 URL 下载到平台 COS，绕开 TikTok / B 站 / 小红书 CDN 防盗链导致前端 403 播放失败的问题',
+    Icon: CloudUpload,
+    emoji: 'MR',
+    category: 'processor',
+    accentHue: 220,
     testable: true,
   },
   'homepage-publisher': {

--- a/prd-admin/src/pages/workflow-agent/workflowTemplates.ts
+++ b/prd-admin/src/pages/workflow-agent/workflowTemplates.ts
@@ -1455,12 +1455,34 @@ result = {
 // 中央 Play 按钮主动点击播放，不打扰用户（autoplay 容易吓跑）。
 //
 
+// 多平台 CTA 文案与 ID 格式，跨两个模板复用
+const PLATFORM_CTA_LABELS: Record<string, string> = {
+  tiktok: '去 TikTok 看完整视频',
+  douyin: '去抖音看完整视频',
+  bilibili: '去 B 站看完整视频',
+  xiaohongshu: '去小红书看完整笔记',
+  youtube: '去 YouTube 看完整视频',
+};
+const PLATFORM_OPTIONS = [
+  { value: 'tiktok', label: 'TikTok（海外短视频，secUid）' },
+  { value: 'douyin', label: '抖音（国内短视频，sec_user_id）' },
+  { value: 'bilibili', label: 'B 站（UP 主投稿，mid 数字）' },
+  { value: 'xiaohongshu', label: '小红书（图文/视频笔记，user_id）' },
+  { value: 'youtube', label: 'YouTube（频道视频，channelId）' },
+];
+const PLATFORM_ID_HELP =
+  'TikTok / 抖音填 secUid 或 sec_user_id（MS4wLjAB... 格式）；'
+  + 'B 站填 UP 主 mid（数字，如 12345678）；'
+  + '小红书填 user_id（从博主主页 URL 末段取）；'
+  + 'YouTube 填 channelId（UCxxxxx 格式）。'
+  + '默认值为 TikHub 官方 TikTok 示例 secUid，换平台时记得替换';
+
 const tiktokCreatorToHomepageTemplate: WorkflowTemplate = {
   id: 'tiktok-creator-to-homepage',
-  name: 'TikTok / 抖音 博主订阅 → 首页广告海报',
-  description: '抓博主最新 N 条视频 → 作为首页登录弹窗海报（4:3 ad 样式，借鉴 Apple/Netflix 视频广告 modal：全 bleed 封面 + 中央 Play 按钮，点击才播）',
+  name: '多平台博主订阅 → 首页广告海报 (TikHub)',
+  description: '通过 TikHub 抓博主最新 N 条作品 → 作为首页登录弹窗海报。支持 TikTok / 抖音 / B 站 / 小红书 / YouTube 五个平台，4:3 ad 样式（全 bleed 封面 + 中央 Play）。注：B 站 / YouTube 不给 mp4 直链，海报点击会跳转原平台',
   icon: 'TT',
-  tags: ['tiktok', 'douyin', 'tikhub', 'video-ad', 'subscription'],
+  tags: ['tiktok', 'douyin', 'bilibili', 'xiaohongshu', 'youtube', 'tikhub', 'video-ad', 'subscription'],
   requiredInputs: [
     {
       key: 'tikHubApiKey',
@@ -1476,19 +1498,16 @@ const tiktokCreatorToHomepageTemplate: WorkflowTemplate = {
       type: 'select',
       required: true,
       defaultValue: 'tiktok',
-      options: [
-        { value: 'tiktok', label: 'TikTok（海外，secUid）' },
-        { value: 'douyin', label: '抖音（国内，sec_user_id）' },
-      ],
-      helpTip: '选 TikTok 用 secUid，选抖音用 sec_user_id',
+      options: PLATFORM_OPTIONS,
+      helpTip: '选择目标平台。下方「博主 ID」字段会按所选平台读取对应 ID 类型',
     },
     {
       key: 'secUid',
-      label: '博主 secUid / sec_user_id',
+      label: '博主 ID',
       type: 'text',
       defaultValue: 'MS4wLjABAAAAv7iSuuXDJGDvJkmH_vz1qkDZYo1apxgzaxdBSeIuPiM',
-      placeholder: 'MS4wLjABAAAA...',
-      helpTip: 'TikTok 默认填 TikHub 官方示例；抖音换成抖音 sec_user_id（参考 TikHub 文档）',
+      placeholder: 'TikTok=secUid / 抖音=sec_user_id / B站=mid / 小红书=user_id / YouTube=channelId',
+      helpTip: PLATFORM_ID_HELP,
       required: true,
     },
     {
@@ -1552,7 +1571,7 @@ const tiktokCreatorToHomepageTemplate: WorkflowTemplate = {
           templateKey: 'promo',
           presentationMode: 'ad-4-3',
           accentColor: '#ff0050',
-          ctaText: platform === 'douyin' ? '去抖音看完整视频' : '去 TikTok 看完整视频',
+          ctaText: PLATFORM_CTA_LABELS[platform] || PLATFORM_CTA_LABELS.tiktok,
           ctaUrlField: 'firstItem.shareUrl',
           publish: 'true',
         },
@@ -2081,10 +2100,10 @@ result = {total:items.length, closed:closed, open:items.length-closed, items:ite
 
 const tiktokCreatorToHomepageRichTemplate: WorkflowTemplate = {
   id: 'tiktok-creator-to-homepage-rich',
-  name: 'TikTok / 抖音 博主订阅 → 首页图文混排海报 (ASR)',
-  description: '比 ad-4-3 模板多一步真音频转写：抓博主作品 → 下载视频 → ffmpeg 抽音 → 流式 ASR → LLM 提炼 hook+bullets → 发布为图文混排海报（左动图 + 右 hook 大字 + bullets，借鉴 Instagram Story Ad / 小红书笔记）',
+  name: '多平台博主订阅 → 首页图文混排海报 (ASR)',
+  description: '比 ad-4-3 模板多一步真音频转写：抓博主作品 → 下载视频 → ffmpeg 抽音 → 流式 ASR → LLM 提炼 hook+bullets → 发布为图文混排海报（左动图 + 右 hook 大字 + bullets）。支持 TikTok / 抖音 / B 站 / 小红书 / YouTube。注：B 站 / YouTube / 小红书图文笔记没 mp4 直链，会跳过 ASR 直接走 cover + 标题',
   icon: 'TT',
-  tags: ['tiktok', 'douyin', 'tikhub', 'asr', 'video-ad', 'subscription', 'rich-text'],
+  tags: ['tiktok', 'douyin', 'bilibili', 'xiaohongshu', 'youtube', 'tikhub', 'asr', 'video-ad', 'subscription', 'rich-text'],
   requiredInputs: [
     {
       key: 'tikHubApiKey',
@@ -2100,19 +2119,16 @@ const tiktokCreatorToHomepageRichTemplate: WorkflowTemplate = {
       type: 'select',
       required: true,
       defaultValue: 'tiktok',
-      options: [
-        { value: 'tiktok', label: 'TikTok（海外，secUid）' },
-        { value: 'douyin', label: '抖音（国内，sec_user_id）' },
-      ],
-      helpTip: '选 TikTok 用 secUid，选抖音用 sec_user_id',
+      options: PLATFORM_OPTIONS,
+      helpTip: '选择目标平台。B 站 / YouTube / 小红书图文笔记没 mp4 直链，ASR 会自动跳过这些条目',
     },
     {
       key: 'secUid',
-      label: '博主 secUid / sec_user_id',
+      label: '博主 ID',
       type: 'text',
       defaultValue: 'MS4wLjABAAAAv7iSuuXDJGDvJkmH_vz1qkDZYo1apxgzaxdBSeIuPiM',
-      placeholder: 'MS4wLjABAAAA...',
-      helpTip: 'TikTok 默认填 TikHub 官方示例；抖音换成抖音 sec_user_id（参考 TikHub 文档）',
+      placeholder: 'TikTok=secUid / 抖音=sec_user_id / B站=mid / 小红书=user_id / YouTube=channelId',
+      helpTip: PLATFORM_ID_HELP,
       required: true,
     },
     {
@@ -2205,7 +2221,7 @@ const tiktokCreatorToHomepageRichTemplate: WorkflowTemplate = {
           templateKey: 'promo',
           presentationMode: 'ad-rich-text',
           accentColor: '#ff0050',
-          ctaText: platform === 'douyin' ? '去抖音看完整视频' : '去 TikTok 看完整视频',
+          ctaText: PLATFORM_CTA_LABELS[platform] || PLATFORM_CTA_LABELS.tiktok,
           ctaUrlField: 'firstItem.shareUrl',
           publish: 'true',
         },

--- a/prd-admin/src/pages/workflow-agent/workflowTemplates.ts
+++ b/prd-admin/src/pages/workflow-agent/workflowTemplates.ts
@@ -1561,6 +1561,22 @@ const tiktokCreatorToHomepageTemplate: WorkflowTemplate = {
         outputSlots: [{ slotId: 'tcf-out', name: 'videos', dataType: 'json', required: true }],
         position: { x: 380, y: 240 },
       },
+      // ─── 媒体迁移（绕开 TikTok / B 站 / 小红书 CDN 防盗链 403）───
+      {
+        nodeId: 'n-rehost',
+        name: '视频/封面迁移到 COS',
+        nodeType: 'media-rehost',
+        config: {
+          itemsField: 'items',
+          rehostFields: 'videoUrl,coverUrl',
+          maxConcurrency: '4',
+          maxBytesMb: '50',
+          timeoutSeconds: '120',
+        },
+        inputSlots: [{ slotId: 'mr-in', name: 'items', dataType: 'json', required: true }],
+        outputSlots: [{ slotId: 'mr-out', name: 'rehosted', dataType: 'json', required: true }],
+        position: { x: 540, y: 240 },
+      },
       // ─── 发布到首页广告海报弹窗 ───
       {
         nodeId: 'n-publish',
@@ -1577,13 +1593,14 @@ const tiktokCreatorToHomepageTemplate: WorkflowTemplate = {
         },
         inputSlots: [{ slotId: 'wp-in', name: 'items', dataType: 'json', required: true }],
         outputSlots: [{ slotId: 'wp-out', name: 'result', dataType: 'json', required: true }],
-        position: { x: 720, y: 240 },
+        position: { x: 820, y: 240 },
       },
     ];
 
     const edges: WorkflowEdge[] = [
       edge('n-trigger', 'manual-out', 'n-fetch', 'tcf-in'),
-      edge('n-fetch', 'tcf-out', 'n-publish', 'wp-in'),
+      edge('n-fetch', 'tcf-out', 'n-rehost', 'mr-in'),
+      edge('n-rehost', 'mr-out', 'n-publish', 'wp-in'),
     ];
 
     return { nodes, edges, variables: [] };
@@ -2195,6 +2212,24 @@ const tiktokCreatorToHomepageRichTemplate: WorkflowTemplate = {
         outputSlots: [{ slotId: 'tcf-out', name: 'videos', dataType: 'json', required: true }],
         position: { x: 360, y: 240 },
       },
+      // ─── 媒体迁移（绕开 CDN 防盗链 403）───
+      // 放在 ASR 之前：rehost 后 ASR 用稳定 COS URL 下载视频，避免短期签名 URL 在
+      // ASR 阶段又过期失败
+      {
+        nodeId: 'n-rehost',
+        name: '视频/封面迁移到 COS',
+        nodeType: 'media-rehost',
+        config: {
+          itemsField: 'items',
+          rehostFields: 'videoUrl,coverUrl',
+          maxConcurrency: '4',
+          maxBytesMb: '50',
+          timeoutSeconds: '120',
+        },
+        inputSlots: [{ slotId: 'mr-in', name: 'items', dataType: 'json', required: true }],
+        outputSlots: [{ slotId: 'mr-out', name: 'rehosted', dataType: 'json', required: true }],
+        position: { x: 540, y: 240 },
+      },
       // ─── 视频转文字（ASR + LLM 二次提炼） ───
       // maxItems 留空 → 自动处理上游所有 items，无需与 count 联动
       {
@@ -2209,7 +2244,7 @@ const tiktokCreatorToHomepageRichTemplate: WorkflowTemplate = {
         },
         inputSlots: [{ slotId: 'vt-in', name: 'videoInfo', dataType: 'json', required: true }],
         outputSlots: [{ slotId: 'vt-out', name: 'textContent', dataType: 'json', required: true }],
-        position: { x: 660, y: 240 },
+        position: { x: 820, y: 240 },
       },
       // ─── 发布到首页图文混排海报 ───
       {
@@ -2227,13 +2262,14 @@ const tiktokCreatorToHomepageRichTemplate: WorkflowTemplate = {
         },
         inputSlots: [{ slotId: 'wp-in', name: 'items', dataType: 'json', required: true }],
         outputSlots: [{ slotId: 'wp-out', name: 'result', dataType: 'json', required: true }],
-        position: { x: 980, y: 240 },
+        position: { x: 1100, y: 240 },
       },
     ];
 
     const edges: WorkflowEdge[] = [
       edge('n-trigger', 'manual-out', 'n-fetch', 'tcf-in'),
-      edge('n-fetch', 'tcf-out', 'n-asr', 'vt-in'),
+      edge('n-fetch', 'tcf-out', 'n-rehost', 'mr-in'),
+      edge('n-rehost', 'mr-out', 'n-asr', 'vt-in'),
       edge('n-asr', 'vt-out', 'n-publish', 'wp-in'),
     ];
 

--- a/prd-admin/src/pages/workflow-agent/workflowTemplates.ts
+++ b/prd-admin/src/pages/workflow-agent/workflowTemplates.ts
@@ -2180,6 +2180,7 @@ const tiktokCreatorToHomepageRichTemplate: WorkflowTemplate = {
         position: { x: 360, y: 240 },
       },
       // ─── 视频转文字（ASR + LLM 二次提炼） ───
+      // maxItems 留空 → 自动处理上游所有 items，无需与 count 联动
       {
         nodeId: 'n-asr',
         name: '音频转写 + AI 提炼',
@@ -2188,7 +2189,6 @@ const tiktokCreatorToHomepageRichTemplate: WorkflowTemplate = {
           extractMode: 'asr',
           videoUrlField: 'videoUrl',
           itemsField: 'items',
-          maxItems: count,
           enableHookExtraction: enableHook,
         },
         inputSlots: [{ slotId: 'vt-in', name: 'videoInfo', dataType: 'json', required: true }],

--- a/prd-admin/src/pages/workflow-agent/workflowTemplates.ts
+++ b/prd-admin/src/pages/workflow-agent/workflowTemplates.ts
@@ -2061,6 +2061,171 @@ result = {total:items.length, closed:closed, open:items.length-closed, items:ite
 };
 
 // ═══════════════════════════════════════════════════════════════
+// 模板: TikTok / 抖音 博主订阅 → 首页图文混排海报 (ad-rich-text)
+// ═══════════════════════════════════════════════════════════════
+//
+// 拓扑图：
+//
+//   👆 手动触发 → 📦 拉取博主视频列表 → 📝 视频转文字 (ASR + hook) → 🪧 发布图文混排海报
+//
+// vs ad-4-3 模板（仅 3 节点，body 是 @author+#aweme+desc）:
+//   多了 video-to-text(asr) 节点，下载视频 → ffmpeg 抽音 → 流式 ASR → LLM 提炼出
+//   每条作品的 hook（一句话钩子）+ bullets（三条要点）+ body（拼好的 markdown bullets）。
+//   ad-rich-text 海报视图直接用 hook 当 title、bullets 当 body 渲染左右双栏布局。
+//
+// 注意:
+//   - ASR 走豆包流式（需要管理员在模型池配置 video-agent.video-to-text::asr）
+//   - 单条视频 ASR 约 10-60s，建议 count<=4 控制总耗时（默认 4 即上限）
+//   - 视频或 ASR 失败时降级为空 transcript，但 item 仍透传不报错
+//
+
+const tiktokCreatorToHomepageRichTemplate: WorkflowTemplate = {
+  id: 'tiktok-creator-to-homepage-rich',
+  name: 'TikTok / 抖音 博主订阅 → 首页图文混排海报 (ASR)',
+  description: '比 ad-4-3 模板多一步真音频转写：抓博主作品 → 下载视频 → ffmpeg 抽音 → 流式 ASR → LLM 提炼 hook+bullets → 发布为图文混排海报（左动图 + 右 hook 大字 + bullets，借鉴 Instagram Story Ad / 小红书笔记）',
+  icon: 'TT',
+  tags: ['tiktok', 'douyin', 'tikhub', 'asr', 'video-ad', 'subscription', 'rich-text'],
+  requiredInputs: [
+    {
+      key: 'tikHubApiKey',
+      label: 'TikHub API 密钥',
+      type: 'password',
+      placeholder: 'Bearer xxx 或直接粘贴 API Key',
+      helpTip: '从 https://tikhub.io 用户中心获取。也可填 {{secrets.TIKHUB_API_KEY}}',
+      required: true,
+    },
+    {
+      key: 'platform',
+      label: '平台',
+      type: 'select',
+      required: true,
+      defaultValue: 'tiktok',
+      options: [
+        { value: 'tiktok', label: 'TikTok（海外，secUid）' },
+        { value: 'douyin', label: '抖音（国内，sec_user_id）' },
+      ],
+      helpTip: '选 TikTok 用 secUid，选抖音用 sec_user_id',
+    },
+    {
+      key: 'secUid',
+      label: '博主 secUid / sec_user_id',
+      type: 'text',
+      defaultValue: 'MS4wLjABAAAAv7iSuuXDJGDvJkmH_vz1qkDZYo1apxgzaxdBSeIuPiM',
+      placeholder: 'MS4wLjABAAAA...',
+      helpTip: 'TikTok 默认填 TikHub 官方示例；抖音换成抖音 sec_user_id（参考 TikHub 文档）',
+      required: true,
+    },
+    {
+      key: 'count',
+      label: '展示几条作品（= 海报页数 = ASR 条数）',
+      type: 'select',
+      required: false,
+      defaultValue: '4',
+      options: [
+        { value: '1', label: '1 条（单页海报，最快约 30s）' },
+        { value: '2', label: '2 条（约 60-90s）' },
+        { value: '4', label: '4 条（推荐，约 2-3 分钟）' },
+        { value: '6', label: '6 条（约 4-5 分钟）' },
+      ],
+      helpTip: 'ASR 模式较慢（每条 10-60s），建议 ≤ 4。一条 item 对应海报一页',
+    },
+    {
+      key: 'enableHook',
+      label: 'AI 提炼 hook + bullets',
+      type: 'select',
+      required: false,
+      defaultValue: 'true',
+      options: [
+        { value: 'true', label: '开启（推荐：转写后 LLM 提炼一句话钩子 + 三条要点）' },
+        { value: 'false', label: '关闭（仅原始转写文字，body 留空，海报会兜底显示作者+描述）' },
+      ],
+      helpTip: '开启后 ad-rich-text 海报右侧才有结构化 hook + bullets。关闭等同 ad-4-3 模板加了一步无意义的 ASR',
+    },
+  ],
+  build: (inputs) => {
+    _edgeIdx = 0;
+
+    const tikHubApiKey = inputs.tikHubApiKey || '';
+    const platform = inputs.platform || 'tiktok';
+    const secUid = inputs.secUid || 'MS4wLjABAAAAv7iSuuXDJGDvJkmH_vz1qkDZYo1apxgzaxdBSeIuPiM';
+    const count = inputs.count || '4';
+    const enableHook = inputs.enableHook || 'true';
+
+    const nodes: WorkflowNode[] = [
+      // ─── 触发 ───
+      {
+        nodeId: 'n-trigger',
+        name: '开始抓取',
+        nodeType: 'manual-trigger',
+        config: { inputPrompt: '点击执行 → 抓博主作品 → ASR 转写 → 发布图文混排海报' },
+        inputSlots: [],
+        outputSlots: [{ slotId: 'manual-out', name: 'input', dataType: 'json', required: true }],
+        position: { x: 80, y: 240 },
+      },
+      // ─── 拉取博主视频列表 ───
+      {
+        nodeId: 'n-fetch',
+        name: '拉取博主视频列表',
+        nodeType: 'tiktok-creator-fetch',
+        config: {
+          platform,
+          apiBaseUrl: 'https://api.tikhub.io',
+          apiKey: tikHubApiKey,
+          secUid,
+          count,
+          cursor: '0',
+        },
+        inputSlots: [{ slotId: 'tcf-in', name: 'trigger', dataType: 'json', required: false }],
+        outputSlots: [{ slotId: 'tcf-out', name: 'videos', dataType: 'json', required: true }],
+        position: { x: 360, y: 240 },
+      },
+      // ─── 视频转文字（ASR + LLM 二次提炼） ───
+      {
+        nodeId: 'n-asr',
+        name: '音频转写 + AI 提炼',
+        nodeType: 'video-to-text',
+        config: {
+          extractMode: 'asr',
+          videoUrlField: 'videoUrl',
+          itemsField: 'items',
+          maxItems: count,
+          enableHookExtraction: enableHook,
+        },
+        inputSlots: [{ slotId: 'vt-in', name: 'videoInfo', dataType: 'json', required: true }],
+        outputSlots: [{ slotId: 'vt-out', name: 'textContent', dataType: 'json', required: true }],
+        position: { x: 660, y: 240 },
+      },
+      // ─── 发布到首页图文混排海报 ───
+      {
+        nodeId: 'n-publish',
+        name: '发布图文混排海报',
+        nodeType: 'weekly-poster-publisher',
+        config: {
+          itemsField: 'items',
+          templateKey: 'promo',
+          presentationMode: 'ad-rich-text',
+          accentColor: '#ff0050',
+          ctaText: platform === 'douyin' ? '去抖音看完整视频' : '去 TikTok 看完整视频',
+          ctaUrlField: 'firstItem.shareUrl',
+          publish: 'true',
+        },
+        inputSlots: [{ slotId: 'wp-in', name: 'items', dataType: 'json', required: true }],
+        outputSlots: [{ slotId: 'wp-out', name: 'result', dataType: 'json', required: true }],
+        position: { x: 980, y: 240 },
+      },
+    ];
+
+    const edges: WorkflowEdge[] = [
+      edge('n-trigger', 'manual-out', 'n-fetch', 'tcf-in'),
+      edge('n-fetch', 'tcf-out', 'n-asr', 'vt-in'),
+      edge('n-asr', 'vt-out', 'n-publish', 'wp-in'),
+    ];
+
+    return { nodes, edges, variables: [] };
+  },
+};
+
+// ═══════════════════════════════════════════════════════════════
 // 注册表
 // ═══════════════════════════════════════════════════════════════
 
@@ -2073,4 +2238,5 @@ export const WORKFLOW_TEMPLATES: WorkflowTemplate[] = [
   apiReviewWorkflowTemplate,
   videoWorkflowTemplate,
   tiktokCreatorToHomepageTemplate,
+  tiktokCreatorToHomepageRichTemplate,
 ];

--- a/prd-admin/src/pages/workflow-agent/workflowTemplates.ts
+++ b/prd-admin/src/pages/workflow-agent/workflowTemplates.ts
@@ -1568,7 +1568,7 @@ const tiktokCreatorToHomepageTemplate: WorkflowTemplate = {
         nodeType: 'media-rehost',
         config: {
           itemsField: 'items',
-          rehostFields: 'videoUrl,coverUrl',
+          rehostFields: 'videoUrl,coverUrl,authorAvatarUrl',
           maxConcurrency: '4',
           maxBytesMb: '50',
           timeoutSeconds: '120',
@@ -2221,7 +2221,7 @@ const tiktokCreatorToHomepageRichTemplate: WorkflowTemplate = {
         nodeType: 'media-rehost',
         config: {
           itemsField: 'items',
-          rehostFields: 'videoUrl,coverUrl',
+          rehostFields: 'videoUrl,coverUrl,authorAvatarUrl',
           maxConcurrency: '4',
           maxBytesMb: '50',
           timeoutSeconds: '120',

--- a/prd-admin/src/services/real/weeklyPoster.ts
+++ b/prd-admin/src/services/real/weeklyPoster.ts
@@ -10,7 +10,8 @@ export type WeeklyPosterPresentationMode =
   | 'fullscreen'
   | 'interactive'
   | 'ad-4-3'
-  | 'ad-rich-text';
+  | 'ad-rich-text'
+  | 'feed-card';
 export type WeeklyPosterSourceType =
   | 'changelog-current-week'
   | 'github-commits'
@@ -51,6 +52,14 @@ export interface WeeklyPosterAutopilotInput {
   ctaUrl?: string;
 }
 
+export interface PosterPageStats {
+  likes?: number | null;
+  comments?: number | null;
+  shares?: number | null;
+  collects?: number | null;
+  plays?: number | null;
+}
+
 export interface WeeklyPosterPage {
   /** 页码,从 0 开始 */
   order: number;
@@ -65,6 +74,18 @@ export interface WeeklyPosterPage {
   secondaryImageUrl?: string | null;
   /** 卡片主色调,空值走默认紫 */
   accentColor?: string | null;
+
+  // ── feed-card 版式新增字段（全部可选向下兼容）──
+  authorName?: string | null;
+  authorAvatarUrl?: string | null;
+  /** 来源平台：tiktok / douyin / bilibili / xiaohongshu / youtube */
+  platform?: string | null;
+  /** 视频时长（秒） */
+  durationSec?: number | null;
+  /** 话题标签数组（去掉 # 前缀） */
+  hashtags?: string[] | null;
+  /** 互动统计 */
+  stats?: PosterPageStats | null;
 }
 
 export interface WeeklyPoster {

--- a/prd-admin/src/services/real/weeklyPoster.ts
+++ b/prd-admin/src/services/real/weeklyPoster.ts
@@ -5,7 +5,12 @@ import { apiRequest } from '@/services/real/apiClient';
 export type WeeklyPosterStatus = 'draft' | 'published' | 'archived';
 
 export type WeeklyPosterTemplateKey = 'release' | 'hotfix' | 'promo' | 'sale';
-export type WeeklyPosterPresentationMode = 'static' | 'fullscreen' | 'interactive' | 'ad-4-3';
+export type WeeklyPosterPresentationMode =
+  | 'static'
+  | 'fullscreen'
+  | 'interactive'
+  | 'ad-4-3'
+  | 'ad-rich-text';
 export type WeeklyPosterSourceType =
   | 'changelog-current-week'
   | 'github-commits'

--- a/prd-admin/src/services/real/weeklyPoster.ts
+++ b/prd-admin/src/services/real/weeklyPoster.ts
@@ -60,6 +60,14 @@ export interface PosterPageStats {
   plays?: number | null;
 }
 
+export interface TranscriptCue {
+  /** 开始时间（秒，相对视频起点） */
+  startSec: number;
+  /** 结束时间（秒） */
+  endSec: number;
+  text: string;
+}
+
 export interface WeeklyPosterPage {
   /** 页码,从 0 开始 */
   order: number;
@@ -86,6 +94,8 @@ export interface WeeklyPosterPage {
   hashtags?: string[] | null;
   /** 互动统计 */
   stats?: PosterPageStats | null;
+  /** 带时间戳字幕（feed-card 模式播放时按 video.currentTime 同步显示当前句） */
+  transcriptCues?: TranscriptCue[] | null;
 }
 
 export interface WeeklyPoster {

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/WeeklyPosterController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/WeeklyPosterController.cs
@@ -744,6 +744,12 @@ public sealed class WeeklyPosterController : ControllerBase
                 ImageUrl = p.ImageUrl,
                 SecondaryImageUrl = p.SecondaryImageUrl,
                 AccentColor = p.AccentColor,
+                AuthorName = p.AuthorName,
+                AuthorAvatarUrl = p.AuthorAvatarUrl,
+                Platform = p.Platform,
+                DurationSec = p.DurationSec,
+                Hashtags = p.Hashtags,
+                Stats = p.Stats,
             }).ToList() ?? new List<WeeklyPosterPageDto>(),
         CtaText = poster.CtaText,
         CtaUrl = poster.CtaUrl,
@@ -803,5 +809,13 @@ public sealed class WeeklyPosterController : ControllerBase
         public string? ImageUrl { get; set; }
         public string? SecondaryImageUrl { get; set; }
         public string? AccentColor { get; set; }
+
+        // feed-card 版式新增字段（与 WeeklyPosterPage 保持一致）
+        public string? AuthorName { get; set; }
+        public string? AuthorAvatarUrl { get; set; }
+        public string? Platform { get; set; }
+        public int? DurationSec { get; set; }
+        public List<string>? Hashtags { get; set; }
+        public PrdAgent.Core.Models.PosterPageStats? Stats { get; set; }
     }
 }

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/WeeklyPosterController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/WeeklyPosterController.cs
@@ -750,6 +750,7 @@ public sealed class WeeklyPosterController : ControllerBase
                 DurationSec = p.DurationSec,
                 Hashtags = p.Hashtags,
                 Stats = p.Stats,
+                TranscriptCues = p.TranscriptCues,
             }).ToList() ?? new List<WeeklyPosterPageDto>(),
         CtaText = poster.CtaText,
         CtaUrl = poster.CtaUrl,
@@ -817,5 +818,6 @@ public sealed class WeeklyPosterController : ControllerBase
         public int? DurationSec { get; set; }
         public List<string>? Hashtags { get; set; }
         public PrdAgent.Core.Models.PosterPageStats? Stats { get; set; }
+        public List<PrdAgent.Core.Models.TranscriptCue>? TranscriptCues { get; set; }
     }
 }

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/WeeklyPosterController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/WeeklyPosterController.cs
@@ -498,6 +498,9 @@ public sealed class WeeklyPosterController : ControllerBase
                         {
                             if (emittedOrders.Contains(p.Order)) continue;
                             emittedOrders.Add(p.Order);
+                            // 流式预览用 DTO：autopilot LLM 模板只生成基础字段（无 author/platform/stats/cues
+                            // 这类来源于真实平台 API 的元数据），新字段保留默认 null。下游消费者只读基础字段，
+                            // 完整字段见末尾持久化后通过 GET /api/weekly-posters/* 取
                             var earlyDto = new WeeklyPosterPageDto
                             {
                                 Order = p.Order,

--- a/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
+++ b/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
@@ -89,6 +89,7 @@ public static class CapsuleExecutor
             CapsuleTypes.VideoToText => await ExecuteVideoToTextAsync(sp, node, variables, inputArtifacts, emitEvent),
             CapsuleTypes.TextToCopywriting => await ExecuteTextToCopywritingAsync(sp, node, variables, inputArtifacts, emitEvent),
             CapsuleTypes.TiktokCreatorFetch => await ExecuteTiktokCreatorFetchAsync(sp, node, variables, inputArtifacts),
+            CapsuleTypes.MediaRehost => await ExecuteMediaRehostAsync(sp, node, variables, inputArtifacts, emitEvent),
             CapsuleTypes.HomepagePublisher => await ExecuteHomepagePublisherAsync(sp, node, variables, inputArtifacts),
             CapsuleTypes.WeeklyPosterPublisher => await ExecuteWeeklyPosterPublisherAsync(sp, node, variables, inputArtifacts),
 
@@ -6605,6 +6606,254 @@ function safeChart(canvasId, config) {
     /// 发布到首页海报：下载上游 URL 指向的媒体文件，写入 HomepageAsset（按 slot 唯一覆盖）。
     /// 与 HomepageAssetsController.Upload 保持完全相同的 slot/路径规则。
     /// </summary>
+    /// <summary>
+    /// 媒体迁移到 COS：把 items 数组里每条记录的视频 / 封面 URL 下载到本平台 COS，
+    /// URL 替换成稳定 COS 直链。专为绕开 TikTok / B 站 / 小红书 CDN 防盗链 403 而生。
+    /// 并发下载（默认 4），失败的字段保留原 URL 不阻塞流水线。
+    /// </summary>
+    public static async Task<CapsuleResult> ExecuteMediaRehostAsync(
+        IServiceProvider sp,
+        WorkflowNode node,
+        Dictionary<string, string> variables,
+        List<ExecutionArtifact> inputArtifacts,
+        EmitEventDelegate? emitEvent)
+    {
+        var sb = new StringBuilder();
+
+        var itemsField = (GetConfigString(node, "itemsField") ?? "items").Trim();
+        var rehostFieldsRaw = GetConfigString(node, "rehostFields") ?? "videoUrl,coverUrl";
+        var rehostFields = rehostFieldsRaw.Split(',', StringSplitOptions.RemoveEmptyEntries)
+            .Select(s => s.Trim()).Where(s => !string.IsNullOrWhiteSpace(s)).ToArray();
+        if (rehostFields.Length == 0) rehostFields = new[] { "videoUrl", "coverUrl" };
+
+        var maxConcurrency = (int.TryParse(GetConfigString(node, "maxConcurrency"), out var mc) && mc > 0) ? Math.Min(mc, 8) : 4;
+        var maxBytesMb = (int.TryParse(GetConfigString(node, "maxBytesMb"), out var mb) && mb > 0) ? mb : 50;
+        var timeoutSeconds = (int.TryParse(GetConfigString(node, "timeoutSeconds"), out var ts) && ts > 0) ? ts : 120;
+
+        var inputContent = inputArtifacts.FirstOrDefault(a => a.SlotId == "mr-in")?.InlineContent
+            ?? inputArtifacts.FirstOrDefault()?.InlineContent;
+        if (string.IsNullOrWhiteSpace(inputContent))
+            throw new InvalidOperationException("上游内容为空");
+
+        using var inputDoc = JsonDocument.Parse(inputContent);
+        var inputRoot = inputDoc.RootElement;
+
+        // 形态识别：裸数组 / {items:[...]} / 单对象（与 video-to-text asr 模式同款检测逻辑）
+        bool wasArrayInput;
+        var rawItems = new List<JsonElement>();
+        if (inputRoot.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var it in inputRoot.EnumerateArray()) rawItems.Add(it);
+            wasArrayInput = true;
+        }
+        else if (inputRoot.ValueKind == JsonValueKind.Object && !string.IsNullOrEmpty(itemsField))
+        {
+            var arr = ResolveJsonElement(inputRoot, itemsField);
+            if (arr.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var it in arr.EnumerateArray()) rawItems.Add(it);
+                wasArrayInput = true;
+            }
+            else
+            {
+                rawItems.Add(inputRoot);
+                wasArrayInput = false;
+            }
+        }
+        else
+        {
+            rawItems.Add(inputRoot);
+            wasArrayInput = false;
+        }
+
+        var totalItems = rawItems.Count;
+        sb.AppendLine($"[MediaRehost] 输入 {totalItems} 条 item，rehost 字段=[{string.Join(",", rehostFields)}]，并发={maxConcurrency}，单文件上限={maxBytesMb}MB");
+
+        if (totalItems == 0)
+            throw new InvalidOperationException("上游 items 为空");
+
+        var assetStorage = sp.GetRequiredService<PrdAgent.Infrastructure.Services.AssetStorage.IAssetStorage>();
+        var httpFactory = sp.GetRequiredService<IHttpClientFactory>();
+
+        var sem = new System.Threading.SemaphoreSlim(maxConcurrency);
+        int rehostedCount = 0;
+        int failedCount = 0;
+        int doneCount = 0;
+
+        async Task<(JsonObject obj, string logs)> ProcessItemAsync(JsonElement item, int idx)
+        {
+            var local = new StringBuilder();
+            await sem.WaitAsync();
+            try
+            {
+                JsonObject obj;
+                try { obj = JsonNode.Parse(item.GetRawText())?.AsObject() ?? new JsonObject(); }
+                catch { obj = new JsonObject(); }
+
+                var http = httpFactory.CreateClient();
+                http.Timeout = TimeSpan.FromSeconds(timeoutSeconds);
+                http.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent",
+                    "Mozilla/5.0 (compatible; PrdAgentMediaRehost/1.0)");
+
+                foreach (var field in rehostFields)
+                {
+                    var url = TryGetJsonString(item, field);
+                    if (string.IsNullOrWhiteSpace(url)) continue;
+                    if (url.StartsWith("//", StringComparison.Ordinal)) url = "https:" + url;
+                    if (!url.StartsWith("http", StringComparison.OrdinalIgnoreCase)) continue;
+
+                    try
+                    {
+                        var resp = await http.GetAsync(url, CancellationToken.None);
+                        if (!resp.IsSuccessStatusCode)
+                        {
+                            local.AppendLine($"[MediaRehost] item#{idx}.{field} HTTP {(int)resp.StatusCode}，保留原 URL");
+                            System.Threading.Interlocked.Increment(ref failedCount);
+                            continue;
+                        }
+                        var bytes = await resp.Content.ReadAsByteArrayAsync(CancellationToken.None);
+                        if (bytes.Length == 0)
+                        {
+                            local.AppendLine($"[MediaRehost] item#{idx}.{field} 0 字节响应，保留原 URL");
+                            System.Threading.Interlocked.Increment(ref failedCount);
+                            continue;
+                        }
+                        if (bytes.Length > (long)maxBytesMb * 1024 * 1024)
+                        {
+                            local.AppendLine($"[MediaRehost] item#{idx}.{field} {bytes.Length / 1024 / 1024}MB 超 maxBytesMb={maxBytesMb}，保留原 URL");
+                            System.Threading.Interlocked.Increment(ref failedCount);
+                            continue;
+                        }
+
+                        var contentType = resp.Content.Headers.ContentType?.MediaType ?? "";
+                        var ext = GuessRehostExt(contentType, field);
+                        var isGenericMime = string.IsNullOrWhiteSpace(contentType)
+                            || string.Equals(contentType, "application/octet-stream", StringComparison.OrdinalIgnoreCase)
+                            || string.Equals(contentType, "binary/octet-stream", StringComparison.OrdinalIgnoreCase);
+                        var mime = isGenericMime ? GuessRehostMime(ext) : contentType;
+
+                        var objectKey = BuildRehostObjectKey(ext);
+                        await assetStorage.UploadToKeyAsync(objectKey, bytes, mime, CancellationToken.None);
+                        var newUrl = assetStorage.BuildUrlForKey(objectKey);
+
+                        obj[field] = newUrl;
+                        System.Threading.Interlocked.Increment(ref rehostedCount);
+                        local.AppendLine($"[MediaRehost] item#{idx}.{field} {bytes.Length / 1024}KB ext={ext} → {newUrl}");
+                    }
+                    catch (Exception ex)
+                    {
+                        local.AppendLine($"[MediaRehost] item#{idx}.{field} 异常: {ex.Message.Replace("\n", " ")}（保留原 URL）");
+                        System.Threading.Interlocked.Increment(ref failedCount);
+                    }
+                }
+
+                var done = System.Threading.Interlocked.Increment(ref doneCount);
+                if (emitEvent != null)
+                {
+                    try
+                    {
+                        await emitEvent("capsule-progress", new
+                        {
+                            message = $"已处理 {done}/{totalItems} 条 item",
+                            index = done,
+                            total = totalItems,
+                        });
+                    }
+                    catch { /* emit 失败不阻塞主流程 */ }
+                }
+
+                return (obj, local.ToString());
+            }
+            finally
+            {
+                sem.Release();
+            }
+        }
+
+        var tasks = new List<Task<(JsonObject, string)>>();
+        for (int i = 0; i < rawItems.Count; i++)
+        {
+            tasks.Add(ProcessItemAsync(rawItems[i], i + 1));
+        }
+
+        var results = await Task.WhenAll(tasks);
+
+        var enrichedList = new List<JsonObject>(results.Length);
+        foreach (var (obj, logs) in results)
+        {
+            enrichedList.Add(obj);
+            sb.Append(logs);
+        }
+
+        sb.AppendLine($"[MediaRehost] 完成：rehosted={rehostedCount} 个 URL, failed={failedCount} 个保留原 URL");
+
+        // 输出形态保持与输入一致
+        JsonNode outputRoot;
+        if (wasArrayInput)
+        {
+            var itemsArr = new JsonArray();
+            foreach (var o in enrichedList) itemsArr.Add(o.DeepClone());
+            JsonObject? firstClone = null;
+            if (enrichedList.Count > 0) firstClone = enrichedList[0].DeepClone().AsObject();
+            outputRoot = new JsonObject
+            {
+                ["items"] = itemsArr,
+                ["firstItem"] = (JsonNode?)firstClone ?? new JsonObject(),
+                ["count"] = enrichedList.Count,
+                ["rehosted"] = rehostedCount,
+                ["failed"] = failedCount,
+            };
+        }
+        else
+        {
+            outputRoot = (JsonNode?)enrichedList.FirstOrDefault() ?? new JsonObject();
+        }
+
+        var outputJson = outputRoot.ToJsonString(JsonPretty);
+        var artifact = MakeTextArtifact(node, "mr-out", "媒体迁移结果", outputJson, "application/json");
+        return new CapsuleResult(new List<ExecutionArtifact> { artifact }, sb.ToString());
+    }
+
+    /// <summary>从 Content-Type / 字段名推断扩展名（rehost 专用，不处理 svg 等异常类型）</summary>
+    private static string GuessRehostExt(string mime, string fieldName)
+    {
+        var m = (mime ?? "").Trim().ToLowerInvariant();
+        if (m.Contains("gif")) return "gif";
+        if (m.Contains("png")) return "png";
+        if (m.Contains("webp")) return "webp";
+        if (m.Contains("jpeg") || m.Contains("jpg")) return "jpg";
+        if (m.Contains("mp4")) return "mp4";
+        if (m.Contains("webm")) return "webm";
+        if (m.Contains("quicktime") || m.Contains("mov")) return "mov";
+        // 兜底：按字段名（videoUrl / coverUrl 等）推断
+        var f = (fieldName ?? "").ToLowerInvariant();
+        if (f.Contains("video") || f.Contains("play") || f.Contains("mp4")) return "mp4";
+        return "jpg";
+    }
+
+    private static string GuessRehostMime(string ext)
+    {
+        var e = (ext ?? "").Trim().ToLowerInvariant().TrimStart('.');
+        return e switch
+        {
+            "png" => "image/png",
+            "jpg" or "jpeg" => "image/jpeg",
+            "webp" => "image/webp",
+            "gif" => "image/gif",
+            "mp4" => "video/mp4",
+            "webm" => "video/webm",
+            "mov" => "video/quicktime",
+            _ => "application/octet-stream"
+        };
+    }
+
+    private static string BuildRehostObjectKey(string ext)
+    {
+        var now = DateTime.UtcNow;
+        var guid = Guid.NewGuid().ToString("N");
+        return $"workflow/media-rehost/{now:yyyy-MM}/{guid}.{ext}";
+    }
+
     public static async Task<CapsuleResult> ExecuteHomepagePublisherAsync(
         IServiceProvider sp,
         WorkflowNode node,

--- a/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
+++ b/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
@@ -5361,7 +5361,11 @@ function safeChart(canvasId, config) {
         EmitEventDelegate? emitEvent)
     {
         var sb = new StringBuilder();
-        var extractMode = GetConfigString(node, "extractMode") ?? "metadata";
+        var extractMode = (GetConfigString(node, "extractMode") ?? "metadata").Trim().ToLowerInvariant();
+
+        // ASR 模式走专门通道（下载视频 + ffmpeg 抽音 + 流式 ASR + 可选 hook 提炼），单独分发避免污染老 metadata/llm 路径
+        if (extractMode == "asr")
+            return await ExecuteVideoToTextAsrAsync(sp, node, variables, inputArtifacts, emitEvent);
 
         var inputContent = inputArtifacts.FirstOrDefault(a => a.SlotId == "vt-in")?.InlineContent
             ?? inputArtifacts.FirstOrDefault()?.InlineContent;
@@ -5442,6 +5446,352 @@ function safeChart(canvasId, config) {
             var outputJson = JsonSerializer.Serialize(textContent, JsonPretty);
             var artifact = MakeTextArtifact(node, "vt-out", "视频文本", outputJson, "application/json");
             return new CapsuleResult(new List<ExecutionArtifact> { artifact }, sb.ToString());
+        }
+    }
+
+    /// <summary>
+    /// ASR 模式：下载视频 → ffmpeg 抽音 → 流式 ASR 转写 → 可选 LLM 提炼 hook + bullets。
+    /// 输入兼容三种形态：单对象 / 裸数组 / {items:[...]}。输出保持形态：
+    ///   - 数组输入 → {items:[enriched...], firstItem:{...}, count, asrProcessed}
+    ///   - 单对象输入 → 单个增强对象
+    /// 每个 item 增加字段：transcript（ASR 全文）、hook（LLM 一句话钩子）、
+    /// bullets（要点数组）、body（拼好的 markdown bullets，可直接喂 ad-rich-text 海报）。
+    /// </summary>
+    private static async Task<CapsuleResult> ExecuteVideoToTextAsrAsync(
+        IServiceProvider sp,
+        WorkflowNode node,
+        Dictionary<string, string> variables,
+        List<ExecutionArtifact> inputArtifacts,
+        EmitEventDelegate? emitEvent)
+    {
+        var sb = new StringBuilder();
+
+        var videoUrlField = (GetConfigString(node, "videoUrlField") ?? "videoUrl").Trim();
+        var itemsField = (GetConfigString(node, "itemsField") ?? "items").Trim();
+        var maxItems = int.TryParse(GetConfigString(node, "maxItems") ?? "4", out var mi)
+            ? Math.Max(1, Math.Min(20, mi)) : 4;
+        var enableHook = ((GetConfigString(node, "enableHookExtraction") ?? "true").Trim().ToLowerInvariant()) != "false";
+        var hookPromptOverride = ReplaceVariables(GetConfigString(node, "hookSystemPrompt") ?? "", variables).Trim();
+
+        var inputContent = inputArtifacts.FirstOrDefault(a => a.SlotId == "vt-in")?.InlineContent
+            ?? inputArtifacts.FirstOrDefault()?.InlineContent;
+        if (string.IsNullOrWhiteSpace(inputContent))
+            throw new InvalidOperationException("上游视频信息为空");
+
+        using var inputDoc = JsonDocument.Parse(inputContent);
+        var inputRoot = inputDoc.RootElement;
+
+        // 形态识别：裸数组 / {items:[...]} / 单对象
+        bool wasArrayInput;
+        var rawItems = new List<JsonElement>();
+        if (inputRoot.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var it in inputRoot.EnumerateArray()) rawItems.Add(it);
+            wasArrayInput = true;
+        }
+        else if (inputRoot.ValueKind == JsonValueKind.Object && !string.IsNullOrEmpty(itemsField))
+        {
+            var arr = ResolveJsonElement(inputRoot, itemsField);
+            if (arr.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var it in arr.EnumerateArray()) rawItems.Add(it);
+                wasArrayInput = true;
+            }
+            else
+            {
+                rawItems.Add(inputRoot);
+                wasArrayInput = false;
+            }
+        }
+        else
+        {
+            rawItems.Add(inputRoot);
+            wasArrayInput = false;
+        }
+
+        var totalCount = rawItems.Count;
+        var processCount = Math.Min(totalCount, maxItems);
+        sb.AppendLine($"[VideoToText:asr] 输入条目 {totalCount} 条，本次处理 {processCount} 条 (maxItems={maxItems})");
+
+        // DI
+        var modelResolver = sp.GetRequiredService<PrdAgent.Infrastructure.LlmGateway.IModelResolver>();
+        var streamAsr = sp.GetRequiredService<DoubaoStreamAsrService>();
+        var httpFactory = sp.GetRequiredService<IHttpClientFactory>();
+        var gateway = sp.GetRequiredService<PrdAgent.Infrastructure.LlmGateway.ILlmGateway>();
+
+        // 解析 ASR 模型（一次解析，所有 item 复用）
+        var resolution = await modelResolver.ResolveAsync(
+            AppCallerRegistry.VideoAgent.VideoToText.Asr, ModelTypes.Asr);
+        if (!resolution.Success)
+            throw new InvalidOperationException(
+                $"ASR 模型调度失败: {resolution.ErrorMessage}（请去模型池配置 video-agent.video-to-text::asr）");
+        if (!resolution.IsExchange || resolution.ExchangeTransformerType != "doubao-asr-stream")
+            throw new InvalidOperationException("当前仅支持豆包流式 ASR (doubao-asr-stream)，请检查模型池配置");
+
+        var apiKeyRaw = resolution.ApiKey ?? "";
+        string appKey = "", accessKey = apiKeyRaw;
+        if (apiKeyRaw.Contains('|'))
+        {
+            var parts = apiKeyRaw.Split('|', 2);
+            appKey = parts[0];
+            accessKey = parts[1];
+        }
+        var wsUrl = resolution.ApiUrl ?? "wss://openspeech.bytedance.com/api/v3/sauc/bigmodel";
+        var asrConfig = resolution.ExchangeTransformerConfig ?? new Dictionary<string, object>
+        {
+            ["resourceId"] = "volc.bigasr.sauc.duration",
+            ["enableItn"] = true,
+            ["enablePunc"] = true,
+            ["enableDdc"] = true,
+        };
+
+        var http = httpFactory.CreateClient("WorkflowAgent");
+        http.Timeout = TimeSpan.FromMinutes(8);
+
+        var enrichedItems = new List<JsonObject>();
+        int idx = 0;
+        foreach (var item in rawItems)
+        {
+            idx++;
+
+            // 复制原 item 为可写 JsonObject（保留所有原字段，再追加 transcript/hook/bullets）
+            JsonObject enriched;
+            try
+            {
+                enriched = JsonNode.Parse(item.GetRawText())?.AsObject() ?? new JsonObject();
+            }
+            catch
+            {
+                enriched = new JsonObject();
+            }
+
+            if (idx > processCount)
+            {
+                // 超出 maxItems 的条目原样透传
+                enrichedItems.Add(enriched);
+                continue;
+            }
+
+            var videoUrl = ResolveJsonPath(item, videoUrlField);
+            if (string.IsNullOrWhiteSpace(videoUrl))
+                videoUrl = TryGetJsonString(item, "videoUrl", "video_url", "playUrl", "play_url", "cosUrl");
+            var origTitle = TryGetJsonString(item, "title", "desc", "description") ?? "";
+
+            if (emitEvent != null)
+            {
+                await emitEvent("capsule-progress", new
+                {
+                    message = $"正在处理第 {idx}/{processCount} 条 (ASR 转写)…",
+                    index = idx,
+                    total = processCount,
+                });
+            }
+
+            string transcript = "";
+            if (!string.IsNullOrWhiteSpace(videoUrl))
+            {
+                try
+                {
+                    sb.AppendLine($"[VideoToText:asr] item#{idx} 下载视频");
+                    var videoBytes = await http.GetByteArrayAsync(videoUrl);
+                    sb.AppendLine($"[VideoToText:asr] item#{idx} 视频 {videoBytes.Length} 字节，开始抽音");
+
+                    var audioBytes = await ExtractAudioWithFfmpegAsync(videoBytes);
+                    sb.AppendLine($"[VideoToText:asr] item#{idx} 音频 {audioBytes.Length} 字节，提交 ASR");
+
+                    var asrResult = await streamAsr.TranscribeWithCallbackAsync(
+                        wsUrl, appKey, accessKey, audioBytes, asrConfig,
+                        onStage: (_, _) => Task.CompletedTask,
+                        onProgress: (_, _) => Task.CompletedTask,
+                        onFrame: (_, _, _) => Task.CompletedTask,
+                        ct: CancellationToken.None);
+
+                    if (asrResult.Success)
+                    {
+                        transcript = asrResult.FullText ?? "";
+                        sb.AppendLine($"[VideoToText:asr] item#{idx} ASR 完成，转写 {transcript.Length} 字");
+                    }
+                    else
+                    {
+                        sb.AppendLine($"[VideoToText:asr] item#{idx} ASR 失败: {asrResult.Error}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    sb.AppendLine($"[VideoToText:asr] item#{idx} 异常: {ex.Message}");
+                }
+            }
+            else
+            {
+                sb.AppendLine($"[VideoToText:asr] item#{idx} 未取到 videoUrl（field={videoUrlField}），跳过 ASR");
+            }
+
+            enriched["transcript"] = transcript;
+
+            // LLM 二次提炼（hook + bullets）
+            if (enableHook && !string.IsNullOrWhiteSpace(transcript))
+            {
+                try
+                {
+                    if (emitEvent != null)
+                        await emitEvent("capsule-progress", new { message = $"正在为第 {idx}/{processCount} 条提炼 hook + bullets…" });
+
+                    var sysPrompt = string.IsNullOrWhiteSpace(hookPromptOverride)
+                        ? "你是短视频文案专家。给定视频原标题和音频转写文字，输出严格 JSON：{\"hook\":\"一句话钩子，14 字内，有冲击力\",\"bullets\":[\"要点1\",\"要点2\",\"要点3\"]}。bullets 三条，每条 25 字内，提炼信息点而非复述原文。只输出 JSON，不要 markdown 包裹。"
+                        : hookPromptOverride;
+                    var userPrompt = $"原标题：{origTitle}\n\n转写文字：\n{transcript}";
+
+                    var llmRequest = new PrdAgent.Infrastructure.LlmGateway.GatewayRequest
+                    {
+                        AppCallerCode = AppCallerRegistry.VideoAgent.VideoToText.Chat,
+                        ModelType = "chat",
+                        RequestBody = new JsonObject
+                        {
+                            ["messages"] = new JsonArray
+                            {
+                                new JsonObject { ["role"] = "system", ["content"] = sysPrompt },
+                                new JsonObject { ["role"] = "user", ["content"] = userPrompt },
+                            },
+                            ["temperature"] = 0.4,
+                        }
+                    };
+                    var llmResponse = await gateway.SendAsync(llmRequest, CancellationToken.None);
+                    var llmContent = (llmResponse.Content ?? "").Trim();
+
+                    if (TryExtractJsonObject(llmContent, out var parsed))
+                    {
+                        var hook = parsed.TryGetProperty("hook", out var h) ? (h.GetString() ?? "") : "";
+                        var bulletsList = new List<string>();
+                        if (parsed.TryGetProperty("bullets", out var bs) && bs.ValueKind == JsonValueKind.Array)
+                        {
+                            foreach (var b in bs.EnumerateArray())
+                            {
+                                var s = b.GetString();
+                                if (!string.IsNullOrWhiteSpace(s)) bulletsList.Add(s.Trim());
+                            }
+                        }
+
+                        if (!string.IsNullOrWhiteSpace(hook)) enriched["hook"] = hook;
+                        var bulletsArr = new JsonArray();
+                        foreach (var b in bulletsList) bulletsArr.Add(b);
+                        enriched["bullets"] = bulletsArr;
+
+                        // 顺手生成 markdown bullets body（直接给 ad-rich-text 海报用）
+                        if (bulletsList.Count > 0)
+                        {
+                            enriched["body"] = string.Join("\n", bulletsList.Select(b => $"- {b}"));
+                        }
+                        sb.AppendLine($"[VideoToText:asr] item#{idx} hook='{hook}' bullets={bulletsList.Count}");
+                    }
+                    else
+                    {
+                        sb.AppendLine($"[VideoToText:asr] item#{idx} LLM 输出非 JSON ({llmContent.Length} 字)，跳过 hook 提炼");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    sb.AppendLine($"[VideoToText:asr] item#{idx} hook 提炼异常: {ex.Message}");
+                }
+            }
+
+            enrichedItems.Add(enriched);
+        }
+
+        // 输出形态保持与输入一致
+        JsonNode outputRoot;
+        if (wasArrayInput)
+        {
+            var itemsArr = new JsonArray();
+            foreach (var o in enrichedItems) itemsArr.Add(o.DeepClone());
+            JsonObject? firstClone = null;
+            if (enrichedItems.Count > 0) firstClone = enrichedItems[0].DeepClone().AsObject();
+            outputRoot = new JsonObject
+            {
+                ["items"] = itemsArr,
+                ["firstItem"] = (JsonNode?)firstClone ?? new JsonObject(),
+                ["count"] = enrichedItems.Count,
+                ["asrProcessed"] = processCount,
+            };
+        }
+        else
+        {
+            outputRoot = (JsonNode?)enrichedItems.FirstOrDefault() ?? new JsonObject();
+        }
+
+        var outputJson = outputRoot.ToJsonString(JsonPretty);
+        var artifact = MakeTextArtifact(node, "vt-out", "ASR 转写结果", outputJson, "application/json");
+        return new CapsuleResult(new List<ExecutionArtifact> { artifact }, sb.ToString());
+    }
+
+    /// <summary>
+    /// 从 LLM 返回字符串里抽取 JSON 对象（去掉 ```json 围栏 + 容忍前后噪声）。
+    /// </summary>
+    private static bool TryExtractJsonObject(string raw, out JsonElement parsed)
+    {
+        parsed = default;
+        if (string.IsNullOrWhiteSpace(raw)) return false;
+        var s = raw.Trim();
+
+        // 去掉 ```json fenced 块包裹
+        if (s.StartsWith("```"))
+        {
+            var firstNewline = s.IndexOf('\n');
+            if (firstNewline > 0) s = s[(firstNewline + 1)..];
+            var lastFence = s.LastIndexOf("```", StringComparison.Ordinal);
+            if (lastFence > 0) s = s[..lastFence];
+            s = s.Trim();
+        }
+
+        var firstBrace = s.IndexOf('{');
+        var lastBrace = s.LastIndexOf('}');
+        if (firstBrace < 0 || lastBrace <= firstBrace) return false;
+        var jsonSlice = s.Substring(firstBrace, lastBrace - firstBrace + 1);
+
+        try
+        {
+            using var doc = JsonDocument.Parse(jsonSlice);
+            parsed = doc.RootElement.Clone();
+            return parsed.ValueKind == JsonValueKind.Object;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// ffmpeg 抽音（16kHz mono wav）。依赖 host 的 ffmpeg 二进制（CDS 容器已预装）。
+    /// 与 SubtitleGenerationProcessor.ExtractAudioWithFfmpegAsync 保持参数一致。
+    /// </summary>
+    private static async Task<byte[]> ExtractAudioWithFfmpegAsync(byte[] videoBytes)
+    {
+        var tmpIn = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"capsule-vt-in-{Guid.NewGuid():N}");
+        var tmpOut = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"capsule-vt-out-{Guid.NewGuid():N}.wav");
+        await System.IO.File.WriteAllBytesAsync(tmpIn, videoBytes);
+        try
+        {
+            var psi = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "ffmpeg",
+                ArgumentList = { "-y", "-i", tmpIn, "-vn", "-ac", "1", "-ar", "16000", "-acodec", "pcm_s16le", tmpOut },
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var process = System.Diagnostics.Process.Start(psi)
+                ?? throw new InvalidOperationException("ffmpeg 启动失败");
+            await process.WaitForExitAsync();
+            if (process.ExitCode != 0)
+            {
+                var err = await process.StandardError.ReadToEndAsync();
+                throw new InvalidOperationException($"ffmpeg 抽音频失败 (exit={process.ExitCode}): {err}");
+            }
+            return await System.IO.File.ReadAllBytesAsync(tmpOut);
+        }
+        finally
+        {
+            try { if (System.IO.File.Exists(tmpIn)) System.IO.File.Delete(tmpIn); } catch { }
+            try { if (System.IO.File.Exists(tmpOut)) System.IO.File.Delete(tmpOut); } catch { }
         }
     }
 

--- a/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
+++ b/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
@@ -6033,6 +6033,50 @@ function safeChart(canvasId, config) {
         return "";
     }
 
+    /// <summary>读取数字字段（支持 number / 数字 string），找不到返回 null</summary>
+    private static long? TryGetJsonLong(JsonElement element, params string[] candidateKeys)
+    {
+        if (element.ValueKind != JsonValueKind.Object) return null;
+        foreach (var key in candidateKeys)
+        {
+            if (!element.TryGetProperty(key, out var prop)) continue;
+            if (prop.ValueKind == JsonValueKind.Number && prop.TryGetInt64(out var n)) return n;
+            if (prop.ValueKind == JsonValueKind.String)
+            {
+                var s = prop.GetString();
+                if (long.TryParse(s, out var parsed)) return parsed;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>从 TikTok / 抖音风格的 {url_list:[...]} 嵌套结构里取第一个 URL（参数是候选父字段名）</summary>
+    private static string ExtractTiktokUrlList(JsonElement parent, params string[] candidateKeys)
+    {
+        if (parent.ValueKind != JsonValueKind.Object) return "";
+        foreach (var key in candidateKeys)
+        {
+            if (!parent.TryGetProperty(key, out var node)) continue;
+            if (node.ValueKind == JsonValueKind.Object && node.TryGetProperty("url_list", out var list) && list.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var u in list.EnumerateArray())
+                {
+                    if (u.ValueKind == JsonValueKind.String)
+                    {
+                        var s = u.GetString();
+                        if (!string.IsNullOrWhiteSpace(s)) return s;
+                    }
+                }
+            }
+            else if (node.ValueKind == JsonValueKind.String)
+            {
+                var s = node.GetString();
+                if (!string.IsNullOrWhiteSpace(s)) return s;
+            }
+        }
+        return "";
+    }
+
     // ── 视频生成 ──────────────────────────────────────────────
 
     private static async Task<CapsuleResult> ExecuteVideoGenerationAsync(
@@ -6331,6 +6375,26 @@ function safeChart(canvasId, config) {
         var author = TryGetJsonString(item, "author", "name", "uname");
         var authorMid = TryGetJsonString(item, "mid", "uid");
         var createUnix = TryGetJsonString(item, "created", "ctime", "pubdate");
+
+        // 时长：B 站给字符串 "MM:SS" 或 "HH:MM:SS"，转秒
+        int? durationSec = null;
+        var lenStr = TryGetJsonString(item, "length", "duration");
+        if (!string.IsNullOrWhiteSpace(lenStr))
+        {
+            var parts = lenStr.Split(':');
+            try
+            {
+                if (parts.Length == 2) durationSec = int.Parse(parts[0]) * 60 + int.Parse(parts[1]);
+                else if (parts.Length == 3) durationSec = int.Parse(parts[0]) * 3600 + int.Parse(parts[1]) * 60 + int.Parse(parts[2]);
+                else if (parts.Length == 1 && int.TryParse(parts[0], out var s)) durationSec = s;
+            }
+            catch { /* ignore */ }
+        }
+
+        // 互动：B 站 vlist 子项的统计字段（play / comment / 没有 share/collect 直接返回）
+        var plays = TryGetJsonLong(item, "play", "view");
+        var comments = TryGetJsonLong(item, "comment", "review");
+
         var shareUrl = !string.IsNullOrWhiteSpace(bvid)
             ? $"https://www.bilibili.com/video/{bvid}"
             : (!string.IsNullOrWhiteSpace(aid) ? $"https://www.bilibili.com/video/av{aid}" : "");
@@ -6343,6 +6407,10 @@ function safeChart(canvasId, config) {
             coverUrl,
             author,
             authorUniqueId = authorMid,
+            authorAvatarUrl = "", // B 站 fetch_user_post_videos 不带头像，需另调 user_info
+            durationSec,
+            hashtags = new List<string>(),
+            stats = new { likes = (long?)null, comments, shares = (long?)null, collects = (long?)null, plays },
             createTime = createUnix,
             shareUrl,
             platform = "bilibili",
@@ -6394,10 +6462,53 @@ function safeChart(canvasId, config) {
 
         var author = "";
         var authorUserId = "";
+        var authorAvatarUrl = "";
         if (item.TryGetProperty("user", out var user) && user.ValueKind == JsonValueKind.Object)
         {
             author = TryGetJsonString(user, "nickname", "name");
             authorUserId = TryGetJsonString(user, "user_id", "userId", "id");
+            authorAvatarUrl = TryGetJsonString(user, "avatar", "image", "images");
+            if (string.IsNullOrWhiteSpace(authorAvatarUrl))
+                authorAvatarUrl = ExtractTiktokUrlList(user, "avatar", "images");
+        }
+
+        // 时长：视频笔记 video.duration（小红书一般给秒，但有些版本给毫秒，按 > 1000 推断）
+        int? durationSec = null;
+        if (item.TryGetProperty("video", out var vidEl) && vidEl.ValueKind == JsonValueKind.Object)
+        {
+            var dur = TryGetJsonLong(vidEl, "duration", "videoDuration");
+            if (dur.HasValue && dur.Value > 0)
+                durationSec = dur.Value > 1000 ? (int)Math.Round(dur.Value / 1000.0) : (int)dur.Value;
+        }
+
+        // 互动：interact_info.{liked_count, comment_count, share_count, collected_count}
+        long? likes = null, comments = null, shares = null, collects = null;
+        if (item.TryGetProperty("interact_info", out var ii) && ii.ValueKind == JsonValueKind.Object)
+        {
+            likes = TryGetJsonLong(ii, "liked_count", "likedCount", "like_count");
+            comments = TryGetJsonLong(ii, "comment_count", "commentCount");
+            shares = TryGetJsonLong(ii, "share_count", "shareCount");
+            collects = TryGetJsonLong(ii, "collected_count", "collectedCount", "collect_count");
+        }
+
+        // 标签：tag_list[].name
+        var hashtags = new List<string>();
+        if (item.TryGetProperty("tag_list", out var tl) && tl.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var t in tl.EnumerateArray())
+            {
+                if (t.ValueKind != JsonValueKind.Object) continue;
+                var n = TryGetJsonString(t, "name", "tag", "hashtag_name");
+                if (!string.IsNullOrWhiteSpace(n) && !hashtags.Contains(n)) hashtags.Add(n);
+            }
+        }
+        if (hashtags.Count == 0 && !string.IsNullOrWhiteSpace(title))
+        {
+            foreach (System.Text.RegularExpressions.Match m in System.Text.RegularExpressions.Regex.Matches(title, @"#([^\s#]+)"))
+            {
+                var tag = m.Groups[1].Value.Trim();
+                if (!string.IsNullOrWhiteSpace(tag) && !hashtags.Contains(tag)) hashtags.Add(tag);
+            }
         }
 
         var shareUrl = !string.IsNullOrWhiteSpace(noteId)
@@ -6412,6 +6523,10 @@ function safeChart(canvasId, config) {
             coverUrl,
             author,
             authorUniqueId = authorUserId,
+            authorAvatarUrl,
+            durationSec,
+            hashtags,
+            stats = new { likes, comments, shares, collects, plays = (long?)null },
             createTime = TryGetJsonString(item, "time", "create_time", "createTime"),
             shareUrl,
             platform = "xiaohongshu",
@@ -6467,6 +6582,51 @@ function safeChart(canvasId, config) {
             coverUrl = $"https://i.ytimg.com/vi/{videoId}/hqdefault.jpg";
         }
 
+        // 时长：YouTube 通常给 lengthSeconds (string) 或 lengthText "1:23"
+        int? durationSec = null;
+        var lengthRaw = TryGetJsonString(item, "lengthSeconds", "length_seconds", "duration");
+        if (!string.IsNullOrWhiteSpace(lengthRaw) && long.TryParse(lengthRaw, out var ls)) durationSec = (int)ls;
+        if (durationSec == null)
+        {
+            var lengthText = TryGetJsonString(item, "lengthText", "length_text", "duration_text");
+            if (!string.IsNullOrWhiteSpace(lengthText))
+            {
+                var parts = lengthText.Split(':');
+                try
+                {
+                    if (parts.Length == 2) durationSec = int.Parse(parts[0]) * 60 + int.Parse(parts[1]);
+                    else if (parts.Length == 3) durationSec = int.Parse(parts[0]) * 3600 + int.Parse(parts[1]) * 60 + int.Parse(parts[2]);
+                }
+                catch { /* ignore */ }
+            }
+        }
+
+        // 频道头像
+        var authorAvatarUrl = "";
+        if (item.TryGetProperty("channelThumbnails", out var ct) && ct.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var t in ct.EnumerateArray())
+            {
+                if (t.ValueKind == JsonValueKind.Object)
+                {
+                    var u = TryGetJsonString(t, "url");
+                    if (!string.IsNullOrWhiteSpace(u)) authorAvatarUrl = u;
+                }
+            }
+        }
+
+        // 互动：YouTube fetch list 一般只给 viewCount
+        var plays = TryGetJsonLong(item, "viewCount", "view_count");
+        if (plays == null)
+        {
+            var viewText = TryGetJsonString(item, "viewCountText", "view_count_text");
+            if (!string.IsNullOrWhiteSpace(viewText))
+            {
+                var digits = new string(viewText.Where(char.IsDigit).ToArray());
+                if (long.TryParse(digits, out var vp)) plays = vp;
+            }
+        }
+
         var shareUrl = !string.IsNullOrWhiteSpace(videoId)
             ? $"https://www.youtube.com/watch?v={videoId}"
             : "";
@@ -6479,6 +6639,10 @@ function safeChart(canvasId, config) {
             coverUrl,
             author = channelName,
             authorUniqueId = channelId,
+            authorAvatarUrl,
+            durationSec,
+            hashtags = new List<string>(),
+            stats = new { likes = (long?)null, comments = (long?)null, shares = (long?)null, collects = (long?)null, plays },
             createTime = TryGetJsonString(item, "publishedTime", "published_time", "publishDate"),
             shareUrl,
             platform = "youtube",
@@ -6557,12 +6721,64 @@ function safeChart(canvasId, config) {
         var title = TryGetJsonString(item, "desc", "description", "title");
         var author = "";
         var authorUniqueId = "";
+        var authorAvatarUrl = "";
         if (item.TryGetProperty("author", out var authorNode) && authorNode.ValueKind == JsonValueKind.Object)
         {
             author = TryGetJsonString(authorNode, "nickname", "name");
             authorUniqueId = TryGetJsonString(authorNode, "unique_id", "uniqueId");
+            authorAvatarUrl = ExtractTiktokUrlList(authorNode, "avatar_thumb", "avatar_medium", "avatar_larger", "avatar_168x168", "avatar_300x300");
         }
         var createTime = TryGetJsonString(item, "create_time", "createTime", "createdAt");
+
+        // 时长（秒）。TikTok / 抖音 video.duration 通常是毫秒
+        int? durationSec = null;
+        if (item.TryGetProperty("video", out var vNode3) && vNode3.ValueKind == JsonValueKind.Object)
+        {
+            if (vNode3.TryGetProperty("duration", out var durEl))
+            {
+                if (durEl.ValueKind == JsonValueKind.Number && durEl.TryGetInt64(out var durMs) && durMs > 0)
+                    durationSec = (int)Math.Round(durMs / 1000.0);
+            }
+        }
+        if (durationSec == null && item.TryGetProperty("duration", out var durTopEl) && durTopEl.ValueKind == JsonValueKind.Number)
+        {
+            if (durTopEl.TryGetInt64(out var durTopMs) && durTopMs > 0)
+                durationSec = durTopMs > 1000 ? (int)Math.Round(durTopMs / 1000.0) : (int)durTopMs;
+        }
+
+        // 互动统计：TikTok statistics.{digg_count, comment_count, share_count, collect_count, play_count}
+        long? likes = null, comments = null, shares = null, collects = null, plays = null;
+        if (item.TryGetProperty("statistics", out var stats) && stats.ValueKind == JsonValueKind.Object)
+        {
+            likes = TryGetJsonLong(stats, "digg_count", "diggCount", "like_count", "likeCount");
+            comments = TryGetJsonLong(stats, "comment_count", "commentCount");
+            shares = TryGetJsonLong(stats, "share_count", "shareCount");
+            collects = TryGetJsonLong(stats, "collect_count", "collectCount", "favourite_count", "favouriteCount");
+            plays = TryGetJsonLong(stats, "play_count", "playCount", "view_count", "viewCount");
+        }
+        // stats 也可能在顶层
+        likes ??= TryGetJsonLong(item, "digg_count", "like_count");
+        plays ??= TryGetJsonLong(item, "play_count", "view_count");
+
+        // 标签：优先 text_extra[].hashtag_name，否则从 desc 正则
+        var hashtags = new List<string>();
+        if (item.TryGetProperty("text_extra", out var teEl) && teEl.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var te in teEl.EnumerateArray())
+            {
+                if (te.ValueKind != JsonValueKind.Object) continue;
+                var hn = TryGetJsonString(te, "hashtag_name", "hashtagName");
+                if (!string.IsNullOrWhiteSpace(hn) && !hashtags.Contains(hn)) hashtags.Add(hn);
+            }
+        }
+        if (hashtags.Count == 0 && !string.IsNullOrWhiteSpace(title))
+        {
+            foreach (System.Text.RegularExpressions.Match m in System.Text.RegularExpressions.Regex.Matches(title, @"#([^\s#]+)"))
+            {
+                var tag = m.Groups[1].Value.Trim();
+                if (!string.IsNullOrWhiteSpace(tag) && !hashtags.Contains(tag)) hashtags.Add(tag);
+            }
+        }
 
         // 公开播放页 URL：TikTok 是 https://www.tiktok.com/@{unique_id}/video/{aweme_id}
         // 抖音是 https://www.douyin.com/video/{aweme_id}
@@ -6585,6 +6801,10 @@ function safeChart(canvasId, config) {
             coverUrl,
             author,
             authorUniqueId,
+            authorAvatarUrl,
+            durationSec,
+            hashtags,
+            stats = new { likes, comments, shares, collects, plays },
             createTime,
             shareUrl,
             platform,
@@ -7194,6 +7414,44 @@ function safeChart(canvasId, config) {
                     imageUrl = TryGetJsonString(item, "url");
                 var posterUrl = string.IsNullOrWhiteSpace(videoUrl) ? null : (string.IsNullOrWhiteSpace(coverUrl) ? null : coverUrl);
 
+                // feed-card 版式所需字段（normalizer 透出的，全部可选）
+                var authorAvatarUrl = TryGetJsonString(item, "authorAvatarUrl", "author_avatar_url", "avatar_url");
+                var itemPlatform = TryGetJsonString(item, "platform");
+                int? itemDurationSec = null;
+                if (item.TryGetProperty("durationSec", out var durEl) && durEl.ValueKind == JsonValueKind.Number && durEl.TryGetInt32(out var dsec))
+                    itemDurationSec = dsec;
+
+                List<string>? itemHashtags = null;
+                if (item.TryGetProperty("hashtags", out var htEl) && htEl.ValueKind == JsonValueKind.Array)
+                {
+                    itemHashtags = new List<string>();
+                    foreach (var t in htEl.EnumerateArray())
+                    {
+                        if (t.ValueKind == JsonValueKind.String)
+                        {
+                            var s = t.GetString();
+                            if (!string.IsNullOrWhiteSpace(s)) itemHashtags.Add(s);
+                        }
+                    }
+                    if (itemHashtags.Count == 0) itemHashtags = null;
+                }
+
+                PosterPageStats? itemStats = null;
+                if (item.TryGetProperty("stats", out var statsEl) && statsEl.ValueKind == JsonValueKind.Object)
+                {
+                    itemStats = new PosterPageStats
+                    {
+                        Likes = TryGetJsonLong(statsEl, "likes"),
+                        Comments = TryGetJsonLong(statsEl, "comments"),
+                        Shares = TryGetJsonLong(statsEl, "shares"),
+                        Collects = TryGetJsonLong(statsEl, "collects"),
+                        Plays = TryGetJsonLong(statsEl, "plays"),
+                    };
+                    // 全 null 视为空
+                    if (itemStats.Likes == null && itemStats.Comments == null && itemStats.Shares == null
+                        && itemStats.Collects == null && itemStats.Plays == null) itemStats = null;
+                }
+
                 pages.Add(new WeeklyPosterPage
                 {
                     Order = order++,
@@ -7202,6 +7460,12 @@ function safeChart(canvasId, config) {
                     ImagePrompt = "",
                     ImageUrl = string.IsNullOrWhiteSpace(imageUrl) ? null : imageUrl,
                     SecondaryImageUrl = posterUrl,
+                    AuthorName = string.IsNullOrWhiteSpace(author) ? null : author,
+                    AuthorAvatarUrl = string.IsNullOrWhiteSpace(authorAvatarUrl) ? null : authorAvatarUrl,
+                    Platform = string.IsNullOrWhiteSpace(itemPlatform) ? null : itemPlatform,
+                    DurationSec = itemDurationSec,
+                    Hashtags = itemHashtags,
+                    Stats = itemStats,
                     AccentColor = string.IsNullOrWhiteSpace(accentColor) ? null : accentColor,
                 });
             }

--- a/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
+++ b/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
@@ -6196,9 +6196,32 @@ function safeChart(canvasId, config) {
         //   web 端点（/api/v1/tiktok/web/fetch_user_post）2026-05 实测连官方示例 secUid 都返回 400，
         //   猜测上游 TikTok web 限流。app/v3 稳定可用，输出 data.aweme_list 结构和抖音对齐。
         // Douyin：/api/v1/douyin/web/fetch_user_post_videos，param=sec_user_id。
-        var requestUrl = platform == "douyin"
-            ? $"{apiBaseUrl}/api/v1/douyin/web/fetch_user_post_videos?sec_user_id={Uri.EscapeDataString(secUid)}&max_cursor={Uri.EscapeDataString(cursor)}&count={count}"
-            : $"{apiBaseUrl}/api/v1/tiktok/app/v3/fetch_user_post_videos?sec_user_id={Uri.EscapeDataString(secUid)}&max_cursor={Uri.EscapeDataString(cursor)}&count={count}";
+        // Bilibili：/api/v1/bilibili/web/fetch_user_post_videos，param=uid (B 站数字 mid)，pn=页码 ps=每页数。
+        //   注：B 站 fetch list 不给 mp4 直链，只给 BV 号 + 封面，海报点击跳转 bilibili.com 播放。
+        // Xiaohongshu：/api/v1/xiaohongshu/web/get_user_notes，param=user_id (从博主主页 URL 末段取)。
+        //   注：图文笔记没视频，只展示封面图集。
+        // YouTube：/api/v1/youtube/web/get_channel_videos_v2，param=channelId (UCxxxxx)。
+        //   注：YouTube 不给 mp4 直链，海报点击跳转 youtube.com 播放。
+        string requestUrl;
+        switch (platform)
+        {
+            case "douyin":
+                requestUrl = $"{apiBaseUrl}/api/v1/douyin/web/fetch_user_post_videos?sec_user_id={Uri.EscapeDataString(secUid)}&max_cursor={Uri.EscapeDataString(cursor)}&count={count}";
+                break;
+            case "bilibili":
+                requestUrl = $"{apiBaseUrl}/api/v1/bilibili/web/fetch_user_post_videos?uid={Uri.EscapeDataString(secUid)}&pn=1&ps={count}";
+                break;
+            case "xiaohongshu":
+                requestUrl = $"{apiBaseUrl}/api/v1/xiaohongshu/web/get_user_notes?user_id={Uri.EscapeDataString(secUid)}&cursor={Uri.EscapeDataString(cursor)}&count={count}";
+                break;
+            case "youtube":
+                requestUrl = $"{apiBaseUrl}/api/v1/youtube/web/get_channel_videos_v2?channelId={Uri.EscapeDataString(secUid)}";
+                break;
+            case "tiktok":
+            default:
+                requestUrl = $"{apiBaseUrl}/api/v1/tiktok/app/v3/fetch_user_post_videos?sec_user_id={Uri.EscapeDataString(secUid)}&max_cursor={Uri.EscapeDataString(cursor)}&count={count}";
+                break;
+        }
 
         sb.AppendLine($"[TiktokCreatorFetch] 平台: {platform}");
         sb.AppendLine($"[TiktokCreatorFetch] 博主: {secUid}");
@@ -6222,14 +6245,21 @@ function safeChart(canvasId, config) {
             throw new InvalidOperationException($"TikHub API 请求失败 (HTTP {(int)response.StatusCode}): {responseBody[..Math.Min(200, responseBody.Length)]}");
         }
 
-        // 解析响应：兼容 TikTok web (data.itemList) / 抖音 web (data.aweme_list) / 其他变体
+        // 解析响应：兼容 TikTok web (data.itemList) / 抖音 web (data.aweme_list) /
+        // B 站 (data.list.vlist) / 小红书 (data.notes) / YouTube (data.videos) / 其他变体
         using var respDoc = JsonDocument.Parse(responseBody);
         var root = respDoc.RootElement;
         var dataElem = root.TryGetProperty("data", out var d) && d.ValueKind == JsonValueKind.Object ? d : root;
 
+        // B 站特例：data.list.vlist 是嵌套两层，先解一层
+        if (platform == "bilibili" && dataElem.TryGetProperty("list", out var bList) && bList.ValueKind == JsonValueKind.Object)
+        {
+            dataElem = bList;
+        }
+
         JsonElement listElem = default;
         var listFound = false;
-        foreach (var key in new[] { "itemList", "aweme_list", "items", "videos", "list" })
+        foreach (var key in new[] { "itemList", "aweme_list", "vlist", "notes", "items", "videos", "list" })
         {
             if (dataElem.TryGetProperty(key, out var arr) && arr.ValueKind == JsonValueKind.Array)
             {
@@ -6245,7 +6275,7 @@ function safeChart(canvasId, config) {
         {
             foreach (var v in listElem.EnumerateArray())
             {
-                items.Add(NormalizeTiktokVideoItem(v, platform));
+                items.Add(NormalizeCreatorVideoItem(v, platform));
             }
         }
 
@@ -6265,6 +6295,193 @@ function safeChart(canvasId, config) {
         var outputJson = JsonSerializer.Serialize(output, JsonPretty);
         var artifact = MakeTextArtifact(node, "tcf-out", $"博主视频列表 ({items.Count} 条)", outputJson, "application/json");
         return new CapsuleResult(new List<ExecutionArtifact> { artifact }, sb.ToString());
+    }
+
+    /// <summary>
+    /// 按平台分发到具体的 item 规范化器，所有规范化器输出同一份 schema：
+    /// { awemeId, title, videoUrl, coverUrl, author, authorUniqueId, createTime, shareUrl, platform }
+    /// 这样下游 weekly-poster-publisher / video-to-text 不需要为每个平台特化逻辑。
+    /// </summary>
+    private static object NormalizeCreatorVideoItem(JsonElement item, string platform)
+    {
+        return platform switch
+        {
+            "bilibili" => NormalizeBilibiliVideoItem(item),
+            "xiaohongshu" => NormalizeXiaohongshuItem(item),
+            "youtube" => NormalizeYoutubeVideoItem(item),
+            _ => NormalizeTiktokVideoItem(item, platform),
+        };
+    }
+
+    /// <summary>
+    /// B 站视频项规范化。fetch_user_post_videos 不给 mp4 直链（需另调 video_playurl 拿 cdn 地址 +
+    /// wbi 签名），这里只输出元数据 + 跳转 URL，videoUrl 留空让海报降级到 cover + 跳转链接。
+    /// 字段参考：data.list.vlist[] = { aid, bvid, title, pic, length, play, comment, created, author, mid }
+    /// </summary>
+    private static object NormalizeBilibiliVideoItem(JsonElement item)
+    {
+        var bvid = TryGetJsonString(item, "bvid", "BVID");
+        var aid = TryGetJsonString(item, "aid", "AID");
+        var title = TryGetJsonString(item, "title");
+        var coverUrl = TryGetJsonString(item, "pic", "cover", "coverUrl");
+        // B 站封面常省略 https: 协议头
+        if (!string.IsNullOrWhiteSpace(coverUrl) && coverUrl.StartsWith("//"))
+            coverUrl = "https:" + coverUrl;
+        var author = TryGetJsonString(item, "author", "name", "uname");
+        var authorMid = TryGetJsonString(item, "mid", "uid");
+        var createUnix = TryGetJsonString(item, "created", "ctime", "pubdate");
+        var shareUrl = !string.IsNullOrWhiteSpace(bvid)
+            ? $"https://www.bilibili.com/video/{bvid}"
+            : (!string.IsNullOrWhiteSpace(aid) ? $"https://www.bilibili.com/video/av{aid}" : "");
+
+        return new
+        {
+            awemeId = !string.IsNullOrWhiteSpace(bvid) ? bvid : aid,
+            title,
+            videoUrl = "",
+            coverUrl,
+            author,
+            authorUniqueId = authorMid,
+            createTime = createUnix,
+            shareUrl,
+            platform = "bilibili",
+        };
+    }
+
+    /// <summary>
+    /// 小红书笔记规范化。视频笔记 type=video 时给 video.url；图文笔记 type=normal 只有 image_list。
+    /// 字段参考：data.notes[] = { id, type, title, display_title, cover, image_list, video, user }
+    /// </summary>
+    private static object NormalizeXiaohongshuItem(JsonElement item)
+    {
+        var noteId = TryGetJsonString(item, "id", "note_id", "noteId");
+        var title = TryGetJsonString(item, "display_title", "title", "desc");
+        var noteType = TryGetJsonString(item, "type", "note_type");
+
+        // 视频笔记的 mp4 URL
+        string videoUrl = "";
+        if (item.TryGetProperty("video", out var video) && video.ValueKind == JsonValueKind.Object)
+        {
+            videoUrl = TryGetJsonString(video, "url", "play_url", "master_url");
+            if (string.IsNullOrWhiteSpace(videoUrl) && video.TryGetProperty("media", out var media) && media.ValueKind == JsonValueKind.Object)
+            {
+                videoUrl = TryGetJsonString(media, "video_url", "url");
+            }
+        }
+
+        // 封面：cover.url_default 优先，没有就取 image_list[0].url
+        string coverUrl = "";
+        if (item.TryGetProperty("cover", out var cover) && cover.ValueKind == JsonValueKind.Object)
+        {
+            coverUrl = TryGetJsonString(cover, "url_default", "url", "url_pre");
+        }
+        if (string.IsNullOrWhiteSpace(coverUrl) && item.TryGetProperty("image_list", out var imgs) && imgs.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var img in imgs.EnumerateArray())
+            {
+                if (img.ValueKind == JsonValueKind.Object)
+                {
+                    coverUrl = TryGetJsonString(img, "url_default", "url");
+                    if (!string.IsNullOrWhiteSpace(coverUrl)) break;
+                }
+            }
+        }
+        if (string.IsNullOrWhiteSpace(coverUrl))
+        {
+            coverUrl = TryGetJsonString(item, "cover_url", "thumb");
+        }
+
+        var author = "";
+        var authorUserId = "";
+        if (item.TryGetProperty("user", out var user) && user.ValueKind == JsonValueKind.Object)
+        {
+            author = TryGetJsonString(user, "nickname", "name");
+            authorUserId = TryGetJsonString(user, "user_id", "userId", "id");
+        }
+
+        var shareUrl = !string.IsNullOrWhiteSpace(noteId)
+            ? $"https://www.xiaohongshu.com/explore/{noteId}"
+            : "";
+
+        return new
+        {
+            awemeId = noteId,
+            title,
+            videoUrl,
+            coverUrl,
+            author,
+            authorUniqueId = authorUserId,
+            createTime = TryGetJsonString(item, "time", "create_time", "createTime"),
+            shareUrl,
+            platform = "xiaohongshu",
+            noteType,
+        };
+    }
+
+    /// <summary>
+    /// YouTube 频道视频规范化。频道 list 不给 mp4 直链（要 itag 协商），海报点击跳转 youtube.com。
+    /// 字段参考：data.videos[] = { videoId, title, description, thumbnails[], duration, channelName, publishedTime }
+    /// </summary>
+    private static object NormalizeYoutubeVideoItem(JsonElement item)
+    {
+        var videoId = TryGetJsonString(item, "videoId", "video_id", "id");
+        var title = TryGetJsonString(item, "title");
+        var channelName = TryGetJsonString(item, "channelName", "author", "channel_name");
+        var channelId = TryGetJsonString(item, "channelId", "channel_id");
+
+        // 缩略图：取最大尺寸的（thumbnails 数组通常按 width 升序，遍历到末尾取 url）
+        string coverUrl = "";
+        if (item.TryGetProperty("thumbnails", out var thumbs) && thumbs.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var t in thumbs.EnumerateArray())
+            {
+                if (t.ValueKind == JsonValueKind.Object)
+                {
+                    var u = TryGetJsonString(t, "url");
+                    if (!string.IsNullOrWhiteSpace(u)) coverUrl = u;
+                }
+            }
+        }
+        if (string.IsNullOrWhiteSpace(coverUrl) && item.TryGetProperty("thumbnail", out var thumbnail))
+        {
+            if (thumbnail.ValueKind == JsonValueKind.Object && thumbnail.TryGetProperty("thumbnails", out var inner) && inner.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var t in inner.EnumerateArray())
+                {
+                    if (t.ValueKind == JsonValueKind.Object)
+                    {
+                        var u = TryGetJsonString(t, "url");
+                        if (!string.IsNullOrWhiteSpace(u)) coverUrl = u;
+                    }
+                }
+            }
+            else if (thumbnail.ValueKind == JsonValueKind.String)
+            {
+                coverUrl = thumbnail.GetString() ?? "";
+            }
+        }
+        // YouTube i.ytimg 兜底
+        if (string.IsNullOrWhiteSpace(coverUrl) && !string.IsNullOrWhiteSpace(videoId))
+        {
+            coverUrl = $"https://i.ytimg.com/vi/{videoId}/hqdefault.jpg";
+        }
+
+        var shareUrl = !string.IsNullOrWhiteSpace(videoId)
+            ? $"https://www.youtube.com/watch?v={videoId}"
+            : "";
+
+        return new
+        {
+            awemeId = videoId,
+            title,
+            videoUrl = "",
+            coverUrl,
+            author = channelName,
+            authorUniqueId = channelId,
+            createTime = TryGetJsonString(item, "publishedTime", "published_time", "publishDate"),
+            shareUrl,
+            platform = "youtube",
+        };
     }
 
     /// <summary>

--- a/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
+++ b/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
@@ -6616,24 +6616,39 @@ function safeChart(canvasId, config) {
             int order = 0;
             foreach (var item in itemsElem.EnumerateArray())
             {
-                var pageTitle = TryGetJsonString(item, "title", "desc", "description", "name");
+                // hook 字段优先（video-to-text asr 模式提炼出的一句话钩子，专为 ad-rich-text 海报设计）
+                var hookField = TryGetJsonString(item, "hook");
+                var pageTitle = !string.IsNullOrWhiteSpace(hookField)
+                    ? hookField!
+                    : TryGetJsonString(item, "title", "desc", "description", "name");
                 if (string.IsNullOrWhiteSpace(pageTitle)) pageTitle = $"作品 #{order + 1}";
                 if (pageTitle.Length > 80) pageTitle = pageTitle[..80] + "…";
 
                 var author = TryGetJsonString(item, "author", "nickname");
                 var createTime = TryGetJsonString(item, "createTime", "create_time");
                 var awemeId = TryGetJsonString(item, "awemeId", "aweme_id", "id");
-                var fullDesc = TryGetJsonString(item, "title", "desc", "description");
 
-                var bodyParts = new List<string>();
-                if (!string.IsNullOrWhiteSpace(author)) bodyParts.Add($"@{author}");
-                if (!string.IsNullOrWhiteSpace(awemeId)) bodyParts.Add($"#{awemeId}");
-                if (!string.IsNullOrWhiteSpace(fullDesc) && fullDesc != pageTitle)
+                // body 优先用上游显式提供的 body（video-to-text asr 模式拼好的 markdown bullets）
+                // 否则回退到 @author + #awemeId + 截断后的描述
+                var explicitBody = TryGetJsonString(item, "body");
+                string body;
+                if (!string.IsNullOrWhiteSpace(explicitBody))
                 {
-                    var truncated = fullDesc.Length > 200 ? fullDesc[..200] + "…" : fullDesc;
-                    bodyParts.Add(truncated);
+                    body = explicitBody!;
                 }
-                var body = string.Join("\n\n", bodyParts);
+                else
+                {
+                    var fullDesc = TryGetJsonString(item, "title", "desc", "description");
+                    var bodyParts = new List<string>();
+                    if (!string.IsNullOrWhiteSpace(author)) bodyParts.Add($"@{author}");
+                    if (!string.IsNullOrWhiteSpace(awemeId)) bodyParts.Add($"#{awemeId}");
+                    if (!string.IsNullOrWhiteSpace(fullDesc) && fullDesc != pageTitle)
+                    {
+                        var truncated = fullDesc.Length > 200 ? fullDesc[..200] + "…" : fullDesc;
+                        bodyParts.Add(truncated);
+                    }
+                    body = string.Join("\n\n", bodyParts);
+                }
 
                 // 优先真实视频 URL（前端 modal 会 <video> 播放）。失败时退回 coverUrl 静图。
                 // ad-4-3 模式下视频不 autoplay，需要用户点中央 Play 按钮，所以 coverUrl 同时填到

--- a/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
+++ b/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
@@ -5468,8 +5468,9 @@ function safeChart(canvasId, config) {
 
         var videoUrlField = (GetConfigString(node, "videoUrlField") ?? "videoUrl").Trim();
         var itemsField = (GetConfigString(node, "itemsField") ?? "items").Trim();
-        var maxItems = int.TryParse(GetConfigString(node, "maxItems") ?? "4", out var mi)
-            ? Math.Max(1, Math.Min(20, mi)) : 4;
+        // maxItems：空值 / 0 / 非数字 → 处理所有上游条目；正整数 → 按数量截断
+        var maxItemsRaw = GetConfigString(node, "maxItems");
+        var maxItems = (int.TryParse(maxItemsRaw, out var mi) && mi > 0) ? mi : int.MaxValue;
         var enableHook = ((GetConfigString(node, "enableHookExtraction") ?? "true").Trim().ToLowerInvariant()) != "false";
         var hookPromptOverride = ReplaceVariables(GetConfigString(node, "hookSystemPrompt") ?? "", variables).Trim();
 
@@ -5519,14 +5520,35 @@ function safeChart(canvasId, config) {
         var httpFactory = sp.GetRequiredService<IHttpClientFactory>();
         var gateway = sp.GetRequiredService<PrdAgent.Infrastructure.LlmGateway.ILlmGateway>();
 
-        // 解析 ASR 模型（一次解析，所有 item 复用）
-        var resolution = await modelResolver.ResolveAsync(
-            AppCallerRegistry.VideoAgent.VideoToText.Asr, ModelTypes.Asr);
-        if (!resolution.Success)
+        // 解析 ASR 模型（fallback 链：先专属 → 再 v2d.transcribe → 再 document-store.subtitle，
+        // 任何一个有 doubao-asr-stream 都行，不强迫用户为本胶囊单独绑模型池）
+        var asrCallerChain = new[]
+        {
+            AppCallerRegistry.VideoAgent.VideoToText.Asr,
+            AppCallerRegistry.VideoAgent.VideoToDoc.Transcribe,
+            AppCallerRegistry.DocumentStoreAgent.Subtitle.Audio,
+        };
+        PrdAgent.Infrastructure.LlmGateway.ModelResolutionResult? resolution = null;
+        string? resolvedCaller = null;
+        var resolutionErrors = new List<string>();
+        foreach (var caller in asrCallerChain)
+        {
+            var r = await modelResolver.ResolveAsync(caller, ModelTypes.Asr);
+            if (r.Success && r.IsExchange && r.ExchangeTransformerType == "doubao-asr-stream")
+            {
+                resolution = r;
+                resolvedCaller = caller;
+                break;
+            }
+            resolutionErrors.Add($"{caller}: {(r.Success ? $"transformer={r.ExchangeTransformerType ?? "(non-exchange)"}" : r.ErrorMessage)}");
+        }
+        if (resolution == null)
+        {
             throw new InvalidOperationException(
-                $"ASR 模型调度失败: {resolution.ErrorMessage}（请去模型池配置 video-agent.video-to-text::asr）");
-        if (!resolution.IsExchange || resolution.ExchangeTransformerType != "doubao-asr-stream")
-            throw new InvalidOperationException("当前仅支持豆包流式 ASR (doubao-asr-stream)，请检查模型池配置");
+                "ASR 模型调度失败：尝试了 video-agent.video-to-text::asr / video-agent.v2d.transcribe::asr / document-store.subtitle::asr 三个 caller，无一绑定可用的 doubao-asr-stream 模型。请去管理后台「模型池」给其中任一 caller 绑定。诊断："
+                + string.Join(" | ", resolutionErrors));
+        }
+        sb.AppendLine($"[VideoToText:asr] ASR caller={resolvedCaller}");
 
         var apiKeyRaw = resolution.ApiKey ?? "";
         string appKey = "", accessKey = apiKeyRaw;
@@ -5544,6 +5566,9 @@ function safeChart(canvasId, config) {
             ["enablePunc"] = true,
             ["enableDdc"] = true,
         };
+
+        // ffmpeg 启动前探测，防止错误被误读为 ASR/网络问题
+        await EnsureFfmpegAvailableAsync();
 
         var http = httpFactory.CreateClient("WorkflowAgent");
         http.Timeout = TimeSpan.FromMinutes(8);
@@ -5655,6 +5680,21 @@ function safeChart(canvasId, config) {
                             ["temperature"] = 0.4,
                         }
                     };
+                    // 按 .claude/rules/llm-gateway.md 强制要求设置 LlmRequestContext。
+                    // workflow 由系统自动触发时 UserId 取 __triggeredBy 变量，否则 fallback 到 workflow-system。
+                    var llmCtx = sp.GetService<PrdAgent.Core.Interfaces.ILLMRequestContextAccessor>();
+                    var triggeredBy = variables.GetValueOrDefault("__triggeredBy") ?? "workflow-system";
+                    using var llmScope = llmCtx?.BeginScope(new PrdAgent.Core.Interfaces.LlmRequestContext(
+                        RequestId: Guid.NewGuid().ToString("N"),
+                        GroupId: null,
+                        SessionId: null,
+                        UserId: triggeredBy,
+                        ViewRole: null,
+                        DocumentChars: transcript.Length,
+                        DocumentHash: null,
+                        SystemPromptRedacted: "video-to-text-asr-hook",
+                        RequestType: "chat",
+                        AppCallerCode: AppCallerRegistry.VideoAgent.VideoToText.Chat));
                     var llmResponse = await gateway.SendAsync(llmRequest, CancellationToken.None);
                     var llmContent = (llmResponse.Content ?? "").Trim();
 
@@ -5756,6 +5796,34 @@ function safeChart(canvasId, config) {
         catch
         {
             return false;
+        }
+    }
+
+    /// <summary>
+    /// ffmpeg 启动前探测。失败时给出指引明确的错误信息，避免被误判为网络/模型问题。
+    /// </summary>
+    private static async Task EnsureFfmpegAvailableAsync()
+    {
+        try
+        {
+            using var probe = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "ffmpeg",
+                ArgumentList = { "-version" },
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            });
+            if (probe == null) throw new InvalidOperationException("ffmpeg 进程启动失败（Process.Start 返回 null）");
+            await probe.WaitForExitAsync();
+            if (probe.ExitCode != 0)
+                throw new InvalidOperationException($"ffmpeg -version 异常退出（exit={probe.ExitCode}）");
+        }
+        catch (Exception ex) when (ex is not InvalidOperationException)
+        {
+            throw new InvalidOperationException(
+                $"环境缺 ffmpeg：{ex.Message}。CDS 容器已预装，命中此错误请重建容器；本地 dev 请安装：apt install ffmpeg / brew install ffmpeg / choco install ffmpeg",
+                ex);
         }
     }
 

--- a/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
+++ b/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
@@ -5636,6 +5636,42 @@ function safeChart(canvasId, config) {
                     {
                         transcript = asrResult.FullText ?? "";
                         sb.AppendLine($"[VideoToText:asr] item#{idx} ASR 完成，转写 {transcript.Length} 字");
+
+                        // 从最后一帧 raw response 抽取 utterances 时间戳（豆包 ASR 返回毫秒）→ TranscriptCue 数组
+                        try
+                        {
+                            var cuesArr = new JsonArray();
+                            var lastResp = asrResult.Responses.LastOrDefault(r => r.PayloadMsg != null);
+                            if (lastResp?.PayloadMsg != null)
+                            {
+                                var payload = lastResp.PayloadMsg.Value;
+                                if (payload.TryGetProperty("result", out var res) && res.TryGetProperty("utterances", out var utts) && utts.ValueKind == JsonValueKind.Array)
+                                {
+                                    foreach (var utt in utts.EnumerateArray())
+                                    {
+                                        var cueText = utt.TryGetProperty("text", out var t) ? t.GetString() ?? "" : "";
+                                        if (string.IsNullOrWhiteSpace(cueText)) continue;
+                                        double startMs = utt.TryGetProperty("start_time", out var stEl) && stEl.ValueKind == JsonValueKind.Number ? stEl.GetDouble() : 0;
+                                        double endMs = utt.TryGetProperty("end_time", out var etEl) && etEl.ValueKind == JsonValueKind.Number ? etEl.GetDouble() : 0;
+                                        cuesArr.Add(new JsonObject
+                                        {
+                                            ["startSec"] = startMs / 1000.0,
+                                            ["endSec"] = endMs / 1000.0,
+                                            ["text"] = cueText.Trim(),
+                                        });
+                                    }
+                                }
+                            }
+                            if (cuesArr.Count > 0)
+                            {
+                                enriched["transcriptCues"] = cuesArr;
+                                sb.AppendLine($"[VideoToText:asr] item#{idx} 提取 {cuesArr.Count} 条带时间戳字幕");
+                            }
+                        }
+                        catch (Exception cueEx)
+                        {
+                            sb.AppendLine($"[VideoToText:asr] item#{idx} cue 抽取异常（不影响 transcript）: {cueEx.Message}");
+                        }
                     }
                     else
                     {
@@ -7452,6 +7488,23 @@ function safeChart(canvasId, config) {
                         && itemStats.Collects == null && itemStats.Plays == null) itemStats = null;
                 }
 
+                // 从上游 item.transcriptCues 抽取带时间戳字幕（video-to-text asr 模式输出）
+                List<TranscriptCue>? itemCues = null;
+                if (item.TryGetProperty("transcriptCues", out var cuesEl) && cuesEl.ValueKind == JsonValueKind.Array)
+                {
+                    itemCues = new List<TranscriptCue>();
+                    foreach (var c in cuesEl.EnumerateArray())
+                    {
+                        if (c.ValueKind != JsonValueKind.Object) continue;
+                        var cueText = TryGetJsonString(c, "text");
+                        if (string.IsNullOrWhiteSpace(cueText)) continue;
+                        double cueStart = c.TryGetProperty("startSec", out var stCe) && stCe.ValueKind == JsonValueKind.Number ? stCe.GetDouble() : 0;
+                        double cueEnd = c.TryGetProperty("endSec", out var etCe) && etCe.ValueKind == JsonValueKind.Number ? etCe.GetDouble() : 0;
+                        itemCues.Add(new TranscriptCue { StartSec = cueStart, EndSec = cueEnd, Text = cueText });
+                    }
+                    if (itemCues.Count == 0) itemCues = null;
+                }
+
                 pages.Add(new WeeklyPosterPage
                 {
                     Order = order++,
@@ -7466,6 +7519,7 @@ function safeChart(canvasId, config) {
                     DurationSec = itemDurationSec,
                     Hashtags = itemHashtags,
                     Stats = itemStats,
+                    TranscriptCues = itemCues,
                     AccentColor = string.IsNullOrWhiteSpace(accentColor) ? null : accentColor,
                 });
             }

--- a/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
+++ b/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
@@ -6938,10 +6938,6 @@ function safeChart(canvasId, config) {
         new(@"^hero\.(.+)$", System.Text.RegularExpressions.RegexOptions.Compiled);
 
     /// <summary>
-    /// 发布到首页海报：下载上游 URL 指向的媒体文件，写入 HomepageAsset（按 slot 唯一覆盖）。
-    /// 与 HomepageAssetsController.Upload 保持完全相同的 slot/路径规则。
-    /// </summary>
-    /// <summary>
     /// 媒体迁移到 COS：把 items 数组里每条记录的视频 / 封面 URL 下载到本平台 COS，
     /// URL 替换成稳定 COS 直链。专为绕开 TikTok / B 站 / 小红书 CDN 防盗链 403 而生。
     /// 并发下载（默认 4），失败的字段保留原 URL 不阻塞流水线。
@@ -7225,6 +7221,10 @@ function safeChart(canvasId, config) {
         return $"workflow/media-rehost/{now:yyyy-MM}/{guid}.{ext}";
     }
 
+    /// <summary>
+    /// 发布到首页海报：下载上游 URL 指向的媒体文件，写入 HomepageAsset（按 slot 唯一覆盖）。
+    /// 与 HomepageAssetsController.Upload 保持完全相同的 slot/路径规则。
+    /// </summary>
     public static async Task<CapsuleResult> ExecuteHomepagePublisherAsync(
         IServiceProvider sp,
         WorkflowNode node,

--- a/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
+++ b/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
@@ -5885,10 +5885,16 @@ function safeChart(canvasId, config) {
             };
             using var process = System.Diagnostics.Process.Start(psi)
                 ?? throw new InvalidOperationException("ffmpeg 启动失败");
+            // 必须在 WaitForExitAsync 之前并发开始读 stderr/stdout：ffmpeg 写 stderr 量大
+            // （codec info + 进度），OS pipe buffer 满会让 ffmpeg 阻塞在 write，
+            // 主线程在 WaitForExit 永远等不到退出 → 经典 .NET deadlock 坑
+            var stderrTask = process.StandardError.ReadToEndAsync();
+            var stdoutTask = process.StandardOutput.ReadToEndAsync();
             await process.WaitForExitAsync();
+            await Task.WhenAll(stderrTask, stdoutTask);
             if (process.ExitCode != 0)
             {
-                var err = await process.StandardError.ReadToEndAsync();
+                var err = await stderrTask;
                 throw new InvalidOperationException($"ffmpeg 抽音频失败 (exit={process.ExitCode}): {err}");
             }
             return await System.IO.File.ReadAllBytesAsync(tmpOut);

--- a/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
+++ b/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
@@ -6241,6 +6241,9 @@ function safeChart(canvasId, config) {
         var platform = (ReplaceVariables(GetConfigString(node, "platform") ?? "tiktok", variables).Trim().ToLowerInvariant()) switch
         {
             "douyin" => "douyin",
+            "bilibili" => "bilibili",
+            "xiaohongshu" => "xiaohongshu",
+            "youtube" => "youtube",
             _ => "tiktok",
         };
         var apiBaseUrl = ReplaceVariables(GetConfigString(node, "apiBaseUrl") ?? "https://api.tikhub.io", variables).TrimEnd('/');
@@ -6960,28 +6963,64 @@ function safeChart(canvasId, config) {
 
                     try
                     {
-                        var resp = await http.GetAsync(url, CancellationToken.None);
+                        // 流式读取防 OOM：先用 ResponseHeadersRead 拿 headers，
+                        // Content-Length 大于 maxBytesMb 直接跳过；否则边读边检查累计字节，
+                        // 超限立刻 break 而非把整个 body 读到内存。
+                        var resp = await http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, CancellationToken.None);
                         if (!resp.IsSuccessStatusCode)
                         {
                             local.AppendLine($"[MediaRehost] item#{idx}.{field} HTTP {(int)resp.StatusCode}，保留原 URL");
                             System.Threading.Interlocked.Increment(ref failedCount);
+                            resp.Dispose();
                             continue;
                         }
-                        var bytes = await resp.Content.ReadAsByteArrayAsync(CancellationToken.None);
+
+                        long maxBytes = (long)maxBytesMb * 1024 * 1024;
+                        var contentLength = resp.Content.Headers.ContentLength;
+                        if (contentLength.HasValue && contentLength.Value > maxBytes)
+                        {
+                            local.AppendLine($"[MediaRehost] item#{idx}.{field} Content-Length {contentLength.Value / 1024 / 1024}MB 超 maxBytesMb={maxBytesMb}，保留原 URL（未下载）");
+                            System.Threading.Interlocked.Increment(ref failedCount);
+                            resp.Dispose();
+                            continue;
+                        }
+
+                        // Content-Type 在读 body 前先取，因为后面要 dispose resp
+                        var contentType = resp.Content.Headers.ContentType?.MediaType ?? "";
+
+                        // 边读边累计，超限立刻 abort，避免把超大文件读完整再判断
+                        byte[] bytes;
+                        bool overrun = false;
+                        try
+                        {
+                            await using var srcStream = await resp.Content.ReadAsStreamAsync(CancellationToken.None);
+                            using var ms = new System.IO.MemoryStream(contentLength.HasValue ? (int)Math.Min(contentLength.Value, maxBytes) : 64 * 1024);
+                            var buf = new byte[64 * 1024];
+                            int n;
+                            while ((n = await srcStream.ReadAsync(buf.AsMemory(0, buf.Length), CancellationToken.None)) > 0)
+                            {
+                                if (ms.Length + n > maxBytes) { overrun = true; break; }
+                                ms.Write(buf, 0, n);
+                            }
+                            bytes = ms.ToArray();
+                        }
+                        finally
+                        {
+                            resp.Dispose();
+                        }
+
+                        if (overrun)
+                        {
+                            local.AppendLine($"[MediaRehost] item#{idx}.{field} 边读边截断 {bytes.Length / 1024 / 1024}MB 已达 maxBytesMb={maxBytesMb}，保留原 URL");
+                            System.Threading.Interlocked.Increment(ref failedCount);
+                            continue;
+                        }
                         if (bytes.Length == 0)
                         {
                             local.AppendLine($"[MediaRehost] item#{idx}.{field} 0 字节响应，保留原 URL");
                             System.Threading.Interlocked.Increment(ref failedCount);
                             continue;
                         }
-                        if (bytes.Length > (long)maxBytesMb * 1024 * 1024)
-                        {
-                            local.AppendLine($"[MediaRehost] item#{idx}.{field} {bytes.Length / 1024 / 1024}MB 超 maxBytesMb={maxBytesMb}，保留原 URL");
-                            System.Threading.Interlocked.Increment(ref failedCount);
-                            continue;
-                        }
-
-                        var contentType = resp.Content.Headers.ContentType?.MediaType ?? "";
                         var ext = GuessRehostExt(contentType, field);
                         var isGenericMime = string.IsNullOrWhiteSpace(contentType)
                             || string.Equals(contentType, "application/octet-stream", StringComparison.OrdinalIgnoreCase)

--- a/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
+++ b/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
@@ -6305,7 +6305,8 @@ function safeChart(canvasId, config) {
                 requestUrl = $"{apiBaseUrl}/api/v1/xiaohongshu/web/get_user_notes?user_id={Uri.EscapeDataString(secUid)}&cursor={Uri.EscapeDataString(cursor)}&count={count}";
                 break;
             case "youtube":
-                requestUrl = $"{apiBaseUrl}/api/v1/youtube/web/get_channel_videos_v2?channelId={Uri.EscapeDataString(secUid)}";
+                // YouTube 频道分页是 continuation token 而非 count；先 best-effort 传 maxResults
+                requestUrl = $"{apiBaseUrl}/api/v1/youtube/web/get_channel_videos_v2?channelId={Uri.EscapeDataString(secUid)}&maxResults={count}";
                 break;
             case "tiktok":
             default:
@@ -6366,10 +6367,14 @@ function safeChart(canvasId, config) {
             foreach (var v in listElem.EnumerateArray())
             {
                 items.Add(NormalizeCreatorVideoItem(v, platform));
+                // 服务端硬上限：API 可能 ignore count（YouTube 走 continuation token、
+                // 各平台默认页大小不一），即使传了 count 也可能返回更多。提前截断防止
+                // 下游 ASR / rehost 处理超量数据导致计费 + 时延爆表
+                if (items.Count >= count) break;
             }
         }
 
-        sb.AppendLine($"[TiktokCreatorFetch] 抓到 {items.Count} 条视频");
+        sb.AppendLine($"[TiktokCreatorFetch] 抓到 {items.Count} 条视频（请求 count={count}）");
 
         var firstItem = items.FirstOrDefault();
         var output = new

--- a/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
+++ b/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
@@ -5616,13 +5616,17 @@ function safeChart(canvasId, config) {
             string transcript = "";
             if (!string.IsNullOrWhiteSpace(videoUrl))
             {
+                string? tmpVideoPath = null;
                 try
                 {
-                    sb.AppendLine($"[VideoToText:asr] item#{idx} 下载视频");
-                    var videoBytes = await http.GetByteArrayAsync(videoUrl);
-                    sb.AppendLine($"[VideoToText:asr] item#{idx} 视频 {videoBytes.Length} 字节，开始抽音");
+                    sb.AppendLine($"[VideoToText:asr] item#{idx} 流式下载视频");
+                    // 流式直写 temp file，避免把整个视频读到 byte[] 内存（视频可能 50MB+，
+                    // maxItems 上限 20 → 1GB 内存压力。同 media-rehost 的修复路径）
+                    tmpVideoPath = await DownloadToTempFileAsync(http, videoUrl);
+                    var videoSize = new System.IO.FileInfo(tmpVideoPath).Length;
+                    sb.AppendLine($"[VideoToText:asr] item#{idx} 视频 {videoSize} 字节落盘，开始抽音");
 
-                    var audioBytes = await ExtractAudioWithFfmpegAsync(videoBytes);
+                    var audioBytes = await ExtractAudioWithFfmpegFromFileAsync(tmpVideoPath);
                     sb.AppendLine($"[VideoToText:asr] item#{idx} 音频 {audioBytes.Length} 字节，提交 ASR");
 
                     var asrResult = await streamAsr.TranscribeWithCallbackAsync(
@@ -5681,6 +5685,14 @@ function safeChart(canvasId, config) {
                 catch (Exception ex)
                 {
                     sb.AppendLine($"[VideoToText:asr] item#{idx} 异常: {ex.Message}");
+                }
+                finally
+                {
+                    // 清理 temp 视频文件
+                    if (tmpVideoPath != null)
+                    {
+                        try { if (System.IO.File.Exists(tmpVideoPath)) System.IO.File.Delete(tmpVideoPath); } catch { }
+                    }
                 }
             }
             else
@@ -5865,8 +5877,61 @@ function safeChart(canvasId, config) {
     }
 
     /// <summary>
+    /// 流式下载到 temp 文件，返回路径。避免把整个 body 读到 byte[] 内存。
+    /// 调用方负责 finally 删除 temp 文件。
+    /// </summary>
+    private static async Task<string> DownloadToTempFileAsync(System.Net.Http.HttpClient http, string url)
+    {
+        var tmpPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"capsule-dl-{Guid.NewGuid():N}");
+        using var resp = await http.GetAsync(url, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, CancellationToken.None);
+        resp.EnsureSuccessStatusCode();
+        await using var srcStream = await resp.Content.ReadAsStreamAsync(CancellationToken.None);
+        await using var dstStream = System.IO.File.Create(tmpPath);
+        await srcStream.CopyToAsync(dstStream, 64 * 1024, CancellationToken.None);
+        return tmpPath;
+    }
+
+    /// <summary>
+    /// 直接从 input 文件路径让 ffmpeg 抽音 → 输出 16kHz mono wav byte[]。
+    /// 与 ExtractAudioWithFfmpegAsync(byte[]) 二选一：流式下载场景应该走这个，
+    /// 避免视频 byte[] 在内存里多停一份
+    /// </summary>
+    private static async Task<byte[]> ExtractAudioWithFfmpegFromFileAsync(string videoPath)
+    {
+        var tmpOut = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"capsule-vt-out-{Guid.NewGuid():N}.wav");
+        try
+        {
+            var psi = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "ffmpeg",
+                ArgumentList = { "-y", "-i", videoPath, "-vn", "-ac", "1", "-ar", "16000", "-acodec", "pcm_s16le", tmpOut },
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var process = System.Diagnostics.Process.Start(psi)
+                ?? throw new InvalidOperationException("ffmpeg 启动失败");
+            var stderrTask = process.StandardError.ReadToEndAsync();
+            var stdoutTask = process.StandardOutput.ReadToEndAsync();
+            await process.WaitForExitAsync();
+            await Task.WhenAll(stderrTask, stdoutTask);
+            if (process.ExitCode != 0)
+            {
+                var err = await stderrTask;
+                throw new InvalidOperationException($"ffmpeg 抽音频失败 (exit={process.ExitCode}): {err}");
+            }
+            return await System.IO.File.ReadAllBytesAsync(tmpOut);
+        }
+        finally
+        {
+            try { if (System.IO.File.Exists(tmpOut)) System.IO.File.Delete(tmpOut); } catch { }
+        }
+    }
+
+    /// <summary>
     /// ffmpeg 抽音（16kHz mono wav）。依赖 host 的 ffmpeg 二进制（CDS 容器已预装）。
     /// 与 SubtitleGenerationProcessor.ExtractAudioWithFfmpegAsync 保持参数一致。
+    /// 注：本接口用于「已经持有完整 byte[]」的场景；流式下载请用 ExtractAudioWithFfmpegFromFileAsync。
     /// </summary>
     private static async Task<byte[]> ExtractAudioWithFfmpegAsync(byte[] videoBytes)
     {

--- a/prd-api/src/PrdAgent.Api/Services/WorkflowRunWorker.cs
+++ b/prd-api/src/PrdAgent.Api/Services/WorkflowRunWorker.cs
@@ -522,6 +522,10 @@ public sealed class WorkflowRunWorker : BackgroundService
         {
             emitEvent = (eventName, payload) => EmitEventAsync(executionId, eventName, payload);
         }
+        // 调试：确保后台 worker 收到的 nodeType 与 CapsuleExecutor 分发常量保持一致
+        // （定位过 CDS 部分部署时 worker 旧代码 / 控制器新代码的 split-brain，加这行强制 CDS 重新打包 worker）
+        _logger.LogDebug("Worker dispatching capsule: nodeType={NodeType} executionId={ExecutionId}",
+            node.NodeType, executionId);
         return await CapsuleExecutor.ExecuteAsync(sp, _logger, node, variables, inputArtifacts, emitEvent);
     }
 

--- a/prd-api/src/PrdAgent.Api/Services/WorkflowRunWorker.cs
+++ b/prd-api/src/PrdAgent.Api/Services/WorkflowRunWorker.cs
@@ -516,9 +516,16 @@ public sealed class WorkflowRunWorker : BackgroundService
         List<ExecutionArtifact> inputArtifacts,
         string executionId)
     {
-        // LLM 类舱支持流式输出事件（分析器 + 报告生成器）
+        // 长任务舱开启 emitEvent 流式推进度事件给 SSE 订阅者：
+        // - LlmAnalyzer / ReportGenerator / WebpageGenerator 的 LLM 流式 token
+        // - MediaRehost 的 N/M 条目 rehost 进度
+        // - VideoToText 的 ASR 转写 + LLM hook 提炼进度（asr 模式才长）
         CapsuleExecutor.EmitEventDelegate? emitEvent = null;
-        if (node.NodeType is CapsuleTypes.LlmAnalyzer or CapsuleTypes.ReportGenerator or CapsuleTypes.WebpageGenerator)
+        if (node.NodeType is CapsuleTypes.LlmAnalyzer
+            or CapsuleTypes.ReportGenerator
+            or CapsuleTypes.WebpageGenerator
+            or CapsuleTypes.MediaRehost
+            or CapsuleTypes.VideoToText)
         {
             emitEvent = (eventName, payload) => EmitEventAsync(executionId, eventName, payload);
         }

--- a/prd-api/src/PrdAgent.Core/Models/AppCallerRegistry.cs
+++ b/prd-api/src/PrdAgent.Core/Models/AppCallerRegistry.cs
@@ -698,6 +698,14 @@ public static class VideoAgent
             Category = "Video"
         )]
         public const string Chat = "video-agent.video-to-text::chat";
+
+        [AppCallerMetadata(
+            "视频转文字-语音识别",
+            "下载视频后通过 ffmpeg 抽取音轨并调用流式 ASR 模型生成转写文字",
+            ModelTypes = new[] { ModelTypes.Asr },
+            Category = "Video"
+        )]
+        public const string Asr = "video-agent.video-to-text::asr";
     }
 
     public static class TextToCopy

--- a/prd-api/src/PrdAgent.Core/Models/CapsuleTypeRegistry.cs
+++ b/prd-api/src/PrdAgent.Core/Models/CapsuleTypeRegistry.cs
@@ -893,6 +893,32 @@ public static class CapsuleTypeRegistry
         },
     };
 
+    public static readonly CapsuleTypeMeta MediaRehost = new()
+    {
+        TypeKey = CapsuleTypes.MediaRehost,
+        Name = "媒体迁移到 COS",
+        Description = "把上游 items 数组里每条记录的视频 / 封面 URL 下载到本平台 COS，输出形态保持一致但 URL 替换成稳定 COS 地址。解决 TikTok / B 站 / 小红书 CDN 防盗链导致前端 403 播放失败的问题。失败的字段保留原 URL 不阻塞流水线",
+        Icon = "cloud-upload",
+        Category = CapsuleCategory.Processor,
+        AccentHue = 220,
+        ConfigSchema = new()
+        {
+            new() { Key = "itemsField", Label = "上游条目字段", FieldType = "text", Required = false, DefaultValue = "items", HelpTip = "上游 JSON 哪个字段是数组（默认 items）。若上游本身是数组或单条目对象，会自动兜底" },
+            new() { Key = "rehostFields", Label = "需要迁移的 URL 字段", FieldType = "text", Required = false, DefaultValue = "videoUrl,coverUrl", HelpTip = "每条 item 的哪些字段是 URL 需要下载迁移（逗号分隔），默认 videoUrl,coverUrl。下游 weekly-poster-publisher 读取的就是这两个字段" },
+            new() { Key = "maxConcurrency", Label = "最大并发数", FieldType = "number", Required = false, DefaultValue = "4", HelpTip = "同时并行下载几个 item，建议 1-8。视频文件较大时降低以避免内存压力" },
+            new() { Key = "maxBytesMb", Label = "单文件上限（MB）", FieldType = "number", Required = false, DefaultValue = "50", HelpTip = "单个媒体文件大于此值视为下载失败，跳过该字段保留原 URL" },
+            new() { Key = "timeoutSeconds", Label = "下载超时（秒）", FieldType = "number", Required = false, DefaultValue = "120", HelpTip = "每个 URL 下载的超时时间。视频文件大时建议 180-300" },
+        },
+        DefaultInputSlots = new()
+        {
+            new() { SlotId = "mr-in", Name = "items", DataType = "json", Required = true, Description = "上游条目数组（含 videoUrl / coverUrl 等字段）" },
+        },
+        DefaultOutputSlots = new()
+        {
+            new() { SlotId = "mr-out", Name = "rehosted", DataType = "json", Required = true, Description = "结构同上游，但指定字段的 URL 已替换为 COS 直链。附带 rehosted / failed 计数" },
+        },
+    };
+
     public static readonly CapsuleTypeMeta HomepagePublisher = new()
     {
         TypeKey = CapsuleTypes.HomepagePublisher,
@@ -1149,7 +1175,7 @@ public static class CapsuleTypeRegistry
         // CLI Agent 执行器
         CliAgentExecutor,
         // 短视频工作流类
-        DouyinParser, VideoDownloader, VideoToText, TextToCopywriting, TiktokCreatorFetch, HomepagePublisher, WeeklyPosterPublisher,
+        DouyinParser, VideoDownloader, VideoToText, TextToCopywriting, TiktokCreatorFetch, MediaRehost, HomepagePublisher, WeeklyPosterPublisher,
     };
 
     /// <summary>按 TypeKey 查找</summary>

--- a/prd-api/src/PrdAgent.Core/Models/CapsuleTypeRegistry.cs
+++ b/prd-api/src/PrdAgent.Core/Models/CapsuleTypeRegistry.cs
@@ -815,8 +815,8 @@ public static class CapsuleTypeRegistry
     public static readonly CapsuleTypeMeta TiktokCreatorFetch = new()
     {
         TypeKey = CapsuleTypes.TiktokCreatorFetch,
-        Name = "TikTok 博主视频列表",
-        Description = "调用 TikHub API 拉取指定 TikTok / 抖音博主的最新视频列表。输出标准化的视频条目数组（含 videoUrl / coverUrl / title / awemeId），可作为「博主订阅」工作流的源头",
+        Name = "博主作品订阅 (TikHub)",
+        Description = "通过 TikHub 一站式拉取多平台博主最新作品：TikTok / 抖音 / B 站 / 小红书 / YouTube。输出标准化条目数组（awemeId / title / videoUrl / coverUrl / author / shareUrl），可作为海报订阅工作流的源头。注：B 站和 YouTube 不给 mp4 直链，海报会展示封面 + 跳转链接",
         Icon = "video",
         Category = CapsuleCategory.Processor,
         AccentHue = 340,
@@ -824,14 +824,17 @@ public static class CapsuleTypeRegistry
         {
             new() { Key = "platform", Label = "平台", FieldType = "select", Required = true, DefaultValue = "tiktok", Options = new()
             {
-                new() { Value = "tiktok", Label = "TikTok（海外，使用 secUid）" },
-                new() { Value = "douyin", Label = "抖音（国内，使用 sec_user_id）" },
-            }, HelpTip = "选择目标平台。TikTok 用 secUid，抖音用 sec_user_id（参考 tikhub.io 文档获取）" },
+                new() { Value = "tiktok", Label = "TikTok（海外短视频，secUid）" },
+                new() { Value = "douyin", Label = "抖音（国内短视频，sec_user_id）" },
+                new() { Value = "bilibili", Label = "B 站（UP 主投稿，mid 数字）" },
+                new() { Value = "xiaohongshu", Label = "小红书（图文/视频笔记，user_id）" },
+                new() { Value = "youtube", Label = "YouTube（频道视频，channelId）" },
+            }, HelpTip = "选择目标平台，下方「博主 ID」字段会按所选平台读取对应 ID 类型" },
             new() { Key = "apiBaseUrl", Label = "TikHub API 地址", FieldType = "text", Required = false, DefaultValue = "https://api.tikhub.io", HelpTip = "TikHub API 基础地址，留空走默认 https://api.tikhub.io" },
             new() { Key = "apiKey", Label = "API 密钥", FieldType = "password", Required = true, Placeholder = "Bearer xxx", HelpTip = "TikHub API 认证密钥，可使用 {{secrets.TIKHUB_API_KEY}} 引用工作流密钥" },
-            new() { Key = "secUid", Label = "博主 secUid / sec_user_id", FieldType = "text", Required = true, Placeholder = "MS4wLjABAAAA...", HelpTip = "TikTok 博主 secUid（从博主主页 URL 或 TikHub 用户搜索接口取得），抖音填 sec_user_id" },
-            new() { Key = "count", Label = "拉取数量", FieldType = "number", Required = false, DefaultValue = "10", HelpTip = "本次最多拉取多少条视频，建议 1-30。首次测试可设为 1" },
-            new() { Key = "cursor", Label = "起始游标", FieldType = "text", Required = false, DefaultValue = "0", HelpTip = "翻页游标，留空或 0 从最新开始" },
+            new() { Key = "secUid", Label = "博主 ID", FieldType = "text", Required = true, Placeholder = "按平台填写：TikTok=secUid / 抖音=sec_user_id / B站=mid / 小红书=user_id / YouTube=channelId", HelpTip = "TikTok / 抖音填 secUid 或 sec_user_id（MS4wLjAB... 格式）；B 站填 UP 主 mid（数字，如 12345678）；小红书填 user_id（从博主主页 URL 末段取）；YouTube 填 channelId（UCxxxxx...）" },
+            new() { Key = "count", Label = "拉取数量", FieldType = "number", Required = false, DefaultValue = "10", HelpTip = "本次最多拉取多少条作品，建议 1-30。首次测试可设为 1" },
+            new() { Key = "cursor", Label = "起始游标", FieldType = "text", Required = false, DefaultValue = "0", HelpTip = "翻页游标（仅对支持游标的平台生效：TikTok / 抖音 / 小红书）。B 站和 YouTube 走页码不用此字段" },
         },
         DefaultInputSlots = new()
         {

--- a/prd-api/src/PrdAgent.Core/Models/CapsuleTypeRegistry.cs
+++ b/prd-api/src/PrdAgent.Core/Models/CapsuleTypeRegistry.cs
@@ -866,8 +866,9 @@ public static class CapsuleTypeRegistry
             new() { Key = "presentationMode", Label = "展示样式", FieldType = "select", Required = false, DefaultValue = "ad-4-3", Options = new()
             {
                 new() { Value = "ad-4-3", Label = "ad-4-3（4:3 视频广告样式，中央 Play 按钮，推荐）" },
+                new() { Value = "ad-rich-text", Label = "ad-rich-text（图文混排：左动图 + 右 hook & bullets，需 video-to-text 提供 body）" },
                 new() { Value = "static", Label = "static（1200×628 横幅样式，自动播放）" },
-            }, HelpTip = "ad-4-3：借鉴 Apple 产品视频弹窗，全 bleed 封面 + 中央 Play 按钮，用户主动点击才播。static：传统横幅 48% 上图 52% 下文" },
+            }, HelpTip = "ad-4-3：全 bleed 封面 + 中央 Play 按钮（Apple 产品视频弹窗风格）。ad-rich-text：左侧 9:16 动态封面 + 右侧 hook 大字 + bullets（Instagram Story Ad / 小红书笔记风格），需上游 body 已结构化。static：传统 48% 上图 52% 下文横幅" },
             new() { Key = "accentColor", Label = "强调色", FieldType = "text", Required = false, DefaultValue = "#ff0050", HelpTip = "页面主色调（hex），TikTok 粉默认 #ff0050" },
             new() { Key = "ctaText", Label = "末页按钮文案", FieldType = "text", Required = false, DefaultValue = "去看完整视频" },
             new() { Key = "ctaUrlField", Label = "CTA 链接字段", FieldType = "text", Required = false, DefaultValue = "firstItem.shareUrl", HelpTip = "从上游 JSON 取哪个字段做 CTA 链接（点号路径），留空时退回到 #" },

--- a/prd-api/src/PrdAgent.Core/Models/CapsuleTypeRegistry.cs
+++ b/prd-api/src/PrdAgent.Core/Models/CapsuleTypeRegistry.cs
@@ -866,12 +866,13 @@ public static class CapsuleTypeRegistry
                 new() { Value = "promo", Label = "promo（推广，TikTok 推荐用）" },
                 new() { Value = "sale", Label = "sale（活动）" },
             } },
-            new() { Key = "presentationMode", Label = "展示样式", FieldType = "select", Required = false, DefaultValue = "ad-4-3", Options = new()
+            new() { Key = "presentationMode", Label = "展示样式", FieldType = "select", Required = false, DefaultValue = "feed-card", Options = new()
             {
-                new() { Value = "ad-4-3", Label = "ad-4-3（4:3 视频广告样式，中央 Play 按钮，推荐）" },
+                new() { Value = "feed-card", Label = "feed-card（抖音 / 小红书风格内容卡：作者头像 + 标题 + 标签 + 互动指标，推荐）" },
+                new() { Value = "ad-4-3", Label = "ad-4-3（4:3 视频广告样式，中央 Play 按钮）" },
                 new() { Value = "ad-rich-text", Label = "ad-rich-text（图文混排：左动图 + 右 hook & bullets，需 video-to-text 提供 body）" },
                 new() { Value = "static", Label = "static（1200×628 横幅样式，自动播放）" },
-            }, HelpTip = "ad-4-3：全 bleed 封面 + 中央 Play 按钮（Apple 产品视频弹窗风格）。ad-rich-text：左侧 9:16 动态封面 + 右侧 hook 大字 + bullets（Instagram Story Ad / 小红书笔记风格），需上游 body 已结构化。static：传统 48% 上图 52% 下文横幅" },
+            }, HelpTip = "feed-card：完整短视频内容卡，把作者头像 / 时长 / 标题 / 标签 / 点赞评论数全部嵌进海报（推荐用于博主订阅）。ad-4-3：全 bleed 封面 + 中央 Play 按钮。ad-rich-text：左侧 9:16 动态封面 + 右侧 hook 大字 + bullets。static：传统 48% 上图 52% 下文横幅" },
             new() { Key = "accentColor", Label = "强调色", FieldType = "text", Required = false, DefaultValue = "#ff0050", HelpTip = "页面主色调（hex），TikTok 粉默认 #ff0050" },
             new() { Key = "ctaText", Label = "末页按钮文案", FieldType = "text", Required = false, DefaultValue = "去看完整视频" },
             new() { Key = "ctaUrlField", Label = "CTA 链接字段", FieldType = "text", Required = false, DefaultValue = "firstItem.shareUrl", HelpTip = "从上游 JSON 取哪个字段做 CTA 链接（点号路径），留空时退回到 #" },

--- a/prd-api/src/PrdAgent.Core/Models/CapsuleTypeRegistry.cs
+++ b/prd-api/src/PrdAgent.Core/Models/CapsuleTypeRegistry.cs
@@ -986,7 +986,7 @@ public static class CapsuleTypeRegistry
             new() { Key = "systemPrompt", Label = "LLM 系统提示词", FieldType = "textarea", Required = false, Placeholder = "你是一个短视频内容分析专家…", HelpTip = "仅 llm 模式生效。自定义 LLM 的分析角色和输出要求" },
             new() { Key = "videoUrlField", Label = "视频 URL 字段", FieldType = "text", Required = false, DefaultValue = "videoUrl", HelpTip = "仅 asr 模式生效。从上游每个 item 取哪个字段作为视频 URL（点号路径，常见：videoUrl / video_url / playUrl / cosUrl）" },
             new() { Key = "itemsField", Label = "上游条目字段", FieldType = "text", Required = false, DefaultValue = "items", HelpTip = "仅 asr 模式生效。上游 JSON 哪个字段是数组（默认 items）。若上游本身是数组或单条目对象，会自动兜底" },
-            new() { Key = "maxItems", Label = "最多处理条目数", FieldType = "number", Required = false, DefaultValue = "4", HelpTip = "仅 asr 模式生效。每条 ASR 大约 10-60s，建议 1-10。超出部分原样透传不做转写" },
+            new() { Key = "maxItems", Label = "最多处理条目数", FieldType = "number", Required = false, DefaultValue = "", HelpTip = "仅 asr 模式生效。空值 = 处理上游全部条目（推荐，自动跟随 count）；填正整数则按数量截断。每条 ASR 约 10-60s" },
             new() { Key = "enableHookExtraction", Label = "AI 二次提炼 hook + bullets", FieldType = "select", Required = false, DefaultValue = "true", Options = new()
             {
                 new() { Value = "true", Label = "开启（转写后再走 LLM 出一句话 hook + 三条要点）" },

--- a/prd-api/src/PrdAgent.Core/Models/CapsuleTypeRegistry.cs
+++ b/prd-api/src/PrdAgent.Core/Models/CapsuleTypeRegistry.cs
@@ -971,7 +971,7 @@ public static class CapsuleTypeRegistry
     {
         TypeKey = CapsuleTypes.VideoToText,
         Name = "视频内容转文本",
-        Description = "使用 LLM 多模态能力或音频转写将视频内容解析为结构化文本（标题、旁白/字幕、画面描述）",
+        Description = "三种模式把视频转文本：metadata 直接读元数据 / llm 多模态深读 / asr 真实下载视频 + ffmpeg 抽音轨 + 流式 ASR 转写。asr 模式默认再走一次 LLM 提炼出 hook 大字 + bullets，可直接喂给 ad-rich-text 海报",
         Icon = "file-text",
         Category = CapsuleCategory.Processor,
         AccentHue = 260,
@@ -979,18 +979,28 @@ public static class CapsuleTypeRegistry
         {
             new() { Key = "extractMode", Label = "提取模式", FieldType = "select", Required = false, DefaultValue = "metadata", Options = new()
             {
-                new() { Value = "metadata", Label = "从元数据提取（标题+描述+字幕，快速免费）" },
-                new() { Value = "llm", Label = "LLM 智能分析（结合封面+描述深度解读）" },
-            }, HelpTip = "metadata 模式直接使用上游解析的元数据；llm 模式调用大模型进行深度内容解读" },
-            new() { Key = "systemPrompt", Label = "LLM 系统提示词", FieldType = "textarea", Required = false, Placeholder = "你是一个短视频内容分析专家…", HelpTip = "仅 LLM 模式生效。自定义 LLM 的分析角色和输出要求" },
+                new() { Value = "metadata", Label = "metadata（直接读上游字段，免费秒级）" },
+                new() { Value = "llm", Label = "llm（封面 + 描述多模态分析）" },
+                new() { Value = "asr", Label = "asr（下载视频 + ffmpeg + 流式 ASR + 可选 hook 提炼，慢但有真实转写）" },
+            }, HelpTip = "metadata：直接拼上游已有 title/desc/subtitle 字段。llm：调多模态模型基于封面 + 描述推断旁白。asr：下载视频→ffmpeg 抽音→ASR 流式转写，每条耗时 10-60s，可用 maxItems 限制" },
+            new() { Key = "systemPrompt", Label = "LLM 系统提示词", FieldType = "textarea", Required = false, Placeholder = "你是一个短视频内容分析专家…", HelpTip = "仅 llm 模式生效。自定义 LLM 的分析角色和输出要求" },
+            new() { Key = "videoUrlField", Label = "视频 URL 字段", FieldType = "text", Required = false, DefaultValue = "videoUrl", HelpTip = "仅 asr 模式生效。从上游每个 item 取哪个字段作为视频 URL（点号路径，常见：videoUrl / video_url / playUrl / cosUrl）" },
+            new() { Key = "itemsField", Label = "上游条目字段", FieldType = "text", Required = false, DefaultValue = "items", HelpTip = "仅 asr 模式生效。上游 JSON 哪个字段是数组（默认 items）。若上游本身是数组或单条目对象，会自动兜底" },
+            new() { Key = "maxItems", Label = "最多处理条目数", FieldType = "number", Required = false, DefaultValue = "4", HelpTip = "仅 asr 模式生效。每条 ASR 大约 10-60s，建议 1-10。超出部分原样透传不做转写" },
+            new() { Key = "enableHookExtraction", Label = "AI 二次提炼 hook + bullets", FieldType = "select", Required = false, DefaultValue = "true", Options = new()
+            {
+                new() { Value = "true", Label = "开启（转写后再走 LLM 出一句话 hook + 三条要点）" },
+                new() { Value = "false", Label = "关闭（仅输出原始转写文字）" },
+            }, HelpTip = "仅 asr 模式生效。开启后输出 item.hook（一句话钩子）+ item.bullets（要点数组）+ item.body（拼好的 markdown），可直接灌到 ad-rich-text 海报的 body 字段" },
+            new() { Key = "hookSystemPrompt", Label = "hook 提炼系统提示词", FieldType = "textarea", Required = false, Placeholder = "你是短视频文案专家…", HelpTip = "仅 asr 模式且开启 hook 提炼时生效。留空走默认提示词，输出 JSON：{\"hook\":\"\",\"bullets\":[\"\"]}" },
         },
         DefaultInputSlots = new()
         {
-            new() { SlotId = "vt-in", Name = "videoInfo", DataType = "json", Required = true, Description = "视频信息（含 title、description、subtitles 等字段）" },
+            new() { SlotId = "vt-in", Name = "videoInfo", DataType = "json", Required = true, Description = "视频信息或 items 数组（asr 模式下会自动检测：单对象按一条处理，{items:[...]} 或裸数组按多条处理）" },
         },
         DefaultOutputSlots = new()
         {
-            new() { SlotId = "vt-out", Name = "textContent", DataType = "json", Required = true, Description = "结构化文本内容（title、transcript、description、tags）" },
+            new() { SlotId = "vt-out", Name = "textContent", DataType = "json", Required = true, Description = "原结构 + 新增字段：transcript / hook / bullets / body（markdown bullets）。数组输入时返回 {items:[...], firstItem:{...}} 包装" },
         },
     };
 

--- a/prd-api/src/PrdAgent.Core/Models/WeeklyPosterAnnouncement.cs
+++ b/prd-api/src/PrdAgent.Core/Models/WeeklyPosterAnnouncement.cs
@@ -79,6 +79,36 @@ public class WeeklyPosterPage
 
     /// <summary>卡片主色调十六进制(如 "#7c3aed"),空值走默认紫</summary>
     public string? AccentColor { get; set; }
+
+    // ── feed-card 版式新增字段（短视频内容卡所需信息单元，全部可选向下兼容）──
+
+    /// <summary>作者昵称（如 @飞天闪客）</summary>
+    public string? AuthorName { get; set; }
+
+    /// <summary>作者头像 URL（推荐已 rehost 到 COS）</summary>
+    public string? AuthorAvatarUrl { get; set; }
+
+    /// <summary>来源平台标识：tiktok / douyin / bilibili / xiaohongshu / youtube</summary>
+    public string? Platform { get; set; }
+
+    /// <summary>视频时长（秒），用于顶部条展示</summary>
+    public int? DurationSec { get; set; }
+
+    /// <summary>话题标签数组（去掉 # 前缀），用于底部 chip 列表渲染</summary>
+    public List<string>? Hashtags { get; set; }
+
+    /// <summary>互动统计（点赞/评论/收藏/分享/播放数）</summary>
+    public PosterPageStats? Stats { get; set; }
+}
+
+/// <summary>短视频互动统计（feed-card 右栏数据）</summary>
+public class PosterPageStats
+{
+    public long? Likes { get; set; }
+    public long? Comments { get; set; }
+    public long? Shares { get; set; }
+    public long? Collects { get; set; }
+    public long? Plays { get; set; }
 }
 
 public static class WeeklyPosterStatus

--- a/prd-api/src/PrdAgent.Core/Models/WeeklyPosterAnnouncement.cs
+++ b/prd-api/src/PrdAgent.Core/Models/WeeklyPosterAnnouncement.cs
@@ -26,7 +26,7 @@ public class WeeklyPosterAnnouncement
     /// <summary>模板 key(release / hotfix / promo / sale),决定 AI 生成的语调与色板</summary>
     public string TemplateKey { get; set; } = "release";
 
-    /// <summary>展示形态(static / fullscreen / interactive),当前仅 static 可用</summary>
+    /// <summary>展示形态。已落地：static（1200×628 横幅）/ ad-4-3（4:3 视频广告）/ ad-rich-text（图文混排 4:3）。fullscreen / interactive 预留未实现</summary>
     public string PresentationMode { get; set; } = "static";
 
     /// <summary>数据源类型(changelog-current-week / freeform 等)</summary>

--- a/prd-api/src/PrdAgent.Core/Models/WeeklyPosterAnnouncement.cs
+++ b/prd-api/src/PrdAgent.Core/Models/WeeklyPosterAnnouncement.cs
@@ -99,6 +99,9 @@ public class WeeklyPosterPage
 
     /// <summary>互动统计（点赞/评论/收藏/分享/播放数）</summary>
     public PosterPageStats? Stats { get; set; }
+
+    /// <summary>带时间戳的字幕轨道（从 ASR utterances 抽取，video.timeupdate 同步显示当前句）</summary>
+    public List<TranscriptCue>? TranscriptCues { get; set; }
 }
 
 /// <summary>短视频互动统计（feed-card 右栏数据）</summary>
@@ -109,6 +112,17 @@ public class PosterPageStats
     public long? Shares { get; set; }
     public long? Collects { get; set; }
     public long? Plays { get; set; }
+}
+
+/// <summary>字幕条目：开始时间、结束时间（秒）、文字</summary>
+public class TranscriptCue
+{
+    /// <summary>开始时间（秒，相对视频起点）</summary>
+    public double StartSec { get; set; }
+    /// <summary>结束时间（秒，相对视频起点）</summary>
+    public double EndSec { get; set; }
+    /// <summary>文字</summary>
+    public string Text { get; set; } = string.Empty;
 }
 
 public static class WeeklyPosterStatus

--- a/prd-api/src/PrdAgent.Core/Models/WorkflowModels.cs
+++ b/prd-api/src/PrdAgent.Core/Models/WorkflowModels.cs
@@ -468,6 +468,7 @@ public static class CapsuleTypes
     public const string TiktokCreatorFetch = "tiktok-creator-fetch";
     public const string HomepagePublisher = "homepage-publisher";
     public const string WeeklyPosterPublisher = "weekly-poster-publisher";
+    public const string MediaRehost = "media-rehost";
 
     // 兼容旧类型映射
     public const string DataCollectorLegacy = "data-collector";
@@ -487,7 +488,7 @@ public static class CapsuleTypes
         // CLI Agent 执行器
         CliAgentExecutor,
         // 短视频工作流类
-        DouyinParser, VideoDownloader, VideoToText, TextToCopywriting, TiktokCreatorFetch,
+        DouyinParser, VideoDownloader, VideoToText, TextToCopywriting, TiktokCreatorFetch, MediaRehost,
         // 旧类型兼容
         DataCollectorLegacy, LlmCodeExecutorLegacy, RendererLegacy,
     };


### PR DESCRIPTION
## 摘要

涌现 1 系列 Phase 2 + Phase 3 全量交付。把「TikTok / 抖音 博主订阅 → 首页广告海报」从原 2 平台 + 1 版式扩展为 **5 平台 + 4 版式 + 真实播放页内容卡** 一站式。

- **Phase 2**（A/B/C）：video-to-text asr 模式 / ad-rich-text 海报 / rich-text 模板，加 7 项还债
- **Phase 3**：5 平台多平台扩展 / media-rehost 胶囊（解决 CDN 防盗链）/ feed-card 9 信息单元布局 / ASR 字幕时间轴浮层 / 海报最小化到右下角

## 改动 diff

### 新增

- `prd-api/Services/CapsuleExecutor.cs` 新增方法：
  - `ExecuteVideoToTextAsrAsync` + `ExtractAudioWithFfmpegAsync` + `EnsureFfmpegAvailableAsync` + `TryExtractJsonObject`（ASR 模式 + 时间戳 cue 抽取）
  - `ExecuteMediaRehostAsync` + `GuessRehostExt` + `GuessRehostMime` + `BuildRehostObjectKey`（媒体迁移到 COS）
  - `NormalizeBilibiliVideoItem` + `NormalizeXiaohongshuItem` + `NormalizeYoutubeVideoItem` + `NormalizeCreatorVideoItem` dispatcher
  - `TryGetJsonLong` + `ExtractTiktokUrlList` 工具
- `prd-api/Models/CapsuleTypeRegistry.cs`：新增 `MediaRehost` meta；TiktokCreatorFetch 平台 2 → 5；WeeklyPosterPublisher 加 `feed-card` + `ad-rich-text` 选项
- `prd-api/Models/WorkflowModels.cs`：`CapsuleTypes.MediaRehost` 常量
- `prd-api/Models/WeeklyPosterAnnouncement.cs`：`WeeklyPosterPage` 加 7 个可选字段（authorName / avatar / platform / durationSec / hashtags / stats / transcriptCues），新增 `PosterPageStats` + `TranscriptCue` 类
- `prd-api/Models/AppCallerRegistry.cs`：`VideoAgent.VideoToText.Asr` 新 caller
- `prd-admin/components/weekly-poster/WeeklyPosterModal.tsx` 新增组件：
  - `PosterFeedCardView`：抖音风格 9 信息单元布局 + 视频比例自适应 + cue timeupdate 同步
  - `PosterRichTextPageView`：左动图 + 右 hook bullets
  - `PosterAdPageView`：4:3 中央 Play
  - `FeedStatChip` + `formatStatNumber` + `formatDuration` 工具
- `prd-admin/services/real/weeklyPoster.ts`：`PosterPageStats` + `TranscriptCue` interface
- `prd-admin/pages/workflow-agent/workflowTemplates.ts`：`tiktokCreatorToHomepageRichTemplate` 模板 + `PLATFORM_OPTIONS` / `PLATFORM_CTA_LABELS` / `PLATFORM_ID_HELP` 共享常量
- `doc/guide.poster-feed-card.md`：用户教程（首发，10 节完整指南）
- `doc/debt.workflow-agent.md`：v2.0 债务台账（Phase 2 7 项 paid + Phase 3 5 项 open）
- `changelogs/2026-05-06_emergence-1-phase-2-rich-text-poster.md`
- `changelogs/2026-05-07_emergence-1-phase-3-feed-card.md`

### 调整

- `prd-api/Controllers/Api/WeeklyPosterController.cs`：`WeeklyPosterPageDto` 同步透出 7 个新字段
- `prd-api/Services/WorkflowRunWorker.cs`：`ExecuteCapsuleAsync` 加 LogDebug
- `prd-admin/pages/workflow-agent/capsuleRegistry.tsx`：`media-rehost` 胶囊注册 CloudUpload 图标
- `doc/plan.emergence-1-tiktok-douyin-poster.md`：加 §3 Phase 3 已交付段
- `doc/index.yml` + `doc/guide.list.directory.md`：注册 `guide.poster-feed-card`

## 测试

- [x] 本地 `dotnet build --no-restore` 零 `error CS*`
- [x] `pnpm tsc --noEmit` + `pnpm exec eslint` 本次改动文件零新增告警
- [x] `capsules/test-run` 端到端验证：media-rehost 真上传 COS（3 个 URL 200 OK）/ feed-card 7 个新字段全部持久化 + GET 返回
- [x] 真跑用户工作流（飞天闪客抖音 5 条作品）：fetch 200 + rehost 7 个文件上 COS + publish feed-card poster，stats 与抖音页面一致
- [x] 5 平台 endpoint 路径探测：fake key 全部 401（路径正确，非 404）
- [ ] 真人通过预览域名验收（依赖切到 static 部署模式）

## 已知边界（详见 `doc/debt.workflow-agent.md` v2.0）

1. **CDS dev 模式 dotnet watch 遇 rude edit 卡进程**：本次新增 case/method/class 期间 worker 跑了 24h 前的 IL，命中率 ~12%。**根本解法是切到 static 部署模式**（CDS dashboard 操作）
2. B 站 / YouTube list endpoint 不给 mp4 直链，海报 CTA 跳转原平台
3. 小红书图文笔记暂不支持图集翻页
4. avatar URL 也防盗链，模板默认已加到 `rehostFields`，用户改配置时易漏
5. `transcriptCues` 仅 ASR 模式可得，metadata/llm 模式不渲染浮层（向下兼容）
6. 任务 D（抖音 OAuth + cron 真订阅）暂缓

## 用户教程

`doc/guide.poster-feed-card.md` —— 10 节面向首次使用者，含 5 平台 ID 怎么取 / 4 种 presentationMode 选择对比 / FAQ / dotnet watch 卡住的解决方案。

## 验收路径

```
登录 https://review-emergence-plan-y8por-claude-prd-agent.miduo.org/
  → 工作流 → 新建 → 选「多平台博主订阅 → 首页广告海报 (TikHub)」
  → 平台选 douyin，secUid 填博主真 sec_user_id，apiKey 填真 TikHub key
  → 执行（约 30s ~ 2min）
  → 登录任意账号 → 首页弹出 feed-card 海报（头像 + 平台 chip + 互动 chip + 标题 + 标签）
  → 点 X 收起到右下角胶囊，点胶囊重新展开，点胶囊上 ✕ 才彻底关闭
```

https://claude.ai/code/session_01L42F1e3JKRsSsb75srTBgs

---
_Generated by [Claude Code](https://claude.ai/code/session_01L42F1e3JKRsSsb75srTBgs)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it adds new workflow capsules that download/rehost media and run ffmpeg/ASR+LLM processing, plus expands poster DTO/schema and modal behavior; failures could impact poster publishing/playback and resource usage.
> 
> **Overview**
> Delivers Phase 2/3 of “creator subscription → homepage poster” by expanding TikHub creator fetch from 2 to **5 platforms** and adding a new `media-rehost` capsule that downloads item media (video/cover/avatar) to COS to avoid hotlink 403s.
> 
> Extends `video-to-text` with an **`asr` mode** (download → ffmpeg extract audio → streaming ASR → optional LLM hook/bullets) and threads new metadata through `weekly-poster-publisher` so pages can prefer upstream `item.hook`/`item.body` and persist **new feed-card fields** (`authorName`, `avatar`, `platform`, `durationSec`, `hashtags`, `stats`, `transcriptCues`).
> 
> Updates the admin poster modal to support new presentation modes `ad-rich-text` and `feed-card` (aspect-aware sizing, interactive stat rail, timestamped subtitle overlay), and changes close behavior to **minimize into a bottom-right capsule**; workflow templates are updated to insert `media-rehost` and offer a new ASR-rich template. Documentation/changelogs add a new user guide and update the workflow-agent debt ledger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9334220a4c65d71e628a006ec455c351be25dfeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->