### PR TITLE
每日熵减计划 2026-W19 — 技能表补齐 cds/findmapskills + changelog manifest 登记

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -401,6 +401,7 @@ echo "https://${SLUG}.miduo.org/"
 | **dev-completion-report** | `/dev-report` | 开发完成后 → 输出三段式报告：200 字总结 + 总结清单（改动/风险/测试/验收）+ 行业对比分析 |
 | **create-skill-file** | `/create-skill` | 输入技能需求 → 生成符合规范的 SKILL.md 文件并评分 |
 | **cds-project-scan** | `/cds-scan` | 输入项目目录 → 自动检测技术栈和基础设施，生成 CDS docker-compose YAML |
+| **cds** | `/cds` | 输入项目/分支 → CDS 全生命周期管理：扫描生成 compose YAML + Agent 鉴权 + 推送部署 + 等待就绪 + 分层冒烟 + 故障诊断自动排查，内置 cdscli Python 封装所有 CDS REST API |
 | **theme-transition** | `/theme-transition` | 输入项目 → 添加 View Transition API 圆形水波纹主题切换动效（含降级方案） |
 | **agent-guide** | `/help` | 无需输入 → 读取 `.agent-workspace/` 进度文件，告知当前阶段和下一步操作 |
 | **create-executor** | `/create-executor` | 输入执行器名称和用途 → 自动读取代码、生成执行器、注册、自测，全自动接入 CLI Agent 执行器 |
@@ -431,6 +432,7 @@ echo "https://${SLUG}.miduo.org/"
 
 | 技能 | 触发词 | 输入 → 输出 |
 |------|--------|-------------|
+| **findmapskills** | `海鲜市场` | 输入能力需求 → 通过长效 API Key 在 PrdAgent 海鲜市场搜索、下载、上传、订阅技能包 |
 | **find-skills** | `找技能` | 输入能力需求 → 从技能生态搜索并推荐可安装的第三方技能 |
 | **api-debug** | — | 输入 API 端点 → 查询真实 API 数据辅助调试 |
 | **dev-setup** | `装环境` | 无需输入 → 自动检测并安装 .NET/Node/Rust/pnpm SDK，执行 API 测试 |

--- a/changelogs/.entropy-manifest.yml
+++ b/changelogs/.entropy-manifest.yml
@@ -3,3 +3,6 @@
 processed:
   - 2026-05-11_defect-title-polish.md
   - 2026-05-11_desktop-post-update-summary.md
+  - 2026-05-11_entropy-cleanup.md
+  - 2026-05-12_cds-branch-card-status-semantics.md
+  - 2026-05-12_cds-github-sync-auth.md


### PR DESCRIPTION
## 摘要

六维双向扫描结果：D1/D2/D3 无实质问题（D3 幽灵全部是变更历史表引用，非真实列表项）；D4 技能表有 2 个缺失条目；D6 有 3 个未登记 changelog。

## 改动 diff

- `CLAUDE.md`：技能表辅助技能区补充 `**cds**` 条目（CDS 全生命周期管理），元技能区补充 `**findmapskills**` 条目（海鲜市场操作）
- `changelogs/.entropy-manifest.yml`：登记 3 个已处理碎片（2026-05-11_entropy-cleanup / 2026-05-12_cds-branch-card-status-semantics / 2026-05-12_cds-github-sync-auth）

## 扫描结论

| 维度 | 发现 | 处置 |
|------|------|------|
| D1 命名规范 | 无违规 | 无需操作 |
| D2 index.yml | 无缺失/幽灵 | 无需操作 |
| D3 guide.list | 扫出 19 条幽灵，经精确校验全为变更历史表引用 | 不删除（历史记录）|
| D4 技能表 | 缺 cds、findmapskills；pnpm 为误报（规则正文引用） | 补充 2 条 |
| D6 changelog | 3 个未登记 | 追加 manifest |

https://claude.ai/code/session_01TXvEebhfFytEvwoP4d8fq8

---
_Generated by [Claude Code](https://claude.ai/code/session_01TXvEebhfFytEvwoP4d8fq8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> 仅更新文档技能清单与 `.entropy-manifest.yml` 登记项，不涉及运行时代码或业务逻辑变更，风险较低。
> 
> **Overview**
> 更新 `CLAUDE.md` 的技能表，新增 **`cds`**（CDS 全生命周期管理）与 **`findmapskills`**（海鲜市场技能包操作）两条缺失条目。
> 
> 更新 `changelogs/.entropy-manifest.yml`，将 3 个已处理的 changelog 碎片文件加入 `processed` 列表，避免后续熵减扫描重复报缺。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b38b41ee1d48bfce852ae02c01bba517d8eb92d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->