### PR TITLE
fix(cdscli): 修复 Vite 短端口解析误回退

### DIFF
--- a/.claude/skills/cds/cli/cdscli.py
+++ b/.claude/skills/cds/cli/cdscli.py
@@ -2500,6 +2500,16 @@ def _is_maven_parent_pom(pom_path: str) -> bool:
 def _read_vite_port(sub_path: str) -> str:
     """尝试从 vite.config.ts/js 读取 server.port，读不出来返回 '3000'。"""
     import re
+
+    def _valid_port(raw: str) -> str | None:
+        try:
+            port = int(raw)
+        except (TypeError, ValueError):
+            return None
+        if 1 <= port <= 65535:
+            return str(port)
+        return None
+
     for cfg_name in ("vite.config.ts", "vite.config.js", "vite.config.mts", "vite.config.mjs"):
         cfg_path = os.path.join(sub_path, cfg_name)
         if not os.path.exists(cfg_path):
@@ -2508,9 +2518,11 @@ def _read_vite_port(sub_path: str) -> str:
             with open(cfg_path, "r", encoding="utf-8", errors="replace") as f:
                 content = f.read()
             # 匹配 server: { port: 3001 } 或 port: 3001
-            m = re.search(r"port\s*:\s*(\d{4,5})", content)
+            m = re.search(r"port\s*:\s*(\d{1,5})", content)
             if m:
-                return m.group(1)
+                validated = _valid_port(m.group(1))
+                if validated:
+                    return validated
         except Exception:
             pass
     # 也检查 package.json scripts 中的 --port
@@ -2522,9 +2534,11 @@ def _read_vite_port(sub_path: str) -> str:
             scripts = pkg.get("scripts", {})
             for v in scripts.values():
                 if isinstance(v, str):
-                    m = re.search(r"--port[=\s]+(\d{4,5})", v)
+                    m = re.search(r"--port[=\s]+(\d{1,5})", v)
                     if m:
-                        return m.group(1)
+                        validated = _valid_port(m.group(1))
+                        if validated:
+                            return validated
         except Exception:
             pass
     return "3000"

--- a/.claude/skills/cds/cli/cdscli.py
+++ b/.claude/skills/cds/cli/cdscli.py
@@ -1692,26 +1692,13 @@ def _detect_app_port(svc: dict, root: str) -> tuple[str, str]:
                     text = f.read()
             except Exception:
                 continue
-            # server 块可能包含嵌套对象(hmr/proxy 等)，不能用 [^}] 提前截断。
-            start = re.search(r"\bserver\s*:\s*\{", text)
-            if not start:
-                continue
-            open_idx = start.end() - 1
-            depth = 0
-            server_body: str | None = None
-            for idx in range(open_idx, len(text)):
-                ch = text[idx]
-                if ch == "{":
-                    depth += 1
-                elif ch == "}":
-                    depth -= 1
-                    if depth == 0:
-                        server_body = text[open_idx + 1:idx]
-                        break
+            server_body = _extract_js_object_body(text, "server")
             if server_body:
-                m = re.search(r"\bport\s*:\s*(\d+)\b", server_body)
-                if m:
-                    return m.group(1), f"vite:{cand}"
+                raw_port = _extract_top_level_numeric_prop(server_body, "port", 5)
+                if raw_port:
+                    validated = _normalize_port(raw_port)
+                    if validated:
+                        return validated, f"vite:{cand}"
 
         # 4. package.json scripts
         pkg = os.path.join(src, "package.json")
@@ -2514,34 +2501,56 @@ def _is_maven_parent_pom(pom_path: str) -> bool:
         return False
 
 
