### PR TITLE
Fix AppCallerCode registration for changelog AI summary feature

### DIFF
--- a/.claude/rules/app-caller-registry.md
+++ b/.claude/rules/app-caller-registry.md
@@ -1,0 +1,102 @@
+# AppCallerCode 注册规则
+
+任何对 `ILlmGateway` 的调用都必须传 `AppCallerCode`。这个 code 不允许在 Controller / Service 里写裸字符串字面量——必须先在 `prd-api/src/PrdAgent.Core/Models/AppCallerRegistry.cs` 用 `[AppCallerMetadata]` 注册一条 `public const string`，再在调用处 `= AppCallerRegistry.X.Y.Z` 引用。
+
+## 强制规则
+
+### 1. 不允许裸字符串
+
+```csharp
+// ❌ 错误：硬编码字面量，注册表不知道有这条 caller
+var req = new GatewayRequest
+{
+    AppCallerCode = "my-agent.feature::chat",  // 运行时炸 "appCallerCode 未注册"
+    ModelType = ModelTypes.Chat,
+    ...
+};
+
+// ✅ 正确：先在 Registry 加常量，再引用
+// 在 AppCallerRegistry.cs:
+//   public static class MyAgent {
+//     public static class Feature {
+//       [AppCallerMetadata("功能-描述", "...", ModelTypes = new[]{ ModelTypes.Chat }, Category = "...")]
+//       public const string Chat = "my-agent.feature::chat";
+//     }
+//   }
+var req = new GatewayRequest
+{
+    AppCallerCode = AppCallerRegistry.MyAgent.Feature.Chat,
+    ModelType = ModelTypes.Chat,
+    ...
+};
+```
+
+### 2. 命名必须 kebab-case
+
+`AppCallerCode` 整体格式：`{app-prefix}.{path-segments}.{...}::{model-type}`。每段（点分割）只能用**小写字母 / 数字 / 连字符**。
+
+```
+✅ prd-admin.changelog.ai-summary::chat
+✅ visual-agent.image-gen.batch-generate::generation
+✅ pr-review.summary::chat
+
+❌ prd-admin.changelog.aiSummary::chat       —— camelCase
+❌ prd-admin.changelog.ai_summary::chat      —— 下划线
+❌ PrdAdmin.Changelog.AiSummary::chat        —— PascalCase
+```
+
+允许的应用前缀已在 `AppCallerCodeRegistryGuardTests.AllowedPrefixes` 列出；`ModelType` 必须是 `chat / vision / generation / intent / embedding / rerank / long-context / code` 之一。
+
+### 3. 注册即可被同步到 DB
+
+`AppCallerRegistrySyncService`（hosted service）启动时反射扫 `AppCallerRegistry` 静态类，把所有 `[AppCallerMetadata]` 的常量同步到 `llm_app_callers` 集合。这意味着：
+
+- 加完常量 → 重启服务 → DB 自动有这条记录
+- 不需要手工写 init script、不需要前端 admin 页面手动建
+- "应用注册表已与代码定义同步"对话框里看到 `+1 已新增` 就说明成功
+
+### 4. 子类组织
+
+按"应用 → 模块 → 功能"的三级嵌套静态类组织：
+
+```csharp
+public static class Admin                    // 应用大类
+{
+    public const string AppName = "PRD Agent Web";
+
+    public static class Changelog            // 模块
+    {
+        [AppCallerMetadata("更新中心-AI总结", "...", ModelTypes = new[]{ModelTypes.Chat}, Category = "Document")]
+        public const string AiSummary = "prd-admin.changelog.ai-summary::chat";  // 功能常量
+    }
+}
+```
+
+`Category` 字段用来做后台管理 UI 分组，可选值参考已有项（`Chat` / `Document` / `Analysis` / `Management` / `Testing` / `Workflow` / `System` / ...）。
+
+## CI 守卫
+
+`prd-api/tests/PrdAgent.Tests/AppCallerCodeRegistryGuardTests.cs` 在 CI 强制：
+
+1. **`EveryAppCallerCodeLiteral_ShouldBeRegistered`**：扫全仓 `*.cs`，找到所有形如 `"...::chat"` 的字面量（含 camelCase / 下划线等违规命名），逐一去 `AppCallerRegistrationService.FindByAppCode` 校验，没注册就 fail
+2. **`RegisteredCodes_ShouldUseKebabCase`**：遍历所有已注册项，发现 camelCase / 下划线 / 大写就 fail，给出"请把 aiSummary 改成 ai-summary"这种提示
+
+`PrdAgent.Tests` 已加入 `PrdAgent.sln`，CI workflow 的 `dotnet test PrdAgent.sln --filter "Category!=Integration&Category!=Manual"` 会自动跑这两个测试。
+
+## 历史教训
+
+| 时间 | 事件 |
+|------|------|
+| 2026-04-27 PR #504 | `ChangelogController` 硬编码 `"prd-admin.changelog.aiSummary::chat"` 但没注册到 Registry，导致点击"AI 总结"运行时报 `appCallerCode 未注册`。逾越守卫的双重原因：(a) 测试正则 `[a-z0-9-]` 段不允许大写，camelCase 被静默跳过 (b) `PrdAgent.Tests` 项目压根没在 `PrdAgent.sln` 里，CI 根本没跑这个测试 |
+| 2026-05-09 fix | 放宽正则到 `[a-zA-Z0-9-]` + 新增 kebab-case 强制测试 + `PrdAgent.Tests` 加入 sln，三层兜底 |
+
+## 排查清单
+
+在 PR / push 前自查：
+
+- [ ] 我新加的 `AppCallerCode` 字面量出现在哪？grep 查一下 `"my-agent\."` 或类似前缀
+- [ ] 出现位置是不是只在 `AppCallerRegistry.cs`？如果在别处直接写裸字符串，立刻改成引用常量
+- [ ] 常量名 / 值是不是 kebab-case？没有大写、没有下划线？
+- [ ] 本地跑 `dotnet test PrdAgent.sln --filter "FullyQualifiedName~AppCallerCodeRegistry"` 能过？
+
+任何一项 ❌，先修再 push。

