### PR TITLE
ux(cds): 数据库初始化显眼入口 + OpsDrawer overflow 防御兜底

### DIFF
--- a/cds/web/src/pages/BranchListPage.tsx
+++ b/cds/web/src/pages/BranchListPage.tsx
@@ -9,6 +9,7 @@ import {
   ChevronDown,
   Copy,
   Cpu,
+  Database,
   Eye,
   ExternalLink,
   Gauge,
@@ -2094,6 +2095,30 @@ export function BranchListPage(): JSX.Element {
           </div>
         ) : null}
 
+        {/* 数据库初始化提示 banner(2026-05-10):用户多次反馈"找不到初始化数据库的入口"。
+            EnvSetupDialog 支持上传 schema.sql 但藏在「项目设置→环境变量配置向导」里。
+            这里给一个常驻的、显眼的入口,deep-link 到 #env tab 后用户点"打开向导"
+            即可进入 EnvSetupDialog 的 schema 上传步骤。Mysql/postgres 容器首次启动时
+            会自动执行 /docker-entrypoint-initdb.d/ 下的 SQL,完成数据库初始化。 */}
+        {state.status === 'ok' ? (
+          <div className="mt-6 flex flex-wrap items-start gap-3 rounded-md border border-sky-500/30 bg-sky-500/10 px-4 py-3 text-sm text-sky-700 dark:text-sky-300">
+            <Database className="mt-0.5 h-4 w-4 shrink-0" />
+            <div className="min-w-0 flex-1">
+              <div className="font-medium">数据库初始化(schema.sql)</div>
+              <div className="mt-0.5 text-xs leading-5 text-sky-700/80 dark:text-sky-300/80">
+                需要给 mysql / postgres 容器导入初始化 SQL?进入「项目设置 → 环境变量配置向导」
+                上传 schema.sql,容器首次启动会自动执行 /docker-entrypoint-initdb.d/ 下的脚本。
+              </div>
+            </div>
+            <Button asChild size="sm" variant="outline">
+              <a href={`/settings/${encodeURIComponent(projectId)}#env`}>
+                <Database />
+                上传初始化 SQL
+              </a>
+            </Button>
+          </div>
+        ) : null}
+
         {/* Branch tile grid — built user mental model: cards in a 3-up
             grid, each with [预览] [部署] [详情] inline + kebab menu for low-frequency
             actions (拉取 / 停止 / 收藏 / 调试 / 标签 / 重置 / 删除). */}
@@ -2913,11 +2938,36 @@ function OpsDrawer({
     window.addEventListener('keydown', onKey);
     const previousOverflow = document.body.style.overflow;
     document.body.style.overflow = 'hidden';
+    // dev log:用户反复反馈"overlay 挡按钮",方便用户给我们 console 截图核对状态机
+    // eslint-disable-next-line no-console
+    console.log('[OpsDrawer] mounted (open=true)', new Date().toISOString());
     return () => {
       window.removeEventListener('keydown', onKey);
       document.body.style.overflow = previousOverflow;
+      // eslint-disable-next-line no-console
+      console.log('[OpsDrawer] unmounted (cleanup)', new Date().toISOString());
     };
   }, [open, onClose]);
+
+  // 防御性兜底(2026-05-10):用户反复反馈"抽屉关了 overlay 还在挡按钮"。
+  // 源码 `if (!open) return null` 和上面 cleanup 都是对的,但浏览器有可能因为
+  // React state stale / 组件 unmount 异常 / 多 modal 叠加 残留 body.overflow=hidden,
+  // 导致用户感知"页面被锁住"。这里在 open=false 时延迟 200ms 二次校验:
+  //   - 如果 body.overflow 仍是 hidden,且 DOM 里没有任何 [role=dialog][aria-modal=true],
+  //     就强制重置 body.overflow=''。
+  // 不替代源码 cleanup,只是兜底之兜底,正常路径下不会触发。
+  useEffect(() => {
+    if (open) return;
+    const t = window.setTimeout(() => {
+      if (document.body.style.overflow !== 'hidden') return;
+      const hasModal = document.querySelector('[role="dialog"][aria-modal="true"]');
+      if (hasModal) return;
+      // eslint-disable-next-line no-console
+      console.warn('[OpsDrawer] defensive: stale body.overflow=hidden detected, resetting');
+      document.body.style.overflow = '';
+    }, 200);
+    return () => window.clearTimeout(t);
+  }, [open]);
 
   if (!open) return null;
 

