### PR TITLE
Add workflow scheduling & auto-publish dialog for weekly posters

### DIFF
--- a/changelogs/2026-05-07_poster-auto-publish.md
+++ b/changelogs/2026-05-07_poster-auto-publish.md
@@ -1,0 +1,5 @@
+| feat | prd-admin | 海报编辑页新增「新建自动发布」入口：选工作流 + 填变量（博主id/视频个数）+ 选 presentationMode/templateKey/品牌色，支持立即执行 / 定时一次 / 循环 (Cron) 三种调度 |
+| feat | prd-api | 新增 `/api/workflow-agent/schedules` CRUD 端点 + `WorkflowScheduleWorker` 后台轮询，按 once/cron 触发工作流；内置极简 5 字段 Cron 解析器 |
+| feat | prd-api | WeeklyPosterPublisher capsule 的 templateKey/presentationMode/accentColor 现在支持 `{{var}}` 模板和 variables 兜底，让海报页对话框不必改工作流配置即可覆盖版式 |
+| fix | prd-api | WeeklyPosterPublisher 找不到 items 字段时新增 TikHub raw 响应路径兜底（data.aweme_list / itemList / list / vlist 等），并在错误信息里列出顶层字段帮助用户排查 |
+| feat | prd-admin | 横屏视频卡尺寸放大约 17%（feed-card 16:9 920→1100、ad-4-3 960→1120），并在 feed-card 模式给视频卡加 accent 色描边 + 顶部 4px 品牌色细带 + 有色光晕，让短视频卡看起来像「海报里嵌的视频」而不是「光秃秃的视频」 |

--- a/changelogs/2026-05-07_poster-cqw-fix.md
+++ b/changelogs/2026-05-07_poster-cqw-fix.md
@@ -1,0 +1,2 @@
+| fix | prd-admin | 海报编辑页 76% 缩放预览下标题溢出修复：把 PosterAdPageView / PosterRichTextPageView / WeeklyPosterPageView 的字号从 vw 改成 cqw（容器查询单位），字号跟随容器宽度自适应而非 viewport，缩放预览不再溢出 |
+| fix | prd-admin | 9:16 竖屏首页弹窗也加大到 540px（+17.4%），4:3/16:9/ad-4-3 视口预算从 80px 缩到 40px 让 cap 在 1080p 屏上能用满 |

--- a/changelogs/2026-05-07_poster-revert-and-polish.md
+++ b/changelogs/2026-05-07_poster-revert-and-polish.md
@@ -1,0 +1,5 @@
+| fix | prd-admin | 海报编辑页缩放预览改用 transform:scale 而非缩小容器宽度，内部 DOM 永远在 1200×628 设计稿尺寸下渲染（vw 字号在容器内永远准确），76% 缩放下不再溢出也不再"更丑"；回滚上一轮的 cqw 改动 |
+| fix | prd-admin | 海报缩略图（页面列表 / 素材卡 / 生成页卡）禁用 autoPlay loop，改用 preload="metadata" 仅取首帧当封面，多卡同屏不再消耗大量 CPU/GPU |
+| fix | prd-admin | 海报编辑页主画布大图视频也改 preload="metadata"，避免编辑页一直在后台播放视频 |
+| feat | prd-admin | 首页海报弹窗改为"每会话只弹一次"：弹出 1.5s 后自动登记已看过到 sessionStorage，同会话再进主页不重弹；浏览器关闭后下次登录视为新会话 |
+| feat | prd-admin | AutoPublishDialog 立即执行后会轮询执行状态最多 60 秒，把首个失败节点的错误（节点名 + 错误信息）直接 toast 给用户，不再"秒过黑盒" |

--- a/changelogs/2026-05-08_bugbot-dedup-and-deadcode.md
+++ b/changelogs/2026-05-08_bugbot-dedup-and-deadcode.md
@@ -1,0 +1,2 @@
+| refactor | prd-admin | hexToRgba 合并到 lib/themeComputed.ts —— 把原版（脆弱：无长度校验、无 #RGB 简写、非法时崩）替换为 robust 版（支持 #RGB / 非法 fallback / trim），WeeklyPosterModal 改 import 不再本地复制 (Bugbot Low) |
+| chore | prd-admin | 删除三个未消费的调度服务函数 listWorkflowSchedules / updateWorkflowSchedule / deleteWorkflowSchedule + 对应 contract 类型；目前只有 createWorkflowSchedule 在 AutoPublishDialog 用，剩余三个属未来用途的死代码，CLAUDE.md 规则禁止 (Bugbot Low) |

--- a/changelogs/2026-05-08_codex-review-fixes.md
+++ b/changelogs/2026-05-08_codex-review-fixes.md
@@ -1,0 +1,3 @@
+| fix | prd-admin | 海报弹窗 1.5s 自动 markSeen 不再关闭 modal —— 之前 dismiss(id) 同时把 id 加入 closedIds 导致 shouldShowCurrent 变 false，modal 立刻消失。改为 markSeen 静默写后端 SeenBy + sessionStorage，dismiss 仅在用户主动 ✕ 时调用 (Codex P1) |
+| fix | prd-api | CronEvaluator 现在按 schedule.Timezone 解释 cron 字段（默认 Asia/Shanghai），cron "0 9 * * *" 真正落在 09:00 CST = 01:00 UTC 而非 09:00 UTC = 17:00 CST。Controller create + WorkflowScheduleWorker 的 next 计算路径都串通 timezone 参数 (Codex P2) |
+| test | prd-api | WorkflowSchedule_DefaultValues 断言适配新 nullable CronExpression：Assert.Empty → Assert.Null + 增加 Mode 默认值断言 |

--- a/changelogs/2026-05-08_cron-bugbot-fixes.md
+++ b/changelogs/2026-05-08_cron-bugbot-fixes.md
@@ -1,0 +1,3 @@
+| fix | prd-api | CronEvaluator dom/dow 改为 Vixie/POSIX OR 语义 — `0 9 1 * 5` 现在按"每月 1 号 OR 每周五 9 点"匹配（之前是 AND，要求同时满足，导致漏触发）(Bugbot Low) |
+| fix | prd-api | CronEvaluator 跳过 DST spring-forward gap — `tz.IsInvalidTime(t)` 命中时 skip 这一分钟而不是抛 ArgumentException（避免 worker 永久禁用调度 + controller 误报"Cron 不合法"）(Bugbot Medium) |
+| test | prd-api | 新增 5 个 CronEvaluator 单元测试：timezone 转换、UTC 默认、dom/dow OR 语义、DST gap 不抛、字段校验 |

--- a/changelogs/2026-05-08_poster-seen-by.md
+++ b/changelogs/2026-05-08_poster-seen-by.md
@@ -1,0 +1,3 @@
+| feat | prd-api | WeeklyPosterAnnouncement 加 SeenBy: List<string>（已看过的用户ID）；GET /current 过滤掉当前用户已读，新增 POST /api/weekly-posters/:id/mark-seen 端点（AddToSet 去重） |
+| feat | prd-admin | 海报弹窗"已读"改走后端持久化：weeklyPosterStore.dismiss 调 markWeeklyPosterSeen API；用户登录看过一次后跨会话/跨设备都不再弹，发布了新海报（不同 id）时所有用户再弹一次 |
+| fix | prd-api | ControllerIdentityExtensions 补 GetUserIdOrNull 扩展（替代 WeeklyPosterController 用过但未声明的 helper） |

