### PR TITLE
优化通知卡交互：批量处理、动态定位、乐观更新

### DIFF
--- a/changelogs/2026-05-13_notification-overlap-fix.md
+++ b/changelogs/2026-05-13_notification-overlap-fix.md
@@ -1,0 +1,2 @@
+| fix | prd-admin | 修复右下角教程面板与通知卡重叠：TipsDrawer 广播 dock 高度，通知卡随 drawer 展开动态上移 |
+| fix | prd-admin | 通知卡固定最小高度(minHeight:110px)并限制消息区高度(maxHeight:72px 可滚动)，防止批量点击时面板忽大忽小 |

--- a/changelogs/2026-05-13_notification-ux-batch.md
+++ b/changelogs/2026-05-13_notification-ux-batch.md
@@ -1,0 +1,5 @@
+| feat | prd-admin | 通知卡新增消息总量徽章（最大 999+）、一键全部处理、一键全部忽略三个操作 |
+| fix | prd-admin | 修复打开应用时通知逐条弹出的无限循环：超时自动消失改为一次性批量 dismiss 全部 |
+| feat | prd-admin | handleNotification 加乐观更新，点击按钮 count 即时 -1 不等接口返回 |
+| fix | prd-admin | 按钮新增 active:scale + brightness 动效与 loading spinner，解决点击无反馈问题 |
+| fix | prd-admin | 全局 count 徽章由 9+ 升级为 999+ 格式 |

--- a/prd-admin/src/components/daily-tips/TipsDrawer.tsx
+++ b/prd-admin/src/components/daily-tips/TipsDrawer.tsx
@@ -34,6 +34,8 @@ const FIRST_VISIT_SHOWN_KEY = 'tipsBookFirstVisitShown';
 export const FLOATING_DOCK_COLLAPSED_KEY = 'floatingDockCollapsed';
 /** 折叠状态变更事件名(同 tab 内 storage 事件不触发,必须用 CustomEvent) */
 export const FLOATING_DOCK_EVENT = 'floating-dock-collapsed-changed';
+/** dock 总高度变更事件:TipsDrawer 在 mode 切换时广播,AppShell 通知卡据此动态定位避免重叠 */
+export const FLOATING_DOCK_HEIGHT_EVENT = 'floating-dock-height-changed';
 const AUTO_COLLAPSE_MS = 5000;
 const EDGE_PEEK_ZONE = 140; // 右下角触发区域大小(px)
 
@@ -229,6 +231,29 @@ export function TipsDrawer() {
     lastExpandedRef.current = expanded;
   }, [expanded, pageMatchedIndex, tips.length]);
 
+  // ── dock 总高度广播:AppShell 通知卡据此动态定位,避免与书/drawer 重叠 ──
+  const drawerRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (mode === 'expanded') return; // expanded 时由 ResizeObserver 处理
+    const dockBottom = mode === 'hidden' ? 20 : BOOK_BOTTOM + 48 + 8; // 20 或 136
+    window.dispatchEvent(new CustomEvent(FLOATING_DOCK_HEIGHT_EVENT, { detail: { dockBottom } }));
+  }, [mode]);
+  useEffect(() => {
+    if (mode !== 'expanded') return;
+    const el = drawerRef.current;
+    if (!el) return;
+    const dispatch = () => {
+      const h = el.getBoundingClientRect().height;
+      window.dispatchEvent(new CustomEvent(FLOATING_DOCK_HEIGHT_EVENT, {
+        detail: { dockBottom: BOOK_BOTTOM + 56 + h + 8 },
+      }));
+    };
+    dispatch();
+    const ro = new ResizeObserver(dispatch);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [mode]);
+
   // ── 自动收起:expanded 5s 内无 hover / 点击就 collapsed ──────
   const drawerHoveredRef = useRef(false);
   useEffect(() => {
@@ -411,6 +436,7 @@ export function TipsDrawer() {
   const drawer =
     mode === 'expanded' ? (
       <div
+        ref={drawerRef}
         onMouseEnter={() => {
           drawerHoveredRef.current = true;
         }}

--- a/prd-admin/src/layouts/AppShell.tsx
+++ b/prd-admin/src/layouts/AppShell.tsx
@@ -70,7 +70,7 @@ import { useGlobalDefectStore } from '@/stores/globalDefectStore';
 import { ChangelogBell } from '@/components/changelog/ChangelogBell';
 import { useChangelogStore, selectUnreadCount } from '@/stores/changelogStore';
 import { SpotlightOverlay } from '@/components/daily-tips/SpotlightOverlay';
-import { TipsDrawer, FLOATING_DOCK_COLLAPSED_KEY, FLOATING_DOCK_EVENT } from '@/components/daily-tips/TipsDrawer';
+import { TipsDrawer, FLOATING_DOCK_COLLAPSED_KEY, FLOATING_DOCK_EVENT, FLOATING_DOCK_HEIGHT_EVENT } from '@/components/daily-tips/TipsDrawer';
 import { CommandPalette } from '@/components/command-palette/CommandPalette';
 import { getAugmentedAdminMenuCatalog } from '@/lib/adminMenuCatalog';
 
@@ -264,6 +264,17 @@ export default function AppShell() {
     return () => window.removeEventListener('mousemove', onMove);
   }, [dockCollapsed]);
 
+  // ── 通知卡动态 bottom 定位:TipsDrawer 广播 dock 总高度,通知卡随之上移避免重叠 ──
+  // 默认 136 = 书图标 bottom(80) + 书高(48) + 间距(8),确保初始渲染书图标可见
+  const [notifCardBottom, setNotifCardBottom] = useState(136);
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<{ dockBottom: number }>).detail;
+      if (detail?.dockBottom != null) setNotifCardBottom(detail.dockBottom);
+    };
+    window.addEventListener(FLOATING_DOCK_HEIGHT_EVENT, handler);
+    return () => window.removeEventListener(FLOATING_DOCK_HEIGHT_EVENT, handler);
+  }, []);
 
   // 导航滚动状态：用于显示渐变阴影指示器
   const navRef = useRef<HTMLElement>(null);
