### PR TITLE
fix(cds): [项目级] 数据库初始化 banner 加条件 (AL)

### DIFF
--- a/cds/web/src/pages/BranchListPage.tsx
+++ b/cds/web/src/pages/BranchListPage.tsx
@@ -2098,9 +2098,14 @@ export function BranchListPage(): JSX.Element {
         {/* 数据库初始化提示 banner(2026-05-10):用户多次反馈"找不到初始化数据库的入口"。
             EnvSetupDialog 支持上传 schema.sql 但藏在「项目设置→环境变量配置向导」里。
             这里给一个常驻的、显眼的入口,deep-link 到 #env tab 后用户点"打开向导"
-            即可进入 EnvSetupDialog 的 schema 上传步骤。Mysql/postgres 容器首次启动时
-            会自动执行 /docker-entrypoint-initdb.d/ 下的 SQL,完成数据库初始化。 */}
-        {state.status === 'ok' ? (
+            即可进入 EnvSetupDialog 的 schema 上传步骤。
+            条件:仅当项目 infraServices 含 mysql/postgres/mariadb/mongo 时显示
+            (用户反馈 MAP 等纯前端项目不该看到此 banner)。 */}
+        {state.status === 'ok' && state.branches.some((b) =>
+          Object.keys(b.services || {}).some((name) =>
+            /(mysql|mariadb|postgres|mongo)/i.test(name)
+          )
+        ) ? (
           <div className="mt-6 flex flex-wrap items-start gap-3 rounded-md border border-sky-500/30 bg-sky-500/10 px-4 py-3 text-sm text-sky-700 dark:text-sky-300">
             <Database className="mt-0.5 h-4 w-4 shrink-0" />
             <div className="min-w-0 flex-1">

--- a/cds/web/src/pages/BranchListPage.tsx
+++ b/cds/web/src/pages/BranchListPage.tsx
@@ -216,6 +216,10 @@ type LoadState =
       previewMode: 'simple' | 'port' | 'multi';
       config: CdsConfigResponse;
       capacity?: BranchesResponse['capacity'];
+      // Codex review(PR #590):banner 条件需要 infra service dockerImage,而非 branch.services 的 key。
+      // 因为数据库通常作 infra service 部署(独立于 build-profile),首次 deploy 前 branch.services 为空,
+      // 又或者 infra id 是 'db' 之类不含 mysql 关键字。fetch infra 接口取真实信号源。
+      hasSchemafulInfra: boolean;
     };
 
 type OpsStatusState =
@@ -884,12 +888,20 @@ export function BranchListPage(): JSX.Element {
     if (!projectId) return;
     if (showLoading) setState({ status: 'loading' });
     try {
-      const [project, branchesRes, previewModeRes, config] = await Promise.all([
+      const [project, branchesRes, previewModeRes, config, infraRes] = await Promise.all([
         apiRequest<ProjectSummary>(`/api/projects/${encodeURIComponent(projectId)}`),
         apiRequest<BranchesResponse>(`/api/branches?project=${encodeURIComponent(projectId)}`),
         apiRequest<PreviewModeResponse>(`/api/projects/${encodeURIComponent(projectId)}/preview-mode`).catch(() => ({ mode: 'multi' as const })),
         apiRequest<CdsConfigResponse>('/api/config').catch(() => ({})),
+        apiRequest<{ services: Array<{ id: string; dockerImage?: string }> }>(
+          `/api/infra?project=${encodeURIComponent(projectId)}`,
+        ).catch(() => ({ services: [] })),
       ]);
+      // Codex review(PR #590):banner 显示条件来自 infra dockerImage,不是 branch.services key。
+      // 兜底也看 id(用户用 'db' 等命名,但 image 字段是真实信号)。
+      const hasSchemafulInfra = (infraRes.services || []).some((s) =>
+        /(mysql|mariadb|postgres|mongo)/i.test(`${s.dockerImage || ''} ${s.id || ''}`),
+      );
       setState((prev) => ({
         status: 'ok',
         project,
@@ -899,6 +911,7 @@ export function BranchListPage(): JSX.Element {
         previewMode: previewModeRes.mode || 'multi',
         config,
         capacity: branchesRes.capacity,
+        hasSchemafulInfra,
       }));
     } catch (err) {
       const message = err instanceof ApiError ? err.message : String(err);
@@ -2101,11 +2114,7 @@ export function BranchListPage(): JSX.Element {
             即可进入 EnvSetupDialog 的 schema 上传步骤。
             条件:仅当项目 infraServices 含 mysql/postgres/mariadb/mongo 时显示
             (用户反馈 MAP 等纯前端项目不该看到此 banner)。 */}
-        {state.status === 'ok' && state.branches.some((b) =>
-          Object.keys(b.services || {}).some((name) =>
-            /(mysql|mariadb|postgres|mongo)/i.test(name)
-          )
-        ) ? (
+        {state.status === 'ok' && state.hasSchemafulInfra ? (
           <div className="mt-6 flex flex-wrap items-start gap-3 rounded-md border border-sky-500/30 bg-sky-500/10 px-4 py-3 text-sm text-sky-700 dark:text-sky-300">
             <Database className="mt-0.5 h-4 w-4 shrink-0" />
             <div className="min-w-0 flex-1">

--- a/cds/web/src/pages/BranchListPage.tsx
+++ b/cds/web/src/pages/BranchListPage.tsx
@@ -899,8 +899,10 @@ export function BranchListPage(): JSX.Element {
       ]);
       // Codex review(PR #590):banner 显示条件来自 infra dockerImage,不是 branch.services key。
       // 兜底也看 id(用户用 'db' 等命名,但 image 字段是真实信号)。
+      // Bugbot review(PR #590):**不**含 mongo。banner 文案专写 "schema.sql / mysql / postgres",
+      // MongoDB 的 init 走 .js/.sh 不走 SQL,放进来会误导用户上传 SQL。
       const hasSchemafulInfra = (infraRes.services || []).some((s) =>
-        /(mysql|mariadb|postgres|mongo)/i.test(`${s.dockerImage || ''} ${s.id || ''}`),
+        /(mysql|mariadb|postgres)/i.test(`${s.dockerImage || ''} ${s.id || ''}`),
       );
       setState((prev) => ({
         status: 'ok',

--- a/changelogs/2026-05-10_banner-conditional.md
+++ b/changelogs/2026-05-10_banner-conditional.md
@@ -1,0 +1,1 @@
+| fix | cds | BranchListPage 数据库初始化 banner 加条件,仅项目 services 含 mysql/postgres/mariadb/mongo 时显示,避免在 MAP 等纯前端项目误展示 |


### PR DESCRIPTION
## 摘要

用户反馈：MAP 等纯前端项目（无 mysql/postgres）顶部仍显示「数据库初始化(schema.sql)」banner，引起困惑。

PR #588 加 banner 时是无条件显示，没看 service 类型。本 PR 加条件：仅当项目 services 中存在 mysql/postgres/mariadb/mongo 时才显示。

## 改动 diff

- `cds/web/src/pages/BranchListPage.tsx`：banner 渲染条件 `state.status === 'ok'` 改为同时要求 `branches.some(b => Object.keys(b.services).some(name => /(mysql|mariadb|postgres|mongo)/i.test(name)))`
- `changelogs/2026-05-10_banner-conditional.md`：碎片

## 测试

- [x] `pnpm tsc --noEmit` 0 error
- [ ] 用户硬刷后 MAP 项目不再显示该 banner，mdimp 仍显示

【预览】https://main-prd-agent.miduo.org/

---
_Generated by [Claude Code](https://claude.ai/code/session_01PEmiBzWA3nr8W97zAUPVJK)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change plus one additional `/api/infra` fetch during page refresh; failures are caught and default to hiding the banner.
> 
> **Overview**
> Fixes over-eager display of the **“数据库初始化(schema.sql)”** banner on `BranchListPage` by gating it behind a new `hasSchemafulInfra` flag.
> 
> The page refresh now also fetches `/api/infra` and derives `hasSchemafulInfra` from infra service `dockerImage`/`id` keyword matches (mysql/postgres/mariadb/mongo), so pure-frontend projects don’t see the database setup prompt. A changelog entry is added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a0db57c645bcf0a19959c1b8ad09c91b453da49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->