### PR TITLE
feat(infra): CDS OAuth-like 授权流与视觉验收系统

### DIFF
--- a/.claude/skills/issues-autofix/SKILL.md
+++ b/.claude/skills/issues-autofix/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: issues-autofix
+description: 无人值守的日常 issue 维护 Agent。手动触发后扫描仓库 open issue，按分类规则自动答复 / 修复 / 升级人工，绝不反向询问用户。完全跳过视觉测试系列、协议元 issue、其他 Agent 领地。触发词："/issues-autofix"、"自动修复issue"、"日常issue巡检"、"unattended issue triage"。
+---
+
+# Issues Autofix — 日常无人值守 issue 维护
+
+> 手动触发的"批量过 issue"技能。一轮跑完输出处理报告。**不和用户来回**，模糊场景按默认分支走，宁可跳过不要卡住。
+>
+> 完整 label 协议、跳过清单、配色等系统说明见 **`doc/rule.issues-system.md`**。本文件只写"执行逻辑"。
+
+## 0. 何时触发 / 何时别用
+
+**用本技能**：
+- 你想批量过一遍 open issues，让 Agent 自动答复/分类/小修复
+- 不想被反向追问，宁愿 Agent 跳过模糊场景
+
+**别用**：
+- Agent 间互相反馈技能/产物 bug → 用 `/audit`（auto-fix-issues 技能，语义不同）
+- 给真人交付前的自检 → 用 `/verify`
+- 给真人验收 → 用 `/uat`
+
+## 1. 可配置参数（每次运行前确认）
+
+```yaml
+project_name: prd_agent
+single_run_max: 30              # 单轮处理 issue 上限
+max_diff_lines: 200             # 自动开 PR 的改动行数上限
+max_minutes_per_issue: 10       # 单 issue 超时阈值
+max_reproduce_retries: 3
+protected_paths:
+  - prd-api/src/PrdAgent.Core/**
+  - prd-api/src/PrdAgent.Infrastructure/Auth/**
+  - .env*
+  - .github/workflows/**
+  - docker-compose*.yml
+  - Dockerfile*
+  - "**/package.json"
+  - "**/pnpm-lock.yaml"
+faq_dir: doc
+faq_prefix: guide.faq.
+reply_language: match_issue
+commit_pr_language: zh-CN
+forbid_emoji: true
+known_bots: ["*[bot]", "dependabot", "renovate", "github-actions", "claude-code-app"]
+```
+
+## 2. 完全跳过清单（最先匹配，命中后**不评论、不标签、不留痕**）
+
+凡命中以下任一，直接 next：
+
+1. **作者是机器人**（`known_bots` 任一匹配或 `user.type == "Bot"`）
+2. **issue 含以下任一 label**：
+   - `visual-test:*`（视觉测试 Agent 领地，见 #605）
+   - `discussion` / `protocol` / `meta` / `rfc`
+   - `tracking` / `epic` / `umbrella`
+   - `wip` / `wontfix` / `invalid` / `on-hold`
+   - `agent-replied` / `agent-fixed` / `agent-timeout` / `proposed-fix` / `needs-human` / `needs-info`
+   - `human-only`
+3. **标题前缀属于元类**：`[visual-test*]` / `[protocol]` / `[rfc]` / `[tracking]` / `[meta]`
+4. **issue body 含** `<!-- agent-handled:` HTML 注释指纹
+5. **issue 已有未关闭的关联 PR**
+6. **作者是 maintainer 且无 `please-fix`/`bug` 类 label**
+7. **草稿 / template 占位**：正文 < 20 字 或 仅含模板未填项
+
+> 完整跳过清单与"为什么这样设计"在 `doc/rule.issues-system.md` §3。
+
+## 3. 扫描范围
+
+- 状态：open
+- 创建者：非机器人
+- 单轮上限：`single_run_max`
+- 排序：`created_at desc`，超出排队下轮
+
+## 4. 并发与幂等
+
+- **乐观锁**：进入处理前加 label `agent-processing`，加失败 → 跳过
+- **指纹评论**：终态评论末尾必须含 `<!-- agent-handled:{run_id}:{ts} -->`
+- **处理结束**：删 `agent-processing` + 加终态 label
+- **超时回滚**：超 `max_minutes_per_issue` 分钟 → 删 `agent-processing` + 加 `agent-timeout`
+
+## 5. 分类判定（按顺序匹配，首个命中即停）
+
+1. **安全/敏感**（密钥泄露、注入、CVE）：`needs-human` + 评论"已上报"，跳过修复
+2. **架构级变更**（`protected_paths` 涉及、跨服务接口、DB schema、依赖大版本）：`needs-human`
+3. **Bug**：进入 §7 修复评估
+4. **Feature Request**：走 §6 答复，不开 PR
+5. **使用问题/文档缺失**：走 §6 答复 + §10 文档沉淀
+6. **重复 issue**：走 §8 去重
+
+## 6. 首次答复（四要素，合并到一条评论）
+
+1. 一句话复述对问题的理解
+2. 判定结论：可修复 / 暂不修复 / 需补充信息 / 重复
+3. 处理时点：本轮做 / 排期 / 暂不做（给原因）
+4. 信息不足：给出复现模板，打 `needs-info`，**只问一次**
+
+**格式硬约束**：
+- 语言按 `reply_language`
+- 禁止 emoji（CLAUDE.md §0）
+- 不写"希望对您有所帮助"等客套
+- 末尾追加 `<!-- agent-handled:{run_id} -->`
+
+## 7. 自动修复边界（全部满足才允许开 PR）
+
+- 改动 ≤ `max_diff_lines` 行
+- 不触碰 `protected_paths`
+- 已有测试覆盖 **或** 本次能补单测
+- 修复语义明确
+- **本地校验全绿**（CLAUDE.md §5.2）：`dotnet build` / `pnpm tsc --noEmit` + `pnpm lint` / 关联 test
+
+任一不满足：评论修复思路（不开 PR），打 `proposed-fix` 等人工。
+
+## 8. 去重规则
+
+- 候选：标题编辑距离 > 0.8 **或** 错误信息 token 重合 ≥ 70%
+- 二次校验：复现路径 + 症状 + 受影响版本 三者中至少两条一致
+- 硬否决：任一 issue 已关联 PR → 不判重
+- 命中：保留最早 issue，其余评论"已合并到 #XXX"，加 `duplicate` + 关闭
+- 拿不准：按独立处理
+
+## 9. PR 规范
+
+- **分支**：`agent/fix-issue-{number}-{slug}` 或 `agent/docs-issue-{number}-{slug}`（避免和 `claude/`、`cursor/` 抢预览域名）
+- **Commit 中文**（CLAUDE.md §5.1）：`fix(scope): 修复 XX 问题 (#issue)`
+- **PR 描述模板**（CLAUDE.md §5.4 必含"改动 diff"）：
+
+  ```markdown
+  ## 摘要
+  1-3 句话：解决什么 / 用什么方案。
+
+  ## 改动 diff
+  - `path/to/file.ts`：一句话说明
+  - `changelogs/YYYY-MM-DD_xxx.md`：新增碎片
+
+  ## 测试
+  - [x] tsc / build 通过
+  - [x] lint 零新增告警
+  - [x] 关联单测全绿
+  - [ ] 真人通过预览域名验收
+
+  ## 风险评估
+  影响面 / 回滚方案 / 已知边界
+
+  Fixes #{issue_number}
+  ```
+
+- PR 创建后回 issue 评论："修复方案已提交 #PR编号，待 review"
+- **绝不 self-merge / force push / --no-verify**
+
+## 10. 文档沉淀触发（任一即触发）
+
+- 同类问题本周 ≥ 3 次
+- 高频使用问题且现有文档检索不到
+- 修复涉及非显而易见的配置项
+
+**沉淀位置**：`doc/guide.faq.{slug}.md`（doc-naming 规则要求）
+**结构**：现象 / 原因 / 解决 / 预防
+**同步**：更新 `doc/index.yml` + `doc/guide.list.directory.md`
+
+## 11. 标签体系
+
+完整定义见 `doc/rule.issues-system.md` §2。
+
+## 12. 失败兜底
+
+- 单 issue 超 `max_minutes_per_issue` 分钟 → `agent-timeout`
+- 复现失败 ≥ `max_reproduce_retries` 次 → `cannot-reproduce`
+- 工具调用失败 → 重试 2 次后跳过，记入本轮报告
+- 任何不确定场景 → 跳过 > 卡住
+
+## 13. 绝对禁止
+
+- 不回复 issue 在你答复后的追问（后续评论一律转 `needs-human`）
+- 不关闭非 `duplicate` 的 issue
+- 不 merge 任何 PR
+- 不动 `protected_paths`
+- 不承诺具体上线日期
+- **不输出任何 emoji**（CLAUDE.md §0）
+- 不 `--no-verify` / `--no-gpg-sign`
+
+## 14. 本轮调度报告（输出到指定日志/Slack/Yuque）
+
+- 扫描数 / 处理数 / 跳过数（按 §2 各子条计数）/ 升级人工数
+- 逐条：issue 链接、判定、动作、耗时
+- 异常项单列
+- 趋势观察：本轮反复出现的问题类型 + 建议沉淀
+- 末尾附 `run_id`，与评论指纹对齐
+
+## 15. 上下游技能
+
+- 上游：`/cds-deploy`（issue 修复后部署）
+- 下游：`/handoff`（修复完通知人工）
+- 兄弟：`/audit`（auto-fix-issues：agent-to-agent 反馈，语义不同，别混）
+- 视觉相关：`/issues-visual-create` + `/issues-visual-run`（本 Agent 完全避让）

