### PR TITLE
fix(cds): computeProfileAliases 接受 slug 作 projectMarker (D-residual 三段)

### DIFF
--- a/cds/src/index.ts
+++ b/cds/src/index.ts
@@ -419,6 +419,10 @@ const containerService = new ContainerService(shell, config, {
   // 适配器拿值。老项目 dockerNetwork 字段可能为空,此时返回 undefined,
   // ContainerService 会兜底到 config.dockerNetwork。
   getDockerNetwork: (projectId) => stateService.getProject(projectId)?.dockerNetwork,
+  // Bug D-residual followup(2026-05-10):computeProfileAliases 用 slug 做
+  // 短别名启发式比对(profile.id 形如 `mysql-mdimp`,projectId 是
+  // `defd4695ab5f`,slug 才是 `mdimp`)。adapter 把 slug 暴露给容器层。
+  getProjectSlug: (projectId) => stateService.getProject(projectId)?.slug,
 });
 const proxyService = new ProxyService(stateService, config);
 proxyService.setWorktreeService(worktreeService);

--- a/cds/src/services/container.ts
+++ b/cds/src/services/container.ts
@@ -21,6 +21,13 @@ import { nodeModulesVolumeName } from '../util/node-modules-volume.js';
 export interface ProjectNetworkResolver {
   /** 返回该项目的 dockerNetwork,缺失则返回 undefined（调用方走 config 兜底）。 */
   getDockerNetwork(projectId: string): string | undefined;
+  /**
+   * 返回该项目的 slug(可读名,如 `mdimp` / `prd-agent`),缺失/未实现则返回
+   * undefined。Bug D-residual 用于把"短别名启发式"的 projectMarker 从 id
+   * (随机后缀) 升级为 slug。可选方法,旧实现不实现也不会编译错(运行时
+   * fallback 到 projectId)。
+   */
+  getProjectSlug?(projectId: string): string | undefined;
 }
 
 /**
@@ -271,21 +278,38 @@ function parseFloatSafe(s: string): number {
  *
  * 这是纯函数,export 出来给 unit test 用。
  */
