### PR TITLE
每日熵减计划 2026-W20 — guide.list 补 debt.cds-state-json + changelog 5 条入库

### DIFF
--- a/changelogs/.entropy-manifest.yml
+++ b/changelogs/.entropy-manifest.yml
@@ -21,3 +21,8 @@ processed:
   - 2026-05-12_cds-railway-onboarding.md
   - 2026-05-12_cds-railway-sidebar-icons.md
   - 2026-05-12_cds-self-update-web-build-gate.md
+  - 2026-05-12_fix-menu-count-mismatch.md
+  - 2026-05-12_nav-count-mismatch-fix.md
+  - 2026-05-12_subtitle-asr-debt.md
+  - 2026-05-12_web-pages-ux-and-media.md
+  - 2026-05-13_cds-branch-card-running-state.md

--- a/doc/guide.list.directory.md
+++ b/doc/guide.list.directory.md
@@ -632,6 +632,9 @@
 - [Claude SDK 执行器 / Python sidecar 债务台账](debt.claude-sdk-executor) `debt.claude-sdk-executor`
   > claude-sdk 执行器与 Python sidecar 的已知债务与边界约束
 
+- [CDS state.json 影子存储 · 债务台账](debt.cds-state-json) `debt.cds-state-json`
+  > 4 条 open：webhook deliveries 全量刷盘 / StateService 内存全量加载 / mongo-split 模式 state.json 同步写 / 无独立清理策略
+
 ### 七、周报
 
 - [CDS Agent 工作台完成复盘（2026-05-15）](report.cds-agent-workbench-2026-05-15) `report.cds-agent-workbench-2026-05-15`


### PR DESCRIPTION
自动生成的每日熵减 PR。

## 修复项

- **D3 补缺**：`doc/guide.list.directory.md` 新增 `debt.cds-state-json` 条目（文件存在但目录未登记）
- **D6 changelog 入库**：`changelogs/.entropy-manifest.yml` 标记 5 个碎片已处理
  - `2026-05-12_fix-menu-count-mismatch.md`
  - `2026-05-12_nav-count-mismatch-fix.md`
  - `2026-05-12_subtitle-asr-debt.md`
  - `2026-05-12_web-pages-ux-and-media.md`
  - `2026-05-13_cds-branch-card-running-state.md`

## 跳过项（diff 核验未通过 / 误报）

- **D3 幽灵**：扫描出的 23 个"幽灵"条目均来自 `guide.list.directory.md` 底部变更历史区的反引号引用，非正式文档链接，属扫描误报，跳过删除
- **D4 幽灵 pnpm**：`**pnpm**` 出现在 CLAUDE.md 正文，非技能表行格式 `| **pnpm** |`，误报，跳过
- **D1/D2**：无违规

## 扫描摘要

| 维度 | 结果 |
|------|------|
| D1 命名规范 | 0 违规 |
| D2 index.yml | 0 缺 / 0 幽灵 |
| D3 guide.list | 1 补缺 / 23 误报（历史区）|
| D4 CLAUDE.md 技能表 | 0 缺 / 1 误报（pnpm 正文）|
| D6 changelog | 5 条入库 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01JX5jJERGKudsKnEp9whady)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates documentation index and a changelog manifest list; no runtime code paths are affected, so risk is low aside from potential doc-sync tooling expectations.
> 
> **Overview**
> Updates the doc index by adding the missing `debt.cds-state-json` entry to `doc/guide.list.directory.md` so the existing debt doc is discoverable by sync tooling.
> 
> Extends `changelogs/.entropy-manifest.yml` to mark five additional changelog fragments as processed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4c9df30fc4172c42b5f0c9c1302bb2f9238983e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->