### PR TITLE
fix(cds): 服务端恢复能力 (#551/#552)

### DIFF
--- a/cds/src/index.ts
+++ b/cds/src/index.ts
@@ -621,6 +621,44 @@ janitorService.setRemoveFn(async (slug: string) => {
       console.log(`  [app] Reconciled ${appReconciled} app container(s)`);
       stateService.save();
     }
+
+    // ── #551 (c)(d) 终态收敛 ──
+    //
+    // 启动时把上次进程没跑完留下的 in-flight 分支状态（building / starting /
+    // restarting / stopping）显式收敛成 'error'。否则 SSE 写崩、CLI 中断
+    // (IncompleteRead)、CDS 进程被 kill -9 等场景会让 branch.status 永远停在
+    // 'building'，前端轮询/Dashboard 无法判断"还在跑"还是"早就死了"，且
+    // history logs 也是空（opLog 在中途被吞，没机会 appendLog）。
+    //
+    // 这里提供清晰的 errorMessage 让用户和 Agent 知道："上一次构建被 CDS
+    // 重启中断，请重新部署"。重新 deploy 会把 errorMessage 清空（branches.ts
+    // 的 deploy 端点头部有 entry.errorMessage = undefined），无副作用。
+    //
+    // 仅扫一次（启动期），与 reconcile 容器状态那段并行处理；不影响热路径。
+    let staleInFlight = 0;
+    const IN_FLIGHT_STATES = new Set(['building', 'starting', 'restarting', 'stopping']);
+    for (const branch of stateService.getAllBranches()) {
+      if (IN_FLIGHT_STATES.has(branch.status)) {
+        const prev = branch.status;
+        branch.status = 'error';
+        branch.errorMessage = `CDS 重启时上一次部署任务（status=${prev}）被中断；请重新部署。`;
+        // 同步把 services 里同样停滞的状态收敛成 error，便于 UI 渲染。
+        for (const svc of Object.values(branch.services)) {
+          if (IN_FLIGHT_STATES.has(svc.status)) {
+            svc.status = 'error';
+            if (!svc.errorMessage) svc.errorMessage = '上一次部署被 CDS 重启中断';
+          }
+        }
+        staleInFlight++;
+      }
+    }
+    if (staleInFlight > 0) {
+      console.warn(
+        `  [boot] Converged ${staleInFlight} stale in-flight branch(es) (status=building/starting/restarting/stopping → error). ` +
+        '这些分支需要重新部署。',
+      );
+      stateService.save();
+    }
   } catch (err) {
     console.error('  [infra] Discovery failed:', (err as Error).message);
   }

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -4184,8 +4184,37 @@ export function createBranchRouter(deps: RouterDeps): Router {
     // through the projectId so consumers don't need to look it up first.
     const branch = stateService.getBranch(id);
     const projectId = branch?.projectId || 'default';
+
+    // #551 (d) — 即使没 opLog 也提供 fallback：当 logs 为空但 branch.status=error
+    // 时合成一条最简记录，把 errorMessage 浮起来给 Agent / UI 看。否则用户只看到
+    // 状态 'error' 没有原因，无法判断发生了什么。这条 fallback 记录带 synthetic=true
+    // 标记，前端可以选择性区分对待。
+    const isFallback = logs.length === 0 && branch?.status === 'error' && !!branch.errorMessage;
+    const fallbackLogs = isFallback
+      ? [{
+          id: `synthetic-${id}`,
+          synthetic: true,
+          status: 'error' as const,
+          startedAt: branch?.lastAccessedAt || branch?.createdAt || new Date().toISOString(),
+          finishedAt: branch?.lastAccessedAt || new Date().toISOString(),
+          events: [{
+            step: 'deploy',
+            status: 'error' as const,
+            title: branch?.errorMessage || '部署失败（无详细日志）',
+            log:
+              '上一次部署没有留下完整 OperationLog（CDS 进程中断、SSE 写入失败或 deploy 在 appendLog 之前抛错）。\n' +
+              `branch.errorMessage = "${branch?.errorMessage || ''}"\n` +
+              '请直接重新部署：POST /api/branches/' + id + '/deploy',
+            timestamp: branch?.lastAccessedAt || new Date().toISOString(),
+          }],
+        }]
+      : [];
+
     res.json({
-      logs,
+      logs: logs.length > 0 ? logs : fallbackLogs,
+      logsAreSynthetic: isFallback || undefined,
+      branchStatus: branch?.status,
+      branchErrorMessage: branch?.errorMessage,
       liveStreamHint: {
         // Subscribe to this URL to receive live deploy events for this
         // branch. Filter by `payload.branchId === <id>` after reception

--- a/cds/src/routes/projects.ts
+++ b/cds/src/routes/projects.ts
@@ -836,7 +836,36 @@ export function createProjectsRouter(deps: ProjectsRouterDeps): Router {
       });
       return;
     }
-    res.json(toSummary(project, statsFor(project)));
+    const summary = toSummary(project, statsFor(project));
+    // CDS-CLI-007 / #551 (a)：识别"半成品"项目（cloneStatus=error 或 git
+    // 项目缺 repoPath）并在响应里附 recovery 指引，避免 Agent 反复尝试
+    // clone 却拿不到具体下一步。这里只读不写，不会引入额外副作用。
+    let recovery: { state: string; nextActions: string[]; hint: string } | undefined;
+    if (project.gitRepoUrl && project.cloneStatus === 'error') {
+      recovery = {
+        state: 'clone_failed',
+        nextActions: [
+          `POST /api/projects/${project.id}/clone — 直接重试，CDS 会清理残留目录后重新 git clone`,
+          `DELETE /api/projects/${project.id} — 如果该项目无法恢复且不需要保留`,
+        ],
+        hint: project.cloneError
+          ? `上次 clone 失败原因：${project.cloneError}`
+          : '上次 clone 失败但未记录详细原因；重试一次会暴露完整 stderr。',
+      };
+    } else if (project.gitRepoUrl && !project.repoPath) {
+      // #551 (a) 旧项目场景：git 项目但 repoPath 为空。clone 端点会自动 backfill。
+      const reposBase = config?.reposBase;
+      recovery = {
+        state: 'legacy_no_repo_path',
+        nextActions: [
+          `POST /api/projects/${project.id}/clone — 服务端会自动派生 repoPath 并 clone`,
+        ],
+        hint: reposBase
+          ? `该项目可能在 reposBase 配置之前创建。CDS 当前 reposBase=${reposBase}，clone 时会自动 backfill repoPath=${reposBase}/${project.id}。`
+          : 'CDS 仍未配置 reposBase，请先在 .cds.env 设置 CDS_REPOS_BASE 后重试。',
+      };
+    }
+    res.json({ ...summary, ...(recovery ? { recovery } : {}) });
   });
 
   // GET /api/projects/:id/recent-auto-deploys?limit=N — webhook 自动部署最近 N 条
@@ -1584,12 +1613,34 @@ export function createProjectsRouter(deps: ProjectsRouterDeps): Router {
       });
       return;
     }
