### PR TITLE
cdscli v0.6.4: 节省回合 — node_modules 名 volume 回退 + 默认 node:22

### DIFF
--- a/.claude/skills/cds/cli/cdscli.py
+++ b/.claude/skills/cds/cli/cdscli.py
@@ -41,7 +41,7 @@ import urllib.parse
 import urllib.request
 from typing import Any, Optional
 
-VERSION = "0.6.3"  # ← bumped on each SKILL.md change; 服务端自动读这一行
+VERSION = "0.6.4"  # ← bumped on each SKILL.md change; 服务端自动读这一行
 _TRACE_ID: str = ""
 _HUMAN: bool = False
 _DRIFT_WARNED: bool = False  # 全进程只提示一次，避免每个请求都刷
@@ -3637,7 +3637,7 @@ def _detect_modules(root: str) -> list[dict]:
             }
         if os.path.exists(os.path.join(sub_path, "package.json")):
             port = _read_vite_port(sub_path)
-            return {"dir": sub, "kind": "node", "image": "node:20-slim", "port": port, "confidence": "high"}
+            return {"dir": sub, "kind": "node", "image": "node:22-slim", "port": port, "confidence": "high"}
         if any(f.endswith(".csproj") for f in _walk(sub_path, depth=2)):
             return {"dir": sub, "kind": "dotnet",
                     "image": "mcr.microsoft.com/dotnet/sdk:8.0", "port": "5000", "confidence": "high"}
@@ -3803,15 +3803,11 @@ def _yaml_from_modules(root: str, modules: list[dict],
         lines.append(f"    working_dir: /app")
         lines.append(f"    volumes:")
         lines.append(f"      - ./{mod['dir']}:/app")
-        # v0.6.3:Node 前端的 node_modules 用 named volume 覆盖 host bind mount,
-        # 解决 "rm: cannot remove 'node_modules': Device or resource busy" —
-        # host worktree 里的 node_modules 子路径被容器挂走时是 readonly,
-        # named volume mount 优先级更高,容器内 /app/node_modules 是可写的 docker volume。
-        # CDS extractCacheMounts 会把非相对源识别为 cacheMount,跨部署持久化。
-        # 命名规则:nm_<svc> 短名稳定,跨 branch 隔离由 CDS 容器名前缀负责。
-        if kind == "node":
-            nm_volume = f"cds-nm-{clean_name}".replace("_", "-")
-            lines.append(f"      - {nm_volume}:/app/node_modules")
+        # v0.6.3 备注:Node service 不在这里再加 node_modules named volume —
+        # CDS container.ts 会自动给 pnpm command 挂 cds-nm-<branch>-<profile>
+        # 的 docker named volume 到 /app/node_modules,我们再写一份会触发
+        # "Duplicate mount point" 错误。npm/yarn 项目 CDS 不挂(为了避免装错版本),
+        # 这种项目要么改用 pnpm,要么 command 不要 rm -rf node_modules。
         lines.append(f"    ports:")
         lines.append(f"      - \"{mod['port']}\"")
         # Issue #560:Vite 前端引用 VITE_*_API_* 时,把 base 指向后端容器


### PR DESCRIPTION
## Summary
- 移除 v0.6.3 给 Node service 加的 `cds-nm-<svc>:/app/node_modules` named volume —— CDS container.ts 已为 pnpm command 自动挂同名 docker volume，重复 mount 触发 `docker: Error response from daemon: Duplicate mount point: /app/node_modules`
- Node service 默认镜像从 `node:20-slim` 升到 `node:22-slim` —— Corepack 当前默认拉 pnpm 11.x，要求 Node ≥ 22.13；node:20 上跑会报 `ERR_UNKNOWN_BUILTIN_MODULE: node:sqlite`
- 保留 v0.6.3 已实测生效的修复：Java service `cds.readiness-timeout=600` / `cds.readiness-interval=5` / Node service `cds.readiness-timeout=300` / 顶层 `volumes:` 段自动生成

## 实测验证（mdimp/mytapd main 部署）
- v0.6.3 生效证据：imp-api-mdimp / ticket-bootstrap-mytapd 都跑了**完整 Maven download + build**（>3min）后才到下一阶段，没被默认 180s 探测打断
- v0.6.4 修复后剩余的失败都是**仓库本身代码问题**（不在 cdscli 范围）：
  - `mvn spring-boot:run` 在 parent module 缺 mainClass（仓库 pom 配置）
  - jansi noexec on /tmp（CDS 主机 mount 选项）
  - 后端依赖 nacos 但仓库没提供 docker compose（cdscli scan 已 warn）

## Test plan
- [x] `python3 cdscli.py --version` → `0.6.4`
- [x] 102/104 测试通过（剩 2 个 onboard fail 在 baseline 也 fail）
- [x] 重新 scan mdimp/mytapd 输出正确（无重复 volume；Node image=node:22-slim）

https://claude.ai/code/session_resolver

---
_Generated by [Claude Code](https://claude.ai/code/session_01PEmiBzWA3nr8W97zAUPVJK)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect generated compose for Node services and runtime image selection, which can impact deployments if projects rely on the previous Node 20 base or custom node_modules mounting behavior.
> 
> **Overview**
> Bumps `cdscli` to `0.6.4` and updates Node module detection to default generated services to `node:22-slim` (from `node:20-slim`).
> 
> Adjusts generated compose for monorepo scans to **stop adding a per-service `node_modules` named-volume mount** for Node services, avoiding Docker "Duplicate mount point" errors when CDS already auto-mounts `/app/node_modules` for `pnpm`-based commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 377dcba65db0c7a7e20cca12fe4980584014430b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->