-export function computeProfileAliases(profileId: string, projectId: string): string[] {
+export function computeProfileAliases(
+  profileId: string,
+  projectMarkers: string | string[],
+): string[] {
   const aliases = new Set<string>();
   if (profileId) aliases.add(profileId);
+
+  // Bug D-residual followup(2026-05-10):callers 传的"项目标识"可能是
+  // project.id(随机后缀如 `defd4695ab5f`)也可能是 project.slug(可读名如
+  // `mdimp`)。若 profile.id 形如 `mysql-mdimp` 但传入的 projectMarker 是
+  // `defd4695ab5f`,startsWith 比对永远 false → 短别名 `mysql` 永远加不上。
+  // 这里把 projectMarkers 标准化成数组,任一 marker 命中即可,鲁棒覆盖
+  // (id, slug, [id, slug]) 三种调用方式,旧调用方零改动。
+  const markers = Array.isArray(projectMarkers) ? projectMarkers : [projectMarkers];
+  const normalizedMarkers = markers
+    .map((m) => (m || '').toLowerCase().replace(/[^a-z0-9]+/g, ''))
+    .filter((m) => m.length > 0);
 
   const lastDashIdx = profileId.lastIndexOf('-');
   if (lastDashIdx > 0 && lastDashIdx < profileId.length - 1) {
     const head = profileId.slice(0, lastDashIdx);
     const tail = profileId.slice(lastDashIdx + 1);
-    const projectIdSlug = (projectId || '').toLowerCase().replace(/[^a-z0-9]+/g, '');
     const tailNorm = tail.toLowerCase();
-    const looksLikeProjectMarker =
+    const tailWellFormed =
       tail.length > 0 &&
       tail.length <= 12 &&
-      /^[a-z0-9]+$/.test(tailNorm) &&
-      (projectIdSlug.startsWith(tailNorm) || tailNorm === projectIdSlug.slice(0, tail.length));
+      /^[a-z0-9]+$/.test(tailNorm);
+    const looksLikeProjectMarker =
+      tailWellFormed &&
+      normalizedMarkers.some(
+        (m) => m.startsWith(tailNorm) || tailNorm === m.slice(0, tail.length),
+      );
     if (looksLikeProjectMarker && head.length >= 2) {
       aliases.add(head);
     }
@@ -320,6 +344,19 @@ export class ContainerService {
   private getNetworkForProject(projectId?: string | null): string {
     if (!projectId || !this.networkResolver) return this.config.dockerNetwork;
     return this.networkResolver.getDockerNetwork(projectId) || this.config.dockerNetwork;
+  }
+
+  /**
+   * Bug D-residual followup(2026-05-10):为 computeProfileAliases 收集"项目
+   * 标识候选"——同时返回 projectId(随机后缀)和 slug(可读名)。短别名启发式
+   * 命中任一即可,不会因为 profile.id 用 slug 而 projectId 用 id 而漏判。
+   */
+  private getProjectMarkers(projectId?: string | null): string[] {
+    if (!projectId) return [];
+    const markers: string[] = [projectId];
+    const slug = this.networkResolver?.getProjectSlug?.(projectId);
+    if (slug && slug !== projectId) markers.push(slug);
+    return markers;
   }
 
   /**
@@ -579,7 +616,10 @@ export class ContainerService {
       //   2. shortAlias        — 去掉项目后缀,如 'imp-api' / 'mysql'(如果与
       //      profile.id 不同)
       // 多 alias 用多个 --network-alias 标志(docker 支持任意多个)。
-      const profileAliases = computeProfileAliases(profile.id, entry.projectId);
+      const profileAliases = computeProfileAliases(
+        profile.id,
+        this.getProjectMarkers(entry.projectId),
+      );
       const profileAliasFlags = profileAliases.map((a) => `--network-alias ${a}`);
 
       const runCmd = [
@@ -1077,7 +1117,10 @@ export class ContainerService {
     // Bug D-residual fix(2026-05-10):reuse / wake 路径都需要保证 infra 容器
     // 在 network 上同时拥有"长名 + 短别名",否则 profile 容器内 getent hosts
     // mysql 仍 NXDOMAIN。这里和 docker run 路径走同一份 alias 列表。
-    const desiredAliases = computeProfileAliases(service.id, service.projectId || '');
+    const desiredAliases = computeProfileAliases(
+      service.id,
+      this.getProjectMarkers(service.projectId),
+    );
     if (inspect.exitCode === 0) {
       const dockerStatus = inspect.stdout.trim();
       if (dockerStatus === 'running') {
@@ -1148,8 +1191,10 @@ export class ContainerService {
     //   - mysql-mdimp + project mdimp → 加 --network-alias mysql
     //   - mysql       + project mdimp → 不加(已是短名)
     //   - mysql-other + project mdimp → 不加(尾段不像本项目 marker)
-    const aliasFlags = computeProfileAliases(service.id, service.projectId || '')
-      .map((a) => `--network-alias ${a}`);
+    const aliasFlags = computeProfileAliases(
+      service.id,
+      this.getProjectMarkers(service.projectId),
+    ).map((a) => `--network-alias ${a}`);
 
     const cmd = [
       'docker run -d',


### PR DESCRIPTION
## 摘要
PR #586 实测仍不通。根因是 `computeProfileAliases('mysql-mdimp', 'defd4695ab5f')` 时 projectId 不以 `mdimp` 开头,启发式判定失败 → 只返回长名 `mysql-mdimp`,短别名 `mysql` 永远加不上。

profile.id 用 slug 后缀(mdimp),但 entry/service.projectId 是随机 id —— 两边对不上。

## 改动 diff
- `cds/src/services/container.ts`:
  - `computeProfileAliases` 第二参改成 `string | string[]`,数组任一 marker 命中即可
  - `ProjectNetworkResolver` 加可选 `getProjectSlug(projectId)`
  - 新增 `getProjectMarkers(projectId)` 私有方法,统一返回 `[id, slug]`
  - 三处调用点(profile docker run / startInfraService / ensureInfraOnNetwork)统一走它
- `cds/src/index.ts`:adapter 暴露 `getProjectSlug` 实现

## 测试
- [x] `npx tsc --noEmit` 0 错误
- [x] `vitest tests/services/` 720/720 通过
- [ ] 部署后 mdimp 重启 + getent hosts mysql 验证

---
_Generated by [Claude Code](https://claude.ai/code/session_01PEmiBzWA3nr8W97zAUPVJK)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Docker `--network-alias` values are computed and applied for both app and infra containers, which can affect service discovery inside project networks. Risk is moderate because regressions would surface as cross-container DNS/connection failures during deploy/reuse paths.
> 
> **Overview**
> Fixes residual multi-project DNS issues by making `computeProfileAliases` accept **slug-based** project markers (or an array of markers) so short service aliases (e.g. `mysql`) are reliably added even when `projectId` is a random id and `profile.id` is suffixed with the project slug.
> 
> `ContainerService` now gathers `[projectId, projectSlug]` via an optional `ProjectNetworkResolver.getProjectSlug()` and routes all alias creation/reconciliation paths (app `docker run`, infra `docker run`, and infra reuse/wake `ensureInfraOnNetwork`) through the same marker-aware alias list. `index.ts` wires the resolver by exposing `getProjectSlug` from `StateService`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3e6bfc24871742b218c8d094e5cc6ce01a2bdf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->