### PR TITLE
每日熵减计划 2026-W20 — 补录 2 篇文档索引 + 标记 5 条 changelog

### DIFF
--- a/changelogs/.entropy-manifest.yml
+++ b/changelogs/.entropy-manifest.yml
@@ -11,3 +11,8 @@ processed:
   - 2026-05-12_cds-infra-scope-model.md
   - 2026-05-12_cds-observability-polish.md
   - 2026-05-12_cds-project-card-compact-actions.md
+  - 2026-05-11_skill-center-wave1.md
+  - 2026-05-12_cds-project-card-footer.md
+  - 2026-05-12_cds-project-card-visual-tokens.md
+  - 2026-05-12_cds-project-icons.md
+  - 2026-05-12_cds-project-infra-isolation.md

--- a/doc/guide.list.directory.md
+++ b/doc/guide.list.directory.md
@@ -1,6 +1,6 @@
 # MAP 平台文档索引 · 指南
 
-> 最后更新：2026-05-11
+> 最后更新：2026-05-13
 >
 > 本文件是 `doc/` 目录的结构化索引，供外部同步工具（语雀、Confluence 等）消费。
 > 元数据定义见 `doc/index.yml`，命名规范见 `doc/rule.doc-naming.md`。
@@ -397,6 +397,9 @@
 - [Claude SDK 三步接入指南](guide.claude-sdk-quickstart) `guide.claude-sdk-quickstart`
   > 三步把 Claude Agent SDK 接进本系统，零代码改动、零专业知识
 
+- [Claude SDK + CDS MAP 配对 MVP 指南](guide.claude-sdk-cds-map-mvp) `guide.claude-sdk-cds-map-mvp`
+  > CDS 调度外部 Anthropic Agent SDK sidecar，MAP 通过 CDS-MAP 配对发现并路由到该 sidecar
+
 - [Playwright E2E 测试指南](guide.e2e-tests) `guide.e2e-tests`
   > 端到端测试的编写、运行与调试操作指南
 
@@ -636,6 +639,9 @@
 
 - [周报 2026-W06 (02-03 ~ 02-08)](report.2026-W06) `report.2026-W06`
   > 2026 年第 6 周工作总结
+
+- [CDS Self-Update 耗时观察记录（2026-05-13）](report.cds-self-update-timing-observation-2026-05-13) `report.cds-self-update-timing-observation-2026-05-13`
+  > CDS 自更新流程各阶段耗时的实测观察与数据记录（2026-05-13）
 
 - [CDS 项目卡片基础设施误读审计报告（2026-05-12）](report.cds-project-card-infra-audit-2026-05-12) `report.cds-project-card-infra-audit-2026-05-12`
   > CDS 项目卡片基础设施节点误读问题的审计与修复报告

--- a/doc/index.yml
+++ b/doc/index.yml
@@ -154,6 +154,7 @@ docs:
   guide.cds-web-migration-runbook: CDS Web 迁移运行手册
   guide.cds-blue-green-handoff: CDS 蓝绿改造交接（已废弃，留档备查）
   guide.claude-sdk-quickstart: Claude SDK 三步接入指南
+  guide.claude-sdk-cds-map-mvp: Claude SDK + CDS MAP 配对 MVP 指南
   guide.e2e-tests: Playwright E2E 测试指南
   guide.infra-sandbox-agent: 基础设施沙箱 Agent 完整手册
   guide.skill-catalog: 技能百科全书指南


### PR DESCRIPTION
## 摘要

本次熵减扫描发现 2 个文档未同步到目录索引，以及 5 条 changelog 片段未标记为已处理。均为纯文档变更，无代码改动。

## 改动 diff

- `doc/index.yml`：补录 `guide.claude-sdk-cds-map-mvp`（文件已存在但 index.yml 遗漏）
- `doc/guide.list.directory.md`：补录 `guide.claude-sdk-cds-map-mvp` + `report.cds-self-update-timing-observation-2026-05-13`（后者已在 index.yml，目录页未同步）；更新最后更新日期为 2026-05-13
- `changelogs/.entropy-manifest.yml`：标记 5 个 changelog 片段为已处理（skill-center-wave1、cds-project-card-footer、cds-project-card-visual-tokens、cds-project-icons、cds-project-infra-isolation）

## 扫描结论

| 维度 | 发现 | 处理 |
|------|------|------|
| D1 命名规范 | 无违规 | 无需操作 |
| D2 index.yml | 1 条缺失 | 已补录 |
| D3 guide.list | 2 条缺失，21 条幽灵（全为历史变更日志/内联引用，假阳性）| 2 条已补录，幽灵不动 |
| D4 技能表 | 1 条幽灵（`**pnpm**` 为规则正文加粗，假阳性）| 不动 |
| D6 changelog | 5 条未处理 | 已标记 |

https://claude.ai/code/session_01SbXtjcqQ51hSVN9K33PwzK

---
_Generated by [Claude Code](https://claude.ai/code/session_01SbXtjcqQ51hSVN9K33PwzK)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-index bookkeeping only (adds missing index entries and updates a processed-changelog manifest) with no runtime code or behavior changes.
> 
> **Overview**
> Updates documentation indexing metadata to reflect existing content: adds `guide.claude-sdk-cds-map-mvp` to `doc/index.yml`, and syncs `doc/guide.list.directory.md` by adding that guide plus `report.cds-self-update-timing-observation-2026-05-13` and bumping the “last updated” date to 2026-05-13.
> 
> Marks five additional changelog fragments as processed in `changelogs/.entropy-manifest.yml` so the entropy/doc-sync workflow stops flagging them as unhandled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4948ce79da17738b4a8fe65c87314a69a7d75e63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->