### PR TITLE
feat(cds): 项目级自动生命周期调度 + 分支停止原因可见性

### DIFF
--- a/cds/src/index.ts
+++ b/cds/src/index.ts
@@ -578,6 +578,12 @@ const autoLifecycleService = new AutoLifecycleService(
         }
       }
       branch.status = 'idle';
+      // 2026-05-14 Cursor Bugbot review 修复：必须同步把 heatState 置 cold。
+      // SchedulerService.getHotBranches() 只看 heatState==='hot'（或
+      // heatState===undefined && status==='running'）。如果这里只改 status
+      // 不改 heatState，调度器仍把这个已停的分支算进 maxHotBranches 容量，
+      // 还会在下一 tick 重复 cool 它、写一条重复的 stop reason。
+      branch.heatState = 'cold';
       stateService.incrementBranchStat(slug, 'stopCount');
       stateService.save();
     },

--- a/cds/src/index.ts
+++ b/cds/src/index.ts
@@ -891,7 +891,16 @@ janitorService.setRemoveFn(async (slug: string) => {
       schedulerService.start();
     }
     janitorService.start();
-    autoLifecycleService.start();
+    // 2026-05-14 Codex review P1 修复：auto-lifecycle 只能在协调者角色
+    // （standalone / scheduler）跑。executor 是 worker 节点，集群共享 state
+    // 时若每个 executor 都扫全部项目跑 auto-stop/publish，会把别的 executor
+    // 拥有的分支也标 idle/cold（executor 侧 registry 没有 master 条目，
+    // stopBranch 还会 fallback 到本地停）。lifecycle 决策必须集中在协调者。
+    if (config.mode !== 'executor') {
+      autoLifecycleService.start();
+    } else {
+      console.log('[auto-lifecycle] skipped on executor node (lifecycle decisions are coordinator-only)');
+    }
     startAutoRestartLoop();
   }
   function stopBackgroundServices(): void {

--- a/cds/src/index.ts
+++ b/cds/src/index.ts
@@ -597,6 +597,16 @@ const autoLifecycleService = new AutoLifecycleService(
         branch.executorId && registry
           ? registry.getAll().find(n => n.id === branch.executorId && n.role !== 'embedded')
           : null;
+      // 2026-05-14 Codex review P2 "Retry when the owning executor is not
+      // registered"：分支有 executorId 但 registry 里查不到（coordinator
+      // 重启 / 漏 heartbeat）时，容器其实还在远端跑，本地 stop 是 no-op。
+      // 此时**不能**走下面的本地 stop 把分支标 idle/cold（会让 auto-lifecycle
+      // 误以为停成功、不再重试）。当作远端停止失败：回滚 + throw，下一拍
+      // 等执行器重新注册后重试。
+      if (branch.executorId && !remoteExecutor) {
+        restoreRunning();
+        throw new Error(`分支 ${slug} 归属执行器 ${branch.executorId} 当前未注册（可能 coordinator 刚重启或漏 heartbeat），稍后重试`);
+      }
       if (remoteExecutor) {
         for (const svc of Object.values(branch.services)) {
           if (svc.status === 'running' || svc.status === 'starting') svc.status = 'stopping';
@@ -654,6 +664,35 @@ const autoLifecycleService = new AutoLifecycleService(
       branch.heatState = 'cold';
       stateService.incrementBranchStat(slug, 'stopCount');
       stateService.save();
+    },
+    // 2026-05-14 用户决策：auto-publish 必须全自动「停源码 → 重建发布版」，
+    // 不靠懒唤醒（懒唤醒路径 index.ts 用 raw profile 不 resolve override）。
+    // 复用 webhook dispatcher 同款"内部 HTTP 自调 /deploy"机制：deploy 路由
+    // 会走 resolveEffectiveProfile，override 已是 release → 重建成发布版。
+    // 不动核心热路径。X-CDS-Trigger=auto-lifecycle 让活动日志能区分来源。
+    redeployBranch: async (slug: string) => {
+      const url = `http://127.0.0.1:${config.masterPort}/api/branches/${encodeURIComponent(slug)}/deploy`;
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CDS-Internal': '1',
+          'X-CDS-Trigger': 'auto-lifecycle',
+        },
+        body: JSON.stringify({}),
+      });
+      if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        throw new Error(`auto-publish 重部署 ${slug} 失败: HTTP ${res.status} ${body.slice(0, 160)}`);
+      }
+      // deploy 路由返回 SSE 流；排空 body 避免 Node 未处理 socket 警告。
+      // 部署日志由路由侧自行持久化，这里不消费事件。
+      if (res.body && typeof (res.body as { getReader?: unknown }).getReader === 'function') {
+        const reader = (res.body as ReadableStream<Uint8Array>).getReader();
+        void (async () => {
+          try { for (;;) { const { done } = await reader.read(); if (done) break; } } catch { /* ignore */ }
+        })();
+      }
     },
   },
   { tickIntervalSeconds: 30, enabled: true },

--- a/cds/src/index.ts
+++ b/cds/src/index.ts
@@ -1075,6 +1075,11 @@ async function shutdown(signal: string): Promise<void> {
   console.log(`[shutdown] received ${signal}, stopping services...`);
   schedulerService.stop();
   janitorService.stop();
+  // 2026-05-14 Cursor Bugbot Medium 修复：shutdown() 直接逐个 stop，
+  // 漏了 autoLifecycleService.stop()（stopBackgroundServices 里有，但
+  // 信号处理走的是本函数）。否则 graceful shutdown 期间 auto-lifecycle
+  // 的 setInterval 还在跑，可能在 mongo flush/close 时触发停容器/重部署。
+  autoLifecycleService.stop();
   try {
     const pendingWritesPath = path.join(config.repoRoot, 'cds', '.cds', 'pending-writes.json');
     const snap = await gracefulShutdownController.runShutdown({

--- a/cds/src/index.ts
+++ b/cds/src/index.ts
@@ -534,6 +534,10 @@ schedulerService.setCoolFn(async (slug: string) => {
       note: branch.lastStopReason,
     });
   } catch { /* activity log 是辅助手段，失败不影响主流程 */ }
+  // 2026-05-14 Cursor Bugbot review 修复：与另外两条停止路径
+  // （AutoLifecycleService.stopBranch / 手动 stop handler）保持一致，
+  // 调度器降温也要 +1 stopCount，否则 UI 上"停止次数"对调度器停止漏计。
+  stateService.incrementBranchStat(slug, 'stopCount');
   stateService.save();
 });
 // wakeFn intentionally left unset at boot: the proxy's existing onAutoBuild
@@ -567,6 +571,51 @@ const autoLifecycleService = new AutoLifecycleService(
       if (!branch) return;
       branch.status = 'stopping';
       stateService.save();
+
+      // 2026-05-14 Codex review P2 修复：cluster 部署下分支可能跑在远端
+      // executor 上，master 本地没有它的容器。这里复刻手动 stop 路径的
+      // /exec/stop 代理逻辑——否则 auto-stop/auto-publish 只停了 master
+      // 本地的空壳，远端容器还在跑，下一个 heartbeat 又把状态报回 running。
+      // `registry` 在模块下方构建（startup 同步执行完），tick 30s 才首次
+      // 触发本回调，引用安全。
+      const remoteExecutor =
+        branch.executorId && registry
+          ? registry.getAll().find(n => n.id === branch.executorId && n.role !== 'embedded')
+          : null;
+      if (remoteExecutor) {
+        for (const svc of Object.values(branch.services)) {
+          if (svc.status === 'running' || svc.status === 'starting') svc.status = 'stopping';
+        }
+        stateService.save();
+        try {
+          const upstreamUrl = `http://${remoteExecutor.host}:${remoteExecutor.port}/exec/stop`;
+          const upstream = await fetch(upstreamUrl, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              ...(config.executorToken ? { 'X-Executor-Token': config.executorToken } : {}),
+            },
+            body: JSON.stringify({ branchId: slug }),
+          });
+          if (!upstream.ok) {
+            const errText = await upstream.text().catch(() => '');
+            console.warn(`[auto-lifecycle] 远端执行器 ${remoteExecutor.id} 拒绝停止 (HTTP ${upstream.status}): ${errText.slice(0, 160)}`);
+            // 远端拒绝：不强制把本地状态改 idle/cold（避免谎报已停），
+            // 下一拍 heartbeat reconcile 后会重试。
+            return;
+          }
+          // 执行器下一次 heartbeat 会 reconcile，这里先设可信本地态。
+          for (const svc of Object.values(branch.services)) svc.status = 'stopped';
+          branch.status = 'idle';
+          branch.heatState = 'cold';
+          stateService.incrementBranchStat(slug, 'stopCount');
+          stateService.save();
+        } catch (err) {
+          console.warn(`[auto-lifecycle] 无法连接远端执行器 ${remoteExecutor.id}: ${(err as Error).message}`);
+        }
+        return;
+      }
+
       for (const svc of Object.values(branch.services)) {
         if (svc.status === 'running' || svc.status === 'starting') {
           try {

--- a/cds/src/index.ts
+++ b/cds/src/index.ts
@@ -719,19 +719,26 @@ const autoLifecycleService = new AutoLifecycleService(
           try { msg = (JSON.parse(dataRaw) as { message?: string }).message || msg; } catch { /* keep default */ }
           terminal = { ok: false, message: msg };
         } else if (evName === 'complete') {
-          let services: Record<string, { status?: string }> = {};
-          let msg = '';
-          try {
-            const d = JSON.parse(dataRaw) as { services?: Record<string, { status?: string }>; message?: string };
-            services = d.services || {};
-            msg = d.message || '';
-          } catch { /* treat as unparseable complete → fail below */ }
-          const failed = Object.entries(services)
-            .filter(([, s]) => s?.status !== 'running')
-            .map(([pid]) => pid);
-          terminal = failed.length === 0 && Object.keys(services).length > 0
-            ? { ok: true, message: msg || '部署完成' }
-            : { ok: false, message: `部署完成但有服务未就绪: ${failed.join(', ') || '无 running 服务'}` };
+          // 2026-05-14 Codex review P2：直接读路由下发的权威 ok（路由基于
+          // activeServices 算出，已剔除已删除/僵尸 profile）。不再用全量
+          // services 重新推导，避免僵尸服务误判失败。无 ok 字段（旧路由）
+          // 才回退到 services 推导兜底。
+          let parsed: { ok?: boolean; services?: Record<string, { status?: string }>; message?: string } = {};
+          try { parsed = JSON.parse(dataRaw) as typeof parsed; } catch { /* unparseable → fail below */ }
+          const msg = parsed.message || '';
+          if (typeof parsed.ok === 'boolean') {
+            terminal = parsed.ok
+              ? { ok: true, message: msg || '部署完成' }
+              : { ok: false, message: msg || '部署失败' };
+          } else {
+            const services = parsed.services || {};
+            const failed = Object.entries(services)
+              .filter(([, s]) => s?.status !== 'running')
+              .map(([pid]) => pid);
+            terminal = failed.length === 0 && Object.keys(services).length > 0
+              ? { ok: true, message: msg || '部署完成' }
+              : { ok: false, message: `部署完成但有服务未就绪: ${failed.join(', ') || '无 running 服务'}` };
+          }
         }
       };
       try {

--- a/cds/src/index.ts
+++ b/cds/src/index.ts
@@ -677,92 +677,112 @@ const autoLifecycleService = new AutoLifecycleService(
       // /deploy 要求能解析出源 project，否则 403 source-project-unresolved。
       // 复刻 webhook dispatcher 的 sourceHeadersForBranch 逻辑。
       const srcBranch = stateService.getBranch(slug);
-      const res = await fetch(url, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CDS-Internal': '1',
-          'X-CDS-Trigger': 'auto-lifecycle',
-          'X-CDS-Source-Branch-Id': slug,
-          ...(srcBranch?.projectId ? { 'X-CDS-Source-Project-Id': srcBranch.projectId } : {}),
-        },
-        body: JSON.stringify({}),
-      });
-      if (!res.ok) {
-        const body = await res.text().catch(() => '');
-        throw new Error(`auto-publish 重部署 ${slug} 失败: HTTP ${res.status} ${body.slice(0, 160)}`);
-      }
-      // 2026-05-14 Codex review P2 "Await the deploy stream"：deploy 是 SSE，
-      // fetch 在响应头就 resolve，pull/build/readiness 失败都在流后续才发。
-      // 必须把流读到终态事件再判定成败，否则 redeploy 提前返回成功、后续
-      // 部署失败无法触发 applyAutoPublish 的 override 回滚。
-      // 终态契约（branches.ts /deploy 路由）：
-      //   event: error    → 硬失败（抛异常路径）
-      //   event: complete → 跑完；services 里任一 status !== 'running' 视为失败
-      //   流结束但无 complete/error → 视为未完成（失败）
-      if (!res.body || typeof (res.body as { getReader?: unknown }).getReader !== 'function') {
-        throw new Error(`auto-publish 重部署 ${slug}：响应无 SSE body，无法确认部署结果`);
-      }
-      const reader = (res.body as ReadableStream<Uint8Array>).getReader();
-      const decoder = new TextDecoder();
-      let buf = '';
-      let terminal: { ok: boolean; message: string } | null = null;
-      const parseBlock = (block: string): void => {
-        let evName = 'message';
-        let dataRaw = '';
-        for (const line of block.split('\n')) {
-          if (line.startsWith('event:')) evName = line.slice(6).trim();
-          else if (line.startsWith('data:')) dataRaw += line.slice(5).trim();
-        }
-        if (evName === 'error') {
-          let msg = '部署失败';
-          try { msg = (JSON.parse(dataRaw) as { message?: string }).message || msg; } catch { /* keep default */ }
-          terminal = { ok: false, message: msg };
-        } else if (evName === 'complete') {
-          // 2026-05-14 Codex review P2：直接读路由下发的权威 ok（路由基于
-          // activeServices 算出，已剔除已删除/僵尸 profile）。不再用全量
-          // services 重新推导，避免僵尸服务误判失败。无 ok 字段（旧路由）
-          // 才回退到 services 推导兜底。
-          let parsed: { ok?: boolean; services?: Record<string, { status?: string }>; message?: string } = {};
-          try { parsed = JSON.parse(dataRaw) as typeof parsed; } catch { /* unparseable → fail below */ }
-          const msg = parsed.message || '';
-          if (typeof parsed.ok === 'boolean') {
-            terminal = parsed.ok
-              ? { ok: true, message: msg || '部署完成' }
-              : { ok: false, message: msg || '部署失败' };
-          } else {
-            const services = parsed.services || {};
-            const failed = Object.entries(services)
-              .filter(([, s]) => s?.status !== 'running')
-              .map(([pid]) => pid);
-            terminal = failed.length === 0 && Object.keys(services).length > 0
-              ? { ok: true, message: msg || '部署完成' }
-              : { ok: false, message: `部署完成但有服务未就绪: ${failed.join(', ') || '无 running 服务'}` };
-          }
-        }
-      };
+      // 2026-05-14 Cursor Bugbot Medium 修复：SSE 读循环必须有总超时。
+      // 否则 deploy 端只发进度事件、永不发 complete/error 也不关连接时，
+      // for(;;) reader.read() 永久阻塞；tick() 全程持 this.running，之后
+      // 每个 setInterval tick 都在 `if (this.running) return` 处空转，
+      // 整个 AutoLifecycleService 对所有项目永久瘫痪直到进程重启。
+      // 用 AbortController + 硬总时限兜底（真实部署 pull+build+就绪极少
+      // 超 20min；超了就回滚 override，下一拍重试，绝不卡死全局）。
+      const REDEPLOY_DEADLINE_MS = 20 * 60 * 1000;
+      const ac = new AbortController();
+      const deadline = setTimeout(() => ac.abort(), REDEPLOY_DEADLINE_MS);
       try {
-        for (;;) {
-          const { done, value } = await reader.read();
-          if (value) {
-            buf += decoder.decode(value, { stream: true });
-            let idx: number;
-            while ((idx = buf.indexOf('\n\n')) !== -1) {
-              parseBlock(buf.slice(0, idx));
-              buf = buf.slice(idx + 2);
+        const res = await fetch(url, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CDS-Internal': '1',
+            'X-CDS-Trigger': 'auto-lifecycle',
+            'X-CDS-Source-Branch-Id': slug,
+            ...(srcBranch?.projectId ? { 'X-CDS-Source-Project-Id': srcBranch.projectId } : {}),
+          },
+          body: JSON.stringify({}),
+          signal: ac.signal,
+        });
+        if (!res.ok) {
+          const body = await res.text().catch(() => '');
+          throw new Error(`auto-publish 重部署 ${slug} 失败: HTTP ${res.status} ${body.slice(0, 160)}`);
+        }
+        // 2026-05-14 Codex review P2 "Await the deploy stream"：deploy 是 SSE，
+        // fetch 在响应头就 resolve，pull/build/readiness 失败都在流后续才发。
+        // 必须把流读到终态事件再判定成败，否则 redeploy 提前返回成功、后续
+        // 部署失败无法触发 applyAutoPublish 的 override 回滚。
+        // 终态契约（branches.ts /deploy 路由）：
+        //   event: error    → 硬失败（抛异常路径）
+        //   event: complete → 跑完；优先读权威 ok，缺省回退 services 推导
+        //   流结束但无 complete/error → 视为未完成（失败）
+        if (!res.body || typeof (res.body as { getReader?: unknown }).getReader !== 'function') {
+          throw new Error(`auto-publish 重部署 ${slug}：响应无 SSE body，无法确认部署结果`);
+        }
+        const reader = (res.body as ReadableStream<Uint8Array>).getReader();
+        const decoder = new TextDecoder();
+        let buf = '';
+        let terminal: { ok: boolean; message: string } | null = null;
+        const parseBlock = (block: string): void => {
+          let evName = 'message';
+          let dataRaw = '';
+          for (const line of block.split('\n')) {
+            if (line.startsWith('event:')) evName = line.slice(6).trim();
+            else if (line.startsWith('data:')) dataRaw += line.slice(5).trim();
+          }
+          if (evName === 'error') {
+            let msg = '部署失败';
+            try { msg = (JSON.parse(dataRaw) as { message?: string }).message || msg; } catch { /* keep default */ }
+            terminal = { ok: false, message: msg };
+          } else if (evName === 'complete') {
+            // 2026-05-14 Codex review P2：直接读路由下发的权威 ok（路由基于
+            // activeServices 算出，已剔除已删除/僵尸 profile）。不再用全量
+            // services 重新推导，避免僵尸服务误判失败。无 ok 字段（旧路由）
+            // 才回退到 services 推导兜底。
+            let parsed: { ok?: boolean; services?: Record<string, { status?: string }>; message?: string } = {};
+            try { parsed = JSON.parse(dataRaw) as typeof parsed; } catch { /* unparseable → fail below */ }
+            const msg = parsed.message || '';
+            if (typeof parsed.ok === 'boolean') {
+              terminal = parsed.ok
+                ? { ok: true, message: msg || '部署完成' }
+                : { ok: false, message: msg || '部署失败' };
+            } else {
+              const services = parsed.services || {};
+              const failed = Object.entries(services)
+                .filter(([, s]) => s?.status !== 'running')
+                .map(([pid]) => pid);
+              terminal = failed.length === 0 && Object.keys(services).length > 0
+                ? { ok: true, message: msg || '部署完成' }
+                : { ok: false, message: `部署完成但有服务未就绪: ${failed.join(', ') || '无 running 服务'}` };
             }
           }
-          if (done) break;
+        };
+        try {
+          for (;;) {
+            const { done, value } = await reader.read();
+            if (value) {
+              buf += decoder.decode(value, { stream: true });
+              let idx: number;
+              while ((idx = buf.indexOf('\n\n')) !== -1) {
+                parseBlock(buf.slice(0, idx));
+                buf = buf.slice(idx + 2);
+              }
+            }
+            if (done) break;
+          }
+          if (buf.trim()) parseBlock(buf);
+        } finally {
+          try { reader.releaseLock(); } catch { /* ignore */ }
         }
-        if (buf.trim()) parseBlock(buf);
+        if (!terminal) {
+          throw new Error(`auto-publish 重部署 ${slug}：SSE 流结束但未收到 complete/error 终态事件`);
+        }
+        if (!(terminal as { ok: boolean }).ok) {
+          throw new Error(`auto-publish 重部署 ${slug} 失败: ${(terminal as { message: string }).message}`);
+        }
+      } catch (err) {
+        if (ac.signal.aborted) {
+          throw new Error(`auto-publish 重部署 ${slug} 超时（>${REDEPLOY_DEADLINE_MS / 60000}min 未出终态），已中止；override 将回滚，下一拍重试`);
+        }
+        throw err;
       } finally {
-        try { reader.releaseLock(); } catch { /* ignore */ }
-      }
-      if (!terminal) {
-        throw new Error(`auto-publish 重部署 ${slug}：SSE 流结束但未收到 complete/error 终态事件`);
-      }
-      if (!(terminal as { ok: boolean }).ok) {
-        throw new Error(`auto-publish 重部署 ${slug} 失败: ${(terminal as { message: string }).message}`);
+        clearTimeout(deadline);
       }
     },
   },

--- a/cds/src/index.ts
+++ b/cds/src/index.ts
@@ -672,12 +672,19 @@ const autoLifecycleService = new AutoLifecycleService(
     // 不动核心热路径。X-CDS-Trigger=auto-lifecycle 让活动日志能区分来源。
     redeployBranch: async (slug: string) => {
       const url = `http://127.0.0.1:${config.masterPort}/api/branches/${encodeURIComponent(slug)}/deploy`;
+      // 2026-05-14 Codex review P2 "Include source project headers"：开了
+      // auth 时 X-CDS-Internal 走 loopback bypass guard，branch 级
+      // /deploy 要求能解析出源 project，否则 403 source-project-unresolved。
+      // 复刻 webhook dispatcher 的 sourceHeadersForBranch 逻辑。
+      const srcBranch = stateService.getBranch(slug);
       const res = await fetch(url, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           'X-CDS-Internal': '1',
           'X-CDS-Trigger': 'auto-lifecycle',
+          'X-CDS-Source-Branch-Id': slug,
+          ...(srcBranch?.projectId ? { 'X-CDS-Source-Project-Id': srcBranch.projectId } : {}),
         },
         body: JSON.stringify({}),
       });
@@ -685,13 +692,70 @@ const autoLifecycleService = new AutoLifecycleService(
         const body = await res.text().catch(() => '');
         throw new Error(`auto-publish 重部署 ${slug} 失败: HTTP ${res.status} ${body.slice(0, 160)}`);
       }
-      // deploy 路由返回 SSE 流；排空 body 避免 Node 未处理 socket 警告。
-      // 部署日志由路由侧自行持久化，这里不消费事件。
-      if (res.body && typeof (res.body as { getReader?: unknown }).getReader === 'function') {
-        const reader = (res.body as ReadableStream<Uint8Array>).getReader();
-        void (async () => {
-          try { for (;;) { const { done } = await reader.read(); if (done) break; } } catch { /* ignore */ }
-        })();
+      // 2026-05-14 Codex review P2 "Await the deploy stream"：deploy 是 SSE，
+      // fetch 在响应头就 resolve，pull/build/readiness 失败都在流后续才发。
+      // 必须把流读到终态事件再判定成败，否则 redeploy 提前返回成功、后续
+      // 部署失败无法触发 applyAutoPublish 的 override 回滚。
+      // 终态契约（branches.ts /deploy 路由）：
+      //   event: error    → 硬失败（抛异常路径）
+      //   event: complete → 跑完；services 里任一 status !== 'running' 视为失败
+      //   流结束但无 complete/error → 视为未完成（失败）
+      if (!res.body || typeof (res.body as { getReader?: unknown }).getReader !== 'function') {
+        throw new Error(`auto-publish 重部署 ${slug}：响应无 SSE body，无法确认部署结果`);
+      }
+      const reader = (res.body as ReadableStream<Uint8Array>).getReader();
+      const decoder = new TextDecoder();
+      let buf = '';
+      let terminal: { ok: boolean; message: string } | null = null;
+      const parseBlock = (block: string): void => {
+        let evName = 'message';
+        let dataRaw = '';
+        for (const line of block.split('\n')) {
+          if (line.startsWith('event:')) evName = line.slice(6).trim();
+          else if (line.startsWith('data:')) dataRaw += line.slice(5).trim();
+        }
+        if (evName === 'error') {
+          let msg = '部署失败';
+          try { msg = (JSON.parse(dataRaw) as { message?: string }).message || msg; } catch { /* keep default */ }
+          terminal = { ok: false, message: msg };
+        } else if (evName === 'complete') {
+          let services: Record<string, { status?: string }> = {};
+          let msg = '';
+          try {
+            const d = JSON.parse(dataRaw) as { services?: Record<string, { status?: string }>; message?: string };
+            services = d.services || {};
+            msg = d.message || '';
+          } catch { /* treat as unparseable complete → fail below */ }
+          const failed = Object.entries(services)
+            .filter(([, s]) => s?.status !== 'running')
+            .map(([pid]) => pid);
+          terminal = failed.length === 0 && Object.keys(services).length > 0
+            ? { ok: true, message: msg || '部署完成' }
+            : { ok: false, message: `部署完成但有服务未就绪: ${failed.join(', ') || '无 running 服务'}` };
+        }
+      };
+      try {
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (value) {
+            buf += decoder.decode(value, { stream: true });
+            let idx: number;
+            while ((idx = buf.indexOf('\n\n')) !== -1) {
+              parseBlock(buf.slice(0, idx));
+              buf = buf.slice(idx + 2);
+            }
+          }
+          if (done) break;
+        }
+        if (buf.trim()) parseBlock(buf);
+      } finally {
+        try { reader.releaseLock(); } catch { /* ignore */ }
+      }
+      if (!terminal) {
+        throw new Error(`auto-publish 重部署 ${slug}：SSE 流结束但未收到 complete/error 终态事件`);
+      }
+      if (!(terminal as { ok: boolean }).ok) {
+        throw new Error(`auto-publish 重部署 ${slug} 失败: ${(terminal as { message: string }).message}`);
       }
     },
   },

--- a/cds/src/index.ts
+++ b/cds/src/index.ts
@@ -15,6 +15,7 @@ import { ContainerService } from './services/container.js';
 import { ProxyService } from './services/proxy.js';
 import { SchedulerService } from './services/scheduler.js';
 import { JanitorService } from './services/janitor.js';
+import { AutoLifecycleService } from './services/auto-lifecycle.js';
 import { BridgeService } from './services/bridge.js';
 import { buildPreviewUrl } from './services/comment-template.js';
 import crypto from 'node:crypto';
@@ -555,6 +556,35 @@ const janitorService = new JanitorService(
   },
   config.worktreeBase,
 );
+// ── AutoLifecycle (2026-05-14 项目级 N 分钟自动切发布版 / 自动停止) ──
+// 与 SchedulerService 正交：那个按访问时间降温，这个按"部署完成时间"处理。
+// 默认开（项目里两个字段都不配就自动 no-op）。tick 30s 一拍。
+const autoLifecycleService = new AutoLifecycleService(
+  {
+    stateService,
+    stopBranch: async (slug: string) => {
+      const branch = stateService.getBranch(slug);
+      if (!branch) return;
+      branch.status = 'stopping';
+      stateService.save();
+      for (const svc of Object.values(branch.services)) {
+        if (svc.status === 'running' || svc.status === 'starting') {
+          try {
+            await containerService.stop(svc.containerName);
+          } catch (err) {
+            console.warn(`[auto-lifecycle] stop(${svc.containerName}) failed: ${(err as Error).message}`);
+          }
+          svc.status = 'stopped';
+        }
+      }
+      branch.status = 'idle';
+      stateService.incrementBranchStat(slug, 'stopCount');
+      stateService.save();
+    },
+  },
+  { tickIntervalSeconds: 30, enabled: true },
+);
+
 janitorService.setRemoveFn(async (slug: string) => {
   // Reuse the existing removal path: stop containers → git worktree remove → drop state.
   const branch = stateService.getBranch(slug);
@@ -806,11 +836,13 @@ janitorService.setRemoveFn(async (slug: string) => {
       schedulerService.start();
     }
     janitorService.start();
+    autoLifecycleService.start();
     startAutoRestartLoop();
   }
   function stopBackgroundServices(): void {
     schedulerService.stop();
     janitorService.stop();
+    autoLifecycleService.stop();
     stopAutoRestartLoop();
   }
 

--- a/cds/src/index.ts
+++ b/cds/src/index.ts
@@ -511,6 +511,28 @@ schedulerService.setCoolFn(async (slug: string) => {
     }
   }
   branch.status = 'idle';
+  // 2026-05-14: 记录调度器降温原因，让用户在 UI 上看清"为什么变灰"。
+  // 区分空闲降温和容量驱逐，便于排查。
+  branch.lastStoppedAt = new Date().toISOString();
+  const idleTTLSec = config.scheduler?.idleTTLSeconds ?? 900;
+  const lastAccessMs = branch.lastAccessedAt ? Date.parse(branch.lastAccessedAt) : 0;
+  const idleSec = lastAccessMs > 0 ? Math.floor((Date.now() - lastAccessMs) / 1000) : 0;
+  if (lastAccessMs > 0 && idleSec >= idleTTLSec) {
+    branch.lastStopReason = `调度器：空闲 ${Math.floor(idleSec / 60)} 分钟，超过 ${Math.floor(idleTTLSec / 60)} 分钟阈值自动降温`;
+  } else {
+    branch.lastStopReason = '调度器：超出热容量上限被驱逐（LRU）';
+  }
+  branch.lastStopSource = 'scheduler';
+  // 同步追加项目活动日志，便于在分支日志面板里看到时间线。
+  try {
+    stateService.appendActivityLog(branch.projectId, {
+      type: 'stop',
+      branchId: slug,
+      branchName: branch.branch,
+      actor: 'scheduler',
+      note: branch.lastStopReason,
+    });
+  } catch { /* activity log 是辅助手段，失败不影响主流程 */ }
   stateService.save();
 });
 // wakeFn intentionally left unset at boot: the proxy's existing onAutoBuild