--- a/changelogs/2026-05-09_changelog-ai-summary-caller-registration.md
+++ b/changelogs/2026-05-09_changelog-ai-summary-caller-registration.md
@@ -1,0 +1,2 @@
+| fix | prd-api | 注册更新中心 AI 总结的 AppCallerCode（prd-admin.changelog.ai-summary::chat），修复点击「AI 总结」报「appCallerCode 未注册」的运行时错误 |
+| fix | prd-api/tests | 加强 AppCallerCodeRegistryGuardTests 正则覆盖 camelCase 字面量并新增 kebab-case 命名规范测试，防止再次出现 #504 那种用 camelCase 绕过守卫的情况 |

--- a/prd-admin/src/services/real/changelog.ts
+++ b/prd-admin/src/services/real/changelog.ts
@@ -113,7 +113,7 @@ export interface ChangelogAiSummaryDto {
 }
 
 /**
- * 更新中心「AI 总结」：服务端经 ILlmGateway 调用，AppCallerCode 为 prd-admin.changelog.aiSummary::chat
+ * 更新中心「AI 总结」：服务端经 ILlmGateway 调用，AppCallerCode 为 prd-admin.changelog.ai-summary::chat
  */
 export async function postChangelogAiSummary(body: {
   subtab: ChangelogAiSummarySubtab;

--- a/prd-api/PrdAgent.sln
+++ b/prd-api/PrdAgent.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PrdAgent.Infrastructure", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PrdAgent.Api.Tests", "tests\PrdAgent.Api.Tests\PrdAgent.Api.Tests.csproj", "{D4E5F6A7-B8C9-0123-DEF0-234567890123}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PrdAgent.Tests", "tests\PrdAgent.Tests\PrdAgent.Tests.csproj", "{E5F6A7B8-C9D0-1234-EF01-345678901234}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{D4E5F6A7-B8C9-0123-DEF0-234567890123}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D4E5F6A7-B8C9-0123-DEF0-234567890123}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D4E5F6A7-B8C9-0123-DEF0-234567890123}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E5F6A7B8-C9D0-1234-EF01-345678901234}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E5F6A7B8-C9D0-1234-EF01-345678901234}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E5F6A7B8-C9D0-1234-EF01-345678901234}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E5F6A7B8-C9D0-1234-EF01-345678901234}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal
 

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ChangelogController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ChangelogController.cs
@@ -25,7 +25,7 @@ namespace PrdAgent.Api.Controllers.Api;
 [AdminController("changelog", AdminPermissionCatalog.Access)]
 public class ChangelogController : ControllerBase
 {
-    private const string ChangelogAiSummaryAppCallerCode = "prd-admin.changelog.aiSummary::chat";
+    private const string ChangelogAiSummaryAppCallerCode = AppCallerRegistry.Admin.Changelog.AiSummary;
 
     private static readonly JsonSerializerOptions AiSummaryPayloadJsonOptions = new()
     {
@@ -83,7 +83,7 @@ public class ChangelogController : ControllerBase
     }
 
     /// <summary>
-    /// AI 总结：走 ILlmGateway + AppCallerCode（prd-admin.changelog.aiSummary::chat），禁止前端本地假摘要。
+    /// AI 总结：走 ILlmGateway + AppCallerCode（prd-admin.changelog.ai-summary::chat），禁止前端本地假摘要。
     /// </summary>
     [HttpPost("ai-summary")]
     public async Task<IActionResult> AiSummary([FromBody] ChangelogAiSummaryRequest? request, CancellationToken ct)

--- a/prd-api/src/PrdAgent.Core/Models/AppCallerRegistry.cs
+++ b/prd-api/src/PrdAgent.Core/Models/AppCallerRegistry.cs
@@ -950,6 +950,17 @@ public static class Admin
         public const string Reclassify = "prd-agent-web.platforms.reclassify::intent";
     }
 
+    public static class Changelog
+    {
+        [AppCallerMetadata(
+            "更新中心-AI总结",
+            "更新中心对 changelog 碎片 / GitHub 日志做 AI 摘要（严格 JSON 输出）",
+            ModelTypes = new[] { ModelTypes.Chat },
+            Category = "Document"
+        )]
+        public const string AiSummary = "prd-admin.changelog.ai-summary::chat";
+    }
+
 }
 
 /// <summary>

--- a/prd-api/tests/PrdAgent.Tests/AppCallerCodeRegistryGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/AppCallerCodeRegistryGuardTests.cs
@@ -25,11 +25,20 @@ public class AppCallerCodeRegistryGuardTests
     }
 
     // 匹配形如 "xxx-agent.feature.sub::chat" 的字符串字面量
