### PR TITLE
Auto-default reposBase to improve fresh CDS installations

### DIFF
--- a/cds/src/config.ts
+++ b/cds/src/config.ts
@@ -168,17 +168,33 @@ export function loadConfig(configPath?: string): CdsConfig {
     path.resolve(process.cwd(), 'cds.config.json'),
   ];
 
+  let cfg: CdsConfig = { ...DEFAULT_CONFIG };
   for (const candidate of candidates) {
     if (candidate && fs.existsSync(candidate)) {
       const raw = fs.readFileSync(candidate, 'utf-8');
       const override = JSON.parse(raw) as Partial<CdsConfig>;
       console.log(`  Config loaded from: ${candidate}`);
-      return deepMerge(DEFAULT_CONFIG, override);
+      cfg = deepMerge(DEFAULT_CONFIG, override) as CdsConfig;
+      break;
     }
   }
 
-  console.log('  Config: using defaults (no cds.config.json found)');
-  return { ...DEFAULT_CONFIG };
+  if (!cfg.reposBase) {
+    // No CDS_REPOS_BASE env and no stored value: fall back to a sensible
+    // default so fresh CDS installs work without manual configuration.
+    cfg.reposBase = process.env.CDS_REPOS_BASE
+      || path.resolve(cfg.repoRoot, '.cds-repos');
+    cfg.reposBaseSource = 'default';
+    console.log(`  Config: reposBase defaulting to ${cfg.reposBase}`);
+  } else {
+    cfg.reposBaseSource = process.env.CDS_REPOS_BASE ? 'env' : 'file';
+  }
+
+  if (candidates.every(c => !c || !fs.existsSync(c))) {
+    console.log('  Config: using defaults (no cds.config.json found)');
+  }
+
+  return cfg;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/cds/src/config.ts
+++ b/cds/src/config.ts
@@ -179,15 +179,19 @@ export function loadConfig(configPath?: string): CdsConfig {
     }
   }
 
-  if (!cfg.reposBase) {
-    // No CDS_REPOS_BASE env and no stored value: fall back to a sensible
-    // default so fresh CDS installs work without manual configuration.
-    cfg.reposBase = process.env.CDS_REPOS_BASE
-      || path.resolve(cfg.repoRoot, '.cds-repos');
-    cfg.reposBaseSource = 'default';
-    console.log(`  Config: reposBase defaulting to ${cfg.reposBase}`);
+  // Priority: CDS_REPOS_BASE env > config file > auto-default.
+  // Apply env explicitly after merge so it always wins over any stored file
+  // value (deepMerge above may have let the file value survive).
+  if (process.env.CDS_REPOS_BASE) {
+    cfg.reposBase = process.env.CDS_REPOS_BASE;
+    cfg.reposBaseSource = 'env';
+  } else if (cfg.reposBase) {
+    cfg.reposBaseSource = 'file';
   } else {
-    cfg.reposBaseSource = process.env.CDS_REPOS_BASE ? 'env' : 'file';
+    // Neither env nor config file supplied reposBase — defer the actual path
+    // resolution to index.ts where repoRoot overrides (CDS_REPO_ROOT) have
+    // already been applied. Mark source here; path computed after overrides.
+    cfg.reposBaseSource = 'default';
   }
 
   if (candidates.every(c => !c || !fs.existsSync(c))) {

--- a/cds/src/index.ts
+++ b/cds/src/index.ts
@@ -396,6 +396,12 @@ if (customEnv.CDS_WORKTREE_BASE) config.worktreeBase = customEnv.CDS_WORKTREE_BA
 if (customEnv.CDS_REPOS_BASE) {
   config.reposBase = customEnv.CDS_REPOS_BASE;
   config.reposBaseSource = 'env';
+} else if (config.reposBaseSource === 'default') {
+  // Default path was deferred in config.ts so that any CDS_REPO_ROOT
+  // override above takes effect first. Compute it now against the final
+  // repoRoot value.
+  config.reposBase = path.resolve(config.repoRoot, '.cds-repos');
+  console.log(`[config] reposBase defaulting to ${config.reposBase}`);
 }
 
 // Ensure reposBase directory exists so git clone commands don't fail on

--- a/cds/src/index.ts
+++ b/cds/src/index.ts
@@ -393,7 +393,20 @@ if (customEnv.CDS_WORKTREE_BASE) config.worktreeBase = customEnv.CDS_WORKTREE_BA
 // env at process-start (config.ts) or via customEnv at runtime (UI).
 // The runtime override wins so operators can flip on multi-repo clone
 // without restarting.
-if (customEnv.CDS_REPOS_BASE) config.reposBase = customEnv.CDS_REPOS_BASE;
+if (customEnv.CDS_REPOS_BASE) {
+  config.reposBase = customEnv.CDS_REPOS_BASE;
+  config.reposBaseSource = 'env';
+}
+
+// Ensure reposBase directory exists so git clone commands don't fail on
+// a fresh install where the operator hasn't created the directory yet.
+if (config.reposBase) {
+  try {
+    fs.mkdirSync(config.reposBase, { recursive: true });
+  } catch (e) {
+    console.warn(`[config] Warning: could not create reposBase directory ${config.reposBase}:`, e);
+  }
+}
 
 // ── Services ──
 // P4 Part 18 (G1.2): WorktreeService is stateless; every call passes

--- a/cds/src/routes/projects.ts
+++ b/cds/src/routes/projects.ts
@@ -1091,10 +1091,24 @@ export function createProjectsRouter(deps: ProjectsRouterDeps): Router {
       });
       return;
     }
