### PR TITLE
修复 PDF 包装站分享时被 Chrome 屏蔽的问题

### DIFF
--- a/changelogs/2026-05-14_pdf-share-direct-iframe.md
+++ b/changelogs/2026-05-14_pdf-share-direct-iframe.md
@@ -1,0 +1,2 @@
+| fix | prd-api | 网页托管分享 PDF 时后端额外返回 pdfAssetUrl 直链，避免前端走「壳子 + 嵌套 iframe」结构 |
+| fix | prd-admin | ShareViewPage 检测到 PDF 包装站时直接 iframe 真实 PDF 链接（移除 sandbox），让浏览器原生 PDF Viewer 接管，修复 Chrome「此页面已被 Chrome 屏蔽」 |

--- a/changelogs/2026-05-14_pdf-thumbnail-placeholder.md
+++ b/changelogs/2026-05-14_pdf-thumbnail-placeholder.md
@@ -1,0 +1,1 @@
+| fix | prd-admin | 网页托管 PDF 站点卡片改用 PDF 设计占位（红色 PDF 徽记 + 大小标签），不再走嵌套 iframe 导致空白破图 |

--- a/changelogs/2026-05-14_pdf-thumbnail-public-profile.md
+++ b/changelogs/2026-05-14_pdf-thumbnail-public-profile.md
@@ -1,0 +1,2 @@
+| fix | prd-api | PublicProfile API 新增 isPdfWrapper / totalSize 字段，前端可识别 PDF 包装站 |
+| fix | prd-admin | 公开个人页 PDF 站点卡片同步走 PdfThumbnail 占位；PdfThumbnail 接口改为接收 sizeBytes，解耦 HostedSite 类型依赖 |

--- a/changelogs/2026-05-14_pdf-wrapper-marker.md
+++ b/changelogs/2026-05-14_pdf-wrapper-marker.md
@@ -1,0 +1,3 @@
+| fix | prd-api | HostedSite 加 WrappedAssetType marker，CreateFromZipAsync 接收并持久化；PDF 包装站识别只看 marker 不看 ZIP 文件形状，避免误判用户上传的"index.html + .pdf"两文件 ZIP（Codex P2 #612） |
+| fix | prd-admin | isPdfSite 改读后端 wrappedAssetType marker；HostedSite 类型加 wrappedAssetType 字段 |
+| test | prd-api | 补 LongTokenExpiresAt 让 HasRecentHealthyProbe 测试跟上 main 871ab45 改动 |

--- a/changelogs/2026-05-14_pdf-wrapper-strict-detection.md
+++ b/changelogs/2026-05-14_pdf-wrapper-strict-detection.md
@@ -1,0 +1,2 @@
+| fix | prd-api | 收紧 PDF 包装站识别条件（entry=index.html + 恰好2文件 + 一个 index.html + 一个根目录 .pdf），避免把含 PDF 子文件的正常 ZIP 站误判为包装站（Codex P2 #612） |
+| fix | prd-admin | 前端 isPdfSite 同步严格匹配 wrapper 形状 |

--- a/prd-admin/src/components/PdfThumbnail.tsx
+++ b/prd-admin/src/components/PdfThumbnail.tsx
@@ -1,0 +1,102 @@
+import { FileText } from 'lucide-react';
+import type { HostedSite } from '@/services/real/webPages';
+
+export function isPdfSite(site: Pick<HostedSite, 'files' | 'entryFile'>): boolean {
+  if (!site.files || site.files.length === 0) return false;
+  return site.files.some(f => f.path?.toLowerCase().endsWith('.pdf'));
+}
+
+export function PdfThumbnail({
+  site,
+  className,
+  compact = false,
+}: {
+  site: Pick<HostedSite, 'files' | 'title' | 'totalSize'>;
+  className?: string;
+  compact?: boolean;
+}) {
+  const pdf = site.files.find(f => f.path?.toLowerCase().endsWith('.pdf'));
+  const sizeMb = pdf ? (pdf.size / 1024 / 1024).toFixed(1) : null;
+
+  if (compact) {
+    return (
+      <div
+        className={className}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: 'linear-gradient(135deg, #dc2626 0%, #991b1b 100%)',
+        }}
+      >
+        <FileText size={20} color="#fff" strokeWidth={2.2} />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={className}
+      style={{
+        position: 'relative',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 12,
+        background:
+          'radial-gradient(120% 80% at 50% 0%, rgba(220, 38, 38, 0.18) 0%, rgba(127, 29, 29, 0.06) 60%, transparent 100%), linear-gradient(180deg, #1a1216 0%, #0f0a0c 100%)',
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        style={{
+          width: 56,
+          height: 68,
+          borderRadius: 8,
+          background: 'linear-gradient(135deg, #ef4444 0%, #b91c1c 100%)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          boxShadow: '0 8px 24px rgba(220, 38, 38, 0.35), inset 0 1px 0 rgba(255,255,255,0.15)',
+          position: 'relative',
+        }}
+      >
+        <span
+          style={{
+            color: '#fff',
+            fontSize: 13,
+            fontWeight: 800,
+            letterSpacing: 1,
+            fontFamily: '-apple-system, BlinkMacSystemFont, system-ui, sans-serif',
+          }}
+        >
+          PDF
+        </span>
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            right: 0,
+            width: 14,
+            height: 14,
+            background: 'rgba(255,255,255,0.18)',
+            borderBottomLeftRadius: 6,
+            borderTopRightRadius: 8,
+          }}
+        />
+      </div>
+      {sizeMb && (
+        <span
+          style={{
+            color: 'rgba(255,255,255,0.55)',
+            fontSize: 11,
+            fontFamily: '-apple-system, BlinkMacSystemFont, system-ui, sans-serif',
+          }}
+        >
+          {sizeMb} MB · PDF 文档
+        </span>
+      )}
+    </div>
+  );
+}

--- a/prd-admin/src/components/PdfThumbnail.tsx
+++ b/prd-admin/src/components/PdfThumbnail.tsx
@@ -1,9 +1,19 @@
 import { FileText } from 'lucide-react';
 import type { HostedSite } from '@/services/real/webPages';
 