-    // - 前缀:kebab-case 应用键
-    // - 中段:点号分隔的路径(至少一段)
+    // - 前缀:kebab-case 应用键(必须 lowercase 开头,允许 a-z0-9-)
+    // - 中段:点号分隔的路径(至少一段);允许 a-zA-Z0-9- ——
+    //   故意放宽,这样 PR #504 那种用 camelCase("aiSummary")的违规命名也能被扫到、
+    //   走到 FindByAppCode 验证,而不是被正则静默吞掉(那才是 #504 能逾越的根因)。
+    //   一旦命中且未注册,本测试会失败并打出文件位置;命名是否规范由
+    //   RegisteredCodes_ShouldUseKebabCase 兜底强制。
     // - 结尾:::modelType
     private static readonly Regex AppCallerCodePattern = new(
-        @"""(?<code>[a-z][a-z0-9-]*(?:-[a-z0-9]+)*(?:\.[a-z0-9][a-z0-9-]*)+::(?:chat|vision|generation|intent|embedding|rerank|long-context|code))""",
+        @"""(?<code>[a-z][a-zA-Z0-9-]*(?:-[a-zA-Z0-9]+)*(?:\.[a-zA-Z0-9][a-zA-Z0-9-]*)+::(?:chat|vision|generation|intent|embedding|rerank|long-context|code))""",
+        RegexOptions.Compiled);
+
+    // kebab-case 校验:每一段(用 . 分割,去掉 ::modelType 后)都必须只包含 a-z / 0-9 / -
+    private static readonly Regex KebabCaseSegmentPattern = new(
+        @"^[a-z][a-z0-9-]*$",
         RegexOptions.Compiled);
 
     /// <summary>允许的命名空间前缀(与 AppCallerRegistry 对齐)。未在此列则不参与扫描。</summary>
@@ -109,6 +118,59 @@ public class AppCallerCodeRegistryGuardTests
         }
 
         _output.WriteLine($"✓ 已扫描 {seen.Count} 个 AppCallerCode 字面量,全部已在 AppCallerRegistry 注册。");
