### PR TITLE
fix(cds): PUT env merge + getProject 接受 slug + infra 短别名 (AA/AD-residual/D-residual)

### DIFF
--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -4736,13 +4736,29 @@ export function createBranchRouter(deps: RouterDeps): Router {
       const incomingBody: any = req.body && typeof req.body === 'object' ? { ...req.body } : req.body;
       if (incomingBody && typeof incomingBody === 'object') {
         const prevEnv: Record<string, string> = (existing as any).env || {};
+        // Bug AA fix (HIGH, 2026-05-10): PUT env 必须 merge,不能 replace。
+        //
+        // 历史行为:incomingBody.env 直接替换 existing.env(stateService.update
+        // BuildProfile 走 Object.assign,把整个 env 字段整体替换)。结果是 UI
+        // 想"只改一个 env key"必须先 GET 全表 → 编辑一个 key → PUT 完整表。
+        // 任意一步失误就把其它密码全干掉。
+        //
+        // 修法:本路由把 incoming env merge 进 prevEnv 后再交给 update。
+        //   - body.env 中出现的 key:用 body 提供的值(经 mask sanitize)
+        //   - body.env 中没出现的 key:沿用 prevEnv 值,一律不删
+        // 想真正删 env key 的客户端走专门的 DELETE 路由(未实现)或显式传
+        // 该 key 的值为空字符串(下游使用方自己判定)—— 不通过"省略"做删除。
+        const mergeEnv = (incoming: Record<string, unknown>): Record<string, string> => {
+          const sanitized = sanitizeEnv(incoming, prevEnv);
+          return { ...prevEnv, ...sanitized };
+        };
         if (incomingBody.env && typeof incomingBody.env === 'object') {
-          incomingBody.env = sanitizeEnv(incomingBody.env, prevEnv);
+          incomingBody.env = mergeEnv(incomingBody.env);
         }
         if (incomingBody.environment && typeof incomingBody.environment === 'object') {
           // Some clients use `environment` as alias; merge into the actual
           // `env` key to avoid creating a duplicate field.
-          incomingBody.env = sanitizeEnv(incomingBody.environment, prevEnv);
+          incomingBody.env = mergeEnv(incomingBody.environment);
           delete incomingBody.environment;
         }
       }

--- a/cds/src/services/container.ts
+++ b/cds/src/services/container.ts
@@ -1135,7 +1135,17 @@ export class ContainerService {
     // 默认只能解析全名。但 cds-compose 里其它 service 用短名(如 db / mysql /
     // redis)做 host 引用 → DNS 解析失败 → nc 报 "bad address 'db'"。
     // --network-alias 给 container 在 network 里再加一个短名,DNS 就能解析。
-    const aliasFlags = [`--network-alias ${service.id}`];
+    //
+    // Bug D-residual fix(2026-05-10):service.id 在多项目场景下经常是
+    // `<short>-<projectIdSlug>`(如 `mysql-mdimp` / `redis-mdimp`),profile
+    // 容器内代码却用裸短名(`mysql` / `redis` / `nacos`)做 host 引用 ——
+    // getent hosts mysql 还是 NXDOMAIN。复用 computeProfileAliases 的同款
+    // 启发式:剥掉看起来像 project marker 的尾段,再注册一个短别名。
+    //   - mysql-mdimp + project mdimp → 加 --network-alias mysql
+    //   - mysql       + project mdimp → 不加(已是短名)
+    //   - mysql-other + project mdimp → 不加(尾段不像本项目 marker)
+    const aliasFlags = computeProfileAliases(service.id, service.projectId || '')
+      .map((a) => `--network-alias ${a}`);
 
     const cmd = [
       'docker run -d',

--- a/cds/src/services/state.ts
+++ b/cds/src/services/state.ts
@@ -872,9 +872,28 @@ export class StateService {
     return this.state.projects || [];
   }
 
-  /** Look up a project by id. Returns undefined when not found. */
-  getProject(id: string): Project | undefined {
-    return (this.state.projects || []).find((p) => p.id === id);
+  /**
+   * Look up a project by id, falling back to slug when id miss. Returns
+   * undefined when neither matches.
+   *
+   * Bug AD-residual fix (2026-05-10): widget script + 部分外部调用方习惯把
+   * project slug(`prd-agent` / `mdimp`)塞进 `:id` 路径段,例如
+   * `GET /api/projects/mdimp` —— 仓库名/分支预览域名都用 slug,实际写库的
+   * project.id 是随机后缀(`defd4695ab5f`)。PR #583 已经把入口路由的过滤白
+   * 名单放宽到 id || slug,但下游 `state.getProject(idOrSlug)` 自身仍只按 id
+   * 精确匹配,导致 routes 拿到 slug 后在 state 层第二次落地依然 404。
+   *
+   * 这里把 slug 当成 fallback:先按 id 精确匹配(O(1)语义,99% 调用走这条),
+   * 没有再按 slug 大小写不敏感扫描。slug 在 state 内部全局唯一(addProject
+   * 已 enforce),所以最多匹配一条,语义不歧义。
+   */
+  getProject(idOrSlug: string): Project | undefined {
+    if (!idOrSlug) return undefined;
+    const projects = this.state.projects || [];
+    const byId = projects.find((p) => p.id === idOrSlug);
+    if (byId) return byId;
+    const lc = idOrSlug.toLowerCase();
+    return projects.find((p) => (p.slug || '').toLowerCase() === lc);
   }
 
   /**


### PR DESCRIPTION
## 摘要
一次性修掉 3 个 CDS 残留 bug,均集中在 cds/ 模块,无前端/.NET 改动。

## 改动 diff
- `cds/src/routes/branches.ts`:PUT /api/build-profiles/:id 对 env 字段改为 merge 而非 replace。body.env 出现的 key 用 body 值,未出现的 key 沿用 prevEnv,避免"只改一个 env key"误删其它密码。`environment` 别名走同一 mergeEnv (Bug AA, HIGH)
- `cds/src/services/state.ts`:`getProject(idOrSlug)` 加 slug fallback,先按 project.id 精确匹配,没有再按 slug 大小写不敏感扫描。修复 GET /api/projects/mdimp 在 routes 层拿到 slug 后又被 state 层 404 的问题 (Bug AD-residual, LOW)
- `cds/src/services/container.ts`:`startInfraService` 复用 `computeProfileAliases` 给 infra 容器注册短别名(mysql-mdimp → mysql)。修复 imp-api 容器内 `getent hosts mysql` NXDOMAIN 的问题 (Bug D-residual, LOW)

## 测试
- [x] `npx tsc --noEmit` 0 错误
- [x] `vitest tests/services/state-projects.test.ts` 26/26 通过
- [ ] 部署后 PoC 复测三个 bug

---
_Generated by [Claude Code](https://claude.ai/code/session_01PEmiBzWA3nr8W97zAUPVJK)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes update semantics for build-profile `env` and container network aliasing, which can affect secret persistence and service connectivity if the merge/alias heuristics behave unexpectedly. Scope is limited to CDS backend routes/services and is straightforward to reason about.
> 
> **Overview**
> Prevents accidental loss of existing build-profile environment variables by changing `PUT /build-profiles/:id` to **merge** incoming `env`/`environment` into the stored env (after mask-sentinel sanitization) instead of replacing the entire map.
> 
> Updates `state.getProject` to accept either *project id or slug* (case-insensitive) to avoid 404s when callers pass slugs in project routes.
> 
> Extends infra container startup to register **multiple Docker `--network-alias` values** (via `computeProfileAliases`) so multi-project service IDs like `mysql-<proj>` remain reachable by bare short hostnames like `mysql` inside the network.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b3cfcb7d49178e85e31243a1b7ed1a15c364524. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->