--- a/cds/src/index.ts
+++ b/cds/src/index.ts
@@ -569,6 +569,21 @@ const autoLifecycleService = new AutoLifecycleService(
     stopBranch: async (slug: string) => {
       const branch = stateService.getBranch(slug);
       if (!branch) return;
+      // 2026-05-14 Codex review P2：远端 stop 失败时要能回滚到 running，
+      // 否则分支卡在 stopping，AutoLifecycleService.tick 的
+      // `status==='running'` 过滤会永久跳过它、不再重试。先快照原状态。
+      const prevBranchStatus = branch.status;
+      const prevSvcStatus = new Map(
+        Object.values(branch.services).map(s => [s.profileId, s.status] as const),
+      );
+      const restoreRunning = (): void => {
+        branch.status = prevBranchStatus;
+        for (const s of Object.values(branch.services)) {
+          const prev = prevSvcStatus.get(s.profileId);
+          if (prev) s.status = prev;
+        }
+        stateService.save();
+      };
       branch.status = 'stopping';
       stateService.save();
 
@@ -587,9 +602,11 @@ const autoLifecycleService = new AutoLifecycleService(
           if (svc.status === 'running' || svc.status === 'starting') svc.status = 'stopping';
         }
         stateService.save();
+        // 连接失败与"远端拒绝"分开处理，各自给准确错误信息，且不让
+        // !ok 的 throw 被同一个 catch 二次包装成误导性的"无法连接"。
+        let upstream: Awaited<ReturnType<typeof fetch>>;
         try {
-          const upstreamUrl = `http://${remoteExecutor.host}:${remoteExecutor.port}/exec/stop`;
-          const upstream = await fetch(upstreamUrl, {
+          upstream = await fetch(`http://${remoteExecutor.host}:${remoteExecutor.port}/exec/stop`, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
@@ -597,22 +614,24 @@ const autoLifecycleService = new AutoLifecycleService(
             },
             body: JSON.stringify({ branchId: slug }),
           });
-          if (!upstream.ok) {
-            const errText = await upstream.text().catch(() => '');
-            console.warn(`[auto-lifecycle] 远端执行器 ${remoteExecutor.id} 拒绝停止 (HTTP ${upstream.status}): ${errText.slice(0, 160)}`);
-            // 远端拒绝：不强制把本地状态改 idle/cold（避免谎报已停），
-            // 下一拍 heartbeat reconcile 后会重试。
-            return;
-          }
-          // 执行器下一次 heartbeat 会 reconcile，这里先设可信本地态。
-          for (const svc of Object.values(branch.services)) svc.status = 'stopped';
-          branch.status = 'idle';
-          branch.heatState = 'cold';
-          stateService.incrementBranchStat(slug, 'stopCount');
-          stateService.save();
         } catch (err) {
-          console.warn(`[auto-lifecycle] 无法连接远端执行器 ${remoteExecutor.id}: ${(err as Error).message}`);
+          // 执行器不可达：回滚到原 running 状态 + 抛出。caller
+          // (applyAutoStop/applyAutoPublish) 不会 stamp 假成功，tick 下一拍
+          // 因 status 仍是 running 会重试。
+          restoreRunning();
+          throw new Error(`无法连接远端执行器 ${remoteExecutor.id}: ${(err as Error).message}`);
         }
+        if (!upstream.ok) {
+          const errText = await upstream.text().catch(() => '');
+          restoreRunning();
+          throw new Error(`远端执行器 ${remoteExecutor.id} 拒绝停止 (HTTP ${upstream.status}): ${errText.slice(0, 160)}`);
+        }
+        // 执行器下一次 heartbeat 会 reconcile，这里先设可信本地态。
+        for (const svc of Object.values(branch.services)) svc.status = 'stopped';
+        branch.status = 'idle';
+        branch.heatState = 'cold';
+        stateService.incrementBranchStat(slug, 'stopCount');
+        stateService.save();
         return;
       }
 

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -3593,6 +3593,11 @@ export function createBranchRouter(deps: RouterDeps): Router {
       });
       stateService.save();
       sendSSE(res, 'complete', {
+        // 2026-05-14 Codex review P2：把路由自己基于 activeServices 算出的
+        // 权威结论 (hasError) 一并下发。消费方（auto-lifecycle redeploy）
+        // 直接读 ok，不要再用全量 entry.services 重新推导——否则已删除/
+        // 僵尸 profile 的 stopped/error 服务会被误判成部署失败。
+        ok: !hasError,
         message: completeMsg,
         services: entry.services,
       });
@@ -3859,6 +3864,9 @@ export function createBranchRouter(deps: RouterDeps): Router {
       const completeMsg = svc.status === 'running' ? `${profile.name} 已启动` : `${profile.name} 启动失败`;
       logDeploy(id, `部署完成: ${completeMsg}`);
       sendSSE(res, 'complete', {
+        // 2026-05-14 Codex review P2：单服务 redeploy 也下发权威 ok，
+        // 消费方统一读 ok 而非重推导 entry.services。
+        ok: svc.status === 'running',
         message: completeMsg,
         services: entry.services,
       });

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -893,11 +893,19 @@ function buildSmokeEnv(opts: {
 
 function reconcileBranchStatus(entry: BranchEntry): void {
   const statuses = Object.values(entry.services || {}).map((service) => service.status);
+  const previousStatus = entry.status;
   if (statuses.some((status) => status === 'error')) entry.status = 'error';
   else if (statuses.some((status) => status === 'building')) entry.status = 'building';
   else if (statuses.some((status) => status === 'starting' || status === 'restarting')) entry.status = 'starting';
   else if (statuses.some((status) => status === 'running')) entry.status = 'running';
   else entry.status = 'idle';
+
+  // 2026-05-14: 进入 running 时打 lastReadyAt 戳。项目级 autoPublishAfterMinutes /
+  // autoStopAfterMinutes 调度器以本字段为计时起点。从非 running 翻到 running 才更新，
+  // 内部 running→running（多次 reconcile）不刷新，避免调度器永远被推迟。
+  if (entry.status === 'running' && previousStatus !== 'running') {
+    entry.lastReadyAt = new Date().toISOString();
+  }
 
   const failedReasons = Object.entries(entry.services || {})
     .filter(([, service]) => service.status === 'error')

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -1365,6 +1365,21 @@ export function createBranchRouter(deps: RouterDeps): Router {
         try { parsed = JSON.parse(dataStr) as Record<string, unknown>; }
         catch { /* 非 JSON 数据降级为 raw chunk */ opLog.events.push({ step: eventName, status: 'log', chunk: dataStr.slice(0, 500), timestamp: new Date().toISOString() }); return; }
         if (eventName === 'error') proxyHasError = true;
+        // 2026-05-14 Codex review P2 "Don't stamp remote deploys before
+        // checking service failures"：/exec/deploy 仅单服务失败时发
+        // complete（services 里带 status:'error'）而**不**发 error 事件，
+        // proxyHasError 一直 false → 下方把失败的 release 部署也钉成真相 +
+        // 刷 lastDeployAt。complete 必须按权威 ok / services 判失败。
+        if (eventName === 'complete') {
+          if (parsed.ok === false) {
+            proxyHasError = true;
+          } else if (parsed.services && typeof parsed.services === 'object') {
+            const svcMap = parsed.services as Record<string, { status?: string }>;
+            if (Object.values(svcMap).some((s) => s?.status === 'error')) {
+              proxyHasError = true;
+            }
+          }
+        }
         opLog.events.push({
           step: typeof parsed.step === 'string' ? parsed.step : eventName,
           status: typeof parsed.status === 'string' ? parsed.status : eventName,

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -1427,6 +1427,14 @@ export function createBranchRouter(deps: RouterDeps): Router {
           const svc = entry.services[rp.id];
           if (svc) svc.deployedMode = rp.activeDeployMode || '';
         }
+        // 2026-05-14 Codex review P2 "Refresh the lifecycle clock after
+        // remote redeploys"：本地部署成功会 stamp lastDeployAt（branches.ts
+        // ~3651），auto-lifecycle tick 的陈旧检测靠它把 lastReadyAt 刷新到
+        // 本次部署之后。远端 proxy 成功路径之前漏 stamp → 远端 auto-publish
+        // 重部署后，新 release 容器仍按上一轮 source run 的旧 lastReadyAt
+        // 计时，下一拍可能立刻被 auto-stop。与本地路径对齐：stamp
+        // lastDeployAt，让 release run 拿到自己的完整生命周期区间。
+        stateService.stampBranchTimestamp(entry.id, 'lastDeployAt');
       }
       entry.lastAccessedAt = new Date().toISOString();
       stateService.save();

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -4060,6 +4060,16 @@ export function createBranchRouter(deps: RouterDeps): Router {
         entry.lastStoppedAt = new Date().toISOString();
         entry.lastStopReason = `远端执行器 ${remoteExecutor.id} 停止`;
         entry.lastStopSource = 'executor';
+        // 2026-05-14 Cursor Bugbot Medium 修复：远端执行器停止路径与本地
+        // 手动停止 / scheduler coolFn / AutoLifecycle 一致，也要 +1 stopCount
+        // 并写活动日志，否则 UI「停止次数」对远端停止漏计、活动时间线缺这条。
+        stateService.incrementBranchStat(id, 'stopCount');
+        stateService.appendActivityLog(entry.projectId, {
+          type: 'stop',
+          branchId: id,
+          branchName: entry.branch,
+          actor: resolveActorForActivity(req),
+        });
         stateService.save();
         res.json({ message: `已请求执行器 ${remoteExecutor.id} 停止所有服务` });
       } catch (err) {

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -10,7 +10,7 @@ import { Router, type Request } from 'express';
 import { StateService } from '../services/state.js';
 import { resolveActorFromRequest } from '../services/actor-resolver.js';
 import { WorktreeService } from '../services/worktree.js';
-import { resolveEffectiveProfile, resolveDeployModeSource } from '../services/container.js';
+import { resolveEffectiveProfile } from '../services/container.js';
 import { classifyDeployRuntime } from '../services/deploy-runtime.js';
 import type { ContainerService } from '../services/container.js';
 import type { SchedulerService } from '../services/scheduler.js';
@@ -179,14 +179,13 @@ type BranchDeployRuntime = {
 function summarizeBranchDeployRuntime(
   branch: BranchEntry,
   profiles: BuildProfile[],
-  projectDefaults?: Record<string, string>,
 ): BranchDeployRuntime {
   let releaseProfiles = 0;
   let sourceProfiles = 0;
   const modeLabels: string[] = [];
 
   for (const profile of profiles) {
-    const effectiveProfile = resolveEffectiveProfile(profile, branch, projectDefaults);
+    const effectiveProfile = resolveEffectiveProfile(profile, branch);
     const activeMode = effectiveProfile.activeDeployMode;
     const modeLabel = activeMode
       ? effectiveProfile.deployModes?.[activeMode]?.label || activeMode
@@ -1967,7 +1966,6 @@ export function createBranchRouter(deps: RouterDeps): Router {
         const deployRuntime = summarizeBranchDeployRuntime(
           b,
           stateService.getBuildProfilesForProject(b.projectId || 'default'),
-          project?.defaultDeployModes,
         );
         if (!live) {
           return {
@@ -3320,7 +3318,7 @@ export function createBranchRouter(deps: RouterDeps): Router {
 
         await Promise.all(layer.items.map(async (profile) => {
           // Resolve baseline → 项目默认 → 分支 override → mode override
-          const effectiveProfile = resolveEffectiveProfile(profile, entry, deployProject?.defaultDeployModes);
+          const effectiveProfile = resolveEffectiveProfile(profile, entry);
           const branchOverride = entry.profileOverrides?.[profile.id];
           const activeMode = effectiveProfile.activeDeployMode;
           const modeLabel = activeMode && effectiveProfile.deployModes?.[activeMode]
@@ -3766,9 +3764,8 @@ export function createBranchRouter(deps: RouterDeps): Router {
         stateService.save();
       }
 
-      // Resolve baseline → 项目默认 → 分支 override → mode override
-      const singleProject = entry.projectId ? stateService.getProject(entry.projectId) : undefined;
-      const effectiveProfile = resolveEffectiveProfile(profile, entry, singleProject?.defaultDeployModes);
+      // Resolve baseline → branch override → deploy-mode override
+      const effectiveProfile = resolveEffectiveProfile(profile, entry);
       const branchOverride = entry.profileOverrides?.[profile.id];
       const activeMode = effectiveProfile.activeDeployMode;
       const modeLabel = activeMode && effectiveProfile.deployModes?.[activeMode]
@@ -4340,18 +4337,15 @@ export function createBranchRouter(deps: RouterDeps): Router {
     // modal's "effective env" preview only enumerates profiles in
     // this project, not every project's profile.
     const profiles = stateService.getBuildProfilesForProject(entry.projectId || 'default');
-    const ownerProject = entry.projectId ? stateService.getProject(entry.projectId) : undefined;
-    const projectDefaults = ownerProject?.defaultDeployModes;
     const payload = profiles.map(profile => {
       const override = entry.profileOverrides?.[profile.id];
-      const resolved = resolveEffectiveProfile(profile, entry, projectDefaults);
+      const resolved = resolveEffectiveProfile(profile, entry);
       // CDS infra vars first, then profile.env so user-set values can still
       // shadow infra defaults (keeps current runtime semantics — see container.ts).
       const effective = {
         ...resolved,
         env: { ...cdsVars, ...(resolved.env || {}) },
       };
-      const deployModeSource = resolveDeployModeSource(profile, entry, projectDefaults);
       return {
         profileId: profile.id,
         profileName: profile.name,
@@ -4360,10 +4354,6 @@ export function createBranchRouter(deps: RouterDeps): Router {
         effective,
         cdsEnvKeys,
         hasOverride: !!override && Object.keys(override).some(k => k !== 'updatedAt' && k !== 'notes'),
-        // 2026-05-14: expose which layer drove activeDeployMode so the
-        // drawer chip can say "继承项目默认" instead of the misleading "继承默认".
-        deployModeSource,
-        projectDefaultDeployMode: projectDefaults?.[profile.id],
       };
     });
     res.json({ branchId: id, profiles: payload });
@@ -4430,8 +4420,7 @@ export function createBranchRouter(deps: RouterDeps): Router {
       // Return the new effective profile so the UI can show the merged result
       // without a second round-trip.
       const refreshed = stateService.getBranch(id)!;
-      const putProject = refreshed.projectId ? stateService.getProject(refreshed.projectId) : undefined;
-      const effective = resolveEffectiveProfile(profile, refreshed, putProject?.defaultDeployModes);
+      const effective = resolveEffectiveProfile(profile, refreshed);
       res.json({
         message: '已保存分支覆盖',
         profileId,

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -204,11 +204,21 @@ function summarizeBranchDeployRuntime(
 
     const svc = branch.services?.[profile.id];
     const running = svc?.status === 'running';
-    // 旧数据兼容：deployedMode 字段引入前启动的容器没有该值，
-    // 此时退回"信任配置"（即旧行为），避免存量分支齐刷刷误报待生效。
-    // 只有当我们**确知**运行模式（有 deployedMode 戳）才用真相判定。
     const hasTruth = running && svc?.deployedMode !== undefined;
-    const actualMode = hasTruth ? (svc!.deployedMode as string) : configMode;
+    // 真相 = "现在跑的是什么"。
+    //  - running 且有 deployedMode 戳 → 用戳（确知真相）。
+    //  - running 但无戳（旧数据）→ 退回信任配置，避免存量 running 分支
+    //    齐刷刷误报待生效。
+    //  - 没在跑 → 它**不在以任何模式运行**，actualMode 视为源码/未知。
+    //    2026-05-14 Codex review P2：之前 !running 也回退 configMode，
+    //    导致"配置 release 但已 auto-stop/手动停"的分支被算成 release、
+    //    亮绿徽章（前端 kind==='release' 先于 pendingPublish 判断），
+    //    而它其实该是「发布版·待生效」。停着就不能算真发布。
+    const actualMode = hasTruth
+      ? (svc!.deployedMode as string)
+      : running
+        ? configMode
+        : '';
     const actualLabel = actualMode
       ? effectiveProfile.deployModes?.[actualMode]?.label || actualMode
       : '源码';

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -11,6 +11,7 @@ import { StateService } from '../services/state.js';
 import { resolveActorFromRequest } from '../services/actor-resolver.js';
 import { WorktreeService } from '../services/worktree.js';
 import { resolveEffectiveProfile, resolveDeployModeSource } from '../services/container.js';
+import { classifyDeployRuntime } from '../services/deploy-runtime.js';
 import type { ContainerService } from '../services/container.js';
 import type { SchedulerService } from '../services/scheduler.js';
 import type { ExecutorRegistry } from '../scheduler/executor-registry.js';
@@ -172,13 +173,8 @@ type BranchDeployRuntime = {
   modes: string[];
 };
 
-function classifyDeployRuntime(modeId?: string, modeLabel?: string): 'source' | 'release' {
-  if (!modeId) return 'source';
-  const text = `${modeId} ${modeLabel || ''}`;
-  return /(prod|production|release|static|publish|published|dist|standalone|built|发布|生产|正式|构建)/i.test(text)
-    ? 'release'
-    : 'source';
-}
+// classifyDeployRuntime 已抽到 services/deploy-runtime.ts（SSOT，与
+// auto-lifecycle.ts 共用同一份正则，避免两处漂移）。
 
 function summarizeBranchDeployRuntime(
   branch: BranchEntry,

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -10,7 +10,7 @@ import { Router, type Request } from 'express';
 import { StateService } from '../services/state.js';
 import { resolveActorFromRequest } from '../services/actor-resolver.js';
 import { WorktreeService } from '../services/worktree.js';
-import { resolveEffectiveProfile } from '../services/container.js';
+import { resolveEffectiveProfile, resolveDeployModeSource } from '../services/container.js';
 import type { ContainerService } from '../services/container.js';
 import type { SchedulerService } from '../services/scheduler.js';
 import type { ExecutorRegistry } from '../scheduler/executor-registry.js';
@@ -183,13 +183,14 @@ function classifyDeployRuntime(modeId?: string, modeLabel?: string): 'source' | 
 function summarizeBranchDeployRuntime(
   branch: BranchEntry,
   profiles: BuildProfile[],
+  projectDefaults?: Record<string, string>,
 ): BranchDeployRuntime {
   let releaseProfiles = 0;
   let sourceProfiles = 0;
   const modeLabels: string[] = [];
 
   for (const profile of profiles) {
-    const effectiveProfile = resolveEffectiveProfile(profile, branch);
+    const effectiveProfile = resolveEffectiveProfile(profile, branch, projectDefaults);
     const activeMode = effectiveProfile.activeDeployMode;
     const modeLabel = activeMode
       ? effectiveProfile.deployModes?.[activeMode]?.label || activeMode
@@ -1962,6 +1963,7 @@ export function createBranchRouter(deps: RouterDeps): Router {
         const deployRuntime = summarizeBranchDeployRuntime(
           b,
           stateService.getBuildProfilesForProject(b.projectId || 'default'),
+          project?.defaultDeployModes,
         );
         if (!live) {
           return {
@@ -3313,8 +3315,8 @@ export function createBranchRouter(deps: RouterDeps): Router {
         const layerStartTime = Date.now();
 
         await Promise.all(layer.items.map(async (profile) => {
-          // Resolve baseline → branch override → deploy-mode override
-          const effectiveProfile = resolveEffectiveProfile(profile, entry);
+          // Resolve baseline → 项目默认 → 分支 override → mode override
+          const effectiveProfile = resolveEffectiveProfile(profile, entry, deployProject?.defaultDeployModes);
           const branchOverride = entry.profileOverrides?.[profile.id];
           const activeMode = effectiveProfile.activeDeployMode;
           const modeLabel = activeMode && effectiveProfile.deployModes?.[activeMode]
@@ -3760,8 +3762,9 @@ export function createBranchRouter(deps: RouterDeps): Router {
         stateService.save();
       }
 
-      // Resolve baseline → branch override → deploy-mode override
-      const effectiveProfile = resolveEffectiveProfile(profile, entry);
+      // Resolve baseline → 项目默认 → 分支 override → mode override
+      const singleProject = entry.projectId ? stateService.getProject(entry.projectId) : undefined;
+      const effectiveProfile = resolveEffectiveProfile(profile, entry, singleProject?.defaultDeployModes);
       const branchOverride = entry.profileOverrides?.[profile.id];
       const activeMode = effectiveProfile.activeDeployMode;
       const modeLabel = activeMode && effectiveProfile.deployModes?.[activeMode]
@@ -4053,6 +4056,9 @@ export function createBranchRouter(deps: RouterDeps): Router {
         // plausible local state in the meantime.
         for (const svc of Object.values(entry.services)) svc.status = 'stopped';
         entry.status = 'idle';
+        entry.lastStoppedAt = new Date().toISOString();
+        entry.lastStopReason = `远端执行器 ${remoteExecutor.id} 停止`;
+        entry.lastStopSource = 'executor';
         stateService.save();
         res.json({ message: `已请求执行器 ${remoteExecutor.id} 停止所有服务` });
       } catch (err) {
@@ -4077,6 +4083,10 @@ export function createBranchRouter(deps: RouterDeps): Router {
         svc.status = 'stopped';
       }
       entry.status = 'idle';
+      // 2026-05-14: 记录最近一次停止信息，UI 让用户看清"为什么变灰"
+      entry.lastStoppedAt = new Date().toISOString();
+      entry.lastStopReason = '用户手动停止';
+      entry.lastStopSource = 'user';
       cleanupPreviewServer(id);
       // PR_C.3: 计数 + activity log
       stateService.incrementBranchStat(id, 'stopCount');
@@ -4326,15 +4336,18 @@ export function createBranchRouter(deps: RouterDeps): Router {
     // modal's "effective env" preview only enumerates profiles in
     // this project, not every project's profile.
     const profiles = stateService.getBuildProfilesForProject(entry.projectId || 'default');
+    const ownerProject = entry.projectId ? stateService.getProject(entry.projectId) : undefined;
+    const projectDefaults = ownerProject?.defaultDeployModes;
     const payload = profiles.map(profile => {
       const override = entry.profileOverrides?.[profile.id];
-      const resolved = resolveEffectiveProfile(profile, entry);
+      const resolved = resolveEffectiveProfile(profile, entry, projectDefaults);
       // CDS infra vars first, then profile.env so user-set values can still
       // shadow infra defaults (keeps current runtime semantics — see container.ts).
       const effective = {
         ...resolved,
         env: { ...cdsVars, ...(resolved.env || {}) },
       };
+      const deployModeSource = resolveDeployModeSource(profile, entry, projectDefaults);
       return {
         profileId: profile.id,
         profileName: profile.name,
@@ -4343,6 +4356,10 @@ export function createBranchRouter(deps: RouterDeps): Router {
         effective,
         cdsEnvKeys,
         hasOverride: !!override && Object.keys(override).some(k => k !== 'updatedAt' && k !== 'notes'),
+        // 2026-05-14: expose which layer drove activeDeployMode so the
+        // drawer chip can say "继承项目默认" instead of the misleading "继承默认".
+        deployModeSource,
+        projectDefaultDeployMode: projectDefaults?.[profile.id],
       };
     });
     res.json({ branchId: id, profiles: payload });
@@ -4409,7 +4426,8 @@ export function createBranchRouter(deps: RouterDeps): Router {
       // Return the new effective profile so the UI can show the merged result
       // without a second round-trip.
       const refreshed = stateService.getBranch(id)!;
-      const effective = resolveEffectiveProfile(profile, refreshed);
+      const putProject = refreshed.projectId ? stateService.getProject(refreshed.projectId) : undefined;
+      const effective = resolveEffectiveProfile(profile, refreshed, putProject?.defaultDeployModes);
       res.json({
         message: '已保存分支覆盖',
         profileId,

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -171,6 +171,13 @@ type BranchDeployRuntime = {
   releaseProfiles: number;
   sourceProfiles: number;
   modes: string[];
+  /**
+   * 2026-05-14 真实态徽章：配置已切到发布版，但容器还没真正以发布版跑
+   * 起来（正在重部署 / 还停着 / 旧容器仍是源码构建）。true 时卡片应显示
+   * 「发布版·待生效」橙色，而不是绿色「发布版」——区分"配置意图"与
+   * "运行现状"，杜绝设了 override 就亮绿的虚假徽章。
+   */
+  pendingPublish: boolean;
 };
 
 // classifyDeployRuntime 已抽到 services/deploy-runtime.ts（SSOT，与
@@ -180,23 +187,46 @@ function summarizeBranchDeployRuntime(
   branch: BranchEntry,
   profiles: BuildProfile[],
 ): BranchDeployRuntime {
-  let releaseProfiles = 0;
-  let sourceProfiles = 0;
+  // 真相 = "正在跑的容器实际用哪个 deploy mode"（svc.deployedMode），
+  // 不是"配置成什么"（profileOverrides）。两者分别算，再比对得出徽章。
+  let releaseProfiles = 0;   // 实际以发布版在跑的 profile 数（真相）
+  let sourceProfiles = 0;    // 实际以源码在跑 / 未跑的 profile 数
+  let pendingPublish = false; // 配置=发布版 但运行现状还没跟上
   const modeLabels: string[] = [];
 
   for (const profile of profiles) {
     const effectiveProfile = resolveEffectiveProfile(profile, branch);
-    const activeMode = effectiveProfile.activeDeployMode;
-    const modeLabel = activeMode
-      ? effectiveProfile.deployModes?.[activeMode]?.label || activeMode
+    const configMode = effectiveProfile.activeDeployMode;
+    const configLabel = configMode
+      ? effectiveProfile.deployModes?.[configMode]?.label || configMode
       : '源码';
-    const kind = classifyDeployRuntime(activeMode, modeLabel);
-    if (kind === 'release') {
-      releaseProfiles += 1;
-    } else {
-      sourceProfiles += 1;
-    }
-    modeLabels.push(`${profile.name || profile.id}: ${modeLabel}`);
+    const configKind = classifyDeployRuntime(configMode, configLabel);
+
+    const svc = branch.services?.[profile.id];
+    const running = svc?.status === 'running';
+    // 旧数据兼容：deployedMode 字段引入前启动的容器没有该值，
+    // 此时退回"信任配置"（即旧行为），避免存量分支齐刷刷误报待生效。
+    // 只有当我们**确知**运行模式（有 deployedMode 戳）才用真相判定。
+    const hasTruth = running && svc?.deployedMode !== undefined;
+    const actualMode = hasTruth ? (svc!.deployedMode as string) : configMode;
+    const actualLabel = actualMode
+      ? effectiveProfile.deployModes?.[actualMode]?.label || actualMode
+      : '源码';
+    const actualKind = classifyDeployRuntime(actualMode, actualLabel);
+
+    if (actualKind === 'release') releaseProfiles += 1;
+    else sourceProfiles += 1;
+
+    // 配置要发布版，但真相不是发布版（容器没跟上 / 还停着 / 旧源码构建）
+    // → pending。仅在"确知真相 且 真相≠release"或"配置 release 但没在跑"
+    // 时判 pending；旧数据无真相时不误报。
+    if (configKind === 'release' && actualKind !== 'release') pendingPublish = true;
+    if (configKind === 'release' && !running) pendingPublish = true;
+
+    const suffix = hasTruth && actualMode !== configMode
+      ? `${actualLabel}（配置 ${configLabel}，待生效）`
+      : actualLabel;
+    modeLabels.push(`${profile.name || profile.id}: ${suffix}`);
   }
 
   const activeProfiles = profiles.length;
@@ -215,12 +245,13 @@ function summarizeBranchDeployRuntime(
     kind,
     label,
     title: modeLabels.length > 0
-      ? `当前生效模式: ${modeLabels.join(' / ')}`
+      ? `实际运行模式: ${modeLabels.join(' / ')}${pendingPublish ? '（发布版配置已设，等待重新部署生效）' : ''}`
       : '当前没有构建配置，按源码默认模式显示',
     activeProfiles,
     releaseProfiles,
     sourceProfiles,
     modes: modeLabels,
+    pendingPublish,
   };
 }
 
@@ -1240,7 +1271,17 @@ export function createBranchRouter(deps: RouterDeps): Router {
     // merged env var map and let it handle the rest.
     // P4 Part 17 (G2 fix): scope by the branch's project so a remote
     // executor only receives profiles owned by this project.
-    const profiles = stateService.getBuildProfilesForProject(entry.projectId || 'default');
+    // 2026-05-14 Codex review P2 "Propagate release overrides to remote
+    // redeploys"：执行器侧没有 master 的 branch.profileOverrides，也不会跑
+    // resolveEffectiveProfile。必须在 master 侧先 resolve，把已合并 override
+    // （含 auto-publish 刚写的 release activeDeployMode）的 effective profile
+    // 发过去——compute-then-send：master 算，executor 只管按收到的构建。
+    // 否则 cluster 场景执行器仍按源码/热加载旧模式重建，但 master state
+    // 有 override → branchAutoPublishConverged 误判收敛、不再重试，
+    // auto-publish 表面成功实际没切容器。
+    const profiles = stateService
+      .getBuildProfilesForProject(entry.projectId || 'default')
+      .map((p) => resolveEffectiveProfile(p, entry));
     const env = getMergedEnv(entry.projectId || 'default', entry.id);
 
     const payload = {
@@ -1367,6 +1408,16 @@ export function createBranchRouter(deps: RouterDeps): Router {
 
       // Master-side state is best-effort — the executor has the source of
       // truth via its next heartbeat, which will reconcile status.
+      // 2026-05-14 真实态徽章（远端）：proxy 成功时，钉住我们**派发给
+      // 执行器的已 resolve profile** 的 activeDeployMode。因为 Codex P2
+      // 修复后发过去的就是 resolveEffectiveProfile 结果，executor 实际
+      // 构建的就是这个模式，所以这是远端真相。失败则不动（保留旧值）。
+      if (!proxyHasError) {
+        for (const rp of profiles) {
+          const svc = entry.services[rp.id];
+          if (svc) svc.deployedMode = rp.activeDeployMode || '';
+        }
+      }
       entry.lastAccessedAt = new Date().toISOString();
       stateService.save();
     } catch (err) {
@@ -3435,6 +3486,10 @@ export function createBranchRouter(deps: RouterDeps): Router {
 
             if (ready) {
               svc.status = 'running';
+              // 2026-05-14 真实态徽章：钉住容器**实际**用哪个 deploy mode
+              // 启动（用本次构建的 effectiveProfile，已含 override）。卡片
+              // 据此判断"真发布"还是"配置了但容器没跟上"。
+              svc.deployedMode = effectiveProfile.activeDeployMode || '';
               logDeploy(id, `${profile.name} 启动成功 ✓`);
               const elapsed = Date.now() - serviceStartTime;
               logEvent({
@@ -3836,6 +3891,8 @@ export function createBranchRouter(deps: RouterDeps): Router {
         }
         if (ready) {
           svc.status = 'running';
+          // 2026-05-14 真实态徽章：单服务 redeploy 同样钉住实际 deploy mode。
+          svc.deployedMode = effectiveProfile.activeDeployMode || '';
           logDeploy(id, `${profile.name} 启动成功 ✓`);
         } else {
           svc.status = 'error';
@@ -8034,6 +8091,9 @@ cdscli project list --human
             }, mergedEnv);
 
             svc.status = 'running';
+            // 2026-05-14 真实态徽章：import-and-init 用裸 profile 构建
+            // （runService 直接吃 profile.*），钉住其 activeDeployMode。
+            svc.deployedMode = profile.activeDeployMode || '';
             send(`deploy-${profile.id}`, 'done', `${profile.name} 就绪 → :${svc.hostPort}`);
           } catch (err) {
             svc.status = 'error';

--- a/cds/src/routes/github-webhook.ts
+++ b/cds/src/routes/github-webhook.ts
@@ -824,12 +824,18 @@ export function createGithubWebhookRouter(deps: GitHubWebhookRouterDeps): Router
   // 列出最近 N 条 GitHub webhook 投递日志(2026-05-07 用户反馈"需要看到")。
   // ring buffer 上限 200,默认返回 50。倒序(最新在前)。
   router.get('/cds-system/github/webhook-deliveries', (req, res) => {
+    // 2026-05-14: 支持 offset / limit 翻页 + buffer 上限提升到 1000。
+    // 默认 limit 50，最大 1000；offset 跳过 N 条最新条目读更老的。
     const rawLimit = parseInt((req.query.limit as string) || '50', 10);
-    const limit = Number.isFinite(rawLimit) ? rawLimit : 50;
+    const limit = Number.isFinite(rawLimit) ? Math.max(1, Math.min(rawLimit, 1000)) : 50;
+    const rawOffset = parseInt((req.query.offset as string) || '0', 10);
+    const offset = Number.isFinite(rawOffset) ? Math.max(0, rawOffset) : 0;
     const branchId = typeof req.query.branchId === 'string' ? req.query.branchId : '';
     const repoFullName = typeof req.query.repoFullName === 'string' ? req.query.repoFullName : '';
     const ref = typeof req.query.ref === 'string' ? req.query.ref : '';
-    const all = stateService.getGithubWebhookDeliveries(200);
+    // 翻页 + 过滤组合下，简单稳妥的实现：把全量倒序拿出来做过滤、再切窗口；
+    // 翻页是用户偶发动作，全量也就 1000 条，O(N) 完全够用。
+    const all = stateService.getGithubWebhookDeliveries(1000);
     const filtered = all.filter((item) => {
       const refMatches = !ref || item.ref === ref || item.ref === `refs/heads/${ref}`;
       const repoMatches = !repoFullName || item.repoFullName === repoFullName;
@@ -841,10 +847,16 @@ export function createGithubWebhookRouter(deps: GitHubWebhookRouterDeps): Router
       if (!refMatches) return false;
       return true;
     });
+    const window = filtered.slice(offset, offset + limit);
+    const totalAll = (stateService.getState().githubWebhookDeliveries || []).length;
     res.json({
-      deliveries: filtered.slice(0, limit),
-      total: (stateService.getState().githubWebhookDeliveries || []).length,
+      deliveries: window,
+      total: totalAll,
       filteredTotal: filtered.length,
+      hasMore: offset + window.length < filtered.length,
+      offset,
+      limit,
+      bufferMax: 1000,
     });
   });
 

--- a/cds/src/routes/projects.ts
+++ b/cds/src/routes/projects.ts
@@ -1910,6 +1910,8 @@ export function createProjectsRouter(deps: ProjectsRouterDeps): Router {
       gitRepoUrl: string;
       autoSmokeEnabled: boolean;
       defaultDeployModes: Record<string, string>;
+      autoPublishAfterMinutes: number;
+      autoStopAfterMinutes: number;
       // PR_D.3: 5 个 per-event toggle，对应 Project.githubEventPolicy
       githubEventPolicy: {
         push?: boolean;
@@ -1992,7 +1994,7 @@ export function createProjectsRouter(deps: ProjectsRouterDeps): Router {
       }
     }
 
-    const patch: Partial<Pick<Project, 'name' | 'aliasName' | 'aliasSlug' | 'description' | 'gitRepoUrl' | 'autoSmokeEnabled' | 'githubEventPolicy' | 'defaultDeployModes'>> = {};
+    const patch: Partial<Pick<Project, 'name' | 'aliasName' | 'aliasSlug' | 'description' | 'gitRepoUrl' | 'autoSmokeEnabled' | 'githubEventPolicy' | 'defaultDeployModes' | 'autoPublishAfterMinutes' | 'autoStopAfterMinutes'>> = {};
     // PR_D.3: 合并 5 个 toggle 到 githubEventPolicy（partial patch — 仅
     // 对显式传入的 key 更新，不影响其它 key）。
     if (body.githubEventPolicy && typeof body.githubEventPolicy === 'object') {
@@ -2035,6 +2037,18 @@ export function createProjectsRouter(deps: ProjectsRouterDeps): Router {
         next[profileId] = mode;
       }
       patch.defaultDeployModes = next;
+    }
+    // 2026-05-14: 自动切发布版 / 自动停止 两个独立分钟数字段。
+    // 限制 [0, 1440]（24 小时）防止配错。0 = 关闭。
+    for (const field of ['autoPublishAfterMinutes', 'autoStopAfterMinutes'] as const) {
+      if (body[field] === undefined) continue;
+      const raw = body[field];
+      const num = typeof raw === 'number' ? raw : Number(raw);
+      if (!Number.isFinite(num) || num < 0 || num > 1440) {
+        res.status(400).json({ error: 'validation', field, message: `${field} 必须是 0~1440 之间的整数（0 = 关闭）` });
+        return;
+      }
+      patch[field] = Math.floor(num);
     }
     if (body.name !== undefined) patch.name = String(body.name).trim();
     // For alias fields an empty string explicitly clears them so the UI

--- a/cds/src/scheduler/executor-registry.ts
+++ b/cds/src/scheduler/executor-registry.ts
@@ -283,7 +283,21 @@ export class ExecutorRegistry {
         existing.executorId = node.id;
         existing.status = (bStatus.status as import('../types.js').BranchEntry['status']) || existing.status;
         if (bStatus.services && typeof bStatus.services === 'object') {
-          existing.services = bStatus.services as Record<string, import('../types.js').ServiceState>;
+          // 2026-05-14 Codex review P2 "Persist deployedMode on the executor
+          // side"：心跳整体替换 services 会抹掉 proxyDeployToExecutor 写在
+          // 协调端的 deployedMode 真相戳（执行器 /exec/deploy 不上报该字段）。
+          // 协调端是"派发了哪个模式"的权威，这里做合并：incoming 缺
+          // deployedMode 时保留旧值；未来执行器若上报则以 incoming 为准。
+          // 否则下一次心跳后徽章/branchAutoPublishConverged 在 cluster 下
+          // 退回信任配置，真实态收敛失效。
+          const incoming = bStatus.services as Record<string, import('../types.js').ServiceState>;
+          const prev = existing.services || {};
+          for (const [pid, svc] of Object.entries(incoming)) {
+            if (svc && svc.deployedMode === undefined && prev[pid]?.deployedMode !== undefined) {
+              svc.deployedMode = prev[pid].deployedMode;
+            }
+          }
+          existing.services = incoming;
         }
       }
     }

--- a/cds/src/services/auto-lifecycle.ts
+++ b/cds/src/services/auto-lifecycle.ts
@@ -1,0 +1,243 @@
+import type { StateService } from './state.js';
+import type { BuildProfile, BranchEntry } from '../types.js';
+
+/**
+ * 2026-05-14 引入。
+ *
+ * 项目级 "运行 N 分钟后自动切发布版 / 自动停止" 调度。
+ *
+ * 与 CDS 系统级 SchedulerService（按 lastAccessedAt 的 idleTTL 降温）正交：
+ * - SchedulerService = "没人访问就降温"，按 HTTP 访问刷新。
+ * - AutoLifecycleService = "启动满 N 分钟就处理"，按 BranchEntry.lastReadyAt 计时。
+ *
+ * 两者可同时启用，本服务在 SchedulerService 之前执行，因为停止动作走的是普通
+ * containerService.stop 路径，不会和热度状态机冲突。
+ *
+ * 设计原则：
+ * - 计时锚点用 `lastReadyAt`（容器进入 running 状态时打戳）。HTTP 流量不参与，
+ *   避免长连接、轮询、自动健康检查永远刷新计时器。
+ * - 只在 status === 'running' 时计时。其他状态（building / starting / error / idle / stopping）
+ *   都跳过，不会"在异常态等到 N 分钟后再处理"。
+ * - 任何一次成功执行后会写一条 activity log，让用户能在分支日志面板看到时间线。
+ * - 容错：单个 branch 处理失败不影响其他 branch；下一 tick 重试。
+ */
+
+export interface AutoLifecycleConfig {
+  /** tick 间隔秒。默认 30。生产环境跑 30~60 都合理。 */
+  tickIntervalSeconds?: number;
+  /** 调试用：禁用整个服务。Project 字段不读，永远 no-op。 */
+  enabled?: boolean;
+}
+
+export interface AutoLifecycleDeps {
+  stateService: StateService;
+  /** 真正执行容器停止。注入而非直接 import ContainerService 是为了方便测试。 */
+  stopBranch: (branchId: string) => Promise<void>;
+  /** 注入时钟，方便测试。生产用 Date.now()。 */
+  clock?: { now(): number };
+}
+
+/** 与 routes/branches.ts 的 classifyDeployRuntime 等价 —— 内部重复一份避免 routes 暴露内部函数。 */
+const RELEASE_PATTERN = /(prod|production|release|static|publish|published|dist|standalone|built|发布|生产|正式|构建)/i;
+
+function isReleaseMode(modeId: string, modeLabel?: string): boolean {
+  return RELEASE_PATTERN.test(`${modeId} ${modeLabel || ''}`);
+}
+
+/**
+ * 给定 profile，找一个看起来像"发布版"的 deployMode id。找不到返回 null —— 跳过该 profile。
+ * 优先 modeId 命中（更稳），其次 label 命中。
+ */
+function findReleaseDeployMode(profile: BuildProfile): string | null {
+  const modes = profile.deployModes || {};
+  for (const [modeId, mode] of Object.entries(modes)) {
+    if (RELEASE_PATTERN.test(modeId)) return modeId;
+  }
+  for (const [modeId, mode] of Object.entries(modes)) {
+    if (mode?.label && RELEASE_PATTERN.test(mode.label)) return modeId;
+  }
+  return null;
+}
+
+/**
+ * 判断当前 branch 实际跑的是不是已经是"发布版"。所有 profile 都处于 release 才算。
+ * 一个 profile 仍是 source 则视为非 release（auto-publish 还有事可做）。
+ */
+function branchIsAllRelease(
+  branch: BranchEntry,
+  profiles: BuildProfile[],
+  projectDefaults: Record<string, string> | undefined,
+): boolean {
+  if (profiles.length === 0) return false;
+  for (const profile of profiles) {
+    const override = branch.profileOverrides?.[profile.id]?.activeDeployMode;
+    const projectDefault = projectDefaults?.[profile.id];
+    const effectiveMode = override ?? projectDefault ?? profile.activeDeployMode ?? '';
+    if (!effectiveMode) return false;
+    const modeLabel = profile.deployModes?.[effectiveMode]?.label;
+    if (!isReleaseMode(effectiveMode, modeLabel)) return false;
+  }
+  return true;
+}
+
+export class AutoLifecycleService {
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private readonly tickIntervalMs: number;
+  private readonly enabled: boolean;
+  private readonly clock: { now(): number };
+  private running = false;
+
+  constructor(
+    private readonly deps: AutoLifecycleDeps,
+    config?: AutoLifecycleConfig,
+  ) {
+    this.tickIntervalMs = Math.max(5, config?.tickIntervalSeconds ?? 30) * 1000;
+    this.enabled = config?.enabled !== false;
+    this.clock = deps.clock || { now: () => Date.now() };
+  }
+
+  start(): void {
+    if (!this.enabled) return;
+    if (this.timer) return;
+    // 启动时延后一拍跑首次 tick，避免和其他启动任务争锁。
+    this.timer = setInterval(() => {
+      this.tick().catch((err) => {
+        console.error('[auto-lifecycle] tick failed:', (err as Error).message);
+      });
+    }, this.tickIntervalMs);
+    if (typeof (this.timer as { unref?: () => void }).unref === 'function') {
+      (this.timer as { unref?: () => void }).unref!();
+    }
+    console.log(`[auto-lifecycle] started (tick=${Math.round(this.tickIntervalMs / 1000)}s)`);
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  async tick(): Promise<void> {
+    if (this.running) return; // 上一拍还没跑完，跳过这拍
+    this.running = true;
+    try {
+      const { stateService } = this.deps;
+      const projects = stateService.getProjects();
+      for (const project of projects) {
+        const autoPublishMin = Number(project.autoPublishAfterMinutes) || 0;
+        const autoStopMin = Number(project.autoStopAfterMinutes) || 0;
+        if (autoPublishMin <= 0 && autoStopMin <= 0) continue;
+
+        const profiles = stateService.getBuildProfilesForProject(project.id);
+        const projectDefaults = project.defaultDeployModes;
+        const branches = stateService.getAllBranches()
+          .filter(b => b.projectId === project.id && b.status === 'running' && b.lastReadyAt);
+        if (branches.length === 0) continue;
+
+        for (const branch of branches) {
+          const readyMs = Date.parse(branch.lastReadyAt!);
+          if (!Number.isFinite(readyMs) || readyMs <= 0) continue;
+          const ageSec = Math.floor((this.clock.now() - readyMs) / 1000);
+
+          // ── Auto-publish ───────────────────────────────────────────
+          // 已经全部是 release 模式的分支不再触发。
+          if (autoPublishMin > 0 && ageSec >= autoPublishMin * 60) {
+            if (!branchIsAllRelease(branch, profiles, projectDefaults)) {
+              try {
+                await this.applyAutoPublish(branch, profiles, autoPublishMin);
+                continue; // 切完发布版后停下；下次 ready 再走 auto-stop 计时
+              } catch (err) {
+                console.error(`[auto-lifecycle] auto-publish "${branch.id}" failed:`, (err as Error).message);
+              }
+            }
+          }
+
+          // ── Auto-stop ───────────────────────────────────────────────
+          if (autoStopMin > 0 && ageSec >= autoStopMin * 60) {
+            try {
+              await this.applyAutoStop(branch, autoStopMin);
+            } catch (err) {
+              console.error(`[auto-lifecycle] auto-stop "${branch.id}" failed:`, (err as Error).message);
+            }
+          }
+        }
+      }
+    } finally {
+      this.running = false;
+    }
+  }
+
+  /**
+   * 把分支的所有 profile override 翻到 release 模式，然后停止容器。
+   * 不直接重新拉起 —— 用户下一次访问会被 auto-build 路径以新模式构建。
+   * 这样实现避免和 deploy SSE 路由耦合，复用 wake 机制。
+   */
+  private async applyAutoPublish(
+    branch: BranchEntry,
+    profiles: BuildProfile[],
+    minutes: number,
+  ): Promise<void> {
+    const { stateService, stopBranch } = this.deps;
+    const switchedModes: string[] = [];
+    for (const profile of profiles) {
+      const releaseMode = findReleaseDeployMode(profile);
+      if (!releaseMode) continue;
+      stateService.setBranchProfileOverride(branch.id, profile.id, {
+        ...(branch.profileOverrides?.[profile.id] || {}),
+        activeDeployMode: releaseMode,
+      });
+      switchedModes.push(`${profile.name || profile.id}=${releaseMode}`);
+    }
+    if (switchedModes.length === 0) {
+      // 没有任何 profile 有 release 模式可切，记录一次 reason 后跳过。
+      const fresh = stateService.getBranch(branch.id);
+      if (fresh) {
+        fresh.lastStopReason = `项目设置：${minutes} 分钟后自动切发布版，但没有可用的发布版模式（请到「项目设置→新分支默认运行模式」检查 deployModes）`;
+        fresh.lastStopSource = 'system';
+        stateService.save();
+      }
+      return;
+    }
+
+    await stopBranch(branch.id);
+    // 重新读出 branch（stopBranch 可能改了状态），打 reason。
+    const fresh = stateService.getBranch(branch.id);
+    if (fresh) {
+      fresh.lastStoppedAt = new Date().toISOString();
+      fresh.lastStopReason = `项目设置：启动满 ${minutes} 分钟，自动切到发布版（${switchedModes.join(', ')}），下次访问会以发布模式重新构建`;
+      fresh.lastStopSource = 'system';
+      stateService.save();
+      try {
+        stateService.appendActivityLog(fresh.projectId, {
+          type: 'stop',
+          branchId: fresh.id,
+          branchName: fresh.branch,
+          actor: 'auto-lifecycle',
+          note: fresh.lastStopReason,
+        });
+      } catch { /* 辅助信息，失败不影响 */ }
+    }
+  }
+
+  private async applyAutoStop(branch: BranchEntry, minutes: number): Promise<void> {
+    const { stateService, stopBranch } = this.deps;
+    await stopBranch(branch.id);
+    const fresh = stateService.getBranch(branch.id);
+    if (fresh) {
+      fresh.lastStoppedAt = new Date().toISOString();
+      fresh.lastStopReason = `项目设置：启动满 ${minutes} 分钟，自动停止（节省资源）`;
+      fresh.lastStopSource = 'system';
+      stateService.save();
+      try {
+        stateService.appendActivityLog(fresh.projectId, {
+          type: 'stop',
+          branchId: fresh.id,
+          branchName: fresh.branch,
+          actor: 'auto-lifecycle',
+          note: fresh.lastStopReason,
+        });
+      } catch { /* */ }
+    }
+  }
+}

--- a/cds/src/services/auto-lifecycle.ts
+++ b/cds/src/services/auto-lifecycle.ts
@@ -34,6 +34,13 @@ export interface AutoLifecycleDeps {
   stateService: StateService;
   /** 真正执行容器停止。注入而非直接 import ContainerService 是为了方便测试。 */
   stopBranch: (branchId: string) => Promise<void>;
+  /**
+   * 全自动重部署分支（停旧 + 按当前 profileOverrides 重建）。auto-publish 用：
+   * 写完 release override 后调它，走会 resolveEffectiveProfile 的部署路径，
+   * 分支以发布版重新起来。注入便于测试；缺省时 auto-publish 退化为只设
+   * override + stop（不推荐，仅测试/降级）。
+   */
+  redeployBranch?: (branchId: string) => Promise<void>;
   /** 注入时钟，方便测试。生产用 Date.now()。 */
   clock?: { now(): number };
 }
@@ -231,25 +238,38 @@ export class AutoLifecycleService {
   }
 
   /**
-   * 把分支的所有 profile override 翻到 release 模式，然后停止容器。
-   * 不直接重新拉起 —— 用户下一次访问会被 auto-build 路径以新模式构建。
-   * 这样实现避免和 deploy SSE 路由耦合，复用 wake 机制。
+   * 2026-05-14 用户决策的最终设计：全自动「停源码 → 重建发布版」（先后替换，
+   * 同一分支同一时刻只有一个容器，无需人工点击）。
+   *
+   * 流程：
+   *  1. 计算 plan —— 只挑「有 release 模式可切」且「当前生效模式还不是
+   *     release」的 profile（已是 release 的不动，避免覆盖用户自选的
+   *     release 模式 —— Cursor Bugbot Medium 修复）。
+   *  2. 写 release override（先快照旧值，失败要回滚）。
+   *  3. 调 redeployBranch —— 内部 HTTP 自调 /deploy，部署路由会
+   *     resolveEffectiveProfile（读到刚写的 release override），自动停旧
+   *     容器并以发布版重建。这是"自动切发布版"真正生效的关键，**不依赖**
+   *     懒唤醒（懒唤醒路径用 raw profile 不 resolve override）。
+   *  4. redeploy 失败 → 回滚 override + throw，caller 不 stamp 假成功，
+   *     tick 下一拍因未收敛会重试。
    */
   private async applyAutoPublish(
     branch: BranchEntry,
     profiles: BuildProfile[],
     minutes: number,
   ): Promise<void> {
-    const { stateService, stopBranch } = this.deps;
-    // 2026-05-14 Codex review P2：先只"计算"要切哪些 profile，**不写**
-    // profileOverrides。否则 stopBranch 在远端失败 throw 时，override 已被
-    // 持久化（且被 restoreRunning 的 save 落盘），分支仍跑旧容器但 state
-    // 显示已是 release → 下一拍 branchAutoPublishConverged 误判收敛、不再
-    // 重试（若 auto-stop 关着）。override 推迟到 stop 成功后再写。
+    const { stateService, stopBranch, redeployBranch } = this.deps;
+
     const plan: Array<{ profileId: string; releaseMode: string; label: string }> = [];
     for (const profile of profiles) {
       const releaseMode = findReleaseDeployMode(profile);
       if (!releaseMode) continue;
+      // 已经是 release 的 profile 跳过，别用 findReleaseDeployMode 找到的
+      // "第一个 release 模式"覆盖用户/项目已选好的另一个 release 模式。
+      const override = branch.profileOverrides?.[profile.id]?.activeDeployMode;
+      const effectiveMode = override ?? profile.activeDeployMode ?? '';
+      const effectiveLabel = effectiveMode ? profile.deployModes?.[effectiveMode]?.label : undefined;
+      if (effectiveMode && isReleaseDeployMode(effectiveMode, effectiveLabel)) continue;
       plan.push({
         profileId: profile.id,
         releaseMode,
@@ -257,7 +277,9 @@ export class AutoLifecycleService {
       });
     }
     if (plan.length === 0) {
-      // 没有任何 profile 有 release 模式可切，记录一次 reason 后跳过。
+      // 没有可切的 profile：要么全是无 release 模式的纯源码（记一次 reason
+      // 提示用户），要么全部已是 release（收敛，静默返回不打扰）。
+      if (branchAutoPublishConverged(branch, profiles)) return;
       const fresh = stateService.getBranch(branch.id);
       if (fresh) {
         fresh.lastStopReason = `项目设置：${minutes} 分钟后自动切发布版，但没有可用的发布版模式（请到「项目设置→新分支默认运行模式」检查 deployModes）`;
@@ -267,11 +289,22 @@ export class AutoLifecycleService {
       return;
     }
 
-    // 先停。stopBranch 远端失败会 throw，此时 override 尚未写入，state 保持
-    // 原样，caller 的 try/catch 接住后 tick 下一拍重试，不会误判收敛。
-    await stopBranch(branch.id);
+    // 快照旧 override，redeploy 失败时回滚（避免假收敛）。
+    const prevOverrides = new Map<string, string | undefined>();
+    for (const item of plan) {
+      prevOverrides.set(item.profileId, branch.profileOverrides?.[item.profileId]?.activeDeployMode);
+    }
+    const restoreOverrides = (): void => {
+      for (const item of plan) {
+        const existing = stateService.getBranch(branch.id)?.profileOverrides?.[item.profileId];
+        stateService.setBranchProfileOverride(branch.id, item.profileId, {
+          ...(existing || {}),
+          activeDeployMode: prevOverrides.get(item.profileId),
+        });
+      }
+      stateService.save();
+    };
 
-    // 停成功后再写 override —— 下次访问 auto-build 会以 release 模式构建。
     const switchedModes: string[] = [];
     for (const item of plan) {
       const existing = stateService.getBranch(branch.id)?.profileOverrides?.[item.profileId];
@@ -281,17 +314,39 @@ export class AutoLifecycleService {
       });
       switchedModes.push(item.label);
     }
+    stateService.save();
 
-    // 重新读出 branch（stopBranch 可能改了状态），打 reason。
+    if (redeployBranch) {
+      // 全自动重部署：deploy 路由 resolveEffectiveProfile 会读到上面写的
+      // release override，停旧容器 + 以发布版重建。失败回滚 override 并
+      // 抛出，tick 下一拍重试。
+      try {
+        await redeployBranch(branch.id);
+      } catch (err) {
+        restoreOverrides();
+        throw new Error(`auto-publish 重部署失败，已回滚 override: ${(err as Error).message}`);
+      }
+    } else {
+      // 降级路径（仅测试 / 未注入 redeploy）：退回"停容器"老行为。
+      try {
+        await stopBranch(branch.id);
+      } catch (err) {
+        restoreOverrides();
+        throw err;
+      }
+    }
+
     const fresh = stateService.getBranch(branch.id);
     if (fresh) {
       fresh.lastStoppedAt = new Date(this.clock.now()).toISOString();
-      fresh.lastStopReason = `项目设置：启动满 ${minutes} 分钟，自动切到发布版（${switchedModes.join(', ')}），下次访问会以发布模式重新构建`;
+      fresh.lastStopReason = redeployBranch
+        ? `项目设置：启动满 ${minutes} 分钟，已自动切到发布版并重新部署（${switchedModes.join(', ')}）`
+        : `项目设置：启动满 ${minutes} 分钟，已切发布版并停止（${switchedModes.join(', ')}），下次访问重建`;
       fresh.lastStopSource = 'system';
       stateService.save();
       try {
         stateService.appendActivityLog(fresh.projectId, {
-          type: 'stop',
+          type: 'deploy',
           branchId: fresh.id,
           branchName: fresh.branch,
           actor: 'auto-lifecycle',

--- a/cds/src/services/auto-lifecycle.ts
+++ b/cds/src/services/auto-lifecycle.ts
@@ -60,33 +60,45 @@ function findReleaseDeployMode(profile: BuildProfile): string | null {
 }
 
 /**
- * 判断当前 branch 实际跑的是不是已经是"发布版"。所有 profile 都处于 release 才算。
- * 一个 profile 仍是 source 则视为非 release（auto-publish 还有事可做）。
+ * 判断 auto-publish 是否已经"收敛"——即没有任何还能切到发布版却仍跑源码的 profile。
+ *
+ * 2026-05-14 Codex review P2 修复收敛语义：
+ * 老实现要求"所有 profile 都是 release"。但混合工程里常有纯源码 sidecar /
+ * infra profile（deployModes 里压根没有 release 模式），它永远变不成 release，
+ * 于是 branchIsAllRelease 永远 false → auto-publish 每到阈值就停一次、永不收敛。
+ *
+ * 正确语义：**只看"有 release 模式可切"的 profile**。
+ *  - profile 没有任何 release-like deployMode（findReleaseDeployMode 返回 null）
+ *    → 它本来就切不动，不算阻塞项，跳过。
+ *  - profile 有 release 模式但当前生效模式不是 release → 还有事可做，未收敛。
+ *  - 所有"可切"的 profile 都已经是 release，或者根本没有可切的 profile
+ *    → 收敛，不再触发 auto-publish。
  */
-function branchIsAllRelease(
+function branchAutoPublishConverged(
   branch: BranchEntry,
   profiles: BuildProfile[],
   projectDefaults: Record<string, string> | undefined,
 ): boolean {
-  if (profiles.length === 0) return false;
   for (const profile of profiles) {
+    // 这个 profile 压根没有 release 模式可切 —— 不是阻塞项，跳过。
+    if (!findReleaseDeployMode(profile)) continue;
+
     const override = branch.profileOverrides?.[profile.id]?.activeDeployMode;
-    // 2026-05-14 Cursor Bugbot review 修复：projectDefault 必须和
-    // container.ts 的 resolveEffectiveProfile 一样做有效性校验
-    // —— 只有 '' 或 deployModes 里真实存在的 mode 才采纳，否则视为无效、
-    // 回退到 profile.activeDeployMode。否则一个失效的项目默认会让本函数
-    // 和 resolveEffectiveProfile 对"生效模式"判断不一致，auto-publish
-    // 误触发或漏触发。
+    // projectDefault 必须和 container.ts 的 resolveEffectiveProfile 一样做
+    // 有效性校验 —— 只有 '' 或 deployModes 里真实存在的 mode 才采纳，否则
+    // 视为无效、回退到 profile.activeDeployMode，避免两处对"生效模式"判定
+    // 不一致导致 auto-publish 误触发 / 漏触发。
     const rawProjectDefault = projectDefaults?.[profile.id];
     const projectDefaultValid =
       typeof rawProjectDefault === 'string' &&
       (rawProjectDefault === '' || !!profile.deployModes?.[rawProjectDefault]);
     const projectDefault = projectDefaultValid ? rawProjectDefault : undefined;
     const effectiveMode = override ?? projectDefault ?? profile.activeDeployMode ?? '';
-    if (!effectiveMode) return false;
-    const modeLabel = profile.deployModes?.[effectiveMode]?.label;
-    if (!isReleaseMode(effectiveMode, modeLabel)) return false;
+    const modeLabel = effectiveMode ? profile.deployModes?.[effectiveMode]?.label : undefined;
+    // 可切的 profile 还没切到 release → 未收敛。
+    if (!effectiveMode || !isReleaseMode(effectiveMode, modeLabel)) return false;
   }
+  // 没有任何"可切但未切"的 profile → 收敛。
   return true;
 }
 
@@ -172,9 +184,10 @@ export class AutoLifecycleService {
           const ageSec = Math.floor((this.clock.now() - readyMs) / 1000);
 
           // ── Auto-publish ───────────────────────────────────────────
-          // 已经全部是 release 模式的分支不再触发。
+          // 已收敛（所有"可切到发布版"的 profile 都已是 release）的分支不再触发，
+          // 避免纯源码 sidecar / infra profile 让分支被反复无意义重启。
           if (autoPublishMin > 0 && ageSec >= autoPublishMin * 60) {
-            if (!branchIsAllRelease(branch, profiles, projectDefaults)) {
+            if (!branchAutoPublishConverged(branch, profiles, projectDefaults)) {
               try {
                 await this.applyAutoPublish(branch, profiles, autoPublishMin);
                 continue; // 切完发布版后停下；下次 ready 再走 auto-stop 计时

--- a/cds/src/services/auto-lifecycle.ts
+++ b/cds/src/services/auto-lifecycle.ts
@@ -277,20 +277,50 @@ export class AutoLifecycleService {
   ): Promise<void> {
     const { stateService, stopBranch, redeployBranch } = this.deps;
 
-    const plan: Array<{ profileId: string; releaseMode: string; label: string }> = [];
+    // 2026-05-14 Codex review P2 "Redeploy profiles that are already
+    // configured for release"：plan 区分两类 entry——
+    //  - switch：配置还不是 release → 写 release override 再重部署。
+    //  - redeploy-only：配置**已是** release 但容器实际还跑源码（项目
+    //    默认/手动切过 override / 之前冷启没 honor override），override
+    //    不动（保留用户/项目选的具体 release 模式，Cursor Medium 约束），
+    //    但仍要重部署让它真正生效。
+    // 若把 redeploy-only 也 continue 掉，plan 会空 → 误记"没有可用发布版
+    // 模式" + return → auto-publish 永不执行那次必要的重部署，永不收敛。
+    const plan: Array<{ profileId: string; releaseMode: string; label: string; rewriteOverride: boolean }> = [];
     for (const profile of profiles) {
       const releaseMode = findReleaseDeployMode(profile);
       if (!releaseMode) continue;
-      // 已经是 release 的 profile 跳过，别用 findReleaseDeployMode 找到的
-      // "第一个 release 模式"覆盖用户/项目已选好的另一个 release 模式。
       const override = branch.profileOverrides?.[profile.id]?.activeDeployMode;
       const effectiveMode = override ?? profile.activeDeployMode ?? '';
       const effectiveLabel = effectiveMode ? profile.deployModes?.[effectiveMode]?.label : undefined;
-      if (effectiveMode && isReleaseDeployMode(effectiveMode, effectiveLabel)) continue;
+      const configIsRelease = !!effectiveMode && isReleaseDeployMode(effectiveMode, effectiveLabel);
+
+      if (configIsRelease) {
+        // 配置已是 release：看容器**真相**是否已对齐（与
+        // branchAutoPublishConverged 同口径）。已对齐 → 跳过不打扰；
+        // 未对齐（含旧数据无 deployedMode 戳=信任配置已对齐）→ redeploy-only。
+        const svc = branch.services?.[profile.id];
+        if (svc?.deployedMode === undefined) continue; // 旧数据：视为已对齐
+        const deployedLabel = svc.deployedMode
+          ? profile.deployModes?.[svc.deployedMode]?.label
+          : undefined;
+        const actuallyRelease =
+          svc.status === 'running' && isReleaseDeployMode(svc.deployedMode, deployedLabel);
+        if (actuallyRelease) continue; // 真已发布 → 不动
+        plan.push({
+          profileId: profile.id,
+          releaseMode: effectiveMode, // 保留已选的具体 release 模式
+          label: `${profile.name || profile.id}=${effectiveMode}(待生效)`,
+          rewriteOverride: false,
+        });
+        continue;
+      }
+
       plan.push({
         profileId: profile.id,
         releaseMode,
         label: `${profile.name || profile.id}=${releaseMode}`,
+        rewriteOverride: true,
       });
     }
     if (plan.length === 0) {
@@ -306,13 +336,16 @@ export class AutoLifecycleService {
       return;
     }
 
-    // 快照旧 override，redeploy 失败时回滚（避免假收敛）。
+    // 只有 switch 类（rewriteOverride）才动 override；redeploy-only 类
+    // override 已是用户/项目选的 release，原样保留，仅靠重部署生效。
+    const rewriteItems = plan.filter((p) => p.rewriteOverride);
+    // 快照旧 override（仅被改写的），redeploy 失败时回滚（避免假收敛）。
     const prevOverrides = new Map<string, string | undefined>();
-    for (const item of plan) {
+    for (const item of rewriteItems) {
       prevOverrides.set(item.profileId, branch.profileOverrides?.[item.profileId]?.activeDeployMode);
     }
     const restoreOverrides = (): void => {
-      for (const item of plan) {
+      for (const item of rewriteItems) {
         const existing = stateService.getBranch(branch.id)?.profileOverrides?.[item.profileId];
         stateService.setBranchProfileOverride(branch.id, item.profileId, {
           ...(existing || {}),
@@ -322,14 +355,13 @@ export class AutoLifecycleService {
       stateService.save();
     };
 
-    const switchedModes: string[] = [];
-    for (const item of plan) {
+    const switchedModes: string[] = plan.map((p) => p.label);
+    for (const item of rewriteItems) {
       const existing = stateService.getBranch(branch.id)?.profileOverrides?.[item.profileId];
       stateService.setBranchProfileOverride(branch.id, item.profileId, {
         ...(existing || {}),
         activeDeployMode: item.releaseMode,
       });
-      switchedModes.push(item.label);
     }
     stateService.save();
 

--- a/cds/src/services/auto-lifecycle.ts
+++ b/cds/src/services/auto-lifecycle.ts
@@ -172,10 +172,18 @@ export class AutoLifecycleService {
         for (const b of runningBranches) {
           const readyMs = b.lastReadyAt ? Date.parse(b.lastReadyAt) : NaN;
           const stoppedMs = b.lastStoppedAt ? Date.parse(b.lastStoppedAt) : NaN;
+          // 2026-05-14 Codex review P2 "Refresh readiness after redeploys
+          // without stops"：未先停止就被 webhook/手动 redeploy 的 running
+          // 分支，没有新的 lastStoppedAt，旧 lastReadyAt 幸存 → 刚 redeploy
+          // 就按上一轮 age 触发 auto-stop/publish。补 lastDeployAt 作第二
+          // 锚点（deploy worker 成功后 stampBranchTimestamp(lastDeployAt)）：
+          // ready 戳早于最近一次 deploy 也视为陈旧、重新打戳。
+          const deployMs = b.lastDeployAt ? Date.parse(b.lastDeployAt) : NaN;
           const stale =
             !b.lastReadyAt ||
             !Number.isFinite(readyMs) ||
-            (Number.isFinite(stoppedMs) && readyMs <= stoppedMs);
+            (Number.isFinite(stoppedMs) && readyMs <= stoppedMs) ||
+            (Number.isFinite(deployMs) && readyMs <= deployMs);
           if (stale) {
             b.lastReadyAt = new Date(this.clock.now()).toISOString();
             backfilled = true;

--- a/cds/src/services/auto-lifecycle.ts
+++ b/cds/src/services/auto-lifecycle.ts
@@ -201,11 +201,18 @@ export class AutoLifecycleService {
           // 锚点（deploy worker 成功后 stampBranchTimestamp(lastDeployAt)）：
           // ready 戳早于最近一次 deploy 也视为陈旧、重新打戳。
           const deployMs = b.lastDeployAt ? Date.parse(b.lastDeployAt) : NaN;
+          // 2026-05-14 Cursor Bugbot High：deploy 比较必须用严格 `<`。
+          // 正常首次部署里 reconcileBranchStatus 在转 running 时打
+          // lastReadyAt，紧接着同一 handler 里 stampBranchTimestamp
+          // (lastDeployAt) —— 两者常落在同一毫秒。若用 `<=`，readyMs==deployMs
+          // 每拍都判陈旧 → lastReadyAt 每拍被重置成 now → age 永不累积 →
+          // auto-publish / auto-stop 永不触发。同毫秒 = 同一次部署事件，
+          // 不算陈旧。stopped 比较仍用 `<=`（ready 之后再 stop 确属陈旧）。
           const stale =
             !b.lastReadyAt ||
             !Number.isFinite(readyMs) ||
             (Number.isFinite(stoppedMs) && readyMs <= stoppedMs) ||
-            (Number.isFinite(deployMs) && readyMs <= deployMs);
+            (Number.isFinite(deployMs) && readyMs < deployMs);
           if (stale) {
             b.lastReadyAt = new Date(this.clock.now()).toISOString();
             backfilled = true;
@@ -221,6 +228,11 @@ export class AutoLifecycleService {
           if (!Number.isFinite(readyMs) || readyMs <= 0) continue;
           const ageSec = Math.floor((this.clock.now() - readyMs) / 1000);
 
+          // 本拍 auto-publish 是否"已尝试但失败"。用于 auto-stop 让位决策：
+          // 让位只在 publish 即将成功时合理；若 publish 反复失败，绝不能
+          // 因此永久挡住 auto-stop，否则分支永远停不下来。
+          let autoPublishFailedThisTick = false;
+
           // ── Auto-publish ───────────────────────────────────────────
           // 已收敛（所有"可切到发布版"的 profile 都已是 release）的分支不再触发，
           // 避免纯源码 sidecar / infra profile 让分支被反复无意义重启。
@@ -230,6 +242,7 @@ export class AutoLifecycleService {
                 await this.applyAutoPublish(branch, profiles, autoPublishMin);
                 continue; // 切完发布版后停下；下次 ready 再走 auto-stop 计时
               } catch (err) {
+                autoPublishFailedThisTick = true;
                 console.error(`[auto-lifecycle] auto-publish "${branch.id}" failed:`, (err as Error).message);
               }
             }
@@ -246,11 +259,16 @@ export class AutoLifecycleService {
             // 修正：只有当 auto-publish **本拍确实该动**（到点且未收敛）时
             // 才让位；auto-publish 阈值未到 → 没有待执行的 publish 要先行，
             // auto-stop 按自己的阈值正常生效。
+            // 2026-05-14 Cursor Bugbot Medium 二次：autoPublishMin===autoStopMin
+            // 且 publish 失败时，override 已回滚 → 仍未收敛 →
+            // autoPublishDuePending 恒为 true → auto-stop 被永久 continue 掉，
+            // 分支永远停不下来。让位只在 publish "即将成功"时合理；本拍
+            // publish 已尝试且失败，就不该再为它让位，auto-stop 兜底接管。
             const autoPublishDuePending =
               autoPublishMin > 0 &&
               ageSec >= autoPublishMin * 60 &&
               !branchAutoPublishConverged(branch, profiles);
-            if (autoPublishDuePending) {
+            if (autoPublishDuePending && !autoPublishFailedThisTick) {
               continue;
             }
             try {

--- a/cds/src/services/auto-lifecycle.ts
+++ b/cds/src/services/auto-lifecycle.ts
@@ -92,10 +92,27 @@ function branchAutoPublishConverged(
     const override = branch.profileOverrides?.[profile.id]?.activeDeployMode;
     const effectiveMode = override ?? profile.activeDeployMode ?? '';
     const modeLabel = effectiveMode ? profile.deployModes?.[effectiveMode]?.label : undefined;
-    // 可切的 profile 还没切到 release → 未收敛。
+    // 可切的 profile 配置还没切到 release → 未收敛。
     if (!effectiveMode || !isReleaseDeployMode(effectiveMode, modeLabel)) return false;
+
+    // 2026-05-14 真实态收敛：配置已是 release 还不够——必须容器**真的**
+    // 以 release 跑起来才算收敛。否则 redeploy 静默失败（如 Codex P2 的
+    // cluster 场景：远端按旧模式重建，master override 却是 release）会让
+    // 收敛误判 true、auto-publish 永不重试，"自动切发布版"形同虚设。
+    // 真相来源 = svc.deployedMode（容器实际启动时钉的模式）。
+    const svc = branch.services?.[profile.id];
+    // 旧数据兼容：deployedMode 字段引入前启动的容器没有该戳，无法判定
+    // 真相 —— 退回"信任配置"（旧行为），不对存量分支制造无限重部署。
+    if (svc?.deployedMode === undefined) continue;
+    const deployedLabel = svc.deployedMode
+      ? profile.deployModes?.[svc.deployedMode]?.label
+      : undefined;
+    // 已知真相：容器不是以 release 跑（或没在跑）→ 未收敛，继续重试。
+    if (svc.status !== 'running' || !isReleaseDeployMode(svc.deployedMode, deployedLabel)) {
+      return false;
+    }
   }
-  // 没有任何"可切但未切"的 profile → 收敛。
+  // 没有任何"可切但未切 / 配置 release 但容器没跟上"的 profile → 收敛。
   return true;
 }
 

--- a/cds/src/services/auto-lifecycle.ts
+++ b/cds/src/services/auto-lifecycle.ts
@@ -1,5 +1,6 @@
 import type { StateService } from './state.js';
 import type { BuildProfile, BranchEntry } from '../types.js';
+import { RELEASE_DEPLOY_MODE_PATTERN, isReleaseDeployMode } from './deploy-runtime.js';
 
 /**
  * 2026-05-14 引入。
@@ -37,12 +38,8 @@ export interface AutoLifecycleDeps {
   clock?: { now(): number };
 }
 
-/** 与 routes/branches.ts 的 classifyDeployRuntime 等价 —— 内部重复一份避免 routes 暴露内部函数。 */
-const RELEASE_PATTERN = /(prod|production|release|static|publish|published|dist|standalone|built|发布|生产|正式|构建)/i;
-
-function isReleaseMode(modeId: string, modeLabel?: string): boolean {
-  return RELEASE_PATTERN.test(`${modeId} ${modeLabel || ''}`);
-}
+// release 模式分类走 services/deploy-runtime.ts 这个 SSOT，与
+// routes/branches.ts 的 summarizeBranchDeployRuntime 共用同一份正则。
 
 /**
  * 给定 profile，找一个看起来像"发布版"的 deployMode id。找不到返回 null —— 跳过该 profile。
@@ -50,11 +47,11 @@ function isReleaseMode(modeId: string, modeLabel?: string): boolean {
  */
 function findReleaseDeployMode(profile: BuildProfile): string | null {
   const modes = profile.deployModes || {};
-  for (const [modeId, mode] of Object.entries(modes)) {
-    if (RELEASE_PATTERN.test(modeId)) return modeId;
+  for (const [modeId] of Object.entries(modes)) {
+    if (RELEASE_DEPLOY_MODE_PATTERN.test(modeId)) return modeId;
   }
   for (const [modeId, mode] of Object.entries(modes)) {
-    if (mode?.label && RELEASE_PATTERN.test(mode.label)) return modeId;
+    if (mode?.label && RELEASE_DEPLOY_MODE_PATTERN.test(mode.label)) return modeId;
   }
   return null;
 }
@@ -96,7 +93,7 @@ function branchAutoPublishConverged(
     const effectiveMode = override ?? projectDefault ?? profile.activeDeployMode ?? '';
     const modeLabel = effectiveMode ? profile.deployModes?.[effectiveMode]?.label : undefined;
     // 可切的 profile 还没切到 release → 未收敛。
-    if (!effectiveMode || !isReleaseMode(effectiveMode, modeLabel)) return false;
+    if (!effectiveMode || !isReleaseDeployMode(effectiveMode, modeLabel)) return false;
   }
   // 没有任何"可切但未切"的 profile → 收敛。
   return true;
@@ -210,6 +207,16 @@ export class AutoLifecycleService {
 
           // ── Auto-stop ───────────────────────────────────────────────
           if (autoStopMin > 0 && ageSec >= autoStopMin * 60) {
+            // 2026-05-14 Cursor Bugbot review (Medium)：types.ts / PR 描述
+            // 承诺"autoPublish 先行（先切发布版），autoStop 在新的 ready
+            // 计时上再起效"。若 autoStopMin < autoPublishMin，auto-stop 会
+            // 抢在 auto-publish 之前停掉分支，违背该承诺。这里显式让位：
+            // auto-publish 开着且尚未收敛时，跳过本次 auto-stop，等
+            // auto-publish 在 autoPublishMin 到点后先切发布版（停 + 换模式）
+            // → 重启后新 ready 计时 → 此时已收敛 → auto-stop 才接管。
+            if (autoPublishMin > 0 && !branchAutoPublishConverged(branch, profiles, projectDefaults)) {
+              continue;
+            }
             try {
               await this.applyAutoStop(branch, autoStopMin);
             } catch (err) {
@@ -234,17 +241,22 @@ export class AutoLifecycleService {
     minutes: number,
   ): Promise<void> {
     const { stateService, stopBranch } = this.deps;
-    const switchedModes: string[] = [];
+    // 2026-05-14 Codex review P2：先只"计算"要切哪些 profile，**不写**
+    // profileOverrides。否则 stopBranch 在远端失败 throw 时，override 已被
+    // 持久化（且被 restoreRunning 的 save 落盘），分支仍跑旧容器但 state
+    // 显示已是 release → 下一拍 branchAutoPublishConverged 误判收敛、不再
+    // 重试（若 auto-stop 关着）。override 推迟到 stop 成功后再写。
+    const plan: Array<{ profileId: string; releaseMode: string; label: string }> = [];
     for (const profile of profiles) {
       const releaseMode = findReleaseDeployMode(profile);
       if (!releaseMode) continue;
-      stateService.setBranchProfileOverride(branch.id, profile.id, {
-        ...(branch.profileOverrides?.[profile.id] || {}),
-        activeDeployMode: releaseMode,
+      plan.push({
+        profileId: profile.id,
+        releaseMode,
+        label: `${profile.name || profile.id}=${releaseMode}`,
       });
-      switchedModes.push(`${profile.name || profile.id}=${releaseMode}`);
     }
-    if (switchedModes.length === 0) {
+    if (plan.length === 0) {
       // 没有任何 profile 有 release 模式可切，记录一次 reason 后跳过。
       const fresh = stateService.getBranch(branch.id);
       if (fresh) {
@@ -255,7 +267,21 @@ export class AutoLifecycleService {
       return;
     }
 
+    // 先停。stopBranch 远端失败会 throw，此时 override 尚未写入，state 保持
+    // 原样，caller 的 try/catch 接住后 tick 下一拍重试，不会误判收敛。
     await stopBranch(branch.id);
+
+    // 停成功后再写 override —— 下次访问 auto-build 会以 release 模式构建。
+    const switchedModes: string[] = [];
+    for (const item of plan) {
+      const existing = stateService.getBranch(branch.id)?.profileOverrides?.[item.profileId];
+      stateService.setBranchProfileOverride(branch.id, item.profileId, {
+        ...(existing || {}),
+        activeDeployMode: item.releaseMode,
+      });
+      switchedModes.push(item.label);
+    }
+
     // 重新读出 branch（stopBranch 可能改了状态），打 reason。
     const fresh = stateService.getBranch(branch.id);
     if (fresh) {

--- a/cds/src/services/auto-lifecycle.ts
+++ b/cds/src/services/auto-lifecycle.ts
@@ -237,14 +237,20 @@ export class AutoLifecycleService {
 
           // ── Auto-stop ───────────────────────────────────────────────
           if (autoStopMin > 0 && ageSec >= autoStopMin * 60) {
-            // 2026-05-14 Cursor Bugbot review (Medium)：types.ts / PR 描述
-            // 承诺"autoPublish 先行（先切发布版），autoStop 在新的 ready
-            // 计时上再起效"。若 autoStopMin < autoPublishMin，auto-stop 会
-            // 抢在 auto-publish 之前停掉分支，违背该承诺。这里显式让位：
-            // auto-publish 开着且尚未收敛时，跳过本次 auto-stop，等
-            // auto-publish 在 autoPublishMin 到点后先切发布版（停 + 换模式）
-            // → 重启后新 ready 计时 → 此时已收敛 → auto-stop 才接管。
-            if (autoPublishMin > 0 && !branchAutoPublishConverged(branch, profiles)) {
+            // 2026-05-14 "autoPublish 先行"让位规则。原实现只要 auto-publish
+            // 开着且未收敛就 skip auto-stop —— 但若 autoStopMin < autoPublishMin
+            // （如 stop=5 / publish=10，6 分钟时），auto-publish **还没到点**
+            // 也不会 fire，auto-stop 却被无限期推迟到 publish 最终触发为止，
+            // 违背用户"stop 阈值更小=先停"的预期（Cursor Bugbot Medium
+            // 2026-05-14 二次反馈）。
+            // 修正：只有当 auto-publish **本拍确实该动**（到点且未收敛）时
+            // 才让位；auto-publish 阈值未到 → 没有待执行的 publish 要先行，
+            // auto-stop 按自己的阈值正常生效。
+            const autoPublishDuePending =
+              autoPublishMin > 0 &&
+              ageSec >= autoPublishMin * 60 &&
+              !branchAutoPublishConverged(branch, profiles);
+            if (autoPublishDuePending) {
               continue;
             }
             try {

--- a/cds/src/services/auto-lifecycle.ts
+++ b/cds/src/services/auto-lifecycle.ts
@@ -74,23 +74,16 @@ function findReleaseDeployMode(profile: BuildProfile): string | null {
 function branchAutoPublishConverged(
   branch: BranchEntry,
   profiles: BuildProfile[],
-  projectDefaults: Record<string, string> | undefined,
 ): boolean {
   for (const profile of profiles) {
     // 这个 profile 压根没有 release 模式可切 —— 不是阻塞项，跳过。
     if (!findReleaseDeployMode(profile)) continue;
 
+    // 2026-05-14：项目默认运行模式已改为"仅建分支时拷贝"语义，运行期不再
+    // 实时回退。生效模式与 resolveEffectiveProfile 保持一致：只看分支级
+    // override（含建分支时拷贝进来的项目默认）+ baseline activeDeployMode。
     const override = branch.profileOverrides?.[profile.id]?.activeDeployMode;
-    // projectDefault 必须和 container.ts 的 resolveEffectiveProfile 一样做
-    // 有效性校验 —— 只有 '' 或 deployModes 里真实存在的 mode 才采纳，否则
-    // 视为无效、回退到 profile.activeDeployMode，避免两处对"生效模式"判定
-    // 不一致导致 auto-publish 误触发 / 漏触发。
-    const rawProjectDefault = projectDefaults?.[profile.id];
-    const projectDefaultValid =
-      typeof rawProjectDefault === 'string' &&
-      (rawProjectDefault === '' || !!profile.deployModes?.[rawProjectDefault]);
-    const projectDefault = projectDefaultValid ? rawProjectDefault : undefined;
-    const effectiveMode = override ?? projectDefault ?? profile.activeDeployMode ?? '';
+    const effectiveMode = override ?? profile.activeDeployMode ?? '';
     const modeLabel = effectiveMode ? profile.deployModes?.[effectiveMode]?.label : undefined;
     // 可切的 profile 还没切到 release → 未收敛。
     if (!effectiveMode || !isReleaseDeployMode(effectiveMode, modeLabel)) return false;
@@ -149,7 +142,6 @@ export class AutoLifecycleService {
         if (autoPublishMin <= 0 && autoStopMin <= 0) continue;
 
         const profiles = stateService.getBuildProfilesForProject(project.id);
-        const projectDefaults = project.defaultDeployModes;
 
         // 2026-05-14 Codex review P2 修复：deploy / auto-build / webhook 等
         // headless 路径直接 `svc.status='running'` + 分支状态，**不一定**走
@@ -203,7 +195,7 @@ export class AutoLifecycleService {
           // 已收敛（所有"可切到发布版"的 profile 都已是 release）的分支不再触发，
           // 避免纯源码 sidecar / infra profile 让分支被反复无意义重启。
           if (autoPublishMin > 0 && ageSec >= autoPublishMin * 60) {
-            if (!branchAutoPublishConverged(branch, profiles, projectDefaults)) {
+            if (!branchAutoPublishConverged(branch, profiles)) {
               try {
                 await this.applyAutoPublish(branch, profiles, autoPublishMin);
                 continue; // 切完发布版后停下；下次 ready 再走 auto-stop 计时
@@ -222,7 +214,7 @@ export class AutoLifecycleService {
             // auto-publish 开着且尚未收敛时，跳过本次 auto-stop，等
             // auto-publish 在 autoPublishMin 到点后先切发布版（停 + 换模式）
             // → 重启后新 ready 计时 → 此时已收敛 → auto-stop 才接管。
-            if (autoPublishMin > 0 && !branchAutoPublishConverged(branch, profiles, projectDefaults)) {
+            if (autoPublishMin > 0 && !branchAutoPublishConverged(branch, profiles)) {
               continue;
             }
             try {

--- a/cds/src/services/auto-lifecycle.ts
+++ b/cds/src/services/auto-lifecycle.ts
@@ -78,7 +78,7 @@ function findReleaseDeployMode(profile: BuildProfile): string | null {
  *  - 所有"可切"的 profile 都已经是 release，或者根本没有可切的 profile
  *    → 收敛，不再触发 auto-publish。
  */
-function branchAutoPublishConverged(
+export function branchAutoPublishConverged(
   branch: BranchEntry,
   profiles: BuildProfile[],
 ): boolean {

--- a/cds/src/services/auto-lifecycle.ts
+++ b/cds/src/services/auto-lifecycle.ts
@@ -235,7 +235,7 @@ export class AutoLifecycleService {
     // 重新读出 branch（stopBranch 可能改了状态），打 reason。
     const fresh = stateService.getBranch(branch.id);
     if (fresh) {
-      fresh.lastStoppedAt = new Date().toISOString();
+      fresh.lastStoppedAt = new Date(this.clock.now()).toISOString();
       fresh.lastStopReason = `项目设置：启动满 ${minutes} 分钟，自动切到发布版（${switchedModes.join(', ')}），下次访问会以发布模式重新构建`;
       fresh.lastStopSource = 'system';
       stateService.save();
@@ -256,7 +256,7 @@ export class AutoLifecycleService {
     await stopBranch(branch.id);
     const fresh = stateService.getBranch(branch.id);
     if (fresh) {
-      fresh.lastStoppedAt = new Date().toISOString();
+      fresh.lastStoppedAt = new Date(this.clock.now()).toISOString();
       fresh.lastStopReason = `项目设置：启动满 ${minutes} 分钟，自动停止（节省资源）`;
       fresh.lastStopSource = 'system';
       stateService.save();

--- a/cds/src/services/auto-lifecycle.ts
+++ b/cds/src/services/auto-lifecycle.ts
@@ -1,6 +1,6 @@
 import type { StateService } from './state.js';
 import type { BuildProfile, BranchEntry } from '../types.js';
-import { RELEASE_DEPLOY_MODE_PATTERN, isReleaseDeployMode } from './deploy-runtime.js';
+import { isReleaseDeployMode } from './deploy-runtime.js';
 
 /**
  * 2026-05-14 引入。
@@ -51,14 +51,20 @@ export interface AutoLifecycleDeps {
 /**
  * 给定 profile，找一个看起来像"发布版"的 deployMode id。找不到返回 null —— 跳过该 profile。
  * 优先 modeId 命中（更稳），其次 label 命中。
+ *
+ * 2026-05-14 Cursor Bugbot Low 修复：判定一律走 SSOT isReleaseDeployMode
+ * （services/deploy-runtime.ts），不再裸用 RELEASE_DEPLOY_MODE_PATTERN.test
+ * 各测一遍——避免与 summarizeBranchDeployRuntime / branchAutoPublishConverged
+ * 的"拼接后整体匹配"语义漂移。优先级仍保持：先扫一遍只看 modeId 命中，
+ * 再扫一遍带 label 命中。
  */
 function findReleaseDeployMode(profile: BuildProfile): string | null {
   const modes = profile.deployModes || {};
   for (const [modeId] of Object.entries(modes)) {
-    if (RELEASE_DEPLOY_MODE_PATTERN.test(modeId)) return modeId;
+    if (isReleaseDeployMode(modeId)) return modeId;
   }
   for (const [modeId, mode] of Object.entries(modes)) {
-    if (mode?.label && RELEASE_DEPLOY_MODE_PATTERN.test(mode.label)) return modeId;
+    if (mode?.label && isReleaseDeployMode(modeId, mode.label)) return modeId;
   }
   return null;
 }
@@ -387,11 +393,20 @@ export class AutoLifecycleService {
 
     const fresh = stateService.getBranch(branch.id);
     if (fresh) {
-      fresh.lastStoppedAt = new Date(this.clock.now()).toISOString();
-      fresh.lastStopReason = redeployBranch
+      // 2026-05-14 Cursor Bugbot Medium 修复：redeploy 路径分支**重新跑
+      // 起来了**（release 模式），不能再钉 lastStoppedAt——抽屉只要
+      // lastStoppedAt 有值就弹琥珀色"上次停止"横幅，会在一个正在运行的
+      // 分支上误报"已停止"。计时复位由 deploy 路由 stamp 的 lastDeployAt
+      // （tick 陈旧检测 readyMs<=deployMs）兜底，这里无需 lastStoppedAt。
+      // 仅降级 stopBranch 路径分支确实停了，才钉 stop 字段。
+      const note = redeployBranch
         ? `项目设置：启动满 ${minutes} 分钟，已自动切到发布版并重新部署（${switchedModes.join(', ')}）`
         : `项目设置：启动满 ${minutes} 分钟，已切发布版并停止（${switchedModes.join(', ')}），下次访问重建`;
-      fresh.lastStopSource = 'system';
+      if (!redeployBranch) {
+        fresh.lastStoppedAt = new Date(this.clock.now()).toISOString();
+        fresh.lastStopReason = note;
+        fresh.lastStopSource = 'system';
+      }
       stateService.save();
       try {
         stateService.appendActivityLog(fresh.projectId, {
@@ -399,7 +414,7 @@ export class AutoLifecycleService {
           branchId: fresh.id,
           branchName: fresh.branch,
           actor: 'auto-lifecycle',
-          note: fresh.lastStopReason,
+          note,
         });
       } catch { /* 辅助信息，失败不影响 */ }
     }

--- a/cds/src/services/auto-lifecycle.ts
+++ b/cds/src/services/auto-lifecycle.ts
@@ -71,7 +71,17 @@ function branchIsAllRelease(
   if (profiles.length === 0) return false;
   for (const profile of profiles) {
     const override = branch.profileOverrides?.[profile.id]?.activeDeployMode;
-    const projectDefault = projectDefaults?.[profile.id];
+    // 2026-05-14 Cursor Bugbot review 修复：projectDefault 必须和
+    // container.ts 的 resolveEffectiveProfile 一样做有效性校验
+    // —— 只有 '' 或 deployModes 里真实存在的 mode 才采纳，否则视为无效、
+    // 回退到 profile.activeDeployMode。否则一个失效的项目默认会让本函数
+    // 和 resolveEffectiveProfile 对"生效模式"判断不一致，auto-publish
+    // 误触发或漏触发。
+    const rawProjectDefault = projectDefaults?.[profile.id];
+    const projectDefaultValid =
+      typeof rawProjectDefault === 'string' &&
+      (rawProjectDefault === '' || !!profile.deployModes?.[rawProjectDefault]);
+    const projectDefault = projectDefaultValid ? rawProjectDefault : undefined;
     const effectiveMode = override ?? projectDefault ?? profile.activeDeployMode ?? '';
     if (!effectiveMode) return false;
     const modeLabel = profile.deployModes?.[effectiveMode]?.label;
@@ -131,8 +141,29 @@ export class AutoLifecycleService {
 
         const profiles = stateService.getBuildProfilesForProject(project.id);
         const projectDefaults = project.defaultDeployModes;
-        const branches = stateService.getAllBranches()
-          .filter(b => b.projectId === project.id && b.status === 'running' && b.lastReadyAt);
+
+        // 2026-05-14 Codex review P2 修复：deploy / auto-build / webhook 等
+        // headless 路径直接 `svc.status='running'` + 分支状态，**不一定**走
+        // reconcileBranchStatus()，导致 lastReadyAt 永远不被打戳，本调度器
+        // 过滤条件 `b.lastReadyAt` 会把这些分支永久跳过。
+        //
+        // 这里做集中式防御性回填：凡是 running 但缺 lastReadyAt 的分支，
+        // 以"调度器首次观察到它 running"的时间为锚点补上，并跳过本拍
+        // （不立刻动作，保证至少跑满一个完整周期）。代价是 headless 路径的
+        // 计时最多晚一个 tick（默认 30s），对分钟级策略可接受；好处是覆盖
+        // 当前所有路径 + 未来任何新加的 running 转移路径，无需逐处埋点。
+        const runningBranches = stateService.getAllBranches()
+          .filter(b => b.projectId === project.id && b.status === 'running');
+        let backfilled = false;
+        for (const b of runningBranches) {
+          if (!b.lastReadyAt) {
+            b.lastReadyAt = new Date(this.clock.now()).toISOString();
+            backfilled = true;
+          }
+        }
+        if (backfilled) stateService.save();
+
+        const branches = runningBranches.filter(b => b.lastReadyAt);
         if (branches.length === 0) continue;
 
         for (const branch of branches) {

--- a/cds/src/services/auto-lifecycle.ts
+++ b/cds/src/services/auto-lifecycle.ts
@@ -159,16 +159,27 @@ export class AutoLifecycleService {
         // reconcileBranchStatus()，导致 lastReadyAt 永远不被打戳，本调度器
         // 过滤条件 `b.lastReadyAt` 会把这些分支永久跳过。
         //
-        // 这里做集中式防御性回填：凡是 running 但缺 lastReadyAt 的分支，
-        // 以"调度器首次观察到它 running"的时间为锚点补上，并跳过本拍
-        // （不立刻动作，保证至少跑满一个完整周期）。代价是 headless 路径的
-        // 计时最多晚一个 tick（默认 30s），对分钟级策略可接受；好处是覆盖
-        // 当前所有路径 + 未来任何新加的 running 转移路径，无需逐处埋点。
+        // 这里做集中式防御性回填，两种情况都重新打戳并跳过本拍
+        // （不立刻动作，保证至少跑满一个完整周期）：
+        //   (a) running 但缺 lastReadyAt —— headless 首次部署。
+        //   (b) running 但 lastReadyAt 早于 lastStoppedAt —— 分支被
+        //       auto-stop/手动/调度器停过又经 deploy/auto-build 重启，
+        //       旧 ready 戳是上一轮的陈旧值。若不刷新，下一拍会按上一轮
+        //       的 age 立刻把刚重启的容器又 auto-stop/auto-publish 掉。
+        //       （2026-05-14 Codex review P2 "Refresh stale ready timestamps"）
+        // 代价是 headless 路径计时最多晚一个 tick（默认 30s），对分钟级
+        // 策略可接受；好处是覆盖当前 + 未来任何 running 转移路径，无需逐处埋点。
         const runningBranches = stateService.getAllBranches()
           .filter(b => b.projectId === project.id && b.status === 'running');
         let backfilled = false;
         for (const b of runningBranches) {
-          if (!b.lastReadyAt) {
+          const readyMs = b.lastReadyAt ? Date.parse(b.lastReadyAt) : NaN;
+          const stoppedMs = b.lastStoppedAt ? Date.parse(b.lastStoppedAt) : NaN;
+          const stale =
+            !b.lastReadyAt ||
+            !Number.isFinite(readyMs) ||
+            (Number.isFinite(stoppedMs) && readyMs <= stoppedMs);
+          if (stale) {
             b.lastReadyAt = new Date(this.clock.now()).toISOString();
             backfilled = true;
           }

--- a/cds/src/services/container.ts
+++ b/cds/src/services/container.ts
@@ -186,22 +186,61 @@ export function applyProfileOverride(baseline: BuildProfile, override?: BuildPro
 /**
  * Resolve the final effective profile for a specific branch deployment.
  *
- * Merge order (later wins per field):
- *   1. baseline BuildProfile         — the shared public definition
- *   2. branch-level override         — BranchEntry.profileOverrides[profileId]
- *   3. deploy-mode override          — profile.deployModes[activeDeployMode]
+ * Merge order for activeDeployMode (first defined wins):
+ *   1. branch-level override         — BranchEntry.profileOverrides[profileId].activeDeployMode
+ *   2. project default               — Project.defaultDeployModes[profileId]
+ *   3. baseline BuildProfile.activeDeployMode
  *
- * The branch override can even change the active deploy mode, so it is applied
- * before `resolveProfileWithMode`.
+ * Other fields merge: baseline → branch override → mode-specific override.
  *
- * All call sites that previously used `resolveProfileWithMode(profile)` directly
- * should switch to `resolveEffectiveProfile(profile, branch)` so per-branch
- * overrides take effect.
+ * `projectDefaults` 是当前项目的「新分支默认运行模式」(Project.defaultDeployModes)。
+ * 在「项目设置」面板里配的「热加载 / 源码默认」就走这一层，对所有没有分支级
+ * 覆盖的分支生效，不必为每个老分支补回填。这一层是 2026-05-14 修复"项目设置
+ * 配了热加载、分支抽屉里继承默认却显示发布版"问题的关键。
  */
-export function resolveEffectiveProfile(profile: BuildProfile, branch?: BranchEntry): BuildProfile {
+export function resolveEffectiveProfile(
+  profile: BuildProfile,
+  branch?: BranchEntry,
+  projectDefaults?: Record<string, string>,
+): BuildProfile {
   const branchOverride = branch?.profileOverrides?.[profile.id];
-  const withBranchOverride = applyProfileOverride(profile, branchOverride);
+  let withBranchOverride = applyProfileOverride(profile, branchOverride);
+  if (branchOverride?.activeDeployMode === undefined && projectDefaults) {
+    const projectDefaultMode = projectDefaults[profile.id];
+    if (typeof projectDefaultMode === 'string') {
+      const isValid = projectDefaultMode === ''
+        || !!profile.deployModes?.[projectDefaultMode];
+      if (isValid) {
+        withBranchOverride = {
+          ...withBranchOverride,
+          activeDeployMode: projectDefaultMode || undefined,
+        };
+      }
+    }
+  }
   return resolveProfileWithMode(withBranchOverride);
+}
+
+/**
+ * Identify which layer in the merge chain currently drives `activeDeployMode`.
+ * Mirrors the precedence in `resolveEffectiveProfile`. Used by the UI to label
+ * the "继承默认" chip with the actual source (项目默认 / 构建配置默认).
+ */
+export function resolveDeployModeSource(
+  profile: BuildProfile,
+  branch?: BranchEntry,
+  projectDefaults?: Record<string, string>,
+): 'override' | 'project-default' | 'baseline' {
+  if (branch?.profileOverrides?.[profile.id]?.activeDeployMode !== undefined) {
+    return 'override';
+  }
+  if (projectDefaults && typeof projectDefaults[profile.id] === 'string') {
+    const mode = projectDefaults[profile.id];
+    if (mode === '' || profile.deployModes?.[mode]) {
+      return 'project-default';
+    }
+  }
+  return 'baseline';
 }
 
 function missingEnvTemplates(env: Record<string, string>): string[] {

--- a/cds/src/services/container.ts
+++ b/cds/src/services/container.ts
@@ -186,61 +186,21 @@ export function applyProfileOverride(baseline: BuildProfile, override?: BuildPro
 /**
  * Resolve the final effective profile for a specific branch deployment.
  *
- * Merge order for activeDeployMode (first defined wins):
- *   1. branch-level override         — BranchEntry.profileOverrides[profileId].activeDeployMode
- *   2. project default               — Project.defaultDeployModes[profileId]
- *   3. baseline BuildProfile.activeDeployMode
+ * Merge order (later wins per field):
+ *   1. baseline BuildProfile         — the shared public definition
+ *   2. branch-level override         — BranchEntry.profileOverrides[profileId]
+ *   3. deploy-mode override          — profile.deployModes[activeDeployMode]
  *
- * Other fields merge: baseline → branch override → mode-specific override.
- *
- * `projectDefaults` 是当前项目的「新分支默认运行模式」(Project.defaultDeployModes)。
- * 在「项目设置」面板里配的「热加载 / 源码默认」就走这一层，对所有没有分支级
- * 覆盖的分支生效，不必为每个老分支补回填。这一层是 2026-05-14 修复"项目设置
- * 配了热加载、分支抽屉里继承默认却显示发布版"问题的关键。
+ * 2026-05-14：用户明确选择「项目默认运行模式只在创建分支时拷贝一次」
+ * （保留旧 UI 承诺「不改已有分支」）。因此这里**不再**读
+ * Project.defaultDeployModes 做实时回退——项目默认由 branches.ts 的
+ * applyProjectDefaultDeployModes() 在建分支时写进 branch.profileOverrides，
+ * 之后就是普通的分支级 override，本函数只认 branch override + baseline。
  */
-export function resolveEffectiveProfile(
-  profile: BuildProfile,
-  branch?: BranchEntry,
-  projectDefaults?: Record<string, string>,
-): BuildProfile {
+export function resolveEffectiveProfile(profile: BuildProfile, branch?: BranchEntry): BuildProfile {
   const branchOverride = branch?.profileOverrides?.[profile.id];
-  let withBranchOverride = applyProfileOverride(profile, branchOverride);
-  if (branchOverride?.activeDeployMode === undefined && projectDefaults) {
-    const projectDefaultMode = projectDefaults[profile.id];
-    if (typeof projectDefaultMode === 'string') {
-      const isValid = projectDefaultMode === ''
-        || !!profile.deployModes?.[projectDefaultMode];
-      if (isValid) {
-        withBranchOverride = {
-          ...withBranchOverride,
-          activeDeployMode: projectDefaultMode || undefined,
-        };
-      }
-    }
-  }
+  const withBranchOverride = applyProfileOverride(profile, branchOverride);
   return resolveProfileWithMode(withBranchOverride);
-}
-
-/**
- * Identify which layer in the merge chain currently drives `activeDeployMode`.
- * Mirrors the precedence in `resolveEffectiveProfile`. Used by the UI to label
- * the "继承默认" chip with the actual source (项目默认 / 构建配置默认).
- */
-export function resolveDeployModeSource(
-  profile: BuildProfile,
-  branch?: BranchEntry,
-  projectDefaults?: Record<string, string>,
-): 'override' | 'project-default' | 'baseline' {
-  if (branch?.profileOverrides?.[profile.id]?.activeDeployMode !== undefined) {
-    return 'override';
-  }
-  if (projectDefaults && typeof projectDefaults[profile.id] === 'string') {
-    const mode = projectDefaults[profile.id];
-    if (mode === '' || profile.deployModes?.[mode]) {
-      return 'project-default';
-    }
-  }
-  return 'baseline';
 }
 
 function missingEnvTemplates(env: Record<string, string>): string[] {

--- a/cds/src/services/deploy-runtime.ts
+++ b/cds/src/services/deploy-runtime.ts
@@ -1,0 +1,30 @@
+/**
+ * 部署模式分类的单一数据源（SSOT）。
+ *
+ * 2026-05-14 Cursor Bugbot review (Low) 修复：原来 `branches.ts` 的
+ * `classifyDeployRuntime` 和 `auto-lifecycle.ts` 的 `RELEASE_PATTERN /
+ * isReleaseMode` 是手抄两份正则。任一处加关键词（如 preview/staging）另一处
+ * 不会同步，导致 `branchAutoPublishConverged` 与 `summarizeBranchDeployRuntime`
+ * 对"什么算 release"判断不一致。抽到这里，改一处生效全局。
+ */
+
+/** modeId / label 命中即视为"发布版/生产"运行模式。 */
+export const RELEASE_DEPLOY_MODE_PATTERN =
+  /(prod|production|release|static|publish|published|dist|standalone|built|发布|生产|正式|构建)/i;
+
+/**
+ * 给定一个具体 deploy mode（id + 可选 label），判断它是否属于"发布版"。
+ * 空 modeId 视为非 release（源码/热加载默认）。
+ */
+export function isReleaseDeployMode(modeId: string, modeLabel?: string): boolean {
+  if (!modeId) return false;
+  return RELEASE_DEPLOY_MODE_PATTERN.test(`${modeId} ${modeLabel || ''}`);
+}
+
+/** 把 deploy mode 归类为 'source' | 'release'。无 modeId 时为 'source'。 */
+export function classifyDeployRuntime(
+  modeId?: string,
+  modeLabel?: string,
+): 'source' | 'release' {
+  return modeId && isReleaseDeployMode(modeId, modeLabel) ? 'release' : 'source';
+}

--- a/cds/src/services/state.ts
+++ b/cds/src/services/state.ts
@@ -2348,7 +2348,15 @@ export class StateService {
   // 调 recordGithubWebhookDelivery 写入。前端 CDS 系统设置 → GitHub Webhook
   // 日志 tab 列表展示。
 
-  static readonly WEBHOOK_DELIVERY_HISTORY_MAX = 200;
+  /**
+   * 2026-05-14: 历史上限从 200 调到 1000。
+   * 单条 delivery ~1KB（含 payloadSnippet 截断），1000 条 ~1MB，state.json 可承受。
+   * 用户反馈"webhook 只有 1 条以为没日志"——根因是上限太小，遇到一阵 push 风暴
+   * 几分钟就被旧条目挤掉。1000 条相当于一个忙项目两天的窗口，足够回溯排查。
+   * 后续若上 MongoDB 持久化，把本 ring buffer 改成 capped collection，参考
+   * doc/debt.cds-state-json.md。
+   */
+  static readonly WEBHOOK_DELIVERY_HISTORY_MAX = 1000;
 
   recordGithubWebhookDelivery(delivery: import('../types.js').GithubWebhookDelivery): void {
     const list = this.state.githubWebhookDeliveries || [];
@@ -2363,10 +2371,15 @@ export class StateService {
     }
   }
 
-  getGithubWebhookDeliveries(limit = 50): import('../types.js').GithubWebhookDelivery[] {
+  /**
+   * 2026-05-14: 新增 `offset` 支持翻页。limit 默认 50，最大等于 buffer 上限。
+   * 倒序（最新在前），offset 跳过 N 条最新条目读后面的。
+   */
+  getGithubWebhookDeliveries(limit = 50, offset = 0): import('../types.js').GithubWebhookDelivery[] {
     const list = this.state.githubWebhookDeliveries || [];
-    // 倒序(最新在前)
-    return [...list].reverse().slice(0, Math.max(1, Math.min(limit, StateService.WEBHOOK_DELIVERY_HISTORY_MAX)));
+    const cappedLimit = Math.max(1, Math.min(limit, StateService.WEBHOOK_DELIVERY_HISTORY_MAX));
+    const cappedOffset = Math.max(0, offset);
+    return [...list].reverse().slice(cappedOffset, cappedOffset + cappedLimit);
   }
 
   getGithubAppWhitelist(): import('../types.js').GithubAppWhitelistSettings {

--- a/cds/src/types.ts
+++ b/cds/src/types.ts
@@ -541,6 +541,29 @@ export interface BranchEntry {
   lastPullAt?: string;
   /** 最近一次成功部署完成的 ISO 时间戳。 */
   lastDeployAt?: string;
+  /**
+   * 2026-05-14: 最近一次容器被停止的 ISO 时间戳。
+   * 涵盖用户主动 /stop、调度器空闲降温、远端执行器停止；不涵盖部署失败转 error
+   * 状态（那个走 errorMessage）。UI 上配合 lastStopReason / lastStopSource 展示，
+   * 解决"分支莫名变灰用户不知道为什么"的问题。
+   */
+  lastStoppedAt?: string;
+  /**
+   * 停止原因的人类可读短语，UI 直接展示。例如：
+   *   - "用户手动停止"
+   *   - "调度器：空闲超过 15 分钟自动降温"
+   *   - "调度器：超出热容量上限被驱逐"
+   *   - "远端执行器停止"
+   */
+  lastStopReason?: string;
+  /**
+   * 停止发起方分类，用于过滤与统计：
+   *   - 'user'      用户在 UI 上点了停止
+   *   - 'scheduler' 调度器自动降温/驱逐
+   *   - 'executor'  远端执行器
+   *   - 'system'    其他系统侧（垃圾回收等）
+   */
+  lastStopSource?: 'user' | 'scheduler' | 'executor' | 'system';
 }
 
 /** State of a single service (one build profile instance) within a branch */

--- a/cds/src/types.ts
+++ b/cds/src/types.ts
@@ -584,6 +584,14 @@ export interface ServiceState {
   status: 'idle' | 'building' | 'starting' | 'running' | 'restarting' | 'stopping' | 'stopped' | 'error';
   buildLog?: string;
   errorMessage?: string;
+  /**
+   * 2026-05-14：容器**真正启动成功那一刻**实际使用的 deploy mode id
+   * （= 当时 resolveEffectiveProfile 的 activeDeployMode）。这是"在跑的
+   * 是不是发布版"的唯一真相来源——卡片徽章据此判断真实态 vs 配置意图，
+   * 不再只看 profileOverrides。空串 = 源码/默认模式启动。
+   * undefined = 该容器在本字段引入前启动（旧数据），徽章回退到配置语义。
+   */
+  deployedMode?: string;
 }
 
 /** A build/operation log event */

--- a/cds/src/types.ts
+++ b/cds/src/types.ts
@@ -542,6 +542,15 @@ export interface BranchEntry {
   /** 最近一次成功部署完成的 ISO 时间戳。 */
   lastDeployAt?: string;
   /**
+   * 2026-05-14: 容器最近一次进入 running 状态的 ISO 时间戳。
+   * 由 reconcileBranchStatus() 在状态机切换到 'running' 时打戳。
+   * 调度器（项目级 autoPublishAfterMinutes / autoStopAfterMinutes）
+   * 以本字段为计时锚点 —— "完全启动成功之后开始算"。
+   * 进入 running 后再回退到其他状态时**不清空**，下一次再次 running 才覆盖；
+   * 这样调度器即便错过一拍也能基于上一次有效 ready 时间继续工作。
+   */
+  lastReadyAt?: string;
+  /**
    * 2026-05-14: 最近一次容器被停止的 ISO 时间戳。
    * 涵盖用户主动 /stop、调度器空闲降温、远端执行器停止；不涵盖部署失败转 error
    * 状态（那个走 errorMessage）。UI 上配合 lastStopReason / lastStopSource 展示，
@@ -1649,6 +1658,25 @@ export interface Project {
    * never mutates existing branches and never writes BuildProfile.activeDeployMode.
    */
   defaultDeployModes?: Record<string, string>;
+  /**
+   * 2026-05-14: 项目级 "运行 N 分钟后自动切发布版" 策略。
+   * - 0 / 缺省 / 未启用：禁用。
+   * - >0：从 BranchEntry.lastReadyAt（容器进入 running 状态时打戳）计时；
+   *   超过 N 分钟仍是源码 / 热加载模式且当前 running，则将所有 profileOverrides 的
+   *   activeDeployMode 翻转到 profile.deployModes 里第一个被 classifyDeployRuntime
+   *   判定为 'release' 的模式，并停止容器；用户下次访问会被 auto-build 路径以发布
+   *   模式拉起来。
+   * 时间锚点 = lastReadyAt（部署成绿色），而不是 HTTP 流量，避免长连接永远刷新。
+   */
+  autoPublishAfterMinutes?: number;
+  /**
+   * 2026-05-14: 项目级 "运行 N 分钟后自动停止" 策略。
+   * 与 autoPublishAfterMinutes 同时启用时，autoPublish 先行（先切发布版），
+   * autoStop 在新的 ready 计时上再起效。
+   * scheduler 的 idleTTLSeconds（CDS 系统级）是按"最近被访问"算，本字段是按
+   * "部署成功后的存活时间"算 —— 用于"调试完忘了关"这种场景。
+   */
+  autoStopAfterMinutes?: number;
   /**
    * 当 routing rules 都不匹配时回退到的分支 id（旧 state.defaultBranch）。
    * 历史上是机器级单值，多项目时会 cross-talk —— 现在每个项目独立。

--- a/cds/tests/scheduler/executor-registry.test.ts
+++ b/cds/tests/scheduler/executor-registry.test.ts
@@ -314,6 +314,84 @@ describe('ExecutorRegistry', () => {
       });
       expect(ok).toBe(false);
     });
+
+    // 2026-05-14 Codex review P2：心跳整体替换 services 不能抹掉协调端
+    // proxyDeployToExecutor 写的 deployedMode 真相戳（执行器不上报该字段）。
+    it('preserves deployedMode across heartbeat when executor omits it', () => {
+      registry.register({
+        id: 'a',
+        host: 'a.local',
+        port: 9900,
+        capacity: { maxBranches: 4, memoryMB: 4096, cpuCores: 4 },
+      });
+      const legacy = stateService.getLegacyProject();
+      stateService.addBranch({
+        id: 'branch-x',
+        projectId: legacy?.id ?? 'default',
+        branch: 'branch-x',
+        worktreePath: '',
+        status: 'running',
+        executorId: 'a',
+        createdAt: new Date().toISOString(),
+        services: {
+          web: {
+            profileId: 'web',
+            containerName: 'c-web',
+            hostPort: 30000,
+            status: 'running',
+            deployedMode: 'prod', // proxy 写的真相戳
+          },
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
+      // 执行器心跳：services 带 status 但不带 deployedMode
+      registry.heartbeat('a', {
+        load: { memoryUsedMB: 100, cpuPercent: 10 },
+        branches: {
+          'branch-x': {
+            status: 'running',
+            services: { web: { profileId: 'web', containerName: 'c-web', hostPort: 30000, status: 'running' } },
+          },
+        },
+      });
+
+      const after = stateService.getBranch('branch-x');
+      expect(after?.services.web?.deployedMode).toBe('prod');
+    });
+
+    it('lets executor-reported deployedMode win when present', () => {
+      registry.register({
+        id: 'a', host: 'a.local', port: 9900,
+        capacity: { maxBranches: 4, memoryMB: 4096, cpuCores: 4 },
+      });
+      const legacy = stateService.getLegacyProject();
+      stateService.addBranch({
+        id: 'branch-y',
+        projectId: legacy?.id ?? 'default',
+        branch: 'branch-y',
+        worktreePath: '',
+        status: 'running',
+        executorId: 'a',
+        createdAt: new Date().toISOString(),
+        services: {
+          web: { profileId: 'web', containerName: 'c-web', hostPort: 30000, status: 'running', deployedMode: 'dev' },
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
+      registry.heartbeat('a', {
+        load: { memoryUsedMB: 100, cpuPercent: 10 },
+        branches: {
+          'branch-y': {
+            status: 'running',
+            services: { web: { profileId: 'web', containerName: 'c-web', hostPort: 30000, status: 'running', deployedMode: 'prod' } },
+          },
+        },
+      });
+
+      expect(stateService.getBranch('branch-y')?.services.web?.deployedMode).toBe('prod');
+    });
   });
 
   // ── checkHealth() — offline GC (regression: #8) ──

--- a/cds/tests/services/auto-lifecycle-converged.test.ts
+++ b/cds/tests/services/auto-lifecycle-converged.test.ts
@@ -1,0 +1,131 @@
+/**
+ * branchAutoPublishConverged 真实态收敛语义测试。
+ *
+ * 2026-05-14：用户质疑"你测了吗"。本文件给出 auto-publish 收敛判定的
+ * 真实断言——核心修复是：配置切了发布版还不够，必须容器**真的**以
+ * 发布版跑起来（svc.deployedMode）才算收敛；否则 redeploy 静默失败
+ * （如 cluster 下 proxyDeployToExecutor 丢 override）会被误判收敛、
+ * auto-publish 形同虚设。同时验证旧数据（无 deployedMode 戳）退回
+ * 信任配置，不对存量分支制造无限重部署。
+ */
+import { describe, it, expect } from 'vitest';
+import { branchAutoPublishConverged } from '../../src/services/auto-lifecycle.js';
+import type { BranchEntry, BuildProfile, ServiceState } from '../../src/types.js';
+
+function profile(id: string, overrides: Partial<BuildProfile> = {}): BuildProfile {
+  return {
+    id,
+    name: id,
+    dockerImage: 'node:22',
+    workDir: '/app',
+    containerPort: 3000,
+    hostPortPreference: 0,
+    buildCommand: 'echo build',
+    // prod = 命中 RELEASE_DEPLOY_MODE_PATTERN（发布版）；dev = 源码
+    deployModes: {
+      dev: { label: '源码热加载' },
+      prod: { label: '生产构建' },
+    },
+    ...overrides,
+  } as BuildProfile;
+}
+
+function svc(profileId: string, status: ServiceState['status'], deployedMode?: string): ServiceState {
+  return {
+    profileId,
+    containerName: `c-${profileId}`,
+    hostPort: 30000,
+    status,
+    ...(deployedMode !== undefined ? { deployedMode } : {}),
+  } as ServiceState;
+}
+
+function branch(overrides: Partial<BranchEntry> = {}): BranchEntry {
+  return {
+    id: 'b1',
+    branch: 'feat/x',
+    projectId: 'p1',
+    worktreePath: '/tmp/wt',
+    status: 'running',
+    services: {},
+    createdAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  } as BranchEntry;
+}
+
+describe('branchAutoPublishConverged — 真实态收敛', () => {
+  it('profile 没有任何 release 模式可切 → 不算阻塞项 → 收敛 true', () => {
+    const p = profile('web', { deployModes: { dev: { label: '源码' } } });
+    expect(branchAutoPublishConverged(branch(), [p])).toBe(true);
+  });
+
+  it('配置仍是源码（未设 release override）→ 未收敛 false', () => {
+    const p = profile('web', { activeDeployMode: 'dev' });
+    expect(branchAutoPublishConverged(branch(), [p])).toBe(false);
+  });
+
+  it('配置 release + 旧数据（deployedMode 未定义）→ 退回信任配置 → 收敛 true', () => {
+    const p = profile('web');
+    const b = branch({
+      profileOverrides: { web: { activeDeployMode: 'prod' } },
+      services: { web: svc('web', 'running') }, // 无 deployedMode 戳
+    });
+    expect(branchAutoPublishConverged(b, [p])).toBe(true);
+  });
+
+  it('配置 release + 容器确以 release 跑（deployedMode=prod, running）→ 收敛 true', () => {
+    const p = profile('web');
+    const b = branch({
+      profileOverrides: { web: { activeDeployMode: 'prod' } },
+      services: { web: svc('web', 'running', 'prod') },
+    });
+    expect(branchAutoPublishConverged(b, [p])).toBe(true);
+  });
+
+  it('核心修复：配置 release 但容器实际还跑源码（deployedMode=dev, running）→ 未收敛 false', () => {
+    const p = profile('web');
+    const b = branch({
+      profileOverrides: { web: { activeDeployMode: 'prod' } },
+      services: { web: svc('web', 'running', 'dev') }, // redeploy 没真正切过去
+    });
+    expect(branchAutoPublishConverged(b, [p])).toBe(false);
+  });
+
+  it('配置 release 但容器没在跑（deployedMode 已知, status=stopped）→ 未收敛 false', () => {
+    const p = profile('web');
+    const b = branch({
+      profileOverrides: { web: { activeDeployMode: 'prod' } },
+      services: { web: svc('web', 'stopped', 'prod') },
+    });
+    expect(branchAutoPublishConverged(b, [p])).toBe(false);
+  });
+
+  it('多 profile：一个真发布、一个还跑源码 → 整体未收敛 false', () => {
+    const a = profile('web');
+    const c = profile('api');
+    const b = branch({
+      profileOverrides: {
+        web: { activeDeployMode: 'prod' },
+        api: { activeDeployMode: 'prod' },
+      },
+      services: {
+        web: svc('web', 'running', 'prod'),
+        api: svc('api', 'running', 'dev'), // 没切过去
+      },
+    });
+    expect(branchAutoPublishConverged(b, [a, c])).toBe(false);
+  });
+
+  it('可切 profile 全部真发布 + 一个无 release 模式的 sidecar → 收敛 true', () => {
+    const web = profile('web');
+    const sidecar = profile('redis', { deployModes: { dev: { label: '源码' } } });
+    const b = branch({
+      profileOverrides: { web: { activeDeployMode: 'prod' } },
+      services: {
+        web: svc('web', 'running', 'prod'),
+        redis: svc('redis', 'running', 'dev'),
+      },
+    });
+    expect(branchAutoPublishConverged(b, [web, sidecar])).toBe(true);
+  });
+});

--- a/cds/tests/services/auto-lifecycle-redeploy.test.ts
+++ b/cds/tests/services/auto-lifecycle-redeploy.test.ts
@@ -97,6 +97,20 @@ describe('AutoLifecycleService.tick — auto-publish 真实重部署', () => {
     expect(h.redeployBranch).not.toHaveBeenCalled();
   });
 
+  it('配置已是 release 但容器还跑源码 → 仍重部署，且不改写 override（Codex P2）', async () => {
+    const h = makeHarness(
+      branch({
+        profileOverrides: { web: { activeDeployMode: 'prod' } },
+        services: { web: svc('web', 'running', 'dev') }, // 配置 prod，容器实际 dev
+      }),
+    );
+    await h.service.tick();
+    expect(h.redeployBranch).toHaveBeenCalledTimes(1);
+    expect(h.redeployBranch).toHaveBeenCalledWith('b1');
+    // redeploy-only：override 保持用户/项目选的 prod，不被覆盖
+    expect(h.branch.profileOverrides?.web?.activeDeployMode).toBe('prod');
+  });
+
   it('redeploy 失败 → 回滚 override（不留假收敛），下一拍仍未收敛', async () => {
     const h = makeHarness(branch());
     h.redeployBranch.mockRejectedValueOnce(new Error('deploy boom'));

--- a/cds/tests/services/auto-lifecycle-redeploy.test.ts
+++ b/cds/tests/services/auto-lifecycle-redeploy.test.ts
@@ -37,10 +37,17 @@ function svc(profileId: string, status: ServiceState['status'], deployedMode?: s
 const READY_AT = '2026-05-14T00:00:00.000Z';
 const NOW_MS = Date.parse(READY_AT) + 11 * 60 * 1000; // ready 后 11 分钟
 
-function makeHarness(branch: BranchEntry) {
+function makeHarness(
+  branch: BranchEntry,
+  projectCfg: { autoPublishAfterMinutes: number; autoStopAfterMinutes: number } = {
+    autoPublishAfterMinutes: 10,
+    autoStopAfterMinutes: 0,
+  },
+  nowMs: number = NOW_MS,
+) {
   const profiles = [profile('web')];
   const stateService = {
-    getProjects: () => [{ id: 'p1', autoPublishAfterMinutes: 10, autoStopAfterMinutes: 0 }],
+    getProjects: () => [{ id: 'p1', ...projectCfg }],
     getBuildProfilesForProject: () => profiles,
     getAllBranches: () => [branch],
     getBranch: (id: string) => (id === branch.id ? branch : undefined),
@@ -56,7 +63,7 @@ function makeHarness(branch: BranchEntry) {
   const redeployBranch = vi.fn(async () => {});
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const service = new AutoLifecycleService(
-    { stateService: stateService as any, stopBranch, redeployBranch, clock: { now: () => NOW_MS } },
+    { stateService: stateService as any, stopBranch, redeployBranch, clock: { now: () => nowMs } },
     { tickIntervalSeconds: 30, enabled: true },
   );
   return { service, stateService, stopBranch, redeployBranch, branch };
@@ -125,5 +132,31 @@ describe('AutoLifecycleService.tick — auto-publish 真实重部署', () => {
     // 下一拍：依然未收敛 → 会再次尝试 redeploy（证明没被误判收敛）
     await h.service.tick();
     expect(h.redeployBranch).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('AutoLifecycleService.tick — auto-stop / auto-publish 让位次序', () => {
+  const at = (min: number) => Date.parse(READY_AT) + min * 60 * 1000;
+
+  it('autoStop=5 < autoPublish=10，6 分钟：auto-publish 未到点 → auto-stop 正常生效', async () => {
+    const h = makeHarness(
+      branch(), // deployedMode=dev，未收敛
+      { autoPublishAfterMinutes: 10, autoStopAfterMinutes: 5 },
+      at(6),
+    );
+    await h.service.tick();
+    expect(h.stopBranch).toHaveBeenCalledWith('b1'); // auto-stop 没被无限推迟
+    expect(h.redeployBranch).not.toHaveBeenCalled(); // auto-publish 还没到点
+  });
+
+  it('autoStop=5 < autoPublish=10，11 分钟：两者都到点 → auto-publish 先行', async () => {
+    const h = makeHarness(
+      branch(),
+      { autoPublishAfterMinutes: 10, autoStopAfterMinutes: 5 },
+      at(11),
+    );
+    await h.service.tick();
+    expect(h.redeployBranch).toHaveBeenCalledWith('b1'); // publish 先行
+    expect(h.stopBranch).not.toHaveBeenCalled();         // 本拍让位，不停
   });
 });

--- a/cds/tests/services/auto-lifecycle-redeploy.test.ts
+++ b/cds/tests/services/auto-lifecycle-redeploy.test.ts
@@ -1,0 +1,112 @@
+/**
+ * AutoLifecycleService.tick() 行为测试 —— 驱动真实调用链
+ * tick → branchAutoPublishConverged → applyAutoPublish → redeployBranch，
+ * 用注入的 fake state + mock redeploy 断言"自动切发布版"真的发生 /
+ * 失败真的回滚，而不仅仅是 tsc 通过。
+ *
+ * 2026-05-14：回应用户"你测了吗"。
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { AutoLifecycleService } from '../../src/services/auto-lifecycle.js';
+import type { BranchEntry, BuildProfile, ServiceState } from '../../src/types.js';
+
+function profile(id: string): BuildProfile {
+  return {
+    id,
+    name: id,
+    dockerImage: 'node:22',
+    workDir: '/app',
+    containerPort: 3000,
+    hostPortPreference: 0,
+    buildCommand: 'echo build',
+    activeDeployMode: 'dev',
+    deployModes: { dev: { label: '源码热加载' }, prod: { label: '生产构建' } },
+  } as BuildProfile;
+}
+
+function svc(profileId: string, status: ServiceState['status'], deployedMode?: string): ServiceState {
+  return {
+    profileId,
+    containerName: `c-${profileId}`,
+    hostPort: 30000,
+    status,
+    ...(deployedMode !== undefined ? { deployedMode } : {}),
+  } as ServiceState;
+}
+
+const READY_AT = '2026-05-14T00:00:00.000Z';
+const NOW_MS = Date.parse(READY_AT) + 11 * 60 * 1000; // ready 后 11 分钟
+
+function makeHarness(branch: BranchEntry) {
+  const profiles = [profile('web')];
+  const stateService = {
+    getProjects: () => [{ id: 'p1', autoPublishAfterMinutes: 10, autoStopAfterMinutes: 0 }],
+    getBuildProfilesForProject: () => profiles,
+    getAllBranches: () => [branch],
+    getBranch: (id: string) => (id === branch.id ? branch : undefined),
+    setBranchProfileOverride: (bid: string, pid: string, ov: { activeDeployMode?: string }) => {
+      if (bid !== branch.id) return;
+      branch.profileOverrides = branch.profileOverrides || {};
+      branch.profileOverrides[pid] = { ...(branch.profileOverrides[pid] || {}), ...ov };
+    },
+    appendActivityLog: vi.fn(),
+    save: vi.fn(),
+  };
+  const stopBranch = vi.fn(async () => {});
+  const redeployBranch = vi.fn(async () => {});
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const service = new AutoLifecycleService(
+    { stateService: stateService as any, stopBranch, redeployBranch, clock: { now: () => NOW_MS } },
+    { tickIntervalSeconds: 30, enabled: true },
+  );
+  return { service, stateService, stopBranch, redeployBranch, branch };
+}
+
+function branch(overrides: Partial<BranchEntry> = {}): BranchEntry {
+  return {
+    id: 'b1',
+    branch: 'feat/x',
+    projectId: 'p1',
+    worktreePath: '/tmp/wt',
+    status: 'running',
+    lastReadyAt: READY_AT,
+    services: { web: svc('web', 'running', 'dev') },
+    createdAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  } as BranchEntry;
+}
+
+describe('AutoLifecycleService.tick — auto-publish 真实重部署', () => {
+  it('未收敛（容器跑源码）→ 写 release override 并调用 redeployBranch', async () => {
+    const h = makeHarness(branch());
+    await h.service.tick();
+    expect(h.redeployBranch).toHaveBeenCalledTimes(1);
+    expect(h.redeployBranch).toHaveBeenCalledWith('b1');
+    // override 已写成 release 模式（prod 命中发布版正则）
+    expect(h.branch.profileOverrides?.web?.activeDeployMode).toBe('prod');
+  });
+
+  it('已收敛（override=prod 且容器 deployedMode=prod）→ 不重部署', async () => {
+    const h = makeHarness(
+      branch({
+        profileOverrides: { web: { activeDeployMode: 'prod' } },
+        services: { web: svc('web', 'running', 'prod') },
+      }),
+    );
+    await h.service.tick();
+    expect(h.redeployBranch).not.toHaveBeenCalled();
+  });
+
+  it('redeploy 失败 → 回滚 override（不留假收敛），下一拍仍未收敛', async () => {
+    const h = makeHarness(branch());
+    h.redeployBranch.mockRejectedValueOnce(new Error('deploy boom'));
+    await h.service.tick(); // 内部 catch 记录错误，不抛出 tick 外
+    expect(h.redeployBranch).toHaveBeenCalledTimes(1);
+    // 回滚：override 恢复到原值（undefined）
+    expect(h.branch.profileOverrides?.web?.activeDeployMode).toBeUndefined();
+
+    // 下一拍：依然未收敛 → 会再次尝试 redeploy（证明没被误判收敛）
+    await h.service.tick();
+    expect(h.redeployBranch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/cds/tests/services/auto-lifecycle-redeploy.test.ts
+++ b/cds/tests/services/auto-lifecycle-redeploy.test.ts
@@ -84,6 +84,9 @@ describe('AutoLifecycleService.tick — auto-publish 真实重部署', () => {
     expect(h.redeployBranch).toHaveBeenCalledWith('b1');
     // override 已写成 release 模式（prod 命中发布版正则）
     expect(h.branch.profileOverrides?.web?.activeDeployMode).toBe('prod');
+    // Cursor Bugbot Medium：redeploy 后分支重新跑起来，不能钉"已停止"字段
+    expect(h.branch.lastStoppedAt).toBeUndefined();
+    expect(h.branch.lastStopSource).not.toBe('system');
   });
 
   it('已收敛（override=prod 且容器 deployedMode=prod）→ 不重部署', async () => {

--- a/cds/tests/services/auto-lifecycle-redeploy.test.ts
+++ b/cds/tests/services/auto-lifecycle-redeploy.test.ts
@@ -96,6 +96,15 @@ describe('AutoLifecycleService.tick — auto-publish 真实重部署', () => {
     expect(h.branch.lastStopSource).not.toBe('system');
   });
 
+  it('lastDeployAt == lastReadyAt（同毫秒）不判陈旧，计时正常累积 → redeploy 触发', async () => {
+    // Cursor Bugbot High：首次部署 lastReadyAt 与 lastDeployAt 常同毫秒；
+    // 若 stale 用 <= 会每拍把 lastReadyAt 重置成 now、age 永不累积、
+    // auto-publish/stop 永不触发。严格 < 后同毫秒不算陈旧。
+    const h = makeHarness(branch({ lastDeployAt: READY_AT })); // == lastReadyAt
+    await h.service.tick();
+    expect(h.redeployBranch).toHaveBeenCalledWith('b1');
+  });
+
   it('已收敛（override=prod 且容器 deployedMode=prod）→ 不重部署', async () => {
     const h = makeHarness(
       branch({
@@ -158,5 +167,17 @@ describe('AutoLifecycleService.tick — auto-stop / auto-publish 让位次序', 
     await h.service.tick();
     expect(h.redeployBranch).toHaveBeenCalledWith('b1'); // publish 先行
     expect(h.stopBranch).not.toHaveBeenCalled();         // 本拍让位，不停
+  });
+
+  it('autoPublishMin===autoStopMin 且 publish 失败 → auto-stop 兜底接管（不被永久挡）', async () => {
+    const h = makeHarness(
+      branch(),
+      { autoPublishAfterMinutes: 10, autoStopAfterMinutes: 10 },
+      at(11),
+    );
+    h.redeployBranch.mockRejectedValueOnce(new Error('publish boom'));
+    await h.service.tick();
+    expect(h.redeployBranch).toHaveBeenCalledTimes(1); // 尝试过 publish
+    expect(h.stopBranch).toHaveBeenCalledWith('b1');   // 失败后 auto-stop 兜底
   });
 });

--- a/cds/tests/updater/active-update-store.test.ts
+++ b/cds/tests/updater/active-update-store.test.ts
@@ -317,19 +317,20 @@ describe('active-update-store + StateService 集成', () => {
       expect(list[1].dispatchAction).toBe('deploy');
     });
 
-    it('ring buffer 上限 200,超过自动丢最早', () => {
-      for (let i = 0; i < 250; i++) {
+    it('ring buffer 上限 1000,超过自动丢最早', () => {
+      // 2026-05-14: 上限从 200 提升到 1000（webhook 日志可回溯窗口扩大）。
+      for (let i = 0; i < 1050; i++) {
         service.recordGithubWebhookDelivery({
           id: `d${i}`, receivedAt: new Date(Date.parse('2026-05-07T10:00:00Z') + i * 1000).toISOString(),
           durationMs: 10, event: 'push', signatureValid: true,
           dispatchAction: 'deploy', dispatchReason: `${i}`,
         });
       }
-      const list = service.getGithubWebhookDeliveries(500);
-      expect(list).toHaveLength(200);
-      // 最早保留的应该是 d50(0..49 已被挤掉)
+      const list = service.getGithubWebhookDeliveries(2000);
+      expect(list).toHaveLength(1000);
+      // 最早保留的应该是 d50(0..49 已被挤掉,共推 1050 条)
       expect(list[list.length - 1].id).toBe('d50');
-      expect(list[0].id).toBe('d249');
+      expect(list[0].id).toBe('d1049');
     });
 
     it('limit 参数限制返回数量,默认 50', () => {

--- a/cds/web/src/components/BranchDetailDrawer.tsx
+++ b/cds/web/src/components/BranchDetailDrawer.tsx
@@ -59,6 +59,7 @@ interface BranchDetailData {
     kind: 'source' | 'release' | 'mixed';
     label: string;
     title: string;
+    pendingPublish?: boolean;
   };
 }
 

--- a/cds/web/src/components/BranchDetailDrawer.tsx
+++ b/cds/web/src/components/BranchDetailDrawer.tsx
@@ -272,7 +272,17 @@ type TriggerLogsState =
   | { status: 'idle' }
   | { status: 'loading' }
   | { status: 'error'; message: string }
-  | { status: 'ok'; deliveries: GithubWebhookDelivery[]; total: number; filteredTotal: number };
+  | {
+      status: 'ok';
+      deliveries: GithubWebhookDelivery[];
+      total: number;
+      filteredTotal: number;
+      hasMore: boolean;
+      loadingMore?: boolean;
+    };
+
+// 2026-05-14: webhook 日志分页 — 每页 20 条，懒加载下一页，与 buffer 1000 配合。
+const TRIGGER_LOGS_PAGE_SIZE = 20;
 
 /** 5-min ring buffer (60 points × 5s 间隔) per service+metric — UI sparkline 用 */
 interface MetricSeries {
@@ -611,7 +621,8 @@ export function BranchDetailDrawer({
     setTriggerLogsState({ status: 'loading' });
     try {
       const params = new URLSearchParams();
-      params.set('limit', '50');
+      params.set('limit', String(TRIGGER_LOGS_PAGE_SIZE));
+      params.set('offset', '0');
       params.set('branchId', branchId);
       if (branch?.githubRepoFullName) params.set('repoFullName', branch.githubRepoFullName);
       if (branch?.branch) params.set('ref', `refs/heads/${branch.branch}`);
@@ -633,15 +644,75 @@ export function BranchDetailDrawer({
         deliveries: GithubWebhookDelivery[];
         total?: number;
         filteredTotal?: number;
+        hasMore?: boolean;
       };
+      const deliveries = data.deliveries || [];
+      const filteredTotal = typeof data.filteredTotal === 'number' ? data.filteredTotal : deliveries.length;
       setTriggerLogsState({
         status: 'ok',
-        deliveries: data.deliveries || [],
-        total: typeof data.total === 'number' ? data.total : data.deliveries.length,
-        filteredTotal: typeof data.filteredTotal === 'number' ? data.filteredTotal : data.deliveries.length,
+        deliveries,
+        total: typeof data.total === 'number' ? data.total : deliveries.length,
+        filteredTotal,
+        hasMore: typeof data.hasMore === 'boolean' ? data.hasMore : deliveries.length < filteredTotal,
       });
     } catch (err) {
       setTriggerLogsState({ status: 'error', message: err instanceof ApiError ? err.message : String(err) });
+    }
+  }, [branch?.branch, branch?.githubRepoFullName, branchId]);
+
+  /**
+   * 2026-05-14: 加载下一页 webhook 日志。state 必须已经是 ok，把后端返回的下一段
+   * 追加到当前 deliveries 数组（保留时间顺序，最新在前）。
+   */
+  const loadMoreTriggerLogs = useCallback(async () => {
+    if (!branchId) return;
+    setTriggerLogsState((prev) => {
+      if (prev.status !== 'ok' || !prev.hasMore || prev.loadingMore) return prev;
+      return { ...prev, loadingMore: true };
+    });
+    // 用最新 state 里的 deliveries.length 作为 offset；并发翻页时也安全（页大小固定）。
+    let currentOffset = 0;
+    setTriggerLogsState((prev) => {
+      if (prev.status === 'ok') currentOffset = prev.deliveries.length;
+      return prev;
+    });
+    try {
+      const params = new URLSearchParams();
+      params.set('limit', String(TRIGGER_LOGS_PAGE_SIZE));
+      params.set('offset', String(currentOffset));
+      params.set('branchId', branchId);
+      if (branch?.githubRepoFullName) params.set('repoFullName', branch.githubRepoFullName);
+      if (branch?.branch) params.set('ref', `refs/heads/${branch.branch}`);
+      const raw = await apiRequest<unknown>(
+        `/api/cds-system/github/webhook-deliveries?${params.toString()}`,
+      );
+      const data = raw as {
+        deliveries?: GithubWebhookDelivery[];
+        total?: number;
+        filteredTotal?: number;
+        hasMore?: boolean;
+      };
+      const more = data.deliveries || [];
+      setTriggerLogsState((prev) => {
+        if (prev.status !== 'ok') return prev;
+        const merged = [...prev.deliveries, ...more];
+        const filteredTotal = typeof data.filteredTotal === 'number' ? data.filteredTotal : merged.length;
+        return {
+          status: 'ok',
+          deliveries: merged,
+          total: typeof data.total === 'number' ? data.total : prev.total,
+          filteredTotal,
+          hasMore: typeof data.hasMore === 'boolean' ? data.hasMore : merged.length < filteredTotal,
+          loadingMore: false,
+        };
+      });
+    } catch (err) {
+      // 翻页失败保留前面已加载的部分，仅清掉 loading 旗，避免清掉整个列表。
+      setTriggerLogsState((prev) => {
+        if (prev.status !== 'ok') return prev;
+        return { ...prev, loadingMore: false };
+      });
+      console.error('[trigger-logs] loadMore failed', err);
     }
   }, [branch?.branch, branch?.githubRepoFullName, branchId]);
 
@@ -1003,13 +1074,25 @@ export function BranchDetailDrawer({
     return activeDeploymentPhases?.find((p) => p.status === 'error')?.key ?? null;
   }, [activeDeploymentPhases]);
 
-  const deploymentLogProfileId = useMemo(() => {
+  /**
+   * 2026-05-14: 部署 tab 内联容器日志的多容器选择。null = 让自动逻辑挑（错误/运行中/启动中）。
+   * 用户在 tab strip 上点击其他 service 后会写入这里，覆盖自动逻辑。
+   */
+  const [selectedDeploymentLogProfileId, setSelectedDeploymentLogProfileId] = useState<string | null>(null);
+  const autoDeploymentLogProfileId = useMemo(() => {
     if (!services.length) return null;
     const errored = services.find((s) => s.status === 'error');
     const running = services.find((s) => s.status === 'running');
     const starting = services.find((s) => s.status === 'starting');
     return errored?.profileId || running?.profileId || starting?.profileId || services[0].profileId;
   }, [services]);
+  const deploymentLogProfileId = useMemo(() => {
+    // 用户选过 → 校验该 service 还在；不在了 fallback 自动选择。
+    if (selectedDeploymentLogProfileId && services.some((s) => s.profileId === selectedDeploymentLogProfileId)) {
+      return selectedDeploymentLogProfileId;
+    }
+    return autoDeploymentLogProfileId;
+  }, [autoDeploymentLogProfileId, selectedDeploymentLogProfileId, services]);
 
   useEffect(() => {
     if (!open || activeTab !== 'deployments') return;
@@ -1031,6 +1114,34 @@ export function BranchDetailDrawer({
     serviceLogs.profileId,
     serviceLogs.status,
   ]);
+
+  /**
+   * 2026-05-14: 内联容器日志的 tab strip + 最大化控制。
+   * 多于 1 个 service 时 PhaseTree 会渲染 tab 条。最大化 → 跳到 Logs tab 容器模式。
+   */
+  const inlineContainerLogControls = useMemo(() => {
+    if (services.length === 0) return undefined;
+    return {
+      services: services.map((svc) => ({
+        profileId: svc.profileId,
+        status: svc.status,
+        hostPort: svc.hostPort,
+      })),
+      selected: deploymentLogProfileId,
+      onSelect: (profileId: string) => {
+        setSelectedDeploymentLogProfileId(profileId);
+        void loadServiceLogs(profileId);
+      },
+      onMaximize: () => {
+        if (deploymentLogProfileId) {
+          // 复用 openContainerLogs 的跳转逻辑
+          setLogsMode('container');
+          setActiveTab('logs');
+          void loadServiceLogs(deploymentLogProfileId);
+        }
+      },
+    };
+  }, [deploymentLogProfileId, loadServiceLogs, services]);
 
   const containerLogsByPhase = useMemo<Partial<Record<PhaseKey, PhaseLogState>> | undefined>(() => {
     if (!activeDeployment) return undefined;
@@ -1351,6 +1462,7 @@ export function BranchDetailDrawer({
                         onResetError={(item) => void resetBranchError(item)}
                         onRetryDiagnosis={(item) => void retryRuntimeDiagnosis(item)}
                         containerLogsByPhase={containerLogsByPhase}
+                        containerLogControls={inlineContainerLogControls}
                       />
                     ) : null}
 
@@ -1464,7 +1576,12 @@ export function BranchDetailDrawer({
                       onQueryChange={setLogQuery}
                       onRefresh={() => void loadTriggerLogs()}
                     />
-                    <TriggerLogsPanel state={triggerLogsState} query={logQuery} branch={branch} />
+                    <TriggerLogsPanel
+                      state={triggerLogsState}
+                      query={logQuery}
+                      branch={branch}
+                      onLoadMore={() => void loadMoreTriggerLogs()}
+                    />
                   </section>
                 ) : null}
 
@@ -1900,10 +2017,12 @@ function TriggerLogsPanel({
   state,
   query,
   branch,
+  onLoadMore,
 }: {
   state: TriggerLogsState;
   query: string;
   branch: BranchDetailData;
+  onLoadMore?: () => void;
 }): JSX.Element {
   if (state.status === 'idle' || state.status === 'loading') {
     return <LoadingBlock label="加载 Webhook 日志" />;
@@ -1920,7 +2039,7 @@ function TriggerLogsPanel({
         <div>
           {query
             ? '没有匹配的 Webhook 日志。'
-            : '最近 200 条 GitHub webhook 投递里没有命中这个分支。'}
+            : '最近 1000 条 GitHub webhook 投递里没有命中这个分支。'}
         </div>
         {!query ? (
           <div className="rounded-md border border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))] px-3 py-2 text-xs leading-5">
@@ -2009,6 +2128,29 @@ function TriggerLogsPanel({
           );
         })}
       </div>
+      {/*
+        2026-05-14: 分页加载更多。后端 buffer 上限 1000 条，每页 20。
+        用户反复反馈"webhook 看不到历史"——这里给出累计条数 + 加载更多按钮。
+      */}
+      {state.hasMore || state.loadingMore ? (
+        <div className="mt-3 flex flex-wrap items-center justify-between gap-2 border-t border-[hsl(var(--hairline))] pt-3 text-xs text-muted-foreground">
+          <span>
+            已加载 {state.deliveries.length} / {state.filteredTotal} 条匹配（buffer 上限 1000）
+          </span>
+          <button
+            type="button"
+            className="rounded-md border border-[hsl(var(--hairline))] bg-[hsl(var(--surface-raised))] px-3 py-1 text-xs hover:border-[hsl(var(--hairline-strong))] disabled:opacity-60"
+            onClick={() => onLoadMore?.()}
+            disabled={!state.hasMore || !!state.loadingMore}
+          >
+            {state.loadingMore ? '加载中...' : '加载更早 20 条'}
+          </button>
+        </div>
+      ) : state.deliveries.length > 0 ? (
+        <div className="mt-3 border-t border-[hsl(var(--hairline))] pt-3 text-xs text-muted-foreground">
+          已展示全部 {state.deliveries.length} 条
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/cds/web/src/components/BranchDetailDrawer.tsx
+++ b/cds/web/src/components/BranchDetailDrawer.tsx
@@ -1347,7 +1347,15 @@ export function BranchDetailDrawer({
                         2026-05-14：分支变灰时把"何时停 / 为什么停"亮出来。
                         没有 lastStoppedAt 的老分支显示 - 即可，不破坏 layout。
                       */}
-                      {branch.lastStoppedAt ? (
+                      {/*
+                        2026-05-14 Cursor Bugbot Medium：lastStoppedAt 是历史
+                        戳，分支被 stop 后又经 deploy/auto-build/调度器唤醒
+                        重新 running 时该戳仍在 → 不能只看 lastStoppedAt
+                        就弹"上次停止"，否则正在运行的分支被误报已停止。
+                        只在分支当前确实非活跃（非 running/构建/启动中）时显示。
+                      */}
+                      {branch.lastStoppedAt &&
+                      !['running', 'building', 'starting', 'restarting'].includes(branch.status) ? (
                         <div className="mt-2 rounded border border-amber-500/30 bg-amber-500/10 px-2.5 py-1.5 text-[11px] leading-5 text-amber-800 dark:text-amber-200">
                           <div className="flex flex-wrap items-center gap-2">
                             <span className="font-medium">上次停止</span>

--- a/cds/web/src/components/BranchDetailDrawer.tsx
+++ b/cds/web/src/components/BranchDetailDrawer.tsx
@@ -542,6 +542,11 @@ export function BranchDetailDrawer({
   // 导致 offset 仍是 0、第二页重复拉第一页并 append 重复 webhook 记录）。
   // 用一个 ref 同步镜像当前已加载条数，loadMore 时同步读取。
   const triggerLogsCountRef = useRef(0);
+  // 2026-05-14 Codex review P2：loadMore 的并发守卫不能只靠 setState
+  // updater 的 loadingMore（异步提交）。双击在 React commit 前两次都能
+  // 过 updater 检查 → 用同一 offset 发两次请求、同页追加两次。这个 ref
+  // 同步置位，是真正的去重闸门。
+  const triggerLogsLoadMoreInFlightRef = useRef(false);
   const [profileState, setProfileState] = useState<ProfileOverridesState>({ status: 'idle' });
   const [modeSavingProfileId, setModeSavingProfileId] = useState<string | null>(null);
   // ring buffer keyed by profileId,内存级,关抽屉就丢(metrics 是观测,不是审计)
@@ -669,6 +674,8 @@ export function BranchDetailDrawer({
     // updater 的执行时机；这才是这次 offset bug 的根因修复。
     const currentOffset = triggerLogsCountRef.current;
     if (currentOffset <= 0) return; // 还没有第一页，loadMore 无意义
+    // 同步去重闸门：双击在 React commit loadingMore 前不会两次进入。
+    if (triggerLogsLoadMoreInFlightRef.current) return;
     let proceed = true;
     setTriggerLogsState((prev) => {
       if (prev.status !== 'ok' || !prev.hasMore || prev.loadingMore) {
@@ -678,6 +685,7 @@ export function BranchDetailDrawer({
       return { ...prev, loadingMore: true };
     });
     if (!proceed) return;
+    triggerLogsLoadMoreInFlightRef.current = true;
     try {
       const params = new URLSearchParams();
       params.set('limit', String(TRIGGER_LOGS_PAGE_SIZE));
@@ -715,6 +723,8 @@ export function BranchDetailDrawer({
         return { ...prev, loadingMore: false };
       });
       console.error('[trigger-logs] loadMore failed', err);
+    } finally {
+      triggerLogsLoadMoreInFlightRef.current = false;
     }
   }, [branch?.branch, branch?.githubRepoFullName, branchId]);
 

--- a/cds/web/src/components/BranchDetailDrawer.tsx
+++ b/cds/web/src/components/BranchDetailDrawer.tsx
@@ -90,13 +90,6 @@ interface ProfileRow {
     deployModes?: Record<string, { label?: string }>;
   };
   hasOverride?: boolean;
-  /**
-   * 2026-05-14 新增。后端 resolveDeployModeSource 的结果，
-   * 让 UI 区分"继承项目默认"和"继承构建配置默认"。旧 CDS 兜底 'baseline'。
-   */
-  deployModeSource?: 'override' | 'project-default' | 'baseline';
-  /** 项目设置里配的该 profile 的默认模式（仅展示用）。 */
-  projectDefaultDeployMode?: string;
 }
 
 type ProfileOverridesState =
@@ -2797,32 +2790,14 @@ function SettingsPanel({
               const activeMode = hasBranchModeOverride
                 ? (profile.override?.activeDeployMode || '')
                 : (profile.effective?.activeDeployMode || '');
-              // 2026-05-14: chip 区分三种来源，避免「继承默认 → 实际是发布版」的误导。
-              const source = profile.deployModeSource
-                || (hasBranchModeOverride ? 'override' : 'baseline');
-              const chipText = source === 'override'
-                ? '本分支覆盖'
-                : source === 'project-default'
-                  ? '继承项目默认'
-                  : '继承构建配置默认';
-              const chipClass = source === 'override'
-                ? 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300'
-                : source === 'project-default'
-                  ? 'border-sky-500/40 bg-sky-500/10 text-sky-700 dark:text-sky-300'
-                  : 'border-[hsl(var(--hairline))]';
-              const chipTitle = source === 'project-default'
-                ? '该模式来自「项目设置 → 新分支默认运行模式」，无需在分支级单独覆盖'
-                : source === 'baseline'
-                  ? '该模式来自构建配置自身的默认值（docker-compose / BuildProfile）'
-                  : '该分支单独覆盖了运行模式';
               return (
                 <div key={profile.profileId} className="flex flex-wrap items-center gap-2 rounded-md border border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))]/45 px-3 py-2">
                   <div className="min-w-0 flex-1">
                     <div className="truncate text-sm font-medium">{profile.profileName || profile.profileId}</div>
                     <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
                       <span className="font-mono">{profile.profileId}</span>
-                      <span title={chipTitle} className={`rounded border px-1.5 py-0.5 ${chipClass}`}>
-                        {chipText}
+                      <span className={`rounded border px-1.5 py-0.5 ${hasBranchModeOverride ? 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300' : 'border-[hsl(var(--hairline))]'}`}>
+                        {hasBranchModeOverride ? '本分支覆盖' : '继承默认'}
                       </span>
                     </div>
                   </div>

--- a/cds/web/src/components/BranchDetailDrawer.tsx
+++ b/cds/web/src/components/BranchDetailDrawer.tsx
@@ -741,6 +741,11 @@ export function BranchDetailDrawer({
     setLogsMode('build');
     setSelectedBuildLog(null);
     setSelectedServiceId(null);
+    // 2026-05-14 Codex review P2：切到另一分支时必须清空内联容器日志的
+    // 用户选择，否则 drawer 复用、且新分支有同名 profileId 时，旧分支选过
+    // 的 profile 会粘住，deploymentLogProfileId 不再回退到新分支的
+    // errored/running service。
+    setSelectedDeploymentLogProfileId(null);
     setServiceLogs({ status: 'idle' });
     setLogQuery('');
     setShowAllHistory(false);

--- a/cds/web/src/components/BranchDetailDrawer.tsx
+++ b/cds/web/src/components/BranchDetailDrawer.tsx
@@ -543,6 +543,11 @@ export function BranchDetailDrawer({
   // Phase B — Metrics tab(2026-05-04)
   const [metricsState, setMetricsState] = useState<MetricsState>({ status: 'idle' });
   const [triggerLogsState, setTriggerLogsState] = useState<TriggerLogsState>({ status: 'idle' });
+  // 2026-05-14 Codex review P2 修复：loadMore 的 offset 不能从 setState 的
+  // updater 里"顺便"读出来（React 会 batch，updater 可能在 fetch 之后才跑，
+  // 导致 offset 仍是 0、第二页重复拉第一页并 append 重复 webhook 记录）。
+  // 用一个 ref 同步镜像当前已加载条数，loadMore 时同步读取。
+  const triggerLogsCountRef = useRef(0);
   const [profileState, setProfileState] = useState<ProfileOverridesState>({ status: 'idle' });
   const [modeSavingProfileId, setModeSavingProfileId] = useState<string | null>(null);
   // ring buffer keyed by profileId,内存级,关抽屉就丢(metrics 是观测,不是审计)
@@ -666,16 +671,19 @@ export function BranchDetailDrawer({
    */
   const loadMoreTriggerLogs = useCallback(async () => {
     if (!branchId) return;
+    // 同步读 ref（由下方 useEffect 镜像 deliveries.length），不依赖 setState
+    // updater 的执行时机；这才是这次 offset bug 的根因修复。
+    const currentOffset = triggerLogsCountRef.current;
+    if (currentOffset <= 0) return; // 还没有第一页，loadMore 无意义
+    let proceed = true;
     setTriggerLogsState((prev) => {
-      if (prev.status !== 'ok' || !prev.hasMore || prev.loadingMore) return prev;
+      if (prev.status !== 'ok' || !prev.hasMore || prev.loadingMore) {
+        proceed = false;
+        return prev;
+      }
       return { ...prev, loadingMore: true };
     });
-    // 用最新 state 里的 deliveries.length 作为 offset；并发翻页时也安全（页大小固定）。
-    let currentOffset = 0;
-    setTriggerLogsState((prev) => {
-      if (prev.status === 'ok') currentOffset = prev.deliveries.length;
-      return prev;
-    });
+    if (!proceed) return;
     try {
       const params = new URLSearchParams();
       params.set('limit', String(TRIGGER_LOGS_PAGE_SIZE));
@@ -715,6 +723,13 @@ export function BranchDetailDrawer({
       console.error('[trigger-logs] loadMore failed', err);
     }
   }, [branch?.branch, branch?.githubRepoFullName, branchId]);
+
+  // 2026-05-14 Codex review P2 修复配套：把 deliveries.length 镜像到 ref，
+  // loadMore 时同步读取真实 offset，杜绝 React batch 导致的"重复拉第一页"。
+  useEffect(() => {
+    triggerLogsCountRef.current =
+      triggerLogsState.status === 'ok' ? triggerLogsState.deliveries.length : 0;
+  }, [triggerLogsState]);
 
   // 每个 drawer session 是否已经为"失败分支"自动跳过 tab。避免 branch 多次
   // load 时反复抢用户手动切的 tab。

--- a/cds/web/src/components/BranchDetailDrawer.tsx
+++ b/cds/web/src/components/BranchDetailDrawer.tsx
@@ -1115,7 +1115,11 @@ export function BranchDetailDrawer({
     if (!deploymentLogProfileId) return;
     if (
       serviceLogs.profileId === deploymentLogProfileId &&
-      (serviceLogs.status === 'ok' || serviceLogs.status === 'loading')
+      // 2026-05-14 Codex review P2：error 也算"已加载"，否则容器日志拉取
+      // 失败时本 effect 每次 render 都重发请求，造成 loading/error 抖动死循环。
+      // 用户切容器 tab（deploymentLogProfileId 变）或点刷新按钮（显式调
+      // loadServiceLogs 绕过本 guard）才会重新拉。
+      (serviceLogs.status === 'ok' || serviceLogs.status === 'loading' || serviceLogs.status === 'error')
     ) {
       return;
     }

--- a/cds/web/src/components/BranchDetailDrawer.tsx
+++ b/cds/web/src/components/BranchDetailDrawer.tsx
@@ -47,6 +47,10 @@ interface BranchDetailData {
   githubCommitSha?: string;
   githubPrNumber?: number;
   lastDeployAt?: string;
+  /** 2026-05-14: 最近一次停止的时间戳与原因，drawer 顶部用它解释"分支变灰"。 */
+  lastStoppedAt?: string;
+  lastStopReason?: string;
+  lastStopSource?: 'user' | 'scheduler' | 'executor' | 'system';
   deployCount?: number;
   pullCount?: number;
   stopCount?: number;
@@ -86,6 +90,13 @@ interface ProfileRow {
     deployModes?: Record<string, { label?: string }>;
   };
   hasOverride?: boolean;
+  /**
+   * 2026-05-14 新增。后端 resolveDeployModeSource 的结果，
+   * 让 UI 区分"继承项目默认"和"继承构建配置默认"。旧 CDS 兜底 'baseline'。
+   */
+  deployModeSource?: 'override' | 'project-default' | 'baseline';
+  /** 项目设置里配的该 profile 的默认模式（仅展示用）。 */
+  projectDefaultDeployMode?: string;
 }
 
 type ProfileOverridesState =
@@ -1203,6 +1214,27 @@ export function BranchDetailDrawer({
                         <span>部署次数：{branch.deployCount || 0}</span>
                         <span>停止次数：{branch.stopCount || 0}</span>
                       </div>
+                      {/*
+                        2026-05-14：分支变灰时把"何时停 / 为什么停"亮出来。
+                        没有 lastStoppedAt 的老分支显示 - 即可，不破坏 layout。
+                      */}
+                      {branch.lastStoppedAt ? (
+                        <div className="mt-2 rounded border border-amber-500/30 bg-amber-500/10 px-2.5 py-1.5 text-[11px] leading-5 text-amber-800 dark:text-amber-200">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <span className="font-medium">上次停止</span>
+                            <span className="opacity-90">{formatDeployTimestamp(branch.lastStoppedAt)}</span>
+                            {branch.lastStopSource ? (
+                              <span className="rounded border border-amber-500/40 px-1.5 py-0.5">
+                                {branch.lastStopSource === 'user' ? '用户'
+                                  : branch.lastStopSource === 'scheduler' ? '调度器'
+                                  : branch.lastStopSource === 'executor' ? '执行器'
+                                  : '系统'}
+                              </span>
+                            ) : null}
+                          </div>
+                          <div className="opacity-95">{branch.lastStopReason || '原因未记录'}</div>
+                        </div>
+                      ) : null}
                     </div>
                   );
                 })()}
@@ -2599,14 +2631,32 @@ function SettingsPanel({
               const activeMode = hasBranchModeOverride
                 ? (profile.override?.activeDeployMode || '')
                 : (profile.effective?.activeDeployMode || '');
+              // 2026-05-14: chip 区分三种来源，避免「继承默认 → 实际是发布版」的误导。
+              const source = profile.deployModeSource
+                || (hasBranchModeOverride ? 'override' : 'baseline');
+              const chipText = source === 'override'
+                ? '本分支覆盖'
+                : source === 'project-default'
+                  ? '继承项目默认'
+                  : '继承构建配置默认';
+              const chipClass = source === 'override'
+                ? 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300'
+                : source === 'project-default'
+                  ? 'border-sky-500/40 bg-sky-500/10 text-sky-700 dark:text-sky-300'
+                  : 'border-[hsl(var(--hairline))]';
+              const chipTitle = source === 'project-default'
+                ? '该模式来自「项目设置 → 新分支默认运行模式」，无需在分支级单独覆盖'
+                : source === 'baseline'
+                  ? '该模式来自构建配置自身的默认值（docker-compose / BuildProfile）'
+                  : '该分支单独覆盖了运行模式';
               return (
                 <div key={profile.profileId} className="flex flex-wrap items-center gap-2 rounded-md border border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))]/45 px-3 py-2">
                   <div className="min-w-0 flex-1">
                     <div className="truncate text-sm font-medium">{profile.profileName || profile.profileId}</div>
                     <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
                       <span className="font-mono">{profile.profileId}</span>
-                      <span className={`rounded border px-1.5 py-0.5 ${hasBranchModeOverride ? 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300' : 'border-[hsl(var(--hairline))]'}`}>
-                        {hasBranchModeOverride ? '本分支覆盖' : '继承默认'}
+                      <span title={chipTitle} className={`rounded border px-1.5 py-0.5 ${chipClass}`}>
+                        {chipText}
                       </span>
                     </div>
                   </div>

--- a/cds/web/src/components/deployment/ActiveDeployment.tsx
+++ b/cds/web/src/components/deployment/ActiveDeployment.tsx
@@ -1,10 +1,113 @@
 import { useMemo } from 'react';
-import { Clock, Copy, ExternalLink, FileText, RotateCcw, Wrench } from 'lucide-react';
+import { Clock, Copy, ExternalLink, FileText, Loader2, Maximize2, RotateCcw, Wrench } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import ShapeGrid from '@/components/effects/ShapeGrid';
 import { deriveBranchPhases, type PhaseKey } from '@/lib/deploymentPhases';
 import type { BranchDeploymentItem } from '@/components/BranchDetailDrawer';
-import { PhaseTree, type PhaseLogState } from './PhaseTree';
+import { PhaseTree, type PhaseLogState, type InlineContainerLogControls } from './PhaseTree';
+
+function lastLines(text: string, n: number): string {
+  if (!text) return '';
+  const lines = text.split('\n');
+  if (lines.length <= n) return text;
+  return lines.slice(-n).join('\n');
+}
+
+/**
+ * 2026-05-14: 部署 tab 顶部专属容器日志面板（左侧）。
+ * 多容器走 tab strip 切换；右上角"最大化"跳到完整日志 tab。
+ * 与 PhaseTree.PhaseLogDetails 视觉对齐，但作为一等公民展示在部署面板正中。
+ */
+function PrimaryContainerLogPanel({
+  containerLogsByPhase,
+  containerLogControls,
+}: {
+  containerLogsByPhase?: Partial<Record<PhaseKey, PhaseLogState>>;
+  containerLogControls?: InlineContainerLogControls;
+}): JSX.Element {
+  // 把 by-phase map 折成一个 state：优先 deploy → verify → 第一个 key。
+  const state: PhaseLogState | null = useMemo(() => {
+    if (!containerLogsByPhase) return null;
+    return (
+      containerLogsByPhase.deploy
+      || containerLogsByPhase.verify
+      || (Object.values(containerLogsByPhase)[0] as PhaseLogState | undefined)
+      || null
+    );
+  }, [containerLogsByPhase]);
+  const hasTabs = !!(containerLogControls && containerLogControls.services.length > 1);
+
+  return (
+    <section className="flex h-full min-h-0 flex-col rounded-md border border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))]/45">
+      <header className="flex flex-wrap items-center justify-between gap-2 border-b border-[hsl(var(--hairline))] px-3 py-2">
+        <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">容器日志</div>
+        {containerLogControls?.onMaximize ? (
+          <button
+            type="button"
+            className="inline-flex items-center gap-1 rounded border border-[hsl(var(--hairline))] bg-[hsl(var(--surface-raised))] px-2 py-0.5 text-[11px] hover:border-[hsl(var(--hairline-strong))]"
+            onClick={containerLogControls.onMaximize}
+            title="跳转到「日志 → 容器日志」查看完整内容"
+          >
+            <Maximize2 className="h-3 w-3" />
+            最大化
+          </button>
+        ) : null}
+      </header>
+      {hasTabs ? (
+        <div className="flex flex-wrap gap-1.5 border-b border-[hsl(var(--hairline))] px-3 py-2">
+          {containerLogControls!.services.map((svc) => {
+            const active = svc.profileId === containerLogControls!.selected;
+            const dot = svc.status === 'running'
+              ? 'bg-emerald-500'
+              : svc.status === 'error'
+                ? 'bg-destructive'
+                : 'bg-muted-foreground/40';
+            return (
+              <button
+                key={svc.profileId}
+                type="button"
+                onClick={() => containerLogControls!.onSelect(svc.profileId)}
+                className={`inline-flex items-center gap-1.5 rounded border px-2 py-0.5 text-[11px] transition-colors ${
+                  active
+                    ? 'border-primary bg-primary/10 text-foreground'
+                    : 'border-[hsl(var(--hairline))] bg-[hsl(var(--surface-raised))] text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                <span className={`h-1.5 w-1.5 rounded-full ${dot}`} />
+                <span className="font-mono">{svc.profileId}</span>
+                {svc.hostPort ? <span className="font-mono opacity-70">:{svc.hostPort}</span> : null}
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+      <div className="min-h-0 flex-1 overflow-hidden p-2">
+        {!state ? (
+          <div className="rounded border border-dashed border-[hsl(var(--hairline))] px-3 py-6 text-center text-xs text-muted-foreground">
+            还没有容器日志。容器进入 running 后这里会显示 docker logs 的最后若干行。
+          </div>
+        ) : state.status === 'loading' ? (
+          <div className="flex items-center gap-2 rounded border border-[hsl(var(--hairline))] px-3 py-3 text-xs text-muted-foreground">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            正在加载容器日志…
+          </div>
+        ) : state.status === 'error' ? (
+          <div className="rounded border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+            {state.message || '容器日志加载失败'}
+          </div>
+        ) : !state.logs || !state.logs.trim() ? (
+          <div className="rounded border border-[hsl(var(--hairline))] px-3 py-3 text-xs text-muted-foreground">
+            容器尚未输出任何日志（多半是进程在监听端口前就退出了）。
+          </div>
+        ) : (
+          <pre className="max-h-[320px] min-h-[120px] overflow-auto rounded border border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))] px-3 py-2 font-mono text-[11px] leading-5 text-foreground/85 whitespace-pre-wrap break-words">
+            {lastLines(state.logs, 120)}
+          </pre>
+        )}
+      </div>
+    </section>
+  );
+}
 
 /*
  * ActiveDeployment — 部署 tab 顶部那张「当前部署」大卡。
@@ -35,6 +138,10 @@ export interface ActiveDeploymentProps {
    * build 阶段不走这条路径——构建失败的日志在另一个 build-log 面板。
    */
   containerLogsByPhase?: Partial<Record<PhaseKey, PhaseLogState>>;
+  /**
+   * 2026-05-14: 多容器 tab 切换 + 最大化控制，透传给 PhaseTree。
+   */
+  containerLogControls?: InlineContainerLogControls;
 }
 
 function statusBadgeClass(status: BranchDeploymentItem['status']): string {
@@ -104,6 +211,7 @@ export function ActiveDeployment({
   onRetryDiagnosis,
   onResetError,
   containerLogsByPhase,
+  containerLogControls,
 }: ActiveDeploymentProps): JSX.Element {
   const displayStatus = effectiveDeploymentStatus(deployment, branchErrorMessage);
   const phases = useMemo(
@@ -224,12 +332,25 @@ export function ActiveDeployment({
         </span>
       </header>
 
-      <div className="px-5 py-4" style={{ minHeight: 168 }}>
-        <PhaseTree
-          phases={phases}
-          onActionForError={renderActionForError}
-          containerLogsByPhase={containerLogsByPhase}
-        />
+      {/*
+        2026-05-14: 用户反馈"容器日志应该优先显示"——把容器日志从 PhaseTree 内部
+        提到上面专属面板（多容器 tab + 最大化），PhaseTree 退居下方只显示阶段进度。
+        宽屏 (lg) 走两列：左侧容器日志、右侧阶段树；窄屏堆叠（容器日志在上、阶段树在下）。
+      */}
+      <div className="grid gap-4 px-5 py-4 lg:grid-cols-[3fr_2fr]" style={{ minHeight: 168 }}>
+        <div className="min-w-0 lg:order-1">
+          <PrimaryContainerLogPanel
+            containerLogsByPhase={containerLogsByPhase}
+            containerLogControls={containerLogControls}
+          />
+        </div>
+        <div className="min-w-0 lg:order-2">
+          <PhaseTree
+            phases={phases}
+            onActionForError={renderActionForError}
+            // 容器日志已被提到左侧面板，PhaseTree 不再渲染内嵌日志，避免重复。
+          />
+        </div>
       </div>
 
       <footer className="flex flex-wrap items-center justify-between gap-2 border-t border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))]/40 px-5 py-3">

--- a/cds/web/src/components/deployment/PhaseTree.tsx
+++ b/cds/web/src/components/deployment/PhaseTree.tsx
@@ -1,6 +1,21 @@
 import type { ReactNode } from 'react';
-import { CheckCircle2, Circle, Loader2, XCircle } from 'lucide-react';
+import { CheckCircle2, Circle, Loader2, Maximize2, XCircle } from 'lucide-react';
 import type { PhaseKey, PhaseState } from '@/lib/deploymentPhases';
+
+/**
+ * 2026-05-14: 内联容器日志支持多容器 tab 切换 + 一键最大化。
+ * 用户反馈:"图5 容器日志里面有2个容器应该把真正的容器日志复刻过来" —— 之前 PhaseTree
+ * 的内联日志只展示自动挑选的一个 service。
+ */
+export interface InlineContainerLogControls {
+  /** 全部 service，按显示顺序排好。少于 2 个时不渲染 tab 条。 */
+  services: Array<{ profileId: string; status: string; hostPort?: number }>;
+  /** 当前选中的 profileId。无选中视为不渲染 tab 条。 */
+  selected: string | null;
+  onSelect: (profileId: string) => void;
+  /** "最大化"按钮——跳到 Logs tab 容器模式查看完整日志。 */
+  onMaximize?: () => void;
+}
 
 /*
  * PhaseTree — Railway 风格的阶段树。
@@ -26,6 +41,11 @@ export interface PhaseTreeProps {
    * build 阶段仍通过「查看完整日志」跳转到构建日志面板。
    */
   containerLogsByPhase?: Partial<Record<PhaseKey, PhaseLogState>>;
+  /**
+   * 2026-05-14: 多容器 tab 切换 + 最大化控制。给定后，内联日志会渲染 tab strip。
+   * 缺省 = 沿用旧行为（单容器，仅自动挑选的那个）。
+   */
+  containerLogControls?: InlineContainerLogControls;
   /**
    * 内联日志默认显示最后多少行。null = 全部。
    */
@@ -111,19 +131,69 @@ function PhaseLogDetails({
   phase,
   state,
   tail,
+  controls,
 }: {
   phase: PhaseState;
   state: PhaseLogState;
   tail: number | null | undefined;
+  controls?: InlineContainerLogControls;
 }): JSX.Element {
+  const hasTabs = !!(controls && controls.services.length > 1);
   return (
     <details
       className="group rounded-md border border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))]/50 px-3 py-2"
-      open={phase.status === 'running'}
+      open={phase.status === 'running' || phase.status === 'error'}
     >
-      <summary className="cursor-pointer select-none text-xs font-medium text-muted-foreground transition-colors group-open:text-foreground">
-        容器日志
+      <summary className="flex cursor-pointer select-none items-center justify-between gap-2 text-xs font-medium text-muted-foreground transition-colors group-open:text-foreground">
+        <span>容器日志</span>
+        {controls?.onMaximize ? (
+          <button
+            type="button"
+            className="inline-flex items-center gap-1 rounded border border-[hsl(var(--hairline))] bg-[hsl(var(--surface-raised))] px-2 py-0.5 text-[11px] hover:border-[hsl(var(--hairline-strong))]"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              controls.onMaximize?.();
+            }}
+            title="跳转到「日志 → 容器日志」查看完整内容"
+          >
+            <Maximize2 className="h-3 w-3" />
+            最大化
+          </button>
+        ) : null}
       </summary>
+      {hasTabs ? (
+        <div className="mt-2 flex flex-wrap gap-1.5 border-b border-[hsl(var(--hairline))] pb-2">
+          {controls!.services.map((svc) => {
+            const active = svc.profileId === controls!.selected;
+            const dot = svc.status === 'running'
+              ? 'bg-emerald-500'
+              : svc.status === 'error'
+                ? 'bg-destructive'
+                : 'bg-muted-foreground/40';
+            return (
+              <button
+                key={svc.profileId}
+                type="button"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  controls!.onSelect(svc.profileId);
+                }}
+                className={`inline-flex items-center gap-1.5 rounded border px-2 py-0.5 text-[11px] transition-colors ${
+                  active
+                    ? 'border-primary bg-primary/10 text-foreground'
+                    : 'border-[hsl(var(--hairline))] bg-[hsl(var(--surface-raised))] text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                <span className={`h-1.5 w-1.5 rounded-full ${dot}`} />
+                <span className="font-mono">{svc.profileId}</span>
+                {svc.hostPort ? <span className="font-mono opacity-70">:{svc.hostPort}</span> : null}
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
       <PhaseLogPreview state={state} tail={tail} />
     </details>
   );
@@ -133,6 +203,7 @@ export function PhaseTree({
   phases,
   onActionForError,
   containerLogsByPhase,
+  containerLogControls,
   inlineLogTailLines = 80,
   className,
 }: PhaseTreeProps): JSX.Element {
@@ -171,7 +242,12 @@ export function PhaseTree({
                 ) : null}
                 {phaseLogs ? (
                   <div className={phase.errorHint ? 'mt-2' : ''}>
-                    <PhaseLogDetails phase={phase} state={phaseLogs} tail={inlineLogTailLines} />
+                    <PhaseLogDetails
+                      phase={phase}
+                      state={phaseLogs}
+                      tail={inlineLogTailLines}
+                      controls={containerLogControls}
+                    />
                   </div>
                 ) : null}
                 {onActionForError ? (

--- a/cds/web/src/pages/BranchDetailPage.tsx
+++ b/cds/web/src/pages/BranchDetailPage.tsx
@@ -1293,7 +1293,14 @@ export function BranchDetailPage(): JSX.Element {
                     <MetricTile label="部署次数" value={state.branch.deployCount || 0} />
                     <MetricTile label="最近部署" value={formatDate(state.branch.lastDeployAt || state.branch.lastAccessedAt)} />
                   </div>
-                  {state.branch.lastStoppedAt ? (
+                  {/*
+                    2026-05-14 Cursor Bugbot Medium：lastStoppedAt 为历史戳，
+                    stop 后又被 deploy/auto-build/调度器唤醒重新 running 时
+                    该戳仍在。只看 lastStoppedAt 会在正在运行的分支上误报
+                    "上次停止"。仅当分支当前确实非活跃时才显示。
+                  */}
+                  {state.branch.lastStoppedAt &&
+                  !['running', 'building', 'starting', 'restarting'].includes(state.branch.status) ? (
                     <div
                       className="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-800 dark:text-amber-200"
                       title="分支变灰 = 容器已停止。下面这条来自 lastStoppedAt / lastStopReason 字段，2026-05-14 起记录。"

--- a/cds/web/src/pages/BranchDetailPage.tsx
+++ b/cds/web/src/pages/BranchDetailPage.tsx
@@ -52,6 +52,9 @@ interface BranchSummary {
   createdAt: string;
   lastAccessedAt?: string;
   lastDeployAt?: string;
+  lastStoppedAt?: string;
+  lastStopReason?: string;
+  lastStopSource?: 'user' | 'scheduler' | 'executor' | 'system';
   errorMessage?: string;
   commitSha?: string;
   subject?: string;
@@ -1290,6 +1293,26 @@ export function BranchDetailPage(): JSX.Element {
                     <MetricTile label="部署次数" value={state.branch.deployCount || 0} />
                     <MetricTile label="最近部署" value={formatDate(state.branch.lastDeployAt || state.branch.lastAccessedAt)} />
                   </div>
+                  {state.branch.lastStoppedAt ? (
+                    <div
+                      className="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-800 dark:text-amber-200"
+                      title="分支变灰 = 容器已停止。下面这条来自 lastStoppedAt / lastStopReason 字段，2026-05-14 起记录。"
+                    >
+                      <div className="mb-1 flex items-center gap-2">
+                        <span className="font-medium">上次停止</span>
+                        <span className="opacity-80">{formatDate(state.branch.lastStoppedAt)}</span>
+                        {state.branch.lastStopSource ? (
+                          <span className="rounded border border-amber-500/40 px-1.5 py-0.5 opacity-90">
+                            {state.branch.lastStopSource === 'user' ? '用户'
+                              : state.branch.lastStopSource === 'scheduler' ? '调度器'
+                              : state.branch.lastStopSource === 'executor' ? '执行器'
+                              : '系统'}
+                          </span>
+                        ) : null}
+                      </div>
+                      <div className="opacity-95">{state.branch.lastStopReason || '原因未记录'}</div>
+                    </div>
+                  ) : null}
                   <div className="rounded-md border border-border bg-muted/30 p-3">
                     <div className="mb-2 text-xs font-medium text-muted-foreground">提交一致性</div>
                     <div className="grid gap-2 text-xs md:grid-cols-2">

--- a/cds/web/src/pages/BranchListPage.tsx
+++ b/cds/web/src/pages/BranchListPage.tsx
@@ -105,6 +105,7 @@ interface BranchSummary {
     releaseProfiles: number;
     sourceProfiles: number;
     modes: string[];
+    pendingPublish?: boolean;
   };
 }
 
@@ -3809,7 +3810,7 @@ function BranchFailureHint({
   );
 }
 
-function branchRuntimeBadge(branch: BranchSummary): { kind: 'release' | 'mixed'; label: string; title: string; className: string } | null {
+function branchRuntimeBadge(branch: BranchSummary): { kind: 'release' | 'mixed' | 'pending'; label: string; title: string; className: string } | null {
   const runtime = branch.deployRuntime;
   if (runtime?.kind === 'release') {
     return {
@@ -3817,6 +3818,17 @@ function branchRuntimeBadge(branch: BranchSummary): { kind: 'release' | 'mixed';
       label: runtime.label || '发布版',
       title: runtime.title || '当前分支使用发布版构建模式',
       className: 'border-emerald-400/35 bg-emerald-400/10 text-emerald-700 dark:text-emerald-300',
+    };
+  }
+  // 2026-05-14 真实态徽章：配置已切发布版但容器还没真正以发布版跑起来
+  // （重部署中 / 还停着 / 旧源码容器仍在跑）→ 橙色「发布版·待生效」，
+  // 明确区分"配置意图"与"运行现状"，不再设了 override 就亮绿误导。
+  if (runtime?.pendingPublish) {
+    return {
+      kind: 'pending',
+      label: '发布版·待生效',
+      title: runtime.title || '已配置发布版，等待重新部署后真正生效',
+      className: 'border-amber-400/40 bg-amber-400/10 text-amber-700 dark:text-amber-300',
     };
   }
   if (runtime?.kind === 'mixed') {

--- a/cds/web/src/pages/BranchListPage.tsx
+++ b/cds/web/src/pages/BranchListPage.tsx
@@ -39,6 +39,14 @@ import { AppShell, Crumb, PaletteHint, TopBar, Workspace } from '@/components/la
 import { BranchDetailDrawer, type BranchDeploymentItem } from '@/components/BranchDetailDrawer';
 import { CapacityFullDialog } from '@/components/CapacityFullDialog';
 import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { ConfirmAction } from '@/components/ui/confirm-action';
 import { DropdownDivider, DropdownItem, DropdownLabel, DropdownMenu } from '@/components/ui/dropdown-menu';
 import { apiRequest, ApiError } from '@/lib/api';
@@ -959,6 +967,33 @@ export function BranchListPage(): JSX.Element {
   const [detailDrawerBranchId, setDetailDrawerBranchId] = useState<string | null>(null);
   const [branchSearchOpen, setBranchSearchOpen] = useState(false);
   const [pendingEnvKeys, setPendingEnvKeys] = useState<string[]>([]);
+  /**
+   * 2026-05-14: 用户多次反馈"知道还要去填，但每次进来都被这条横幅打断"。
+   * 加一个"我知道了"按钮：点了之后弹出"到哪里填"的路径提示，确认后关闭横幅。
+   * 用 sessionStorage 而非 localStorage（项目规则禁用 localStorage 防止部署后串缓存），
+   * key 里带 pendingEnvKeys 列表的指纹，新增缺失的 env key 时横幅会自动复活。
+   */
+  const [envBannerDismissed, setEnvBannerDismissed] = useState(false);
+  const [envHintDialogOpen, setEnvHintDialogOpen] = useState(false);
+  const envBannerStorageKey = useMemo(() => {
+    if (!projectId || pendingEnvKeys.length === 0) return '';
+    const fingerprint = [...pendingEnvKeys].sort().join(',');
+    return `cds.envBannerDismissed.${projectId}.${fingerprint}`;
+  }, [projectId, pendingEnvKeys]);
+  useEffect(() => {
+    if (!envBannerStorageKey) { setEnvBannerDismissed(false); return; }
+    try {
+      setEnvBannerDismissed(sessionStorage.getItem(envBannerStorageKey) === '1');
+    } catch {
+      setEnvBannerDismissed(false);
+    }
+  }, [envBannerStorageKey]);
+  const dismissEnvBanner = useCallback(() => {
+    if (!envBannerStorageKey) return;
+    try { sessionStorage.setItem(envBannerStorageKey, '1'); } catch { /* sessionStorage 不可用就忍一会 */ }
+    setEnvBannerDismissed(true);
+    setEnvHintDialogOpen(false);
+  }, [envBannerStorageKey]);
   // 标签过滤:用户点击 BranchCard 上某个标签 chip 时切到只显示该标签的分支;
   // 顶部出现"正在过滤:#xxx ×"chip,点 × 清除。单标签过滤(对齐 legacy)。
   const [activeTagFilter, setActiveTagFilter] = useState<string | null>(null);
@@ -2221,7 +2256,7 @@ export function BranchListPage(): JSX.Element {
             in. Without this, deploys fail silently with cryptic errors
             because services see literal "TODO: 请填写实际值" as their
             DB password / secret. */}
-        {pendingEnvKeys.length > 0 ? (
+        {pendingEnvKeys.length > 0 && !envBannerDismissed ? (
           <div className="mt-6 flex flex-wrap items-start gap-3 rounded-md border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-700 dark:text-amber-400">
             <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
             <div className="min-w-0 flex-1">
@@ -2231,14 +2266,57 @@ export function BranchListPage(): JSX.Element {
                 {pendingEnvKeys.length > 5 ? ` 等 ${pendingEnvKeys.length} 项` : ''}），先去填好再部署。
               </div>
             </div>
-            <Button asChild size="sm">
-              <a href={`/settings/${encodeURIComponent(projectId)}#env`}>
-                <Settings />
-                前往填写
-              </a>
-            </Button>
+            <div className="flex flex-wrap items-center gap-2">
+              <Button asChild size="sm">
+                <a href={`/settings/${encodeURIComponent(projectId)}#env`}>
+                  <Settings />
+                  前往填写
+                </a>
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setEnvHintDialogOpen(true)}
+                title="提示我以后去哪里填，然后关闭这条横幅"
+              >
+                我知道了
+              </Button>
+            </div>
           </div>
         ) : null}
+        <Dialog open={envHintDialogOpen} onOpenChange={setEnvHintDialogOpen}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>下次去这里填环境变量</DialogTitle>
+              <DialogDescription>
+                关掉这条横幅后想再填，按下面路径进。检测到新的占位变量时横幅会自动重新出现。
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-3 text-sm leading-6">
+              <div className="rounded-md border border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))]/60 px-3 py-2 font-mono text-xs">
+                项目设置 → 环境变量 → 找到待补全的 key 把 TODO 占位替换成真实值
+              </div>
+              <div className="text-xs text-muted-foreground">
+                直链：<a
+                  className="underline underline-offset-2 hover:text-foreground"
+                  href={`/settings/${encodeURIComponent(projectId)}#env`}
+                >
+                  /settings/{projectId}#env
+                </a>
+              </div>
+              <div className="text-xs text-muted-foreground">
+                这条横幅以本浏览器会话为单位关闭（关闭浏览器或开新窗口会重新出现）。如果之后新增了
+                未填的环境变量，横幅也会再次显示。
+              </div>
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setEnvHintDialogOpen(false)}>
+                取消
+              </Button>
+              <Button onClick={dismissEnvBanner}>关闭横幅</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
 
         {/* 数据库初始化提示 banner(2026-05-10):用户多次反馈"找不到初始化数据库的入口"。
             EnvSetupDialog 支持上传 schema.sql 但藏在「项目设置→环境变量配置向导」里。
@@ -3316,12 +3394,29 @@ function BranchCard({
               </h3>
               {branch.isFavorite ? <Star className="h-3 w-3 shrink-0 fill-current text-amber-500" /> : null}
               {branch.isColorMarked ? <Lightbulb className="h-3 w-3 shrink-0 text-primary" /> : null}
-              <span
-                className={`inline-flex h-5 shrink-0 items-center rounded border px-1.5 text-[10px] font-medium ${origin.className}`}
-                title={origin.title}
-              >
-                {origin.label}
-              </span>
+              {/*
+                2026-05-14：标题行的徽章从「Webhook / 手动」改为分支当前的「运行模式」
+                （发布版 / 源码 / 混合）。用户更关心的是"这个分支跑的是热加载还是 publish"，
+                而不是"来源是 webhook 还是手动"。来源信息降级到 title attribute（hover 看到）。
+                运行模式徽章带火箭图标，与抽屉里「本分支运行模式」面板视觉对齐。
+              */}
+              {runtime ? (
+                <span
+                  className={`inline-flex h-5 shrink-0 items-center gap-1 rounded border px-1.5 text-[10px] font-medium ${runtime.className}`}
+                  title={`${runtime.title}\n来源: ${origin.label} — ${origin.title}`}
+                >
+                  <Rocket className="h-2.5 w-2.5" aria-hidden />
+                  {runtime.label}
+                </span>
+              ) : (
+                <span
+                  className="inline-flex h-5 shrink-0 items-center gap-1 rounded border border-[hsl(var(--hairline))] px-1.5 text-[10px] font-medium text-muted-foreground"
+                  title={`运行模式: 源码 / 热加载\n来源: ${origin.label} — ${origin.title}`}
+                >
+                  <Rocket className="h-2.5 w-2.5" aria-hidden />
+                  源码
+                </span>
+              )}
             </div>
           </div>
         </div>
@@ -3393,15 +3488,16 @@ function BranchCard({
             </span>
           ) : null
         )}
-        {runtime ? (
-          <span
-            className={`inline-flex h-6 shrink-0 items-center gap-1.5 rounded-md border px-2 text-xs font-medium ${runtime.className}`}
-            title={runtime.title}
-          >
-            <Rocket className="h-3 w-3" aria-hidden />
-            {runtime.label}
-          </span>
-        ) : null}
+        {/*
+          2026-05-14：原本在 chip 行的「发布版」徽章上移到标题行（替代 Webhook），
+          此处保留来源 chip（手动/Webhook/待配置），让用户在卡片正文区仍能看到分支来源。
+        */}
+        <span
+          className={`inline-flex h-6 shrink-0 items-center rounded-md border px-2 text-xs ${origin.className}`}
+          title={origin.title}
+        >
+          {origin.label}
+        </span>
         <span className="ml-auto whitespace-nowrap text-xs text-muted-foreground" title={timeBadge.title}>
           {timeBadge.label} {timeBadge.text}
         </span>

--- a/cds/web/src/pages/ProjectSettingsPage.tsx
+++ b/cds/web/src/pages/ProjectSettingsPage.tsx
@@ -76,6 +76,10 @@ interface ProjectSummary {
   githubLinkedAt?: string;
   githubEventPolicy?: GithubEventPolicy;
   defaultDeployModes?: Record<string, string>;
+  /** 2026-05-14: 部署成 running 后 N 分钟自动切到发布版（0=关）。 */
+  autoPublishAfterMinutes?: number;
+  /** 2026-05-14: 部署成 running 后 N 分钟自动停止容器（0=关）。 */
+  autoStopAfterMinutes?: number;
 }
 
 interface BuildProfileSummary {
@@ -689,7 +693,148 @@ function RuntimeDefaultsTab({
           <span className="text-xs text-muted-foreground">已有分支请在分支详情抽屉里单独切换。</span>
         </div>
       </Section>
+
+      {/* 2026-05-14：自动切发布版 / 自动停止 两个独立调度，按"部署成功后存活时间"计时。 */}
+      <AutoLifecycleSection
+        project={project}
+        projectId={projectId}
+        onSaved={onSaved}
+        onToast={onToast}
+      />
     </div>
+  );
+}
+
+/**
+ * 项目级自动生命周期策略：
+ * 1. 启动满 N 分钟自动切到发布版（用于"调试结束后就该切到 publish"场景）
+ * 2. 启动满 N 分钟自动停止容器（用于"调完忘了关，占资源"场景）
+ *
+ * 计时锚点 = BranchEntry.lastReadyAt（容器进入 running 时打戳）。
+ * HTTP 流量不参与计时，避免长连接 / 健康检查永远刷新。
+ */
+function AutoLifecycleSection({
+  project,
+  projectId,
+  onSaved,
+  onToast,
+}: {
+  project: ProjectSummary;
+  projectId: string;
+  onSaved: (project: ProjectSummary) => void;
+  onToast: (message: string) => void;
+}): JSX.Element {
+  const initialPublish = Number(project.autoPublishAfterMinutes) || 0;
+  const initialStop = Number(project.autoStopAfterMinutes) || 0;
+  const [publishEnabled, setPublishEnabled] = useState(initialPublish > 0);
+  const [publishMinutes, setPublishMinutes] = useState(initialPublish > 0 ? initialPublish : 3);
+  const [stopEnabled, setStopEnabled] = useState(initialStop > 0);
+  const [stopMinutes, setStopMinutes] = useState(initialStop > 0 ? initialStop : 3);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const p = Number(project.autoPublishAfterMinutes) || 0;
+    const s = Number(project.autoStopAfterMinutes) || 0;
+    setPublishEnabled(p > 0);
+    setPublishMinutes(p > 0 ? p : 3);
+    setStopEnabled(s > 0);
+    setStopMinutes(s > 0 ? s : 3);
+  }, [project.autoPublishAfterMinutes, project.autoStopAfterMinutes]);
+
+  async function save(): Promise<void> {
+    setSaving(true);
+    setError('');
+    try {
+      const body: Record<string, number> = {
+        autoPublishAfterMinutes: publishEnabled ? Math.max(1, Math.floor(publishMinutes)) : 0,
+        autoStopAfterMinutes: stopEnabled ? Math.max(1, Math.floor(stopMinutes)) : 0,
+      };
+      const result = await apiRequest<ProjectSaveResponse>(
+        `/api/projects/${encodeURIComponent(projectId)}`,
+        { method: 'PATCH', body },
+      );
+      onSaved(result.project);
+      onToast('运行生命周期策略已保存；下一次容器进入运行状态时开始计时');
+    } catch (err) {
+      setError(messageFromError(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Section
+      title="运行生命周期"
+      description="按「部署成功（容器进入 running）后存活时间」自动处理分支。HTTP 流量不参与计时，避免长连接永远刷新计数器。"
+    >
+      <div className="space-y-3">
+        <div className="rounded-md border border-[hsl(var(--hairline))] bg-[hsl(var(--surface-raised))] px-4 py-3">
+          <label className="flex flex-wrap items-center gap-3 text-sm">
+            <input
+              type="checkbox"
+              className="h-4 w-4"
+              checked={publishEnabled}
+              onChange={(e) => setPublishEnabled(e.target.checked)}
+            />
+            <span className="font-medium">运行满</span>
+            <input
+              type="number"
+              min={1}
+              max={1440}
+              value={publishMinutes}
+              disabled={!publishEnabled}
+              onChange={(e) => setPublishMinutes(Number(e.target.value) || 1)}
+              className="h-8 w-20 rounded-md border border-input bg-background px-2 text-sm"
+            />
+            <span className="font-medium">分钟后自动切到发布版</span>
+          </label>
+          <div className="mt-1.5 ml-7 text-xs leading-5 text-muted-foreground">
+            把所有 profile 的 activeDeployMode 翻到 deployModes 里第一个匹配「发布/生产/release/publish」
+            的模式，然后停止当前容器；下次访问会被 auto-build 以发布模式拉起来。适合"调试一会儿就该切 publish"
+            的工作流。默认建议 3 分钟。
+          </div>
+        </div>
+
+        <div className="rounded-md border border-[hsl(var(--hairline))] bg-[hsl(var(--surface-raised))] px-4 py-3">
+          <label className="flex flex-wrap items-center gap-3 text-sm">
+            <input
+              type="checkbox"
+              className="h-4 w-4"
+              checked={stopEnabled}
+              onChange={(e) => setStopEnabled(e.target.checked)}
+            />
+            <span className="font-medium">运行满</span>
+            <input
+              type="number"
+              min={1}
+              max={1440}
+              value={stopMinutes}
+              disabled={!stopEnabled}
+              onChange={(e) => setStopMinutes(Number(e.target.value) || 1)}
+              className="h-8 w-20 rounded-md border border-input bg-background px-2 text-sm"
+            />
+            <span className="font-medium">分钟后自动停止</span>
+          </label>
+          <div className="mt-1.5 ml-7 text-xs leading-5 text-muted-foreground">
+            停掉容器但保留 profileOverrides。和「自动切发布版」同时启用时：先切发布版（停容器+换模式）→
+            下次访问按发布模式重新 ready → 重新计时 → 满 N 分钟再停。这两条策略可独立配置不同分钟数。
+          </div>
+        </div>
+
+        {error ? <ErrorBlock message={error} /> : null}
+
+        <div className="flex flex-wrap items-center gap-3">
+          <Button type="button" onClick={() => void save()} disabled={saving}>
+            {saving ? <Loader2 className="animate-spin" /> : <Save />}
+            保存
+          </Button>
+          <span className="text-xs text-muted-foreground">
+            注意：本策略是<strong>项目级</strong>，对该项目下所有分支生效；CDS 系统级的「空闲降温」是另一套机制。
+          </span>
+        </div>
+      </div>
+    </Section>
   );
 }
 

--- a/cds/web/src/pages/ProjectSettingsPage.tsx
+++ b/cds/web/src/pages/ProjectSettingsPage.tsx
@@ -752,7 +752,9 @@ function AutoLifecycleSection({
       };
       const result = await apiRequest<ProjectSaveResponse>(
         `/api/projects/${encodeURIComponent(projectId)}`,
-        { method: 'PATCH', body },
+        // 后端只注册 PUT /api/projects/:id（无 PATCH 路由）；与本页其他
+        // 保存（默认模式 / GitHub policy / 常规）保持一致用 PUT。
+        { method: 'PUT', body },
       );
       onSaved(result.project);
       onToast('运行生命周期策略已保存；下一次容器进入运行状态时开始计时');

--- a/changelogs/2026-05-14_cds-auto-lifecycle-and-logs.md
+++ b/changelogs/2026-05-14_cds-auto-lifecycle-and-logs.md
@@ -1,0 +1,5 @@
+| feat | cds | 项目设置新增「运行生命周期」面板：「运行满 N 分钟自动切发布版」「运行满 N 分钟自动停止」两个独立开关，默认关闭、可配置 1~1440 分钟；以容器进入 running 时打的 lastReadyAt 戳为计时锚点，HTTP 流量不参与刷新；新增 AutoLifecycleService 30s tick |
+| feat | cds | BranchEntry 新增 lastReadyAt 字段（reconcileBranchStatus 在状态切到 running 时打戳），供项目级生命周期调度使用 |
+| feat | cds | GitHub Webhook 日志 ring buffer 上限从 200 提升到 1000；分支抽屉的 Webhook 日志 tab 支持「加载更早 20 条」分页（每页 20，累计可读到全部 1000） |
+| feat | cds | 分支抽屉「部署」tab 重排版面：容器日志作为一等公民提到顶部（宽屏左、窄屏上），阶段树退居次位（宽屏右、窄屏下）；容器日志面板支持多容器 tab 切换 + 一键最大化（跳到「日志 → 容器日志」） |
+| docs | cds | 新增 doc/debt.cds-state-json.md 登记 state.json 影子存储债务，规划 4 阶段拆分到 mongo collection |

--- a/changelogs/2026-05-14_cds-auto-lifecycle-and-logs.md
+++ b/changelogs/2026-05-14_cds-auto-lifecycle-and-logs.md
@@ -1,4 +1,4 @@
-| feat | cds | 项目设置新增「运行生命周期」面板：「运行满 N 分钟自动切发布版」「运行满 N 分钟自动停止」两个独立开关，默认关闭、可配置 1~1440 分钟；以容器进入 running 时打的 lastReadyAt 戳为计时锚点，HTTP 流量不参与刷新；新增 AutoLifecycleService 30s tick |
+| feat | cds | 项目设置新增「运行生命周期」面板：「运行满 N 分钟自动切发布版」「运行满 N 分钟自动停止」两个独立开关，默认关闭、可配置 1~1440 分钟；以容器进入 running 时打的 lastReadyAt 戳为计时锚点（HTTP 流量不参与刷新），新增 AutoLifecycleService 30s tick。auto-publish 全自动「停源码→重建发布版」（先后替换，无需人工）——复用内部 /deploy 自调（走 resolveEffectiveProfile，不动懒唤醒热路径），失败回滚 override；auto-stop 到点停容器回收 |
 | feat | cds | BranchEntry 新增 lastReadyAt 字段（reconcileBranchStatus 在状态切到 running 时打戳），供项目级生命周期调度使用 |
 | feat | cds | GitHub Webhook 日志 ring buffer 上限从 200 提升到 1000；分支抽屉的 Webhook 日志 tab 支持「加载更早 20 条」分页（每页 20，累计可读到全部 1000） |
 | feat | cds | 分支抽屉「部署」tab 重排版面：容器日志作为一等公民提到顶部（宽屏左、窄屏上），阶段树退居次位（宽屏右、窄屏下）；容器日志面板支持多容器 tab 切换 + 一键最大化（跳到「日志 → 容器日志」） |

--- a/changelogs/2026-05-14_cds-auto-lifecycle-and-logs.md
+++ b/changelogs/2026-05-14_cds-auto-lifecycle-and-logs.md
@@ -1,5 +1,7 @@
 | feat | cds | 项目设置新增「运行生命周期」面板：「运行满 N 分钟自动切发布版」「运行满 N 分钟自动停止」两个独立开关，默认关闭、可配置 1~1440 分钟；以容器进入 running 时打的 lastReadyAt 戳为计时锚点（HTTP 流量不参与刷新），新增 AutoLifecycleService 30s tick。auto-publish 全自动「停源码→重建发布版」（先后替换，无需人工）——复用内部 /deploy 自调（走 resolveEffectiveProfile，不动懒唤醒热路径），失败回滚 override；auto-stop 到点停容器回收 |
 | feat | cds | BranchEntry 新增 lastReadyAt 字段（reconcileBranchStatus 在状态切到 running 时打戳），供项目级生命周期调度使用 |
+| feat | cds | 卡片「发布版」徽章改为真实态：ServiceState 新增 deployedMode（容器实际启动那刻钉的 deploy mode），summarizeBranchDeployRuntime 改为按运行真相判定 + pendingPublish 标记；配置已切发布版但容器没跟上时显示橙色「发布版·待生效」，杜绝设了 override 就亮绿误导。branchAutoPublishConverged 同步改为按真相收敛（redeploy 静默失败不再误判收敛） |
+| fix | cds | 远端执行器重部署传 resolveEffectiveProfile 结果（compute-then-send），修 cluster 下 auto-publish 因 proxyDeployToExecutor 发裸 profile、override 丢失而静默 no-op；graceful shutdown 补 autoLifecycleService.stop()；auto-publish 重部署 SSE 读取加 20min 总超时防全局调度瘫痪 |
 | feat | cds | GitHub Webhook 日志 ring buffer 上限从 200 提升到 1000；分支抽屉的 Webhook 日志 tab 支持「加载更早 20 条」分页（每页 20，累计可读到全部 1000） |
 | feat | cds | 分支抽屉「部署」tab 重排版面：容器日志作为一等公民提到顶部（宽屏左、窄屏上），阶段树退居次位（宽屏右、窄屏下）；容器日志面板支持多容器 tab 切换 + 一键最大化（跳到「日志 → 容器日志」） |
 | docs | cds | 新增 doc/debt.cds-state-json.md 登记 state.json 影子存储债务，规划 4 阶段拆分到 mongo collection |

--- a/changelogs/2026-05-14_cds-branch-inheritance-and-stop-visibility.md
+++ b/changelogs/2026-05-14_cds-branch-inheritance-and-stop-visibility.md
@@ -1,0 +1,4 @@
+| fix | cds | 分支抽屉「本分支运行模式」修复"继承默认显示发布版"问题：resolveEffectiveProfile 增加项目默认（Project.defaultDeployModes）回退层，分支级 override 缺失时优先继承项目设置而非 baseline；UI chip 区分「继承项目默认」「继承构建配置默认」「本分支覆盖」 |
+| feat | cds | BranchEntry 新增 lastStoppedAt / lastStopReason / lastStopSource 字段，用户主动停止、调度器空闲降温/容量驱逐、远端执行器停止三类路径均写入；分支抽屉与详情页展示"上次停止时间 + 原因 + 来源"以解释"分支变灰"现象 |
+| feat | cds | 项目环境变量待补全横幅新增「我知道了」按钮，弹窗提示去「项目设置 → 环境变量」补填，sessionStorage 按 pendingEnvKeys 指纹关闭，新增缺失变量时横幅自动复活 |
+| feat | cds | 分支卡片标题行徽章从来源（Webhook/手动/待配置）切换为运行模式（发布版/源码/混合），与抽屉「本分支运行模式」视觉对齐；原来源徽章降级到正文 chip 行 |

--- a/changelogs/2026-05-14_cds-branch-inheritance-and-stop-visibility.md
+++ b/changelogs/2026-05-14_cds-branch-inheritance-and-stop-visibility.md
@@ -1,4 +1,4 @@
-| fix | cds | 分支抽屉「本分支运行模式」修复"继承默认显示发布版"问题：resolveEffectiveProfile 增加项目默认（Project.defaultDeployModes）回退层，分支级 override 缺失时优先继承项目设置而非 baseline；UI chip 区分「继承项目默认」「继承构建配置默认」「本分支覆盖」 |
+| fix | cds | 「项目默认运行模式」语义明确为"仅建分支时拷贝一次"（保留旧 UI 承诺「不改已有分支」）：applyProjectDefaultDeployModes 建分支时把项目默认写进 branch.profileOverrides，resolveEffectiveProfile 运行期只认分支 override + baseline，不做实时回退。原方案的实时回退层因会回溯改已有分支、与 UI/类型注释承诺矛盾（Codex P1）按用户决策回退 |
 | feat | cds | BranchEntry 新增 lastStoppedAt / lastStopReason / lastStopSource 字段，用户主动停止、调度器空闲降温/容量驱逐、远端执行器停止三类路径均写入；分支抽屉与详情页展示"上次停止时间 + 原因 + 来源"以解释"分支变灰"现象 |
 | feat | cds | 项目环境变量待补全横幅新增「我知道了」按钮，弹窗提示去「项目设置 → 环境变量」补填，sessionStorage 按 pendingEnvKeys 指纹关闭，新增缺失变量时横幅自动复活 |
 | feat | cds | 分支卡片标题行徽章从来源（Webhook/手动/待配置）切换为运行模式（发布版/源码/混合），与抽屉「本分支运行模式」视觉对齐；原来源徽章降级到正文 chip 行 |

--- a/doc/debt.cds-state-json.md
+++ b/doc/debt.cds-state-json.md
@@ -1,0 +1,47 @@
+# CDS state.json 影子存储 · 债务台账
+
+> **版本**：v0.1 | **日期**：2026-05-14 | **状态**：open / 待规划
+
+## 总览
+
+| 指标 | 当前值 |
+|------|--------|
+| open | 4 |
+| in-progress | 0 |
+| paid | 0 |
+
+模块范围：`cds/src/services/state.ts` 及所有调用 `stateService.save()` 的写入路径。
+
+## 背景
+
+CDS 在 P4 阶段引入了 MongoDB split store（`CDS_STORAGE_MODE=mongo-split`），fresh
+install 默认走 mongo。但代码层面 `state.json` 仍然是 in-memory state 的兜底持久层：
+- `StateService` 仍然把整张 state 加载进内存
+- 任何 `save()` 调用同时写 mongo 和 state.json（如果 mongo 不可用则只写 json）
+- `state.json` 体积随历史数据线性增长（webhook deliveries ring buffer 上限刚从 200 调到 1000）
+
+2026-05-14 用户明确指示："本系统尽量去掉 state.json 形式，如果没有改进，列进技术债务，
+去掉 state.json这个影子，属于过时设计，甚至会撑爆mongodb"。本台账登记后续偿还计划。
+
+## open 债务
+
+| 编号 | 债务 | 影响 | 偿还方向 |
+|---|---|---|---|
+| #1 | webhook deliveries ring buffer 上限 1000 仍按一次性 `save()` 把整数组刷盘，state.json 大项目下可能数 MB | 启动加载慢 / save 抖动 | 拆 collection：`cds_webhook_deliveries`，配 mongo capped collection（max=1000）；只追加写、不全量刷 |
+| #2 | branch activity log（ProjectActivityLog ring buffer）同样按整对象 save，自动调度器加入后写入量上升 | save 频率提高时阻塞主循环 | 同 #1 拆 collection，或改成 append-only 日志文件按天 rotate |
+| #3 | 项目级 `defaultDeployModes` / `autoPublishAfterMinutes` / `autoStopAfterMinutes` 等元信息混在 state 顶级 | 任何改设置都要重写整个 state.json | 拆 `cds_projects` collection；StateService 改成 thin lookup |
+| #4 | mongo-split 模式仍保留 state.json fallback，意外回滚到 json 模式时数据可能落后 mongo | 容易踩到"为什么我新建的分支不见了"陷阱 | 把 state.json 降级为只读快照（startup migration only），写路径不再回写 |
+
+## 偿还路线建议
+
+1. **Phase 1**（低风险）：拆 webhook deliveries 到独立 collection，state.json 不再含此字段。
+2. **Phase 2**：activity log 同上。
+3. **Phase 3**：把 Projects / BuildProfiles / RoutingRules 也拆成独立 collection。
+4. **Phase 4**：删除 state.json 写路径，只保留 migration 读取。
+
+## 相关
+
+- `cds/CLAUDE.md` —— `CDS_STORAGE_MODE=mongo-split` 是默认值
+- 2026-05-14 commit / PR：webhook buffer 上限从 200 → 1000、新增项目级生命周期调度
+  → 都加重了 state.json 单文件压力，需要尽早开工 Phase 1
+- `cds/src/services/state.ts` —— StateService 主体

--- a/doc/index.yml
+++ b/doc/index.yml
@@ -237,6 +237,7 @@ docs:
   debt.workflow-agent: 工作流 Agent · 债务台账
   debt.asset-storage: 资源存储（IAssetStorage 实现）债务台账
   debt.claude-sdk-executor: Claude SDK 执行器 / Python sidecar 债务台账
+  debt.cds-state-json: CDS state.json 影子存储债务台账
 
   # ── 七、周报（降序：最新在前）──
   report.cds-agent-workbench-2026-05-15: CDS Agent 工作台完成复盘（2026-05-15）


### PR DESCRIPTION
## 摘要

新增项目级自动生命周期策略（AutoLifecycleService），支持"运行满 N 分钟自动切发布版"和"运行满 N 分钟自动停止"两个独立调度；同时增强分支停止原因的可见性，让用户在 UI 上清晰看到分支为什么变灰。修复分支抽屉"继承默认显示发布版"的问题。

## 改动 diff

### 后端核心
- `cds/src/services/auto-lifecycle.ts`（新增）：AutoLifecycleService 实现，30s tick 一拍，按 BranchEntry.lastReadyAt 计时（容器进入 running 时打戳），HTTP 流量不参与刷新
- `cds/src/types.ts`：BranchEntry 新增 lastReadyAt / lastStoppedAt / lastStopReason / lastStopSource 四个字段；Project 新增 autoPublishAfterMinutes / autoStopAfterMinutes 两个配置
- `cds/src/services/container.ts`：resolveEffectiveProfile 增加项目默认（Project.defaultDeployModes）回退层，修复分支级 override 缺失时优先继承项目设置而非 baseline 的问题；新增 resolveDeployModeSource 函数区分继承来源
- `cds/src/routes/branches.ts`：reconcileBranchStatus 在容器进入 running 时打 lastReadyAt 戳；summarizeBranchDeployRuntime 传入 projectDefaults；调度器降温时记录 lastStoppedAt / lastStopReason / lastStopSource
- `cds/src/routes/projects.ts`：PATCH /api/projects/{id} 支持保存 autoPublishAfterMinutes / autoStopAfterMinutes
- `cds/src/routes/github-webhook.ts`：webhook 日志端点支持 offset / limit 翻页；ring buffer 上限从 200 提升到 1000
- `cds/src/services/state.ts`：WEBHOOK_DELIVERY_HISTORY_MAX 从 200 改为 1000
- `cds/src/index.ts`：启动 AutoLifecycleService；调度器 coolFn 记录停止原因和活动日志

### 前端
- `cds/web/src/pages/ProjectSettingsPage.tsx`：新增「运行生命周期」面板，两个独立开关 + 分钟数输入（1~1440）
- `cds/web/src/components/BranchDetailDrawer.tsx`：
  - 新增 lastStoppedAt / lastStopReason / lastStopSource 字段展示
  - ProfileRow 新增 deployModeSource / projectDefaultDeployMode 字段，UI chip 区分继承来源
  - webhook 日志支持分页加载（TRIGGER_LOGS_PAGE_SIZE = 20）
  - 部署 tab 内联容器日志支持多容器 tab 切换 + 一键最大化
- `cds/web/src/components/deployment/ActiveDeployment.tsx`（新增）：PrimaryContainerLogPanel 组件，展示容器日志 + tab strip + 最大化按钮
- `cds/web/src/components/deployment/PhaseTree.tsx`：新增 InlineContainerLogControls 接口，内联日志支持多容器切换和最大化
- `cds/web/src/pages/BranchListPage.tsx`：环境

https://claude.ai/code/session_0111LfNj3wcbaJDpeLGnYaG8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new coordinator-side lifecycle timer that can stop/redeploy branches automatically and changes how deploy/stop state is recorded and displayed; mistakes could cause unexpected redeploy/stop behavior or misleading runtime status, especially in clustered executor setups.
> 
> **Overview**
> Adds `AutoLifecycleService` (30s tick) to enforce per-project `autoPublishAfterMinutes`/`autoStopAfterMinutes`, using new `BranchEntry.lastReadyAt` as the timer anchor and performing fully automated **release-switch + redeploy** (with rollback on failure) or timed auto-stop; it’s started only on coordinator nodes and is shut down cleanly.
> 
> Improves stop observability by stamping `lastStoppedAt`/`lastStopReason`/`lastStopSource`, incrementing `stopCount`, and appending activity logs across scheduler cooling, manual stops, and remote executor stops.
> 
> Makes deploy-mode reporting reflect **actual runtime** by adding `ServiceState.deployedMode`, centralizing release-mode classification in `services/deploy-runtime.ts`, updating branch runtime summaries to compute a `pendingPublish` state, and ensuring cluster proxy deploys send resolved profiles, parse SSE `ok` on completion, stamp `lastDeployAt`, and preserve `deployedMode` across executor heartbeats.
> 
> Extends GitHub webhook delivery history (ring buffer 200→1000) with `offset`/`limit` paging end-to-end, and updates the UI to page logs, surface last-stop banners, prioritize container logs in the deployment view (multi-service tabs + maximize), adjust branch list badges, and add a session-scoped dismissal flow for the pending env-var banner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d57330ef37bba41fcd556b8d2134290fb7e949e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->