+def _normalize_port(raw: str) -> str | None:
+    try:
+        port = int(raw)
+    except (TypeError, ValueError):
+        return None
+    if 1 <= port <= 65535:
+        return str(port)
+    return None
+
+
+def _extract_js_object_body(text: str, key: str) -> str | None:
+    import re
+    m = re.search(r"\b" + re.escape(key) + r"\s*:\s*\{", text)
+    if not m:
+        return None
+    open_idx = m.end() - 1
+    depth = 0
+    for idx in range(open_idx, len(text)):
+        ch = text[idx]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[open_idx + 1:idx]
+    return None
+
+
+def _extract_top_level_numeric_prop(object_body: str, key: str, max_digits: int = 5) -> str | None:
+    import re
+    depth = 0
+    top_chars: list[str] = []
+    for ch in object_body:
+        if ch == "{":
+            depth += 1
+            top_chars.append(" ")
+            continue
+        if ch == "}":
+            depth = max(0, depth - 1)
+            top_chars.append(" ")
+            continue
+        top_chars.append(ch if depth == 0 else " ")
+    top_text = "".join(top_chars)
+    m = re.search(r"\b" + re.escape(key) + r"\s*:\s*(\d{1," + str(max_digits) + r"})\b", top_text)
+    return m.group(1) if m else None
+
+
 def _read_vite_port(sub_path: str) -> str:
     """尝试从 vite.config.ts/js 读取 server.port，读不出来返回 '3000'。"""
     import re
-
-    def _valid_port(raw: str) -> str | None:
-        try:
-            port = int(raw)
-        except (TypeError, ValueError):
-            return None
-        if 1 <= port <= 65535:
-            return str(port)
-        return None
-
-    def _extract_object_body(text: str, key: str) -> str | None:
-        m = re.search(r"\b" + re.escape(key) + r"\s*:\s*\{", text)
-        if not m:
-            return None
-        open_idx = m.end() - 1
-        depth = 0
-        for idx in range(open_idx, len(text)):
-            ch = text[idx]
-            if ch == "{":
-                depth += 1
-            elif ch == "}":
-                depth -= 1
-                if depth == 0:
-                    return text[open_idx + 1:idx]
-        return None
 
     for cfg_name in ("vite.config.ts", "vite.config.js", "vite.config.mts", "vite.config.mjs"):
         cfg_path = os.path.join(sub_path, cfg_name)
@@ -2550,15 +2559,11 @@ def _read_vite_port(sub_path: str) -> str:
         try:
             with open(cfg_path, "r", encoding="utf-8", errors="replace") as f:
                 content = f.read()
-            # 只匹配 Vite server 块内的 port，避免误抓 preview.port / hmr.clientPort。
-            # server 块里可能有 hmr: { ... } 等嵌套对象，不能用 [^}] 截断。
-            server_block = _extract_object_body(content, "server")
-            if server_block:
-                m = re.search(r"\bport\s*:\s*(\d{1,5})\b", server_block)
-            else:
-                m = None
-            if m is not None:
-                validated = _valid_port(m.group(1))
+            # 只识别 server 顶层 port，避免误抓 preview.port / hmr.port。
+            server_block = _extract_js_object_body(content, "server")
+            raw_port = _extract_top_level_numeric_prop(server_block, "port", 5) if server_block else None
+            if raw_port is not None:
+                validated = _normalize_port(raw_port)
                 if validated:
                     return validated
         except Exception:
@@ -2574,7 +2579,7 @@ def _read_vite_port(sub_path: str) -> str:
                 if isinstance(v, str):
                     m = re.search(r"--port[=\s]+(\d{1,5})", v)
                     if m:
-                        validated = _valid_port(m.group(1))
+                        validated = _normalize_port(m.group(1))
                         if validated:
                             return validated
         except Exception:

--- a/.claude/skills/cds/cli/cdscli.py
+++ b/.claude/skills/cds/cli/cdscli.py
@@ -2517,8 +2517,8 @@ def _read_vite_port(sub_path: str) -> str:
         try:
             with open(cfg_path, "r", encoding="utf-8", errors="replace") as f:
                 content = f.read()
-            # 匹配 server: { port: 3001 } 或 port: 3001
-            m = re.search(r"port\s*:\s*(\d{1,5})", content)
+            # 只匹配 Vite server 块内的 port，避免误抓 preview.port / hmr.clientPort
+            m = re.search(r"\bserver\s*:\s*\{[^}]*?\bport\s*:\s*(\d{1,5})\b", content, re.DOTALL)
             if m:
                 validated = _valid_port(m.group(1))
                 if validated:

--- a/.claude/skills/cds/cli/cdscli.py
+++ b/.claude/skills/cds/cli/cdscli.py
@@ -1692,9 +1692,26 @@ def _detect_app_port(svc: dict, root: str) -> tuple[str, str]:
                     text = f.read()
             except Exception:
                 continue
