### PR TITLE
修复 CDS 近期视觉回归并验证生命周期状态

### DIFF
--- a/cds/web/src/components/BranchDetailDrawer.tsx
+++ b/cds/web/src/components/BranchDetailDrawer.tsx
@@ -956,7 +956,7 @@ export function BranchDetailDrawer({
           </div>
         </header>
 
-        <div className="min-h-0 flex-1 overflow-y-auto" style={{ overscrollBehavior: 'contain' }}>
+        <div className="min-h-0 flex-1 overflow-y-auto pb-24" style={{ overscrollBehavior: 'contain' }}>
           {loading && !branch ? <LoadingBlock label="加载分支详情" /> : null}
           {error ? <div className="p-5"><ErrorBlock message={error} /></div> : null}
           {branch ? (
@@ -1870,6 +1870,20 @@ function VariablesPanel({
   );
 }
 
+function isSensitiveEnvKey(key: string): boolean {
+  const normalized = key.toLowerCase();
+  if (/password|secret|token|credential|private|jwt/.test(normalized)) return true;
+  const parts = normalized.split(/[^a-z0-9]+/).filter(Boolean);
+  return parts.includes('pat') || parts.includes('key');
+}
+
+function maskedEnvValue(entry: EffectiveEnvVar, isSecretFromKey: boolean): string {
+  if (entry.isSecret) return entry.value || '••••';
+  if (!isSecretFromKey) return entry.value;
+  const length = entry.valueLength ?? entry.value.length;
+  return length > 0 ? `•••••••• (${length} 字符)` : '••••••••';
+}
+
 function EnvRow({
   entry,
   revealedPlain,
@@ -1882,13 +1896,16 @@ function EnvRow({
   onToggleReveal: () => void;
   onCopySecret: () => void;
 }): JSX.Element {
+  const effectiveIsSecret = entry.isSecret || isSensitiveEnvKey(entry.key);
   const isRevealed = revealedPlain !== undefined;
-  // 非 secret:entry.value 是明文,直接展示。
-  // secret 已 reveal:展示 revealedPlain。
-  // secret 未 reveal:entry.value 是 server-side 的 mask 串,直接展示。
-  const displayValue = entry.isSecret
+  // 后端 isSecret=false 但 key 看起来敏感时,列表里的 entry.value 可能是明文;
+  // 未 reveal 前必须用前端 mask 兜底,避免 GITHUB_PAT 等直接暴露。
+  const displayValue = effectiveIsSecret
     ? (isRevealed ? (revealedPlain as string) : entry.value)
     : entry.value;
+  const safeDisplayValue = effectiveIsSecret && !isRevealed
+    ? maskedEnvValue(entry, !entry.isSecret)
+    : displayValue;
   return (
     <li className="flex items-center gap-3 px-4 py-2 text-sm">
       <span className={`inline-flex h-5 shrink-0 items-center rounded-md border px-1.5 text-[10px] font-medium ${envSourceClass(entry.source)}`}>
@@ -1899,11 +1916,11 @@ function EnvRow({
       </span>
       <span
         className="min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground"
-        title={entry.isSecret && !isRevealed ? '点击右侧眼睛查看真实值' : displayValue}
+        title={effectiveIsSecret && !isRevealed ? '点击右侧眼睛查看真实值' : safeDisplayValue}
       >
-        {displayValue}
+        {safeDisplayValue}
       </span>
-      {entry.isSecret ? (
+      {effectiveIsSecret ? (
         <button
           type="button"
           onClick={onToggleReveal}
@@ -1918,7 +1935,7 @@ function EnvRow({
         type="button"
         onClick={() => {
           // secret 走 reveal 端点取明文再复制,non-secret 直接 entry.value
-          if (entry.isSecret) onCopySecret();
+          if (effectiveIsSecret) onCopySecret();
           else void navigator.clipboard.writeText(entry.value);
         }}
         className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-[hsl(var(--surface-sunken))] hover:text-foreground"

--- a/cds/web/src/components/CommandPalette.tsx
+++ b/cds/web/src/components/CommandPalette.tsx
@@ -241,10 +241,10 @@ export function CommandPalette({ open, onClose }: { open: boolean; onClose: () =
         aria-label="关闭命令面板"
       />
       <div
-        className="cds-surface-raised cds-hairline relative z-10 mx-4 w-full max-w-[560px] overflow-hidden shadow-2xl"
+        className="cds-surface-raised cds-hairline relative z-10 mx-4 flex max-h-[72vh] w-full max-w-[560px] flex-col overflow-hidden shadow-2xl"
         style={{ animation: 'cds-overlay-fade-in 160ms ease-out' }}
       >
-        <div className="flex items-center gap-3 border-b border-[hsl(var(--hairline))] px-4">
+        <div className="flex shrink-0 items-center gap-3 border-b border-[hsl(var(--hairline))] px-4">
           <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
           <input
             ref={inputRef}
@@ -261,7 +261,7 @@ export function CommandPalette({ open, onClose }: { open: boolean; onClose: () =
             ESC
           </kbd>
         </div>
-        <div ref={listRef} className="max-h-[60vh] overflow-y-auto py-1">
+        <div ref={listRef} className="min-h-0 flex-1 overflow-y-auto py-1 pb-3">
           {results.length === 0 ? (
             <div className="px-4 py-8 text-center text-sm text-muted-foreground">
               {loading ? '加载中…' : '没有匹配项'}
@@ -290,7 +290,7 @@ export function CommandPalette({ open, onClose }: { open: boolean; onClose: () =
             ))
           )}
         </div>
-        <div className="flex items-center justify-between gap-3 border-t border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))]/40 px-4 py-2 text-[11px] text-muted-foreground">
+        <div className="flex shrink-0 items-center justify-between gap-3 border-t border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))]/40 px-4 py-2 text-[11px] text-muted-foreground">
           <span>↑↓ 选择 · Enter 跳转 · Esc 关闭</span>
           <span>{results.length} 项</span>
         </div>

--- a/cds/web/src/components/deployment/ActiveDeployment.tsx
+++ b/cds/web/src/components/deployment/ActiveDeployment.tsx
@@ -48,6 +48,20 @@ function statusBadgeLabel(status: BranchDeploymentItem['status']): string {
   return '失败';
 }
 
+function effectiveDeploymentStatus(
+  deployment: BranchDeploymentItem,
+  branchErrorMessage?: string,
+): BranchDeploymentItem['status'] {
+  /*
+   * A deployment action can be recorded as success while the branch is now in
+   * error state after health/runtime checks. In the drawer this looked like
+   * "异常" in the header and "已完成" in the deployment card, which is a
+   * misleading lifecycle signal. Prefer the current branch error for display.
+   */
+  if (deployment.status === 'success' && branchErrorMessage) return 'error';
+  return deployment.status;
+}
+
 function deploymentKindLabel(kind: BranchDeploymentItem['kind']): string {
   return ({
     preview: '预览部署',
@@ -90,13 +104,14 @@ export function ActiveDeployment({
   onResetError,
   containerLogsByPhase,
 }: ActiveDeploymentProps): JSX.Element {
+  const displayStatus = effectiveDeploymentStatus(deployment, branchErrorMessage);
   const phases = useMemo(
-    () => deriveBranchPhases(deployment.log, deployment.status, branchErrorMessage || deployment.message),
-    [branchErrorMessage, deployment.log, deployment.message, deployment.status],
+    () => deriveBranchPhases(deployment.log, displayStatus, branchErrorMessage || deployment.message),
+    [branchErrorMessage, deployment.log, deployment.message, displayStatus],
   );
 
   const duration = formatDuration((deployment.finishedAt || now) - deployment.startedAt);
-  const isError = deployment.status === 'error';
+  const isError = displayStatus === 'error';
   const errorPhaseKey = phases.find((phase) => phase.status === 'error')?.key;
 
   function renderActionForError(key: PhaseKey): JSX.Element | null {
@@ -180,8 +195,8 @@ export function ActiveDeployment({
       }`}
     >
       <header className="flex flex-wrap items-center gap-3 border-b border-[hsl(var(--hairline))] px-5 py-4">
-        <span className={`rounded border px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wide ${statusBadgeClass(deployment.status)}`}>
-          {statusBadgeLabel(deployment.status)}
+        <span className={`rounded border px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wide ${statusBadgeClass(displayStatus)}`}>
+          {deployment.status === 'success' && displayStatus === 'error' ? '运行异常' : statusBadgeLabel(displayStatus)}
         </span>
         <span className="text-sm font-semibold">{deploymentKindLabel(deployment.kind)}</span>
         {deployment.commitSha ? (
@@ -203,7 +218,7 @@ export function ActiveDeployment({
 
       <footer className="flex flex-wrap items-center justify-between gap-2 border-t border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))]/40 px-5 py-3">
         <div className="min-w-0 truncate text-xs text-muted-foreground">
-          {deployment.message || '部署进行中…'}
+          {branchErrorMessage || deployment.message || '部署进行中…'}
         </div>
         <div className="flex shrink-0 items-center gap-2">
           <Button type="button" size="sm" variant="outline" onClick={() => onCopyDiagnosis(deployment)}>

--- a/cds/web/src/components/ui/confirm-action.tsx
+++ b/cds/web/src/components/ui/confirm-action.tsx
@@ -1,6 +1,11 @@
-import { ReactElement, ReactNode, cloneElement, useEffect, useRef, useState } from 'react';
+import { ReactElement, ReactNode, cloneElement, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 import { Button } from '@/components/ui/button';
+
+const POPOVER_WIDTH = 288;
+const POPOVER_GAP = 8;
+const VIEWPORT_PADDING = 8;
 
 interface ConfirmActionProps {
   trigger: ReactElement<{ onClick?: () => void; disabled?: boolean; 'aria-expanded'?: boolean }>;
@@ -24,13 +29,62 @@ export function ConfirmAction({
   onConfirm,
 }: ConfirmActionProps): JSX.Element {
   const [open, setOpen] = useState(false);
+  const [position, setPosition] = useState<{ left: number; top: number; maxHeight: number } | null>(null);
   const rootRef = useRef<HTMLDivElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    if (!open) {
+      setPosition(null);
+      return;
+    }
+
+    function updatePosition(): void {
+      const triggerRect = rootRef.current?.getBoundingClientRect();
+      if (!triggerRect) return;
+
+      const viewportWidth = window.visualViewport?.width ?? window.innerWidth;
+      const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
+      const viewportLeft = window.visualViewport?.offsetLeft ?? 0;
+      const viewportTop = window.visualViewport?.offsetTop ?? 0;
+      const popoverHeight = popoverRef.current?.offsetHeight ?? 0;
+      const minLeft = viewportLeft + VIEWPORT_PADDING;
+      const maxLeft = viewportLeft + viewportWidth - POPOVER_WIDTH - VIEWPORT_PADDING;
+      const preferredLeft = triggerRect.right - POPOVER_WIDTH;
+      const left = Math.min(Math.max(preferredLeft, minLeft), Math.max(minLeft, maxLeft));
+
+      const belowTop = triggerRect.bottom + POPOVER_GAP;
+      const aboveTop = triggerRect.top - popoverHeight - POPOVER_GAP;
+      const belowSpace = viewportTop + viewportHeight - VIEWPORT_PADDING - belowTop;
+      const aboveSpace = triggerRect.top - (viewportTop + VIEWPORT_PADDING) - POPOVER_GAP;
+      const shouldPlaceAbove = popoverHeight > 0 && belowSpace < popoverHeight && aboveSpace > belowSpace;
+      const unclampedTop = shouldPlaceAbove ? aboveTop : belowTop;
+      const maxTop = viewportTop + viewportHeight - VIEWPORT_PADDING - popoverHeight;
+      const top = Math.min(Math.max(unclampedTop, viewportTop + VIEWPORT_PADDING), Math.max(viewportTop + VIEWPORT_PADDING, maxTop));
+      const maxHeight = Math.max(120, viewportHeight - VIEWPORT_PADDING * 2);
+
+      setPosition({ left, top, maxHeight });
+    }
+
+    updatePosition();
+    window.addEventListener('resize', updatePosition);
+    window.addEventListener('scroll', updatePosition, true);
+    window.visualViewport?.addEventListener('resize', updatePosition);
+    window.visualViewport?.addEventListener('scroll', updatePosition);
+    return () => {
+      window.removeEventListener('resize', updatePosition);
+      window.removeEventListener('scroll', updatePosition, true);
+      window.visualViewport?.removeEventListener('resize', updatePosition);
+      window.visualViewport?.removeEventListener('scroll', updatePosition);
+    };
+  }, [open, title, description]);
 
   useEffect(() => {
     if (!open) return;
 
     function onPointerDown(event: PointerEvent): void {
-      if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
+      const target = event.target as Node;
+      if (!rootRef.current?.contains(target) && !popoverRef.current?.contains(target)) setOpen(false);
     }
 
     function onKeyDown(event: KeyboardEvent): void {
@@ -54,6 +108,43 @@ export function ConfirmAction({
     },
   });
 
+  const popover = open
+    ? createPortal(
+        // 2026-05-04 fix(.claude/rules/cds-theme-tokens.md):
+        // 之前 bg-popover / text-popover-foreground 在 cds/web/src/index.css
+        // 完全没定义 → CSS var 解析为空 → popover 透明,下方"更新日志"
+        // 卡片内容直接穿透显示,用户看不清是什么。
+        // 改用 CDS 已确实存在的 surface-raised + hairline + foreground 三 token,
+        // 两个主题(dark/light)都有显式定义,绝不透明。
+        // z-50 → z-[200] 提高,popover 必须高于同 tab 内的 surface 内容。
+        <div
+          ref={popoverRef}
+          className="fixed z-[200] w-72 rounded-md border border-[hsl(var(--hairline))] bg-[hsl(var(--surface-raised))] p-3 text-left shadow-2xl"
+          role="dialog"
+          aria-label={typeof title === 'string' ? title : '确认操作'}
+          style={{
+            left: position?.left ?? VIEWPORT_PADDING,
+            top: position?.top ?? VIEWPORT_PADDING,
+            maxHeight: position?.maxHeight,
+            overflowY: 'auto',
+            visibility: position ? 'visible' : 'hidden',
+          }}
+        >
+          <div className="text-sm font-semibold leading-5 text-foreground">{title}</div>
+          {description ? <div className="mt-1 text-xs leading-5 text-muted-foreground">{description}</div> : null}
+          <div className="mt-3 flex justify-end gap-2">
+            <Button type="button" variant="ghost" size="sm" onClick={() => setOpen(false)} disabled={pending}>
+              {cancelLabel}
+            </Button>
+            <Button type="button" variant="destructive" size="sm" onClick={() => void confirm()} disabled={pending}>
+              {confirmLabel}
+            </Button>
+          </div>
+        </div>,
+        document.body,
+      )
+    : null;
+
   async function confirm(): Promise<void> {
     // 2026-05-04 fix(用户反馈"点了按钮 popover 不关闭"):
     // 之前是 await onConfirm() 完才 setOpen(false),但 self-update / force-sync
@@ -73,33 +164,9 @@ export function ConfirmAction({
   }
 
   return (
-    <div ref={rootRef} className="relative inline-flex">
+    <div ref={rootRef} className="inline-flex">
       {triggerNode}
-      {open ? (
-        // 2026-05-04 fix(.claude/rules/cds-theme-tokens.md):
-        // 之前 bg-popover / text-popover-foreground 在 cds/web/src/index.css
-        // 完全没定义 → CSS var 解析为空 → popover 透明,下方"更新日志"
-        // 卡片内容直接穿透显示,用户看不清是什么。
-        // 改用 CDS 已确实存在的 surface-raised + hairline + foreground 三 token,
-        // 两个主题(dark/light)都有显式定义,绝不透明。
-        // z-50 → z-[200] 提高,popover 必须高于同 tab 内的 surface 内容。
-        <div
-          className="absolute right-0 top-full z-[200] mt-2 w-72 rounded-md border border-[hsl(var(--hairline))] bg-[hsl(var(--surface-raised))] p-3 text-left shadow-2xl"
-          role="dialog"
-          aria-label={typeof title === 'string' ? title : '确认操作'}
-        >
-          <div className="text-sm font-semibold leading-5 text-foreground">{title}</div>
-          {description ? <div className="mt-1 text-xs leading-5 text-muted-foreground">{description}</div> : null}
-          <div className="mt-3 flex justify-end gap-2">
-            <Button type="button" variant="ghost" size="sm" onClick={() => setOpen(false)} disabled={pending}>
-              {cancelLabel}
-            </Button>
-            <Button type="button" variant="destructive" size="sm" onClick={() => void confirm()} disabled={pending}>
-              {confirmLabel}
-            </Button>
-          </div>
-        </div>
-      ) : null}
+      {popover}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- 修复分支详情抽屉底部内容被 quick action footer 遮挡的问题，并为敏感环境变量增加前端兜底遮罩。
- 将删除确认层改为 portal + fixed 定位，避免在卡片内被裁切。
- 调整命令面板列表布局，避免底部 footer 挤压最后一项；同时修正部署卡在异常场景下误显示为“已完成”的生命周期状态。

## Testing
- `pnpm --prefix cds/web typecheck`
- `pnpm --prefix cds/web build`
- 本地 Vite + 临时 API 代理进行了浏览器复验，确认删除弹层、抽屉滚动、变量遮罩、命令面板和部署状态展示均正常。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly frontend layout and display-logic changes, but it touches secret redaction behavior and deployment status interpretation, so regressions could leak values or mislead operators if incorrect.
> 
> **Overview**
> Fixes several CDS web UI regressions in overlays/drawers: the branch detail drawer scroll area now has extra bottom padding so content isn’t hidden behind the quick-action footer, and the command palette is restructured as a flex column so the results list scrolls without the footer covering the last item.
> 
> Hardens environment-variable display by treating *key names that look sensitive* as secret even when `isSecret=false`, masking them until explicitly revealed/copied.
> 
> Improves lifecycle signaling in the deployment card by deriving a display status that prefers the current branch error state over a stale `success` deployment record (including a new “运行异常” label) and showing the branch error message in the footer.
> 
> Updates `ConfirmAction` to render the confirmation popover via a `portal` + `fixed` positioning with viewport-aware placement, preventing it from being clipped inside cards and ensuring outside-click dismissal works with the portaled element.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1e7becb155b4ad92e477e1ca34a1711e3c7d6dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->