### PR TITLE
security(P1): reveal/customEnv require project-scoped credentials

### DIFF
--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -2194,14 +2194,34 @@ export function createBranchRouter(deps: RouterDeps): Router {
       res.status(404).json({ error: '分支不存在' });
       return;
     }
-    const m = assertProjectAccess(req as any, branch.projectId || 'default');
+    const projectId = branch.projectId || 'default';
+    const m = assertProjectAccess(req as any, projectId);
     if (m) {
       res.status(m.status).json(m.body);
       return;
     }
+    // SECURITY P1 (2026-05-09): plaintext secret reveal now requires
+    // project-scoped credentials. Static AI_ACCESS_KEY (req.aiSession scope
+    // '_global'), cdsg_ global agent keys, and cluster bootstrap tokens
+    // historically returned 200 because assertProjectAccess only checks
+    // when req.cdsProjectKey is set. The audit P1 PoC showed `curl -H
+    // "X-AI-Access-Key: $static" .../reveal?key=CDS_MYSQL_PASSWORD` → 200
+    // + plaintext. Lock it down: only cdsp_ project key matching this
+    // project, or human cookie auth, may reveal.
+    const projKey = (req as any).cdsProjectKey as { projectId: string } | undefined;
+    const cookieAuth = (req as any)._cdsCookieAuth === true;
+    const ownerOk = (projKey && projKey.projectId === projectId) || cookieAuth;
+    if (!ownerOk) {
+      res.status(403).json({
+        error: 'forbidden_secret_reveal',
+        reason: 'reveal requires project-scoped key (cdsp_) or human cookie session',
+        projectId,
+        hint: '请在该项目下「授权 Agent」生成 cdsp_ 项目级 key 后再调用 reveal。静态 AI_ACCESS_KEY 与 cdsg_ 全局 key 不再允许读取明文 secret。',
+      });
+      return;
+    }
     // 共用 list 端点的 merge 逻辑 — 保证两端 source 判定 100% 一致,Bugbot
     // 第四轮的"reveal 与 list 优先级可能漂移"顾虑由共享 builder 根除。