-            m = re.search(r"server\s*:\s*\{[^}]*?port\s*:\s*(\d+)", text, re.DOTALL)
-            if m:
-                return m.group(1), f"vite:{cand}"
+            # server 块可能包含嵌套对象(hmr/proxy 等)，不能用 [^}] 提前截断。
+            start = re.search(r"\bserver\s*:\s*\{", text)
+            if not start:
+                continue
+            open_idx = start.end() - 1
+            depth = 0
+            server_body: str | None = None
+            for idx in range(open_idx, len(text)):
+                ch = text[idx]
+                if ch == "{":
+                    depth += 1
+                elif ch == "}":
+                    depth -= 1
+                    if depth == 0:
+                        server_body = text[open_idx + 1:idx]
+                        break
+            if server_body:
+                m = re.search(r"\bport\s*:\s*(\d+)\b", server_body)
+                if m:
+                    return m.group(1), f"vite:{cand}"
 
         # 4. package.json scripts
         pkg = os.path.join(src, "package.json")
@@ -2510,6 +2527,22 @@ def _read_vite_port(sub_path: str) -> str:
             return str(port)
         return None
 
+    def _extract_object_body(text: str, key: str) -> str | None:
+        m = re.search(r"\b" + re.escape(key) + r"\s*:\s*\{", text)
+        if not m:
+            return None
+        open_idx = m.end() - 1
+        depth = 0
+        for idx in range(open_idx, len(text)):
+            ch = text[idx]
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    return text[open_idx + 1:idx]
+        return None
+
     for cfg_name in ("vite.config.ts", "vite.config.js", "vite.config.mts", "vite.config.mjs"):
         cfg_path = os.path.join(sub_path, cfg_name)
         if not os.path.exists(cfg_path):
@@ -2517,9 +2550,14 @@ def _read_vite_port(sub_path: str) -> str:
         try:
             with open(cfg_path, "r", encoding="utf-8", errors="replace") as f:
                 content = f.read()
-            # 只匹配 Vite server 块内的 port，避免误抓 preview.port / hmr.clientPort
-            m = re.search(r"\bserver\s*:\s*\{[^}]*?\bport\s*:\s*(\d{1,5})\b", content, re.DOTALL)
-            if m:
+            # 只匹配 Vite server 块内的 port，避免误抓 preview.port / hmr.clientPort。
+            # server 块里可能有 hmr: { ... } 等嵌套对象，不能用 [^}] 截断。
+            server_block = _extract_object_body(content, "server")
+            if server_block:
+                m = re.search(r"\bport\s*:\s*(\d{1,5})\b", server_block)
+            else:
+                m = None
+            if m is not None:
                 validated = _valid_port(m.group(1))
                 if validated:
                     return validated

--- a/.claude/skills/cds/tests/test_scan_phase3.py
+++ b/.claude/skills/cds/tests/test_scan_phase3.py
@@ -299,5 +299,36 @@ services:
         assert '- "80"' in yaml_out, f"应识别 scripts --port 80,实际:\n{yaml_out}"
 
 
+def test_scenario_7_vite_server_port_should_win_over_preview_port():
+    """vite.config 里 preview.port 在前时，仍应优先识别 server.port。"""
+    with tempfile.TemporaryDirectory() as tmp:
+        Path(tmp, "frontend").mkdir()
+        Path(tmp, "frontend", "package.json").write_text(
+            json.dumps({"name": "fe", "scripts": {"dev": "vite"}})
+        )
+        Path(tmp, "frontend", "vite.config.ts").write_text("""
+export default {
+  preview: { port: 80 },
+  hmr: { clientPort: 443 },
+  server: { port: 5173 },
+};
+""")
+        Path(tmp, "docker-compose.yml").write_text("""\
+services:
+  frontend:
+    image: node:20
+    working_dir: /app
+    volumes:
+      - "./frontend:/app"
+    command: pnpm dev
+""")
+
+        result = run_scan(tmp)
+        assert result["ok"] is True
+        yaml_out = result["data"]["yaml"]
+        assert '- "5173"' in yaml_out, f"应优先识别 server.port=5173,实际:\n{yaml_out}"
+        assert '- "80"' not in yaml_out, "不应把 preview.port 误当成服务端口"
+
+
 if __name__ == "__main__":
     sys.exit(__import__("pytest").main([__file__, "-v"]))

