### PR TITLE
security(P1.5+P0.5): /api/env mask + drop deploy from internal bypass

### DIFF
--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -5336,10 +5336,44 @@ export function createBranchRouter(deps: RouterDeps): Router {
 
   router.get('/env', (req, res) => {
     const scope = resolveScope(req);
+
+    // SECURITY P1.5 (2026-05-09): /api/env GET historically returned plaintext
+    // values to ANY caller with a valid AI_ACCESS_KEY (static / cdsg_ / cdsp_
+    // any-project). The audit P1.5 PoC showed
+    //   curl -H "X-AI-Access-Key: $static" /api/env?scope=_global  → JWT_SECRET plaintext
+    //   curl -H "X-AI-Access-Key: $static" /api/env?scope=<projId> → project secret plaintext
+    //
+    // Mirror the masking applied to /api/projects (routes/projects.ts) and
+    // /branches/:id/effective-env/reveal: only the project owner (cdsp_ key
+    // matching scope, or human cookie session) sees plaintext. Everyone else
+    // gets `***[masked]***` — UI keeps rendering "X env vars configured" but
+    // no machine credential walks away with the secret material.
+    const projKey = (req as any).cdsProjectKey as { projectId: string } | undefined;
+    const cookieAuth = (req as any)._cdsCookieAuth === true;
+    const maskValues = (env: Record<string, string>): Record<string, string> => {
+      const out: Record<string, string> = {};
+      for (const k of Object.keys(env || {})) out[k] = '***[masked]***';
+      return out;
+    };
+    const ownerOkFor = (s: string): boolean => {
+      if (cookieAuth) return true;
+      if (projKey && projKey.projectId === s) return true;
+      return false;
+    };
+
     // /env?scope=_all — give the Settings UI the full scoped map in one
     // round trip so it can render both global and per-project vars.
     if (scope === '_all') {
-      res.json({ env: stateService.getCustomEnvRaw(), scope: '_all' });
+      const raw = stateService.getCustomEnvRaw();
+      // _all spans every scope incl. _global; only cookie auth (admin UI)
+      // may see plaintext. Any token-based caller gets full mask.
+      if (cookieAuth) {
+        res.json({ env: raw, scope: '_all' });
+        return;
+      }
+      const masked: Record<string, Record<string, string>> = {};
+      for (const s of Object.keys(raw || {})) masked[s] = maskValues(raw[s] || {});
+      res.json({ env: masked, scope: '_all' });
       return;
     }
     // Phase 8 — 项目级 scope 同时返回 envMeta + missingRequired,UI 弹窗一次拿到全部数据
@@ -5349,13 +5383,18 @@ export function createBranchRouter(deps: RouterDeps): Router {
     // 项目 scope 的值,而 missingRequiredEnvKeys 是按 merged(global ⊕ project)
     // 算的,导致 UI 上一个全局已填的 required key 既不显示值也不报 missing,
     // 视觉上"空白但不告警"产生数据错觉。
-    const env = stateService.getCustomEnvScope(scope);
+    const rawEnv = stateService.getCustomEnvScope(scope);
+    const env = ownerOkFor(scope) ? rawEnv : maskValues(rawEnv);
     if (scope !== '_global') {
       const project = stateService.getProject(scope);
       if (project) {
         const envMeta = stateService.getEnvMeta(scope);
         const missingRequiredEnvKeys = stateService.getMissingRequiredEnvKeys(scope);
-        const globalEnv = stateService.getCustomEnvScope('_global');
+        const rawGlobal = stateService.getCustomEnvScope('_global');
+        // _global plaintext only when caller owns _global (i.e. cookie auth);
+        // a project-scoped cdsp_ key sees its own project plaintext but
+        // global stays masked (consistent with reveal/customEnv P1 model).
+        const globalEnv = ownerOkFor('_global') ? rawGlobal : maskValues(rawGlobal);
         res.json({ env, scope, envMeta, missingRequiredEnvKeys, globalEnv });
         return;
       }

--- a/cds/src/server.ts
+++ b/cds/src/server.ts
@@ -1132,10 +1132,24 @@ export function createServer(deps: ServerDeps): express.Express {
           /^\/api\/check-updates/,
           /^\/api\/bridge\/(check|navigate-requests|handshake-requests)/,
         ];
-        // POST allowlist — widget deploy / log panel / bridge
+        // POST allowlist — widget log panel / bridge
+        //
+        // SECURITY P0.5 (2026-05-09): /api/branches/:id/deploy and
+        // /api/branches/:id/deploy/:profile were previously in this list so
+        // a preview-container widget could "one-click redeploy this branch"
+        // without re-authenticating. The audit P0.5 PoC showed
+        //   curl -X POST https://main-prd-agent.miduo.org/_cds/api/branches/mdimp-main/deploy
+        //   → 200, mdimp deployCount really increments
+        // — i.e. ANY preview container could trigger deploys against ANY
+        // OTHER project's branch via the worker's `x-cds-internal:1`
+        // injection, because ALLOW_POST didn't (and can't here) verify that
+        // the branchId belongs to the source project. We pull deploy out of
+        // the internal-bypass entirely; widgets that genuinely need to
+        // deploy must authenticate with a real AI_ACCESS_KEY / cookie /
+        // cdsp_ project key, and assertProjectAccess inside the deploy
+        // handler will then enforce single-project scope. cdscli is
+        // unaffected because it always sends X-AI-Access-Key.
         const ALLOW_POST: RegExp[] = [
-          /^\/api\/branches\/[^/]+\/deploy(\?|$)/,
-          /^\/api\/branches\/[^/]+\/deploy\/[^/]+/,
           /^\/api\/branches\/[^/]+\/container-logs(\?|$)/,
           /^\/api\/bridge\/(heartbeat|result|end-session|dismiss|approve|reject)/,
         ];


### PR DESCRIPTION
## Context

Follow-up to PR #573 (P0 worker proxy) and PR #575 (P1 reveal/customEnv mask). Re-audit found two breaches still open. This PR closes both.

## Vulnerability A — P1.5 — `/api/env` plaintext leak

```bash
# static AI_ACCESS_KEY (no project scope)
curl -H "X-AI-Access-Key: $AI_ACCESS_KEY" "https://cds.miduo.org/api/env?scope=_global"
# → 200, body contained JWT_SECRET / AI_ACCESS_KEY itself in plaintext

curl -H "X-AI-Access-Key: $AI_ACCESS_KEY" "https://cds.miduo.org/api/env?scope=<projId>"
# → 200, project secrets in plaintext
```

P1 added owner check on `/branches/:id/effective-env/reveal` and `/api/projects` customEnv, but the underlying GET `/api/env` handler in `routes/branches.ts` still returned raw values to any AI_ACCESS_KEY holder. Static keys, `cdsg_` global agent keys, and `cdsp_` keys for other projects all got plaintext.

## Vulnerability B — P0.5 — cross-project deploy via internal bypass

```bash
# called from inside any preview container (sets x-cds-internal:1 via worker)
curl -X POST https://main-prd-agent.miduo.org/_cds/api/branches/mdimp-main/deploy
# → 200, mdimp project deployCount really increments
```

`server.ts` ALLOW_POST contained two `/api/branches/:id/deploy[/:profile]` regexes that the `x-cds-internal:1` bypass admitted unauthenticated. Because the bypass treats the worker container as trusted, any preview can trigger deploy against **any other project's branch** — the bypass has no source-project check.

## Changes

### `cds/src/routes/branches.ts` — `GET /api/env`

- Added `ownerOkFor(scope)` check (cookie session, or `cdsp_` key matching that scope).
- For `scope=_all` (Settings UI bulk read): only cookie auth sees plaintext; any token caller gets fully-masked map.
- For `scope=_global`: plaintext only for cookie auth; everyone else gets `***[masked]***` for each key.
- For `scope=<projectId>`: plaintext only for owner (`cdsp_` matching, or cookie). The bundled `globalEnv` field returned alongside is masked unless caller owns `_global` (cookie).
- Mask format mirrors `routes/projects.ts` `maskEnvMap()` so the UI keeps showing key names + "X env vars configured" without leaking values.
- Audit log endpoint `/env/audit` and `PUT /env` (writes) untouched.

### `cds/src/server.ts` — `ALLOW_POST` list

- Removed `^/api/branches/[^/]+/deploy(\?|$)` and `^/api/branches/[^/]+/deploy/[^/]+`.
- Widget callers that need to deploy must now authenticate with a real `X-AI-Access-Key` (or cookie, or `cdsp_` project key); the existing `assertProjectAccess()` inside the deploy handler then enforces single-project scope.
- DENY list / loopback / IP gate from PR #573 unchanged.

## Compatibility

- **cdscli**: always sends `X-AI-Access-Key`, hits the deploy handler through the normal auth path. Unaffected. `cdscli deploy` still returns 200.
- **Widget one-click redeploy**: now requires login (cookie) or a `cdsp_` project key. Anonymous cross-project deploy via the worker bypass is gone.
- **Settings UI `/cds-settings`**: served with cookie auth, sees plaintext as before.
- **Project Settings panel `/settings/<projId>`**: cookie auth or owner `cdsp_` key, sees plaintext for that project.

## Re-test expectations after merge + self-update

- `GET /api/env?scope=_global` with static `X-AI-Access-Key` → 200 with values masked.
- `GET /api/env?scope=<projId>` with static `X-AI-Access-Key` → 200 with values masked.
- `POST /_cds/api/branches/<otherProj>/deploy` from a preview container → 401/403 (not allowlisted, hits cookie/token auth).
- `POST /api/branches/<own>/deploy` with valid `X-AI-Access-Key` (cdscli path) → 200.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PEmiBzWA3nr8W97zAUPVJK)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes security-critical behavior for secret exposure and deploy authorization, which could break existing callers and has direct impact on access control. Also modifies the internal bypass allowlist, affecting widget/worker traffic patterns.
> 
> **Overview**
> **Closes two security gaps** by restricting who can read plaintext env secrets and who can trigger deploys via internal bypass.
> 
> `GET /api/env` now **masks all values** as `***[masked]***` unless the caller is the scope owner (cookie-auth session, or a `cdsp_` project key matching the requested project). For `scope=_all`, plaintext is only returned for cookie auth; token callers receive a fully masked per-scope map, and project responses include `globalEnv` masked unless the caller also owns `_global`.
> 
> The server’s `x-cds-internal:1` bypass no longer allowlists `POST /api/branches/:id/deploy[/:profile]`, forcing deploys to go through normal authentication/project-scope enforcement instead of being callable from any preview container.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10d4e03638ec5a12e34373c406dbe59f9ef07576. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->