--- a/cds/web/src/pages/BranchTopologyPage.tsx
+++ b/cds/web/src/pages/BranchTopologyPage.tsx
@@ -1114,6 +1114,13 @@ function NodeDetails({
   }
 
   if (selectedInfra) {
+    // 数据库初始化提示(2026-05-10):用户多次反馈"找不到初始化数据库的入口"。
+    // 当 infra 镜像是 mysql / postgres / mongo / mariadb 时,这里提供一个显眼的
+    // "上传初始化 SQL" 按钮,deep-link 到项目设置 #env tab,让用户走 EnvSetupDialog
+    // 上传 schema.sql。schema.sql 会被挂到 /docker-entrypoint-initdb.d/,容器首次启动
+    // 时自动执行,完成数据库初始化。
+    const image = (selectedInfra.dockerImage || '').toLowerCase();
+    const isDatabase = /mysql|postgres|mariadb|mongo/.test(image);
     return (
       <div className="space-y-5">
         <DetailHeader icon={<Database className="h-5 w-5" />} title={selectedInfra.name || selectedInfra.id} subtitle="基础设施" />
@@ -1127,6 +1134,24 @@ function NodeDetails({
           ]}
         />
         {selectedInfra.errorMessage ? <ErrorBlock message={selectedInfra.errorMessage} /> : null}
+        {isDatabase ? (
+          <div className="flex flex-wrap items-start gap-3 rounded-md border border-sky-500/30 bg-sky-500/10 px-3 py-2 text-xs text-sky-700 dark:text-sky-300">
+            <Database className="mt-0.5 h-4 w-4 shrink-0" />
+            <div className="min-w-0 flex-1 leading-5">
+              <div className="font-medium">数据库初始化(schema.sql)</div>
+              <div className="text-sky-700/80 dark:text-sky-300/80">
+                上传 schema.sql 到仓库根目录,容器首次启动时自动执行
+                <code className="mx-1">/docker-entrypoint-initdb.d/</code>下的脚本。
+              </div>
+            </div>
+            <Button asChild size="sm" variant="outline">
+              <a href={`/settings/${encodeURIComponent(projectId)}#env`}>
+                <Database />
+                上传初始化 SQL
+              </a>
+            </Button>
+          </div>
+        ) : null}
         <Button asChild variant="outline">
           <a href={`/settings/${encodeURIComponent(projectId)}#cache`}>打开项目设置</a>
         </Button>

--- a/changelogs/2026-05-10_db-init-and-overlay-guard.md
+++ b/changelogs/2026-05-10_db-init-and-overlay-guard.md
@@ -1,0 +1,2 @@
+| feat | cds | 分支列表 / 拓扑详情新增「数据库初始化(schema.sql)」入口 chip,deep-link 到项目设置 #env tab,解决用户找不到初始化数据库入口的问题 |
+| fix | cds | OpsDrawer 增加防御性 body.overflow 兜底 + dev console 日志,解决用户反复反馈的"运维抽屉关了 overlay 还在挡按钮"问题 |


### PR DESCRIPTION
## 摘要

修两个 UX 问题:
1. 用户反复说"想初始化数据库,但找不到合适的地方"——EnvSetupDialog 已经支持上传 schema.sql,但入口埋在「项目设置 → 环境变量配置向导」一个不起眼的按钮里。本 PR 在分支列表页 + 拓扑详情页加了显眼的入口 chip,deep-link 到 `/settings/<projectId>#env`。
2. 用户反复反馈"运维抽屉关了 overlay 还在挡按钮",源码 `if (!open) return null` 是对的,但浏览器有可能因 React state stale 残留 `body.overflow=hidden`。本 PR 增加防御兜底 + console 日志方便排错。

## 改动 diff

- `cds/web/src/pages/BranchListPage.tsx`:
  - 新增"数据库初始化(schema.sql)" banner,deep-link 到项目设置 #env tab
  - OpsDrawer 增加防御性 useEffect:open=false 200ms 后二次校验 body.overflow,若仍 hidden 且 DOM 里没 modal 就强制重置
  - OpsDrawer 增加 mount/unmount/defensive 时间戳 console.log,便于用户截图反馈
- `cds/web/src/pages/BranchTopologyPage.tsx`:
  - InfraDetails 当 dockerImage 含 mysql/postgres/mongo/mariadb 时,新增"上传初始化 SQL" chip
- `changelogs/2026-05-10_db-init-and-overlay-guard.md`:碎片

## 测试

- [x] `pnpm tsc --noEmit` 零 error
- [x] 不破坏既有 EnvSetupDialog / 项目设置链路,只是加显眼入口
- [x] 防御兜底是 hidden 且无 modal 时才触发,正常路径不会跑

## 用户路径

1. 分支列表页 → "数据库初始化(schema.sql)" banner → 点"上传初始化 SQL" → 项目设置 #env tab → 点"打开向导" → EnvSetupDialog → 上传 schema.sql
2. 拓扑视图 → 点击 mysql/postgres infra 节点 → 右侧详情面板 → 同款 chip → 同上路径

https://claude.ai/code/session_01PEmiBzWA3nr8W97zAUPVJK

---
_Generated by [Claude Code](https://claude.ai/code/session_01PEmiBzWA3nr8W97zAUPVJK)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI/UX changes; the main behavioral risk is the new defensive `body.style.overflow` reset potentially interacting with other modals, but it is gated behind a DOM check and timeout.
> 
> **Overview**
> Adds a **persistent “数据库初始化(schema.sql)” entrypoint** on the branch list and a **contextual chip in topology infra details** (for mysql/postgres/mariadb/mongo images) that deep-links users to `项目设置#env` to upload `schema.sql`.
> 
> Improves `OpsDrawer` robustness by adding mount/unmount console diagnostics and a defensive delayed check that resets `document.body.style.overflow` if the drawer is closed and no modal dialogs remain, mitigating reports of the overlay still blocking clicks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cac862a7e74ea369f1e85e19977d411e1f43724. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->