+    // Fail fast when a git repo is requested but reposBase is unavailable.
+    // With the auto-default in config.ts this should be rare, but guard
+    // against environments where the default directory couldn't be created.
+    if (gitRepoUrl && !reposBase) {
+      res.status(503).json({
+        error: 'reposBase_missing',
+        message: 'CDS 未配置源码仓库根目录（reposBase），无法 clone 外部 git 仓库。',
+        fixAction: '在 CDS 服务端设置环境变量 CDS_REPOS_BASE=<path>（如 /root/cds/.cds-repos）并重启 CDS。',
+        settingsUrl: '/cds-settings',
+      });
+      return;
+    }
     if (isSandbox && !reposBase) {
-      res.status(500).json({
+      res.status(503).json({
         error: 'reposBase_missing',
         message: 'CDS 未配置 reposBase,沙盒模式无法定位本地仓库目录(检查 .cds.env)',
+        fixAction: '在 CDS 服务端设置环境变量 CDS_REPOS_BASE=<path> 并重启 CDS。',
+        settingsUrl: '/cds-settings',
       });
       return;
     }

--- a/cds/src/types.ts
+++ b/cds/src/types.ts
@@ -1921,9 +1921,15 @@ export interface CdsConfig {
    *
    * Typically wired from `CDS_REPOS_BASE=/repos` in exec_cds.sh and
    * mounted as a persistent host volume so cloned repos survive
-   * container rebuilds (self-update).
+   * container rebuilds (self-update). When neither `CDS_REPOS_BASE` nor
+   * a stored config value is present, CDS auto-defaults to
+   * `${repoRoot}/.cds-repos` so fresh installs work without manual
+   * configuration.
    */
   reposBase?: string;
+  /** How `reposBase` was resolved: explicit env var, loaded from config file,
+   *  or auto-defaulted. Surfaced in `GET /api/config` for UI display. */
+  reposBaseSource?: 'env' | 'file' | 'default';
   worktreeBase: string;
   /** Master dashboard port */
   masterPort: number;


### PR DESCRIPTION
## Summary
Improve the CDS configuration system to automatically default `reposBase` to `${repoRoot}/.cds-repos` when neither an environment variable nor a stored config value is present. This eliminates manual configuration requirements for fresh installations while maintaining explicit control for operators who need it.

## Key Changes

- **config.ts**: Refactored `loadConfig()` to apply intelligent defaults for `reposBase` after loading configuration files. Added `reposBaseSource` tracking to distinguish between environment variables, file-based config, and auto-defaults.

- **index.ts**: Added automatic directory creation for `reposBase` at startup to ensure the directory exists before git operations. Updated runtime environment variable handling to track the source of `reposBase` configuration.

- **projects.ts**: Enhanced error handling for missing `reposBase`:
  - Added early validation when git repository cloning is requested but `reposBase` is unavailable
  - Changed HTTP status codes from 500 to 503 (Service Unavailable) to better reflect the nature of the error
  - Improved error messages with actionable fix instructions and settings URL

- **types.ts**: Updated `CdsConfig` interface to include `reposBaseSource` field for tracking configuration source, and expanded documentation to explain the auto-default behavior.

## Implementation Details

The configuration resolution now follows this priority order:
1. Environment variable `CDS_REPOS_BASE` (highest priority)
2. Value loaded from `cds.config.json`
3. Auto-default to `${repoRoot}/.cds-repos` (lowest priority)

The `reposBaseSource` field is exposed via the config API to allow the UI to display how the configuration was resolved, improving transparency for operators.

Directory creation is wrapped in error handling to gracefully degrade if the directory cannot be created, with warnings logged for operator visibility.

https://claude.ai/code/session_01EXPp4ZCUDCQDr1vKvW2swg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes startup config resolution/precedence and filesystem side effects (`mkdir`) that can affect repo cloning paths and deployment behavior across environments.
> 
> **Overview**
> **Auto-defaults `reposBase` for fresh installs and makes its resolution explicit.** `loadConfig()` now merges config overrides without early-returning, then applies a strict precedence (`CDS_REPOS_BASE` env > config file > default) and records `reposBaseSource`.
> 
> **Defers default path computation until after runtime overrides and ensures the directory exists.** `index.ts` computes the default `${repoRoot}/.cds-repos` only after `CDS_REPO_ROOT`/custom env overrides are applied, logs the chosen default, and attempts `fs.mkdirSync(..., { recursive: true })` for `reposBase`.
> 
> **Improves API failure modes when `reposBase` is missing.** Project creation now fails fast with `503` (instead of `500` in sandbox case) and returns actionable guidance (`fixAction`, `settingsUrl`) when cloning/sandbox mode requires `reposBase` but it’s unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b28ed7b82d1b93033fc54bf1c75cc428d16c31af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->