-export function isPdfSite(site: Pick<HostedSite, 'files'>): boolean {
-  if (!site.files || site.files.length === 0) return false;
-  return site.files.some(f => f.path?.toLowerCase().endsWith('.pdf'));
+// 严格匹配后端 BuildWrapperZip 生成的 wrapper 形状，避免把"含 PDF 子文件的
+// 正常 ZIP 站"误判（Codex P2 反馈 #612）：
+//   - entryFile == "index.html"
+//   - 恰好 2 个文件
+//   - 一个 index.html + 另一个在根目录的 .pdf
+export function isPdfSite(site: Pick<HostedSite, 'files' | 'entryFile'>): boolean {
+  if (!site.files || site.files.length !== 2) return false;
+  if (site.entryFile?.toLowerCase() !== 'index.html') return false;
+  const hasIndex = site.files.some(f => f.path?.toLowerCase() === 'index.html');
+  const hasRootPdf = site.files.some(f =>
+    !!f.path && !f.path.includes('/') && f.path.toLowerCase().endsWith('.pdf'),
+  );
+  return hasIndex && hasRootPdf;
 }
 
 export function PdfThumbnail({

--- a/prd-admin/src/components/PdfThumbnail.tsx
+++ b/prd-admin/src/components/PdfThumbnail.tsx
@@ -1,22 +1,24 @@
 import { FileText } from 'lucide-react';
 import type { HostedSite } from '@/services/real/webPages';
 
-export function isPdfSite(site: Pick<HostedSite, 'files' | 'entryFile'>): boolean {
+export function isPdfSite(site: Pick<HostedSite, 'files'>): boolean {
   if (!site.files || site.files.length === 0) return false;
   return site.files.some(f => f.path?.toLowerCase().endsWith('.pdf'));
 }
 
 export function PdfThumbnail({
-  site,
+  sizeBytes,
   className,
   compact = false,
 }: {
-  site: Pick<HostedSite, 'files' | 'title' | 'totalSize'>;
+  /** 优先用 PDF 文件本身大小；公开页等场景没有文件清单时用站点总大小（误差可忽略） */
+  sizeBytes?: number;
   className?: string;
   compact?: boolean;
 }) {
-  const pdf = site.files.find(f => f.path?.toLowerCase().endsWith('.pdf'));
-  const sizeMb = pdf ? (pdf.size / 1024 / 1024).toFixed(1) : null;
+  const sizeMb = typeof sizeBytes === 'number' && sizeBytes > 0
+    ? (sizeBytes / 1024 / 1024).toFixed(1)
+    : null;
 
   if (compact) {
     return (

--- a/prd-admin/src/components/PdfThumbnail.tsx
+++ b/prd-admin/src/components/PdfThumbnail.tsx
@@ -1,19 +1,10 @@
 import { FileText } from 'lucide-react';
 import type { HostedSite } from '@/services/real/webPages';
 
-// 严格匹配后端 BuildWrapperZip 生成的 wrapper 形状，避免把"含 PDF 子文件的
-// 正常 ZIP 站"误判（Codex P2 反馈 #612）：
-//   - entryFile == "index.html"
-//   - 恰好 2 个文件
-//   - 一个 index.html + 另一个在根目录的 .pdf
-export function isPdfSite(site: Pick<HostedSite, 'files' | 'entryFile'>): boolean {
-  if (!site.files || site.files.length !== 2) return false;
-  if (site.entryFile?.toLowerCase() !== 'index.html') return false;
-  const hasIndex = site.files.some(f => f.path?.toLowerCase() === 'index.html');
-  const hasRootPdf = site.files.some(f =>
-    !!f.path && !f.path.includes('/') && f.path.toLowerCase().endsWith('.pdf'),
-  );
-  return hasIndex && hasRootPdf;
+// 只看后端 marker 字段，不靠 ZIP 文件形状——避免把"用户上传的 index.html + report.pdf"
+// 这种 2 文件普通 ZIP 误判为系统自动包装的 PDF 站（Codex P2 反复抓到，PR #612）。
+export function isPdfSite(site: Pick<HostedSite, 'wrappedAssetType'>): boolean {
+  return site.wrappedAssetType?.toLowerCase() === 'pdf';
 }
 
 export function PdfThumbnail({

--- a/prd-admin/src/pages/PublicProfilePage.tsx
+++ b/prd-admin/src/pages/PublicProfilePage.tsx
@@ -28,6 +28,7 @@ import {
   type LucideIcon,
 } from 'lucide-react';
 import { SitePreview } from '@/components/SitePreview';
+import { PdfThumbnail } from '@/components/PdfThumbnail';
 import { useAuthStore } from '@/stores/authStore';
 import { resolveBackgroundTheme } from './public-profile/profileBackgrounds';
 import { OwnerDecorator } from './public-profile/OwnerDecorator';
@@ -379,6 +380,8 @@ function SitesGrid({
                 alt={s.title}
                 className="absolute inset-0 h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
               />
+            ) : s.isPdfWrapper ? (
+              <PdfThumbnail sizeBytes={s.totalSize} className="absolute inset-0 h-full w-full" />
             ) : (
               <SitePreview url={s.siteUrl} className="h-full w-full" />
             )}

--- a/prd-admin/src/pages/ShareViewPage.tsx
+++ b/prd-admin/src/pages/ShareViewPage.tsx
@@ -330,7 +330,7 @@ export default function ShareViewPage() {
               </button>
             )}
             <a
-              href={site.siteUrl}
+              href={site.pdfAssetUrl || site.siteUrl}
               target="_blank"
               rel="noopener noreferrer"
               style={{ display: 'flex', alignItems: 'center', gap: 4, color: '#3b82f6', fontSize: 13, textDecoration: 'none' }}
@@ -340,12 +340,15 @@ export default function ShareViewPage() {
             </a>
           </div>
         </div>
-        {/* Iframe */}
+        {/* Iframe
+            PDF 包装站走直链：后端把 PDF 包装成 index.html + .pdf 的双文件结构，
+            如果这里仍 iframe 到 siteUrl(index.html) + sandbox，壳子里的 <iframe src=".pdf">
+            会被 Chrome 屏蔽 PDF Viewer。直接指向 PDF URL、不加 sandbox，让浏览器原生 PDF Viewer 接管。 */}
         <iframe
-          src={site.siteUrl}
+          src={site.pdfAssetUrl || site.siteUrl}
           title={site.title}
           style={{ flex: 1, border: 'none', width: '100%' }}
-          sandbox="allow-scripts allow-same-origin allow-popups allow-forms"
+          sandbox={site.pdfAssetUrl ? undefined : 'allow-scripts allow-same-origin allow-popups allow-forms'}
         />
       </div>
     );

--- a/prd-admin/src/pages/WebPagesPage.tsx
+++ b/prd-admin/src/pages/WebPagesPage.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/design/Button';
 import { Badge } from '@/components/design/Badge';
 import { PageHeader } from '@/components/design/PageHeader';
 import { SitePreview } from '@/components/SitePreview';
+import { PdfThumbnail, isPdfSite } from '@/components/PdfThumbnail';
 import { Dialog } from '@/components/ui/Dialog';
 import {
   uploadSite,
@@ -836,6 +837,8 @@ function SiteCard({ site, selected, fresh, onSelect, onTogglePublic, onEdit, onD
               alt=""
               className="absolute inset-0 h-full w-full object-cover transition-transform duration-700 group-hover:scale-[1.035]"
             />
+          ) : isPdfSite(site) ? (
+            <PdfThumbnail site={site} className="absolute inset-0 h-full w-full" />
           ) : (
             <SitePreview url={site.siteUrl} className="h-full w-full transition-transform duration-700 group-hover:scale-[1.035]" />
           )}
@@ -1032,6 +1035,8 @@ function SiteListItem({ site, selected, onSelect, onEdit, onDelete, onShare, onQ
 
       {site.coverImageUrl ? (
         <img src={site.coverImageUrl} alt="" className="shrink-0 w-10 h-10 rounded object-cover" />
+      ) : isPdfSite(site) ? (
+        <PdfThumbnail site={site} className="shrink-0 w-10 h-10 rounded overflow-hidden" compact />
       ) : (
         <div className="shrink-0 w-10 h-10 rounded overflow-hidden" style={{ background: 'var(--bg-sunken)' }}>
           <SitePreview url={site.siteUrl} className="w-full h-full" />

--- a/prd-admin/src/pages/WebPagesPage.tsx
+++ b/prd-admin/src/pages/WebPagesPage.tsx
@@ -838,7 +838,10 @@ function SiteCard({ site, selected, fresh, onSelect, onTogglePublic, onEdit, onD
               className="absolute inset-0 h-full w-full object-cover transition-transform duration-700 group-hover:scale-[1.035]"
             />
           ) : isPdfSite(site) ? (
-            <PdfThumbnail site={site} className="absolute inset-0 h-full w-full" />
+            <PdfThumbnail
+              sizeBytes={site.files.find(f => f.path?.toLowerCase().endsWith('.pdf'))?.size ?? site.totalSize}
+              className="absolute inset-0 h-full w-full"
+            />
           ) : (
             <SitePreview url={site.siteUrl} className="h-full w-full transition-transform duration-700 group-hover:scale-[1.035]" />
           )}
@@ -1036,7 +1039,7 @@ function SiteListItem({ site, selected, onSelect, onEdit, onDelete, onShare, onQ
       {site.coverImageUrl ? (
         <img src={site.coverImageUrl} alt="" className="shrink-0 w-10 h-10 rounded object-cover" />
       ) : isPdfSite(site) ? (
-        <PdfThumbnail site={site} className="shrink-0 w-10 h-10 rounded overflow-hidden" compact />
+        <PdfThumbnail className="shrink-0 w-10 h-10 rounded overflow-hidden" compact />
       ) : (
         <div className="shrink-0 w-10 h-10 rounded overflow-hidden" style={{ background: 'var(--bg-sunken)' }}>
           <SitePreview url={site.siteUrl} className="w-full h-full" />

--- a/prd-admin/src/services/real/publicProfile.ts
+++ b/prd-admin/src/services/real/publicProfile.ts
@@ -41,6 +41,9 @@ export interface PublicSite {
   viewCount: number;
   publishedAt?: string | null;
   updatedAt: string;
+  /** 是否为 PDF 包装站点（前端据此渲染 PDF 占位卡，避免嵌套 iframe 破图） */
+  isPdfWrapper?: boolean;
+  totalSize?: number;
 }
 
 export interface PublicSkill {

--- a/prd-admin/src/services/real/webPages.ts
+++ b/prd-admin/src/services/real/webPages.ts
@@ -230,6 +230,9 @@ export interface SharedSiteInfo {
   totalSize: number;
   fileCount: number;
   coverImageUrl?: string;
+  // 仅当本站点是「PDF 包装站」时填充。前端应直接 iframe 这个 URL，
+  // 不能走 siteUrl + sandbox 嵌套——会被 Chrome 屏蔽 PDF Viewer。
+  pdfAssetUrl?: string;
 }
 
 export interface ShareViewData {

--- a/prd-admin/src/services/real/webPages.ts
+++ b/prd-admin/src/services/real/webPages.ts
@@ -20,6 +20,8 @@ export interface HostedSite {
   sourceRef?: string;
   cosPrefix: string;
   entryFile: string;
+  /** 自动包装的资产类型 ("pdf" / "video" / "markdown" / undefined=非包装站)；用于区分用户上传的"index.html + .pdf" 与系统自动包装的 PDF 壳子 */
+  wrappedAssetType?: string;
   siteUrl: string;
   files: HostedSiteFile[];
   totalSize: number;

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/PublicProfileController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/PublicProfileController.cs
@@ -135,6 +135,12 @@ public class PublicProfileController : ControllerBase
                     viewCount = s.ViewCount,
                     publishedAt = s.PublishedAt,
                     updatedAt = s.UpdatedAt,
+                    // 标记本站点是「PDF 包装站」，前端据此渲染 PDF 占位卡而不是
+                    // 走嵌套 iframe（会被 Chrome 屏蔽，公开页同样会破图）。
+                    isPdfWrapper = s.Files.Any(f =>
+                        !string.IsNullOrEmpty(f.Path) &&
+                        f.Path.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase)),
+                    totalSize = s.TotalSize,
                 }).ToList(),
                 total = sitesTask.Result.Count,
             },

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/PublicProfileController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/PublicProfileController.cs
@@ -4,6 +4,7 @@ using MongoDB.Driver;
 using PrdAgent.Core.Interfaces;
 using PrdAgent.Core.Models;
 using PrdAgent.Infrastructure.Database;
+using PrdAgent.Infrastructure.Services;
 
 namespace PrdAgent.Api.Controllers.Api;
 
@@ -137,9 +138,9 @@ public class PublicProfileController : ControllerBase
                     updatedAt = s.UpdatedAt,
                     // 标记本站点是「PDF 包装站」，前端据此渲染 PDF 占位卡而不是
                     // 走嵌套 iframe（会被 Chrome 屏蔽，公开页同样会破图）。
-                    isPdfWrapper = s.Files.Any(f =>
-                        !string.IsNullOrEmpty(f.Path) &&
-                        f.Path.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase)),
+                    // 严格匹配 wrapper 形状（HostedSiteService.IsPdfWrapperSite 同款逻辑），
+                    // 避免误判"含 PDF 子文件的普通 ZIP 站"。
+                    isPdfWrapper = HostedSiteService.IsPdfWrapperSite(s, out _),
                     totalSize = s.TotalSize,
                 }).ToList(),
                 total = sitesTask.Result.Count,

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/WebPagesController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/WebPagesController.cs
@@ -101,7 +101,12 @@ public class WebPagesController : ControllerBase
                     ? Path.GetFileNameWithoutExtension(file.FileName)
                     : title!.Trim();
                 var zipBytes = BuildWrapperZip(file.FileName, fileBytes, ext, effectiveTitle);
-                site = await _siteService.CreateFromZipAsync(userId, zipBytes, effectiveTitle, description, folder, tagList);
+                // 写 marker，下游靠它判定包装站，避免"用户上传的 index.html + report.pdf"被误判
+                var assetType = ext == ".pdf" ? "pdf"
+                    : VideoExtensions.Contains(ext) ? "video"
+                    : MarkdownExtensions.Contains(ext) ? "markdown"
+                    : null;
+                site = await _siteService.CreateFromZipAsync(userId, zipBytes, effectiveTitle, description, folder, tagList, assetType);
             }
             else
             {

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/WebPagesController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/WebPagesController.cs
@@ -377,15 +377,22 @@ public class WebPagesController : ControllerBase
         var uploadName = file.FileName;
 
         // 视频 / PDF / Markdown：包装成 ZIP（保持与 Upload 一致的行为）
+        string? wrappedAssetType = null;
         if (VideoExtensions.Contains(ext) || MarkdownExtensions.Contains(ext) || ext == ".pdf")
         {
             fileBytes = BuildWrapperZip(file.FileName, fileBytes, ext, title: null);
             uploadName = Path.ChangeExtension(file.FileName, ".zip");
+            wrappedAssetType = ext == ".pdf" ? "pdf"
+                : VideoExtensions.Contains(ext) ? "video"
+                : MarkdownExtensions.Contains(ext) ? "markdown"
+                : null;
         }
 
         try
         {
-            var updated = await _siteService.ReuploadAsync(id, GetUserId(), fileBytes, uploadName);
+            // 显式传 wrappedAssetType，普通 HTML/ZIP 传 null 会清空旧 marker（避免站点
+            // 从 PDF 包装改成 HTML 后前端还在渲染 PDF 占位，Codex P2 #612 抓到）
+            var updated = await _siteService.ReuploadAsync(id, GetUserId(), fileBytes, uploadName, wrappedAssetType);
             return Ok(ApiResponse<object>.Ok(updated));
         }
         catch (KeyNotFoundException)

--- a/prd-api/src/PrdAgent.Api/Program.cs
+++ b/prd-api/src/PrdAgent.Api/Program.cs
@@ -239,6 +239,9 @@ builder.Services.AddScoped<PrdAgent.Api.Services.WorkflowAiFillService>();
 // 工作流调度轮询：每 30 秒扫一次到期的 once / cron 调度，自动入队
 builder.Services.AddHostedService<PrdAgent.Api.Services.WorkflowScheduleWorker>();
 
+// 一次性回填存量 PDF 包装站的 WrappedAssetType marker（PR #612）
+builder.Services.AddHostedService<PrdAgent.Api.Services.HostedSiteBackfillService>();
+
 // 涌现探索器
 builder.Services.AddSingleton<PrdAgent.Api.Services.SystemCapabilityScanner>();
 builder.Services.AddScoped<PrdAgent.Api.Services.EmergenceService>();

--- a/prd-api/src/PrdAgent.Api/Services/HostedSiteBackfillService.cs
+++ b/prd-api/src/PrdAgent.Api/Services/HostedSiteBackfillService.cs
@@ -1,0 +1,46 @@
+using Microsoft.Extensions.Logging;
+using PrdAgent.Core.Interfaces;
+
+namespace PrdAgent.Api.Services;
+
+/// <summary>
+/// 一次性启动任务：回填 PR #612 之前创建的 PDF 包装站的 WrappedAssetType marker。
+/// 启动延迟 30s 让数据库连接稳定后再扫描；扫描自身幂等（已带 marker 的会跳过），
+/// 重复启动不会出问题。回填完成后该服务进入空闲状态，不再做任何事。
+/// </summary>
+public class HostedSiteBackfillService : BackgroundService
+{
+    private readonly IServiceProvider _services;
+    private readonly ILogger<HostedSiteBackfillService> _logger;
+
+    public HostedSiteBackfillService(IServiceProvider services, ILogger<HostedSiteBackfillService> logger)
+    {
+        _services = services;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            await Task.Delay(TimeSpan.FromSeconds(30), stoppingToken);
+        }
+        catch (OperationCanceledException) { return; }
+
+        try
+        {
+            using var scope = _services.CreateScope();
+            var siteService = scope.ServiceProvider.GetRequiredService<IHostedSiteService>();
+            var count = await siteService.BackfillPdfWrapperMarkersAsync(stoppingToken);
+            if (count > 0)
+            {
+                _logger.LogInformation("HostedSiteBackfillService: 已回填 {Count} 个 PDF 包装站 marker", count);
+            }
+        }
+        catch (OperationCanceledException) { /* 正常停机 */ }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "HostedSiteBackfillService 回填任务失败");
+        }
+    }
+}

--- a/prd-api/src/PrdAgent.Core/Interfaces/IHostedSiteService.cs
+++ b/prd-api/src/PrdAgent.Core/Interfaces/IHostedSiteService.cs
@@ -33,11 +33,15 @@ public interface IHostedSiteService
 
     // ── 替换内容 ──
 
-    /// <summary>重新上传站点文件（HTML 或 ZIP），替换原有内容</summary>
+    /// <summary>重新上传站点文件（HTML 或 ZIP），替换原有内容；wrappedAssetType 由调用方按原始资产类型显式传入（"pdf"/"video"/"markdown"），普通 HTML/ZIP 传 null 会清空 marker</summary>
     Task<HostedSite> ReuploadAsync(
         string siteId, string userId,
         byte[] fileBytes, string fileName,
+        string? wrappedAssetType = null,
         CancellationToken ct = default);
+
+    /// <summary>回填存量 PDF 包装站的 WrappedAssetType marker（一次性维护任务，由 HostedSiteBackfillService 启动调用）</summary>
+    Task<int> BackfillPdfWrapperMarkersAsync(CancellationToken ct = default);
 
     // ── 查询 ──
 

--- a/prd-api/src/PrdAgent.Core/Interfaces/IHostedSiteService.cs
+++ b/prd-api/src/PrdAgent.Core/Interfaces/IHostedSiteService.cs
@@ -16,10 +16,11 @@ public interface IHostedSiteService
         string? title, string? description, string? folder, List<string>? tags,
         CancellationToken ct = default);
 
-    /// <summary>从 ZIP 文件字节创建站点</summary>
+    /// <summary>从 ZIP 文件字节创建站点；wrappedAssetType 由调用方在生成"壳子+资产"包装 ZIP 时显式传入</summary>
     Task<HostedSite> CreateFromZipAsync(
         string userId, byte[] zipBytes,
         string? title, string? description, string? folder, List<string>? tags,
+        string? wrappedAssetType = null,
         CancellationToken ct = default);
 
     /// <summary>从 HTML 字符串创建站点（供工作流/Agent 调用）</summary>

--- a/prd-api/src/PrdAgent.Core/Interfaces/IHostedSiteService.cs
+++ b/prd-api/src/PrdAgent.Core/Interfaces/IHostedSiteService.cs
@@ -134,4 +134,11 @@ public class SharedSiteInfo
     public long TotalSize { get; set; }
     public int FileCount { get; set; }
     public string? CoverImageUrl { get; set; }
+
+    /// <summary>
+    /// 仅当本站点是「PDF 包装站」（index.html 壳子 + 单个 .pdf 资产）时填充，
+    /// 指向真实 PDF 文件的直链。前端拿到后应直接 iframe 这个 URL，让浏览器原生
+    /// PDF Viewer 接管；否则嵌套 iframe + sandbox 会被 Chrome 屏蔽。
+    /// </summary>
+    public string? PdfAssetUrl { get; set; }
 }

--- a/prd-api/src/PrdAgent.Core/Models/WebPage.cs
+++ b/prd-api/src/PrdAgent.Core/Models/WebPage.cs
@@ -31,6 +31,15 @@ public class HostedSite
     /// <summary>入口文件名 (默认 index.html)</summary>
     public string EntryFile { get; set; } = "index.html";
 
+    /// <summary>
+    /// 自动包装的资产类型（"pdf" / "video" / "markdown" / null=非包装站）。
+    /// 当用户上传单个 PDF/视频/Markdown 时，Controller 会现场生成 index.html
+    /// 壳子 + 原文件，打包成 ZIP 走托管路径；此字段标记原始资产类型，下游
+    /// 据此选直接打开原始文件 URL（避免 sandbox iframe 嵌套被屏蔽）或走
+    /// 专用缩略图占位。值由 BuildWrapperZip 调用方写入。
+    /// </summary>
+    public string? WrappedAssetType { get; set; }
+
     /// <summary>完整入口 URL (COS public URL + cosPrefix + entryFile)</summary>
     public string SiteUrl { get; set; } = string.Empty;
 

--- a/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
@@ -593,7 +593,7 @@ public class HostedSiteService : IHostedSiteService
     private string? TryBuildPdfAssetUrl(HostedSite site)
         => IsPdfWrapperSite(site, out var pdf) ? _storage.BuildUrlForKey(pdf!.CosKey) : null;
 
-    internal static bool IsPdfWrapperSite(HostedSite site, out HostedSiteFile? pdf)
+    public static bool IsPdfWrapperSite(HostedSite site, out HostedSiteFile? pdf)
     {
         pdf = null;
         if (site.Files == null || site.Files.Count != 2) return false;

--- a/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
@@ -191,7 +191,8 @@ public class HostedSiteService : IHostedSiteService
     public async Task<HostedSite> ReuploadAsync(
         string siteId, string userId,
         byte[] fileBytes, string fileName,
-        CancellationToken ct)
+        string? wrappedAssetType = null,
+        CancellationToken ct = default)
     {
         var site = await _db.HostedSites.Find(x => x.Id == siteId && x.OwnerUserId == userId).FirstOrDefaultAsync(ct);
         if (site == null)
@@ -237,6 +238,12 @@ public class HostedSiteService : IHostedSiteService
 
         var siteUrl = _storage.BuildUrlForKey(_storage.BuildSiteKey(siteId, entryFile));
 
+        // wrappedAssetType 必须显式覆盖（包括清空）：
+        // - 用户把 PDF 重传到原 HTML 站，应写入 "pdf" 让分享/缩略走 PDF 路径
+        // - 用户把 HTML 重传覆盖原 PDF 包装站，应清空 marker，避免前端继续渲染 PDF 占位
+        var normalizedType = string.IsNullOrWhiteSpace(wrappedAssetType)
+            ? null : wrappedAssetType.Trim().ToLowerInvariant();
+
         await _db.HostedSites.UpdateOneAsync(
             x => x.Id == siteId,
             Builders<HostedSite>.Update
@@ -244,6 +251,7 @@ public class HostedSiteService : IHostedSiteService
                 .Set(x => x.SiteUrl, siteUrl)
                 .Set(x => x.Files, siteFiles)
                 .Set(x => x.TotalSize, totalSize)
+                .Set(x => x.WrappedAssetType, normalizedType)
                 .Set(x => x.UpdatedAt, DateTime.UtcNow),
             cancellationToken: ct);
 
@@ -609,6 +617,68 @@ public class HostedSiteService : IHostedSiteService
         return true;
     }
 
+    // 老数据回填：本 PR 引入 WrappedAssetType marker 之前，所有 PDF 包装站
+    // marker 都是 null。这里扫描"形状疑似 PDF 包装站"的存量数据：
+    //   - WrappedAssetType is null
+    //   - EntryFile == "index.html"
+    //   - 恰好 2 个文件，一个 index.html、一个根目录 .pdf
+    // 然后下载 index.html，匹配 BuildPdfWrapper 模板独有的特征字符串，命中
+    // 才回填 marker。特征字符串选了"浏览器不支持内嵌 PDF"——只有该模板会有，
+    // 用户自己写的 landing.html 几乎不会撞。返回成功回填的站点数。
+    private const string PdfWrapperSignature = "浏览器不支持内嵌 PDF";
+
+    public async Task<int> BackfillPdfWrapperMarkersAsync(CancellationToken ct = default)
+    {
+        var fb = Builders<HostedSite>.Filter;
+        // Mongo 的 {field: null} 同时匹配 null 与字段缺失，覆盖未升级的存量数据
+        var filter = fb.And(
+            fb.Eq(x => x.WrappedAssetType, (string?)null),
+            fb.Eq(x => x.EntryFile, "index.html"),
+            fb.Size(x => x.Files, 2));
+
+        var candidates = await _db.HostedSites.Find(filter).ToListAsync(ct);
+        var backfilled = 0;
+
+        foreach (var site in candidates)
+        {
+            if (ct.IsCancellationRequested) break;
+
+            var pdf = site.Files.FirstOrDefault(f =>
+                !string.IsNullOrEmpty(f.Path) &&
+                !f.Path.Contains('/') &&
+                f.Path.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase));
+            var index = site.Files.FirstOrDefault(f =>
+                string.Equals(f.Path, "index.html", StringComparison.OrdinalIgnoreCase));
+            if (pdf == null || index == null || string.IsNullOrEmpty(index.CosKey)) continue;
+
+            try
+            {
+                var bytes = await _storage.TryDownloadBytesAsync(index.CosKey, ct);
+                if (bytes == null || bytes.Length == 0) continue;
+                var html = System.Text.Encoding.UTF8.GetString(bytes);
+                if (!html.Contains(PdfWrapperSignature, StringComparison.Ordinal)) continue;
+
+                await _db.HostedSites.UpdateOneAsync(
+                    x => x.Id == site.Id,
+                    Builders<HostedSite>.Update
+                        .Set(x => x.WrappedAssetType, "pdf"),
+                    cancellationToken: ct);
+                backfilled++;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "PDF wrapper marker 回填失败: site={SiteId}", site.Id);
+            }
+        }
+
+        if (backfilled > 0 || candidates.Count > 0)
+        {
+            _logger.LogInformation("PDF wrapper marker 回填完成: candidates={Candidates} backfilled={Backfilled}",
+                candidates.Count, backfilled);
+        }
+        return backfilled;
+    }
+
     // ─────────────────────────────────────────────
     // 观看记录
     // ─────────────────────────────────────────────
@@ -703,6 +773,7 @@ public class HostedSiteService : IHostedSiteService
                 Tags = original.Tags.ToList(),
                 Folder = original.Folder,
                 CoverImageUrl = original.CoverImageUrl,
+                WrappedAssetType = original.WrappedAssetType,
                 OwnerUserId = userId,
             };
             savedSites.Add(saved);

--- a/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
@@ -549,19 +549,19 @@ public class HostedSiteService : IHostedSiteService
         if (share.SiteId != null && !siteIds.Contains(share.SiteId))
             siteIds.Insert(0, share.SiteId);
 
-        var sites = await _db.HostedSites.Find(x => siteIds.Contains(x.Id))
-            .Project(Builders<HostedSite>.Projection.Expression(s => new SharedSiteInfo
-            {
-                Id = s.Id,
-                Title = s.Title,
-                Description = s.Description,
-                SiteUrl = s.SiteUrl,
-                EntryFile = s.EntryFile,
-                TotalSize = s.TotalSize,
-                FileCount = s.Files.Count,
-                CoverImageUrl = s.CoverImageUrl,
-            }))
-            .ToListAsync(ct);
+        var rawSites = await _db.HostedSites.Find(x => siteIds.Contains(x.Id)).ToListAsync(ct);
+        var sites = rawSites.Select(s => new SharedSiteInfo
+        {
+            Id = s.Id,
+            Title = s.Title,
+            Description = s.Description,
+            SiteUrl = s.SiteUrl,
+            EntryFile = s.EntryFile,
+            TotalSize = s.TotalSize,
+            FileCount = s.Files.Count,
+            CoverImageUrl = s.CoverImageUrl,
+            PdfAssetUrl = TryBuildPdfAssetUrl(s),
+        }).ToList();
 
         await _db.HostedSites.UpdateManyAsync(
             x => siteIds.Contains(x.Id),
@@ -578,6 +578,22 @@ public class HostedSiteService : IHostedSiteService
             CreatedByName = share.CreatedByName ?? await LookupDisplayNameAsync(share.CreatedBy, ct),
             Sites = sites,
         };
+    }
+
+    // PDF 包装站识别：上传 .pdf 时控制器会把它打包成「index.html 壳子 + 原 PDF」
+    // 的 ZIP（见 WebPagesController.BuildWrapperZip / BuildPdfWrapper）。壳子里的
+    // `<iframe src="xxx.pdf">` 在被 ShareViewPage 的 sandbox iframe 二次嵌套时，
+    // Chrome PDF Viewer 会被屏蔽（"此页面已被 Chrome 屏蔽"）。这里把真实 PDF 文件
+    // 的 URL 暴露给前端，前端检测到后绕过壳子直接 iframe，让浏览器原生 PDF Viewer 接管。
+    private string? TryBuildPdfAssetUrl(HostedSite site)
+    {
+        if (site.Files == null || site.Files.Count == 0) return null;
+        var pdf = site.Files.FirstOrDefault(f =>
+            !string.IsNullOrEmpty(f.Path) &&
+            f.Path.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase));
+        if (pdf == null) return null;
+        if (string.IsNullOrEmpty(pdf.CosKey)) return null;
+        return _storage.BuildUrlForKey(pdf.CosKey);
     }
 
     // ─────────────────────────────────────────────

--- a/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
@@ -108,7 +108,8 @@ public class HostedSiteService : IHostedSiteService
     public async Task<HostedSite> CreateFromZipAsync(
         string userId, byte[] zipBytes,
         string? title, string? description, string? folder, List<string>? tags,
-        CancellationToken ct)
+        string? wrappedAssetType = null,
+        CancellationToken ct = default)
     {
         var siteId = Guid.NewGuid().ToString("N");
         var result = await ExtractAndUploadZip(siteId, zipBytes);
@@ -132,6 +133,7 @@ public class HostedSiteService : IHostedSiteService
             Tags = tags ?? new(),
             Folder = folder?.Trim(),
             OwnerUserId = userId,
+            WrappedAssetType = string.IsNullOrWhiteSpace(wrappedAssetType) ? null : wrappedAssetType.Trim().ToLowerInvariant(),
         };
 
         await _db.HostedSites.InsertOneAsync(site, cancellationToken: ct);
@@ -581,27 +583,21 @@ public class HostedSiteService : IHostedSiteService
     }
 
     // PDF 包装站识别：上传 .pdf 时控制器会把它打包成「index.html 壳子 + 原 PDF」
-    // 的 ZIP（见 WebPagesController.BuildWrapperZip / BuildPdfWrapper）。壳子里的
-    // `<iframe src="xxx.pdf">` 在被 ShareViewPage 的 sandbox iframe 二次嵌套时，
+    // 的 ZIP，并在 site.WrappedAssetType 写入 "pdf" marker（见 WebPagesController.Upload）。
+    // 壳子里的 `<iframe src="xxx.pdf">` 在被 ShareViewPage 的 sandbox iframe 二次嵌套时，
     // Chrome PDF Viewer 会被屏蔽（"此页面已被 Chrome 屏蔽"）。这里把真实 PDF 文件
     // 的 URL 暴露给前端，前端检测到后绕过壳子直接 iframe，让浏览器原生 PDF Viewer 接管。
     //
-    // 严格匹配 wrapper 形状，避免把"含 PDF 子文件的正常 ZIP 站"误判（Codex P2 反馈）：
-    //   - EntryFile == "index.html"
-    //   - 恰好 2 个文件
-    //   - 一个是 "index.html"，另一个在根目录（path 不含 '/'）且 .pdf 结尾
+    // 只看 marker，不依赖 ZIP 文件形状——避免把"用户上传的 custom landing.html + report.pdf"
+    // 这种 2 文件普通 ZIP 误判为包装站（Codex P2 反复抓到，PR #612）。
     private string? TryBuildPdfAssetUrl(HostedSite site)
         => IsPdfWrapperSite(site, out var pdf) ? _storage.BuildUrlForKey(pdf!.CosKey) : null;
 
     public static bool IsPdfWrapperSite(HostedSite site, out HostedSiteFile? pdf)
     {
         pdf = null;
-        if (site.Files == null || site.Files.Count != 2) return false;
-        if (!string.Equals(site.EntryFile, "index.html", StringComparison.OrdinalIgnoreCase)) return false;
-
-        var hasIndex = site.Files.Any(f =>
-            string.Equals(f.Path, "index.html", StringComparison.OrdinalIgnoreCase));
-        if (!hasIndex) return false;
+        if (!string.Equals(site.WrappedAssetType, "pdf", StringComparison.OrdinalIgnoreCase)) return false;
+        if (site.Files == null) return false;
 
         var candidate = site.Files.FirstOrDefault(f =>
             !string.IsNullOrEmpty(f.Path) &&

--- a/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
@@ -585,15 +585,32 @@ public class HostedSiteService : IHostedSiteService
     // `<iframe src="xxx.pdf">` 在被 ShareViewPage 的 sandbox iframe 二次嵌套时，
     // Chrome PDF Viewer 会被屏蔽（"此页面已被 Chrome 屏蔽"）。这里把真实 PDF 文件
     // 的 URL 暴露给前端，前端检测到后绕过壳子直接 iframe，让浏览器原生 PDF Viewer 接管。
+    //
+    // 严格匹配 wrapper 形状，避免把"含 PDF 子文件的正常 ZIP 站"误判（Codex P2 反馈）：
+    //   - EntryFile == "index.html"
+    //   - 恰好 2 个文件
+    //   - 一个是 "index.html"，另一个在根目录（path 不含 '/'）且 .pdf 结尾
     private string? TryBuildPdfAssetUrl(HostedSite site)
+        => IsPdfWrapperSite(site, out var pdf) ? _storage.BuildUrlForKey(pdf!.CosKey) : null;
+
+    internal static bool IsPdfWrapperSite(HostedSite site, out HostedSiteFile? pdf)
     {
-        if (site.Files == null || site.Files.Count == 0) return null;
-        var pdf = site.Files.FirstOrDefault(f =>
+        pdf = null;
+        if (site.Files == null || site.Files.Count != 2) return false;
+        if (!string.Equals(site.EntryFile, "index.html", StringComparison.OrdinalIgnoreCase)) return false;
+
+        var hasIndex = site.Files.Any(f =>
+            string.Equals(f.Path, "index.html", StringComparison.OrdinalIgnoreCase));
+        if (!hasIndex) return false;
+
+        var candidate = site.Files.FirstOrDefault(f =>
             !string.IsNullOrEmpty(f.Path) &&
+            !f.Path.Contains('/') &&
             f.Path.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase));
-        if (pdf == null) return null;
-        if (string.IsNullOrEmpty(pdf.CosKey)) return null;
-        return _storage.BuildUrlForKey(pdf.CosKey);
+        if (candidate == null || string.IsNullOrEmpty(candidate.CosKey)) return false;
+
+        pdf = candidate;
+        return true;
     }
 
     // ─────────────────────────────────────────────

--- a/prd-api/tests/PrdAgent.Api.Tests/Controllers/InfraAgentSessionsControllerTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Controllers/InfraAgentSessionsControllerTests.cs
@@ -16,11 +16,14 @@ public class InfraAgentSessionsControllerTests
     [Fact]
     public void HasRecentHealthyProbe_ShouldTreatRecentlyProbedConnectionAsUsable()
     {
+        // 871ab45 把判定改成看 LongTokenExpiresAt 是否在未来，原测试只塞 LastProbedAt
+        // 已经过时（PR #612 在合并 main 后修）。LastProbeOk + 未过期 token = "可用"。
         var connection = new InfraConnection
         {
             Status = "revoked",
             LastProbeOk = true,
             LastProbedAt = DateTime.UtcNow.AddMinutes(-1),
+            LongTokenExpiresAt = DateTime.UtcNow.AddDays(1),
         };
 
         InfraAgentSessionService.HasRecentHealthyProbe(connection).ShouldBeTrue();


### PR DESCRIPTION
## 摘要

修复网页托管 PDF 站点分享时，因嵌套 iframe + sandbox 导致 Chrome PDF Viewer 被屏蔽的问题。后端新增 `pdfAssetUrl` 直链字段，前端检测到 PDF 包装站时直接 iframe 真实 PDF 文件，让浏览器原生 PDF Viewer 接管。同时为 PDF 站点卡片新增专用占位设计，避免嵌套 iframe 导致的空白破图。

## 改动 diff

### 后端（prd-api）
- `HostedSiteService.cs`：
  - 修改 `GetShareViewData` 方法，改用 LINQ to Objects 而非 MongoDB Projection，新增 `TryBuildPdfAssetUrl` 方法识别 PDF 包装站并返回真实 PDF 文件直链
  - `SharedSiteInfo` 新增 `PdfAssetUrl` 字段（仅 PDF 包装站填充）
- `PublicProfileController.cs`：
  - 公开个人页 API 新增 `isPdfWrapper` 和 `totalSize` 字段，前端据此识别 PDF 站点

### 前端（prd-admin）
- `components/PdfThumbnail.tsx`（新增）：
  - 新增 `isPdfSite` 工具函数识别 PDF 包装站
  - 新增 `PdfThumbnail` 组件，支持标准和紧凑两种模式，展示红色 PDF 徽记 + 文件大小标签
- `pages/ShareViewPage.tsx`：
  - iframe 源改为 `site.pdfAssetUrl || site.siteUrl`，检测到 PDF 包装站时直接指向真实 PDF
  - 移除 PDF 直链场景的 sandbox 属性，让浏览器原生 PDF Viewer 接管
  - 下载链接同步改为 PDF 直链
- `pages/WebPagesPage.tsx`：
  - 网页托管列表卡片改用 `PdfThumbnail` 占位（替代嵌套 iframe 预览）
  - 列表项缩略图同步使用 `PdfThumbnail` 紧凑模式
- `pages/PublicProfilePage.tsx`：
  - 公开个人页 PDF 站点卡片改用 `PdfThumbnail` 占位
- `services/real/webPages.ts` 和 `services/real/publicProfile.ts`：
  - 更新类型定义，新增 `pdfAssetUrl`、`isPdfWrapper`、`totalSize` 字段

### 文档
- 新增 3 个 changelog 碎片文件，分别记录 PDF 分享直链、公开页识别、占位设计三个方面的改动

## 实现细节

1. **PDF 包装站识别**：后端检查文件列表中是否存在 `.pdf` 文件，若存在则构建其 COS 直链返回给前端
2. **嵌套 iframe 问题根因**：PDF 包装站的 index.html 壳子内含 `<iframe src="xxx.pdf">`，当壳子本身被嵌入 sandbox iframe 时，Chrome 会屏蔽内层 PDF Viewer；直接 iframe PDF 文件可绕过此限制
3. **占位设计**：PDF 卡片不再走嵌套 iframe 预览（会导致

https://claude.ai/code/session_013tJpGMokqXjzV4ppYfViei

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches web-page upload/reupload metadata, share-view response shape, and adds a startup backfill job that scans and updates existing records; regressions could affect hosted site rendering and share links if wrapper detection/marker handling is wrong.
> 
> **Overview**
> Shared hosted *PDF wrapper* sites now return a `pdfAssetUrl` direct link from the API and the admin ShareView embeds/opens that URL (and drops `sandbox` only for that case) to avoid Chrome blocking nested PDF viewers.
> 
> Backend introduces a persisted `WrappedAssetType` marker for wrapper ZIPs (set on upload/reupload, propagated on save-from-share), plus a one-time startup `HostedSiteBackfillService` to backfill markers for legacy PDF wrappers and stricter wrapper detection for `IsPdfWrapperSite`.
> 
> Admin UI adds a `PdfThumbnail` placeholder and switches hosted site cards and public profile site cards to use it when the backend marks a site as PDF (`wrappedAssetType` / `isPdfWrapper`), extending TS models accordingly; also updates a small infra test fixture to include `LongTokenExpiresAt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d397e68b98a6828bcc8ad61b3cd1a0fc08181eb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->