--- a/prd-admin/src/components/weekly-poster/AutoPublishDialog.tsx
+++ b/prd-admin/src/components/weekly-poster/AutoPublishDialog.tsx
@@ -4,6 +4,7 @@ import { Loader2, Play, Send, Calendar, Repeat, X, Sparkles, Eye, ChevronDown } 
 import {
   listWorkflows,
   executeWorkflow,
+  getExecution,
   createWorkflowSchedule,
   type Workflow,
   type WeeklyPosterPresentationMode,
@@ -136,12 +137,26 @@ export function AutoPublishDialog({ open, onClose, onPublished }: AutoPublishDia
     try {
       if (mode === 'now') {
         const res = await executeWorkflow({ id: selectedWorkflowId, variables: finalVars });
-        if (res.success) {
-          toast.success('已入队执行，几秒后查看首页弹窗');
+        if (!res.success || !res.data) {
+          toast.error(res.error?.message || '执行入队失败');
+          return;
+        }
+        const execId = res.data.execution.id;
+        toast.success('已入队，正在执行…');
+        // 轮询执行状态，最多 60 秒；失败时把首个失败节点的错误展示给用户
+        // —— 解决「秒过但仍报错」的盲区，让用户立刻看到根因
+        const result = await pollExecution(execId, 60_000);
+        if (result.kind === 'completed') {
+          toast.success(`已发布到首页 · 海报${result.posterCount > 0 ? ` (${result.posterCount} 页)` : ''} · 刷新主页查看`);
           onPublished?.();
           onClose();
+        } else if (result.kind === 'failed') {
+          const detail = result.failedNode
+            ? `节点「${result.failedNode.nodeName || result.failedNode.nodeType}」失败：${result.failedNode.errorMessage || result.errorMessage || '未知原因'}`
+            : (result.errorMessage || '执行失败');
+          toast.error(detail);
         } else {
-          toast.error(res.error?.message || '执行失败');
+          toast.error('执行超时（60s 仍未完成），可去执行历史查看进度');
         }
       } else if (mode === 'once') {
         const runAtUtc = new Date(runAtLocal).toISOString();
@@ -502,4 +517,51 @@ function formatDisplayTime(local: string): string {
   // 本地时间字符串 → 友好展示
   const d = new Date(local);
   return d.toLocaleString('zh-CN', { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' });
+}
+
+type PollResult =
+  | { kind: 'completed'; posterCount: number }
+  | { kind: 'failed'; errorMessage?: string; failedNode?: { nodeName?: string; nodeType?: string; errorMessage?: string } }
+  | { kind: 'timeout' };
+
+/**
+ * 轮询工作流执行直到完成/失败/超时。
+ * 这是"立即执行"模式下让用户立刻看到执行结果（含节点级错误）的关键 —— 不再"秒过 + 黑盒"。
+ */
+async function pollExecution(executionId: string, timeoutMs: number): Promise<PollResult> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    await sleep(1500);
+    const res = await getExecution(executionId);
+    if (!res.success || !res.data) continue;
+    const ex = res.data.execution;
+    if (ex.status === 'completed') {
+      // 在 nodeExecutions 里找 weekly-poster-publisher 的输出，提取页数
+      let posterCount = 0;
+      for (const ne of ex.nodeExecutions || []) {
+        if (ne.nodeType === 'weekly-poster-publisher' || ne.nodeType === 'WeeklyPosterPublisher') {
+          for (const a of ne.outputArtifacts || []) {
+            try {
+              const j = a.inlineContent ? JSON.parse(a.inlineContent) : null;
+              if (j && typeof j.pageCount === 'number') posterCount = j.pageCount;
+            } catch { /* ignore */ }
+          }
+        }
+      }
+      return { kind: 'completed', posterCount };
+    }
+    if (ex.status === 'failed' || ex.status === 'cancelled') {
+      const failed = (ex.nodeExecutions || []).find((n) => n.status === 'failed');
+      return {
+        kind: 'failed',
+        errorMessage: ex.errorMessage,
+        failedNode: failed ? { nodeName: failed.nodeName, nodeType: failed.nodeType, errorMessage: failed.errorMessage } : undefined,
+      };
+    }
+  }
+  return { kind: 'timeout' };
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/prd-admin/src/components/weekly-poster/AutoPublishDialog.tsx
+++ b/prd-admin/src/components/weekly-poster/AutoPublishDialog.tsx
@@ -1,0 +1,505 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Loader2, Play, Send, Calendar, Repeat, X, Sparkles, Eye, ChevronDown } from 'lucide-react';
+import {
+  listWorkflows,
+  executeWorkflow,
+  createWorkflowSchedule,
+  type Workflow,
+  type WeeklyPosterPresentationMode,
+  type WeeklyPosterTemplateKey,
+} from '@/services';
+import { POSTER_TEMPLATES_SEED } from '@/lib/posterTemplates';
+import { toast } from '@/lib/toast';
+
+type ScheduleMode = 'now' | 'once' | 'cron';
+
+const PRESENTATION_OPTIONS: { value: WeeklyPosterPresentationMode; label: string; hint: string }[] = [
+  { value: 'feed-card', label: 'feed-card 短视频卡', hint: '抖音/TikTok 风格的视频卡，9:16 / 16:9 自适应' },
+  { value: 'ad-4-3', label: 'ad-4-3 横屏海报', hint: '4:3 横版广告位，标题 + 主图 + CTA' },
+  { value: 'ad-rich-text', label: 'ad-rich-text 图文混排', hint: '左图右文，适合长文案' },
+  { value: 'static', label: 'static 静态图片', hint: '不带交互，纯展示' },
+];
+
+const POSTER_TIPS = [
+  '【博主id】= 抖音/TikTok 主页 URL 里 `secUid=` 后面那串',
+  '【视频个数】= 拉取最近 N 条视频，建议 3 ~ 10',
+  '工作流变量会覆盖工作流节点配置；留空则用工作流默认值',
+];
+
+export interface AutoPublishDialogProps {
+  /** 弹窗 mounted 但未开 = false；开了 = true */
+  open: boolean;
+  onClose: () => void;
+  /** 创建/触发成功后回调，用于上层刷新海报列表 */
+  onPublished?: () => void;
+}
+
+/**
+ * 海报编辑页"自动发布"入口：把工作流执行/调度收口到这里。
+ * Tab：立即执行 / 定时一次 / 循环 (Cron)
+ * 用户只需选工作流 + 填变量（博主id、视频个数等）+ 选模板/版式/品牌色，
+ * 不必再去工作流编辑器里手动改配置 + 手动跑一次 + 等海报出现在首页。
+ *
+ * 遵守 .claude/rules/frontend-modal.md 三硬约束：createPortal、inline 高度、min-h-0 滚动
+ */
+export function AutoPublishDialog({ open, onClose, onPublished }: AutoPublishDialogProps) {
+  const [mode, setMode] = useState<ScheduleMode>('now');
+  const [workflows, setWorkflows] = useState<Workflow[]>([]);
+  const [loadingWorkflows, setLoadingWorkflows] = useState(false);
+  const [selectedWorkflowId, setSelectedWorkflowId] = useState<string>('');
+  const [variables, setVariables] = useState<Record<string, string>>({});
+  const [presentationMode, setPresentationMode] = useState<WeeklyPosterPresentationMode>('feed-card');
+  const [templateKey, setTemplateKey] = useState<WeeklyPosterTemplateKey>('promo');
+  const [accentColor, setAccentColor] = useState('#ff0050');
+  const [scheduleName, setScheduleName] = useState('');
+  // 默认 30 分钟后
+  const defaultRunAt = useRef(new Date(Date.now() + 30 * 60 * 1000));
+  const [runAtLocal, setRunAtLocal] = useState(() => formatDatetimeLocal(defaultRunAt.current));
+  const [cronExpression, setCronExpression] = useState('0 9 * * *');
+  const [submitting, setSubmitting] = useState(false);
+
+  // 拉取工作流
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setLoadingWorkflows(true);
+    listWorkflows({ pageSize: 50 })
+      .then((res) => {
+        if (cancelled) return;
+        if (res.success && res.data) {
+          setWorkflows(res.data.items);
+          if (res.data.items.length > 0 && !selectedWorkflowId) {
+            setSelectedWorkflowId(res.data.items[0].id);
+          }
+        } else if (!res.success) {
+          toast.error(res.error?.message || '加载工作流失败');
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingWorkflows(false);
+      });
+    return () => { cancelled = true; };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  // ESC 关闭
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !submitting) onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [open, submitting, onClose]);
+
+  // 切换工作流时根据其 variables 重置默认值
+  const selectedWorkflow = useMemo(
+    () => workflows.find((w) => w.id === selectedWorkflowId),
+    [workflows, selectedWorkflowId],
+  );
+  useEffect(() => {
+    if (!selectedWorkflow) return;
+    const next: Record<string, string> = {};
+    for (const v of selectedWorkflow.variables) {
+      next[v.key] = v.defaultValue ?? '';
+    }
+    setVariables(next);
+  }, [selectedWorkflow]);
+
+  if (!open) return null;
+
+  const handleSubmit = async () => {
+    if (!selectedWorkflowId) {
+      toast.error('请先选择一个工作流');
+      return;
+    }
+    // 必填变量校验
+    if (selectedWorkflow) {
+      for (const v of selectedWorkflow.variables) {
+        if (v.required && !variables[v.key]) {
+          toast.error(`请填写「${v.label || v.key}」`);
+          return;
+        }
+      }
+    }
+
+    // 把 presentationMode / templateKey / accentColor 注入变量，让 WeeklyPosterPublisher 兜底取
+    const finalVars: Record<string, string> = {
+      ...variables,
+      presentationMode,
+      templateKey,
+      accentColor,
+    };
+
+    setSubmitting(true);
+    try {
+      if (mode === 'now') {
+        const res = await executeWorkflow({ id: selectedWorkflowId, variables: finalVars });
+        if (res.success) {
+          toast.success('已入队执行，几秒后查看首页弹窗');
+          onPublished?.();
+          onClose();
+        } else {
+          toast.error(res.error?.message || '执行失败');
+        }
+      } else if (mode === 'once') {
+        const runAtUtc = new Date(runAtLocal).toISOString();
+        const res = await createWorkflowSchedule({
+          workflowId: selectedWorkflowId,
+          name: scheduleName.trim(),
+          mode: 'once',
+          runAtUtc,
+          variables: finalVars,
+        });
+        if (res.success) {
+          toast.success(`定时调度已创建，将在 ${formatDisplayTime(runAtLocal)} 触发`);
+          onPublished?.();
+          onClose();
+        } else {
+          toast.error(res.error?.message || '创建调度失败');
+        }
+      } else {
+        const res = await createWorkflowSchedule({
+          workflowId: selectedWorkflowId,
+          name: scheduleName.trim(),
+          mode: 'cron',
+          cronExpression,
+          variables: finalVars,
+        });
+        if (res.success) {
+          toast.success('循环调度已创建并启用');
+          onPublished?.();
+          onClose();
+        } else {
+          toast.error(res.error?.message || '创建调度失败');
+        }
+      }
+    } catch (e: unknown) {
+      toast.error(e instanceof Error ? e.message : '未知错误');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const dialog = (
+    <div
+      className="fixed inset-0 z-[10000] flex items-center justify-center"
+      style={{
+        background: 'rgba(3,3,6,0.78)',
+        backdropFilter: 'blur(12px)',
+        WebkitBackdropFilter: 'blur(12px)',
+      }}
+      onClick={() => { if (!submitting) onClose(); }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="relative flex flex-col overflow-hidden"
+        style={{
+          width: 'min(720px, calc(100vw - 32px))',
+          height: 'min(90vh, 820px)',
+          maxHeight: '90vh',
+          minHeight: 0,
+          background: '#0f1014',
+          borderRadius: 24,
+          border: '1px solid rgba(255,255,255,0.1)',
+          boxShadow: '0 40px 80px -20px rgba(0,0,0,0.6), 0 0 120px rgba(124,58,237,0.18)',
+        }}
+      >
+        {/* Header */}
+        <div className="shrink-0 px-6 py-5 flex items-center justify-between border-b" style={{ borderColor: 'rgba(255,255,255,0.08)' }}>
+          <div>
+            <div className="text-[16px] font-semibold text-white inline-flex items-center gap-2">
+              <Sparkles size={16} className="text-pink-400" />
+              新建自动发布
+            </div>
+            <div className="text-[12px] text-white/55 mt-1">把工作流执行/调度收口到海报编辑页 — 选工作流、填博主信息、选版式即可发布</div>
+          </div>
+          <button
+            type="button"
+            aria-label="关闭"
+            disabled={submitting}
+            onClick={onClose}
+            className="w-8 h-8 rounded-full flex items-center justify-center hover:bg-white/10 disabled:opacity-40"
+            style={{ color: 'rgba(255,255,255,0.7)' }}
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* Mode Tabs */}
+        <div className="shrink-0 px-6 pt-4">
+          <div className="grid grid-cols-3 gap-2 p-1 rounded-xl" style={{ background: 'rgba(255,255,255,0.04)' }}>
+            <ModeTab active={mode === 'now'} onClick={() => setMode('now')} icon={<Play size={14} />} label="立即执行" />
+            <ModeTab active={mode === 'once'} onClick={() => setMode('once')} icon={<Calendar size={14} />} label="定时一次" />
+            <ModeTab active={mode === 'cron'} onClick={() => setMode('cron')} icon={<Repeat size={14} />} label="循环 (Cron)" />
+          </div>
+        </div>
+
+        {/* Body — 滚动区域 */}
+        <div
+          className="flex-1 px-6 py-4 space-y-4"
+          style={{ minHeight: 0, overflowY: 'auto', overscrollBehavior: 'contain' }}
+        >
+          {/* 工作流选择 */}
+          <Field label="选择工作流" required>
+            {loadingWorkflows ? (
+              <div className="text-[12px] text-white/55 inline-flex items-center gap-2"><Loader2 size={12} className="animate-spin" /> 加载中…</div>
+            ) : workflows.length === 0 ? (
+              <div className="text-[12px] text-white/55">还没有工作流，先去工作流编辑器创建一个</div>
+            ) : (
+              <SelectInput
+                value={selectedWorkflowId}
+                onChange={setSelectedWorkflowId}
+                options={workflows.map((w) => ({ value: w.id, label: w.name || '未命名' }))}
+              />
+            )}
+          </Field>
+
+          {/* 调度参数 */}
+          {mode === 'once' && (
+            <Field label="执行时间" required>
+              <input
+                type="datetime-local"
+                value={runAtLocal}
+                onChange={(e) => setRunAtLocal(e.target.value)}
+                className="w-full h-9 px-3 rounded-lg text-[13px] outline-none"
+                style={{
+                  background: 'rgba(255,255,255,0.04)',
+                  border: '1px solid rgba(255,255,255,0.12)',
+                  color: 'rgba(255,255,255,0.92)',
+                  colorScheme: 'dark',
+                }}
+              />
+            </Field>
+          )}
+          {mode === 'cron' && (
+            <Field label="Cron 表达式 (5 字段：分 时 日 月 周)" required>
+              <input
+                type="text"
+                value={cronExpression}
+                onChange={(e) => setCronExpression(e.target.value)}
+                placeholder="0 9 * * *"
+                className="w-full h-9 px-3 rounded-lg text-[13px] outline-none font-mono"
+                style={{
+                  background: 'rgba(255,255,255,0.04)',
+                  border: '1px solid rgba(255,255,255,0.12)',
+                  color: 'rgba(255,255,255,0.92)',
+                }}
+              />
+              <div className="text-[11px] text-white/45 mt-1">
+                例：<code className="text-white/70">0 9 * * *</code> 每天 9 点；<code className="text-white/70">0 9 * * 1</code> 每周一 9 点
+              </div>
+            </Field>
+          )}
+          {(mode === 'once' || mode === 'cron') && (
+            <Field label="调度别名 (可选)">
+              <input
+                type="text"
+                value={scheduleName}
+                onChange={(e) => setScheduleName(e.target.value)}
+                placeholder="例：每天早 9 点抓博主视频"
+                className="w-full h-9 px-3 rounded-lg text-[13px] outline-none"
+                style={{
+                  background: 'rgba(255,255,255,0.04)',
+                  border: '1px solid rgba(255,255,255,0.12)',
+                  color: 'rgba(255,255,255,0.92)',
+                }}
+              />
+            </Field>
+          )}
+
+          {/* 工作流变量 */}
+          {selectedWorkflow && selectedWorkflow.variables.length > 0 && (
+            <div className="space-y-2 pt-2">
+              <div className="text-[12px] font-semibold text-white/75">工作流变量</div>
+              {selectedWorkflow.variables.map((v) => (
+                <Field
+                  key={v.key}
+                  label={`${v.label || v.key}${v.required ? ' *' : ''}`}
+                  hint={v.key}
+                >
+                  <input
+                    type={v.isSecret ? 'password' : 'text'}
+                    value={variables[v.key] ?? ''}
+                    onChange={(e) => setVariables((p) => ({ ...p, [v.key]: e.target.value }))}
+                    placeholder={v.defaultValue ?? ''}
+                    className="w-full h-9 px-3 rounded-lg text-[13px] outline-none"
+                    style={{
+                      background: 'rgba(255,255,255,0.04)',
+                      border: '1px solid rgba(255,255,255,0.12)',
+                      color: 'rgba(255,255,255,0.92)',
+                    }}
+                  />
+                </Field>
+              ))}
+            </div>
+          )}
+          {selectedWorkflow && selectedWorkflow.variables.length === 0 && (
+            <div className="text-[11px] text-white/45 px-3 py-2 rounded-md" style={{ background: 'rgba(255,255,255,0.04)' }}>
+              该工作流未声明变量。如需传入博主id/视频个数，请去工作流编辑器为这些字段加变量绑定。
+            </div>
+          )}
+
+          {/* 海报版式 */}
+          <div className="space-y-2 pt-2">
+            <div className="text-[12px] font-semibold text-white/75">海报版式（运行时覆盖工作流配置）</div>
+            <Field label="presentationMode 版式">
+              <SelectInput
+                value={presentationMode}
+                onChange={(v) => setPresentationMode(v as WeeklyPosterPresentationMode)}
+                options={PRESENTATION_OPTIONS.map((o) => ({ value: o.value, label: o.label }))}
+              />
+              <div className="text-[11px] text-white/45 mt-1">
+                {PRESENTATION_OPTIONS.find((o) => o.value === presentationMode)?.hint}
+              </div>
+            </Field>
+            <Field label="templateKey 模板">
+              <SelectInput
+                value={templateKey}
+                onChange={(v) => setTemplateKey(v as WeeklyPosterTemplateKey)}
+                options={POSTER_TEMPLATES_SEED.map((t) => ({ value: t.key, label: `${t.label} · ${t.description}` }))}
+              />
+            </Field>
+            <Field label="品牌色 (accentColor)">
+              <div className="flex items-center gap-2">
+                <input
+                  type="color"
+                  value={accentColor}
+                  onChange={(e) => setAccentColor(e.target.value)}
+                  className="w-10 h-9 rounded-lg cursor-pointer"
+                  style={{ background: 'transparent', border: '1px solid rgba(255,255,255,0.12)' }}
+                />
+                <input
+                  type="text"
+                  value={accentColor}
+                  onChange={(e) => setAccentColor(e.target.value)}
+                  className="w-32 h-9 px-3 rounded-lg text-[13px] outline-none font-mono"
+                  style={{
+                    background: 'rgba(255,255,255,0.04)',
+                    border: '1px solid rgba(255,255,255,0.12)',
+                    color: 'rgba(255,255,255,0.92)',
+                  }}
+                />
+              </div>
+            </Field>
+          </div>
+
+          {/* Tips */}
+          <div className="pt-2">
+            <div className="text-[11px] font-semibold text-white/55 mb-1">提示</div>
+            <ul className="text-[11px] text-white/45 space-y-0.5 list-disc pl-4">
+              {POSTER_TIPS.map((t) => <li key={t}>{t}</li>)}
+            </ul>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div
+          className="shrink-0 px-6 py-4 flex items-center justify-between border-t"
+          style={{ borderColor: 'rgba(255,255,255,0.08)', background: 'rgba(0,0,0,0.2)' }}
+        >
+          <div className="text-[11px] text-white/40 inline-flex items-center gap-1">
+            <Eye size={12} /> 预览效果与首页弹窗完全一致（同一 PosterCarousel 组件）
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={submitting}
+              className="h-9 px-4 rounded-lg text-[13px] disabled:opacity-40"
+              style={{
+                background: 'rgba(255,255,255,0.06)',
+                color: 'rgba(255,255,255,0.78)',
+                border: '1px solid rgba(255,255,255,0.1)',
+              }}
+            >
+              取消
+            </button>
+            <button
+              type="button"
+              onClick={handleSubmit}
+              disabled={submitting || !selectedWorkflowId}
+              className="h-9 px-5 rounded-lg text-[13px] font-semibold inline-flex items-center gap-1.5 disabled:opacity-40"
+              style={{
+                background: 'linear-gradient(90deg, rgba(255,0,80,0.85), rgba(255,77,140,0.9))',
+                color: '#fff',
+                border: '1px solid rgba(255,77,140,0.4)',
+              }}
+            >
+              {submitting ? <Loader2 size={14} className="animate-spin" /> : <Send size={14} />}
+              {mode === 'now' ? '立即执行' : '创建调度'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
+  return createPortal(dialog, document.body);
+}
+
+function ModeTab({ active, onClick, icon, label }: { active: boolean; onClick: () => void; icon: React.ReactNode; label: string }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="h-8 rounded-lg text-[12px] font-medium inline-flex items-center justify-center gap-1.5 transition-all"
+      style={{
+        background: active ? 'rgba(255,0,80,0.16)' : 'transparent',
+        color: active ? '#ff4d8c' : 'rgba(255,255,255,0.7)',
+        border: active ? '1px solid rgba(255,77,140,0.32)' : '1px solid transparent',
+      }}
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}
+
+function Field({ label, required, hint, children }: { label: string; required?: boolean; hint?: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <div className="text-[11px] font-medium text-white/65 mb-1.5 inline-flex items-center gap-2">
+        <span>{label}{required && <span className="text-pink-400 ml-0.5">*</span>}</span>
+        {hint && <code className="text-[10px] text-white/35 font-mono">{hint}</code>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function SelectInput({ value, onChange, options }: { value: string; onChange: (v: string) => void; options: { value: string; label: string }[] }) {
+  return (
+    <div className="relative">
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full h-9 px-3 pr-8 rounded-lg text-[13px] outline-none appearance-none"
+        style={{
+          background: 'rgba(255,255,255,0.04)',
+          border: '1px solid rgba(255,255,255,0.12)',
+          color: 'rgba(255,255,255,0.92)',
+          colorScheme: 'dark',
+        }}
+      >
+        {options.map((o) => (
+          <option key={o.value} value={o.value} style={{ background: '#1a1b22', color: '#fff' }}>{o.label}</option>
+        ))}
+      </select>
+      <ChevronDown size={14} className="absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none text-white/40" />
+    </div>
+  );
+}
+
+/** Date → "YYYY-MM-DDTHH:mm" 本地时间 */
+function formatDatetimeLocal(d: Date): string {
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function formatDisplayTime(local: string): string {
+  // 本地时间字符串 → 友好展示
+  const d = new Date(local);
+  return d.toLocaleString('zh-CN', { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' });
+}

--- a/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
+++ b/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
@@ -104,19 +104,20 @@ export function PosterCarousel({
     else if (feedCardMediaAspect > 0.85) feedCardAspect = '4 / 3';
   }
   const aspect = isFeedCard ? feedCardAspect : (isWideMode ? '4 / 3' : '1200 / 628');
-  // 三档尺寸（横屏整体再放大 ~17%，竖屏不变以避免破坏短视频比例）：
-  //   9:16 竖屏 460px（不变）/ 4:3 方屏 760→880px / 16:9 横屏 920→1100px
+  // 三档尺寸（用户反馈 9:16 竖屏太小不显眼，全档位整体放大 ~17%）：
+  //   9:16 竖屏 460→540px / 4:3 方屏 760→880px / 16:9 横屏 920→1100px
   //   ad-4-3 / ad-rich-text 宽模式 960→1120px / 长 banner 1120→1280px
-  // 受视口高度 + 视口宽度约束防止超出屏幕
+  // 同时把视口高度预算从 80px 缩到 40px（顶部只有 dismiss 按钮 + 圆角，不需要那么多 chrome），
+  // 让 9:16 在 1080p 屏上能用满 540 cap 而不是被视口卡到 460
   const widthCalc = isFeedCard
     ? (feedCardAspect === '16 / 9'
-        ? 'min(1100px, calc((100vh - 80px) * 1.778), calc(100vw - 32px))'
+        ? 'min(1100px, calc((100vh - 40px) * 1.778), calc(100vw - 32px))'
         : feedCardAspect === '4 / 3'
-          ? 'min(880px, calc((100vh - 80px) * 1.333), calc(100vw - 32px))'
-          : 'min(460px, calc((100vh - 80px) * 0.5625), calc(100vw - 32px))')
+          ? 'min(880px, calc((100vh - 40px) * 1.333), calc(100vw - 32px))'
+          : 'min(540px, calc((100vh - 40px) * 0.5625), calc(100vw - 32px))')
     : isWideMode
-      ? 'min(1120px, calc((100vh - 80px) * 1.333), calc(100vw - 64px))'
-      : 'min(1280px, calc((100vh - 80px) * 1.91), calc(100vw - 64px))';
+      ? 'min(1120px, calc((100vh - 40px) * 1.333), calc(100vw - 64px))'
+      : 'min(1280px, calc((100vh - 40px) * 1.91), calc(100vw - 64px))';
 
   // 最小化态：右下角胶囊浮层（缩略图 + 标题 + 展开/关闭）。
   // 主模态在 minimized 时 display:none 不卸载子组件 → PosterFeedCardView 的
@@ -348,7 +349,16 @@ export function WeeklyPosterPageView({
   const hasImage = !!page.imageUrl;
 
   return (
-    <div className="relative h-full flex flex-col" style={{ minHeight: 0, background: '#06111e' }}>
+    <div
+      className="relative h-full flex flex-col"
+      style={{
+        minHeight: 0,
+        background: '#06111e',
+        // 容器查询：让子节点的 cqw 字号跟随容器宽度自适应，不再因 viewport 大小或 scale
+        // 缩放导致溢出（PosterDesignerPage 的 76% 缩放下标题溢出 = vw 单位的锅）
+        containerType: 'inline-size',
+      }}
+    >
       <div
         className="relative shrink-0"
         style={{
@@ -419,7 +429,7 @@ export function WeeklyPosterPageView({
         }}
       >
         <h2
-          className="mb-4 text-[clamp(24px,3vw,36px)] font-black tracking-normal"
+          className="mb-4 text-[clamp(20px,4.4cqw,36px)] font-black tracking-normal"
           style={{ color: '#fff', lineHeight: 1.12 }}
         >
           {page.title}
@@ -428,7 +438,7 @@ export function WeeklyPosterPageView({
           <div className="max-w-[78%] overflow-hidden" style={{ maxHeight: '48%' }}>
             <MarkdownContent
               content={page.body}
-              className="text-[clamp(15px,1.65vw,22px)] leading-relaxed poster-body-markdown"
+              className="text-[clamp(13px,2.4cqw,22px)] leading-relaxed poster-body-markdown"
             />
           </div>
         ) : null}
@@ -507,7 +517,14 @@ export function PosterAdPageView({
   const showFallbackBg = !hasPlayed && (!coverUrl || coverErrored);
 
   return (
-    <div className="relative h-full" style={{ background: '#000' }}>
+    <div
+      className="relative h-full"
+      style={{
+        background: '#000',
+        // 标题/正文用 cqw 自适应容器宽度，避免 PosterDesignerPage 的缩放预览下文字溢出
+        containerType: 'inline-size',
+      }}
+    >
       {/* 媒体层 */}
       <div className="absolute inset-0">
         {/* Cover 静图层（仅播放前） */}
@@ -619,7 +636,7 @@ export function PosterAdPageView({
           <h2
             className="font-black text-white leading-tight"
             style={{
-              fontSize: 'clamp(20px, 2.4vw, 32px)',
+              fontSize: 'clamp(16px, 2.6cqw, 32px)',
               textShadow: '0 2px 12px rgba(0,0,0,0.6)',
             }}
           >
@@ -629,7 +646,7 @@ export function PosterAdPageView({
             <div
               className="mt-3 max-w-[80%] text-white/85 leading-relaxed line-clamp-2"
               style={{
-                fontSize: 'clamp(13px, 1.3vw, 16px)',
+                fontSize: 'clamp(11px, 1.4cqw, 16px)',
                 textShadow: '0 1px 8px rgba(0,0,0,0.5)',
               }}
             >
@@ -733,6 +750,8 @@ export function PosterRichTextPageView({
       style={{
         background: `linear-gradient(135deg, #0b0b14 0%, #15101a 60%, #0a0a12 100%)`,
         color: 'rgba(255,255,255,0.92)',
+        // cqw 字号锚定在容器宽度，让 76% 缩放下标题不再溢出
+        containerType: 'inline-size',
       }}
     >
       {/* 左侧 cover 区（约 44% 宽，动态/静态封面 + 中央 Play hover） */}
@@ -836,7 +855,7 @@ export function PosterRichTextPageView({
           className="font-black tracking-tight"
           style={{
             color: '#fff',
-            fontSize: 'clamp(22px, 2.8vw, 38px)',
+            fontSize: 'clamp(18px, 3.2cqw, 38px)',
             lineHeight: 1.14,
             marginBottom: '3.2%',
           }}
@@ -859,7 +878,7 @@ export function PosterRichTextPageView({
           <div
             className="text-white/82 leading-relaxed overflow-hidden [&_ul]:list-disc [&_ul]:pl-5 [&_ol]:list-decimal [&_ol]:pl-5 [&_li]:my-1.5 [&_p]:my-1.5 [&_strong]:text-white"
             style={{
-              fontSize: 'clamp(13px, 1.35vw, 17px)',
+              fontSize: 'clamp(11px, 1.6cqw, 17px)',
               maxHeight: '52%',
             }}
           >

--- a/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
+++ b/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { ChevronLeft, ChevronRight, X, ArrowRight, Sparkles, Play, Heart, MessageCircle, Bookmark, Share2, Eye, Clock, Maximize2 } from 'lucide-react';
 import { useWeeklyPosterStore } from '@/stores/weeklyPosterStore';
 import { MarkdownContent } from '@/components/ui/MarkdownContent';
+import { hexToRgba } from '@/lib/themeComputed';
 import type { WeeklyPoster, WeeklyPosterPage } from '@/services';
 
 /**
@@ -1231,18 +1232,6 @@ function formatStatNumber(n: number): string {
   if (n < 10000) return `${(n / 1000).toFixed(1).replace(/\.0$/, '')}k`;
   if (n < 1000000) return `${(n / 10000).toFixed(1).replace(/\.0$/, '')}w`;
   return `${(n / 1000000).toFixed(1).replace(/\.0$/, '')}M`;
-}
-
-/** 将 #RRGGBB / #RGB 转 rgba(r,g,b,alpha)；非法值兜底 TikTok 粉 */
-function hexToRgba(hex: string, alpha: number): string {
-  if (!hex) return `rgba(255,0,80,${alpha})`;
-  let h = hex.trim().replace('#', '');
-  if (h.length === 3) h = h.split('').map((c) => c + c).join('');
-  if (h.length !== 6 || !/^[0-9a-fA-F]{6}$/.test(h)) return `rgba(255,0,80,${alpha})`;
-  const r = parseInt(h.slice(0, 2), 16);
-  const g = parseInt(h.slice(2, 4), 16);
-  const b = parseInt(h.slice(4, 6), 16);
-  return `rgba(${r},${g},${b},${alpha})`;
 }
 
 function formatDuration(sec: number): string {

--- a/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
+++ b/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
@@ -349,16 +349,7 @@ export function WeeklyPosterPageView({
   const hasImage = !!page.imageUrl;
 
   return (
-    <div
-      className="relative h-full flex flex-col"
-      style={{
-        minHeight: 0,
-        background: '#06111e',
-        // 容器查询：让子节点的 cqw 字号跟随容器宽度自适应，不再因 viewport 大小或 scale
-        // 缩放导致溢出（PosterDesignerPage 的 76% 缩放下标题溢出 = vw 单位的锅）
-        containerType: 'inline-size',
-      }}
-    >
+    <div className="relative h-full flex flex-col" style={{ minHeight: 0, background: '#06111e' }}>
       <div
         className="relative shrink-0"
         style={{
@@ -375,8 +366,7 @@ export function WeeklyPosterPageView({
               className="absolute inset-0 w-full h-full object-cover"
               muted
               playsInline
-              autoPlay
-              loop
+              preload="metadata"
             />
           ) : (
             <img
@@ -429,7 +419,7 @@ export function WeeklyPosterPageView({
         }}
       >
         <h2
-          className="mb-4 text-[clamp(20px,4.4cqw,36px)] font-black tracking-normal"
+          className="mb-4 text-[clamp(24px,3vw,36px)] font-black tracking-normal"
           style={{ color: '#fff', lineHeight: 1.12 }}
         >
           {page.title}
@@ -438,7 +428,7 @@ export function WeeklyPosterPageView({
           <div className="max-w-[78%] overflow-hidden" style={{ maxHeight: '48%' }}>
             <MarkdownContent
               content={page.body}
-              className="text-[clamp(13px,2.4cqw,22px)] leading-relaxed poster-body-markdown"
+              className="text-[clamp(15px,1.65vw,22px)] leading-relaxed poster-body-markdown"
             />
           </div>
         ) : null}
@@ -517,14 +507,7 @@ export function PosterAdPageView({
   const showFallbackBg = !hasPlayed && (!coverUrl || coverErrored);
 
   return (
-    <div
-      className="relative h-full"
-      style={{
-        background: '#000',
-        // 标题/正文用 cqw 自适应容器宽度，避免 PosterDesignerPage 的缩放预览下文字溢出
-        containerType: 'inline-size',
-      }}
-    >
+    <div className="relative h-full" style={{ background: '#000' }}>
       {/* 媒体层 */}
       <div className="absolute inset-0">
         {/* Cover 静图层（仅播放前） */}
@@ -636,7 +619,7 @@ export function PosterAdPageView({
           <h2
             className="font-black text-white leading-tight"
             style={{
-              fontSize: 'clamp(16px, 2.6cqw, 32px)',
+              fontSize: 'clamp(20px, 2.4vw, 32px)',
               textShadow: '0 2px 12px rgba(0,0,0,0.6)',
             }}
           >
@@ -646,7 +629,7 @@ export function PosterAdPageView({
             <div
               className="mt-3 max-w-[80%] text-white/85 leading-relaxed line-clamp-2"
               style={{
-                fontSize: 'clamp(11px, 1.4cqw, 16px)',
+                fontSize: 'clamp(13px, 1.3vw, 16px)',
                 textShadow: '0 1px 8px rgba(0,0,0,0.5)',
               }}
             >
@@ -750,8 +733,6 @@ export function PosterRichTextPageView({
       style={{
         background: `linear-gradient(135deg, #0b0b14 0%, #15101a 60%, #0a0a12 100%)`,
         color: 'rgba(255,255,255,0.92)',
-        // cqw 字号锚定在容器宽度，让 76% 缩放下标题不再溢出
-        containerType: 'inline-size',
       }}
     >
       {/* 左侧 cover 区（约 44% 宽，动态/静态封面 + 中央 Play hover） */}
@@ -855,7 +836,7 @@ export function PosterRichTextPageView({
           className="font-black tracking-tight"
           style={{
             color: '#fff',
-            fontSize: 'clamp(18px, 3.2cqw, 38px)',
+            fontSize: 'clamp(22px, 2.8vw, 38px)',
             lineHeight: 1.14,
             marginBottom: '3.2%',
           }}
@@ -878,7 +859,7 @@ export function PosterRichTextPageView({
           <div
             className="text-white/82 leading-relaxed overflow-hidden [&_ul]:list-disc [&_ul]:pl-5 [&_ol]:list-decimal [&_ol]:pl-5 [&_li]:my-1.5 [&_p]:my-1.5 [&_strong]:text-white"
             style={{
-              fontSize: 'clamp(11px, 1.6cqw, 17px)',
+              fontSize: 'clamp(13px, 1.35vw, 17px)',
               maxHeight: '52%',
             }}
           >
@@ -1276,11 +1257,23 @@ function formatDuration(sec: number): string {
 /**
  * 主页弹窗包装 - 从 store 读取当前海报 + 已读状态。
  * 登录后主页挂载这个组件,有未读就弹。
+ *
+ * "每次登录展示一次"约束：弹出 1.5s 后自动登记已看过（写入 sessionStorage），用户即便不
+ * 点 ✕ 也只会看一次；同会话内任何页面再次挂载主页不再弹；浏览器关闭后 sessionStorage
+ * 清空，下次登录视为新会话再弹一次（符合"一天一次"的口语预期）。
  */
 export function WeeklyPosterModal() {
   const currentPoster = useWeeklyPosterStore((s) => s.currentPoster);
   const shouldShow = useWeeklyPosterStore((s) => s.shouldShowCurrent());
   const dismiss = useWeeklyPosterStore((s) => s.dismiss);
+
+  useEffect(() => {
+    if (!currentPoster?.id || !shouldShow) return;
+    const id = currentPoster.id;
+    // 1.5s 后自动标记已看过 — 期间用户主动 ✕ 也会触发同样的 dismiss，二者等价
+    const t = setTimeout(() => dismiss(id), 1500);
+    return () => clearTimeout(t);
+  }, [currentPoster?.id, shouldShow, dismiss]);
 
   if (!shouldShow || !currentPoster) return null;
   return (

--- a/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
+++ b/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
@@ -93,6 +93,8 @@ export function PosterCarousel({
   const isAdMode = poster.presentationMode === 'ad-4-3';
   const isRichText = poster.presentationMode === 'ad-rich-text';
   const isFeedCard = poster.presentationMode === 'feed-card';
+  // 取当前页 accentColor 作为品牌色；feed-card 视频卡的外框光晕、顶部细带都吃这个色
+  const brandAccent = currentPage?.accentColor || '#ff0050';
   // ad-4-3 / ad-rich-text 走 4:3 横屏；feed-card 默认 9:16 竖屏，但若检测到当前页视频是
   // 横屏（aspect>1.2）则切到 16:9，方屏（0.85~1.2）切到 4:3
   const isWideMode = isAdMode || isRichText;
@@ -102,18 +104,19 @@ export function PosterCarousel({
     else if (feedCardMediaAspect > 0.85) feedCardAspect = '4 / 3';
   }
   const aspect = isFeedCard ? feedCardAspect : (isWideMode ? '4 / 3' : '1200 / 628');
-  // 三档尺寸（用户反馈横屏太小，全部加大）：
-  //   9:16 竖屏 460px / 4:3 方屏 760px / 16:9 横屏 920px
-  // 受视口高度约束防止超出屏幕
+  // 三档尺寸（横屏整体再放大 ~17%，竖屏不变以避免破坏短视频比例）：
+  //   9:16 竖屏 460px（不变）/ 4:3 方屏 760→880px / 16:9 横屏 920→1100px
+  //   ad-4-3 / ad-rich-text 宽模式 960→1120px / 长 banner 1120→1280px
+  // 受视口高度 + 视口宽度约束防止超出屏幕
   const widthCalc = isFeedCard
     ? (feedCardAspect === '16 / 9'
-        ? 'min(920px, calc((100vh - 80px) * 1.778), calc(100vw - 32px))'
+        ? 'min(1100px, calc((100vh - 80px) * 1.778), calc(100vw - 32px))'
         : feedCardAspect === '4 / 3'
-          ? 'min(760px, calc((100vh - 80px) * 1.333), calc(100vw - 32px))'
+          ? 'min(880px, calc((100vh - 80px) * 1.333), calc(100vw - 32px))'
           : 'min(460px, calc((100vh - 80px) * 0.5625), calc(100vw - 32px))')
     : isWideMode
-      ? 'min(960px, calc((100vh - 80px) * 1.333), calc(100vw - 64px))'
-      : 'min(1120px, calc((100vh - 80px) * 1.91), calc(100vw - 64px))';
+      ? 'min(1120px, calc((100vh - 80px) * 1.333), calc(100vw - 64px))'
+      : 'min(1280px, calc((100vh - 80px) * 1.91), calc(100vw - 64px))';
 
   // 最小化态：右下角胶囊浮层（缩略图 + 标题 + 展开/关闭）。
   // 主模态在 minimized 时 display:none 不卸载子组件 → PosterFeedCardView 的
@@ -191,12 +194,27 @@ export function PosterCarousel({
           width: widthCalc,
           aspectRatio: aspect,
           background: isFeedCard || isWideMode ? '#000' : '#06111e',
-          border: '1px solid rgba(255,255,255,0.1)',
+          // feed-card 用 accent 色描边 + 有色光晕，把"光秃秃的视频"包装成"海报里嵌的视频"
+          border: isFeedCard
+            ? `1.5px solid ${hexToRgba(brandAccent, 0.55)}`
+            : '1px solid rgba(255,255,255,0.1)',
           borderRadius: 28,
-          boxShadow:
-            '0 40px 80px -20px rgba(0,0,0,0.6), 0 0 120px rgba(124,58,237,0.18), inset 0 1px 0 rgba(255,255,255,0.08)',
+          boxShadow: isFeedCard
+            ? `0 40px 80px -20px rgba(0,0,0,0.6), 0 0 140px ${hexToRgba(brandAccent, 0.32)}, 0 0 0 1px ${hexToRgba(brandAccent, 0.18)}, inset 0 1px 0 rgba(255,255,255,0.08)`
+            : '0 40px 80px -20px rgba(0,0,0,0.6), 0 0 120px rgba(124,58,237,0.18), inset 0 1px 0 rgba(255,255,255,0.08)',
         }}
       >
+        {/* feed-card 模式：顶部一条 accent 色细带 + 渐隐光，让视频卡有"海报外框"的视觉重量 */}
+        {isFeedCard && (
+          <div
+            className="absolute inset-x-0 top-0 z-20 pointer-events-none"
+            style={{
+              height: 4,
+              background: `linear-gradient(90deg, transparent, ${brandAccent} 30%, ${brandAccent} 70%, transparent)`,
+              boxShadow: `0 0 24px ${hexToRgba(brandAccent, 0.7)}`,
+            }}
+          />
+        )}
         {/* 右上角只保留一个按钮：收起到右下角胶囊。彻底 dismiss 在胶囊上的 ✕ 触发 */}
         <button
           type="button"
@@ -1213,6 +1231,18 @@ function formatStatNumber(n: number): string {
   if (n < 10000) return `${(n / 1000).toFixed(1).replace(/\.0$/, '')}k`;
   if (n < 1000000) return `${(n / 10000).toFixed(1).replace(/\.0$/, '')}w`;
   return `${(n / 1000000).toFixed(1).replace(/\.0$/, '')}M`;
+}
+
+/** 将 #RRGGBB / #RGB 转 rgba(r,g,b,alpha)；非法值兜底 TikTok 粉 */
+function hexToRgba(hex: string, alpha: number): string {
+  if (!hex) return `rgba(255,0,80,${alpha})`;
+  let h = hex.trim().replace('#', '');
+  if (h.length === 3) h = h.split('').map((c) => c + c).join('');
+  if (h.length !== 6 || !/^[0-9a-fA-F]{6}$/.test(h)) return `rgba(255,0,80,${alpha})`;
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  return `rgba(${r},${g},${b},${alpha})`;
 }
 
 function formatDuration(sec: number): string {

--- a/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
+++ b/prd-admin/src/components/weekly-poster/WeeklyPosterModal.tsx
@@ -1266,14 +1266,16 @@ export function WeeklyPosterModal() {
   const currentPoster = useWeeklyPosterStore((s) => s.currentPoster);
   const shouldShow = useWeeklyPosterStore((s) => s.shouldShowCurrent());
   const dismiss = useWeeklyPosterStore((s) => s.dismiss);
+  const markSeen = useWeeklyPosterStore((s) => s.markSeen);
 
   useEffect(() => {
     if (!currentPoster?.id || !shouldShow) return;
     const id = currentPoster.id;
-    // 1.5s 后自动标记已看过 — 期间用户主动 ✕ 也会触发同样的 dismiss，二者等价
-    const t = setTimeout(() => dismiss(id), 1500);
+    // 1.5s 后**静默**标记已读（写后端 SeenBy + sessionStorage） — modal 保持显示，让用户
+    // 想看多久看多久。只有点 ✕ 才走 dismiss 真正关闭。
+    const t = setTimeout(() => markSeen(id), 1500);
     return () => clearTimeout(t);
-  }, [currentPoster?.id, shouldShow, dismiss]);
+  }, [currentPoster?.id, shouldShow, markSeen]);
 
   if (!shouldShow || !currentPoster) return null;
   return (

--- a/prd-admin/src/lib/themeComputed.ts
+++ b/prd-admin/src/lib/themeComputed.ts
@@ -153,9 +153,16 @@ export function getCSSVar(name: string): string {
 /**
  * 将 hex 颜色转换为 rgba
  */
+/**
+ * 将 hex 颜色转换为 rgba。支持 #RRGGBB / #RGB 简写；非法输入回退 TikTok 粉品牌色。
+ */
 export function hexToRgba(hex: string, alpha: number): string {
-  const r = parseInt(hex.slice(1, 3), 16);
-  const g = parseInt(hex.slice(3, 5), 16);
-  const b = parseInt(hex.slice(5, 7), 16);
+  if (!hex) return `rgba(255,0,80,${alpha})`;
+  let h = hex.trim().replace('#', '');
+  if (h.length === 3) h = h.split('').map((c) => c + c).join('');
+  if (h.length !== 6 || !/^[0-9a-fA-F]{6}$/.test(h)) return `rgba(255,0,80,${alpha})`;
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }

--- a/prd-admin/src/pages/weekly-poster/PosterDesignerPage.tsx
+++ b/prd-admin/src/pages/weekly-poster/PosterDesignerPage.tsx
@@ -1613,16 +1613,26 @@ function WorkspacePosterStage({
   progress?: PageProgress;
 }) {
   const accent = page.accentColor || template.accentPalette[0] || DEFAULT_ACCENT;
-  const baseWidth = devicePreview === 'mobile' ? 360 : orientation === 'portrait' ? 720 : 920;
-  const width = Math.round(baseWidth * (scale / 100));
-  const ratio = devicePreview === 'mobile' || orientation === 'portrait' ? '4 / 5' : '1200 / 628';
+  // 关键：内部 DOM 永远渲染在「设计稿原始尺寸」上 → 字号 / 间距 / 折行规律全部稳定
+  // 视觉缩放走 transform: scale，不影响内部布局，避免 76% 缩放下文字溢出海报边界
+  const designWidth = orientation === 'portrait' ? 1080 : 1200;
+  const designHeight = orientation === 'portrait' ? 1350 : 628;
+  const previewBaseWidth = devicePreview === 'mobile' ? 360 : orientation === 'portrait' ? 720 : 920;
+  const fitScale = previewBaseWidth / designWidth;
+  const userScale = scale / 100;
+  const totalScale = fitScale * userScale;
+  const displayWidth = Math.round(designWidth * totalScale);
+  const displayHeight = Math.round(designHeight * totalScale);
 
   return (
-    <div style={{ width, maxWidth: '100%' }}>
+    <div style={{ width: displayWidth, height: displayHeight, maxWidth: '100%' }}>
       <div
         className="relative overflow-hidden rounded-[28px]"
         style={{
-          aspectRatio: ratio,
+          width: designWidth,
+          height: designHeight,
+          transform: `scale(${totalScale})`,
+          transformOrigin: 'top left',
           background: page.imageUrl ? '#06111e' : `linear-gradient(135deg, ${accent} 0%, #07101e 72%)`,
           border: '1px solid rgba(255,255,255,0.08)',
           boxShadow: '0 28px 70px rgba(0,0,0,0.36), 0 0 48px rgba(90,109,255,0.18)',
@@ -2769,7 +2779,9 @@ function fileToDataUri(file: File): Promise<string> {
 
 function renderMedia(url: string, className: string) {
   if (isVideoUrl(url)) {
-    return <video src={url} className={className} muted playsInline autoPlay loop />;
+    // 缩略图场景禁止 autoPlay loop —— 多个 page 同屏会同时跑视频解码，CPU/GPU 飙升
+    // 只用 metadata 拿首帧当封面图，用户点击进入大图预览才会真正播放
+    return <video src={url} className={className} muted playsInline preload="metadata" />;
   }
   return <img src={url} alt="" className={className} draggable={false} />;
 }

--- a/prd-admin/src/pages/weekly-poster/PosterDesignerPage.tsx
+++ b/prd-admin/src/pages/weekly-poster/PosterDesignerPage.tsx
@@ -25,6 +25,7 @@ import {
   Sparkles,
   Upload,
   X,
+  Zap,
 } from 'lucide-react';
 import {
   createWeeklyPoster,
@@ -45,6 +46,7 @@ import {
 import { MarkdownContent } from '@/components/ui/MarkdownContent';
 import { MapSpinner } from '@/components/ui/VideoLoader';
 import { PosterCarousel, WeeklyPosterPageView } from '@/components/weekly-poster/WeeklyPosterModal';
+import { AutoPublishDialog } from '@/components/weekly-poster/AutoPublishDialog';
 import { findTemplate, POSTER_TEMPLATES_SEED, SOURCE_TYPES } from '@/lib/posterTemplates';
 import { toast } from '@/lib/toast';
 import { useSseStream } from '@/lib/useSseStream';
@@ -112,6 +114,7 @@ export default function PosterDesignerPage({ embedded = false }: PosterDesignerP
   const [createOpen, setCreateOpen] = useState(false);
   const [createConfig, setCreateConfig] = useState<CreatePosterInitialConfig | undefined>(undefined);
   const [previewOpen, setPreviewOpen] = useState(false);
+  const [autoPublishOpen, setAutoPublishOpen] = useState(false);
   const [publishing, setPublishing] = useState(false);
   const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
   const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
@@ -630,6 +633,19 @@ export default function PosterDesignerPage({ embedded = false }: PosterDesignerP
                     </div>
 
                     <div className="flex shrink-0 items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => setAutoPublishOpen(true)}
+                        title="选择工作流 + 填变量 + 选版式 → 立即/定时/循环 触发，发布到首页"
+                        className="h-9 rounded-xl px-4 inline-flex items-center gap-1.5 text-[12px] font-medium transition-colors"
+                        style={{
+                          color: 'rgba(255,77,140,0.95)',
+                          background: 'rgba(255,0,80,0.12)',
+                          border: '1px solid rgba(255,77,140,0.32)',
+                        }}
+                      >
+                        <Zap size={14} /> 新建自动发布
+                      </button>
                       <button
                         type="button"
                         onClick={() => setPreviewOpen(true)}
@@ -1565,6 +1581,16 @@ export default function PosterDesignerPage({ embedded = false }: PosterDesignerP
           navigateOnCta={false}
         />
       )}
+      <AutoPublishDialog
+        open={autoPublishOpen}
+        onClose={() => setAutoPublishOpen(false)}
+        onPublished={() => {
+          // 触发后刷新海报列表（ListWeeklyPosters 在顶部 useEffect 已绑定 setPosters，
+          // 这里 toast 已经提示用户去首页查看，列表会在下次进入时自动拉取）
+          // 后续可加入「执行历史」抽屉，但本期先保持简洁
+          void 0;
+        }}
+      />
     </div>
   );
 }

--- a/prd-admin/src/services/api.ts
+++ b/prd-admin/src/services/api.ts
@@ -949,6 +949,11 @@ export const api = {
       analyze: (executionId: string) => `/api/workflow-agent/executions/${executionId}/analyze`,
     },
     aiFill: () => '/api/workflow-agent/ai-fill',
+    schedules: {
+      list: () => '/api/workflow-agent/schedules',
+      create: () => '/api/workflow-agent/schedules',
+      byId: (id: string) => `/api/workflow-agent/schedules/${id}`,
+    },
   },
 
   // ============ Video Agent 视频创作 ============

--- a/prd-admin/src/services/contracts/workflowAgent.ts
+++ b/prd-admin/src/services/contracts/workflowAgent.ts
@@ -447,3 +447,48 @@ export type ChatWorkflowContract = (input: {
   codeSnippet?: string;
   codeUrl?: string;
 }) => Promise<Response>;
+
+// ─────────────────────── Schedule ───────────────────────
+
+export interface WorkflowSchedule {
+  id: string;
+  workflowId: string;
+  workflowName: string;
+  name: string;
+  /** once = 一次性指定时间触发 / cron = 按 Cron 表达式循环 */
+  mode: 'once' | 'cron';
+  runAtUtc?: string | null;
+  cronExpression?: string | null;
+  timezone: string;
+  isEnabled: boolean;
+  nextRunAt?: string | null;
+  lastTriggeredAt?: string | null;
+  triggerCount: number;
+  variableOverrides?: Record<string, string> | null;
+  createdBy: string;
+  createdAt: string;
+}
+
+export type ListSchedulesContract = (
+  workflowId?: string
+) => Promise<ApiResponse<{ items: WorkflowSchedule[] }>>;
+
+export type CreateScheduleContract = (input: {
+  workflowId: string;
+  name?: string;
+  mode: 'once' | 'cron';
+  runAtUtc?: string;
+  cronExpression?: string;
+  timezone?: string;
+  isEnabled?: boolean;
+  variables?: Record<string, string>;
+}) => Promise<ApiResponse<{ schedule: WorkflowSchedule }>>;
+
+export type UpdateScheduleContract = (input: {
+  id: string;
+  name?: string;
+  isEnabled?: boolean;
+  variables?: Record<string, string>;
+}) => Promise<ApiResponse<{ schedule: WorkflowSchedule }>>;
+
+export type DeleteScheduleContract = (id: string) => Promise<ApiResponse<{ ok: boolean }>>;

--- a/prd-admin/src/services/contracts/workflowAgent.ts
+++ b/prd-admin/src/services/contracts/workflowAgent.ts
@@ -469,10 +469,6 @@ export interface WorkflowSchedule {
   createdAt: string;
 }
 
-export type ListSchedulesContract = (
-  workflowId?: string
-) => Promise<ApiResponse<{ items: WorkflowSchedule[] }>>;
-
 export type CreateScheduleContract = (input: {
   workflowId: string;
   name?: string;
@@ -483,12 +479,3 @@ export type CreateScheduleContract = (input: {
   isEnabled?: boolean;
   variables?: Record<string, string>;
 }) => Promise<ApiResponse<{ schedule: WorkflowSchedule }>>;
-
-export type UpdateScheduleContract = (input: {
-  id: string;
-  name?: string;
-  isEnabled?: boolean;
-  variables?: Record<string, string>;
-}) => Promise<ApiResponse<{ schedule: WorkflowSchedule }>>;
-
-export type DeleteScheduleContract = (id: string) => Promise<ApiResponse<{ ok: boolean }>>;

--- a/prd-admin/src/services/index.ts
+++ b/prd-admin/src/services/index.ts
@@ -1450,6 +1450,7 @@ export type {
 // Weekly Poster 周报海报（登录后主页轮播弹窗）
 export {
   getCurrentWeeklyPoster,
+  markWeeklyPosterSeen,
   listWeeklyPosters,
   getWeeklyPoster,
   createWeeklyPoster,

--- a/prd-admin/src/services/index.ts
+++ b/prd-admin/src/services/index.ts
@@ -1543,7 +1543,12 @@ import type {
   TestRunCapsuleContract,
   GetChatHistoryContract,
   AiFillParametersContract,
+  ListSchedulesContract,
+  CreateScheduleContract,
+  UpdateScheduleContract,
+  DeleteScheduleContract,
 } from '@/services/contracts/workflowAgent';
+export type { Workflow, WorkflowVariable, WorkflowExecution, WorkflowSchedule } from '@/services/contracts/workflowAgent';
 import {
   listWorkflowsReal,
   createWorkflowReal,
@@ -1565,6 +1570,10 @@ import {
   testRunCapsuleReal,
   getChatHistoryReal,
   aiFillParametersReal,
+  listWorkflowSchedulesReal,
+  createWorkflowScheduleReal,
+  updateWorkflowScheduleReal,
+  deleteWorkflowScheduleReal,
 } from '@/services/real/workflowAgent';
 
 export const listWorkflows: ListWorkflowsContract = withAuth(listWorkflowsReal);
@@ -1590,6 +1599,10 @@ export { chatWorkflowReal as chatWorkflow } from '@/services/real/workflowAgent'
 export { analyzeExecutionReal as analyzeExecution } from '@/services/real/workflowAgent';
 export { validateTapdCookie } from '@/services/real/workflowAgent';
 export const aiFillParameters: AiFillParametersContract = withAuth(aiFillParametersReal);
+export const listWorkflowSchedules: ListSchedulesContract = withAuth(listWorkflowSchedulesReal);
+export const createWorkflowSchedule: CreateScheduleContract = withAuth(createWorkflowScheduleReal);
+export const updateWorkflowSchedule: UpdateScheduleContract = withAuth(updateWorkflowScheduleReal);
+export const deleteWorkflowSchedule: DeleteScheduleContract = withAuth(deleteWorkflowScheduleReal);
 
 // 数据迁移服务
 import type {

--- a/prd-admin/src/services/index.ts
+++ b/prd-admin/src/services/index.ts
@@ -1544,10 +1544,7 @@ import type {
   TestRunCapsuleContract,
   GetChatHistoryContract,
   AiFillParametersContract,
-  ListSchedulesContract,
   CreateScheduleContract,
-  UpdateScheduleContract,
-  DeleteScheduleContract,
 } from '@/services/contracts/workflowAgent';
 export type { Workflow, WorkflowVariable, WorkflowExecution, WorkflowSchedule } from '@/services/contracts/workflowAgent';
 import {
@@ -1571,10 +1568,7 @@ import {
   testRunCapsuleReal,
   getChatHistoryReal,
   aiFillParametersReal,
-  listWorkflowSchedulesReal,
   createWorkflowScheduleReal,
-  updateWorkflowScheduleReal,
-  deleteWorkflowScheduleReal,
 } from '@/services/real/workflowAgent';
 
 export const listWorkflows: ListWorkflowsContract = withAuth(listWorkflowsReal);
@@ -1600,10 +1594,7 @@ export { chatWorkflowReal as chatWorkflow } from '@/services/real/workflowAgent'
 export { analyzeExecutionReal as analyzeExecution } from '@/services/real/workflowAgent';
 export { validateTapdCookie } from '@/services/real/workflowAgent';
 export const aiFillParameters: AiFillParametersContract = withAuth(aiFillParametersReal);
-export const listWorkflowSchedules: ListSchedulesContract = withAuth(listWorkflowSchedulesReal);
 export const createWorkflowSchedule: CreateScheduleContract = withAuth(createWorkflowScheduleReal);
-export const updateWorkflowSchedule: UpdateScheduleContract = withAuth(updateWorkflowScheduleReal);
-export const deleteWorkflowSchedule: DeleteScheduleContract = withAuth(deleteWorkflowScheduleReal);
 
 // 数据迁移服务
 import type {

--- a/prd-admin/src/services/real/weeklyPoster.ts
+++ b/prd-admin/src/services/real/weeklyPoster.ts
@@ -140,10 +140,20 @@ export interface WeeklyPosterUpsertInput {
 
 /**
  * 主页拉取当前待展示的海报(最新一篇 published)。
- * 无可用海报时返回 null。
+ * 后端会过滤掉当前用户已经标记 seen 的海报，所以拉到 null = "没有新的可弹"。
  */
 export async function getCurrentWeeklyPoster() {
   return await apiRequest<WeeklyPoster | null>('/api/weekly-posters/current');
+}
+
+/**
+ * 标记当前用户已看过这张海报。前端弹窗展示 1.5s 后调用，写入后端 SeenBy。
+ * 之后这张海报不再返回给当前用户；有新海报（不同 id）发布时仍会弹一次。
+ */
+export async function markWeeklyPosterSeen(posterId: string) {
+  return await apiRequest<{ ok: boolean }>(`/api/weekly-posters/${posterId}/mark-seen`, {
+    method: 'POST',
+  });
 }
 
 /** 管理端:列出所有海报 */

--- a/prd-admin/src/services/real/workflowAgent.ts
+++ b/prd-admin/src/services/real/workflowAgent.ts
@@ -34,10 +34,7 @@ import type {
   CapsuleCategoryInfo,
   CapsuleTestRunResult,
   WorkflowSchedule,
-  ListSchedulesContract,
   CreateScheduleContract,
-  UpdateScheduleContract,
-  DeleteScheduleContract,
 } from '../contracts/workflowAgent';
 
 // ========== Workflows ==========
@@ -278,32 +275,9 @@ export const aiFillParametersReal: AiFillParametersContract = async (input) => {
 
 // ========== Schedules (一次性 / 循环 自动发布) ==========
 
-export const listWorkflowSchedulesReal: ListSchedulesContract = async (workflowId) => {
-  const qs = workflowId ? `?workflowId=${encodeURIComponent(workflowId)}` : '';
-  return await apiRequest<{ items: WorkflowSchedule[] }>(
-    api.workflowAgent.schedules.list() + qs,
-    { method: 'GET' }
-  );
-};
-
 export const createWorkflowScheduleReal: CreateScheduleContract = async (input) => {
   return await apiRequest<{ schedule: WorkflowSchedule }>(
     api.workflowAgent.schedules.create(),
     { method: 'POST', body: input }
-  );
-};
-
-export const updateWorkflowScheduleReal: UpdateScheduleContract = async (input) => {
-  const { id, ...body } = input;
-  return await apiRequest<{ schedule: WorkflowSchedule }>(
-    api.workflowAgent.schedules.byId(id),
-    { method: 'PATCH', body }
-  );
-};
-
-export const deleteWorkflowScheduleReal: DeleteScheduleContract = async (id) => {
-  return await apiRequest<{ ok: boolean }>(
-    api.workflowAgent.schedules.byId(id),
-    { method: 'DELETE' }
   );
 };

--- a/prd-admin/src/services/real/workflowAgent.ts
+++ b/prd-admin/src/services/real/workflowAgent.ts
@@ -33,6 +33,11 @@ import type {
   CapsuleTypeMeta,
   CapsuleCategoryInfo,
   CapsuleTestRunResult,
+  WorkflowSchedule,
+  ListSchedulesContract,
+  CreateScheduleContract,
+  UpdateScheduleContract,
+  DeleteScheduleContract,
 } from '../contracts/workflowAgent';
 
 // ========== Workflows ==========
@@ -268,5 +273,37 @@ export const aiFillParametersReal: AiFillParametersContract = async (input) => {
   return await apiRequest<AiFillResult>(
     api.workflowAgent.aiFill(),
     { method: 'POST', body: input }
+  );
+};
+
+// ========== Schedules (一次性 / 循环 自动发布) ==========
+
+export const listWorkflowSchedulesReal: ListSchedulesContract = async (workflowId) => {
+  const qs = workflowId ? `?workflowId=${encodeURIComponent(workflowId)}` : '';
+  return await apiRequest<{ items: WorkflowSchedule[] }>(
+    api.workflowAgent.schedules.list() + qs,
+    { method: 'GET' }
+  );
+};
+
+export const createWorkflowScheduleReal: CreateScheduleContract = async (input) => {
+  return await apiRequest<{ schedule: WorkflowSchedule }>(
+    api.workflowAgent.schedules.create(),
+    { method: 'POST', body: input }
+  );
+};
+
+export const updateWorkflowScheduleReal: UpdateScheduleContract = async (input) => {
+  const { id, ...body } = input;
+  return await apiRequest<{ schedule: WorkflowSchedule }>(
+    api.workflowAgent.schedules.byId(id),
+    { method: 'PATCH', body }
+  );
+};
+
+export const deleteWorkflowScheduleReal: DeleteScheduleContract = async (id) => {
+  return await apiRequest<{ ok: boolean }>(
+    api.workflowAgent.schedules.byId(id),
+    { method: 'DELETE' }
   );
 };

--- a/prd-admin/src/stores/weeklyPosterStore.ts
+++ b/prd-admin/src/stores/weeklyPosterStore.ts
@@ -40,18 +40,24 @@ interface WeeklyPosterState {
   /** 后端返回的当前可见海报（已过滤已读） */
   currentPoster: WeeklyPoster | null;
   loading: boolean;
-  /** 同会话已关闭的 id（防止瞬时重弹） */
-  dismissedIds: Set<string>;
+  /**
+   * 用户**主动**点 ✕ 关闭过的 id（仅当前 SPA 视图生效）。
+   * 不包含 1.5s 自动 markSeen 的 id —— 静默持久化不应让 modal 消失。
+   */
+  closedIds: Set<string>;
 
   loadCurrent: () => Promise<void>;
+  /** 用户主动关闭：写后端 SeenBy + 立即隐藏 UI */
   dismiss: (posterId: string) => void;
+  /** 静默标记已读：仅写后端 SeenBy + sessionStorage，不隐藏 UI（让用户继续看完） */
+  markSeen: (posterId: string) => void;
   shouldShowCurrent: () => boolean;
 }
 
 export const useWeeklyPosterStore = create<WeeklyPosterState>((set, get) => ({
   currentPoster: null,
   loading: false,
-  dismissedIds: loadSessionDismissed(),
+  closedIds: loadSessionDismissed(),
 
   loadCurrent: async () => {
     if (get().loading) return;
@@ -68,20 +74,31 @@ export const useWeeklyPosterStore = create<WeeklyPosterState>((set, get) => ({
     }
   },
 
+  markSeen: (posterId: string) => {
+    // 仅持久化（后端 SeenBy + sessionStorage 当作"已经登记"标记），不动 closedIds → modal 保持显示
+    const cur = get().closedIds;
+    if (!cur.has(posterId)) {
+      const next = new Set(cur);
+      next.add(posterId);
+      saveSessionDismissed(next);
+      // 注意：写 sessionStorage 但**不** set({closedIds:next})，避免触发 shouldShowCurrent 变 false
+    }
+    void markWeeklyPosterSeen(posterId).catch(() => { /* ignore */ });
+  },
+
   dismiss: (posterId: string) => {
-    // 1) 同会话内立刻隐藏
-    const next = new Set(get().dismissedIds);
+    // 用户主动关闭：先持久化，再隐藏 UI
+    void markWeeklyPosterSeen(posterId).catch(() => { /* ignore */ });
+    const next = new Set(get().closedIds);
     next.add(posterId);
     saveSessionDismissed(next);
-    set({ dismissedIds: next });
-    // 2) 持久化到后端 SeenBy（fire-and-forget；失败也只是下次进还会弹一次，无副作用）
-    void markWeeklyPosterSeen(posterId).catch(() => { /* ignore */ });
+    set({ closedIds: next });
   },
 
   shouldShowCurrent: () => {
     const poster = get().currentPoster;
     if (!poster || !poster.id) return false;
     if (!poster.pages || poster.pages.length === 0) return false;
-    return !get().dismissedIds.has(poster.id);
+    return !get().closedIds.has(poster.id);
   },
 }));

--- a/prd-admin/src/stores/weeklyPosterStore.ts
+++ b/prd-admin/src/stores/weeklyPosterStore.ts
@@ -1,22 +1,26 @@
 import { create } from 'zustand';
 import {
   getCurrentWeeklyPoster,
+  markWeeklyPosterSeen,
   type WeeklyPoster,
 } from '@/services';
 
 /**
  * 周报海报弹窗状态。
  *
- * 用户维度的「已读」状态用 sessionStorage 本地记录即可(关闭浏览器后重开再弹一次也不会打扰,
- * 登录后的主页展示期望是「同一会话只看一次」)。无需开用户表,遵循奥卡姆剃刀。
- * 若未来需要跨会话精确统计,再在后端加 mark-seen 端点。
+ * "已读"持久化走后端：每张海报有 SeenBy: List<string>（用户ID 列表），用户看过一次后
+ * 后端 GET /current 不再返回该海报；管理员发布新海报（不同 id，SeenBy 为空）时所有用户
+ * 又会再弹一次。这样跨浏览器、跨设备、跨重新登录都对齐——"看过的不再看，有更新就再弹"。
+ *
+ * 同会话内的优化：dismissedIds (sessionStorage) 防止网络抖动导致 mark-seen 重复弹窗，
+ * 但权威状态来自后端。
  */
 
-const DISMISSED_STORAGE_KEY = 'weekly-poster-dismissed';
+const SESSION_DISMISS_KEY = 'weekly-poster-dismissed';
 
-function loadDismissedIds(): Set<string> {
+function loadSessionDismissed(): Set<string> {
   try {
-    const raw = sessionStorage.getItem(DISMISSED_STORAGE_KEY);
+    const raw = sessionStorage.getItem(SESSION_DISMISS_KEY);
     if (raw) return new Set(JSON.parse(raw) as string[]);
   } catch {
     /* ignore */
@@ -24,33 +28,30 @@ function loadDismissedIds(): Set<string> {
   return new Set();
 }
 
-function saveDismissedIds(ids: Set<string>) {
+function saveSessionDismissed(ids: Set<string>) {
   try {
-    sessionStorage.setItem(DISMISSED_STORAGE_KEY, JSON.stringify([...ids]));
+    sessionStorage.setItem(SESSION_DISMISS_KEY, JSON.stringify([...ids]));
   } catch {
     /* ignore */
   }
 }
 
 interface WeeklyPosterState {
-  /** 后端最新可见的 published 海报 */
+  /** 后端返回的当前可见海报（已过滤已读） */
   currentPoster: WeeklyPoster | null;
   loading: boolean;
-  /** 当前会话已关闭的海报 id 集合 */
+  /** 同会话已关闭的 id（防止瞬时重弹） */
   dismissedIds: Set<string>;
 
-  /** 拉取当前海报(首屏挂载时调一次即可) */
   loadCurrent: () => Promise<void>;
-  /** 关闭当前海报(本次会话不再弹出) */
   dismiss: (posterId: string) => void;
-  /** 是否应该弹出当前海报 */
   shouldShowCurrent: () => boolean;
 }
 
 export const useWeeklyPosterStore = create<WeeklyPosterState>((set, get) => ({
   currentPoster: null,
   loading: false,
-  dismissedIds: loadDismissedIds(),
+  dismissedIds: loadSessionDismissed(),
 
   loadCurrent: async () => {
     if (get().loading) return;
@@ -61,17 +62,20 @@ export const useWeeklyPosterStore = create<WeeklyPosterState>((set, get) => ({
         set({ currentPoster: res.data ?? null });
       }
     } catch {
-      /* silent fail - 海报能失败不影响主页加载 */
+      /* silent fail - 海报失败不能挡主页加载 */
     } finally {
       set({ loading: false });
     }
   },
 
   dismiss: (posterId: string) => {
+    // 1) 同会话内立刻隐藏
     const next = new Set(get().dismissedIds);
     next.add(posterId);
-    saveDismissedIds(next);
+    saveSessionDismissed(next);
     set({ dismissedIds: next });
+    // 2) 持久化到后端 SeenBy（fire-and-forget；失败也只是下次进还会弹一次，无副作用）
+    void markWeeklyPosterSeen(posterId).catch(() => { /* ignore */ });
   },
 
   shouldShowCurrent: () => {

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/WeeklyPosterController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/WeeklyPosterController.cs
@@ -58,8 +58,18 @@ public sealed class WeeklyPosterController : ControllerBase
     [HttpGet("current")]
     public async Task<IActionResult> GetCurrent(CancellationToken ct = default)
     {
+        var userId = this.GetUserIdOrNull();
+        // 跨会话「已读」：过滤掉当前用户已经标记 seen 的海报；这样用户登录看过一次后就不再弹，
+        // 但发布了新海报（不同 id）时，新海报的 SeenBy 不含当前用户 → 仍会弹一次
+        var filter = Builders<WeeklyPosterAnnouncement>.Filter.Eq(x => x.Status, WeeklyPosterStatus.Published);
+        if (!string.IsNullOrEmpty(userId))
+        {
+            filter &= Builders<WeeklyPosterAnnouncement>.Filter.Not(
+                Builders<WeeklyPosterAnnouncement>.Filter.AnyEq(x => x.SeenBy, userId));
+        }
+
         var poster = await _db.WeeklyPosters
-            .Find(x => x.Status == WeeklyPosterStatus.Published)
+            .Find(filter)
             .SortByDescending(x => x.PublishedAt)
             .ThenByDescending(x => x.CreatedAt)
             .FirstOrDefaultAsync(ct);
@@ -70,6 +80,29 @@ public sealed class WeeklyPosterController : ControllerBase
         }
 
         return Ok(ApiResponse<WeeklyPosterDto?>.Ok(ToDto(poster)));
+    }
+
+    /// <summary>
+    /// 标记当前用户已看过这张海报。前端在弹窗展示 1.5s 后调用此端点，把当前用户写入 SeenBy。
+    /// 之后 GET /current 不再返回这张海报，直到发布了新的（不同 id）海报。
+    /// 同一用户对同一海报只记一次（用 AddToSet 去重）。
+    /// </summary>
+    [HttpPost("{id}/mark-seen")]
+    public async Task<IActionResult> MarkSeen(string id, CancellationToken ct = default)
+    {
+        var userId = this.GetUserIdOrNull();
+        if (string.IsNullOrEmpty(userId))
+            return Unauthorized(ApiResponse<object>.Fail(ErrorCodes.UNAUTHORIZED, "未登录"));
+
+        var result = await _db.WeeklyPosters.UpdateOneAsync(
+            x => x.Id == id,
+            Builders<WeeklyPosterAnnouncement>.Update.AddToSet(x => x.SeenBy, userId),
+            cancellationToken: ct);
+
+        if (result.MatchedCount == 0)
+            return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "海报不存在"));
+
+        return Ok(ApiResponse<object>.Ok(new { ok = true }));
     }
 
     // ────────────────────────────────────────────────────────────

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/WorkflowAgentController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/WorkflowAgentController.cs
@@ -1226,7 +1226,9 @@ public class WorkflowAgentController : ControllerBase
                 return BadRequest(ApiResponse<object>.Fail("INVALID_REQUEST", "循环调度需要 cronExpression"));
             try
             {
-                nextRunAt = CronEvaluator.NextOccurrence(request.CronExpression!, DateTime.UtcNow);
+                // cron 字段按 schedule.Timezone（默认 Asia/Shanghai）解释，避免 0 9 * * * 被当成 09:00 UTC = 17:00 CST
+                var tz = string.IsNullOrWhiteSpace(request.Timezone) ? "Asia/Shanghai" : request.Timezone!;
+                nextRunAt = CronEvaluator.NextOccurrence(request.CronExpression!, DateTime.UtcNow, tz);
             }
             catch (Exception ex)
             {

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/WorkflowAgentController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/WorkflowAgentController.cs
@@ -1169,6 +1169,136 @@ public class WorkflowAgentController : ControllerBase
     }
 
     // ─────────────────────────────────────────────────────────
+    // 自动发布调度（WorkflowSchedule）
+    //   一次性 (Mode=once + RunAtUtc) / 循环 (Mode=cron + CronExpression)
+    //   WorkflowScheduleWorker 负责定时轮询触发
+    // ─────────────────────────────────────────────────────────
+
+    /// <summary>列出当前用户可见的调度（管理员可见全部）</summary>
+    [HttpGet("schedules")]
+    public async Task<IActionResult> ListSchedules(
+        [FromQuery] string? workflowId,
+        CancellationToken ct = default)
+    {
+        var userId = GetUserId();
+        var filter = HasManagePermission()
+            ? Builders<WorkflowSchedule>.Filter.Empty
+            : Builders<WorkflowSchedule>.Filter.Eq(s => s.CreatedBy, userId);
+
+        if (!string.IsNullOrWhiteSpace(workflowId))
+            filter &= Builders<WorkflowSchedule>.Filter.Eq(s => s.WorkflowId, workflowId);
+
+        var items = await _db.WorkflowSchedules
+            .Find(filter)
+            .SortByDescending(s => s.CreatedAt)
+            .ToListAsync(ct);
+
+        return Ok(ApiResponse<object>.Ok(new { items }));
+    }
+
+    /// <summary>创建调度（once 或 cron）。NextRunAt 由后端计算</summary>
+    [HttpPost("schedules")]
+    public async Task<IActionResult> CreateSchedule(
+        [FromBody] CreateScheduleRequest request,
+        CancellationToken ct = default)
+    {
+        if (request == null || string.IsNullOrWhiteSpace(request.WorkflowId))
+            return BadRequest(ApiResponse<object>.Fail("INVALID_REQUEST", "workflowId 必填"));
+
+        var workflow = await _db.Workflows.Find(w => w.Id == request.WorkflowId).FirstOrDefaultAsync(ct);
+        if (workflow == null)
+            return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "工作流不存在"));
+
+        var mode = (request.Mode ?? "once").Trim().ToLowerInvariant();
+        DateTime? nextRunAt = null;
+
+        if (mode == "once")
+        {
+            if (request.RunAtUtc == null)
+                return BadRequest(ApiResponse<object>.Fail("INVALID_REQUEST", "一次性调度需要 runAtUtc"));
+            if (request.RunAtUtc <= DateTime.UtcNow)
+                return BadRequest(ApiResponse<object>.Fail("INVALID_REQUEST", "一次性调度的执行时间必须在未来"));
+            nextRunAt = request.RunAtUtc;
+        }
+        else if (mode == "cron")
+        {
+            if (string.IsNullOrWhiteSpace(request.CronExpression))
+                return BadRequest(ApiResponse<object>.Fail("INVALID_REQUEST", "循环调度需要 cronExpression"));
+            try
+            {
+                nextRunAt = CronEvaluator.NextOccurrence(request.CronExpression!, DateTime.UtcNow);
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(ApiResponse<object>.Fail("INVALID_CRON", $"Cron 表达式不合法: {ex.Message}"));
+            }
+        }
+        else
+        {
+            return BadRequest(ApiResponse<object>.Fail("INVALID_REQUEST", $"不支持的 Mode: {mode}（仅支持 once / cron）"));
+        }
+
+        var schedule = new WorkflowSchedule
+        {
+            WorkflowId = workflow.Id,
+            WorkflowName = workflow.Name,
+            Name = (request.Name ?? "").Trim(),
+            Mode = mode,
+            RunAtUtc = mode == "once" ? request.RunAtUtc : null,
+            CronExpression = mode == "cron" ? request.CronExpression : null,
+            Timezone = string.IsNullOrWhiteSpace(request.Timezone) ? "Asia/Shanghai" : request.Timezone!,
+            IsEnabled = request.IsEnabled ?? true,
+            NextRunAt = nextRunAt,
+            VariableOverrides = request.Variables,
+            CreatedBy = GetUserId(),
+            CreatedAt = DateTime.UtcNow,
+        };
+
+        await _db.WorkflowSchedules.InsertOneAsync(schedule, cancellationToken: ct);
+        _logger.LogInformation("[{AppKey}] Schedule created: {Id} workflow={WorkflowId} mode={Mode} next={Next}",
+            AppKey, schedule.Id, schedule.WorkflowId, schedule.Mode, schedule.NextRunAt);
+
+        return Ok(ApiResponse<object>.Ok(new { schedule }));
+    }
+
+    /// <summary>更新调度（启停 / 变量覆盖）</summary>
+    [HttpPatch("schedules/{id}")]
+    public async Task<IActionResult> UpdateSchedule(
+        string id,
+        [FromBody] UpdateScheduleRequest request,
+        CancellationToken ct = default)
+    {
+        var schedule = await _db.WorkflowSchedules.Find(s => s.Id == id).FirstOrDefaultAsync(ct);
+        if (schedule == null)
+            return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "调度不存在"));
+
+        if (schedule.CreatedBy != GetUserId() && !HasManagePermission())
+            return StatusCode(403, ApiResponse<object>.Fail(ErrorCodes.PERMISSION_DENIED, "无权限"));
+
+        if (request.IsEnabled.HasValue) schedule.IsEnabled = request.IsEnabled.Value;
+        if (request.Name != null) schedule.Name = request.Name.Trim();
+        if (request.Variables != null) schedule.VariableOverrides = request.Variables;
+
+        await _db.WorkflowSchedules.ReplaceOneAsync(s => s.Id == id, schedule, cancellationToken: ct);
+        return Ok(ApiResponse<object>.Ok(new { schedule }));
+    }
+
+    /// <summary>删除调度</summary>
+    [HttpDelete("schedules/{id}")]
+    public async Task<IActionResult> DeleteSchedule(string id, CancellationToken ct = default)
+    {
+        var schedule = await _db.WorkflowSchedules.Find(s => s.Id == id).FirstOrDefaultAsync(ct);
+        if (schedule == null)
+            return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "调度不存在"));
+
+        if (schedule.CreatedBy != GetUserId() && !HasManagePermission())
+            return StatusCode(403, ApiResponse<object>.Fail(ErrorCodes.PERMISSION_DENIED, "无权限"));
+
+        await _db.WorkflowSchedules.DeleteOneAsync(s => s.Id == id, ct);
+        return Ok(ApiResponse<object>.Ok(new { ok = true }));
+    }
+
+    // ─────────────────────────────────────────────────────────
     // Helpers
     // ─────────────────────────────────────────────────────────
 
@@ -2053,6 +2183,30 @@ public class AiFillWorkflowSnapshot
     public string? Description { get; set; }
     public List<WorkflowNode> Nodes { get; set; } = new();
     public List<WorkflowEdge> Edges { get; set; } = new();
+}
+
+// ─────────────────────── 调度 ───────────────────────
+
+public class CreateScheduleRequest
+{
+    public string WorkflowId { get; set; } = string.Empty;
+    public string? Name { get; set; }
+
+    /// <summary>once | cron</summary>
+    public string? Mode { get; set; } = "once";
+    public DateTime? RunAtUtc { get; set; }
+    public string? CronExpression { get; set; }
+    public string? Timezone { get; set; } = "Asia/Shanghai";
+
+    public bool? IsEnabled { get; set; } = true;
+    public Dictionary<string, string>? Variables { get; set; }
+}
+
+public class UpdateScheduleRequest
+{
+    public string? Name { get; set; }
+    public bool? IsEnabled { get; set; }
+    public Dictionary<string, string>? Variables { get; set; }
 }
 
 #endregion

--- a/prd-api/src/PrdAgent.Api/Extensions/ControllerIdentityExtensions.cs
+++ b/prd-api/src/PrdAgent.Api/Extensions/ControllerIdentityExtensions.cs
@@ -25,4 +25,15 @@ public static class ControllerIdentityExtensions
             throw new UnauthorizedAccessException("Missing user identity claims");
         return id;
     }
+
+    /// <summary>
+    /// 同 GetRequiredUserId 但找不到时返回 null（用于"匿名也允许的端点"场景，如
+    /// /api/weekly-posters/current —— 未登录读取最新公开海报、登录读取过滤已读后的海报）。
+    /// </summary>
+    public static string? GetUserIdOrNull(this ControllerBase controller)
+    {
+        return controller.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value
+            ?? controller.User.FindFirst("sub")?.Value
+            ?? controller.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+    }
 }

--- a/prd-api/src/PrdAgent.Api/Program.cs
+++ b/prd-api/src/PrdAgent.Api/Program.cs
@@ -230,6 +230,9 @@ builder.Services.AddHostedService<PrdAgent.Api.Services.ChatRunWorker>();
 builder.Services.AddHostedService<PrdAgent.Api.Services.WorkflowRunWorker>();
 builder.Services.AddScoped<PrdAgent.Api.Services.WorkflowAiFillService>();
 
+// 工作流调度轮询：每 30 秒扫一次到期的 once / cron 调度，自动入队
+builder.Services.AddHostedService<PrdAgent.Api.Services.WorkflowScheduleWorker>();
+
 // 涌现探索器
 builder.Services.AddSingleton<PrdAgent.Api.Services.SystemCapabilityScanner>();
 builder.Services.AddScoped<PrdAgent.Api.Services.EmergenceService>();

--- a/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
+++ b/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
@@ -7825,28 +7825,62 @@ function safeChart(canvasId, config) {
             var weekKey = ReplaceVariables(GetConfigString(node, "weekKey") ?? "", variables).Trim();
             var titleConfig = ReplaceVariables(GetConfigString(node, "title") ?? "", variables).Trim();
             var subtitle = ReplaceVariables(GetConfigString(node, "subtitle") ?? "", variables).Trim();
-            var templateKey = (GetConfigString(node, "templateKey") ?? "promo").Trim();
-            var presentationMode = (GetConfigString(node, "presentationMode") ?? "ad-4-3").Trim();
-            var accentColor = (GetConfigString(node, "accentColor") ?? "#ff0050").Trim();
+            // templateKey / presentationMode / accentColor 支持 {{var}} 模板，且 variables 同名 key 可以
+            // 兜底 —— 让"海报编辑页 自动发布"对话框可以直接覆盖这些字段而不需要改工作流配置
+            var templateKey = ReplaceVariables(GetConfigString(node, "templateKey") ?? "", variables).Trim();
+            if (string.IsNullOrEmpty(templateKey)) templateKey = variables.GetValueOrDefault("templateKey") ?? "promo";
+            var presentationMode = ReplaceVariables(GetConfigString(node, "presentationMode") ?? "", variables).Trim();
+            if (string.IsNullOrEmpty(presentationMode)) presentationMode = variables.GetValueOrDefault("presentationMode") ?? "ad-4-3";
+            var accentColor = ReplaceVariables(GetConfigString(node, "accentColor") ?? "", variables).Trim();
+            if (string.IsNullOrEmpty(accentColor)) accentColor = variables.GetValueOrDefault("accentColor") ?? "#ff0050";
             var ctaText = ReplaceVariables(GetConfigString(node, "ctaText") ?? "去看完整视频", variables).Trim();
             var ctaUrlDirect = ReplaceVariables(GetConfigString(node, "ctaUrl") ?? "", variables).Trim();
             var ctaUrlField = (GetConfigString(node, "ctaUrlField") ?? "firstItem.shareUrl").Trim();
             var publishFlag = (GetConfigString(node, "publish") ?? "true").Trim().ToLowerInvariant() != "false";
 
-            // 取 items 数组
+            // 取 items 数组：优先用户配置 itemsField，再退一组 TikHub / 抖音 / B 站 / 小红书 / YouTube
+            // 原始响应里常见的数组路径，让用户即便绕过 tiktok-creator-fetch 直接用智能HTTP 也能跑通
             JsonElement itemsElem = ResolveJsonElement(inputRoot, itemsField);
+            JsonDocument? wrapDoc = null;
             if (itemsElem.ValueKind != JsonValueKind.Array)
             {
-                // 兜底：如果上游就是数组本身
+                // 兜底 1：如果上游就是数组本身
                 if (inputRoot.ValueKind == JsonValueKind.Array) itemsElem = inputRoot;
-                // 兜底：取 firstItem 包装成单元素数组（适配 tiktok-creator-fetch 的简化输出）
+                // 兜底 2：取 firstItem 包装成单元素数组（适配 tiktok-creator-fetch 简化输出）
                 else if (inputRoot.TryGetProperty("firstItem", out var fi) && fi.ValueKind == JsonValueKind.Object)
                 {
-                    var single = JsonDocument.Parse("[" + fi.GetRawText() + "]");
-                    itemsElem = single.RootElement;
+                    wrapDoc = JsonDocument.Parse("[" + fi.GetRawText() + "]");
+                    itemsElem = wrapDoc.RootElement;
                 }
                 else
-                    throw new InvalidOperationException($"上游 JSON 中找不到数组字段「{itemsField}」（也没有 items / firstItem 兜底）");
+                {
+                    // 兜底 3：常见 raw 响应路径（智能HTTP 直拉 TikHub 时）
+                    foreach (var probe in new[]
+                    {
+                        "data.aweme_list", "data.itemList", "data.list.vlist", "data.notes",
+                        "data.videos", "data.list", "data.feed",
+                        "aweme_list", "itemList", "list", "videos", "notes", "vlist", "feed",
+                    })
+                    {
+                        var probed = ResolveJsonElement(inputRoot, probe);
+                        if (probed.ValueKind == JsonValueKind.Array)
+                        {
+                            itemsElem = probed;
+                            sb.AppendLine($"[WeeklyPosterPublisher] 兜底命中数组路径「{probe}」");
+                            break;
+                        }
+                    }
+                }
+
+                if (itemsElem.ValueKind != JsonValueKind.Array)
+                {
+                    var topKeys = inputRoot.ValueKind == JsonValueKind.Object
+                        ? string.Join(", ", inputRoot.EnumerateObject().Take(10).Select(p => p.Name))
+                        : inputRoot.ValueKind.ToString();
+                    throw new InvalidOperationException(
+                        $"上游 JSON 中找不到数组字段「{itemsField}」（兜底也未命中）。上游顶层字段: [{topKeys}]。" +
+                        "请检查工作流是否接入了「TikTok 创作者订阅」capsule，或在节点配置里把「上游条目字段」改成实际数组路径，例如 data.aweme_list");
+                }
             }
 
             var pages = new List<WeeklyPosterPage>();

--- a/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
+++ b/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
@@ -7825,6 +7825,11 @@ function safeChart(canvasId, config) {
             var weekKey = ReplaceVariables(GetConfigString(node, "weekKey") ?? "", variables).Trim();
             var titleConfig = ReplaceVariables(GetConfigString(node, "title") ?? "", variables).Trim();
             var subtitle = ReplaceVariables(GetConfigString(node, "subtitle") ?? "", variables).Trim();
+            // 调试：打印 variables 字典前 20 键值（troubleshoot 变量兜底为何不生效）
+            sb.AppendLine($"[WeeklyPosterPublisher][debug] variables keys=[{string.Join(",", variables.Keys.Take(20))}]");
+            sb.AppendLine($"[WeeklyPosterPublisher][debug] vars.presentationMode={(variables.TryGetValue("presentationMode", out var _pm) ? $"\"{_pm}\"" : "(missing)")}");
+            sb.AppendLine($"[WeeklyPosterPublisher][debug] vars.templateKey={(variables.TryGetValue("templateKey", out var _tk) ? $"\"{_tk}\"" : "(missing)")}");
+            sb.AppendLine($"[WeeklyPosterPublisher][debug] vars.accentColor={(variables.TryGetValue("accentColor", out var _ac) ? $"\"{_ac}\"" : "(missing)")}");
             // templateKey / presentationMode / accentColor 支持 {{var}} 模板，且 variables 同名 key 可以
             // 兜底 —— 让"海报编辑页 自动发布"对话框可以直接覆盖这些字段而不需要改工作流配置
             var templateKey = ReplaceVariables(GetConfigString(node, "templateKey") ?? "", variables).Trim();

--- a/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
+++ b/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
@@ -7825,11 +7825,6 @@ function safeChart(canvasId, config) {
             var weekKey = ReplaceVariables(GetConfigString(node, "weekKey") ?? "", variables).Trim();
             var titleConfig = ReplaceVariables(GetConfigString(node, "title") ?? "", variables).Trim();
             var subtitle = ReplaceVariables(GetConfigString(node, "subtitle") ?? "", variables).Trim();
-            // 调试：打印 variables 字典前 20 键值（troubleshoot 变量兜底为何不生效）
-            sb.AppendLine($"[WeeklyPosterPublisher][debug] variables keys=[{string.Join(",", variables.Keys.Take(20))}]");
-            sb.AppendLine($"[WeeklyPosterPublisher][debug] vars.presentationMode={(variables.TryGetValue("presentationMode", out var _pm) ? $"\"{_pm}\"" : "(missing)")}");
-            sb.AppendLine($"[WeeklyPosterPublisher][debug] vars.templateKey={(variables.TryGetValue("templateKey", out var _tk) ? $"\"{_tk}\"" : "(missing)")}");
-            sb.AppendLine($"[WeeklyPosterPublisher][debug] vars.accentColor={(variables.TryGetValue("accentColor", out var _ac) ? $"\"{_ac}\"" : "(missing)")}");
             // templateKey / presentationMode / accentColor 支持 {{var}} 模板，且 variables 同名 key 可以
             // 兜底 —— 让"海报编辑页 自动发布"对话框可以直接覆盖这些字段而不需要改工作流配置
             var templateKey = ReplaceVariables(GetConfigString(node, "templateKey") ?? "", variables).Trim();
@@ -8125,6 +8120,3 @@ function safeChart(canvasId, config) {
         return cur;
     }
 }
-
-// 让 dotnet watch 强制 cold-restart 而不只 hot-reload —— 增加成员是 hot reload 做不到的
-public static class CapsuleExecutorRebuildSentinel { public static readonly string Token = "rebuild-{60897ff}-1"; }

--- a/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
+++ b/prd-api/src/PrdAgent.Api/Services/CapsuleExecutor.cs
@@ -8125,3 +8125,6 @@ function safeChart(canvasId, config) {
         return cur;
     }
 }
+
+// 让 dotnet watch 强制 cold-restart 而不只 hot-reload —— 增加成员是 hot reload 做不到的
+public static class CapsuleExecutorRebuildSentinel { public static readonly string Token = "rebuild-{60897ff}-1"; }

--- a/prd-api/src/PrdAgent.Api/Services/CronEvaluator.cs
+++ b/prd-api/src/PrdAgent.Api/Services/CronEvaluator.cs
@@ -80,3 +80,4 @@ public static class CronEvaluator
         return result;
     }
 }
+

--- a/prd-api/src/PrdAgent.Api/Services/CronEvaluator.cs
+++ b/prd-api/src/PrdAgent.Api/Services/CronEvaluator.cs
@@ -24,6 +24,10 @@ public static class CronEvaluator
         var dom = ParseField(fields[2], 1, 31);
         var month = ParseField(fields[3], 1, 12);
         var dow = ParseField(fields[4], 0, 6);
+        // Vixie/POSIX cron 语义：dom 和 dow 都是 '*' 表示无约束，否则任一字段被限制时
+        // 应该用 OR 合并（"每月 1 号 OR 每周五" 而不是"既是 1 号又是周五"）
+        var domWild = fields[2] == "*";
+        var dowWild = fields[4] == "*";
 
         TimeZoneInfo tz;
         try
@@ -46,10 +50,19 @@ public static class CronEvaluator
         while (t < deadline)
         {
             if (!month.Contains(t.Month)) { t = t.AddMonths(1); t = new DateTime(t.Year, t.Month, 1, 0, 0, 0, DateTimeKind.Unspecified); continue; }
-            if (!dom.Contains(t.Day) || !dow.Contains((int)t.DayOfWeek)) { t = t.AddDays(1); t = new DateTime(t.Year, t.Month, t.Day, 0, 0, 0, DateTimeKind.Unspecified); continue; }
+            // dom/dow OR 语义：两者都 *  → 不限制；只一个 *  → 用另一个；都限制 → OR
+            bool dayOk;
+            if (domWild && dowWild) dayOk = true;
+            else if (domWild) dayOk = dow.Contains((int)t.DayOfWeek);
+            else if (dowWild) dayOk = dom.Contains(t.Day);
+            else dayOk = dom.Contains(t.Day) || dow.Contains((int)t.DayOfWeek);
+            if (!dayOk) { t = t.AddDays(1); t = new DateTime(t.Year, t.Month, t.Day, 0, 0, 0, DateTimeKind.Unspecified); continue; }
             if (!hour.Contains(t.Hour)) { t = t.AddHours(1); t = new DateTime(t.Year, t.Month, t.Day, t.Hour, 0, 0, DateTimeKind.Unspecified); continue; }
             if (!minute.Contains(t.Minute)) { t = t.AddMinutes(1); continue; }
-            // 命中：tz 本地 t → UTC
+            // DST spring-forward gap：t 落在被跳过的小时内（如 America/New_York 转换日的 02:00-03:00）
+            // ConvertTimeToUtc 会抛 ArgumentException → worker 永久禁用调度，controller 返回 "Cron 不合法"。
+            // 跳过这一分钟，下一分钟再试
+            if (tz.IsInvalidTime(t)) { t = t.AddMinutes(1); continue; }
             return TimeZoneInfo.ConvertTimeToUtc(t, tz);
         }
 

--- a/prd-api/src/PrdAgent.Api/Services/CronEvaluator.cs
+++ b/prd-api/src/PrdAgent.Api/Services/CronEvaluator.cs
@@ -8,8 +8,12 @@ namespace PrdAgent.Api.Services;
 /// </summary>
 public static class CronEvaluator
 {
-    /// <summary>找到 from（含）之后下一个匹配的 UTC 时间。最多向前找 366 天。</summary>
-    public static DateTime NextOccurrence(string cron, DateTime from)
+    /// <summary>
+    /// 找到 fromUtc（含）之后下一个匹配的 UTC 时间，cron 字段按 <paramref name="timezone"/> 本地时间解释。
+    /// 例：cron="0 9 * * *" + timezone="Asia/Shanghai" → 每天 09:00 CST = 01:00 UTC（不是 09:00 UTC）。
+    /// 找不到 timezone 时回退 UTC。最多向前找 366 天。
+    /// </summary>
+    public static DateTime NextOccurrence(string cron, DateTime fromUtc, string timezone = "UTC")
     {
         var fields = cron.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries);
         if (fields.Length != 5)
@@ -21,20 +25,35 @@ public static class CronEvaluator
         var month = ParseField(fields[3], 1, 12);
         var dow = ParseField(fields[4], 0, 6);
 
-        // 从 from 的下一分钟开始扫描
-        var t = new DateTime(from.Year, from.Month, from.Day, from.Hour, from.Minute, 0, DateTimeKind.Utc).AddMinutes(1);
+        TimeZoneInfo tz;
+        try
+        {
+            tz = string.IsNullOrWhiteSpace(timezone) || timezone.Equals("UTC", StringComparison.OrdinalIgnoreCase)
+                ? TimeZoneInfo.Utc
+                : TimeZoneInfo.FindSystemTimeZoneById(timezone);
+        }
+        catch
+        {
+            // 找不到 tz id（如 Windows tzdata 不全）→ 回退 UTC，避免抛 500
+            tz = TimeZoneInfo.Utc;
+        }
+
+        // UTC → tz local 后做 cron 字段匹配；最终结果再换回 UTC 存库
+        var localFrom = TimeZoneInfo.ConvertTimeFromUtc(fromUtc, tz);
+        var t = new DateTime(localFrom.Year, localFrom.Month, localFrom.Day, localFrom.Hour, localFrom.Minute, 0, DateTimeKind.Unspecified).AddMinutes(1);
         var deadline = t.AddDays(366);
 
         while (t < deadline)
         {
-            if (!month.Contains(t.Month)) { t = t.AddMonths(1); t = new DateTime(t.Year, t.Month, 1, 0, 0, 0, DateTimeKind.Utc); continue; }
-            if (!dom.Contains(t.Day) || !dow.Contains((int)t.DayOfWeek)) { t = t.AddDays(1); t = new DateTime(t.Year, t.Month, t.Day, 0, 0, 0, DateTimeKind.Utc); continue; }
-            if (!hour.Contains(t.Hour)) { t = t.AddHours(1); t = new DateTime(t.Year, t.Month, t.Day, t.Hour, 0, 0, DateTimeKind.Utc); continue; }
+            if (!month.Contains(t.Month)) { t = t.AddMonths(1); t = new DateTime(t.Year, t.Month, 1, 0, 0, 0, DateTimeKind.Unspecified); continue; }
+            if (!dom.Contains(t.Day) || !dow.Contains((int)t.DayOfWeek)) { t = t.AddDays(1); t = new DateTime(t.Year, t.Month, t.Day, 0, 0, 0, DateTimeKind.Unspecified); continue; }
+            if (!hour.Contains(t.Hour)) { t = t.AddHours(1); t = new DateTime(t.Year, t.Month, t.Day, t.Hour, 0, 0, DateTimeKind.Unspecified); continue; }
             if (!minute.Contains(t.Minute)) { t = t.AddMinutes(1); continue; }
-            return t;
+            // 命中：tz 本地 t → UTC
+            return TimeZoneInfo.ConvertTimeToUtc(t, tz);
         }
 
-        throw new InvalidOperationException($"Cron 在 366 天内找不到下次执行时间: {cron}");
+        throw new InvalidOperationException($"Cron 在 366 天内找不到下次执行时间: {cron} (tz={tz.Id})");
     }
 
     private static HashSet<int> ParseField(string field, int min, int max)

--- a/prd-api/src/PrdAgent.Api/Services/CronEvaluator.cs
+++ b/prd-api/src/PrdAgent.Api/Services/CronEvaluator.cs
@@ -1,0 +1,82 @@
+namespace PrdAgent.Api.Services;
+
+/// <summary>
+/// 极简 5 字段 Cron 解析器：分 时 日 月 周（0=Sun ~ 6=Sat）。
+/// 支持: '*' / 整数 / 'a,b,c' 列表 / '*\/n' 步长 / 'a-b' 范围。
+/// 不支持: '?', 'L', 'W', 'JAN-DEC' / 'MON-SUN' 字符。
+/// 仅用于工作流定时调度，足以覆盖 90% 的"每天 X 点 / 每周 X 几点 / 每月 X 号"场景。
+/// </summary>
+public static class CronEvaluator
+{
+    /// <summary>找到 from（含）之后下一个匹配的 UTC 时间。最多向前找 366 天。</summary>
+    public static DateTime NextOccurrence(string cron, DateTime from)
+    {
+        var fields = cron.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (fields.Length != 5)
+            throw new ArgumentException($"Cron 必须是 5 字段（分 时 日 月 周），实际收到 {fields.Length} 字段: {cron}");
+
+        var minute = ParseField(fields[0], 0, 59);
+        var hour = ParseField(fields[1], 0, 23);
+        var dom = ParseField(fields[2], 1, 31);
+        var month = ParseField(fields[3], 1, 12);
+        var dow = ParseField(fields[4], 0, 6);
+
+        // 从 from 的下一分钟开始扫描
+        var t = new DateTime(from.Year, from.Month, from.Day, from.Hour, from.Minute, 0, DateTimeKind.Utc).AddMinutes(1);
+        var deadline = t.AddDays(366);
+
+        while (t < deadline)
+        {
+            if (!month.Contains(t.Month)) { t = t.AddMonths(1); t = new DateTime(t.Year, t.Month, 1, 0, 0, 0, DateTimeKind.Utc); continue; }
+            if (!dom.Contains(t.Day) || !dow.Contains((int)t.DayOfWeek)) { t = t.AddDays(1); t = new DateTime(t.Year, t.Month, t.Day, 0, 0, 0, DateTimeKind.Utc); continue; }
+            if (!hour.Contains(t.Hour)) { t = t.AddHours(1); t = new DateTime(t.Year, t.Month, t.Day, t.Hour, 0, 0, DateTimeKind.Utc); continue; }
+            if (!minute.Contains(t.Minute)) { t = t.AddMinutes(1); continue; }
+            return t;
+        }
+
+        throw new InvalidOperationException($"Cron 在 366 天内找不到下次执行时间: {cron}");
+    }
+
+    private static HashSet<int> ParseField(string field, int min, int max)
+    {
+        var result = new HashSet<int>();
+        foreach (var part in field.Split(',', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var trimmed = part.Trim();
+            int step = 1;
+            string range = trimmed;
+
+            // step: a/n 或 *\/n
+            var slashIdx = trimmed.IndexOf('/');
+            if (slashIdx >= 0)
+            {
+                step = int.Parse(trimmed[(slashIdx + 1)..]);
+                if (step <= 0) throw new ArgumentException($"步长必须 > 0: {trimmed}");
+                range = trimmed[..slashIdx];
+            }
+
+            int lo, hi;
+            if (range == "*")
+            {
+                lo = min; hi = max;
+            }
+            else if (range.Contains('-'))
+            {
+                var dashIdx = range.IndexOf('-');
+                lo = int.Parse(range[..dashIdx]);
+                hi = int.Parse(range[(dashIdx + 1)..]);
+            }
+            else
+            {
+                lo = hi = int.Parse(range);
+            }
+
+            if (lo < min || hi > max || lo > hi)
+                throw new ArgumentException($"字段越界 [{lo},{hi}] 不在 [{min},{max}] 内: {trimmed}");
+
+            for (int i = lo; i <= hi; i += step)
+                result.Add(i);
+        }
+        return result;
+    }
+}

--- a/prd-api/src/PrdAgent.Api/Services/WorkflowScheduleWorker.cs
+++ b/prd-api/src/PrdAgent.Api/Services/WorkflowScheduleWorker.cs
@@ -1,0 +1,155 @@
+using MongoDB.Driver;
+using PrdAgent.Core.Interfaces;
+using PrdAgent.Core.Models;
+using PrdAgent.Infrastructure.Database;
+
+namespace PrdAgent.Api.Services;
+
+/// <summary>
+/// 调度轮询 worker：每 30 秒扫一次 workflow_schedules，将到期的调度入队执行。
+///   once 模式：触发后 IsEnabled = false，NextRunAt = null
+///   cron 模式：触发后重新计算 NextRunAt
+/// </summary>
+public sealed class WorkflowScheduleWorker : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IRunQueue _runQueue;
+    private readonly ILogger<WorkflowScheduleWorker> _logger;
+    private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(30);
+
+    public WorkflowScheduleWorker(IServiceScopeFactory scopeFactory, IRunQueue runQueue, ILogger<WorkflowScheduleWorker> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _runQueue = runQueue;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("WorkflowScheduleWorker started, poll interval = {Interval}s", PollInterval.TotalSeconds);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await TickAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "WorkflowScheduleWorker tick failed");
+            }
+
+            try { await Task.Delay(PollInterval, stoppingToken); }
+            catch (OperationCanceledException) { break; }
+        }
+
+        _logger.LogInformation("WorkflowScheduleWorker stopped");
+    }
+
+    private async Task TickAsync()
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MongoDbContext>();
+
+        var now = DateTime.UtcNow;
+        var due = await db.WorkflowSchedules
+            .Find(s => s.IsEnabled && s.NextRunAt != null && s.NextRunAt <= now)
+            .Limit(50)
+            .ToListAsync(CancellationToken.None);
+
+        if (due.Count == 0) return;
+
+        foreach (var schedule in due)
+        {
+            try
+            {
+                await TriggerAsync(db, schedule);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Schedule trigger failed: {Id} workflow={WorkflowId}", schedule.Id, schedule.WorkflowId);
+            }
+        }
+    }
+
+    private async Task TriggerAsync(MongoDbContext db, WorkflowSchedule schedule)
+    {
+        var workflow = await db.Workflows.Find(w => w.Id == schedule.WorkflowId).FirstOrDefaultAsync(CancellationToken.None);
+        if (workflow == null)
+        {
+            _logger.LogWarning("Schedule {Id} 关联的工作流 {WorkflowId} 不存在，禁用此调度", schedule.Id, schedule.WorkflowId);
+            await db.WorkflowSchedules.UpdateOneAsync(
+                s => s.Id == schedule.Id,
+                Builders<WorkflowSchedule>.Update.Set(s => s.IsEnabled, false),
+                cancellationToken: CancellationToken.None);
+            return;
+        }
+
+        // 合并变量：工作流默认值 < 调度覆盖
+        var variables = new Dictionary<string, string>();
+        foreach (var v in workflow.Variables)
+        {
+            if (v.DefaultValue != null) variables[v.Key] = v.DefaultValue;
+        }
+        if (schedule.VariableOverrides != null)
+        {
+            foreach (var kv in schedule.VariableOverrides) variables[kv.Key] = kv.Value;
+        }
+
+        var execution = new WorkflowExecution
+        {
+            WorkflowId = workflow.Id,
+            WorkflowName = workflow.Name,
+            TriggerType = schedule.Mode == "cron" ? WorkflowTriggerTypes.Cron : "scheduled-once",
+            TriggeredBy = schedule.CreatedBy,
+            TriggeredByName = $"schedule:{(string.IsNullOrWhiteSpace(schedule.Name) ? schedule.Id[..6] : schedule.Name)}",
+            Variables = variables,
+            NodeSnapshot = workflow.Nodes,
+            EdgeSnapshot = workflow.Edges,
+            NodeExecutions = workflow.Nodes.Select(n => new NodeExecution
+            {
+                NodeId = n.NodeId,
+                NodeName = n.Name,
+                NodeType = n.NodeType,
+                Status = NodeExecutionStatus.Pending,
+            }).ToList(),
+            Status = WorkflowExecutionStatus.Queued,
+        };
+
+        await db.WorkflowExecutions.InsertOneAsync(execution, cancellationToken: CancellationToken.None);
+        await _runQueue.EnqueueAsync(RunKinds.Workflow, execution.Id, CancellationToken.None);
+
+        // 更新 schedule
+        DateTime? nextRunAt = null;
+        bool keepEnabled = schedule.IsEnabled;
+        if (schedule.Mode == "cron" && !string.IsNullOrWhiteSpace(schedule.CronExpression))
+        {
+            try
+            {
+                nextRunAt = CronEvaluator.NextOccurrence(schedule.CronExpression!, DateTime.UtcNow);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Cron 重新计算失败，禁用此调度: {Id}", schedule.Id);
+                keepEnabled = false;
+            }
+        }
+        else
+        {
+            // once 模式，触发后停用
+            keepEnabled = false;
+        }
+
+        await db.WorkflowSchedules.UpdateOneAsync(
+            s => s.Id == schedule.Id,
+            Builders<WorkflowSchedule>.Update
+                .Set(s => s.LastTriggeredAt, DateTime.UtcNow)
+                .Set(s => s.NextRunAt, nextRunAt)
+                .Set(s => s.IsEnabled, keepEnabled)
+                .Inc(s => s.TriggerCount, 1),
+            cancellationToken: CancellationToken.None);
+
+        _logger.LogInformation("Schedule {Id} triggered, execution={ExecId} workflow={WorkflowId} mode={Mode} next={Next}",
+            schedule.Id, execution.Id, schedule.WorkflowId, schedule.Mode, nextRunAt);
+    }
+}

--- a/prd-api/src/PrdAgent.Api/Services/WorkflowScheduleWorker.cs
+++ b/prd-api/src/PrdAgent.Api/Services/WorkflowScheduleWorker.cs
@@ -126,7 +126,8 @@ public sealed class WorkflowScheduleWorker : BackgroundService
         {
             try
             {
-                nextRunAt = CronEvaluator.NextOccurrence(schedule.CronExpression!, DateTime.UtcNow);
+                // 重新计算下次也按 schedule.Timezone，否则 cron `0 9 * * *` 会一直按 09:00 UTC 跑
+                nextRunAt = CronEvaluator.NextOccurrence(schedule.CronExpression!, DateTime.UtcNow, schedule.Timezone);
             }
             catch (Exception ex)
             {

--- a/prd-api/src/PrdAgent.Core/Models/WeeklyPosterAnnouncement.cs
+++ b/prd-api/src/PrdAgent.Core/Models/WeeklyPosterAnnouncement.cs
@@ -55,6 +55,13 @@ public class WeeklyPosterAnnouncement
 
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// 已看过本海报的用户 ID 列表（跨会话持久化"已读"状态）
+    /// 一个用户对一张海报只记一次；GET /current 会过滤掉当前用户已看过的海报，
+    /// 这样用户登录看过一次后就再也不弹，但有新海报（不同 id）发布时仍会弹。
+    /// </summary>
+    public List<string> SeenBy { get; set; } = new();
 }
 
 public class WeeklyPosterPage

--- a/prd-api/src/PrdAgent.Core/Models/WorkflowModels.cs
+++ b/prd-api/src/PrdAgent.Core/Models/WorkflowModels.cs
@@ -324,7 +324,19 @@ public class WorkflowSchedule
     public string Id { get; set; } = Guid.NewGuid().ToString("N");
 
     public string WorkflowId { get; set; } = string.Empty;
-    public string CronExpression { get; set; } = string.Empty;
+    /// <summary>WorkflowName 冗余便于列表展示（来自 Workflow.Name 快照）</summary>
+    public string WorkflowName { get; set; } = string.Empty;
+    /// <summary>用户给的别名，例如「每天早 9 点抓博主视频」</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>once = 一次性指定时间触发；cron = 按 Cron 循环</summary>
+    public string Mode { get; set; } = "once";
+
+    /// <summary>once 模式：触发时间（UTC）</summary>
+    public DateTime? RunAtUtc { get; set; }
+
+    /// <summary>cron 模式：5 字段 Cron 表达式（分 时 日 月 周）</summary>
+    public string? CronExpression { get; set; }
     public string Timezone { get; set; } = "Asia/Shanghai";
 
     public bool IsEnabled { get; set; } = true;

--- a/prd-api/tests/PrdAgent.Api.Tests/Services/WorkflowAgentTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Services/WorkflowAgentTests.cs
@@ -451,7 +451,9 @@ public class WorkflowAgentTests
 
         Assert.NotNull(schedule.Id);
         Assert.Empty(schedule.WorkflowId);
-        Assert.Empty(schedule.CronExpression);
+        // CronExpression 改为 nullable string —— once 模式下不需要 cron，默认 null 比 "" 更干净
+        Assert.Null(schedule.CronExpression);
+        Assert.Equal("once", schedule.Mode);
         Assert.Equal("Asia/Shanghai", schedule.Timezone);
         Assert.True(schedule.IsEnabled);
         Assert.Null(schedule.NextRunAt);

--- a/prd-api/tests/PrdAgent.Api.Tests/Services/WorkflowAgentTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Services/WorkflowAgentTests.cs
@@ -1,3 +1,4 @@
+using PrdAgent.Api.Services;
 using PrdAgent.Core.Models;
 using PrdAgent.Core.Security;
 using Xunit;
@@ -473,6 +474,59 @@ public class WorkflowAgentTests
 
         Assert.Equal("0 9 1 * *", schedule.CronExpression);
         Assert.NotNull(schedule.NextRunAt);
+    }
+
+    [Fact]
+    public void CronEvaluator_HonorsTimezone()
+    {
+        // 0 9 * * * + Asia/Shanghai → 09:00 CST = 01:00 UTC（不是 09:00 UTC）
+        var from = new DateTime(2026, 5, 8, 0, 0, 0, DateTimeKind.Utc);
+        var next = CronEvaluator.NextOccurrence("0 9 * * *", from, "Asia/Shanghai");
+        Assert.Equal(new DateTime(2026, 5, 8, 1, 0, 0, DateTimeKind.Utc), next);
+    }
+
+    [Fact]
+    public void CronEvaluator_DefaultsToUtcWhenNoTimezone()
+    {
+        var from = new DateTime(2026, 5, 8, 0, 0, 0, DateTimeKind.Utc);
+        var next = CronEvaluator.NextOccurrence("0 9 * * *", from);
+        Assert.Equal(new DateTime(2026, 5, 8, 9, 0, 0, DateTimeKind.Utc), next);
+    }
+
+    [Fact]
+    public void CronEvaluator_DomDowOrSemantics()
+    {
+        // Vixie/POSIX cron：dom 和 dow 都被限制时，OR 合并 — "每月 1 号 OR 每周五"
+        // 从 2026-05-01 (Friday) 开始扫
+        var from = new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc); // Fri
+        var next1 = CronEvaluator.NextOccurrence("0 9 1 * 5", from);
+        // 当天 9:00 UTC（同时是 dom=1 + dow=5）
+        Assert.Equal(new DateTime(2026, 5, 1, 9, 0, 0, DateTimeKind.Utc), next1);
+
+        // 从 5/2（Sat）扫，下一次：5/8 (Fri，dow 命中) 而不是 6/1
+        var from2 = new DateTime(2026, 5, 2, 10, 0, 0, DateTimeKind.Utc);
+        var next2 = CronEvaluator.NextOccurrence("0 9 1 * 5", from2);
+        Assert.Equal(new DateTime(2026, 5, 8, 9, 0, 0, DateTimeKind.Utc), next2);
+    }
+
+    [Fact]
+    public void CronEvaluator_DstSpringForwardGapDoesNotThrow()
+    {
+        // America/New_York 2026-03-08 02:00-03:00 是 DST gap（不存在的本地时间）
+        // 从前一天扫，cron 0 2 * * * 应该跳过 gap、不抛异常
+        var from = new DateTime(2026, 3, 7, 0, 0, 0, DateTimeKind.Utc);
+        var ex = Record.Exception(() => CronEvaluator.NextOccurrence("0 2 * * *", from, "America/New_York"));
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void CronEvaluator_RejectsMalformedExpressions()
+    {
+        var from = DateTime.UtcNow;
+        Assert.Throws<ArgumentException>(() => CronEvaluator.NextOccurrence("garbage", from));
+        Assert.Throws<ArgumentException>(() => CronEvaluator.NextOccurrence("* * *", from));
+        Assert.Throws<ArgumentException>(() => CronEvaluator.NextOccurrence("60 * * * *", from));
+        Assert.Throws<ArgumentException>(() => CronEvaluator.NextOccurrence("* * 32 * *", from));
     }
 
     #endregion


### PR DESCRIPTION
## Summary

This PR adds a comprehensive workflow scheduling system and an "Auto Publish" dialog to the weekly poster editor, enabling users to execute workflows immediately, schedule them for a specific time, or set up recurring schedules using Cron expressions—all without leaving the poster design interface.

## Key Changes

### Frontend (prd-admin)

- **New AutoPublishDialog component** (`AutoPublishDialog.tsx`): A modal dialog that allows users to:
  - Select a workflow from available options
  - Fill in workflow variables (e.g., creator ID, video count)
  - Choose poster presentation mode, template, and accent color
  - Execute immediately, schedule for a specific datetime, or set up recurring Cron schedules
  - Polls execution status for immediate runs and displays detailed error messages from failed nodes

- **PosterDesignerPage integration**: Added "Auto Publish" button (⚡ icon) in the poster editor toolbar that opens the dialog

- **WeeklyPosterModal improvements**: 
  - Increased poster preview sizes (~17% larger) for better visibility
  - Adjusted viewport height budget from 80px to 40px for more efficient space usage
  - Added `brandAccent` color support to feed-card presentation mode

- **Service layer updates**:
  - Added `createWorkflowSchedule`, `listWorkflowSchedules`, `updateWorkflowSchedule`, `deleteWorkflowSchedule` API contracts
  - Implemented real service methods in `workflowAgent.ts`
  - Added `markWeeklyPosterSeen` service for persistent "seen" tracking

- **Weekly poster store refactor**: Changed "dismissed" state from session-only to backend-persistent, with session-level optimization to prevent duplicate mark-seen calls

### Backend (prd-api)

- **WorkflowScheduleWorker** (`WorkflowScheduleWorker.cs`): New background service that:
  - Polls every 30 seconds for due schedules
  - Triggers "once" schedules and disables them after execution
  - Recalculates next run time for Cron schedules
  - Merges workflow default variables with schedule overrides
  - Enqueues executions with proper trigger type tracking

- **CronEvaluator** (`CronEvaluator.cs`): Lightweight 5-field Cron parser supporting:
  - Wildcards (`*`), integers, lists (`a,b,c`), ranges (`a-b`), and step values (`*/n`)
  - UTC-based next occurrence calculation with 366-day lookahead
  - Comprehensive validation with clear error messages

- **WorkflowAgentController endpoints**:
  - `GET /api/workflow-agent/schedules` - List schedules (filtered by user unless admin)
  - `POST /api/workflow-agent/schedules` - Create once/cron schedules with validation
  - `PATCH /api/workflow-agent/schedules/{id}` - Update schedule state and variables
  - `DELETE /api/workflow-agent/schedules/{id}` - Delete schedules

- **CapsuleExecutor enhancement**: Modified `ExecuteWeeklyPosterPublisherAsync` to support variable-based overrides for `templateKey`, `presentationMode`, and `accentColor`, allowing the dialog to inject these values at runtime

- **WeeklyPosterController improvements**:
  - `GET /current` now filters out posters already seen by the current user
  - New `POST /mark-seen` endpoint to persist user viewing history
  - Added `SeenBy` field to `WeeklyPosterAnnouncement` model

- **WorkflowSchedule model** (`WorkflowModels.cs`): Enhanced with:
  - `WorkflowName` (snapshot for display)
  - `Name` (user-provided alias)
  - `Mode` (once/cron)
  - `RunAtUtc`, `CronExpression`, `Timezone`
  - `NextRunAt`, `LastTriggeredAt`, `TriggerCount`
  - `VariableOverrides` for schedule-specific variable injection

- **Program.cs**: Registered `WorkflowScheduleWorker` as a hosted service

https://claude.ai/code/session_01VueEfQBhnyvDdA8FEs8SWT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds new scheduling persistence, API endpoints, and a background worker that enqueues workflow executions based on `once`/`cron` timing, plus changes weekly-poster seen tracking; failures here could cause missed/duplicate runs or user-facing banner regressions.
> 
> **Overview**
> Enables weekly posters to be published by running a workflow from the poster designer, with **immediate execution** (including 60s status polling + surfaced failed-node errors) or **saved schedules** for one-time or recurring Cron runs.
> 
> Adds backend **workflow scheduling**: new `/api/workflow-agent/schedules` CRUD endpoints, a `WorkflowScheduleWorker` hosted service that polls and enqueues due executions, and a lightweight `CronEvaluator` (timezone-aware, dom/dow OR semantics, DST-gap safe) with tests.
> 
> Improves poster publishing/view UX and robustness: `WeeklyPosterPublisher` now allows `templateKey`/`presentationMode`/`accentColor` overrides via variables and adds fallback paths for common upstream item arrays; weekly-poster “seen” state is persisted server-side via `SeenBy` + `POST /api/weekly-posters/{id}/mark-seen`, with the admin modal updated accordingly, plus sizing/styling and video preload tweaks for performance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1b5848332698f48272dfd152bebeca06b748d8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->