### PR TITLE
fix(prd-api): 补 WeeklyPosterController 缺失的 using PrdAgent.Core.Attrib…

### DIFF
--- a/prd-api/src/PrdAgent.Api/Controllers/Api/WeeklyPosterController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/WeeklyPosterController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using MongoDB.Driver;
 using PrdAgent.Api.Extensions;
+using PrdAgent.Core.Attributes;
 using PrdAgent.Core.Interfaces;
 using PrdAgent.Core.Models;
 using PrdAgent.Core.Security;


### PR DESCRIPTION
…utes

AppNames.ReportAgent 引用了 PrdAgent.Core.Attributes 命名空间， 但 using 声明缺失，导致 CS0103 编译失败，API 容器无法启动，
所有端点返回 400/502。

https://claude.ai/code/session_01NfEVw4YwYvpY7dzRdMhSn3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single missing `using` to resolve a compile-time reference for `AdminController`/app identity attributes; no runtime logic changes.
> 
> **Overview**
> Fixes a build-breaking missing import by adding `using PrdAgent.Core.Attributes;` to `WeeklyPosterController.cs`, ensuring the controller’s attribute references compile and the API container can start normally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e063bf6461316f1932eb2eacaf55b128271607c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->