-    const projectId = branch.projectId || 'default';
     const merged = buildBranchEnvMap(projectId);
     const entry = merged.get(key);
     if (!entry) {

--- a/cds/src/routes/projects.ts
+++ b/cds/src/routes/projects.ts
@@ -308,6 +308,47 @@ function toSummary(project: Project, stats: ProjectStats): ProjectSummary {
   return { ...project, ...stats };
 }
 
+/**
+ * SECURITY P1 (2026-05-09): mask plaintext values in `customEnv` /
+ * `defaultEnv` when the caller is NOT this project's owner.
+ *
+ * Audit P1 PoC: `curl -H "X-AI-Access-Key: $static" /api/projects` returned
+ * customEnv with ROOT_ACCESS_PASSWORD / JWT_SECRET / GITHUB_PAT / the
+ * AI_ACCESS_KEY itself in plaintext. Static keys, cdsg_ global keys, and
+ * unscoped sessions are NOT project owners — they get the key names but
+ * not the values. Project-scoped cdsp_ keys (matching project) and human
+ * cookie sessions get the real values.
+ *
+ * We replace each value with `***[masked]***` so the UI can still render
+ * "X env vars configured" and the user knows which keys exist, but no
+ * machine credential walks away with the secret material.
+ */
+function hasOwnerAccess(req: unknown, projectId: string): boolean {
+  const r = req as {
+    cdsProjectKey?: { projectId: string };
+    _cdsCookieAuth?: boolean;
+  };
+  if (r._cdsCookieAuth === true) return true;
+  if (r.cdsProjectKey && r.cdsProjectKey.projectId === projectId) return true;
+  return false;
+}
+
+function maskEnvMap(env: Record<string, string> | undefined): Record<string, string> | undefined {
+  if (!env) return env;
+  const out: Record<string, string> = {};
+  for (const k of Object.keys(env)) out[k] = '***[masked]***';
+  return out;
+}
+
+function maskProjectSummary<T extends ProjectSummary>(req: unknown, summary: T): T {
+  if (hasOwnerAccess(req, summary.id)) return summary;
+  return {
+    ...summary,
+    customEnv: maskEnvMap(summary.customEnv),
+    defaultEnv: maskEnvMap(summary.defaultEnv),
+  };
+}
+
 export function createProjectsRouter(deps: ProjectsRouterDeps): Router {
   const router = Router();
   const { stateService, shell, config } = deps;
@@ -796,10 +837,13 @@ export function createProjectsRouter(deps: ProjectsRouterDeps): Router {
   // an opaque Express default response. Without this, the dashboard
   // showed the unhelpful "加载项目列表失败：HTTP 400" with no clue
   // what triggered the failure.
-  router.get('/projects', (_req, res) => {
+  router.get('/projects', (req, res) => {
     try {
       const projects = stateService.getProjects();
-      const summaries = projects.map((p) => toSummary(p, statsFor(p)));
+      // SECURITY P1 (2026-05-09): mask customEnv/defaultEnv for non-owners.
+      // Static AI_ACCESS_KEY / cdsg_ global key callers get key names but
+      // not values. cdsp_ project key (matching) and cookie auth bypass.
+      const summaries = projects.map((p) => maskProjectSummary(req, toSummary(p, statsFor(p))));
       // Sort: legacy pinned first (existing UX), then by runtime liveness
       // so projects with running services bubble up — useful once you
       // have many projects and only a few are active.
@@ -836,7 +880,7 @@ export function createProjectsRouter(deps: ProjectsRouterDeps): Router {
       });
       return;
     }
-    const summary = toSummary(project, statsFor(project));
+    const summary = maskProjectSummary(req, toSummary(project, statsFor(project)));
     // CDS-CLI-007 / #551 (a)：识别"半成品"项目（cloneStatus=error 或 git
     // 项目缺 repoPath）并在响应里附 recovery 指引，避免 Agent 反复尝试
     // clone 却拿不到具体下一步。这里只读不写，不会引入额外副作用。

--- a/cds/src/server.ts
+++ b/cds/src/server.ts
@@ -1200,7 +1200,15 @@ export function createServer(deps: ServerDeps): express.Express {
       const cookieToken = parseCookie(req.headers.cookie || '', 'cds_token');
       const headerToken = req.headers['x-cds-token'] as string | undefined;
       const token = cookieToken || headerToken;
-      if (token === validToken) return next();
+      if (token === validToken) {
+        // SECURITY P1 (2026-05-09): stamp a marker so secret-reveal handlers
+        // can distinguish human cookie auth (admin-equivalent on this single-
+        // tenant CDS) from machine credentials. Static AI_ACCESS_KEY and
+        // global cdsg_ keys deliberately do NOT set this — see reveal /
+        // customEnv masking in routes/branches.ts and routes/projects.ts.
+        (req as any)._cdsCookieAuth = true;
+        return next();
+      }
 
       // Check AI session auth
       const aiSession = resolveAiSession(req, deps.stateService);


### PR DESCRIPTION
## Why

P0 (#573) closed the `/_cds/` `x-cds-internal` worker-proxy bypass. Audit P1 follow-up showed the **direct** `https://cds.miduo.org/api` surface still leaked plaintext secrets to anyone holding the static `AI_ACCESS_KEY`:

```
curl -H "X-AI-Access-Key: $AI_ACCESS_KEY" \
  https://cds.miduo.org/api/branches/mdimp-main/effective-env/reveal?key=CDS_MYSQL_PASSWORD
  → 200 + plaintext

curl -H "X-AI-Access-Key: $AI_ACCESS_KEY" \
  https://cds.miduo.org/api/projects
  → 200, customEnv had ROOT_ACCESS_PASSWORD / JWT_SECRET / GITHUB_PAT /
    the AI_ACCESS_KEY itself in plaintext
```

**Root cause**: `assertProjectAccess()` only enforces scoping when `req.cdsProjectKey` is set. A static `AI_ACCESS_KEY` request has no `cdsProjectKey` → `assertProjectAccess` returns `null` → the handler treats it as admin and emits plaintext.

## What changed

1. **`cds/src/server.ts`** — when cookie auth matches `validToken`, stamp `req._cdsCookieAuth = true` so secret-reveal handlers can distinguish human admin from machine credentials. Static / cdsg_ paths deliberately do NOT set this.

2. **`cds/src/routes/branches.ts`** — `GET /api/branches/:id/effective-env/reveal` now checks `ownerOk = (cdsProjectKey.projectId === branch.projectId) || _cdsCookieAuth` BEFORE returning plaintext. Otherwise → `403 forbidden_secret_reveal`.

3. **`cds/src/routes/projects.ts`** — `GET /api/projects` and `GET /api/projects/:id` mask `customEnv` / `defaultEnv` values to `'***[masked]***'` for non-owners. Key names still visible (UI keeps working, "X env vars configured" still rendered) but no secret material walks away.

## Compatibility

- cdscli is unaffected: scan / import / deploy never need plaintext reveal. They only call `/api/projects` for listing (key names suffice) and `/api/branches/.../deploy` (no env reveal).
- To read/mutate secrets you now need a `cdsp_` project-scoped Agent Key (issued through "授权 Agent" on the project page) or a logged-in human cookie session.
- `cdsg_` global agent keys are admin-equivalent for write but DO NOT auto-grant reveal — a deliberate downgrade matching the audit expectation.

## Test plan

- [x] `npx tsc --noEmit` clean in `cds/`
- [ ] `curl -H "X-AI-Access-Key: $static" .../effective-env/reveal?key=...` → 403
- [ ] `curl -H "X-AI-Access-Key: $static" /api/projects` → customEnv values are `***[masked]***`
- [ ] `cdscli` scan/list still 200
- [ ] cdsp_ project key on the matching project still gets plaintext reveal


---
_Generated by [Claude Code](https://claude.ai/code/session_01PEmiBzWA3nr8W97zAUPVJK)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens authorization and response shaping around secret material; risk is moderate because it changes access-control behavior and could break automation that relied on global/static keys seeing plaintext envs.
> 
> **Overview**
> Closes a plaintext secret leak by requiring **project-owner context** to access secret material.
> 
> `GET /api/branches/:id/effective-env/reveal` now returns `403 forbidden_secret_reveal` unless the request is authenticated via a matching project-scoped `cdsp_` key or a human cookie session (cookie auth is explicitly stamped via `req._cdsCookieAuth`).
> 
> `GET /api/projects` and `GET /api/projects/:id` now **mask** `customEnv`/`defaultEnv` values as `***[masked]***` for non-owners while still returning the key names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b146da311fabb3fe22e2f3bb5c26140497a0c2fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->