--- a/.claude/skills/issues-visual-create/SKILL.md
+++ b/.claude/skills/issues-visual-create/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: issues-visual-create
+description: 手动触发创建一个视觉验收子 issue。输入"要测什么"（PR 号 / 页面路径 / 提交 hash），按 #605 元 issue 模板 v0.x 生成一条 [visual-test] 子 issue，挂 label visual-test:pending，等待执行者 Agent 接单。触发词："/issues-visual-create"、"创建视觉验收"、"开视觉测试 issue"、"visual test create"。
+---
+
+# Issues Visual Create — 创建视觉验收子 issue
+
+> 把"我想给这个改动做视觉验收"变成一条结构化、可被 24h 执行者 Agent 接单的 GitHub issue。
+>
+> **本技能只做"开单"**。执行由 `/issues-visual-run` 负责，协议演化在元 issue #605 讨论。系统说明见 `doc/rule.issues-system.md`。
+
+## 0. 何时触发 / 何时别用
+
+**用本技能**：
+- 你刚 push 完代码，想让 24h 视觉测试 Agent 做一次验收
+- 想要矩阵化（视口 × 主题 × 状态 × 交互）覆盖，而不是自己手点
+- 想把项目硬约束（无 emoji / 双主题 / Modal 三约束等）一次性测过
+
+**别用**：
+- 自己有空亲手过 UAT → 用 `/uat`
+- 只是想看预览地址 → 用 `/preview`
+- 修改协议本身 → 直接去 #605 评论，不要新开 issue
+
+## 1. 必要输入（缺一项就找用户要）
+
+| 字段 | 说明 | 示例 |
+|---|---|---|
+| **测试标的** | PR 号 / commit hash / 页面路由 | `#512` / `a3f5b21` / `/admin/literary` |
+| **影响页面/组件** | 至少 1 个具体路由 + 组件名 | `/marketplace`, `MarketplaceCard.tsx` |
+| **变更类型** | 新增 / 样式 / 布局 / 交互 / bug 修复 | `样式` |
+| **业务用例** | 至少 3 条"角色+任务+预期"路径 | 见模板 §5 |
+
+可选输入：
+- 测试账号 / mock 数据约定
+- 已知不覆盖范围
+
+## 2. 自动从环境推导
+
+- **预览地址**：按 CLAUDE.md 规则 #11 v3 公式自动拼接 `{tail}-{prefix}-{project-slug}.miduo.org`
+- **分支**：`git branch --show-current`
+- **项目 slug**：`basename $(git rev-parse --show-toplevel)`
+- **commit**：默认取 `git rev-parse --short HEAD`
+
+## 3. 执行步骤
+
+1. **校验**：检查必要输入是否齐，缺则要求用户补
+2. **拉模板**：从 #605 元 issue 取**最新 v0.x 模板正文**（§四节子模板部分）
+3. **填入参数**：自动填预览地址 / 分支 / commit / 标的
+4. **建 issue**：
+   - 标题：`[visual-test] <feature 一句话> @ <branch>`
+   - body：填好的模板
+   - label：`visual-test:pending`
+5. **回执**：返回 issue URL 给用户，并提示"执行者 Agent 订阅 label 自动接单"
+
+## 4. 标题命名
+
+格式：`[visual-test] {简短特征描述} @ {branch}`
+
+| ✅ 好 | ❌ 差 |
+|---|---|
+| `[visual-test] 海鲜市场卡片 hover 态修复 @ fix/marketplace-hover` | `[visual-test] PR 512` |
+| `[visual-test] 文学创作面板新增模型徽章 @ feat/literary-model-badge` | `[visual-test] 测试视觉` |
+
+## 5. 硬约束（生成 body 前自检）
+
+- ✅ 预览地址用 v3 公式（`{tail}-{prefix}-{project-slug}`），不用 v1/v2
+- ✅ §4 硬约束 10 条必须**完整列出**（不允许"按需精简"——见 #605 元 issue 决议）
+- ✅ §7 失败回报表格的列名与协议对齐：`# / 检查点 / 视口 / 主题 / 截图 / 问题描述 / 严重级`
+- ✅ 业务用例 §5 至少 3 条，每条必须含角色 + 任务 + 预期
+- ✅ §6 "已知不覆盖" 不能为空（防止执行者越界）
+- ❌ 不允许 body 出现任何 emoji 字符（CLAUDE.md §0）
+- ❌ 不允许跳过双主题（必填 dark + light）
+
+## 6. 调用工具
+
+- `git rev-parse` / `git branch --show-current` — 取分支与 commit
+- `mcp__github__issue_write`（method: create）— 创建 issue
+- 可选：`mcp__github__pull_request_read` — 当输入是 PR 号时读 PR 元信息辅助填写
+
+## 7. 失败兜底
+
+- 必要输入缺：列出缺哪几项，等用户补，不要瞎填
+- label 不存在：提示用户先按 #605 评论里的 `gh label create` 脚本建好 4 个 label
+- 模板版本对不上：以 #605 当前正文为准；如果用户希望用旧版本，明确说明 + 在子 issue 标注版本号
+
+## 8. 输出
+
+返回给用户：
+
+```
+[已创建] #N — [visual-test] xxx
+URL: https://github.com/inernoro/prd_agent/issues/N
+Label: visual-test:pending
+预览: https://{slug}.miduo.org/
+执行者 Agent 应在 N 分钟内接单。如超时请检查 label 订阅。
+```
+
+## 9. 上下游
+
+- 上游：`/cds-deploy`（确保预览域名就位）/ `/preview`（拿预览地址）
+- 下游：`/issues-visual-run`（执行者）/ `/handoff`（视觉通过后正式交付）
+- 协议演化：#605 评论区

--- a/.claude/skills/issues-visual-run/SKILL.md
+++ b/.claude/skills/issues-visual-run/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: issues-visual-run
+description: 24h 视觉测试执行者 Agent 的逻辑。手动触发后从仓库拉取所有 label = visual-test:pending 的 issue，按子 issue body 的矩阵跑用例，回评论失败项 + 截图 + 严重级，或 /visual-pass 通过。完全不创建新 issue。触发词："/issues-visual-run"、"执行视觉验收"、"视觉测试接单"、"visual test run"。
+---
+
+# Issues Visual Run — 24h 视觉测试执行者
+
+> 视觉测试执行者 Agent 的"接单 → 跑测 → 回报"逻辑。
+>
+> **本技能不开 issue**（那是 `/issues-visual-create` 的活）。只读取已存在的 `visual-test:pending` issue、按 issue body 的矩阵跑、回评论。
+>
+> 协议本体与 label 体系见 `doc/rule.issues-system.md`。模板演化讨论在 #605。
+
+## 0. 何时触发 / 何时别用
+
+**用本技能**：
+- 24h 调度命中 `visual-test:pending` 队列
+- 用户手动让你"过一遍视觉验收待办"
+- 开发者修了 P0/P1 后让你"重测受影响项"
+
+**别用**：
+- 改协议、改模板 → 去 #605 评论
+- 自己想测但还没开 issue → 用 `/issues-visual-create`
+- 通用 issue 维护 → 用 `/issues-autofix`（且本技能与之**互斥避让**）
+
+## 1. 接单条件（全部满足才进）
+
+- label 含 `visual-test:pending`
+- label 不含 `agent-processing` / `visual-test:reviewing` / `visual-test:passed` / `visual-test:blocked`
+- issue 标题以 `[visual-test]` 开头
+- issue body 满足"模板 v0.x 子 issue 模板"结构（含 §1-§6 必填项）
+
+不满足任一 → 跳过，**不留痕**。
+
+## 2. 并发锁
+
+进入处理前：
+1. 加 label `agent-processing`（加失败 = 已被别的实例接单 → 跳过）
+2. 评论："已接单 · 预计 N 分钟 · run_id={uuid}"
+
+处理结束（任一终态）：
+1. 删 `agent-processing`
+2. 加对应终态 label（`visual-test:reviewing` / `visual-test:passed` / `visual-test:blocked`）
+3. 终态评论末尾追加 `<!-- visual-run:{run_id}:{ts} -->` 指纹
+
+## 3. 执行矩阵
+
+读 issue body §3 勾选的矩阵，逐项跑。
+
+**双主题强制**：即使用户漏勾，dark + light 都必须跑（cds-theme-tokens.md 是硬规则）。
+
+**视口默认**：未勾选时按 `1440×900` 跑。
+
+**截图规约**（首次执行者上线时在 #605 §五 第 1 问对齐）：
+- 格式：PNG（单图）/ MP4（短交互）
+- 命名：`{issue#}-{viewport}-{theme}-{state}-{check#}.png`
+- 上传：评论里直接附图，或托管到 GitHub Issues 自带 CDN
+
+## 4. 硬约束自动化清单（§4 10 条）
+
+按"机器化优先 + 人工兜底"策略：
+
+| 检查点 | 机器化方式 | 兜底 |
+|---|---|---|
+| 无 emoji | 截图 OCR + 表情符号正则扫描 | 人工目视 |
+| 白天无暗色 modal | 浏览器自动化抓主题切换后 modal 背景色 RGB，比对 `--bg-*` 系列 | 人工目视 |
+| Modal createPortal + min-h:0 | DevTools 注入脚本检查 `position: fixed` 元素是否挂在 body 直系 | 人工 |
+| 撑满视口 | viewport 高度 vs body scrollHeight，差 > 100px 报缺失 | 人工 |
+| 空状态有引导 | 检测空列表区是否含 `<button>` / role=button | 人工 |
+| LLM 面板模型名 | DOM 抓 `[data-llm-model-badge]` 或字符串"模型: " | 人工 |
+| >2s 静止 = 缺陷 | 录屏帧差检测，连续 2s 像素差 < 阈值 = fail | 人工 |
+| 输入零摩擦 | 检测 form 是否含 input[type=file] / select / placeholder 含模板 | 人工 |
+| 画布手势统一 | 模拟 wheel + ctrlKey + pinch，断言事件被 preventDefault | 人工 |
+| MAP Loader | grep DOM 中是否含 `<Loader2 spin>` 裸用 | 人工 |
+
+无法机器化的，必须截图 + 人工目视，**不允许沉默跳过**。跳过的视为该 issue `visual-test:blocked`。
+
+## 5. 失败回报格式（评论 body，与 §7 协议对齐）
+
+```markdown
+## 失败清单（按严重级排序）
+
+| # | 检查点 | 视口 | 主题 | 截图 | 问题描述 | 严重级 |
+|---|---|---|---|---|---|---|
+| 1 | Modal 高度 | 1440×900 | dark | ![](url1) | Modal 超出视口底部 60px,内容截断 | P0 |
+| 2 | 模型名展示 | 1440×900 | light | ![](url2) | LLM 面板顶部缺少模型名 chip | P1 |
+| ... |
+
+## 已通过项
+
+- §3 矩阵全部勾选项的其他维度
+- §4 硬约束第 1,3,5,6,7,8,9 条
+
+## 备注
+
+- 第 4 条「页面撑满视口」无法机器化判定,转人工目视
+- 全部用例耗时 N 分钟,run_id={uuid}
+
+<!-- visual-run:{run_id}:{ts} -->
+```
+
+**严重级判定**：
+- **P0** 阻塞合并：白天黑底、emoji 出现、Modal 撑破屏幕、登录走不通、空状态无 CTA
+- **P1** 必须修：模型名缺、加载组件不统一、双主题样式不一致
+- **P2** 可延后：配色微调、间距 1-2px
+- **P3** 优化建议：动效、文案
+
+终态：
+- 至少有一条 P0/P1 → label `visual-test:reviewing`（等开发者修）
+- 全部 P0/P1 清零（只有 P2/P3 或无问题）→ 评论 `/visual-pass` + label `visual-test:passed` + 关闭 issue
+- 环境不通 / 模板填不全 → label `visual-test:blocked` + 评论说明缺什么
+
+## 6. 重测策略
+
+开发者修复后会评论 `已修 commit <hash>` + 移除 `visual-test:reviewing` + 加回 `visual-test:pending`。
+
+重测时**不需要全量重跑**，按"受影响项 + P0 全量回归"策略：
+1. 读修复前评论里所有 P0/P1 失败项
+2. 仅重跑这些项 + 该 issue 的 P0 全量回归（防止改 A 坏 B）
+3. P2/P3 在原 issue 标记"已知遗留",不重测
+
+## 7. 工具依赖
+
+- `mcp__github__list_issues` 拉 `visual-test:pending` 队列
+- `mcp__github__pull_request_read` / `mcp__github__get_commit` 读关联 PR/commit
+- `mcp__github__add_issue_comment` 回报失败/通过
+- `mcp__github__issue_write`(update) 改 label
+- `bridge` 技能 — 操作 CDS 预览页面（鼠标轨迹、截图、状态读取）
+- Playwright / Puppeteer / Chrome DevTools Protocol — 矩阵化跑测
+
+## 8. 失败兜底
+
+- 预览域名 5 分钟内拉不起来 → `visual-test:blocked` 评论"预览未就绪,检查 /cds-deploy 状态"
+- issue body 模板填不全 → `visual-test:blocked` 评论缺什么字段
+- 工具调用失败 → 重试 2 次后 `visual-test:blocked` 评论
+- 单 issue 处理超 30 分钟 → `visual-test:blocked` + `agent-timeout` 评论
+
+## 9. 协议演化反馈
+
+每次跑完后,如果发现:
+- 哪条检查点从来过不了 / 总是误报
+- 哪个失败列名不够用
+- 哪个严重级口径不清
+
+**不要**改本技能,**直接去 #605 评论建议**。维护者会 bump 模板版本,本技能下次跑时自动按新版本。
+
+## 10. 绝对禁止
+
+- 不创建新 issue（那是 `/issues-visual-create`）
+- 不动 `protected_paths`（同 `/issues-autofix`）
+- 不 self-pass（评论 `/visual-pass` 必须基于矩阵跑完）
+- 不输出 emoji（CLAUDE.md §0）
+- 不沉默跳过无法机器化的检查点（必须 blocked + 说明）
+- 不和开发者反向追问（只回报,不要"请问你的预期是..."）
+
+## 11. 上下游
+
+- 上游：`/issues-visual-create`（开单方）/ `/cds-deploy`（保证预览就位）
+- 下游：开发者修复 push 后 → 重测循环
+- 兄弟：`/issues-autofix`（互斥避让,本 issue 不归它管）
+- 协议演化：#605 评论

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,6 +382,9 @@ echo "https://${SLUG}.miduo.org/"
 | **acceptance-checklist** | `/uat` | 输入功能场景 → 生成真人逐步打勾的 UAT 清单（Phase 0-7：前置 → 冷启 → 执行 → 验证 → 回归 → 回滚 → 负面），每步含预期结果 + 失败排查手册。CLI/Web 双通道支持 |
 | **task-handoff-checklist** | `/handoff` | 输入当前变更 → 扫描导航/文档/规则/工作流/测试/风险/质量/后续 8 个维度，输出交接清单 |
 | **auto-fix-issues** | `/audit` | Agent 间 issue 反馈/修复/复测协议。三档标签 (`待解决` / `已解决待验收` / `已验收`)、issue + tracker + PR 收尾 + 复测报告四套模板，PR 合并必须改 label 的强制清单，杜绝"修了忘改 label" |
