### PR TITLE
fix(prd-admin): 回应 Bugbot review — 修正 JSDoc 与 compact 代码块圆角

### DIFF
--- a/prd-admin/src/components/ui/MarkdownContent.tsx
+++ b/prd-admin/src/components/ui/MarkdownContent.tsx
@@ -14,7 +14,7 @@ interface MarkdownContentProps {
   /**
    * 排版变体：
    * - `compact`（默认）：紧凑型，用于聊天气泡 / 任务面板等高密度场景
-   * - `reading`：长文阅读型，约束行宽 72ch、放大标题层级、舒展段距，用于知识库 / 周报等
+   * - `reading`：长文阅读型，放大标题层级、舒展段距、启用紫色调表格/引用/代码样式，用于知识库 / 周报等
    */
   variant?: 'compact' | 'reading';
 }
@@ -98,12 +98,19 @@ export const MarkdownContent = memo(function MarkdownContent({ content, classNam
                     style={oneDark}
                     language={match[1]}
                     PreTag="div"
-                    customStyle={{
+                    customStyle={isReading ? {
                       margin: 0,
                       borderRadius: 0,
-                      fontSize: isReading ? '0.82rem' : '0.75rem',
-                      lineHeight: isReading ? 1.7 : 1.5,
-                      padding: isReading ? '14px 16px' : undefined,
+                      fontSize: '0.82rem',
+                      lineHeight: 1.7,
+                      padding: '14px 16px',
+                    } : {
+                      margin: 0,
+                      borderTopLeftRadius: 0,
+                      borderTopRightRadius: 0,
+                      borderBottomLeftRadius: '0.5rem',
+                      borderBottomRightRadius: '0.5rem',
+                      fontSize: '0.75rem',
                     }}
                   >
                     {codeStr}


### PR DESCRIPTION
1. JSDoc：删除已撤销的"约束行宽 72ch"描述，与实际行为对齐
2. SyntaxHighlighter customStyle 按 variant 分支：
   - reading：维持 borderRadius:0（外层 wrapper 已 overflow:hidden + radius:10px）
   - compact：恢复 bottomLeft/Right:0.5rem（无外层 clip，避免底部直角回归）

PR #563 已合并，本次为后续修复。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes limited to markdown rendering styles and JSDoc text; main risk is minor visual regressions in code block rounding/padding across variants.
> 
> **Overview**
> Updates `MarkdownContent`’s `reading` variant JSDoc to match current behavior (removes the withdrawn 72ch line-width claim).
> 
> Adjusts `SyntaxHighlighter` `customStyle` to fully branch by `variant`: `reading` keeps a flat radius (relying on the outer clipped wrapper), while `compact` restores bottom corner rounding so code blocks don’t render with square bottoms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19c78cc0c95e1f414dd239c317ea1dcdc8df2633. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->