### PR TITLE
每日熵减计划 2026-W20 — CDS changelog 入库（5 条）

### DIFF
--- a/changelogs/.entropy-manifest.yml
+++ b/changelogs/.entropy-manifest.yml
@@ -26,3 +26,8 @@ processed:
   - 2026-05-12_subtitle-asr-debt.md
   - 2026-05-12_web-pages-ux-and-media.md
   - 2026-05-13_cds-branch-card-running-state.md
+  - 2026-05-13_cds-branch-card-selected-state.md
+  - 2026-05-13_cds-branch-list-fast-first-paint.md
+  - 2026-05-13_cds-branch-list-skip-gitlog.md
+  - 2026-05-13_cds-commit-inbox-click-target.md
+  - 2026-05-13_cds-commit-inbox-density.md

--- a/doc/design.cds.md
+++ b/doc/design.cds.md
@@ -495,3 +495,15 @@ target: `http://localhost:${process.env.VITE_API_PORT || 5000}`
 | `plan.cds-roadmap.md` | Phase 0-3 里程碑 |
 | `plan.cds-resilience-rollout.md` | 高可用改造落地进度（可续传）|
 | `guide.cds-ai-auth.md` | 认证问题故障排查 |
+
+---
+
+## 13. 近期变更记录（2026-05-13）
+
+| 类型 | 模块 | 说明 |
+|------|------|------|
+| fix | cds | 将分支搜索命中提示改为稳定选中态，避免短暂闪烁后用户找不到目标卡片 |
+| fix | cds | 分支列表首屏使用缓存态快速渲染，后台再同步 Docker 实时状态 |
+| fix | cds | 分支列表首屏快路径跳过 worktree git log，进一步缩短首屏等待 |
+| fix | cds | 扩大提交实时流记录点击热区，并为提交标签增加状态图标 |
+| fix | cds | 优化提交实时流面板信息密度，折叠态显示最新分支与精确更新时间 |


### PR DESCRIPTION
自动生成的每日熵减 PR。

## 修复项

- **D6 changelog 入库（5 条）**：将 2026-05-13 的 5 条 CDS 修复 changelog 片段追加到 `doc/design.cds.md` § 13，并写入 `changelogs/.entropy-manifest.yml`
  - fix: 分支搜索命中稳定选中态
  - fix: 分支列表首屏缓存态快速渲染
  - fix: 首屏快路径跳过 worktree git log
  - fix: 扩大提交实时流点击热区 + 状态图标
  - fix: 提交实时流面板信息密度优化

## 跳过项（diff 核验未通过）

- **D3 幽灵（18 条）**：全部位于 `guide.list.directory.md` 的变更历史表格或文件头说明文本，属于合法历史记录引用，删除会破坏变更历史，跳过
- **D4 幽灵（pnpm）**：CLAUDE.md 中加粗的规则文本，非技能表条目，跳过

## 扫描结果摘要

| 维度 | 结果 |
|------|------|
| D1 命名违规 | 0 项 |
| D2 index.yml 补缺/幽灵 | 0 项 |
| D3 guide.list 补缺 | 0 项 / 幽灵跳过 |
| D4 技能表补缺/幽灵 | 0 项 / 幽灵跳过 |
| D6 changelog 入库 | 5 条 |

https://claude.ai/code/session_01DKPrWcHCv5DsHBFck5WVfz

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKPrWcHCv5DsHBFck5WVfz)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/manifest-only update that records changelog entries; no runtime or behavior changes.
> 
> **Overview**
> Adds five new CDS fix changelog entries for **2026-05-13** to `doc/design.cds.md` §13 (branch search stable selection, faster branch list first paint via cached render + skipping git log, and commit inbox click-target/density tweaks).
> 
> Updates `changelogs/.entropy-manifest.yml` to mark the corresponding five changelog fragments as processed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3518c34988c562aa9591e39f0d2dd82337c27c94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->