+    // #551 (a) backfill：对于在 reposBase=null 时创建的旧项目，project.repoPath
+    // 为空。reposBase 现在已配置时（PR #546 默认 ${repoRoot}/.cds-repos），可以
+    // 从 reposBase + project.id 派生标准路径并 persist 回 store，让 clone 接着走。
+    // 这样不需要让用户重建项目。
     if (!project.repoPath) {
-      res.status(400).json({
-        error: 'no_repo_path',
-        message: 'CDS 未配置 reposBase（见 exec_cds.sh），无法确定克隆目标路径。',
-      });
-      return;
+      const reposBase = config?.reposBase;
+      if (reposBase && project.id) {
+        const derivedRepoPath = nodePath.resolve(reposBase, project.id);
+        // eslint-disable-next-line no-console
+        console.log(
+          `[project] backfilled repoPath=${derivedRepoPath} for project id=${project.id} ` +
+          `(legacy project created without reposBase, now reposBase=${reposBase})`,
+        );
+        stateService.updateProject(project.id, {
+          repoPath: derivedRepoPath,
+          cloneStatus: project.cloneStatus || 'pending',
+        });
+        // Mutate the in-memory copy too so the rest of this handler sees it.
+        project.repoPath = derivedRepoPath;
+        if (!project.cloneStatus) project.cloneStatus = 'pending';
+      } else {
+        res.status(400).json({
+          error: 'no_repo_path',
+          message: 'CDS 未配置 reposBase（见 exec_cds.sh），无法确定克隆目标路径。',
+          hint: '若该项目是在 reposBase 修复前创建的，请先在 CDS 系统设置或 .cds.env 中确认 CDS_REPOS_BASE 已生效，再重试。',
+        });
+        return;
+      }
     }
     if (project.cloneStatus === 'cloning') {
       res.status(409).json({

--- a/cds/src/server.ts
+++ b/cds/src/server.ts
@@ -631,7 +631,17 @@ function resolveAiSession(req: express.Request, stateService?: StateService): Ap
   // Static mode: CDS_AI_ACCESS_KEY (canonical) 或 legacy AI_ACCESS_KEY 二者命中其一即放行；
   // dashboard customEnv 里的 AI_ACCESS_KEY 字段是用户在 UI 上配的另一个层面，
   // 字段名维持 AI_ACCESS_KEY 不动（用户可见，改名会破坏现有表单存档）。
-  const headerKey = req.headers['x-ai-access-key'] as string | undefined;
+  //
+  // CDS-CLI-005 兼容：除了规范 header `x-ai-access-key`，还接受用户常误用的
+  // `ai-access-key`（无 x- 前缀）和 `Authorization: Bearer <key>`。Express
+  // 会把 header 名规范化为小写，所以这里只需要小写比较。
+  const headerKey = (req.headers['x-ai-access-key'] as string | undefined)
+    || (req.headers['ai-access-key'] as string | undefined)
+    || (() => {
+        const auth = req.headers['authorization'] as string | undefined;
+        if (auth && /^Bearer\s+/i.test(auth)) return auth.replace(/^Bearer\s+/i, '').trim();
+        return undefined;
+      })();
   if (headerKey) {
     const processKey = process.env.CDS_AI_ACCESS_KEY || process.env.AI_ACCESS_KEY;
     const customKey = stateService?.getCustomEnv()?.['AI_ACCESS_KEY'];
@@ -1127,7 +1137,31 @@ export function createServer(deps: ServerDeps): express.Express {
       }
 
       if (req.path.startsWith('/api/')) {
-        res.status(401).json({ error: '未登录' });
+        // CDS-CLI-005：让用户/Agent 一眼看清正确的 header 名。历史上反复出现
+        // 的错误是用 `ai-access-key`（无 X- 前缀）→ Express 大小写不敏感命中
+        // 不到 `x-ai-access-key` → 401 但提示"未登录"，AI 不知道哪里错。
+        // 现在 alias 已兼容（见 resolveAiSession），但仍给出明确 hint，避免
+        // 旧版客户端在 token 真不对时盲猜。
+        const hasAnyKeyHeader =
+          !!req.headers['x-ai-access-key'] ||
+          !!req.headers['ai-access-key'] ||
+          !!req.headers['x-cds-ai-token'] ||
+          !!req.headers['authorization'];
+        res.status(401).json({
+          error: 'unauthorized',
+          message: hasAnyKeyHeader
+            ? '提供的访问凭据无效或已过期，CDS 拒绝该请求。'
+            : '未登录或缺少访问凭据。',
+          hint:
+            '请在请求头中提供 X-AI-Access-Key（首选） 或 Authorization: Bearer <key>。' +
+            '注意 header 名必须含 X- 前缀（兼容别名 ai-access-key / Authorization Bearer，' +
+            '但不接受 access-key / cds-key 等其他变体）。',
+          acceptedHeaders: [
+            'X-AI-Access-Key',
+            'Authorization: Bearer <key>',
+            'ai-access-key (alias, 不推荐)',
+          ],
+        });
       } else {
         res.sendFile(path.join(webDir, 'login.html'));
       }
@@ -1169,7 +1203,14 @@ export function createServer(deps: ServerDeps): express.Express {
   // disabled. Cheap no-op when the header is absent or the key is
   // malformed.
   app.use((req, _res, next) => {
-    const h = req.headers['x-ai-access-key'] as string | undefined;
+    // CDS-CLI-005：同时支持 `X-AI-Access-Key` / `ai-access-key` / Bearer。
+    const h = (req.headers['x-ai-access-key'] as string | undefined)
+      || (req.headers['ai-access-key'] as string | undefined)
+      || (() => {
+          const auth = req.headers['authorization'] as string | undefined;
+          if (auth && /^Bearer\s+/i.test(auth)) return auth.replace(/^Bearer\s+/i, '').trim();
+          return undefined;
+        })();
     if (h && h.startsWith('cdsp_') && !(req as unknown as { cdsProjectKey?: unknown }).cdsProjectKey) {
       const match = deps.stateService.findAgentKeyForAuth(h);
       if (match) {

--- a/changelogs/2026-05-09_cds-server-recovery.md
+++ b/changelogs/2026-05-09_cds-server-recovery.md
@@ -1,0 +1,5 @@
+| fix | cds | clone 端点对旧项目缺失 repoPath 自动 backfill（#551 a），不再返回 no_repo_path 让用户重建项目 |
+| fix | cds | 启动时把 stale building/starting/restarting 分支收敛为 error 并写明 errorMessage（#551 c）|
+| fix | cds | branch logs 端点在无 OperationLog 但状态为 error 时返回合成 fallback 记录暴露 errorMessage（#551 d）|
+| feat | cds | 401 响应新增 hint + acceptedHeaders，并兼容 ai-access-key / Authorization Bearer 别名（#552 CDS-CLI-005）|
+| feat | cds | GET /api/projects/:id 对半成品/未 clone 项目返回 recovery.nextActions 提示 Agent 下一步（#552 CDS-CLI-007）|


### PR DESCRIPTION
## 摘要

修复 CDS 服务端三类恢复能力缺口：旧项目缺 repoPath 不可恢复（#551 a）、部署被中断后状态停在 building 且 history 空（#551 c/d）、401 响应缺乏 header hint（#552 CDS-CLI-005）、半成品项目 Agent 不知道下一步（#552 CDS-CLI-007）。所有修复都在服务端，cdscli 不需要改动；本地 + CDS 上的 Agent 重新部署后立刻生效。

## 改动 diff

- `cds/src/routes/projects.ts`
  - **#551 (a)** clone 端点（`POST /api/projects/:id/clone`）：当 `project.repoPath` 为空但 `config.reposBase` 已配置时，自动派生 `${reposBase}/${project.id}`，调 `stateService.updateProject()` 持久化并继续 clone。这样 PR #546 之前在 `reposBase=null` 时创建的旧项目（如 issue 里 `7defdc0a1779`）不需要重建，直接重新 clone 即可恢复。同时把原来的 400 `no_repo_path` 错误改为带 `hint` 字段的友好提示。
  - **CDS-CLI-007** GET `/api/projects/:id`：对 `cloneStatus=error` 或 git 项目缺 `repoPath` 的"半成品"返回新增 `recovery: { state, nextActions[], hint }` 字段，告诉 Agent 接下来是重 clone 还是删项目，避免反复盲试。
- `cds/src/index.ts`
  - **#551 (c)(d)** 启动期终态收敛：在容器 reconcile 那段后，扫所有 branch，把停留在 `building/starting/restarting/stopping` 的状态显式翻为 `error` + 写明 `errorMessage="CDS 重启时上一次部署任务被中断；请重新部署"`。services 下同步处理。这样 SSE 写崩 / CLI `IncompleteRead` / `kill -9` 等场景不再让 branch 永远停在 building。
- `cds/src/routes/branches.ts`
  - **#551 (d)** GET `/api/branches/:id/logs`：当 `logs` 为空但 `branch.status=error` 且有 `errorMessage` 时，返回一条 `synthetic: true` 的合成 OperationLog，把 errorMessage 浮上来。同时新加 `logsAreSynthetic / branchStatus / branchErrorMessage` 字段供 UI / cdscli 区分。
- `cds/src/server.ts`
  - **CDS-CLI-005** `resolveAiSession()` 和后置 `cdsProjectKey` stamper：除规范 `X-AI-Access-Key` 外，新接受 `ai-access-key`（无 X- 前缀）和 `Authorization: Bearer <key>` 两种 alias。`/api/*` 401 响应新增 `error: 'unauthorized'` + `hint` + `acceptedHeaders[]`，让用户/Agent 一眼看到正确 header 名。
- `changelogs/2026-05-09_cds-server-recovery.md`
  - 5 条碎片记录上面 5 个 fix/feat。

## 测试

- [x] `cd cds && pnpm tsc --noEmit` 0 错误
- [ ] **真人通过预览域名验收**（push 后 CDS auto-deploy；启动日志应能看到 `[boot] Converged N stale in-flight branch(es)` 当前预期 N=0）
- [ ] CDS-CLI-005：用 `curl -H 'ai-access-key: <key>' /api/projects` 应该 200（之前会 401）
- [ ] #551 (a)：找一个 `repoPath` 为空的旧项目，POST `/api/projects/:id/clone` 不应再返回 `no_repo_path`，并能在日志看到 `[project] backfilled repoPath=...`

## 已知边界 / debt

- 任务 2 只做了"收敛"——状态不再卡死。**真正的"中途 checkpoint mid-deploy 日志持久化"未做**（需要重构 deploy 端点把 opLog 改为 incremental save 而不是 finally append），属于 deferred work。建议在 issue #551 关闭后单独提一个 `debt.cds-deploy-checkpoint.md`。
- `recovery` 字段目前只在 `/api/projects/:id` 暴露，没改 list 端点（避免影响热路径）。如果 dashboard 列表想直接显示"半成品"标记，要再扩 GET `/api/projects`。

https://claude.ai/code/session_01EXPp4ZCUDCQDr1vKvW2swg

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXPp4ZCUDCQDr1vKvW2swg)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches startup state reconciliation and authentication header parsing, and changes API response shapes; regressions could affect deploy status visibility or client integrations if assumptions about logs/auth/errors differ.
> 
> **Overview**
> Improves CDS *recovery semantics* after interrupted deploys: on boot it now converges any branch/service left in `building|starting|restarting|stopping` to `error` and writes a user-facing `errorMessage` prompting redeploy.
> 
> Enhances API feedback for “half-broken” states: `GET /api/branches/:id/logs` can synthesize a minimal error log entry (and returns `logsAreSynthetic`, `branchStatus`, `branchErrorMessage`) when no `OperationLog` exists, and `GET /api/projects/:id` adds an optional `recovery` block with next actions for clone failures or legacy git projects missing `repoPath`.
> 
> Makes cloning legacy projects recoverable by auto-backfilling `repoPath` from `reposBase` during `POST /api/projects/:id/clone` (otherwise returning a friendlier 400 with `hint`), and improves AI/Agent auth UX by accepting `ai-access-key` and `Authorization: Bearer <key>` aliases plus returning a more actionable 401 JSON payload (`hint`, `acceptedHeaders`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bf2d18c3b289ef6271085c3e1fd8042fdb67046. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->