### PR TITLE
security(P0): close x-cds-internal bypass — IP+allowlist guard

### DIFF
--- a/cds/src/server.ts
+++ b/cds/src/server.ts
@@ -1089,7 +1089,80 @@ export function createServer(deps: ServerDeps): express.Express {
       if (req.method === 'POST' && req.path === '/api/github/webhook') return next();
       if (/\.(css|js|ico|png|svg|woff2?)$/i.test(req.path)) return next();
       // Allow internal requests from widget proxy (/_cds/ → master)
-      if (req.headers['x-cds-internal'] === '1') return next();
+      if (req.headers['x-cds-internal'] === '1') {
+        const remoteIp = req.socket.remoteAddress || '';
+        const isLoopback = remoteIp === '127.0.0.1' || remoteIp === '::1' || remoteIp === '::ffff:127.0.0.1';
+        const url = req.url || '';
+        const reqMethodUpper = (req.method || 'GET').toUpperCase();
+
+        // Hard deny — even loopback GET is rejected on these endpoints
+        const DENY: RegExp[] = [
+          /\/effective-env\/reveal/,
+          /\/container-exec/,
+          /\/factory-reset/,
+          /\/self-update/,
+          /\/storage-mode\/switch/,
+          /\/cleanup(\?|$)/,
+          /\/cleanup-orphans/,
+          /\/cleanup-cross-project-services/,
+          /\/prune-stale-branches/,
+          /\/api\/env/,            // global/project env read+write (incl. reveal)
+          /\/api\/projects\/[^/]+\/agent-keys/,
+          /\/api\/global-agent-keys/,
+          /\/api\/cluster\/(issue-token|join|strategy)/,
+          /\/api\/cds-system\/connections\/(issue|accept)/,
+          /\/api\/import-and-init/,
+          /\/api\/import-config/,
+          /\/api\/snapshots\/[^/]+\/rollback/,
+        ];
+        // GET allowlist — what the widget actually needs
+        const ALLOW_GET: RegExp[] = [
+          /^\/api\/branches(\?|$)/,
+          /^\/api\/branches\/[^/]+(\?|$)/,
+          /^\/api\/branches\/[^/]+\/(metrics|profile-overrides|effective-env)(\?|$)/,
+          /^\/api\/branches\/stream/,
+          /^\/api\/build-profiles(\?|$)/,
+          /^\/api\/projects(\?|$)/,
+          /^\/api\/projects\/[^/]+(\?|$)/,
+          /^\/api\/activity-stream/,
+          /^\/api\/config(\?|$)/,
+          /^\/api\/me(\?|$)/,
+          /^\/api\/auth\/status/,
+          /^\/api\/cli-version/,
+          /^\/api\/check-updates/,
+          /^\/api\/bridge\/(check|navigate-requests|handshake-requests)/,
+        ];
+        // POST allowlist — widget deploy / log panel / bridge
+        const ALLOW_POST: RegExp[] = [
+          /^\/api\/branches\/[^/]+\/deploy(\?|$)/,
+          /^\/api\/branches\/[^/]+\/deploy\/[^/]+/,
+          /^\/api\/branches\/[^/]+\/container-logs(\?|$)/,
+          /^\/api\/bridge\/(heartbeat|result|end-session|dismiss|approve|reject)/,
+        ];
+        const ALLOW_PUT: RegExp[] = [
+          /^\/api\/build-profiles\/[^/]+\/deploy-mode/,
+        ];
+
+        const denied = DENY.some((re) => re.test(url));
+        const allowedByMethod =
+          (reqMethodUpper === 'GET' && ALLOW_GET.some((re) => re.test(url))) ||
+          (reqMethodUpper === 'POST' && ALLOW_POST.some((re) => re.test(url))) ||
+          (reqMethodUpper === 'PUT' && ALLOW_PUT.some((re) => re.test(url)));
+
+        if (!isLoopback || denied || !allowedByMethod) {
+          res.statusCode = 403;
+          res.setHeader('content-type', 'application/json');
+          res.end(JSON.stringify({
+            error: 'forbidden_internal_bypass',
+            reason: !isLoopback ? 'non-loopback' : (denied ? 'deny-listed' : 'not-allowlisted'),
+            url: url.replace(/\?.*/, ''),
+            method: reqMethodUpper,
+          }));
+          console.warn('[security] x-cds-internal bypass denied', { remoteIp, method: reqMethodUpper, url });
+          return;
+        }
+        return next();
+      }
 
       // ── Cluster peer-to-peer endpoints ──
       //


### PR DESCRIPTION
## 摘要

`x-cds-internal: 1` header 此前在 cookie 鉴权中间件里被无条件放行,任何能路由到 master 的客户端(包括非 loopback)都可以借此免鉴权访问高权限端点,实测可通过 `https://main-mdimp.miduo.org/_cds/api/branches/<id>/effective-env/reveal` 直接拿到明文 `CDS_MYSQL_PASSWORD`,通过 `POST .../container-exec` 直接 RCE。

本 PR 把 `x-cds-internal` 通道收紧成"loopback + DENY + ALLOW 三重闸门",即使 loopback 自己来也无法访问 reveal / exec / factory-reset / self-update / env 这些路径,而 widget 真正需要的 GET/POST 显式列入白名单。

## 改动 diff

- `cds/src/server.ts` 第 1091 行附近 cookie 鉴权中间件:
  - 校验 `req.socket.remoteAddress` 为 `127.0.0.1` / `::1` / `::ffff:127.0.0.1`
  - DENY 正则覆盖 `/effective-env/reveal`、`/container-exec`、`/factory-reset`、`/self-update`、`/storage-mode/switch`、`/cleanup*`、`/prune-stale-branches`、`/api/env`、`/api/{projects/:id/agent-keys,global-agent-keys}`、`/api/cluster/{issue-token,join,strategy}`、`/api/cds-system/connections/{issue,accept}`、`/api/import-and-init`、`/api/import-config`、`/api/snapshots/:id/rollback`
  - ALLOW (按 method) 仅放行 widget 必需:`/api/branches[*]`(metrics/profile-overrides/effective-env/stream)、`/api/build-profiles`、`/api/projects[*]`、`/api/{config,me,auth/status,cli-version,check-updates,activity-stream}`、`/api/bridge/*` 受控子集;POST 的 deploy / container-logs / bridge 写操作;PUT 的 deploy-mode
  - 不满足条件返回 `403 forbidden_internal_bypass` + 原因(`non-loopback` / `deny-listed` / `not-allowlisted`),并 `console.warn` 落审计日志

## PoC(修复前后对比期望)

| 命令 | 修复前 | 修复后 |
|------|--------|--------|
| `GET https://main-mdimp.miduo.org/_cds/api/branches/mdimp-main/effective-env/reveal?key=CDS_MYSQL_PASSWORD` | 200 + 明文 | 403 `deny-listed` |
| `POST .../container-exec {"command":"id"}` | 200 + RCE | 403 `deny-listed` |
| `GET .../effective-env`(不带 reveal) | 200 | 200(在 ALLOW_GET) |
| `GET https://main-prd-agent.miduo.org/_cds/api/branches` | 200 | 200(widget 仍可用) |

## 测试

- [x] 本地 `tsc --noEmit` 在补丁所在区域(server.ts 1090-1180 行)零新增错误(其他报错都是本地缺 `@types/node` / `express` 类型声明的预存噪音)
- [ ] 真人通过 CDS self-update 后在预览域名复测三个 PoC,确认全部 403,widget 仍工作

## 历史

替代了 #?(`claude/security-p0-internal-bypass` 分支,server.ts 因 LLM token 预算被截断到 81 行,已 force-reset 回 main 让分支自然作废)。

---
_Generated by [Claude Code](https://claude.ai/code/session_01PEmiBzWA3nr8W97zAUPVJK)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes a security-critical auth bypass path and could block legitimate widget/forwarder traffic if the allowlists miss any required endpoints, but prevents unauthenticated access to high-privilege operations (env reveal, exec, reset, updates).
> 
> **Overview**
> Closes the unconditional `x-cds-internal` cookie-auth bypass by requiring **loopback-only** requests and enforcing **denylist + per-method allowlists** for internal proxy traffic.
> 
> Denied internal-bypass requests now return `403` with a structured `forbidden_internal_bypass` JSON payload and emit a security warning log, preventing the header from being used to reach high-privilege endpoints like secret reveal, container exec, self-update, cleanup, agent key, cluster join/token, import, and snapshot rollback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9d5fbd6c2421af07608fc006f83dba5fb3c2afe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->