### PR TITLE
每日熵减计划 2026-W19 — 补充新报告文档索引 + 标记5条changelog已处理

### DIFF
--- a/changelogs/.entropy-manifest.yml
+++ b/changelogs/.entropy-manifest.yml
@@ -6,3 +6,8 @@ processed:
   - 2026-05-11_entropy-cleanup.md
   - 2026-05-12_cds-branch-card-status-semantics.md
   - 2026-05-12_cds-github-sync-auth.md
+  - 2026-05-12_cds-floating-inbox-position.md
+  - 2026-05-12_cds-infra-brand-icons.md
+  - 2026-05-12_cds-infra-scope-model.md
+  - 2026-05-12_cds-observability-polish.md
+  - 2026-05-12_cds-project-card-compact-actions.md

--- a/doc/guide.list.directory.md
+++ b/doc/guide.list.directory.md
@@ -631,6 +631,9 @@
 - [周报 2026-W06 (02-03 ~ 02-08)](report.2026-W06) `report.2026-W06`
   > 2026 年第 6 周工作总结
 
+- [CDS 项目卡片基础设施误读审计报告（2026-05-12）](report.cds-project-card-infra-audit-2026-05-12) `report.cds-project-card-infra-audit-2026-05-12`
+  > CDS 项目卡片基础设施节点误读问题的审计与修复报告
+
 - [CDS GitHub 自动部署验收报告（2026-05-11）](report.cds-github-auto-deploy-acceptance-2026-05-11) `report.cds-github-auto-deploy-acceptance-2026-05-11`
   > CDS GitHub 自动部署 webhook 链路验收测试报告
 

--- a/doc/index.yml
+++ b/doc/index.yml
@@ -240,6 +240,7 @@ docs:
   report.2026-W09: 周报 2026-W09 (02-23 ~ 03-01)
   report.2026-W07: 周报 2026-W07 (02-09 ~ 02-15)
   report.2026-W06: 周报 2026-W06 (02-03 ~ 02-08)
+  report.cds-project-card-infra-audit-2026-05-12: CDS 项目卡片基础设施误读审计报告（2026-05-12）
   report.cds-github-auto-deploy-acceptance-2026-05-11: CDS GitHub 自动部署验收报告（2026-05-11）
   report.cds-forwarder-success: CDS Forwarder 替代蓝绿部署收尾报告
   report.cds-self-update-timing-audit: CDS Self-Update 时间体系审视报告


### PR DESCRIPTION
## 摘要

日常熵减计划（2026-05-12）：补充新文档到索引、标记已处理的 changelog 碎片。

## 改动 diff

- `doc/index.yml`：新增 `report.cds-project-card-infra-audit-2026-05-12` 条目（D2 缺失修复）
- `doc/guide.list.directory.md`：新增上述报告的目录索引条目（D3 缺失修复）
- `changelogs/.entropy-manifest.yml`：追加 5 条 2026-05-12 CDS fix changelog 已处理记录（D6 manifest 同步）

## 扫描结论

| 维度 | 发现 | 处理 |
|------|------|------|
| D1 命名规范 | 无违规 | 无需操作 |
| D2 index.yml | 缺 1 条新文档 | 已补充 |
| D3 guide.list | 缺 1 条新文档 | 已补充 |
| D4 技能表 | `pnpm` 为 false positive（正文加粗非技能条目） | 无需操作 |
| D6 changelog | 5 条未标记已处理 | 已追加到 manifest |

---
_Generated by [Claude Code](https://claude.ai/code/session_019j6UoijUKQEAkAtX2jZmqX)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to add a missing report entry and sync the processed changelog manifest; no runtime code paths are affected.
> 
> **Overview**
> Adds the new `report.cds-project-card-infra-audit-2026-05-12` document to the doc metadata/index (`doc/index.yml`) and to the human-facing directory listing (`doc/guide.list.directory.md`).
> 
> Updates `changelogs/.entropy-manifest.yml` to mark five 2026-05-12 CDS changelog fragments as processed so the changelog→doc sync stays consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ba84c13442a0b69044f354baecea73e478cc40f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->