+| **issues-autofix** | `/issues-autofix` | 无人值守日常 issue 维护 Agent。批跑 open issue，按分类规则自动答复/修复/升级，绝不反向询问。完全跳过 `visual-test:*` / `discussion` / 其他 Agent 领地（详见 `doc/rule.issues-system.md` §3） |
+| **issues-visual-create** | `/issues-visual-create` | 创建一条视觉验收子 issue。输入"测什么"(PR#/commit/页面)，按 #605 模板 v0.x 生成 `[visual-test]` issue，挂 `visual-test:pending` 等执行者接单 |
+| **issues-visual-run** | `/issues-visual-run` | 24h 视觉测试执行者 Agent 逻辑。拉 `visual-test:pending` 队列，按矩阵跑用例(双主题强制)，回评论失败清单(P0-P3) 或 `/visual-pass`。完全不开新 issue |
 | **weekly-update-summary** | `/weekly` | 输入时间范围 → 从 git 历史收集 commit/PR/贡献者数据，输出分类周报（完成项 + 下周优先级） |
 
 ### 辅助技能（按需使用）

--- a/cds/src/middleware/github-auth.ts
+++ b/cds/src/middleware/github-auth.ts
@@ -24,6 +24,8 @@ const PUBLIC_PATHS: (string | RegExp)[] = [
   '/login-gh.html',
   '/api/auth/github/login',
   '/api/auth/github/callback',
+  '/api/cds-system/connections/authorize',
+  '/api/cds-system/connections/token',
   // GitHub App webhook is authenticated by HMAC signature verification
   // inside the route handler, not by the CDS session cookie. Must be
   // public so GitHub's outbound webhook can reach it.

--- a/cds/src/routes/cds-system-connections.ts
+++ b/cds/src/routes/cds-system-connections.ts
@@ -172,6 +172,112 @@ export function createCdsSystemConnectionsRouter(
     }
   });
 