+    }
+
+    /// <summary>
+    /// 强制所有已注册的 AppCallerCode 用 kebab-case。
+    /// 历史教训:PR #504 的 "prd-admin.changelog.aiSummary::chat" 用了 camelCase,
+    /// 既违反约定,又恰好绕过早期版本的扫描正则(只允许 [a-z0-9-]),
+    /// 导致 EveryAppCallerCodeLiteral_ShouldBeRegistered 静默漏检。
+    /// 本测试与上面的扫描互为兜底。
+    /// </summary>
+    [Fact]
+    public void RegisteredCodes_ShouldUseKebabCase()
+    {
+        var defs = AppCallerRegistrationService.GetAllDefinitions();
+        var bad = new List<string>();
+
+        foreach (var def in defs)
+        {
+            var code = def.AppCode ?? string.Empty;
+            var idx = code.IndexOf("::", StringComparison.Ordinal);
+            if (idx < 0)
+            {
+                bad.Add($"{code}  (缺少 ::modelType 后缀)");
+                continue;
+            }
+
+            var pathPart = code[..idx];               // "prd-admin.changelog.ai-summary"
+            var modelType = code[(idx + 2)..];        // "chat"
+
+            foreach (var seg in pathPart.Split('.'))
+            {
+                if (!KebabCaseSegmentPattern.IsMatch(seg))
+                {
+                    bad.Add($"{code}  (段 \"{seg}\" 不是 kebab-case;请用小写字母+数字+连字符)");
+                    break;
+                }
+            }
+
+            if (!KebabCaseSegmentPattern.IsMatch(modelType))
+            {
+                bad.Add($"{code}  (modelType \"{modelType}\" 不是 kebab-case)");
+            }
+        }
+
+        if (bad.Count > 0)
+        {
+            var msg = "以下已注册 AppCallerCode 不符合 kebab-case 规范 ——\n" +
+                     "请改用全小写 + 连字符,例如把 aiSummary 改成 ai-summary:\n\n" +
+                     string.Join('\n', bad.Select(s => "  ❌ " + s));
+            _output.WriteLine(msg);
+            Assert.Fail(msg);
+        }
+
+        _output.WriteLine($"✓ 已校验 {defs.Count} 个注册项,全部符合 kebab-case 规范。");
     }
 
     private static string LocateSrcRoot()


### PR DESCRIPTION
## Summary

This PR fixes a runtime error where the changelog AI summary feature failed with "appCallerCode 未注册" by properly registering the `AppCallerCode` in the registry and strengthening the CI guard tests to prevent similar issues.

## Key Changes

- **Registered missing AppCallerCode**: Added `prd-admin.changelog.ai-summary::chat` to `AppCallerRegistry.Admin.Changelog` with proper metadata
- **Fixed controller reference**: Updated `ChangelogController` to use the registered constant instead of a hardcoded string literal
- **Enhanced CI guard tests**: 
  - Relaxed the regex pattern to catch camelCase violations (e.g., `aiSummary`) that were previously silently skipped
  - Added new `RegisteredCodes_ShouldUseKebabCase()` test to enforce kebab-case naming on all registered codes
  - This dual-layer validation prevents the PR #504 scenario where camelCase naming bypassed the original guard
- **Added test project to solution**: Included `PrdAgent.Tests` in `PrdAgent.sln` so CI actually runs the guard tests
- **Added comprehensive documentation**: Created `.claude/rules/app-caller-registry.md` documenting the registration rules, naming conventions, and historical lessons learned
- **Updated frontend comments**: Corrected JSDoc references to use the correct kebab-case format

## Implementation Details

The root cause of the original issue was twofold:
1. The regex pattern `[a-z0-9-]` silently skipped camelCase segments, allowing violations to slip through
2. The test project wasn't included in the solution, so CI never ran the validation

The fix implements three layers of defense:
- **Literal scanning**: Catches any `AppCallerCode` string literal in source code and validates it's registered
- **Naming validation**: Enforces kebab-case on all registered codes to catch violations at registration time
- **CI integration**: Ensures tests run as part of the standard build pipeline

All existing code now follows the established pattern: define constants in `AppCallerRegistry` with `[AppCallerMetadata]` attributes, then reference them by constant rather than hardcoding strings.

https://claude.ai/code/session_01UhVvqNoJHyG2zt8LCmXqP4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily replaces a hardcoded `AppCallerCode` with a registered constant and strengthens test/CI coverage; main risk is new guard tests causing CI failures if existing registered codes violate kebab-case.
> 
> **Overview**
> Fixes the changelog "AI 总结" runtime failure by registering `prd-admin.changelog.ai-summary::chat` in `AppCallerRegistry` and updating `ChangelogController` to reference the registry constant instead of a string literal.
> 
> Hardens the AppCallerCode CI guard by widening the literal-scan regex to catch camelCase/uppercase segments and adding a new kebab-case enforcement test, and ensures these guards run in CI by adding `PrdAgent.Tests` to `PrdAgent.sln`. Also updates related docs/changelog and corrects the frontend comment to the kebab-case code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 086bf509832c8434d93373775da73d70bad8e258. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->