### PR TITLE
security(cds): widget /api/build-profiles 隔离 + projects/:id 接受 slug (AB/AD)

### DIFF
--- a/cds/src/server.ts
+++ b/cds/src/server.ts
@@ -1274,6 +1274,7 @@ export function createServer(deps: ServerDeps): express.Express {
           const branchDetailRe = /^\/api\/branches\/([^/]+)$/;
           const projectsListRe = /^\/api\/projects$/;
           const projectDetailRe = /^\/api\/projects\/([^/]+)$/;
+          const buildProfilesListRe = /^\/api\/build-profiles$/;
 
           const wrap = (filterFn: (body: any) => any) => {
             const origJson = res.json.bind(res);
@@ -1284,6 +1285,17 @@ export function createServer(deps: ServerDeps): express.Express {
                 return origJson(body);
               }
             };
+          };
+
+          // Accept both project id and slug as valid identifiers for the
+          // current source project — a widget loaded from
+          // main-mdimp.miduo.org resolves sourceProjectId=<hash> + slug=mdimp,
+          // but the widget script may request /api/projects/<slug>.
+          // Without slug acceptance the bypass filter would 403 the widget's
+          // own project (Bug AD: GET /api/projects/<slug> rejected).
+          const matchesSourceProject = (id: string | null | undefined): boolean => {
+            if (!id) return false;
+            return id === sourceProjectId || id === sourceProjectSlug;
           };
 
           if (branchesListRe.test(pathOnly)) {
@@ -1321,7 +1333,7 @@ export function createServer(deps: ServerDeps): express.Express {
             });
           } else if (projectDetailRe.test(pathOnly)) {
             const m = projectDetailRe.exec(pathOnly)!;
-            if (m[1] !== sourceProjectId) {
+            if (!matchesSourceProject(m[1])) {
               res.statusCode = 403;
               res.setHeader('content-type', 'application/json');
               res.end(JSON.stringify({
@@ -1331,6 +1343,24 @@ export function createServer(deps: ServerDeps): express.Express {
               }));
               return;
             }
+          } else if (buildProfilesListRe.test(pathOnly)) {
+            // Bug AB (2026-05-10): the widget浮窗 lists "其他项目 service"
+            // because `/api/build-profiles` returns the global table for
+            // every project. Filter the response body so a widget loaded
+            // under preview host main-prd-agent only sees profiles whose
+            // projectId matches its own project. Legacy profiles without
+            // an explicit projectId are treated as 'default' and only
+            // surface for the legacy default project.
+            wrap((body) => {
+              if (!body || typeof body !== 'object') return body;
+              const arr = Array.isArray(body.profiles) ? body.profiles : null;
+              if (!arr) return body;
+              const filtered = arr.filter((p: any) => {
+                const pid = p?.projectId || 'default';
+                return pid === sourceProjectId;
+              });
+              return { ...body, profiles: filtered };
+            });
           }
         }
 

--- a/changelogs/2026-05-10_widget-build-profiles-isolation.md
+++ b/changelogs/2026-05-10_widget-build-profiles-isolation.md
@@ -1,0 +1,2 @@
+| security | cds | widget /_cds/api/build-profiles 按 sourceProject 过滤，杜绝其它项目 service 出现在浮窗（Bug AB） |
+| fix | cds | widget bypass 项目详情接受 slug 而非仅 hash id，修复 main-{slug}.miduo.org 下 GET /api/projects/{slug} 误 403（Bug AD） |


### PR DESCRIPTION
## 摘要

PR #582 把 widget 浮窗的 source-project 隔离做到了 `/api/branches` 和 `/api/projects` 两端，但用户截图显示 `main-prd-agent.miduo.org` 浮窗仍列出 6 个 service（含 mdimp / mytapd 项目的 imp-api-mdimp / imp-admin-mdimp / miduo-frontend / ticket-bootstrap）。根因是 widget-script 实际还调 `/api/build-profiles` 拉构建配置全表，PR #582 的过滤分支没覆盖到这个端点。本 PR 补齐过滤；同时修复跨项目详情查询误把自家 slug 当作越界（Bug AD 的 403 表象）。

## 改动 diff

- `cds/src/server.ts`：在 `x-cds-internal` bypass 的 GET 响应过滤分支新增 `buildProfilesListRe`，对 `/api/build-profiles` 的响应 body 过滤 `profiles[]`，仅保留 `projectId === sourceProjectId`（legacy 走 `'default'` 兜底）；`projectDetailRe` 由严格 `m[1] === sourceProjectId` 改为 `matchesSourceProject(id||slug)`，避免 mdimp widget 调 `/api/projects/mdimp` 被误 403。
- `changelogs/2026-05-10_widget-build-profiles-isolation.md`：碎片记录。

## Bug 覆盖

| Bug | 修了 | 证据 |
|---|---|---|
| AB widget UI 真隔离 | 是 | 部署前 build-profiles 返回 6 条跨项目；部署后期望 prd-agent 仅 2 条 / mdimp 仅 2 条 |
| AC overlay 挡按钮 | 代码审查 | OpsDrawer 已 `if(!open) return null`，源码层无 bug；现网若仍复现是 build 陈旧 |
| AD `/api/projects/:id` 误 403 | 是 | 增加 slug 接受，mdimp widget 访问 `/api/projects/mdimp` 不再 403 |
| AE mytapd 内部 hostname URL | 调查 | 容器内未发现 `ticket-bootstrap:8080` 字面量；建议在 MiDouTech/myTapd 提 issue（不动 CDS 代码） |

## 测试

- [x] `cd cds && npx tsc --noEmit` 0 error
- [ ] self-update 后通过 `curl https://main-prd-agent.miduo.org/_cds/api/build-profiles` 验证返回仅 2 条 prd-agent profile
- [ ] `curl https://main-mdimp.miduo.org/_cds/api/build-profiles` 验证仅 mdimp 项目
- [ ] `curl -i https://main-mdimp.miduo.org/_cds/api/projects/mdimp` 验证 200（之前 403）


---
_Generated by [Claude Code](https://claude.ai/code/session_01PEmiBzWA3nr8W97zAUPVJK)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the `x-cds-internal` bypass filtering/authorization path, so mistakes could unintentionally leak cross-project data or block legitimate widget requests. Scope is limited to GET response filtering for `/api/build-profiles` and project detail identifier matching.
> 
> **Overview**
> Tightens widget cross-project isolation by filtering `GET /api/build-profiles` responses under the `x-cds-internal` bypass so the widget only receives build profiles whose `projectId` matches the resolved `sourceProjectId` (treating missing `projectId` as `default`).
> 
> Fixes a false 403 in the same bypass path by allowing `GET /api/projects/:id` to match the source project by either hash `id` *or* `slug`, so widgets requesting `/api/projects/<slug>` are treated as in-scope.
> 
> Adds a changelog entry documenting the `build-profiles` isolation (Bug AB) and the slug acceptance fix (Bug AD).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e625a54058e4d8f98d13da18d5edc4b5b7afd96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->