### PR TITLE
每日熵减计划 2026-W20 — spec.short-links 补缺 + 5 条 changelog 入库

### DIFF
--- a/changelogs/.entropy-manifest.yml
+++ b/changelogs/.entropy-manifest.yml
@@ -16,3 +16,8 @@ processed:
   - 2026-05-12_cds-project-card-visual-tokens.md
   - 2026-05-12_cds-project-icons.md
   - 2026-05-12_cds-project-infra-isolation.md
+  - 2026-05-11_report-version-history.md
+  - 2026-05-12_cds-project-list-breathing-room.md
+  - 2026-05-12_cds-railway-onboarding.md
+  - 2026-05-12_cds-railway-sidebar-icons.md
+  - 2026-05-12_cds-self-update-web-build-gate.md

--- a/doc/guide.list.directory.md
+++ b/doc/guide.list.directory.md
@@ -1,6 +1,6 @@
 # MAP 平台文档索引 · 指南
 
-> 最后更新：2026-05-13
+> 最后更新：2026-05-14
 >
 > 本文件是 `doc/` 目录的结构化索引，供外部同步工具（语雀、Confluence 等）消费。
 > 元数据定义见 `doc/index.yml`，命名规范见 `doc/rule.doc-naming.md`。
@@ -68,6 +68,9 @@
 
 - [CDS 多项目数据字典](spec.cds-project-model) `spec.cds-project-model`
   > CDS 多项目数据模型的字段定义与约束
+
+- [统一短链系统规格](spec.short-links) `spec.short-links`
+  > 统一短链系统产品规格，已落地（PR #613）
 
 ### 二、设计文档
 

--- a/doc/index.yml
+++ b/doc/index.yml
@@ -41,6 +41,7 @@ docs:
   spec.cds-lifecycle: CDS 服务生命周期与缓存范围规格
   spec.cds-map-pairing-protocol: CDS MAP 配对协议规格
   spec.cds-project-model: CDS 多项目数据字典
+  spec.short-links: 统一短链系统规格
 
   # ── 二、设计文档 ──
   # 先看核心架构，再看各模块设计


### PR DESCRIPTION
自动生成的每日熵减 PR（2026-05-14）。

## 修复项

- **D2 index.yml 补缺 1 项**：`spec.short-links`（统一短链系统规格，PR #613 已落地）
- **D3 guide.list.directory.md 补缺 1 项**：`spec.short-links` + 更新"最后更新"日期至 2026-05-14
- **D6 changelog 入库 5 条**：
  - `2026-05-11_report-version-history.md`（周报版本记录）
  - `2026-05-12_cds-project-list-breathing-room.md`（项目列表留白修复）
  - `2026-05-12_cds-railway-onboarding.md`（Railway 式部署向导）
  - `2026-05-12_cds-railway-sidebar-icons.md`（侧栏图标修复）
  - `2026-05-12_cds-self-update-web-build-gate.md`（自更新构建门禁修复）

## 跳过项（diff 核验未通过）

- **D3 ghost 项（18 条）**：全部位于 guide.list.directory.md 变更历史表中，属于历史记录，不是活跃文档条目，安全跳过
- **D4 ghost：pnpm**：CLAUDE.md 中 `**pnpm**` 是规则正文强调语，非技能表条目，假阳性跳过

## 验证

全部改动为纯追加行（+10 行，-1 行仅为日期更新），diff 核验无异常删除。

https://claude.ai/code/session_0172JGWU7pcTYvZMeBbDMBx5

---
_Generated by [Claude Code](https://claude.ai/code/session_0172JGWU7pcTYvZMeBbDMBx5)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/index maintenance only (adds missing `spec.short-links` entries, updates an index date, and appends changelog manifest rows) with no runtime code impact.
> 
> **Overview**
> Adds the missing `spec.short-links` document to both `doc/index.yml` and the human-readable `doc/guide.list.directory.md` (including updating the "最后更新" date to 2026-05-14).
> 
> Updates `changelogs/.entropy-manifest.yml` to mark five additional changelog fragments as processed so they won’t be re-imported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b94da1c6b23d912cb9f45bc5ab0e67a9b3fdd9b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->