+  // ── authorize / token（MAP 端输入 CDS 地址后跳转授权） ─────────────
+  router.get('/cds-system/connections/authorize', (req, res) => {
+    const redirectUri = String(req.query.redirectUri || '');
+    const state = String(req.query.state || '');
+    const mapBaseUrl = String(req.query.mapBaseUrl || '');
+    const mapId = String(req.query.mapId || '');
+    const mapName = String(req.query.mapName || 'MAP');
+    const approved = String(req.query.approve || '') === '1';
+
+    if (!redirectUri || !state || !mapBaseUrl || !mapId) {
+      res.status(400).type('html').send(renderAuthorizeError('授权参数不完整，请回到 MAP 重新发起连接。'));
+      return;
+    }
+
+    let redirectUrl: URL;
+    try {
+      redirectUrl = new URL(redirectUri);
+    } catch {
+      res.status(400).type('html').send(renderAuthorizeError('MAP 回跳地址无效，请检查 MAP 配置。'));
+      return;
+    }
+
+    if (!approved) {
+      const approveUrl = new URL(`${req.protocol}://${req.get('host')}${req.originalUrl}`);
+      approveUrl.searchParams.set('approve', '1');
+      res.type('html').send(renderAuthorizePage({
+        mapName,
+        mapBaseUrl,
+        redirectHost: redirectUrl.origin,
+        approveUrl: approveUrl.toString(),
+      }));
+      return;
+    }
+
+    try {
+      const result = pairing.issue({
+        name: `authorize ${mapName}`,
+        scopes: ['shared-service:deploy', 'instance:read', 'deployment:stream'],
+        ttlMinutes: 10,
+        hint: { supportsSidecar: true, defaultSidecarPort: 7400 },
+      });
+      redirectUrl.searchParams.set('cds_code', result.pairingToken);
+      redirectUrl.searchParams.set('state', state);
+      redirectUrl.searchParams.set('cds_base_url', cdsBaseUrlGetter());
+      res.redirect(302, redirectUrl.toString());
+    } catch (err) {
+      res.status(500).type('html').send(renderAuthorizeError(
+        err instanceof Error ? err.message : String(err),
+      ));
+    }
+  });
+
+  router.post('/cds-system/connections/token', (req, res) => {
+    const body = (req.body || {}) as Record<string, unknown>;
+    const projectIntent = (body.projectIntent || {}) as Record<string, unknown>;
+    if (projectIntent.kind !== 'shared-service') {
+      res.status(400).json({
+        error: { code: 'project_intent_unsupported', message: 'projectIntent.kind must be shared-service in v1' },
+      });
+      return;
+    }
+
+    try {
+      const partnerId = String(body.mapId || body.partnerId || '');
+      const partnerName = String(body.mapName || body.partnerName || '');
+      const partnerBaseUrl = String(body.mapBaseUrl || body.partnerBaseUrl || '');
+      const result = pairing.accept(
+        {
+          pairingToken: String(body.code || ''),
+          partnerKind: 'map',
+          partnerId,
+          partnerName,
+          partnerBaseUrl,
+          projectIntent: {
+            kind: 'shared-service',
+            name: String(projectIntent.name || 'shared-service'),
+            displayName:
+              typeof projectIntent.displayName === 'string'
+                ? (projectIntent.displayName as string)
+                : undefined,
+          },
+        },
+        intent => createSharedServiceProject(stateService, intent, partnerName),
+      );
+      res.status(200).json({
+        ...result,
+        cdsId: cdsIdGetter(),
+        cdsName: cdsNameGetter(),
+        scopes: ['shared-service:deploy', 'instance:read', 'deployment:stream'],
+      });
+    } catch (err) {
+      if (err instanceof PairingError) {
+        res.status(err.httpStatus).json({
+          error: { code: err.errorCode, message: err.message },
+        });
+        return;
+      }
+      res.status(500).json({
+        error: {
+          code: 'internal_error',
+          message: err instanceof Error ? err.message : String(err),
+        },
+      });
+    }
+  });
+
   // ── list / get / delete ──────────────────────
   router.get('/cds-system/connections', (_req, res) => {
     stateService.gcExpiredPairingConnections();
@@ -290,4 +396,77 @@ function createSharedServiceProject(
   };
   stateService.addProject(project);
   return project;
+}
+
+function escapeHtml(input: string): string {
+  return input
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function renderAuthorizePage(input: {
+  mapName: string;
+  mapBaseUrl: string;
+  redirectHost: string;
+  approveUrl: string;
+}): string {
+  const mapName = escapeHtml(input.mapName || 'MAP');
+  const mapBaseUrl = escapeHtml(input.mapBaseUrl);
+  const redirectHost = escapeHtml(input.redirectHost);
+  const approveUrl = escapeHtml(input.approveUrl);
+  return `<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>授权 MAP 连接 CDS</title>
+  <style>
+    body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #0f172a; color: #e5e7eb; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    main { width: min(560px, calc(100vw - 32px)); border: 1px solid rgba(148,163,184,.28); background: rgba(15,23,42,.96); border-radius: 12px; padding: 28px; box-shadow: 0 24px 80px rgba(0,0,0,.32); }
+    h1 { margin: 0 0 10px; font-size: 22px; }
+    p { color: #94a3b8; line-height: 1.7; }
+    dl { display: grid; gap: 10px; margin: 20px 0; }
+    div.row { display: grid; grid-template-columns: 96px 1fr; gap: 12px; font-size: 14px; }
+    dt { color: #94a3b8; }
+    dd { margin: 0; word-break: break-all; }
+    .scopes { border: 1px solid rgba(148,163,184,.18); border-radius: 10px; padding: 12px; color: #cbd5e1; background: rgba(255,255,255,.03); }
+    a.button { display: inline-flex; margin-top: 18px; padding: 10px 14px; border-radius: 8px; background: #38bdf8; color: #082f49; text-decoration: none; font-weight: 700; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>授权 MAP 连接 CDS</h1>
+    <p>授权后，MAP 将创建一个 shared-service 项目，用于发现并调用 Claude SDK sidecar 等远程执行实例。</p>
+    <dl>
+      <div class="row"><dt>MAP 名称</dt><dd>${mapName}</dd></div>
+      <div class="row"><dt>MAP 地址</dt><dd>${mapBaseUrl}</dd></div>
+      <div class="row"><dt>回跳地址</dt><dd>${redirectHost}</dd></div>
+    </dl>
+    <div class="scopes">授权范围：shared-service:deploy, instance:read, deployment:stream</div>
+    <a class="button" href="${approveUrl}">授权并返回 MAP</a>
+  </main>
+</body>
+</html>`;
+}
+
+function renderAuthorizeError(message: string): string {
+  const safe = escapeHtml(message);
+  return `<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>CDS 授权失败</title>
+  <style>
+    body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #0f172a; color: #e5e7eb; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    main { width: min(520px, calc(100vw - 32px)); border: 1px solid rgba(248,113,113,.35); background: rgba(15,23,42,.96); border-radius: 12px; padding: 28px; }
+    h1 { margin: 0 0 10px; font-size: 22px; }
+    p { color: #fecaca; line-height: 1.7; }
+  </style>
+</head>
+<body><main><h1>授权失败</h1><p>${safe}</p></main></body>
+</html>`;
 }

--- a/cds/src/server.ts
+++ b/cds/src/server.ts
@@ -1090,6 +1090,7 @@ export function createServer(deps: ServerDeps): express.Express {
     app.use((req, res, next) => {
       if (req.path === '/login.html' || req.path === '/api/login' || req.path === '/api/logout') return next();
       if (req.path.startsWith('/api/ai/request-access') || req.path.startsWith('/api/ai/request-status/')) return next();
+      if (req.path === '/api/cds-system/connections/authorize' || req.path === '/api/cds-system/connections/token') return next();
       // GitHub webhook is public — it's authenticated by HMAC signature
       // verification inside the handler, not by the cookie/token middleware.
       if (req.method === 'POST' && req.path === '/api/github/webhook') return next();

--- a/changelogs/2026-05-13_cds-map-authorize-flow.md
+++ b/changelogs/2026-05-13_cds-map-authorize-flow.md
@@ -1,0 +1,5 @@
+| feat | prd-api | MAP 基础设施连接新增 CDS 地址授权流：start 生成跳转 URL，complete 用授权 code 换 longToken 并复用实例发现 |
+| feat | cds | CDS 连接协议新增授权页与 token 端点，支持 MAP 跳转授权后回调建立 shared-service 连接 |
+| fix | cds | CDS 授权码入口加入鉴权放行名单，避免生产 GitHub/basic 鉴权模式下授权页被 401 拦截 |
+| feat | prd-admin | 基础设施服务页新增“输入 CDS 地址授权连接”，保留配对密钥粘贴作为兜底路径 |
+| fix | prd-admin | 基础设施服务页说明文案改为 CDS 地址授权优先，避免视觉验收时仍显示旧配对密钥主流程 |

--- a/doc/guide.list.directory.md
+++ b/doc/guide.list.directory.md
@@ -450,6 +450,9 @@
 - [AI 模型可见性原则](rule.ai-model-visibility) `rule.ai-model-visibility`
   > 大模型调用功能必须向用户展示当前模型名称的强制规则
 
+- [Issues 体系协议规则](rule.issues-system) `rule.issues-system`
+  > 三技能协同（autofix/visual-create/visual-run）+ label 全局体系 + #605 模板演化机制
+
 - [流式文本动效统一规范](rule.streaming-text) `rule.streaming-text`
   > prd-admin 所有 LLM 流式输出统一通过 StreamingText 组件，默认 Blur focus 动效
 

--- a/doc/index.yml
+++ b/doc/index.yml
@@ -174,6 +174,7 @@ docs:
   rule.skill-system: 技能系统规则与创建指南
   rule.audit-prd-desktop-codebase: PRD Agent 全面代码审计报告
   rule.ai-model-visibility: AI 模型可见性原则
+  rule.issues-system: Issues 体系协议规则（autofix + 视觉验收 + 元 issue #605）
   rule.streaming-text: 流式文本动效统一规范 (Blur focus 默认)
   rule.cds-mongo-migration: CDS state.json → MongoDB 迁移与回滚规则
   rule.cds-project-isolation-audit: CDS 多项目隔离审计规则

--- a/doc/rule.issues-system.md
+++ b/doc/rule.issues-system.md
@@ -1,0 +1,284 @@
+# Issues 体系 · 协议规则
+
+> 创建日期：2026-05-14
+> 状态：活跃
+> 维护人：协议演化讨论在 [#605](https://github.com/inernoro/prd_agent/issues/605)
+> 配套技能：`/issues-autofix`、`/issues-visual-create`、`/issues-visual-run`
+
+GitHub issue 在本项目同时承载三类工作：日常 bug/feature 维护、视觉验收的开单与执行、协议本身的演化讨论。本文件做一次系统性解释，让三类工作可机器化协同、不互相打架、不需要每次重新沟通。
+
+---
+
+## 1. 体系全景
+
+```
+                           ┌────────────────────────────────────┐
+                           │  GitHub Issues (inernoro/prd_agent) │
+                           └────────────────────────────────────┘
+                                          │
+        ┌─────────────────────────────────┼─────────────────────────────────┐
+        │                                 │                                 │
+        ▼                                 ▼                                 ▼
+  日常 bug/feature              视觉验收 工单 + 执行              协议元 issue (#605)
+  /issues-autofix              /issues-visual-create             label = visual-test:protocol
+                               /issues-visual-run                永久开放，讨论模板演化
+                                                                  │
+  label: agent-replied         label: visual-test:pending          ▼
+         agent-fixed                  :reviewing               讨论后 bump 模板版本
+         needs-human                  :passed                  本文件 §5 + #605 §四同步更新
+         needs-info                   :blocked
+         duplicate                    :protocol (元 issue 独占)
+         agent-timeout
+         cannot-reproduce
+```
+
+三条主线**互不重叠、互不打扰**：
+
+| 主线 | 触发方式 | 谁处理 | 何时关闭 |
+|---|---|---|---|
+| 日常 bug/feature | `/issues-autofix` 手动批跑 | 通用 Agent | 修完合并 / 答复完毕 |
+| 视觉验收 | `/issues-visual-create` 开单 → `/issues-visual-run` 接单 | 24h 视觉测试 Agent | P0/P1 全清零 |
+| 协议演化 | 直接评论 #605 | 维护者 | **永不关闭** |
+
+---
+
+## 2. Label 体系（全局唯一权威）
+
+任何新增 label 必须先在本表登记。**本表是 SSOT**，技能文件、自动化 Agent、PR 模板都从这里查。
+
+### 2.1 日常 Agent 处理标签
+
+| Label | 颜色 hex | 含义 | 谁加 | 谁清 |
+|---|---|---|---|---|
+| `agent-processing` | `9CA3AF` 灰 | 本 Agent 正在处理（乐观锁） | `/issues-autofix` 进入时 | 同一 Agent 处理结束时 |
+| `agent-replied` | `94A3B8` 浅灰 | 已答复无修复 | `/issues-autofix` | — |
+| `agent-fixed` | `10B981` 绿 | 已答复且提了 PR | `/issues-autofix` | — |
+| `proposed-fix` | `60A5FA` 浅蓝 | 给了思路未提 PR | `/issues-autofix` | — |
+| `needs-human` | `F59E0B` 橙 | 升级人工 | `/issues-autofix` 或 `/issues-visual-run` | — |
+| `needs-info` | `EAB308` 黄 | 信息不足（只允许一次） | `/issues-autofix` | 下轮 |
+| `duplicate` | `D1D5DB` 灰 | 重复 | `/issues-autofix` | — |
+| `agent-timeout` | `EF4444` 红 | 处理超时 | `/issues-autofix` 或 `/issues-visual-run` | — |
+| `cannot-reproduce` | `DC2626` 深红 | 复现失败 ≥ 3 次 | `/issues-autofix` | — |
+
+### 2.2 视觉验收标签
+
+| Label | 颜色 hex | 含义 | 谁加 | 谁清 |
+|---|---|---|---|---|
+| `visual-test:protocol` | `8B5CF6` 紫 | **元 issue (#605) 独占**，演化讨论 | 维护者 | 不清 |
+| `visual-test:pending` | `FBBF24` 黄 | 执行者订阅，看到即接单 | `/issues-visual-create` | `/issues-visual-run` 接单时 |
+| `visual-test:reviewing` | `3B82F6` 蓝 | 已接单，等待开发者回应 | `/issues-visual-run` 报失败时 | 开发者修复 push 后 |
+| `visual-test:passed` | `10B981` 绿 | 全部 P0/P1 通过，可关闭 | `/issues-visual-run` 通过时 | — |
+| `visual-test:blocked` | `EF4444` 红 | 环境不通 / 模板填不全 | `/issues-visual-run` 阻塞时 | 开发者澄清后 |
+
+### 2.3 全局豁免标签
+
+凡有以下任一 label，`/issues-autofix` **完全跳过**（不评论、不留痕）：
+
+| Label | 含义 |
+|---|---|
+| `human-only` | 显式禁止 Agent 介入 |
+| `discussion` / `protocol` / `meta` / `rfc` | 长期讨论，不是请求 |
+| `tracking` / `epic` / `umbrella` | 追踪型，无单点修复 |
+| `wip` / `wontfix` / `invalid` / `on-hold` | 状态明确不需 Agent |
+
+### 2.4 首次部署：创建 label 脚本
+
+```bash
+REPO=inernoro/prd_agent
+# 日常 Agent
+gh label create "agent-processing"   --color 9CA3AF --description "本 Agent 正在处理（乐观锁）" --repo $REPO
+gh label create "agent-replied"      --color 94A3B8 --description "已答复无修复"             --repo $REPO
+gh label create "agent-fixed"        --color 10B981 --description "已答复且提了 PR"          --repo $REPO
+gh label create "proposed-fix"       --color 60A5FA --description "给了思路未提 PR"          --repo $REPO
+gh label create "needs-human"        --color F59E0B --description "升级人工"                 --repo $REPO
+gh label create "needs-info"         --color EAB308 --description "信息不足（只允许一次）"    --repo $REPO
+gh label create "agent-timeout"      --color EF4444 --description "处理超时"                 --repo $REPO
+gh label create "cannot-reproduce"   --color DC2626 --description "复现失败 ≥ 3 次"           --repo $REPO
+# 视觉验收
+gh label create "visual-test:pending"   --color FBBF24 --description "执行者订阅：接单中"           --repo $REPO
+gh label create "visual-test:reviewing" --color 3B82F6 --description "已接单，等待开发者回应"        --repo $REPO
+gh label create "visual-test:passed"    --color 10B981 --description "全部 P0/P1 通过，可关闭"      --repo $REPO
+gh label create "visual-test:blocked"   --color EF4444 --description "环境/需求阻塞，需澄清"        --repo $REPO
+gh label edit   "visual-test:protocol"  --color 8B5CF6 --description "元 issue 独占，演化讨论"      --repo $REPO
+# 豁免
+gh label create "human-only"   --color 1F2937 --description "显式禁止 Agent 介入"  --repo $REPO
+gh label create "discussion"   --color 6B7280 --description "长期讨论，不是请求"   --repo $REPO
+```
+
+---
+
+## 3. `/issues-autofix` 完全跳过清单
+
+为防止通用 Agent 误入"其他 Agent 领地"，跳过条件按顺序判定，命中即静默 next：
+
+1. **作者是机器人**：用户名匹配 `*[bot]` / `dependabot` / `renovate` / `github-actions` / `claude-code-app`，或 GitHub API `user.type == "Bot"`
+2. **issue 含 §2.2 任一 `visual-test:*` label**（视觉测试 Agent 领地）
+3. **issue 含 §2.3 任一豁免 label**
+4. **标题前缀属于元类**：`[visual-test*]` / `[protocol]` / `[rfc]` / `[tracking]` / `[meta]`
+5. **issue body 含** `<!-- agent-handled:` HTML 注释指纹（已处理过）
+6. **issue 已有未关闭的关联 PR**
+7. **作者是 maintainer** 且无 `please-fix`/`bug` 类 label
+8. **草稿/template 占位**：正文 < 20 字 或 仅含模板未填项
+
+**设计意图**：本节是兜底防火墙。label 是主防线，body 指纹是次防线，标题前缀是第三防线。任何一道触发都跳过。
+
+---
+
+## 4. 三个技能的协同
+
+| 技能 | 输入 | 输出 | 终态 label |
+|---|---|---|---|
+| `/issues-autofix` | 仓库 open issue 队列 | 评论/PR/label 改动 | `agent-replied` / `agent-fixed` / `needs-human` / `duplicate` / `agent-timeout` |
+| `/issues-visual-create` | PR# / commit / 页面路径 + 业务用例 | 一条 `[visual-test]` 子 issue | `visual-test:pending` |
+| `/issues-visual-run` | 仓库 `visual-test:pending` 队列 | 评论失败清单或 `/visual-pass` | `visual-test:reviewing` / `visual-test:passed` / `visual-test:blocked` |
+
+**互斥关系**：
+
+- `/issues-autofix` 看到 `visual-test:*` 一律跳过
+- `/issues-visual-run` 只看 `visual-test:pending`，不动其他 issue
+- `/issues-visual-create` 只开单，不接单（接单是 `/issues-visual-run`）
+
+**协作关系**：
+
+```
+开发者推代码
+   │
+   ├─ "测一下视觉" → /issues-visual-create → 子 issue(pending) → /issues-visual-run 接单
+   │                                                                │
+   │                                                                ├─ 失败 → reviewing → 开发者修 → pending → 重测
+   │                                                                └─ 通过 → passed → close
+   │
+   └─ "看看待办 issues" → /issues-autofix → 批量答复/修复/升级
+                              │
+                              └─ 遇到 visual-test:* / discussion / 等 → 跳过
+```
+
+---
+
+## 5. 视觉验收模板（v0.1，与 #605 §四同步）
+
+模板正文以 [#605](https://github.com/inernoro/prd_agent/issues/605) 当前内容为准。**修改模板的唯一入口是 #605 评论**，不要直接改本文件。本节是镜像快照，便于 AI 离线读取。
+
+模板字段：
+- §1 范围（提交/PR、影响页面、变更类型）
+- §2 入口（预览地址按规则 #11 v3 公式、登录账号）
+- §3 测试矩阵（视口 × 主题 × 状态 × 交互态，dark+light 双主题强制）
+- §4 项目专属硬约束（10 条，对应 CLAUDE.md / .claude/rules/）
+- §5 业务用例（至少 3 条角色+任务+预期）
+- §6 已知不覆盖（防止执行者越界）
+- §7 失败回报格式（表格列：# / 检查点 / 视口 / 主题 / 截图 / 问题描述 / 严重级）
+- §8 通过标志（P0/P1 清零 → `/visual-pass`）
+
+### 5.1 §4 硬约束 10 条（与项目规则一一对应）
+
+| # | 检查点 | 规则来源 |
+|---|---|---|
+| 1 | 无 emoji | `CLAUDE.md` §0 |
+| 2 | 白天模式无暗色 modal/弹窗/代码块 | `.claude/rules/cds-theme-tokens.md` |
+| 3 | Modal 走 createPortal + inline style 高度 + min-h:0 | `.claude/rules/frontend-modal.md` |
+| 4 | 页面撑满视口，无 `calc(100vh-Npx)` 魔数 | `.claude/rules/full-height-layout.md` |
+| 5 | 空状态有引导 CTA | `.claude/rules/guided-exploration.md` |
+| 6 | LLM 面板顶部展示模型名 + 平台 | `.claude/rules/ai-model-visibility.md` |
+| 7 | 长任务 >2s 静止 = 缺陷，屏幕必须持续变化 | `CLAUDE.md` §6 |
+| 8 | 输入框有上传/选择/预填通道之一 | `.claude/rules/zero-friction-input.md` |
+| 9 | 2D 画布手势统一 | `.claude/rules/gesture-unification.md` |
+| 10 | 加载组件走 MAP Loader，禁 `<Loader2>` 裸用 | `.claude/rules/frontend-architecture.md` §统一加载组件 |
+
+### 5.2 严重级口径
+
+| 级别 | 含义 | 示例 |
+|---|---|---|
+| **P0** | 阻塞合并 | 白天黑底、emoji 出现、Modal 撑破屏幕、登录走不通、空状态无 CTA |
+| **P1** | 必须修 | 模型名缺、加载组件不统一、双主题样式不一致 |
+| **P2** | 可延后 | 配色微调、间距 1-2px |
+| **P3** | 优化建议 | 动效更顺、文案更准 |
+
+---
+
+## 6. 工作流（端到端）
+
+### 6.1 视觉验收完整循环
+
+```
+1. 开发者 push 代码
+2. 开发者跑 /issues-visual-create
+   ├─ 必要输入：标的(PR#/commit/页面) + 业务用例
+   └─ 自动推导：预览地址(规则 #11 v3) + 分支 + commit
+3. 子 issue 创建 → label: visual-test:pending
+4. 视觉测试 Agent 跑 /issues-visual-run
+   ├─ 加 agent-processing 乐观锁
+   ├─ 评论"已接单 · 预计 N 分钟"
+   ├─ 按 §3 矩阵跑（双主题强制）
+   └─ 按 §7 格式回评论
+5. 分两种终态：
+   ├─ 有 P0/P1 → label: visual-test:reviewing
+   │     │
+   │     └─ 开发者修复 push
+   │           ├─ 评论"已修 commit <hash>"
+   │           ├─ 移除 visual-test:reviewing
+   │           └─ 加回 visual-test:pending
+   │           │
+   │           └─ 回到第 4 步重测（仅受影响项 + P0 全量回归）
+   │
+   └─ 全清零 → 评论 /visual-pass → label: visual-test:passed → close
+```
+
+### 6.2 日常 issue 维护循环
+
+```
+1. 用户/外部贡献者开 issue
+2. 维护者跑 /issues-autofix（手动批跑）
+3. Agent 按 §3 跳过清单过滤
+4. 通过过滤的 issue 按 §5 分类（安全/架构/Bug/Feature/使用问题/重复）
+5. 每条 issue 一条结构化答复（四要素）
+6. 满足开 PR 条件的 → 推到 agent/fix-issue-N-slug 分支 → 开 PR
+7. 终态 label
+8. 输出本轮报告（扫描数/处理数/跳过数/升级数）
+```
+
+---
+
+## 7. 模板演化机制
+
+**唯一入口**：#605 评论。
+
+- 用过觉得啰嗦/漏字段 → 在 #605 评论建议
+- 维护者每攒够 N 条建议或 K 次执行回顾 → 合并到 #605 正文 → bump 版本号 (v0.1 → v0.2)
+- 每次 bump 同步更新本文件 §5
+- 当模板稳定连续 K 次执行无大改 → 固化为 `.github/ISSUE_TEMPLATE/visual-test.yml`，本文件 §5 改为引用该 YAML
+
+**严禁**：
+- 不要新开 issue 讨论模板（应集中在 #605）
+- 不要直接改本文件 §5 而不同步 #605（会引发不一致）
+- 不要把项目专属硬约束精简到 10 条以下（#605 元 issue 决议）
+
+---
+
+## 8. 历史背景
+
+- **2026-05-14** v0.1 协议落地：
+  - #605 元 issue 创建（含模板 v0.1 + 协议正文）
+  - 自动化 issue Agent 加跳过规则
+  - 用户决议："保留 10 条硬约束"、"用 label 触发不依赖 @-mention"、"先开元 issue 不动 `.github/`"
+- **Phase 1 进行中**：等 24h 视觉测试 Agent 上线 + 订阅 `visual-test:pending` label
+- **Phase 3 计划**：模板稳定后固化为 `.github/ISSUE_TEMPLATE/visual-test.yml`，本文件 §5 改为引用
+
+---
+
+## 9. 相关文件
+
+| 文件 | 内容 |
+|---|---|
+| `.claude/skills/issues-autofix/SKILL.md` | 日常 Agent 执行逻辑 |
+| `.claude/skills/issues-visual-create/SKILL.md` | 开单技能 |
+| `.claude/skills/issues-visual-run/SKILL.md` | 执行者技能 |
+| `doc/rule.doc-naming.md` | doc/ 文件命名规则（本文件本身遵守） |
+| `.claude/rules/cds-theme-tokens.md` | 双主题硬规则（§5.1 第 2 条） |
+| `.claude/rules/frontend-modal.md` | Modal 三约束（§5.1 第 3 条） |
+| `.claude/rules/full-height-layout.md` | 撑满视口（§5.1 第 4 条） |
+| `.claude/rules/guided-exploration.md` | 空状态引导（§5.1 第 5 条） |
+| `.claude/rules/ai-model-visibility.md` | LLM 模型可见性（§5.1 第 6 条） |
+| `.claude/rules/zero-friction-input.md` | 输入零摩擦（§5.1 第 8 条） |
+| `.claude/rules/gesture-unification.md` | 画布手势（§5.1 第 9 条） |
+| `.claude/rules/frontend-architecture.md` | MAP Loader（§5.1 第 10 条）+ 组件复用 |
+| GitHub issue [#605](https://github.com/inernoro/prd_agent/issues/605) | 模板演化讨论 |

--- a/prd-admin/src/pages/infra-services/InfraServicesPage.tsx
+++ b/prd-admin/src/pages/infra-services/InfraServicesPage.tsx
@@ -19,10 +19,12 @@ import { MapSpinner } from '@/components/ui/VideoLoader';
 import { toast } from '@/lib/toast';
 import {
   deleteInfraConnection,
+  completeCdsAuthorization,
   listInfraConnections,
   parseClipboardPreview,
   pasteInfraConnection,
   probeInfraConnection,
+  startCdsAuthorization,
   type ClipboardPayloadPreview,
   type InfraConnectionPublicView,
 } from '@/services/real/infraConnections';
@@ -113,6 +115,7 @@ export default function InfraServicesPage() {
   const [loading, setLoading] = useState(true);
   const [pasteOpen, setPasteOpen] = useState(false);
   const [busyId, setBusyId] = useState<string | null>(null);
+  const [completingAuthorization, setCompletingAuthorization] = useState(false);
 
   async function loadConnections() {
     setLoading(true);
@@ -127,6 +130,37 @@ export default function InfraServicesPage() {
 
   useEffect(() => {
     void loadConnections();
+  }, []);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get('cds_code');
+    const state = params.get('state');
+    if (!code || !state) return;
+
+    const marker = `${code}:${state}`;
+    if (sessionStorage.getItem('infra.cdsAuthorize.marker') === marker) return;
+    sessionStorage.setItem('infra.cdsAuthorize.marker', marker);
+
+    setCompletingAuthorization(true);
+    completeCdsAuthorization(code, state)
+      .then((res) => {
+        if (res.success && res.data?.item) {
+          onPasted(res.data.item);
+          toast.success('CDS 连接已建立', `${res.data.item.partnerName || res.data.item.partnerId} · ${res.data.item.partnerBaseUrl}`);
+          void loadConnections();
+        } else {
+          toast.error('CDS 授权连接失败', res.error?.message ?? '请重新发起连接');
+        }
+      })
+      .finally(() => {
+        setCompletingAuthorization(false);
+        params.delete('cds_code');
+        params.delete('state');
+        params.delete('cds_base_url');
+        const qs = params.toString();
+        window.history.replaceState(null, '', `${window.location.pathname}${qs ? `?${qs}` : ''}${window.location.hash}`);
+      });
   }, []);
 
   async function onProbe(id: string) {
@@ -180,7 +214,7 @@ export default function InfraServicesPage() {
           <h1 className="text-xl font-semibold text-white">基础设施服务</h1>
           <p className="text-sm text-white/60 mt-1.5 max-w-2xl">
             shared 基础设施服务（如 claude-sdk sidecar）的连接管理、实例分布、路由策略与业务监控。
-            部署 / 编排能力由 CDS 提供，本页通过剪贴板配对密钥与之建立信任连接。
+            部署 / 编排能力由 CDS 提供，本页通过 CDS 地址授权建立信任连接，配对密钥作为兜底路径保留。
           </p>
         </div>
         <button
@@ -208,15 +242,28 @@ export default function InfraServicesPage() {
           <ShieldCheck size={18} style={{ color: 'rgba(134,239,172,0.95)', marginTop: 2 }} />
           <div className="text-sm text-white/85 leading-relaxed">
             <strong className="text-white">v1 已上线：</strong>
-            通过剪贴板配对密钥连接 CDS（
+            输入 CDS 地址后跳转授权，授权完成自动回到 MAP 建立连接；无法跳转时仍可使用配对密钥兜底（
             <code className="mx-1 px-1 py-0.5 rounded bg-white/10 text-white/90">
               doc/spec.cds-map-pairing-protocol.md
             </code>
-            ）。在 CDS 系统设置「对接 MAP」生成密钥 → 复制 → 粘贴到下方「连接 CDS」即可。
+            ）。
             后续将逐步迁入实例只读列表 / 路由策略 / 业务监控等能力。
           </div>
         </div>
       </section>
+
+      {completingAuthorization && (
+        <section
+          className="rounded-xl p-4 flex items-center gap-3"
+          style={{
+            background: 'rgba(99,179,237,0.08)',
+            border: '1px solid rgba(99,179,237,0.28)',
+          }}
+        >
+          <MapSpinner size={16} />
+          <div className="text-sm text-white/80">正在完成 CDS 授权连接...</div>
+        </section>
+      )}
 
       {/* 连接列表 */}
       <section
@@ -485,14 +532,18 @@ function PasteDialog({
   onSuccess: (item: InfraConnectionPublicView) => void;
 }) {
   const [text, setText] = useState('');
+  const [cdsBaseUrl, setCdsBaseUrl] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  const [authorizing, setAuthorizing] = useState(false);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
   useEffect(() => {
     if (!open) {
       setText('');
+      setCdsBaseUrl('');
       setErrorMsg(null);
       setSubmitting(false);
+      setAuthorizing(false);
     }
   }, [open]);
 
@@ -534,6 +585,23 @@ function PasteDialog({
     }
   }
 
+  async function handleAuthorize() {
+    const value = cdsBaseUrl.trim();
+    if (!value) {
+      setErrorMsg('请输入 CDS 地址');
+      return;
+    }
+    setAuthorizing(true);
+    setErrorMsg(null);
+    const res = await startCdsAuthorization(value);
+    setAuthorizing(false);
+    if (res.success && res.data?.authorizeUrl) {
+      window.location.href = res.data.authorizeUrl;
+    } else {
+      setErrorMsg(res.error?.message ?? '发起 CDS 授权失败，请检查地址');
+    }
+  }
+
   return (
     <Dialog
       open={open}
@@ -542,16 +610,58 @@ function PasteDialog({
       }}
       maxWidth={620}
       title="连接 CDS"
-      description="把从 CDS 复制的密钥粘贴到下方，确认 base URL 后建立连接。"
+      description="输入 CDS 地址跳转授权；无法跳转时可继续使用配对密钥兜底。"
       content={
         <div className="flex flex-col gap-4">
+          <div
+            className="rounded-lg p-3"
+            style={{
+              background: 'rgba(99,179,237,0.06)',
+              border: '1px solid rgba(99,179,237,0.22)',
+            }}
+          >
+            <label className="block text-xs font-medium text-white/70 mb-1.5">CDS 地址</label>
+            <div className="flex gap-2">
+              <input
+                value={cdsBaseUrl}
+                onChange={(e) => setCdsBaseUrl(e.target.value)}
+                placeholder="https://cds.example.com"
+                autoFocus
+                spellCheck={false}
+                className="flex-1 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none"
+                style={{
+                  background: 'rgba(0,0,0,0.25)',
+                  border: '1px solid rgba(255,255,255,0.12)',
+                  color: 'rgba(255,255,255,0.92)',
+                }}
+              />
+              <button
+                type="button"
+                onClick={() => void handleAuthorize()}
+                disabled={authorizing}
+                className="inline-flex items-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium"
+                style={{
+                  background: 'rgba(99,179,237,0.22)',
+                  color: 'rgba(186,230,253,0.98)',
+                  border: '1px solid rgba(99,179,237,0.5)',
+                  opacity: authorizing ? 0.6 : 1,
+                }}
+              >
+                {authorizing ? <MapSpinner size={12} /> : <ExternalLink size={12} />}
+                授权
+              </button>
+            </div>
+            <div className="text-[11px] text-white/45 mt-2 leading-relaxed">
+              MAP 会跳转到 CDS 授权页，授权完成后自动回到本页建立连接。
+            </div>
+          </div>
+
           <div>
-            <label className="block text-xs font-medium text-white/70 mb-1.5">CDS 配对密钥</label>
+            <label className="block text-xs font-medium text-white/70 mb-1.5">CDS 配对密钥（兜底）</label>
             <textarea
               value={text}
               onChange={(e) => setText(e.target.value)}
               placeholder="cds-connect:v1:eyJ2ZXJzaW9uIjox..."
-              autoFocus
               spellCheck={false}
               rows={6}
               className="w-full rounded-lg px-3 py-2.5 text-sm font-mono leading-relaxed resize-none focus:outline-none"

--- a/prd-admin/src/services/api.ts
+++ b/prd-admin/src/services/api.ts
@@ -762,6 +762,8 @@ export const api = {
   infraConnections: {
     list: () => '/api/infra-connections',
     paste: () => '/api/infra-connections/paste',
+    cdsAuthorizeStart: () => '/api/infra-connections/cds/authorize/start',
+    cdsAuthorizeComplete: () => '/api/infra-connections/cds/authorize/complete',
     byId: (id: string) => `/api/infra-connections/${id}`,
     probe: (id: string) => `/api/infra-connections/${id}/probe`,
   },

--- a/prd-admin/src/services/real/infraConnections.ts
+++ b/prd-admin/src/services/real/infraConnections.ts
@@ -36,6 +36,13 @@ interface DeleteResp {
   deleted: boolean;
 }
 
+interface CdsAuthorizeStartResp {
+  authorizeUrl: string;
+  state: string;
+  cdsBaseUrl: string;
+  expiresAt: string;
+}
+
 export async function listInfraConnections(): Promise<ApiResponse<ListResp>> {
   return await apiRequest<ListResp>(api.infraConnections.list(), { method: 'GET' });
 }
@@ -46,6 +53,25 @@ export async function pasteInfraConnection(
   return await apiRequest<ItemResp>(api.infraConnections.paste(), {
     method: 'POST',
     body: { clipboardText },
+  });
+}
+
+export async function startCdsAuthorization(
+  cdsBaseUrl: string,
+): Promise<ApiResponse<CdsAuthorizeStartResp>> {
+  return await apiRequest<CdsAuthorizeStartResp>(api.infraConnections.cdsAuthorizeStart(), {
+    method: 'POST',
+    body: { cdsBaseUrl },
+  });
+}
+
+export async function completeCdsAuthorization(
+  code: string,
+  state: string,
+): Promise<ApiResponse<ItemResp>> {
+  return await apiRequest<ItemResp>(api.infraConnections.cdsAuthorizeComplete(), {
+    method: 'POST',
+    body: { code, state },
   });
 }
 

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/InfraConnectionsController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/InfraConnectionsController.cs
@@ -32,6 +32,17 @@ public class InfraConnectionsController : ControllerBase
         public string ClipboardText { get; set; } = string.Empty;
     }
 
+    public class CdsAuthorizeStartRequest
+    {
+        public string CdsBaseUrl { get; set; } = string.Empty;
+    }
+
+    public class CdsAuthorizeCompleteRequest
+    {
+        public string Code { get; set; } = string.Empty;
+        public string State { get; set; } = string.Empty;
+    }
+
     /// <summary>
     /// 粘贴 CDS 密钥 → 解析 → 调对端 accept → 加密落库。
     /// 成功返回 201 + 脱敏视图。失败返回 spec §3.3 错误码。
@@ -50,6 +61,67 @@ public class InfraConnectionsController : ControllerBase
         try
         {
             var view = await _service.PasteAsync(req.ClipboardText, userId, ct);
+            return StatusCode(StatusCodes.Status201Created, ApiResponse<object>.Ok(new { item = view }));
+        }
+        catch (InfraConnectionException ex)
+        {
+            return StatusCode(ex.HttpStatus, ApiResponse<object>.Fail(ex.ErrorCode, ex.Message));
+        }
+    }
+
+    /// <summary>
+    /// 输入 CDS 地址 → 生成 CDS 授权页跳转 URL。
+    /// 用户在 CDS 授权后会回跳到 MAP /infra-services?cds_code=...&state=...
+    /// </summary>
+    [HttpPost("cds/authorize/start")]
+    public async Task<IActionResult> StartCdsAuthorization(
+        [FromBody] CdsAuthorizeStartRequest req,
+        CancellationToken ct)
+    {
+        if (req == null || string.IsNullOrWhiteSpace(req.CdsBaseUrl))
+        {
+            return BadRequest(ApiResponse<object>.Fail(
+                InfraConnectionErrorCodes.CdsBaseUrlInvalid,
+                "CDS 地址不能为空"));
+        }
+
+        var userId = this.GetRequiredUserId();
+        try
+        {
+            var view = await _service.StartCdsAuthorizationAsync(req.CdsBaseUrl, userId, ct);
+            return Ok(ApiResponse<object>.Ok(new
+            {
+                authorizeUrl = view.AuthorizeUrl,
+                state = view.State,
+                cdsBaseUrl = view.CdsBaseUrl,
+                expiresAt = view.ExpiresAt
+            }));
+        }
+        catch (InfraConnectionException ex)
+        {
+            return StatusCode(ex.HttpStatus, ApiResponse<object>.Fail(ex.ErrorCode, ex.Message));
+        }
+    }
+
+    /// <summary>
+    /// CDS 授权回跳后，MAP 用一次性 code 换 longToken 并保存连接。
+    /// </summary>
+    [HttpPost("cds/authorize/complete")]
+    public async Task<IActionResult> CompleteCdsAuthorization(
+        [FromBody] CdsAuthorizeCompleteRequest req,
+        CancellationToken ct)
+    {
+        if (req == null || string.IsNullOrWhiteSpace(req.Code) || string.IsNullOrWhiteSpace(req.State))
+        {
+            return BadRequest(ApiResponse<object>.Fail(
+                InfraConnectionErrorCodes.AuthorizationStateInvalid,
+                "授权参数不完整"));
+        }
+
+        var userId = this.GetRequiredUserId();
+        try
+        {
+            var view = await _service.CompleteCdsAuthorizationAsync(req.Code, req.State, userId, ct);
             return StatusCode(StatusCodes.Status201Created, ApiResponse<object>.Ok(new { item = view }));
         }
         catch (InfraConnectionException ex)

--- a/prd-api/src/PrdAgent.Core/Interfaces/IInfraConnectionService.cs
+++ b/prd-api/src/PrdAgent.Core/Interfaces/IInfraConnectionService.cs
@@ -13,6 +13,17 @@ public interface IInfraConnectionService
     /// </summary>
     Task<InfraConnectionPublicView> PasteAsync(string clipboardText, string userId, CancellationToken ct);
 
+    /// <summary>
+    /// OAuth-like CDS 连接：根据用户输入的 CDS 地址生成跳转授权 URL。
+    /// state 为短期签名令牌，callback 时用于防串改和恢复 cdsBaseUrl。
+    /// </summary>
+    Task<CdsAuthorizationStartView> StartCdsAuthorizationAsync(string cdsBaseUrl, string userId, CancellationToken ct);
+
+    /// <summary>
+    /// OAuth-like CDS 连接：CDS 授权后回跳 MAP，MAP 用 code 换 longToken 并加密落库。
+    /// </summary>
+    Task<InfraConnectionPublicView> CompleteCdsAuthorizationAsync(string code, string state, string userId, CancellationToken ct);
+
     /// <summary>列表（脱敏视图）</summary>
     Task<List<InfraConnectionPublicView>> ListAsync(CancellationToken ct);
 
@@ -59,6 +70,13 @@ public record InfraConnectionPublicView(
     DateTime LongTokenExpiresAt
 );
 
+public record CdsAuthorizationStartView(
+    string AuthorizeUrl,
+    string State,
+    string CdsBaseUrl,
+    DateTime ExpiresAt
+);
+
 /// <summary>InfraConnection 协议错误码（spec §3.3）。</summary>
 public static class InfraConnectionErrorCodes
 {
@@ -72,6 +90,9 @@ public static class InfraConnectionErrorCodes
     public const string AcceptResponseInvalid = "accept_response_invalid";
     public const string ConnectionNotFound = "connection_not_found";
     public const string TokenUnprotectFailed = "token_unprotect_failed";
+    public const string CdsBaseUrlInvalid = "cds_base_url_invalid";
+    public const string AuthorizationStateInvalid = "authorization_state_invalid";
+    public const string AuthorizationCodeInvalid = "authorization_code_invalid";
 }
 
 /// <summary>InfraConnection 协议异常 —— Controller 统一捕获并按 HttpStatus + ErrorCode 返回。</summary>

--- a/prd-api/src/PrdAgent.Infrastructure/Services/InfraConnections/InfraConnectionService.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/InfraConnections/InfraConnectionService.cs
@@ -2,12 +2,14 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 using PrdAgent.Core.Interfaces;
@@ -41,6 +43,7 @@ public class InfraConnectionService : IInfraConnectionService
     private readonly IDataProtector _protector;
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IConfiguration _configuration;
     private readonly ILogger<InfraConnectionService> _logger;
 
     public InfraConnectionService(
@@ -48,12 +51,14 @@ public class InfraConnectionService : IInfraConnectionService
         IDataProtectionProvider protectionProvider,
         IHttpClientFactory httpClientFactory,
         IHttpContextAccessor httpContextAccessor,
+        IConfiguration configuration,
         ILogger<InfraConnectionService> logger)
     {
         _db = db;
         _protector = protectionProvider.CreateProtector(ProtectorPurpose);
         _httpClientFactory = httpClientFactory;
         _httpContextAccessor = httpContextAccessor;
+        _configuration = configuration;
         _logger = logger;
     }
 
@@ -129,6 +134,149 @@ public class InfraConnectionService : IInfraConnectionService
         await _db.InfraConnections.InsertOneAsync(entity, cancellationToken: ct);
         _logger.LogInformation(
             "InfraConnection created id={Id} partner={Partner} partnerId={PartnerId} project={Project}",
+            entity.Id, entity.Partner, entity.PartnerId, entity.ProjectId);
+
+        return ToPublicView(entity);
+    }
+
+    public async Task<CdsAuthorizationStartView> StartCdsAuthorizationAsync(
+        string cdsBaseUrl,
+        string userId,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(cdsBaseUrl))
+        {
+            throw new InfraConnectionException(
+                InfraConnectionErrorCodes.CdsBaseUrlInvalid,
+                "CDS 地址不能为空");
+        }
+
+        var normalized = NormalizeAndValidateHttpBaseUrl(cdsBaseUrl);
+        var mapId = await EnsureMapInstanceIdAsync(ct);
+        var mapBaseUrl = ResolveMapBaseUrl();
+        var expiresAt = DateTime.UtcNow.AddMinutes(10);
+        var state = EncodeAuthorizationState(new AuthorizationStatePayload
+        {
+            CdsBaseUrl = normalized,
+            MapBaseUrl = mapBaseUrl,
+            MapId = mapId,
+            UserId = userId,
+            ExpiresAtUnix = new DateTimeOffset(expiresAt).ToUnixTimeSeconds(),
+            Nonce = Guid.NewGuid().ToString("N")
+        });
+
+        var redirectUri = JoinUrl(mapBaseUrl, "/infra-services");
+        var query = new Dictionary<string, string?>
+        {
+            ["redirectUri"] = redirectUri,
+            ["state"] = state,
+            ["mapBaseUrl"] = mapBaseUrl,
+            ["mapId"] = mapId,
+            ["mapName"] = "prd-agent"
+        };
+        var authorizeUrl = QueryHelpers.AddQueryString(
+            JoinUrl(normalized, "/api/cds-system/connections/authorize"),
+            query);
+
+        return new CdsAuthorizationStartView(authorizeUrl, state, normalized, expiresAt);
+    }
+
+    public async Task<InfraConnectionPublicView> CompleteCdsAuthorizationAsync(
+        string code,
+        string state,
+        string userId,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(code))
+        {
+            throw new InfraConnectionException(
+                InfraConnectionErrorCodes.AuthorizationCodeInvalid,
+                "授权 code 为空");
+        }
+
+        var payload = DecodeAuthorizationState(state);
+        if (payload.ExpiresAtUnix < DateTimeOffset.UtcNow.ToUnixTimeSeconds())
+        {
+            throw new InfraConnectionException(
+                InfraConnectionErrorCodes.AuthorizationStateInvalid,
+                "授权会话已过期，请重新连接",
+                StatusCodes.Status410Gone);
+        }
+        if (!string.Equals(payload.UserId, userId, StringComparison.Ordinal))
+        {
+            throw new InfraConnectionException(
+                InfraConnectionErrorCodes.AuthorizationStateInvalid,
+                "授权会话不属于当前用户，请重新连接",
+                StatusCodes.Status403Forbidden);
+        }
+
+        var mapId = string.IsNullOrWhiteSpace(payload.MapId)
+            ? await EnsureMapInstanceIdAsync(ct)
+            : payload.MapId;
+        var mapBaseUrl = string.IsNullOrWhiteSpace(payload.MapBaseUrl)
+            ? ResolveMapBaseUrl()
+            : payload.MapBaseUrl;
+
+        var duplicateByUrl = await _db.InfraConnections
+            .Find(c => c.Partner == "cds"
+                && c.PartnerBaseUrl == NormalizeBaseUrl(payload.CdsBaseUrl)
+                && c.Status == "active")
+            .FirstOrDefaultAsync(ct);
+        if (duplicateByUrl != null)
+        {
+            throw new InfraConnectionException(
+                InfraConnectionErrorCodes.ConnectionDuplicate,
+                $"已有同一 CDS（{duplicateByUrl.PartnerName}）连接，请先删除旧连接",
+                StatusCodes.Status409Conflict);
+        }
+
+        var tokenResp = await CallCdsTokenAsync(
+            payload.CdsBaseUrl,
+            code.Trim(),
+            mapId,
+            mapBaseUrl,
+            "prd-agent",
+            ct);
+
+        var partnerId = !string.IsNullOrWhiteSpace(tokenResp.CdsId)
+            ? tokenResp.CdsId!
+            : NormalizeBaseUrl(payload.CdsBaseUrl);
+        var partnerName = !string.IsNullOrWhiteSpace(tokenResp.CdsName)
+            ? tokenResp.CdsName!
+            : partnerId;
+
+        var dup = await _db.InfraConnections
+            .Find(c => c.Partner == "cds" && c.PartnerId == partnerId && c.Status == "active")
+            .FirstOrDefaultAsync(ct);
+        if (dup != null)
+        {
+            throw new InfraConnectionException(
+                InfraConnectionErrorCodes.ConnectionDuplicate,
+                $"已有同一 CDS（{dup.PartnerName}）连接，请先删除旧连接",
+                StatusCodes.Status409Conflict);
+        }
+
+        var entity = new InfraConnection
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Partner = "cds",
+            PartnerName = partnerName,
+            PartnerId = partnerId,
+            PartnerBaseUrl = NormalizeBaseUrl(payload.CdsBaseUrl),
+            LongTokenEncrypted = _protector.Protect(tokenResp.CdsLongToken),
+            LongTokenExpiresAt = tokenResp.CdsLongTokenExpiresAt ?? DateTime.UtcNow.AddYears(1),
+            ProjectId = tokenResp.ProjectId ?? string.Empty,
+            InstanceDiscoveryUrl = tokenResp.InstanceDiscoveryUrl ?? string.Empty,
+            Scopes = tokenResp.Scopes ?? new List<string>(),
+            Status = "active",
+            CreatedByUserId = userId,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+
+        await _db.InfraConnections.InsertOneAsync(entity, cancellationToken: ct);
+        _logger.LogInformation(
+            "InfraConnection authorized id={Id} partner={Partner} partnerId={PartnerId} project={Project}",
             entity.Id, entity.Partner, entity.PartnerId, entity.ProjectId);
 
         return ToPublicView(entity);
@@ -428,6 +576,83 @@ public class InfraConnectionService : IInfraConnectionService
         return parsed;
     }
 
+    private async Task<AcceptResponse> CallCdsTokenAsync(
+        string cdsBaseUrl,
+        string code,
+        string mapId,
+        string mapBaseUrl,
+        string mapName,
+        CancellationToken ct)
+    {
+        var client = _httpClientFactory.CreateClient(HttpClientName);
+        client.Timeout = TimeSpan.FromSeconds(10);
+
+        var url = JoinUrl(cdsBaseUrl, "/api/cds-system/connections/token");
+        var body = new TokenRequest
+        {
+            Code = code,
+            MapBaseUrl = mapBaseUrl,
+            MapId = mapId,
+            MapName = mapName,
+            ProjectIntent = new ProjectIntent
+            {
+                Kind = "shared-service",
+                Name = "sidecar-pool",
+                DisplayName = "Claude SDK Sidecar Pool"
+            }
+        };
+
+        HttpResponseMessage resp;
+        try
+        {
+            resp = await client.PostAsJsonAsync(url, body, JsonOpts, ct);
+        }
+        catch (TaskCanceledException ex) when (!ct.IsCancellationRequested)
+        {
+            throw new InfraConnectionException(
+                InfraConnectionErrorCodes.CdsUnreachable,
+                $"无法访问 CDS：连接超时（{ex.Message}）",
+                StatusCodes.Status502BadGateway);
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new InfraConnectionException(
+                InfraConnectionErrorCodes.CdsUnreachable,
+                $"无法访问 CDS：{ex.Message}",
+                StatusCodes.Status502BadGateway);
+        }
+
+        if (!resp.IsSuccessStatusCode)
+        {
+            var bodyText = await SafeReadAsStringAsync(resp.Content, ct);
+            var (errCode, message) = MapAcceptError(resp.StatusCode, bodyText);
+            throw new InfraConnectionException(errCode, message, (int)resp.StatusCode);
+        }
+
+        AcceptResponse? parsed;
+        try
+        {
+            parsed = await resp.Content.ReadFromJsonAsync<AcceptResponse>(JsonOpts, ct);
+        }
+        catch (Exception ex)
+        {
+            throw new InfraConnectionException(
+                InfraConnectionErrorCodes.AcceptResponseInvalid,
+                $"对端 token 响应解析失败：{ex.Message}",
+                StatusCodes.Status502BadGateway);
+        }
+
+        if (parsed == null || string.IsNullOrWhiteSpace(parsed.CdsLongToken))
+        {
+            throw new InfraConnectionException(
+                InfraConnectionErrorCodes.AcceptResponseInvalid,
+                "对端 token 响应缺少 cdsLongToken",
+                StatusCodes.Status502BadGateway);
+        }
+
+        return parsed;
+    }
+
     private static (string code, string message) MapAcceptError(HttpStatusCode status, string body)
     {
         // 优先解析对端返回的 errorCode（spec §3.3 一致约定）
@@ -489,6 +714,20 @@ public class InfraConnectionService : IInfraConnectionService
         return url.TrimEnd('/');
     }
 
+    private static string NormalizeAndValidateHttpBaseUrl(string url)
+    {
+        var trimmed = url.Trim().TrimEnd('/');
+        if (!Uri.TryCreate(trimmed, UriKind.Absolute, out var uri)
+            || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)
+            || string.IsNullOrWhiteSpace(uri.Host))
+        {
+            throw new InfraConnectionException(
+                InfraConnectionErrorCodes.CdsBaseUrlInvalid,
+                "CDS 地址必须是 http 或 https URL");
+        }
+        return uri.GetLeftPart(UriPartial.Authority);
+    }
+
     private static string JoinUrl(string baseUrl, string path)
     {
         var b = (baseUrl ?? string.Empty).TrimEnd('/');
@@ -496,6 +735,78 @@ public class InfraConnectionService : IInfraConnectionService
         if (string.IsNullOrEmpty(p)) return b;
         if (!p.StartsWith('/')) p = "/" + p;
         return b + p;
+    }
+
+    private string EncodeAuthorizationState(AuthorizationStatePayload payload)
+    {
+        var json = JsonSerializer.Serialize(payload, JsonOpts);
+        var payloadPart = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(json));
+        var signature = SignStatePayload(payloadPart);
+        return $"{payloadPart}.{signature}";
+    }
+
+    private AuthorizationStatePayload DecodeAuthorizationState(string state)
+    {
+        if (string.IsNullOrWhiteSpace(state))
+        {
+            throw new InfraConnectionException(
+                InfraConnectionErrorCodes.AuthorizationStateInvalid,
+                "授权 state 为空");
+        }
+
+        var parts = state.Split('.', 2);
+        if (parts.Length != 2 || string.IsNullOrWhiteSpace(parts[0]) || string.IsNullOrWhiteSpace(parts[1]))
+        {
+            throw new InfraConnectionException(
+                InfraConnectionErrorCodes.AuthorizationStateInvalid,
+                "授权 state 格式错误");
+        }
+
+        var expected = SignStatePayload(parts[0]);
+        if (!CryptographicOperations.FixedTimeEquals(
+                Encoding.UTF8.GetBytes(expected),
+                Encoding.UTF8.GetBytes(parts[1])))
+        {
+            throw new InfraConnectionException(
+                InfraConnectionErrorCodes.AuthorizationStateInvalid,
+                "授权 state 签名无效",
+                StatusCodes.Status403Forbidden);
+        }
+
+        try
+        {
+            var json = Encoding.UTF8.GetString(WebEncoders.Base64UrlDecode(parts[0]));
+            var payload = JsonSerializer.Deserialize<AuthorizationStatePayload>(json, JsonOpts);
+            if (payload == null || string.IsNullOrWhiteSpace(payload.CdsBaseUrl))
+            {
+                throw new InvalidOperationException("empty authorization state");
+            }
+            return payload;
+        }
+        catch (InfraConnectionException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new InfraConnectionException(
+                InfraConnectionErrorCodes.AuthorizationStateInvalid,
+                $"授权 state 解析失败：{ex.Message}");
+        }
+    }
+
+    private string SignStatePayload(string payloadPart)
+    {
+        var secret = _configuration["Jwt:Secret"];
+        if (string.IsNullOrWhiteSpace(secret))
+        {
+            throw new InfraConnectionException(
+                InfraConnectionErrorCodes.AuthorizationStateInvalid,
+                "Jwt:Secret 未配置，无法发起 CDS 授权",
+                StatusCodes.Status503ServiceUnavailable);
+        }
+        using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
+        return WebEncoders.Base64UrlEncode(hmac.ComputeHash(Encoding.UTF8.GetBytes(payloadPart)));
     }
 
     internal static InfraConnectionPublicView ToPublicView(InfraConnection c)
@@ -544,6 +855,15 @@ public class InfraConnectionService : IInfraConnectionService
         [JsonPropertyName("projectIntent")] public ProjectIntent ProjectIntent { get; set; } = new();
     }
 
+    private sealed class TokenRequest
+    {
+        [JsonPropertyName("code")] public string Code { get; set; } = string.Empty;
+        [JsonPropertyName("mapBaseUrl")] public string MapBaseUrl { get; set; } = string.Empty;
+        [JsonPropertyName("mapId")] public string MapId { get; set; } = string.Empty;
+        [JsonPropertyName("mapName")] public string MapName { get; set; } = string.Empty;
+        [JsonPropertyName("projectIntent")] public ProjectIntent ProjectIntent { get; set; } = new();
+    }
+
     private sealed class ProjectIntent
     {
         [JsonPropertyName("kind")] public string Kind { get; set; } = "shared-service";
@@ -559,5 +879,18 @@ public class InfraConnectionService : IInfraConnectionService
         [JsonPropertyName("projectId")] public string? ProjectId { get; set; }
         [JsonPropertyName("instanceDiscoveryUrl")] public string? InstanceDiscoveryUrl { get; set; }
         [JsonPropertyName("deployStreamUrlTemplate")] public string? DeployStreamUrlTemplate { get; set; }
+        [JsonPropertyName("cdsId")] public string? CdsId { get; set; }
+        [JsonPropertyName("cdsName")] public string? CdsName { get; set; }
+        [JsonPropertyName("scopes")] public List<string>? Scopes { get; set; }
+    }
+
+    private sealed class AuthorizationStatePayload
+    {
+        [JsonPropertyName("cdsBaseUrl")] public string CdsBaseUrl { get; set; } = string.Empty;
+        [JsonPropertyName("mapBaseUrl")] public string MapBaseUrl { get; set; } = string.Empty;
+        [JsonPropertyName("mapId")] public string MapId { get; set; } = string.Empty;
+        [JsonPropertyName("userId")] public string UserId { get; set; } = string.Empty;
+        [JsonPropertyName("expiresAtUnix")] public long ExpiresAtUnix { get; set; }
+        [JsonPropertyName("nonce")] public string Nonce { get; set; } = string.Empty;
     }
 }

--- a/prd-api/tests/PrdAgent.Tests/DynamicSidecarRegistryTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/DynamicSidecarRegistryTests.cs
@@ -125,6 +125,12 @@ public class DynamicSidecarRegistryTests
         public Task<InfraConnectionPublicView> PasteAsync(string clipboardText, string userId, CancellationToken ct) =>
             throw new NotImplementedException();
 
+        public Task<CdsAuthorizationStartView> StartCdsAuthorizationAsync(string cdsBaseUrl, string userId, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<InfraConnectionPublicView> CompleteCdsAuthorizationAsync(string code, string state, string userId, CancellationToken ct) =>
+            throw new NotImplementedException();
+
         public Task<List<InfraConnectionPublicView>> ListAsync(CancellationToken ct) =>
             Task.FromResult(_items);
 


### PR DESCRIPTION
## 摘要

新增 CDS 地址授权流（OAuth-like）替代剪贴板密钥配对，用户输入 CDS 地址后跳转授权页完成连接。同时建立完整的视觉验收协议体系与三个配套技能（autofix / visual-create / visual-run），支持矩阵化测试与自动化硬约束检查。

## 改动 diff

### 后端 API（prd-api）
- `InfraConnectionService.cs`：新增 `StartCdsAuthorizationAsync` 与 `CompleteCdsAuthorizationAsync` 方法，实现授权流的 state 编码/解码、token 交换、连接保存
- `InfraConnectionService.cs`：新增 `CallCdsTokenAsync` 调用 CDS token 端点，处理超时与错误映射
- `InfraConnectionService.cs`：新增 `NormalizeAndValidateHttpBaseUrl` 校验 CDS 地址格式
- `InfraConnectionService.cs`：新增 `EncodeAuthorizationState` / `DecodeAuthorizationState` 实现 state 令牌签名与验证
- `InfraConnectionService.cs`：新增 `EnsureMapInstanceIdAsync` / `ResolveMapBaseUrl` 获取 MAP 实例标识
- `InfraConnectionsController.cs`：新增 `/cds/authorize/start` 与 `/cds/authorize/complete` 端点
- `IInfraConnectionService.cs`：接口声明新增两个授权方法
- `DynamicSidecarRegistryTests.cs`：测试桩更新以支持新接口

### 前端（prd-admin）
- `InfraServicesPage.tsx`：新增授权流回调处理，监听 URL 参数 `cds_code` / `state` 自动完成授权
- `InfraServicesPage.tsx`：新增授权进行中的加载状态提示
- `infraConnections.ts`：新增 `startCdsAuthorization` / `completeCdsAuthorization` 服务函数
- `api.ts`：新增两个授权端点路由

### CDS 端（cds）
- `cds-system-connections.ts`：新增 `/cds-system/connections/authorize` GET 端点，渲染授权确认页面
- `cds-system-connections.ts`：新增 `/cds-system/connections/token` POST 端点，处理 MAP 的 token 交换请求
- `cds-system-connections.ts`：新增 `renderAuthorizePage` / `renderAuthorizeError` HTML 渲染函数
- `github-auth.ts`：授权端点加入公开路径豁免名单
- `server.ts`：CORS 配置调整支持授权流跨域

### 文档与规则
- `doc/rule.issues-system.md`（新增）：完整的 Issues 体系协议，包含 label 全局体系、三技能协同、视觉验收模板 v0.1、工作流端到端说明
- `.claude/skills/issues-autofix/SKILL.md`（新增）：日常无人值守 issue 维护技能，支持自动答复/修复/升级人工
- `.claude/skills/issues-visual-create/SKILL.md`（新增）：视觉验收开单技能，按模板生成结构化 issue
- `.claude/skills/issues-visual-run/SKILL.md`（新增）：24h 视

https://claude.ai/code/session_01Aju8TK3oA6qcn72LJNVaer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces new unauthenticated CDS endpoints and an OAuth-like code/state exchange that creates long-lived infra connections; mistakes could weaken auth boundaries or allow token misuse. Also adds sizable new operational protocols/docs that change how issues are triaged and visual testing is coordinated.
> 
> **Overview**
> Adds an OAuth-like **CDS address authorization flow** to replace/augment clipboard pairing: MAP can start authorization, redirect to CDS for approval, then complete the connection by exchanging a one-time `code` for a long token (new `prd-api` endpoints and service logic, plus new `cds` `authorize` HTML page + `token` API).
> 
> Updates `prd-admin` infra services UI to initiate the redirect-based flow, handle the callback (`cds_code`/`state`) to finalize the connection, and keep clipboard pairing as a fallback.
> 
> Formalizes an **Issues/visual-test protocol** by adding three new Claude skills (`/issues-autofix`, `/issues-visual-create`, `/issues-visual-run`), registering them in `CLAUDE.md`, and adding `doc/rule.issues-system.md` + index entries to define labels, skip rules, and the visual-test workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1cd49d7b68ed2008d596f1f7134ab32cdbd00aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->