--- a/.claude/skills/cds/tests/test_scan_phase3.py
+++ b/.claude/skills/cds/tests/test_scan_phase3.py
@@ -254,5 +254,50 @@ services:
         assert "端口推断来源: webpack:" in yaml_out
 
 
+def test_scenario_6_vite_short_port_and_script_short_port():
+    """Vite/--port 的 2~3 位端口也应被正确识别，不应误回退到 3000。"""
+    with tempfile.TemporaryDirectory() as tmp:
+        # case A: vite.config.ts 里显式 server.port=443
+        Path(tmp, "frontend-a").mkdir()
+        Path(tmp, "frontend-a", "package.json").write_text(
+            json.dumps({"name": "fe-a", "scripts": {"dev": "vite"}})
+        )
+        Path(tmp, "frontend-a", "vite.config.ts").write_text("""
+export default {
+  server: {
+    port: 443,
+  },
+};
+""")
+
+        # case B: 无 vite.config，靠 package.json --port 80
+        Path(tmp, "frontend-b").mkdir()
+        Path(tmp, "frontend-b", "package.json").write_text(
+            json.dumps({"name": "fe-b", "scripts": {"dev": "vite --port 80"}})
+        )
+
+        Path(tmp, "docker-compose.yml").write_text("""\
+services:
+  frontend-a:
+    image: node:20
+    working_dir: /app
+    volumes:
+      - "./frontend-a:/app"
+    command: pnpm dev
+  frontend-b:
+    image: node:20
+    working_dir: /app
+    volumes:
+      - "./frontend-b:/app"
+    command: pnpm dev
+""")
+
+        result = run_scan(tmp)
+        assert result["ok"] is True
+        yaml_out = result["data"]["yaml"]
+        assert '- "443"' in yaml_out, f"应识别 vite.config.ts 的 443 端口,实际:\n{yaml_out}"
+        assert '- "80"' in yaml_out, f"应识别 scripts --port 80,实际:\n{yaml_out}"
+
+
 if __name__ == "__main__":
     sys.exit(__import__("pytest").main([__file__, "-v"]))

--- a/.claude/skills/cds/tests/test_scan_phase3.py
+++ b/.claude/skills/cds/tests/test_scan_phase3.py
@@ -330,5 +330,36 @@ services:
         assert '- "80"' not in yaml_out, "不应把 preview.port 误当成服务端口"
 
 
+def test_scenario_8_vite_server_port_with_nested_object():
+    """server 块内有嵌套对象(hmr)时，仍应能识别后面的 server.port。"""
+    with tempfile.TemporaryDirectory() as tmp:
+        Path(tmp, "frontend").mkdir()
+        Path(tmp, "frontend", "package.json").write_text(
+            json.dumps({"name": "fe", "scripts": {"dev": "vite"}})
+        )
+        Path(tmp, "frontend", "vite.config.ts").write_text("""
+export default {
+  server: {
+    hmr: { clientPort: 443 },
+    port: 5173,
+  },
+};
+""")
+        Path(tmp, "docker-compose.yml").write_text("""\
+services:
+  frontend:
+    image: node:20
+    working_dir: /app
+    volumes:
+      - "./frontend:/app"
+    command: pnpm dev
+""")
+
+        result = run_scan(tmp)
+        assert result["ok"] is True
+        yaml_out = result["data"]["yaml"]
+        assert '- "5173"' in yaml_out, f"应识别嵌套对象后的 server.port=5173,实际:\n{yaml_out}"
+
+
 if __name__ == "__main__":
     sys.exit(__import__("pytest").main([__file__, "-v"]))

--- a/.claude/skills/cds/tests/test_scan_phase3.py
+++ b/.claude/skills/cds/tests/test_scan_phase3.py
@@ -361,5 +361,67 @@ services:
         assert '- "5173"' in yaml_out, f"应识别嵌套对象后的 server.port=5173,实际:\n{yaml_out}"
 
 