@@ -595,9 +606,12 @@ export default function AppShell() {
         ) : (
           // 展开状态：完整通知卡片
           <div
-            className="fixed bottom-5 right-5 z-[120] w-[360px] rounded-[18px] p-4 shadow-xl"
+            className="fixed right-5 z-[120] w-[360px] rounded-[18px] p-4 shadow-xl"
             style={{
               ...glassFloatingButton,
+              bottom: notifCardBottom,
+              minHeight: 110,
+              transition: 'bottom 260ms cubic-bezier(.2,.8,.2,1)',
               background: 'var(--panel-solid, rgba(18, 18, 22, 0.92))',
               border: `1px solid ${getNotificationTone(toastNotification.level).border}`,
               boxShadow: '0 12px 30px rgba(0,0,0,0.45)',
@@ -614,6 +628,8 @@ export default function AppShell() {
                 <div className="text-[13px] font-semibold" style={{ color: 'var(--text-primary)' }}>
                   {toastNotification.title}
                 </div>
+                {/* 消息 + 附件区域:固定 maxHeight 防止批量切换时面板高度跳变 */}
+                <div style={{ maxHeight: 72, overflowY: 'auto', overscrollBehavior: 'contain' }}>
                 {toastNotification.message && (
                   looksLikeMarkdown(toastNotification.message) ? (
                     <div
@@ -663,6 +679,7 @@ export default function AppShell() {
                     ))}
                   </div>
                 )}
+                </div>{/* end scrollable content area */}
               </div>
               {/* 收缩按钮 */}
               <button

--- a/prd-admin/src/layouts/AppShell.tsx
+++ b/prd-admin/src/layouts/AppShell.tsx
@@ -54,7 +54,7 @@ import { getLauncherCatalog } from '@/lib/launcherCatalog';
 import { getShortLabel } from '@/lib/shortLabel';
 import { useBreakpoint } from '@/hooks/useBreakpoint';
 import { SystemDialogHost } from '@/components/ui/SystemDialogHost';
-import { InlinePageLoader } from '@/components/ui/VideoLoader';
+import { InlinePageLoader, MapSpinner } from '@/components/ui/VideoLoader';
 import { AvatarEditDialog } from '@/components/ui/AvatarEditDialog';
 import { Dialog } from '@/components/ui/Dialog';
 import { MobileDrawer } from '@/components/ui/MobileDrawer';
@@ -228,6 +228,8 @@ export default function AppShell() {
   });
   const [toastCollapsed, setToastCollapsed] = useState(false);
   const [toastHovering, setToastHovering] = useState(false);
+  const [handlingAll, setHandlingAll] = useState(false);
+  const [handlingId, setHandlingId] = useState<string | null>(null);
 
   // ── 悬浮组整体折叠(联动 TipsDrawer 的「收起书 + 铃铛」把手) ──
   // TipsDrawer 通过 sessionStorage(FLOATING_DOCK_COLLAPSED_KEY) + FLOATING_DOCK_EVENT
@@ -495,19 +497,51 @@ export default function AppShell() {
   }, []);
 
   const handleNotification = useCallback(async (id: string, actionUrl?: string | null) => {
-    const res = await handleAdminNotification(id);
-    if (res.success && actionUrl) {
-      navigate(actionUrl);
+    // 乐观更新：立即从本地状态移除，同时加入 dismiss 黑名单，count 即时 -1
+    setHandlingId(id);
+    setNotifications((prev) => prev.map((n) => n.id === id ? { ...n, status: 'closed' as const } : n));
+    setDismissedToastIds((prev) => {
+      const next = new Set(prev);
+      next.add(id);
+      try { sessionStorage.setItem('dismissedToastIds', JSON.stringify(Array.from(next))); } catch { /* noop */ }
+      return next;
+    });
+    try {
+      const res = await handleAdminNotification(id);
+      if (res.success && actionUrl) navigate(actionUrl);
+    } finally {
+      setHandlingId(null);
+      await loadNotifications({ silent: true });
     }
-    await loadNotifications({ silent: true });
   }, [loadNotifications, navigate]);
 
   const handleAllNotifications = useCallback(async () => {
-    const res = await handleAllAdminNotifications();
-    if (res.success) {
+    setHandlingAll(true);
+    // 乐观更新：立即清空本地
+    setNotifications((prev) => prev.map((n) => ({ ...n, status: 'closed' as const })));
+    setDismissedToastIds(new Set());
+    try {
+      sessionStorage.removeItem('dismissedToastIds');
+    } catch { /* noop */ }
+    try {
+      await handleAllAdminNotifications();
+    } finally {
+      setHandlingAll(false);
       await loadNotifications({ silent: true });
     }
   }, [loadNotifications]);
+
+  // 一键已读：仅从视图隐藏，不标记已处理
+  const dismissAllToasts = useCallback(() => {
+    setDismissedToastIds((prev) => {
+      const next = new Set(prev);
+      for (const n of activeNotifications) next.add(n.id);
+      try {
+        sessionStorage.setItem('dismissedToastIds', JSON.stringify(Array.from(next)));
+      } catch { /* noop */ }
+      return next;
+    });
+  }, [activeNotifications]);
 
   const dismissToast = useCallback((id: string) => {
     setDismissedToastIds((prev) => {
@@ -523,15 +557,22 @@ export default function AppShell() {
   }, []);
 
   // 自动消失逻辑：悬浮或收缩时暂停计时
+  // 关键修复：超时后一次性 dismiss 全部当前通知，防止逐条弹出形成无限循环
   useEffect(() => {
     if (!toastNotification) return;
-    // 悬浮或收缩状态下不自动消失
     if (toastHovering || toastCollapsed) return;
     const timer = window.setTimeout(() => {
-      dismissToast(toastNotification.id);
+      setDismissedToastIds((prev) => {
+        const next = new Set(prev);
+        for (const n of activeNotifications) next.add(n.id);
+        try {
+          sessionStorage.setItem('dismissedToastIds', JSON.stringify(Array.from(next)));
+        } catch { /* noop */ }
+        return next;
+      });
     }, 12000);
     return () => window.clearTimeout(timer);
-  }, [toastNotification, dismissToast, toastHovering, toastCollapsed]);
+  }, [toastNotification, toastHovering, toastCollapsed, activeNotifications]);
 
   // 当通知消失时，重置收缩状态
   useEffect(() => {
@@ -597,10 +638,10 @@ export default function AppShell() {
             <Bell size={18} style={{ color: getNotificationTone(toastNotification.level).text }} />
             {/* 未读数徽章 */}
             <span
-              className="absolute -top-1 -right-1 h-5 w-5 rounded-full flex items-center justify-center text-[10px] font-bold"
+              className="absolute -top-1 -right-1 min-w-5 h-5 px-1 rounded-full flex items-center justify-center text-[10px] font-bold"
               style={{ background: 'var(--accent-gold)', color: '#1a1a1a' }}
             >
-              {activeNotifications.length > 9 ? '9+' : activeNotifications.length}
+              {activeNotifications.length > 999 ? '999+' : activeNotifications.length}
             </span>
           </button>
         ) : (
@@ -621,12 +662,23 @@ export default function AppShell() {
           >
             <div className="flex items-start gap-3">
               <div
-                className="mt-1 h-2.5 w-2.5 rounded-full"
+                className="mt-1 h-2.5 w-2.5 shrink-0 rounded-full"
                 style={{ background: getNotificationTone(toastNotification.level).text }}
               />
               <div className="flex-1 min-w-0">
-                <div className="text-[13px] font-semibold" style={{ color: 'var(--text-primary)' }}>
-                  {toastNotification.title}
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span className="text-[13px] font-semibold leading-snug" style={{ color: 'var(--text-primary)' }}>
+                    {toastNotification.title}
+                  </span>
+                  {/* 消息总量徽章 */}
+                  {notificationCount > 0 && (
+                    <span
+                      className="shrink-0 text-[10px] font-bold px-1.5 py-0.5 rounded-full leading-none"
+                      style={{ background: 'rgba(255,255,255,0.12)', color: 'var(--text-muted)' }}
+                    >
+                      {notificationCount > 999 ? '999+' : notificationCount} 条
+                    </span>
+                  )}
                 </div>
                 {/* 消息 + 附件区域:固定 maxHeight 防止批量切换时面板高度跳变 */}
                 <div style={{ maxHeight: 72, overflowY: 'auto', overscrollBehavior: 'contain' }}>
@@ -701,23 +753,51 @@ export default function AppShell() {
                 <X size={14} />
               </button>
             </div>
-            <div className="mt-3 flex items-center justify-end gap-2">
+            <div className="mt-3 flex items-center gap-2 flex-wrap">
+              {/* 一键全部处理：仅当有多条时显示 */}
+              {notificationCount > 1 && (
+                <button
+                  type="button"
+                  disabled={handlingAll}
+                  className="flex items-center gap-1.5 px-3 py-1.5 text-[12px] rounded-full transition-all duration-100 hover:brightness-110 active:scale-[0.93] active:brightness-90 disabled:opacity-60 disabled:cursor-not-allowed"
+                  style={{ background: 'rgba(255,165,0,0.18)', color: 'var(--accent-gold)', border: '1px solid rgba(255,165,0,0.3)' }}
+                  onClick={handleAllNotifications}
+                >
+                  {handlingAll ? <MapSpinner size={12} /> : null}
+                  全部处理 ({notificationCount > 999 ? '999+' : notificationCount})
+                </button>
+              )}
+              {/* 一键已读：从视图隐藏但不标记处理 */}
+              {notificationCount > 1 && (
+                <button
+                  type="button"
+                  className="px-3 py-1.5 text-[12px] rounded-full transition-all duration-100 hover:bg-white/15 active:scale-[0.93] active:brightness-75"
+                  style={{ background: 'rgba(255,255,255,0.06)', color: 'var(--text-muted)' }}
+                  onClick={dismissAllToasts}
+                >
+                  全部忽略
+                </button>
+              )}
+              <div className="flex-1" />
               {toastNotification.actionUrl && (
                 <button
                   type="button"
-                  className="px-3 py-1.5 text-[12px] rounded-full transition-all hover:bg-white/15 active:scale-[0.97]"
+                  disabled={handlingId === toastNotification.id}
+                  className="px-3 py-1.5 text-[12px] rounded-full transition-all duration-100 hover:bg-white/15 active:scale-[0.93] active:brightness-75 disabled:opacity-60"
                   style={{ background: 'rgba(255, 255, 255, 0.08)', color: 'var(--text-primary)' }}
                   onClick={() => handleNotification(toastNotification.id, toastNotification.actionUrl)}
                 >
-                  {toastNotification.actionLabel || '去处理'}
+                  {toastNotification.actionLabel || '查看详情'}
                 </button>
               )}
               <button
                 type="button"
-                className="px-3 py-1.5 text-[12px] rounded-full transition-all hover:brightness-110 active:scale-[0.97]"
+                disabled={handlingId === toastNotification.id}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-[12px] rounded-full transition-all duration-100 hover:brightness-110 active:scale-[0.93] active:brightness-90 disabled:opacity-60 disabled:cursor-not-allowed"
                 style={{ background: 'var(--accent-gold)', color: '#1a1a1a' }}
                 onClick={() => handleNotification(toastNotification.id)}
               >
+                {handlingId === toastNotification.id ? <MapSpinner size={12} color="#1a1a1a" /> : null}
                 标记已处理
               </button>
             </div>
@@ -774,7 +854,7 @@ export default function AppShell() {
                   className="absolute top-1 right-1 h-4 w-4 rounded-full flex items-center justify-center text-[9px] font-bold"
                   style={{ background: 'var(--accent-gold)', color: '#1a1a1a' }}
                 >
-                  {notificationCount > 9 ? '9+' : notificationCount}
+                  {notificationCount > 999 ? '999+' : notificationCount}
                 </span>
               )}
             </button>
@@ -826,7 +906,7 @@ export default function AppShell() {
                     lineHeight: 1,
                   }}
                 >
-                  {notificationCount > 9 ? '9+' : notificationCount}
+                  {notificationCount > 999 ? '999+' : notificationCount}
                 </span>
               )}
             </button>
@@ -1399,7 +1479,7 @@ export default function AppShell() {
               <div className="flex h-full flex-col gap-3">
                 <div className="flex items-center justify-between">
                   <div className="text-[12px]" style={{ color: 'var(--text-muted)' }}>
-                    {notificationsLoading ? '加载中...' : `未处理 ${notificationCount} 条`}
+                    {notificationsLoading ? '加载中...' : `未处理 ${notificationCount > 999 ? '999+' : notificationCount} 条`}
                   </div>
                   <button
                     type="button"


### PR DESCRIPTION
## 摘要

改进右下角通知卡的用户体验，新增批量操作能力、修复与教程面板重叠问题、实现乐观更新减少等待感。

## 改动 diff

### prd-admin/src/layouts/AppShell.tsx
- 导入 `MapSpinner` 加载指示器和 `FLOATING_DOCK_HEIGHT_EVENT` 事件常量
- 新增状态：`handlingAll`（全部处理中）、`handlingId`（单条处理中）、`notifCardBottom`（通知卡动态定位）
- 实现 `FLOATING_DOCK_HEIGHT_EVENT` 监听器，使通知卡随教程面板展开自动上移，避免重叠
- 重构 `handleNotification`：乐观更新本地状态 + dismiss 黑名单，点击后立即 count -1，后台异步确认
- 重构 `handleAllNotifications`：全部处理时批量乐观更新，防止逐条弹出无限循环
- 新增 `dismissAllToasts`：一键全部忽略（仅隐藏，不标记处理）
- 修复自动消失逻辑：超时后一次性 dismiss 全部当前通知，而非逐条消失
- 通知卡 UI 增强：
  - 消息总量徽章（最大 999+）
  - 一键全部处理按钮（多条时显示）
  - 一键全部忽略按钮（多条时显示）
  - 固定最小高度 + 消息区可滚动，防止批量切换时面板高度跳变
  - 按钮新增 loading spinner + active 动效反馈
- 全局 count 徽章由 9+ 升级为 999+ 格式

### prd-admin/src/components/daily-tips/TipsDrawer.tsx
- 导出 `FLOATING_DOCK_HEIGHT_EVENT` 常量
- 新增 `drawerRef` 引用
- 实现 dock 高度广播机制：
  - `mode` 变更时同步广播（hidden: 20px，collapsed: 136px）
  - `expanded` 时用 ResizeObserver 监听 drawer 高度变化，实时计算 dockBottom 并广播
- AppShell 通知卡据此动态定位，避免与书图标/drawer 重叠

### changelogs/
- `2026-05-13_notification-ux-batch.md`：新增消息总量徽章、批量操作、乐观更新、动效反馈、count 格式升级
- `2026-05-13_notification-overlap-fix.md`：修复重叠问题、固定面板高度

## 测试
- [x] pnpm tsc --noEmit 通过
- [x] pnpm lint 本文件零新增告警
- [x] 通知卡与教程面板展开/收起时动态定位验证
- [x] 批量操作（全部处理/全部忽略）状态同步验证
- [x] 乐观更新：点击按钮后 count 即时 -1 验证
- [x] 自动消失：超时后全部 dismiss 而非逐条弹出验证

https://claude.ai/code/session_01Rs96F37h5gsECGpDCZQrMZ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes notification handling flow with optimistic state updates, bulk actions, and new cross-component event-driven positioning that could affect toast visibility/count accuracy.
> 
> **Overview**
> Improves the bottom-right notification toast with **batch actions** (handle all, ignore all), a total-count badge (up to `999+`), and clearer button feedback (active animations + `MapSpinner` loading state) while standardizing badge formatting across desktop/mobile/dialog.
> 
> Fixes UX bugs by switching auto-dismiss to **dismiss all current notifications at once** (preventing repeated re-toasting loops), adding optimistic updates in `handleNotification`/`handleAllNotifications` so counts drop immediately, and constraining toast layout (`minHeight` + scrollable message area) to avoid size jitter.
> 
> Prevents overlap with the tutorial drawer by having `TipsDrawer` broadcast dock height via `FLOATING_DOCK_HEIGHT_EVENT` (using `ResizeObserver` when expanded) and making the notification card animate its `bottom` position accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de397bd4a396f440f7c521162465ea9bbf5504f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->