+def test_scenario_9_vite_nested_hmr_port_should_not_override_server_port():
+    """server.hmr.port 不应覆盖 server.port。"""
+    with tempfile.TemporaryDirectory() as tmp:
+        Path(tmp, "frontend").mkdir()
+        Path(tmp, "frontend", "package.json").write_text(
+            json.dumps({"name": "fe", "scripts": {"dev": "vite"}})
+        )
+        Path(tmp, "frontend", "vite.config.ts").write_text("""
+export default {
+  server: {
+    hmr: { port: 443 },
+    port: 5173,
+  },
+};
+""")
+        Path(tmp, "docker-compose.yml").write_text("""\
+services:
+  frontend:
+    image: node:20
+    working_dir: /app
+    volumes:
+      - "./frontend:/app"
+    command: pnpm dev
+""")
+
+        result = run_scan(tmp)
+        assert result["ok"] is True
+        yaml_out = result["data"]["yaml"]
+        assert '- "5173"' in yaml_out, f"应优先识别 server.port=5173,实际:\n{yaml_out}"
+        assert '- "443"' not in yaml_out, "不应把 server.hmr.port 误当成服务端口"
+
+
+def test_scenario_10_vite_invalid_server_port_should_be_ignored():
+    """无效端口(>65535)不应被写入 compose。"""
+    with tempfile.TemporaryDirectory() as tmp:
+        Path(tmp, "frontend").mkdir()
+        Path(tmp, "frontend", "package.json").write_text(
+            json.dumps({"name": "fe", "scripts": {"dev": "vite"}})
+        )
+        Path(tmp, "frontend", "vite.config.ts").write_text("""
+export default {
+  server: {
+    port: 70000,
+  },
+};
+""")
+        Path(tmp, "docker-compose.yml").write_text("""\
+services:
+  frontend:
+    image: node:20
+    working_dir: /app
+    volumes:
+      - "./frontend:/app"
+    command: pnpm dev
+""")
+
+        result = run_scan(tmp)
+        assert result["ok"] is True
+        yaml_out = result["data"]["yaml"]
+        assert '- "70000"' not in yaml_out, "无效端口不应进入生成结果"
+
+
 if __name__ == "__main__":
     sys.exit(__import__("pytest").main([__file__, "-v"]))

--- a/changelogs/2026-05-09_cdscli-vite-port-parse-hardening.md
+++ b/changelogs/2026-05-09_cdscli-vite-port-parse-hardening.md
@@ -1,0 +1,1 @@
+| fix | cds | 修复 Vite 端口识别误判：忽略 server.hmr.port 且过滤无效端口 |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
本 PR 持续修复 `cdscli` 的 Vite 端口识别问题，当前已覆盖短端口、误匹配与嵌套对象三类边界：
1) 支持 `80/443` 等短端口；
2) 不再误读 `preview.port` / `server.hmr.port`；
3) `server` 块有嵌套对象时仍能正确命中顶层 `server.port`；
4) 过滤无效端口（如 `70000`）。

## 改动 diff
- `.claude/skills/cds/cli/cdscli.py`
  - 新增解析辅助：`_normalize_port`、`_extract_js_object_body`、`_extract_top_level_numeric_prop`。
  - `_read_vite_port`：只取 `server` 顶层 `port`，并做 `1..65535` 校验。
  - `_detect_app_port` 的 Vite 路径：同样只取 `server` 顶层 `port`，并做合法性校验。
- `.claude/skills/cds/tests/test_scan_phase3.py`
  - `scenario_6`：短端口识别（`443` / `--port 80`）。
  - `scenario_7`：`preview.port` 不覆盖 `server.port`。
  - `scenario_8`：`server` 中有嵌套对象时仍识别 `server.port`。
  - `scenario_9`：`server.hmr.port` 不覆盖 `server.port`。
  - `scenario_10`：无效端口（`70000`）被忽略。
- `changelogs/2026-05-09_cdscli-vite-port-parse-hardening.md`
  - 新增 changelog 碎片。

## 复现与验证
- 复现（修复前）
  - `server: { hmr: { port: 443 }, port: 5173 }` 被误识别为 `443`。
  - `_detect_app_port` 会接受无效端口 `70000`。
- 修复后
  - 同场景返回 `5173`，无效端口返回 `no-signal`。
- 自动化测试
  - `python3 -m pytest .claude/skills/cds/tests/test_scan_phase3.py -k "scenario_6 or scenario_7 or scenario_8 or scenario_9 or scenario_10" -v` 通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e86fa0ae-22ac-47a1-a0b2-a65d8e0a1809"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e86fa0ae-22ac-47a1-a0b2-a65d8e0a1809"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

