### PR TITLE
作品广场动态列数自适应 + 创作者头像筛选行

### DIFF
--- a/changelogs/2026-05-16_showcase-dynamic-grid.md
+++ b/changelogs/2026-05-16_showcase-dynamic-grid.md
@@ -7,3 +7,4 @@
 | perf | prd-admin | 作品广场封面图视口懒挂载（IntersectionObserver，未滚动到的卡片零请求）+ 首屏批量缩小（首页20→12 / showcase 24→18）+ decoding=async，大幅降低首屏流量 |
 | fix | prd-admin | fetchCreators 增加请求令牌防竞态，快速切 tab 时旧创作者响应不再覆盖新 tab |
 | fix | prd-admin | 全部 tab 下选中创作者无作品时补空状态提示（避免空白区）；LiteraryCard 复用 waterfall.ts 的 getAspectRatio 消除重复 |
+| fix | prd-admin | useWaterfallColumns 改回调 ref + 测量内容盒宽度（扣除 padding，修复带 padding 容器多算一列；条件 remount 后 ResizeObserver 重新挂载） |

--- a/changelogs/2026-05-16_showcase-dynamic-grid.md
+++ b/changelogs/2026-05-16_showcase-dynamic-grid.md
@@ -9,3 +9,4 @@
 | fix | prd-admin | 全部 tab 下选中创作者无作品时补空状态提示（避免空白区）；LiteraryCard 复用 waterfall.ts 的 getAspectRatio 消除重复 |
 | fix | prd-admin | useWaterfallColumns 改回调 ref + 测量内容盒宽度（扣除 padding，修复带 padding 容器多算一列；条件 remount 后 ResizeObserver 重新挂载） |
 | fix | prd-admin | PortfolioShowcasePage 筛选无结果时改显「没有符合条件的作品」+ 查看全部，不再误导用户去创作 |
+| refactor | prd-admin | 抽取 useCreatorFilter 共享 hook，消除两个作品广场组件重复的创作者筛选状态/竞态逻辑 |

--- a/changelogs/2026-05-16_showcase-dynamic-grid.md
+++ b/changelogs/2026-05-16_showcase-dynamic-grid.md
@@ -6,3 +6,4 @@
 | fix | prd-admin | 前三名创作者改用金/银/铜彩色光圈（替代看不清的小皇冠） |
 | perf | prd-admin | 作品广场封面图视口懒挂载（IntersectionObserver，未滚动到的卡片零请求）+ 首屏批量缩小（首页20→12 / showcase 24→18）+ decoding=async，大幅降低首屏流量 |
 | fix | prd-admin | fetchCreators 增加请求令牌防竞态，快速切 tab 时旧创作者响应不再覆盖新 tab |
+| fix | prd-admin | 全部 tab 下选中创作者无作品时补空状态提示（避免空白区）；LiteraryCard 复用 waterfall.ts 的 getAspectRatio 消除重复 |

--- a/changelogs/2026-05-16_showcase-dynamic-grid.md
+++ b/changelogs/2026-05-16_showcase-dynamic-grid.md
@@ -2,3 +2,4 @@
 | feat | prd-admin | 作品广场新增创作者头像筛选行，点击头像只看该创作者作品，切类型标签自动刷新 |
 | feat | prd-admin | 作品广场增强极光渐变动效背景（柔和漂移+呼吸，支持 prefers-reduced-motion 降级） |
 | feat | prd-api | 投稿 public 列表支持 ownerUserId 过滤 + 新增 public/creators 聚合接口 |
+| fix | prd-admin | 创作者头像行隐藏老土滚动条（保留滚动），前三名头顶加金/银/铜小皇冠，首页区块移除有色极光背景 |

--- a/changelogs/2026-05-16_showcase-dynamic-grid.md
+++ b/changelogs/2026-05-16_showcase-dynamic-grid.md
@@ -5,3 +5,4 @@
 | fix | prd-admin | 创作者头像行隐藏老土滚动条（保留滚动），首页区块移除有色极光背景 |
 | fix | prd-admin | 前三名创作者改用金/银/铜彩色光圈（替代看不清的小皇冠） |
 | perf | prd-admin | 作品广场封面图视口懒挂载（IntersectionObserver，未滚动到的卡片零请求）+ 首屏批量缩小（首页20→12 / showcase 24→18）+ decoding=async，大幅降低首屏流量 |
+| fix | prd-admin | fetchCreators 增加请求令牌防竞态，快速切 tab 时旧创作者响应不再覆盖新 tab |

--- a/changelogs/2026-05-16_showcase-dynamic-grid.md
+++ b/changelogs/2026-05-16_showcase-dynamic-grid.md
@@ -8,3 +8,4 @@
 | fix | prd-admin | fetchCreators 增加请求令牌防竞态，快速切 tab 时旧创作者响应不再覆盖新 tab |
 | fix | prd-admin | 全部 tab 下选中创作者无作品时补空状态提示（避免空白区）；LiteraryCard 复用 waterfall.ts 的 getAspectRatio 消除重复 |
 | fix | prd-admin | useWaterfallColumns 改回调 ref + 测量内容盒宽度（扣除 padding，修复带 padding 容器多算一列；条件 remount 后 ResizeObserver 重新挂载） |
+| fix | prd-admin | PortfolioShowcasePage 筛选无结果时改显「没有符合条件的作品」+ 查看全部，不再误导用户去创作 |

--- a/changelogs/2026-05-16_showcase-dynamic-grid.md
+++ b/changelogs/2026-05-16_showcase-dynamic-grid.md
@@ -1,0 +1,4 @@
+| feat | prd-admin | 作品广场列数随屏宽动态自适应（标准屏5列，带鱼屏6-7列防卡片过大，小屏降至3/2列） |
+| feat | prd-admin | 作品广场新增创作者头像筛选行，点击头像只看该创作者作品，切类型标签自动刷新 |
+| feat | prd-admin | 作品广场增强极光渐变动效背景（柔和漂移+呼吸，支持 prefers-reduced-motion 降级） |
+| feat | prd-api | 投稿 public 列表支持 ownerUserId 过滤 + 新增 public/creators 聚合接口 |

--- a/changelogs/2026-05-16_showcase-dynamic-grid.md
+++ b/changelogs/2026-05-16_showcase-dynamic-grid.md
@@ -2,4 +2,6 @@
 | feat | prd-admin | 作品广场新增创作者头像筛选行，点击头像只看该创作者作品，切类型标签自动刷新 |
 | feat | prd-admin | 作品广场增强极光渐变动效背景（柔和漂移+呼吸，支持 prefers-reduced-motion 降级） |
 | feat | prd-api | 投稿 public 列表支持 ownerUserId 过滤 + 新增 public/creators 聚合接口 |
-| fix | prd-admin | 创作者头像行隐藏老土滚动条（保留滚动），前三名头顶加金/银/铜小皇冠，首页区块移除有色极光背景 |
+| fix | prd-admin | 创作者头像行隐藏老土滚动条（保留滚动），首页区块移除有色极光背景 |
+| fix | prd-admin | 前三名创作者改用金/银/铜彩色光圈（替代看不清的小皇冠） |
+| perf | prd-admin | 作品广场封面图视口懒挂载（IntersectionObserver，未滚动到的卡片零请求）+ 首屏批量缩小（首页20→12 / showcase 24→18）+ decoding=async，大幅降低首屏流量 |

--- a/prd-admin/src/components/showcase/CreatorFilterRow.tsx
+++ b/prd-admin/src/components/showcase/CreatorFilterRow.tsx
@@ -1,4 +1,4 @@
-import { Users, Crown } from 'lucide-react';
+import { Users } from 'lucide-react';
 import { resolveAvatarUrl, DEFAULT_AVATAR_FALLBACK } from '@/lib/avatar';
 import type { SubmissionCreator } from '@/services/real/submissions';
 
@@ -11,11 +11,11 @@ interface Props {
 
 const ITEM_WIDTH = 64;
 
-/** Crown color for the top-3 creators (gold / silver / bronze) */
-const RANK_CROWN: Record<number, string> = {
-  0: '#FACC15',
-  1: '#CBD5E1',
-  2: '#D8975A',
+/** Colored ring for the top-3 creators: gold / silver / bronze */
+const RANK_RING: Record<number, { ring: string; glow: string; label: string }> = {
+  0: { ring: 'linear-gradient(135deg, #FDE68A 0%, #F59E0B 100%)', glow: 'rgba(245,158,11,0.55)', label: '#FBBF24' },
+  1: { ring: 'linear-gradient(135deg, #E5E7EB 0%, #94A3B8 100%)', glow: 'rgba(148,163,184,0.5)', label: '#CBD5E1' },
+  2: { ring: 'linear-gradient(135deg, #E0A472 0%, #B26B33 100%)', glow: 'rgba(178,107,51,0.5)', label: '#D8975A' },
 };
 
 /**
@@ -84,7 +84,7 @@ export function CreatorFilterRow({ creators, selectedUserId, onSelect, loading }
       {creators.map((c, index) => {
         const active = selectedUserId === c.ownerUserId;
         const avatarUrl = resolveAvatarUrl({ avatarFileName: c.ownerAvatarFileName });
-        const crownColor = RANK_CROWN[index];
+        const rank = RANK_RING[index];
         return (
           <button
             key={c.ownerUserId}
@@ -98,26 +98,19 @@ export function CreatorFilterRow({ creators, selectedUserId, onSelect, loading }
             <div
               className="relative w-11 h-11 rounded-full transition-all duration-200"
               style={{
-                padding: 2,
+                padding: rank ? 2.5 : 2,
                 background: active
                   ? 'linear-gradient(135deg, #818CF8 0%, #A78BFA 100%)'
-                  : 'rgba(255,255,255,0.08)',
-                boxShadow: active ? '0 0 14px rgba(129,140,248,0.4)' : 'none',
+                  : rank
+                    ? rank.ring
+                    : 'rgba(255,255,255,0.08)',
+                boxShadow: active
+                  ? '0 0 14px rgba(129,140,248,0.4)'
+                  : rank
+                    ? `0 0 12px ${rank.glow}`
+                    : 'none',
               }}
             >
-              {crownColor && (
-                <Crown
-                  size={13}
-                  fill={crownColor}
-                  strokeWidth={1.5}
-                  className="absolute left-1/2 -translate-x-1/2 pointer-events-none"
-                  style={{
-                    top: -10,
-                    color: crownColor,
-                    filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.6))',
-                  }}
-                />
-              )}
               <img
                 src={avatarUrl}
                 alt={c.ownerUserName}
@@ -131,7 +124,7 @@ export function CreatorFilterRow({ creators, selectedUserId, onSelect, loading }
             </div>
             <span
               className="text-[11px] truncate w-full text-center"
-              style={{ color: active ? '#A5B4FC' : 'rgba(255,255,255,0.5)' }}
+              style={{ color: active ? '#A5B4FC' : rank ? rank.label : 'rgba(255,255,255,0.5)' }}
             >
               {c.ownerUserName}
             </span>

--- a/prd-admin/src/components/showcase/CreatorFilterRow.tsx
+++ b/prd-admin/src/components/showcase/CreatorFilterRow.tsx
@@ -1,0 +1,122 @@
+import { Users } from 'lucide-react';
+import { resolveAvatarUrl, DEFAULT_AVATAR_FALLBACK } from '@/lib/avatar';
+import type { SubmissionCreator } from '@/services/real/submissions';
+
+interface Props {
+  creators: SubmissionCreator[];
+  selectedUserId: string | null;
+  onSelect: (userId: string | null) => void;
+  loading?: boolean;
+}
+
+const ITEM_WIDTH = 64;
+
+/**
+ * Horizontal row of circular creator avatars. Clicking a creator filters the
+ * gallery to that author; the leading "全部" chip resets the filter.
+ */
+export function CreatorFilterRow({ creators, selectedUserId, onSelect, loading }: Props) {
+  if (loading) {
+    return (
+      <div className="flex items-center gap-3 overflow-hidden" style={{ height: 72 }}>
+        {Array.from({ length: 10 }).map((_, i) => (
+          <div key={i} className="flex flex-col items-center gap-1.5 shrink-0" style={{ width: ITEM_WIDTH }}>
+            <div
+              className="w-11 h-11 rounded-full animate-pulse"
+              style={{ background: 'rgba(255,255,255,0.05)' }}
+            />
+            <div
+              className="h-2 rounded animate-pulse"
+              style={{ width: 40, background: 'rgba(255,255,255,0.04)' }}
+            />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (creators.length === 0) return null;
+
+  const allActive = !selectedUserId;
+
+  return (
+    <div
+      className="flex items-center gap-3 overflow-x-auto pb-1"
+      style={{ scrollbarWidth: 'thin', overscrollBehaviorX: 'contain' }}
+    >
+      {/* 全部 reset chip */}
+      <button
+        type="button"
+        onClick={() => onSelect(null)}
+        className="flex flex-col items-center gap-1.5 shrink-0 transition-all duration-200"
+        style={{ width: ITEM_WIDTH }}
+        aria-pressed={allActive}
+      >
+        <div
+          className="w-11 h-11 rounded-full flex items-center justify-center transition-all duration-200"
+          style={{
+            background: allActive
+              ? 'linear-gradient(135deg, rgba(99,102,241,0.35) 0%, rgba(168,85,247,0.3) 100%)'
+              : 'rgba(255,255,255,0.06)',
+            border: allActive
+              ? '2px solid rgba(129,140,248,0.7)'
+              : '2px solid rgba(255,255,255,0.08)',
+            boxShadow: allActive ? '0 0 14px rgba(129,140,248,0.35)' : 'none',
+          }}
+        >
+          <Users size={17} style={{ color: allActive ? '#C7D2FE' : 'rgba(255,255,255,0.5)' }} />
+        </div>
+        <span
+          className="text-[11px] truncate w-full text-center"
+          style={{ color: allActive ? '#A5B4FC' : 'rgba(255,255,255,0.45)' }}
+        >
+          全部
+        </span>
+      </button>
+
+      {creators.map((c) => {
+        const active = selectedUserId === c.ownerUserId;
+        const avatarUrl = resolveAvatarUrl({ avatarFileName: c.ownerAvatarFileName });
+        return (
+          <button
+            key={c.ownerUserId}
+            type="button"
+            onClick={() => onSelect(active ? null : c.ownerUserId)}
+            title={`${c.ownerUserName} · ${c.submissionCount} 件作品`}
+            className="flex flex-col items-center gap-1.5 shrink-0 transition-all duration-200"
+            style={{ width: ITEM_WIDTH }}
+            aria-pressed={active}
+          >
+            <div
+              className="w-11 h-11 rounded-full transition-all duration-200"
+              style={{
+                padding: 2,
+                background: active
+                  ? 'linear-gradient(135deg, #818CF8 0%, #A78BFA 100%)'
+                  : 'rgba(255,255,255,0.08)',
+                boxShadow: active ? '0 0 14px rgba(129,140,248,0.4)' : 'none',
+              }}
+            >
+              <img
+                src={avatarUrl}
+                alt={c.ownerUserName}
+                className="w-full h-full rounded-full object-cover"
+                style={{ background: '#0a0a0f' }}
+                loading="lazy"
+                onError={(e) => {
+                  (e.target as HTMLImageElement).src = DEFAULT_AVATAR_FALLBACK;
+                }}
+              />
+            </div>
+            <span
+              className="text-[11px] truncate w-full text-center"
+              style={{ color: active ? '#A5B4FC' : 'rgba(255,255,255,0.5)' }}
+            >
+              {c.ownerUserName}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/prd-admin/src/components/showcase/CreatorFilterRow.tsx
+++ b/prd-admin/src/components/showcase/CreatorFilterRow.tsx
@@ -1,4 +1,4 @@
-import { Users } from 'lucide-react';
+import { Users, Crown } from 'lucide-react';
 import { resolveAvatarUrl, DEFAULT_AVATAR_FALLBACK } from '@/lib/avatar';
 import type { SubmissionCreator } from '@/services/real/submissions';
 
@@ -10,6 +10,13 @@ interface Props {
 }
 
 const ITEM_WIDTH = 64;
+
+/** Crown color for the top-3 creators (gold / silver / bronze) */
+const RANK_CROWN: Record<number, string> = {
+  0: '#FACC15',
+  1: '#CBD5E1',
+  2: '#D8975A',
+};
 
 /**
  * Horizontal row of circular creator avatars. Clicking a creator filters the
@@ -41,8 +48,8 @@ export function CreatorFilterRow({ creators, selectedUserId, onSelect, loading }
 
   return (
     <div
-      className="flex items-center gap-3 overflow-x-auto pb-1"
-      style={{ scrollbarWidth: 'thin', overscrollBehaviorX: 'contain' }}
+      className="nav-scroll-hidden flex items-center gap-3 overflow-x-auto pb-1"
+      style={{ overscrollBehaviorX: 'contain' }}
     >
       {/* 全部 reset chip */}
       <button
@@ -74,9 +81,10 @@ export function CreatorFilterRow({ creators, selectedUserId, onSelect, loading }
         </span>
       </button>
 
-      {creators.map((c) => {
+      {creators.map((c, index) => {
         const active = selectedUserId === c.ownerUserId;
         const avatarUrl = resolveAvatarUrl({ avatarFileName: c.ownerAvatarFileName });
+        const crownColor = RANK_CROWN[index];
         return (
           <button
             key={c.ownerUserId}
@@ -88,7 +96,7 @@ export function CreatorFilterRow({ creators, selectedUserId, onSelect, loading }
             aria-pressed={active}
           >
             <div
-              className="w-11 h-11 rounded-full transition-all duration-200"
+              className="relative w-11 h-11 rounded-full transition-all duration-200"
               style={{
                 padding: 2,
                 background: active
@@ -97,6 +105,19 @@ export function CreatorFilterRow({ creators, selectedUserId, onSelect, loading }
                 boxShadow: active ? '0 0 14px rgba(129,140,248,0.4)' : 'none',
               }}
             >
+              {crownColor && (
+                <Crown
+                  size={13}
+                  fill={crownColor}
+                  strokeWidth={1.5}
+                  className="absolute left-1/2 -translate-x-1/2 pointer-events-none"
+                  style={{
+                    top: -10,
+                    color: crownColor,
+                    filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.6))',
+                  }}
+                />
+              )}
               <img
                 src={avatarUrl}
                 alt={c.ownerUserName}

--- a/prd-admin/src/components/showcase/LiteraryCard.tsx
+++ b/prd-admin/src/components/showcase/LiteraryCard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Eye, BookOpen } from 'lucide-react';
 import { resolveAvatarUrl, DEFAULT_AVATAR_FALLBACK } from '@/lib/avatar';
 import { HeartLikeButton } from '@/components/effects/HeartLikeButton';
+import { useInViewport } from '@/hooks/useInViewport';
 import type { SubmissionItem } from '@/services/real/submissions';
 
 interface LiteraryCardProps {
@@ -49,6 +50,7 @@ export function LiteraryCard({ item, onLikeToggle, onClick }: LiteraryCardProps)
   useEffect(() => { setLiked(item.likedByMe); }, [item.likedByMe]);
   useEffect(() => { setLikeCount(item.likeCount); }, [item.likeCount]);
 
+  const [boxRef, inView] = useInViewport<HTMLDivElement>();
   const avatarUrl = resolveAvatarUrl({ avatarFileName: item.ownerAvatarFileName });
   const hasCover = !!item.coverUrl && !imgError;
 
@@ -78,20 +80,22 @@ export function LiteraryCard({ item, onLikeToggle, onClick }: LiteraryCardProps)
     >
       {/* Card — natural aspect ratio for waterfall, image full-bleed, text at bottom */}
       <div
+        ref={boxRef}
         className="relative w-full overflow-hidden rounded-xl transition-all duration-300 group-hover:shadow-xl group-hover:shadow-black/30 group-hover:scale-[1.02]"
         style={{
           aspectRatio: getAspectRatio(item),
           background: hasCover ? '#0a0a0f' : getFallbackGradient(item.id),
         }}
       >
-        {/* Cover image */}
-        {item.coverUrl && !imgError && (
+        {/* Cover image — only requested once the card nears the viewport */}
+        {item.coverUrl && !imgError && inView && (
           <img
             src={item.coverUrl}
             alt={item.title}
             className="absolute inset-0 w-full h-full object-cover transition-transform duration-700 group-hover:scale-[1.06]"
             style={{ opacity: imgLoaded ? 1 : 0, transition: 'opacity 0.5s ease' }}
             loading="lazy"
+            decoding="async"
             onLoad={() => setImgLoaded(true)}
             onError={() => setImgError(true)}
           />

--- a/prd-admin/src/components/showcase/LiteraryCard.tsx
+++ b/prd-admin/src/components/showcase/LiteraryCard.tsx
@@ -3,6 +3,7 @@ import { Eye, BookOpen } from 'lucide-react';
 import { resolveAvatarUrl, DEFAULT_AVATAR_FALLBACK } from '@/lib/avatar';
 import { HeartLikeButton } from '@/components/effects/HeartLikeButton';
 import { useInViewport } from '@/hooks/useInViewport';
+import { getAspectRatio } from './waterfall';
 import type { SubmissionItem } from '@/services/real/submissions';
 
 interface LiteraryCardProps {
@@ -15,14 +16,6 @@ interface LiteraryCardProps {
  * 文学创作卡片 — 瀑布流风格
  * 自然比例 + 封面图全覆盖 + 底部渐变遮罩 + 文字叠加
  */
-
-/** Get aspect ratio string for a submission item */
-function getAspectRatio(item: SubmissionItem): string {
-  if (item.coverWidth && item.coverHeight) {
-    return `${item.coverWidth}/${item.coverHeight}`;
-  }
-  return '16/10';
-}
 
 /* 无封面图时的默认渐变背景 */
 const FALLBACK_GRADIENTS = [

--- a/prd-admin/src/components/showcase/ShowcaseGallery.tsx
+++ b/prd-admin/src/components/showcase/ShowcaseGallery.tsx
@@ -487,7 +487,7 @@ export function ShowcaseGallery() {
       )}
 
       {/* Empty state */}
-      {!loading && items.length === 0 && activeTab && (
+      {!loading && items.length === 0 && (activeTab || selectedCreatorId) && (
         <div
           className="flex flex-col items-center justify-center h-40 gap-2"
           style={{ color: 'var(--text-muted, rgba(255,255,255,0.3))' }}

--- a/prd-admin/src/components/showcase/ShowcaseGallery.tsx
+++ b/prd-admin/src/components/showcase/ShowcaseGallery.tsx
@@ -9,10 +9,6 @@ import {
   adminWithdrawSubmission,
   type SubmissionItem,
 } from '@/services/real/submissions';
-import {
-  listSubmissionCreators,
-  type SubmissionCreator,
-} from '@/services/real/submissions';
 import { resolveAvatarUrl, DEFAULT_AVATAR_FALLBACK } from '@/lib/avatar';
 import { HeartLikeButton } from '@/components/effects/HeartLikeButton';
 import { useAuthStore } from '@/stores/authStore';
@@ -20,6 +16,7 @@ import { toast } from '@/lib/toast';
 import { distributeToColumns, getAspectRatio } from './waterfall';
 import { useWaterfallColumns } from '@/hooks/useWaterfallColumns';
 import { useInViewport } from '@/hooks/useInViewport';
+import { useCreatorFilter } from '@/hooks/useCreatorFilter';
 import { CreatorFilterRow } from './CreatorFilterRow';
 
 const TABS = [
@@ -241,13 +238,17 @@ export function ShowcaseGallery() {
   const [loading, setLoading] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [creators, setCreators] = useState<SubmissionCreator[]>([]);
-  const [creatorsLoading, setCreatorsLoading] = useState(false);
-  const [selectedCreatorId, setSelectedCreatorId] = useState<string | null>(null);
-  const selectedCreatorRef = useRef<string | null>(null);
+  const {
+    creators,
+    creatorsLoading,
+    selectedCreatorId,
+    selectedCreatorRef,
+    fetchCreators,
+    selectCreator,
+    resetCreator,
+  } = useCreatorFilter();
   const initialLoadDone = useRef(false);
   const fetchIdRef = useRef(0);
-  const creatorsFetchIdRef = useRef(0);
 
   const fetchItems = useCallback(async (contentType: string, skip: number, append: boolean) => {
     const myFetchId = ++fetchIdRef.current;
@@ -272,19 +273,7 @@ export function ShowcaseGallery() {
         setLoadingMore(false);
       }
     }
-  }, []);
-
-  const fetchCreators = useCallback(async (contentType: string) => {
-    const myFetchId = ++creatorsFetchIdRef.current;
-    setCreatorsLoading(true);
-    try {
-      const res = await listSubmissionCreators({ contentType: contentType || undefined });
-      if (creatorsFetchIdRef.current !== myFetchId) return;
-      if (res.success) setCreators(res.data.creators);
-    } finally {
-      if (creatorsFetchIdRef.current === myFetchId) setCreatorsLoading(false);
-    }
-  }, []);
+  }, [selectedCreatorRef]);
 
   useEffect(() => {
     if (!initialLoadDone.current) {
@@ -297,15 +286,13 @@ export function ShowcaseGallery() {
   const handleTabChange = (tab: string) => {
     setActiveTab(tab);
     setItems([]);
-    setSelectedCreatorId(null);
-    selectedCreatorRef.current = null;
+    resetCreator();
     fetchItems(tab, 0, false);
     fetchCreators(tab);
   };
 
   const handleSelectCreator = (userId: string | null) => {
-    setSelectedCreatorId(userId);
-    selectedCreatorRef.current = userId;
+    selectCreator(userId);
     setItems([]);
     fetchItems(activeTab, 0, false);
   };

--- a/prd-admin/src/components/showcase/ShowcaseGallery.tsx
+++ b/prd-admin/src/components/showcase/ShowcaseGallery.tsx
@@ -354,9 +354,8 @@ export function ShowcaseGallery() {
 
   const hasMore = items.length < total;
 
-  // Waterfall column count — driven by actual container width (ultrawide-aware)
-  const sectionRef = useRef<HTMLElement>(null);
-  const { columnCount, gap } = useWaterfallColumns(sectionRef);
+  // Waterfall column count — driven by actual container content width (ultrawide-aware)
+  const { columnCount, gap, ref: gridRef } = useWaterfallColumns();
   const columns = useMemo(() => distributeToColumns(items, columnCount), [items, columnCount]);
 
   // Infinite scroll: observe a sentinel at the bottom
@@ -380,7 +379,7 @@ export function ShowcaseGallery() {
   if (!loading && items.length === 0 && initialLoadDone.current && !activeTab && !selectedCreatorId) return null;
 
   return (
-    <section ref={sectionRef} className="mt-10">
+    <section ref={gridRef} className="mt-10">
       {/* Section header with tabs */}
       <div className="flex items-center justify-between mb-6">
         <div

--- a/prd-admin/src/components/showcase/ShowcaseGallery.tsx
+++ b/prd-admin/src/components/showcase/ShowcaseGallery.tsx
@@ -373,16 +373,7 @@ export function ShowcaseGallery() {
   if (!loading && items.length === 0 && initialLoadDone.current && !activeTab && !selectedCreatorId) return null;
 
   return (
-    <section ref={sectionRef} className="mt-10 relative">
-      {/* Decorative aurora glow behind the gallery (pointer-events none) */}
-      <div
-        className="absolute inset-0 overflow-hidden pointer-events-none -z-10"
-        style={{ opacity: 0.5 }}
-        aria-hidden
-      >
-        <div className="showcase-aurora" />
-      </div>
-
+    <section ref={sectionRef} className="mt-10">
       {/* Section header with tabs */}
       <div className="flex items-center justify-between mb-6">
         <div

--- a/prd-admin/src/components/showcase/ShowcaseGallery.tsx
+++ b/prd-admin/src/components/showcase/ShowcaseGallery.tsx
@@ -19,6 +19,7 @@ import { useAuthStore } from '@/stores/authStore';
 import { toast } from '@/lib/toast';
 import { distributeToColumns, getAspectRatio } from './waterfall';
 import { useWaterfallColumns } from '@/hooks/useWaterfallColumns';
+import { useInViewport } from '@/hooks/useInViewport';
 import { CreatorFilterRow } from './CreatorFilterRow';
 
 const TABS = [
@@ -27,7 +28,7 @@ const TABS = [
   { key: 'literary', label: '文学创作' },
 ] as const;
 
-const PAGE_SIZE = 20;
+const PAGE_SIZE = 12;
 
 /* ── NotebookLM-style gradient fallbacks ── */
 const FALLBACK_GRADIENTS = [
@@ -69,6 +70,7 @@ function ShowcaseCard({
   useEffect(() => { setLiked(item.likedByMe); }, [item.likedByMe]);
   useEffect(() => { setLikeCount(item.likeCount); }, [item.likeCount]);
 
+  const [boxRef, inView] = useInViewport<HTMLDivElement>();
   const avatarUrl = resolveAvatarUrl({ avatarFileName: item.ownerAvatarFileName });
   const hasCover = !!item.coverUrl && !imgError;
 
@@ -98,20 +100,22 @@ function ShowcaseCard({
     >
       {/* Card — full-bleed image/gradient, natural aspect ratio for waterfall */}
       <div
+        ref={boxRef}
         className="relative w-full overflow-hidden rounded-xl transition-all duration-300 group-hover:shadow-xl group-hover:shadow-black/30 group-hover:scale-[1.02]"
         style={{
           aspectRatio: getAspectRatio(item),
           background: hasCover ? '#0a0a0f' : getFallbackGradient(item.id),
         }}
       >
-        {/* Cover image */}
-        {item.coverUrl && !imgError && (
+        {/* Cover image — only requested once the card nears the viewport */}
+        {item.coverUrl && !imgError && inView && (
           <img
             src={item.coverUrl}
             alt={item.title}
             className="absolute inset-0 w-full h-full object-cover transition-transform duration-700 group-hover:scale-[1.06]"
             style={{ opacity: imgLoaded ? 1 : 0, transition: 'opacity 0.5s ease' }}
             loading="lazy"
+            decoding="async"
             onLoad={() => setImgLoaded(true)}
             onError={() => setImgError(true)}
           />

--- a/prd-admin/src/components/showcase/ShowcaseGallery.tsx
+++ b/prd-admin/src/components/showcase/ShowcaseGallery.tsx
@@ -247,6 +247,7 @@ export function ShowcaseGallery() {
   const selectedCreatorRef = useRef<string | null>(null);
   const initialLoadDone = useRef(false);
   const fetchIdRef = useRef(0);
+  const creatorsFetchIdRef = useRef(0);
 
   const fetchItems = useCallback(async (contentType: string, skip: number, append: boolean) => {
     const myFetchId = ++fetchIdRef.current;
@@ -274,12 +275,14 @@ export function ShowcaseGallery() {
   }, []);
 
   const fetchCreators = useCallback(async (contentType: string) => {
+    const myFetchId = ++creatorsFetchIdRef.current;
     setCreatorsLoading(true);
     try {
       const res = await listSubmissionCreators({ contentType: contentType || undefined });
+      if (creatorsFetchIdRef.current !== myFetchId) return;
       if (res.success) setCreators(res.data.creators);
     } finally {
-      setCreatorsLoading(false);
+      if (creatorsFetchIdRef.current === myFetchId) setCreatorsLoading(false);
     }
   }, []);
 

--- a/prd-admin/src/components/showcase/ShowcaseGallery.tsx
+++ b/prd-admin/src/components/showcase/ShowcaseGallery.tsx
@@ -9,11 +9,17 @@ import {
   adminWithdrawSubmission,
   type SubmissionItem,
 } from '@/services/real/submissions';
+import {
+  listSubmissionCreators,
+  type SubmissionCreator,
+} from '@/services/real/submissions';
 import { resolveAvatarUrl, DEFAULT_AVATAR_FALLBACK } from '@/lib/avatar';
 import { HeartLikeButton } from '@/components/effects/HeartLikeButton';
-import { useBreakpoint } from '@/hooks/useBreakpoint';
 import { useAuthStore } from '@/stores/authStore';
 import { toast } from '@/lib/toast';
+import { distributeToColumns, getAspectRatio } from './waterfall';
+import { useWaterfallColumns } from '@/hooks/useWaterfallColumns';
+import { CreatorFilterRow } from './CreatorFilterRow';
 
 const TABS = [
   { key: '', label: '全部' },
@@ -22,30 +28,6 @@ const TABS = [
 ] as const;
 
 const PAGE_SIZE = 20;
-
-/** Distribute items into columns by shortest-column-first for waterfall layout */
-function distributeToColumns<T extends { coverWidth: number; coverHeight: number }>(
-  items: T[],
-  columnCount: number,
-): T[][] {
-  const columns: T[][] = Array.from({ length: columnCount }, () => []);
-  const heights = new Array(columnCount).fill(0);
-  for (const item of items) {
-    const ratio = item.coverWidth && item.coverHeight ? item.coverHeight / item.coverWidth : 0.625;
-    const shortest = heights.indexOf(Math.min(...heights));
-    columns[shortest].push(item);
-    heights[shortest] += ratio;
-  }
-  return columns;
-}
-
-/** Get aspect ratio string for a submission item */
-function getAspectRatio(item: SubmissionItem): string {
-  if (item.coverWidth && item.coverHeight) {
-    return `${item.coverWidth}/${item.coverHeight}`;
-  }
-  return '16/10';
-}
 
 /* ── NotebookLM-style gradient fallbacks ── */
 const FALLBACK_GRADIENTS = [
@@ -247,7 +229,6 @@ function ShowcaseCard({
 /* ── ShowcaseGallery ── */
 
 export function ShowcaseGallery() {
-  const { isMobile } = useBreakpoint();
   const user = useAuthStore((s) => s.user);
   const isAdmin = user?.role === 'ADMIN';
   const [activeTab, setActiveTab] = useState('');
@@ -256,6 +237,10 @@ export function ShowcaseGallery() {
   const [loading, setLoading] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [creators, setCreators] = useState<SubmissionCreator[]>([]);
+  const [creatorsLoading, setCreatorsLoading] = useState(false);
+  const [selectedCreatorId, setSelectedCreatorId] = useState<string | null>(null);
+  const selectedCreatorRef = useRef<string | null>(null);
   const initialLoadDone = useRef(false);
   const fetchIdRef = useRef(0);
 
@@ -267,6 +252,7 @@ export function ShowcaseGallery() {
     try {
       const res = await listPublicSubmissions({
         contentType: contentType || undefined,
+        ownerUserId: selectedCreatorRef.current || undefined,
         skip,
         limit: PAGE_SIZE,
       });
@@ -283,17 +269,38 @@ export function ShowcaseGallery() {
     }
   }, []);
 
+  const fetchCreators = useCallback(async (contentType: string) => {
+    setCreatorsLoading(true);
+    try {
+      const res = await listSubmissionCreators({ contentType: contentType || undefined });
+      if (res.success) setCreators(res.data.creators);
+    } finally {
+      setCreatorsLoading(false);
+    }
+  }, []);
+
   useEffect(() => {
     if (!initialLoadDone.current) {
       initialLoadDone.current = true;
       fetchItems('', 0, false);
+      fetchCreators('');
     }
-  }, [fetchItems]);
+  }, [fetchItems, fetchCreators]);
 
   const handleTabChange = (tab: string) => {
     setActiveTab(tab);
     setItems([]);
+    setSelectedCreatorId(null);
+    selectedCreatorRef.current = null;
     fetchItems(tab, 0, false);
+    fetchCreators(tab);
+  };
+
+  const handleSelectCreator = (userId: string | null) => {
+    setSelectedCreatorId(userId);
+    selectedCreatorRef.current = userId;
+    setItems([]);
+    fetchItems(activeTab, 0, false);
   };
 
   const handleLikeToggle = async (id: string, liked: boolean) => {
@@ -340,9 +347,9 @@ export function ShowcaseGallery() {
 
   const hasMore = items.length < total;
 
-  // Waterfall column count
-  const columnCount = isMobile ? 2 : 4;
-  const gap = isMobile ? 12 : 16;
+  // Waterfall column count — driven by actual container width (ultrawide-aware)
+  const sectionRef = useRef<HTMLElement>(null);
+  const { columnCount, gap } = useWaterfallColumns(sectionRef);
   const columns = useMemo(() => distributeToColumns(items, columnCount), [items, columnCount]);
 
   // Infinite scroll: observe a sentinel at the bottom
@@ -363,10 +370,19 @@ export function ShowcaseGallery() {
   }, [loading, loadingMore, items.length, total, activeTab, fetchItems]);
 
   // 只在初始加载（全部tab）没有数据时隐藏整个区域
-  if (!loading && items.length === 0 && initialLoadDone.current && !activeTab) return null;
+  if (!loading && items.length === 0 && initialLoadDone.current && !activeTab && !selectedCreatorId) return null;
 
   return (
-    <section className="mt-10">
+    <section ref={sectionRef} className="mt-10 relative">
+      {/* Decorative aurora glow behind the gallery (pointer-events none) */}
+      <div
+        className="absolute inset-0 overflow-hidden pointer-events-none -z-10"
+        style={{ opacity: 0.5 }}
+        aria-hidden
+      >
+        <div className="showcase-aurora" />
+      </div>
+
       {/* Section header with tabs */}
       <div className="flex items-center justify-between mb-6">
         <div
@@ -402,6 +418,18 @@ export function ShowcaseGallery() {
           ))}
         </div>
       </div>
+
+      {/* Creator avatar filter row */}
+      {(creatorsLoading || creators.length > 0) && (
+        <div className="mb-6">
+          <CreatorFilterRow
+            creators={creators}
+            selectedUserId={selectedCreatorId}
+            onSelect={handleSelectCreator}
+            loading={creatorsLoading}
+          />
+        </div>
+      )}
 
       {/* Loading skeleton — waterfall */}
       {loading && (

--- a/prd-admin/src/components/showcase/waterfall.ts
+++ b/prd-admin/src/components/showcase/waterfall.ts
@@ -1,0 +1,30 @@
+/** Shared waterfall (masonry) layout helpers for the showcase gallery. */
+
+interface CoverDims {
+  coverWidth: number;
+  coverHeight: number;
+}
+
+/** Distribute items into columns by shortest-column-first for waterfall layout */
+export function distributeToColumns<T extends CoverDims>(
+  items: T[],
+  columnCount: number,
+): T[][] {
+  const columns: T[][] = Array.from({ length: columnCount }, () => []);
+  const heights = new Array(columnCount).fill(0);
+  for (const item of items) {
+    const ratio = item.coverWidth && item.coverHeight ? item.coverHeight / item.coverWidth : 0.625;
+    const shortest = heights.indexOf(Math.min(...heights));
+    columns[shortest].push(item);
+    heights[shortest] += ratio;
+  }
+  return columns;
+}
+
+/** Get aspect ratio string for a cover (falls back to 16/10) */
+export function getAspectRatio(item: CoverDims): string {
+  if (item.coverWidth && item.coverHeight) {
+    return `${item.coverWidth}/${item.coverHeight}`;
+  }
+  return '16/10';
+}

--- a/prd-admin/src/hooks/useCreatorFilter.ts
+++ b/prd-admin/src/hooks/useCreatorFilter.ts
@@ -1,0 +1,60 @@
+import { useCallback, useRef, useState, type MutableRefObject } from 'react';
+import { listSubmissionCreators, type SubmissionCreator } from '@/services/real/submissions';
+
+/**
+ * Shared creator-filter state for the showcase galleries (homepage embed +
+ * full-screen page). Owns the creators list, the selected creator, and the
+ * stale-response guard so the race-condition fix lives in one place.
+ *
+ * Item fetching stays in the consumer (page sizes differ); the consumer reads
+ * `selectedCreatorRef.current` inside its own `fetchItems`.
+ */
+export interface CreatorFilter {
+  creators: SubmissionCreator[];
+  creatorsLoading: boolean;
+  selectedCreatorId: string | null;
+  selectedCreatorRef: MutableRefObject<string | null>;
+  fetchCreators: (contentType: string) => Promise<void>;
+  selectCreator: (userId: string | null) => void;
+  resetCreator: () => void;
+}
+
+export function useCreatorFilter(): CreatorFilter {
+  const [creators, setCreators] = useState<SubmissionCreator[]>([]);
+  const [creatorsLoading, setCreatorsLoading] = useState(false);
+  const [selectedCreatorId, setSelectedCreatorId] = useState<string | null>(null);
+  const selectedCreatorRef = useRef<string | null>(null);
+  const creatorsFetchIdRef = useRef(0);
+
+  const fetchCreators = useCallback(async (contentType: string) => {
+    const myFetchId = ++creatorsFetchIdRef.current;
+    setCreatorsLoading(true);
+    try {
+      const res = await listSubmissionCreators({ contentType: contentType || undefined });
+      if (creatorsFetchIdRef.current !== myFetchId) return;
+      if (res.success) setCreators(res.data.creators);
+    } finally {
+      if (creatorsFetchIdRef.current === myFetchId) setCreatorsLoading(false);
+    }
+  }, []);
+
+  const selectCreator = useCallback((userId: string | null) => {
+    setSelectedCreatorId(userId);
+    selectedCreatorRef.current = userId;
+  }, []);
+
+  const resetCreator = useCallback(() => {
+    setSelectedCreatorId(null);
+    selectedCreatorRef.current = null;
+  }, []);
+
+  return {
+    creators,
+    creatorsLoading,
+    selectedCreatorId,
+    selectedCreatorRef,
+    fetchCreators,
+    selectCreator,
+    resetCreator,
+  };
+}

--- a/prd-admin/src/hooks/useInViewport.ts
+++ b/prd-admin/src/hooks/useInViewport.ts
@@ -1,0 +1,33 @@
+import { useEffect, useRef, useState, type RefObject } from 'react';
+
+/**
+ * Returns a ref + whether that element has entered (or come near) the viewport.
+ * Once true it stays true (observer disconnects), so a card's cover image is
+ * only requested when the card is about to be seen — off-screen cards make
+ * zero network requests until the user scrolls toward them.
+ */
+export function useInViewport<T extends Element>(
+  rootMargin = '600px',
+): [RefObject<T>, boolean] {
+  const ref = useRef<T>(null);
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    if (inView) return;
+    const el = ref.current;
+    if (!el) return;
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          setInView(true);
+          io.disconnect();
+        }
+      },
+      { rootMargin },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [inView, rootMargin]);
+
+  return [ref, inView];
+}

--- a/prd-admin/src/hooks/useWaterfallColumns.ts
+++ b/prd-admin/src/hooks/useWaterfallColumns.ts
@@ -1,15 +1,19 @@
-import { useEffect, useState, type RefObject } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 
 /**
- * Responsive waterfall column count driven by the actual container width
- * (ResizeObserver), not the viewport — this correctly handles ultrawide /
- * 带鱼屏 monitors and the homepage section's own padding/max-width.
+ * Responsive waterfall column count driven by the actual container content
+ * width (ResizeObserver), not the viewport — this correctly handles ultrawide /
+ * 带鱼屏 monitors and any container padding/max-width.
  *
  * Standard desktop (~1280-1600px) anchors at 5 columns; ultrawide expands to
  * 6-7 so cards never grow oversized; narrow widths step down to 3/2.
  *
  * Pure-JS computation (mirrors the existing inline `isMobile ? 2 : 4` pattern)
  * because the project uses Tailwind v4 with no 3xl breakpoint.
+ *
+ * Uses a callback ref (not a passed RefObject) so the observer is re-attached
+ * whenever the measured node mounts/remounts — important because consumers may
+ * conditionally render `null` and remount the container later.
  */
 function columnsForWidth(width: number): number {
   if (width < 540) return 2;
@@ -23,27 +27,36 @@ function columnsForWidth(width: number): number {
 export interface WaterfallLayout {
   columnCount: number;
   gap: number;
+  /** Attach to the element whose content width should drive the column count. */
+  ref: (node: HTMLElement | null) => void;
 }
 
-export function useWaterfallColumns(
-  containerRef: RefObject<HTMLElement | null>,
-): WaterfallLayout {
+export function useWaterfallColumns(): WaterfallLayout {
+  const [node, setNode] = useState<HTMLElement | null>(null);
   const [width, setWidth] = useState(0);
 
+  const ref = useCallback((el: HTMLElement | null) => setNode(el), []);
+
   useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    const measure = () => setWidth(el.clientWidth);
+    if (!node) return;
+    // Measure the content box (exclude horizontal padding) — the flex columns
+    // are laid out inside the padding, so clientWidth would over-count and
+    // bump an extra column near breakpoints.
+    const measure = () => {
+      const cs = getComputedStyle(node);
+      const padX = parseFloat(cs.paddingLeft || '0') + parseFloat(cs.paddingRight || '0');
+      setWidth(Math.max(0, node.clientWidth - padX));
+    };
     measure();
     const ro = new ResizeObserver(measure);
-    ro.observe(el);
+    ro.observe(node);
     return () => ro.disconnect();
-  }, [containerRef]);
+  }, [node]);
 
   // Before first measurement, fall back to viewport width so SSR-less first
   // paint still picks a sensible column count instead of flashing 2 columns.
   const effectiveWidth = width || (typeof window !== 'undefined' ? window.innerWidth : 1280);
   const columnCount = columnsForWidth(effectiveWidth);
   const gap = columnCount <= 2 ? 12 : 16;
-  return { columnCount, gap };
+  return { columnCount, gap, ref };
 }

--- a/prd-admin/src/hooks/useWaterfallColumns.ts
+++ b/prd-admin/src/hooks/useWaterfallColumns.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState, type RefObject } from 'react';
+
+/**
+ * Responsive waterfall column count driven by the actual container width
+ * (ResizeObserver), not the viewport — this correctly handles ultrawide /
+ * 带鱼屏 monitors and the homepage section's own padding/max-width.
+ *
+ * Standard desktop (~1280-1600px) anchors at 5 columns; ultrawide expands to
+ * 6-7 so cards never grow oversized; narrow widths step down to 3/2.
+ *
+ * Pure-JS computation (mirrors the existing inline `isMobile ? 2 : 4` pattern)
+ * because the project uses Tailwind v4 with no 3xl breakpoint.
+ */
+function columnsForWidth(width: number): number {
+  if (width < 540) return 2;
+  if (width < 900) return 3;
+  if (width < 1280) return 4;
+  if (width < 1728) return 5;
+  if (width < 2200) return 6;
+  return 7;
+}
+
+export interface WaterfallLayout {
+  columnCount: number;
+  gap: number;
+}
+
+export function useWaterfallColumns(
+  containerRef: RefObject<HTMLElement | null>,
+): WaterfallLayout {
+  const [width, setWidth] = useState(0);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const measure = () => setWidth(el.clientWidth);
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [containerRef]);
+
+  // Before first measurement, fall back to viewport width so SSR-less first
+  // paint still picks a sensible column count instead of flashing 2 columns.
+  const effectiveWidth = width || (typeof window !== 'undefined' ? window.innerWidth : 1280);
+  const columnCount = columnsForWidth(effectiveWidth);
+  const gap = columnCount <= 2 ? 12 : 16;
+  return { columnCount, gap };
+}

--- a/prd-admin/src/pages/PortfolioShowcasePage.tsx
+++ b/prd-admin/src/pages/PortfolioShowcasePage.tsx
@@ -12,11 +12,9 @@ import {
 } from 'lucide-react';
 import {
   listPublicSubmissions,
-  listSubmissionCreators,
   likeSubmission,
   unlikeSubmission,
   type SubmissionItem,
-  type SubmissionCreator,
 } from '@/services/real/submissions';
 import { SubmissionDetailModal } from '@/components/showcase/SubmissionDetailModal';
 import { LiteraryCard } from '@/components/showcase/LiteraryCard';
@@ -26,6 +24,7 @@ import { resolveAvatarUrl, DEFAULT_AVATAR_FALLBACK } from '@/lib/avatar';
 import { useBreakpoint } from '@/hooks/useBreakpoint';
 import { useWaterfallColumns } from '@/hooks/useWaterfallColumns';
 import { useInViewport } from '@/hooks/useInViewport';
+import { useCreatorFilter } from '@/hooks/useCreatorFilter';
 import { distributeToColumns, getAspectRatio } from '@/components/showcase/waterfall';
 import { MapSpinner } from '@/components/ui/VideoLoader';
 
@@ -199,12 +198,16 @@ export default function PortfolioShowcasePage() {
   const [searchQuery, setSearchQuery] = useState('');
   const [searchFocused, setSearchFocused] = useState(false);
   const [scrollY, setScrollY] = useState(0);
-  const [creators, setCreators] = useState<SubmissionCreator[]>([]);
-  const [creatorsLoading, setCreatorsLoading] = useState(false);
-  const [selectedCreatorId, setSelectedCreatorId] = useState<string | null>(null);
-  const selectedCreatorRef = useRef<string | null>(null);
+  const {
+    creators,
+    creatorsLoading,
+    selectedCreatorId,
+    selectedCreatorRef,
+    fetchCreators,
+    selectCreator,
+    resetCreator,
+  } = useCreatorFilter();
   const fetchIdRef = useRef(0);
-  const creatorsFetchIdRef = useRef(0);
   const scrollRef = useRef<HTMLDivElement>(null);
 
   // Track scroll for parallax hero
@@ -239,19 +242,7 @@ export default function PortfolioShowcasePage() {
         setLoadingMore(false);
       }
     }
-  }, []);
-
-  const fetchCreators = useCallback(async (contentType: string) => {
-    const myFetchId = ++creatorsFetchIdRef.current;
-    setCreatorsLoading(true);
-    try {
-      const res = await listSubmissionCreators({ contentType: contentType || undefined });
-      if (creatorsFetchIdRef.current !== myFetchId) return;
-      if (res.success) setCreators(res.data.creators);
-    } finally {
-      if (creatorsFetchIdRef.current === myFetchId) setCreatorsLoading(false);
-    }
-  }, []);
+  }, [selectedCreatorRef]);
 
   useEffect(() => {
     fetchItems('', 0, false);
@@ -261,15 +252,13 @@ export default function PortfolioShowcasePage() {
   const handleTabChange = (tab: string) => {
     setActiveTab(tab);
     setItems([]);
-    setSelectedCreatorId(null);
-    selectedCreatorRef.current = null;
+    resetCreator();
     fetchItems(tab, 0, false);
     fetchCreators(tab);
   };
 
   const handleSelectCreator = (userId: string | null) => {
-    setSelectedCreatorId(userId);
-    selectedCreatorRef.current = userId;
+    selectCreator(userId);
     setItems([]);
     fetchItems(activeTab, 0, false);
   };

--- a/prd-admin/src/pages/PortfolioShowcasePage.tsx
+++ b/prd-admin/src/pages/PortfolioShowcasePage.tsx
@@ -653,32 +653,61 @@ export default function PortfolioShowcasePage() {
 
           {/* Empty state */}
           {!loading && items.length === 0 && (
-            <div className="flex flex-col items-center justify-center py-32 gap-4">
-              <div
-                className="w-20 h-20 rounded-2xl flex items-center justify-center"
-                style={{
-                  background: 'rgba(129,140,248,0.08)',
-                  border: '1px solid rgba(129,140,248,0.15)',
-                }}
-              >
-                <Sparkles size={32} style={{ color: 'rgba(129,140,248,0.4)' }} />
+            (activeTab || selectedCreatorId) ? (
+              <div className="flex flex-col items-center justify-center py-32 gap-4">
+                <div
+                  className="w-20 h-20 rounded-2xl flex items-center justify-center"
+                  style={{
+                    background: 'rgba(129,140,248,0.08)',
+                    border: '1px solid rgba(129,140,248,0.15)',
+                  }}
+                >
+                  <Sparkles size={32} style={{ color: 'rgba(129,140,248,0.4)' }} />
+                </div>
+                <p className="text-[15px]" style={{ color: 'rgba(255,255,255,0.3)' }}>
+                  没有符合条件的作品
+                </p>
+                <button
+                  type="button"
+                  onClick={() => handleTabChange('')}
+                  className="mt-2 px-6 py-2.5 rounded-full text-[13px] font-medium transition-all duration-200 hover:scale-105"
+                  style={{
+                    background: 'rgba(255,255,255,0.08)',
+                    color: 'rgba(255,255,255,0.7)',
+                    border: '1px solid rgba(255,255,255,0.12)',
+                  }}
+                >
+                  查看全部作品
+                </button>
               </div>
-              <p className="text-[15px]" style={{ color: 'rgba(255,255,255,0.3)' }}>
-                暂无作品，创作第一件作品吧
-              </p>
-              <button
-                type="button"
-                onClick={() => navigate('/')}
-                className="mt-2 px-6 py-2.5 rounded-full text-[13px] font-medium transition-all duration-200 hover:scale-105"
-                style={{
-                  background: 'linear-gradient(135deg, #6366F1, #8B5CF6)',
-                  color: '#fff',
-                  boxShadow: '0 4px 20px rgba(99,102,241,0.3)',
-                }}
-              >
-                开始创作
-              </button>
-            </div>
+            ) : (
+              <div className="flex flex-col items-center justify-center py-32 gap-4">
+                <div
+                  className="w-20 h-20 rounded-2xl flex items-center justify-center"
+                  style={{
+                    background: 'rgba(129,140,248,0.08)',
+                    border: '1px solid rgba(129,140,248,0.15)',
+                  }}
+                >
+                  <Sparkles size={32} style={{ color: 'rgba(129,140,248,0.4)' }} />
+                </div>
+                <p className="text-[15px]" style={{ color: 'rgba(255,255,255,0.3)' }}>
+                  暂无作品，创作第一件作品吧
+                </p>
+                <button
+                  type="button"
+                  onClick={() => navigate('/')}
+                  className="mt-2 px-6 py-2.5 rounded-full text-[13px] font-medium transition-all duration-200 hover:scale-105"
+                  style={{
+                    background: 'linear-gradient(135deg, #6366F1, #8B5CF6)',
+                    color: '#fff',
+                    boxShadow: '0 4px 20px rgba(99,102,241,0.3)',
+                  }}
+                >
+                  开始创作
+                </button>
+              </div>
+            )
           )}
         </div>
       </div>

--- a/prd-admin/src/pages/PortfolioShowcasePage.tsx
+++ b/prd-admin/src/pages/PortfolioShowcasePage.tsx
@@ -204,6 +204,7 @@ export default function PortfolioShowcasePage() {
   const [selectedCreatorId, setSelectedCreatorId] = useState<string | null>(null);
   const selectedCreatorRef = useRef<string | null>(null);
   const fetchIdRef = useRef(0);
+  const creatorsFetchIdRef = useRef(0);
   const scrollRef = useRef<HTMLDivElement>(null);
   const gridRef = useRef<HTMLDivElement>(null);
 
@@ -242,12 +243,14 @@ export default function PortfolioShowcasePage() {
   }, []);
 
   const fetchCreators = useCallback(async (contentType: string) => {
+    const myFetchId = ++creatorsFetchIdRef.current;
     setCreatorsLoading(true);
     try {
       const res = await listSubmissionCreators({ contentType: contentType || undefined });
+      if (creatorsFetchIdRef.current !== myFetchId) return;
       if (res.success) setCreators(res.data.creators);
     } finally {
-      setCreatorsLoading(false);
+      if (creatorsFetchIdRef.current === myFetchId) setCreatorsLoading(false);
     }
   }, []);
 

--- a/prd-admin/src/pages/PortfolioShowcasePage.tsx
+++ b/prd-admin/src/pages/PortfolioShowcasePage.tsx
@@ -206,7 +206,6 @@ export default function PortfolioShowcasePage() {
   const fetchIdRef = useRef(0);
   const creatorsFetchIdRef = useRef(0);
   const scrollRef = useRef<HTMLDivElement>(null);
-  const gridRef = useRef<HTMLDivElement>(null);
 
   // Track scroll for parallax hero
   useEffect(() => {
@@ -298,8 +297,8 @@ export default function PortfolioShowcasePage() {
 
   const hasMore = items.length < total;
 
-  // Waterfall column count — driven by actual container width (ultrawide-aware)
-  const { columnCount, gap } = useWaterfallColumns(gridRef);
+  // Waterfall column count — driven by actual container content width (ultrawide-aware)
+  const { columnCount, gap, ref: gridRef } = useWaterfallColumns();
   const columns = useMemo(() => distributeToColumns(items, columnCount), [items, columnCount]);
 
   // Infinite scroll sentinel

--- a/prd-admin/src/pages/PortfolioShowcasePage.tsx
+++ b/prd-admin/src/pages/PortfolioShowcasePage.tsx
@@ -25,6 +25,7 @@ import { HeartLikeButton } from '@/components/effects/HeartLikeButton';
 import { resolveAvatarUrl, DEFAULT_AVATAR_FALLBACK } from '@/lib/avatar';
 import { useBreakpoint } from '@/hooks/useBreakpoint';
 import { useWaterfallColumns } from '@/hooks/useWaterfallColumns';
+import { useInViewport } from '@/hooks/useInViewport';
 import { distributeToColumns, getAspectRatio } from '@/components/showcase/waterfall';
 import { MapSpinner } from '@/components/ui/VideoLoader';
 
@@ -36,7 +37,7 @@ const TABS = [
   { key: 'literary', label: '文学创作', icon: TrendingUp },
 ] as const;
 
-const PAGE_SIZE = 24;
+const PAGE_SIZE = 18;
 
 // ── Unified Visual Card (NotebookLM style) ──
 
@@ -58,6 +59,7 @@ function MasonryCard({
   useEffect(() => { setLiked(item.likedByMe); }, [item.likedByMe]);
   useEffect(() => { setLikeCount(item.likeCount); }, [item.likeCount]);
 
+  const [boxRef, inView] = useInViewport<HTMLDivElement>();
   const avatarUrl = resolveAvatarUrl({ avatarFileName: item.ownerAvatarFileName });
   const hasCover = !!item.coverUrl && !imgError;
 
@@ -89,20 +91,22 @@ function MasonryCard({
     >
       {/* Card — natural aspect ratio for waterfall layout */}
       <div
+        ref={boxRef}
         className="relative w-full overflow-hidden rounded-xl transition-all duration-300 group-hover:shadow-xl group-hover:shadow-black/30 group-hover:scale-[1.02]"
         style={{
           aspectRatio: getAspectRatio(item),
           background: hasCover ? '#0a0a0f' : 'rgba(255,255,255,0.03)',
         }}
       >
-        {/* Cover image */}
-        {item.coverUrl && !imgError && (
+        {/* Cover image — only requested once the card nears the viewport */}
+        {item.coverUrl && !imgError && inView && (
           <img
             src={item.coverUrl}
             alt={item.title}
             className="absolute inset-0 w-full h-full object-cover transition-transform duration-700 group-hover:scale-[1.06]"
             style={{ opacity: imgLoaded ? 1 : 0, transition: 'opacity 0.5s ease' }}
             loading="lazy"
+            decoding="async"
             onLoad={() => setImgLoaded(true)}
             onError={() => { setImgError(true); setImgLoaded(true); }}
           />

--- a/prd-admin/src/pages/PortfolioShowcasePage.tsx
+++ b/prd-admin/src/pages/PortfolioShowcasePage.tsx
@@ -12,15 +12,20 @@ import {
 } from 'lucide-react';
 import {
   listPublicSubmissions,
+  listSubmissionCreators,
   likeSubmission,
   unlikeSubmission,
   type SubmissionItem,
+  type SubmissionCreator,
 } from '@/services/real/submissions';
 import { SubmissionDetailModal } from '@/components/showcase/SubmissionDetailModal';
 import { LiteraryCard } from '@/components/showcase/LiteraryCard';
+import { CreatorFilterRow } from '@/components/showcase/CreatorFilterRow';
 import { HeartLikeButton } from '@/components/effects/HeartLikeButton';
 import { resolveAvatarUrl, DEFAULT_AVATAR_FALLBACK } from '@/lib/avatar';
 import { useBreakpoint } from '@/hooks/useBreakpoint';
+import { useWaterfallColumns } from '@/hooks/useWaterfallColumns';
+import { distributeToColumns, getAspectRatio } from '@/components/showcase/waterfall';
 import { MapSpinner } from '@/components/ui/VideoLoader';
 
 // ── Constants ──
@@ -32,30 +37,6 @@ const TABS = [
 ] as const;
 
 const PAGE_SIZE = 24;
-
-/** Distribute items into columns by shortest-column-first for waterfall layout */
-function distributeToColumns<T extends { coverWidth: number; coverHeight: number }>(
-  items: T[],
-  columnCount: number,
-): T[][] {
-  const columns: T[][] = Array.from({ length: columnCount }, () => []);
-  const heights = new Array(columnCount).fill(0);
-  for (const item of items) {
-    const ratio = item.coverWidth && item.coverHeight ? item.coverHeight / item.coverWidth : 0.625;
-    const shortest = heights.indexOf(Math.min(...heights));
-    columns[shortest].push(item);
-    heights[shortest] += ratio;
-  }
-  return columns;
-}
-
-/** Get aspect ratio string for a submission item */
-function getAspectRatio(item: SubmissionItem): string {
-  if (item.coverWidth && item.coverHeight) {
-    return `${item.coverWidth}/${item.coverHeight}`;
-  }
-  return '16/10';
-}
 
 // ── Unified Visual Card (NotebookLM style) ──
 
@@ -214,8 +195,13 @@ export default function PortfolioShowcasePage() {
   const [searchQuery, setSearchQuery] = useState('');
   const [searchFocused, setSearchFocused] = useState(false);
   const [scrollY, setScrollY] = useState(0);
+  const [creators, setCreators] = useState<SubmissionCreator[]>([]);
+  const [creatorsLoading, setCreatorsLoading] = useState(false);
+  const [selectedCreatorId, setSelectedCreatorId] = useState<string | null>(null);
+  const selectedCreatorRef = useRef<string | null>(null);
   const fetchIdRef = useRef(0);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const gridRef = useRef<HTMLDivElement>(null);
 
   // Track scroll for parallax hero
   useEffect(() => {
@@ -234,6 +220,7 @@ export default function PortfolioShowcasePage() {
     try {
       const res = await listPublicSubmissions({
         contentType: contentType || undefined,
+        ownerUserId: selectedCreatorRef.current || undefined,
         skip,
         limit: PAGE_SIZE,
       });
@@ -250,14 +237,35 @@ export default function PortfolioShowcasePage() {
     }
   }, []);
 
+  const fetchCreators = useCallback(async (contentType: string) => {
+    setCreatorsLoading(true);
+    try {
+      const res = await listSubmissionCreators({ contentType: contentType || undefined });
+      if (res.success) setCreators(res.data.creators);
+    } finally {
+      setCreatorsLoading(false);
+    }
+  }, []);
+
   useEffect(() => {
     fetchItems('', 0, false);
-  }, [fetchItems]);
+    fetchCreators('');
+  }, [fetchItems, fetchCreators]);
 
   const handleTabChange = (tab: string) => {
     setActiveTab(tab);
     setItems([]);
+    setSelectedCreatorId(null);
+    selectedCreatorRef.current = null;
     fetchItems(tab, 0, false);
+    fetchCreators(tab);
+  };
+
+  const handleSelectCreator = (userId: string | null) => {
+    setSelectedCreatorId(userId);
+    selectedCreatorRef.current = userId;
+    setItems([]);
+    fetchItems(activeTab, 0, false);
   };
 
   const handleLikeToggle = async (id: string, liked: boolean) => {
@@ -283,9 +291,8 @@ export default function PortfolioShowcasePage() {
 
   const hasMore = items.length < total;
 
-  // Waterfall column count + distribution
-  const columnCount = isMobile ? 2 : 4;
-  const gap = isMobile ? 12 : 16;
+  // Waterfall column count — driven by actual container width (ultrawide-aware)
+  const { columnCount, gap } = useWaterfallColumns(gridRef);
   const columns = useMemo(() => distributeToColumns(items, columnCount), [items, columnCount]);
 
   // Infinite scroll sentinel
@@ -311,6 +318,15 @@ export default function PortfolioShowcasePage() {
 
   return (
     <div className="fixed inset-0 flex flex-col" style={{ background: '#0a0a0f' }}>
+      {/* Decorative aurora glow behind the whole page (so it isn't dead-black below the hero) */}
+      <div
+        className="absolute inset-0 overflow-hidden pointer-events-none"
+        style={{ zIndex: 0, opacity: 0.55 }}
+        aria-hidden
+      >
+        <div className="showcase-aurora" />
+      </div>
+
       {/* ── Floating top bar ── */}
       <div
         className="absolute top-0 left-0 right-0 z-50 flex items-center justify-between transition-all duration-500"
@@ -381,7 +397,7 @@ export default function PortfolioShowcasePage() {
       </div>
 
       {/* ── Scrollable content ── */}
-      <div ref={scrollRef} className="flex-1 overflow-auto">
+      <div ref={scrollRef} className="flex-1 overflow-auto relative z-10">
         {/* ── Hero Section ── */}
         <div
           className="relative overflow-hidden"
@@ -396,15 +412,8 @@ export default function PortfolioShowcasePage() {
               transition: 'transform 0.1s linear',
             }}
           >
-            {/* Multi-layer gradient orbs */}
-            <div className="absolute inset-0" style={{
-              background: `
-                radial-gradient(ellipse 80% 60% at 20% 40%, rgba(99,102,241,0.15) 0%, transparent 60%),
-                radial-gradient(ellipse 60% 80% at 80% 30%, rgba(168,85,247,0.12) 0%, transparent 55%),
-                radial-gradient(ellipse 50% 50% at 50% 80%, rgba(236,72,153,0.08) 0%, transparent 50%),
-                radial-gradient(ellipse 90% 40% at 60% 10%, rgba(59,130,246,0.10) 0%, transparent 50%)
-              `,
-            }} />
+            {/* Multi-layer animated aurora orbs */}
+            <div className="showcase-aurora" style={{ opacity: 0.9 }} />
 
             {/* Animated floating particles effect via CSS */}
             <div className="absolute inset-0" style={{
@@ -556,10 +565,22 @@ export default function PortfolioShowcasePage() {
               <span>最受欢迎</span>
             </div>
           </div>
+
+          {/* Creator avatar filter row */}
+          {(creatorsLoading || creators.length > 0) && (
+            <div style={{ padding: isMobile ? '0 16px 12px' : '0 48px 14px' }}>
+              <CreatorFilterRow
+                creators={creators}
+                selectedUserId={selectedCreatorId}
+                onSelect={handleSelectCreator}
+                loading={creatorsLoading}
+              />
+            </div>
+          )}
         </div>
 
         {/* ── Gallery content ── */}
-        <div style={{ padding: isMobile ? '20px 12px 80px' : '32px 48px 80px' }}>
+        <div ref={gridRef} style={{ padding: isMobile ? '20px 12px 80px' : '32px 48px 80px' }}>
           {/* Loading skeleton — waterfall */}
           {loading && (
             <div style={{ display: 'flex', gap, alignItems: 'flex-start' }}>

--- a/prd-admin/src/services/api.ts
+++ b/prd-admin/src/services/api.ts
@@ -1095,6 +1095,7 @@ export const api = {
   // ============ 作品投稿展示 ============
   submissions: {
     public: () => '/api/submissions/public',
+    creators: () => '/api/submissions/public/creators',
     mine: () => '/api/submissions/mine',
     create: () => '/api/submissions',
     check: () => '/api/submissions/check',

--- a/prd-admin/src/services/real/submissions.ts
+++ b/prd-admin/src/services/real/submissions.ts
@@ -20,16 +20,37 @@ export interface SubmissionItem {
 
 export async function listPublicSubmissions(params?: {
   contentType?: string;
+  ownerUserId?: string;
   skip?: number;
   limit?: number;
 }) {
   const query = new URLSearchParams();
   if (params?.contentType) query.set('contentType', params.contentType);
+  if (params?.ownerUserId) query.set('ownerUserId', params.ownerUserId);
   if (params?.skip != null) query.set('skip', String(params.skip));
   if (params?.limit != null) query.set('limit', String(params.limit));
   const qs = query.toString();
   const url = api.submissions.public() + (qs ? `?${qs}` : '');
   return apiRequest<{ total: number; items: SubmissionItem[] }>(url);
+}
+
+export interface SubmissionCreator {
+  ownerUserId: string;
+  ownerUserName: string;
+  ownerAvatarFileName?: string;
+  submissionCount: number;
+}
+
+export async function listSubmissionCreators(params?: {
+  contentType?: string;
+  limit?: number;
+}) {
+  const query = new URLSearchParams();
+  if (params?.contentType) query.set('contentType', params.contentType);
+  if (params?.limit != null) query.set('limit', String(params.limit));
+  const qs = query.toString();
+  const url = api.submissions.creators() + (qs ? `?${qs}` : '');
+  return apiRequest<{ creators: SubmissionCreator[] }>(url);
 }
 
 export interface RelatedAsset {

--- a/prd-admin/src/styles/motion.css
+++ b/prd-admin/src/styles/motion.css
@@ -1151,3 +1151,40 @@
     animation: none;
   }
 }
+
+/* ── 作品广场：增强极光渐变背景（柔和漂移 + 呼吸） ── */
+.showcase-aurora {
+  position: absolute;
+  inset: -25%;
+  pointer-events: none;
+  background:
+    radial-gradient(ellipse 55% 45% at 22% 32%, rgba(99, 102, 241, 0.30) 0%, transparent 60%),
+    radial-gradient(ellipse 50% 55% at 78% 26%, rgba(168, 85, 247, 0.26) 0%, transparent 58%),
+    radial-gradient(ellipse 60% 45% at 60% 78%, rgba(236, 72, 153, 0.18) 0%, transparent 55%),
+    radial-gradient(ellipse 70% 40% at 38% 68%, rgba(59, 130, 246, 0.22) 0%, transparent 55%);
+  filter: blur(44px);
+  animation: showcaseAuroraDrift 26s ease-in-out infinite alternate;
+}
+.showcase-aurora::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse 45% 50% at 70% 40%, rgba(129, 140, 248, 0.22) 0%, transparent 60%),
+    radial-gradient(ellipse 55% 45% at 30% 60%, rgba(192, 132, 252, 0.18) 0%, transparent 58%);
+  animation: showcaseAuroraBreathe 18s ease-in-out infinite alternate;
+}
+@keyframes showcaseAuroraDrift {
+  0%   { transform: translate3d(-3%, -2%, 0) scale(1.05) rotate(0deg); }
+  100% { transform: translate3d(3%, 2%, 0) scale(1.15) rotate(4deg); }
+}
+@keyframes showcaseAuroraBreathe {
+  0%   { opacity: 0.55; transform: scale(1); }
+  100% { opacity: 1; transform: scale(1.12); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .showcase-aurora,
+  .showcase-aurora::after {
+    animation: none;
+  }
+}

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/SubmissionsController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/SubmissionsController.cs
@@ -200,6 +200,7 @@ public class SubmissionsController : ControllerBase
     [HttpGet("public")]
     public async Task<IActionResult> ListPublicSubmissions(
         [FromQuery] string? contentType = null,
+        [FromQuery] string? ownerUserId = null,
         [FromQuery] int skip = 0,
         [FromQuery] int limit = 20)
     {
@@ -209,6 +210,8 @@ public class SubmissionsController : ControllerBase
         var filter = Builders<Submission>.Filter.Eq(x => x.IsPublic, true);
         if (!string.IsNullOrWhiteSpace(contentType))
             filter &= Builders<Submission>.Filter.Eq(x => x.ContentType, contentType);
+        if (!string.IsNullOrWhiteSpace(ownerUserId))
+            filter &= Builders<Submission>.Filter.Eq(x => x.OwnerUserId, ownerUserId);
 
         var total = await _db.Submissions.CountDocumentsAsync(filter);
         var sort = Builders<Submission>.Sort
@@ -282,6 +285,47 @@ public class SubmissionsController : ControllerBase
         });
 
         return Ok(ApiResponse<object>.Ok(new { total, items = result }));
+    }
+
+    /// <summary>
+    /// 获取公开作品的热门创作者列表（按投稿数排序，用于头像筛选行）
+    /// </summary>
+    [HttpGet("public/creators")]
+    public async Task<IActionResult> ListPublicSubmissionCreators(
+        [FromQuery] string? contentType = null,
+        [FromQuery] int limit = 24)
+    {
+        limit = Math.Clamp(limit, 1, 60);
+
+        var filter = Builders<Submission>.Filter.Eq(x => x.IsPublic, true);
+        if (!string.IsNullOrWhiteSpace(contentType))
+            filter &= Builders<Submission>.Filter.Eq(x => x.ContentType, contentType);
+
+        var grouped = await _db.Submissions
+            .Aggregate()
+            .Match(filter)
+            .Group(x => x.OwnerUserId, g => new
+            {
+                OwnerUserId = g.Key,
+                OwnerUserName = g.First().OwnerUserName,
+                OwnerAvatarFileName = g.First().OwnerAvatarFileName,
+                SubmissionCount = g.Count(),
+            })
+            .SortByDescending(x => x.SubmissionCount)
+            .Limit(limit)
+            .ToListAsync();
+
+        var creators = grouped
+            .Where(x => !string.IsNullOrWhiteSpace(x.OwnerUserId))
+            .Select(x => new
+            {
+                ownerUserId = x.OwnerUserId,
+                ownerUserName = x.OwnerUserName,
+                ownerAvatarFileName = x.OwnerAvatarFileName,
+                submissionCount = x.SubmissionCount,
+            });
+
+        return Ok(ApiResponse<object>.Ok(new { creators }));
     }
 
     /// <summary>


### PR DESCRIPTION
## 摘要

增强作品广场（PortfolioShowcasePage 和 ShowcaseGallery）的响应式布局和交互能力：
1. 列数根据容器实际宽度动态自适应（ResizeObserver），标准屏 5 列、带鱼屏 6-7 列、小屏 2-3 列
2. 新增创作者头像筛选行，点击头像可按创作者过滤作品
3. 增强极光渐变背景动效（柔和漂移 + 呼吸）
4. 优化首屏性能：封面图视口懒挂载、首屏批量缩小、async 解码

## 改动 diff

### 前端（prd-admin）

- **新增 `src/components/showcase/CreatorFilterRow.tsx`**：创作者头像筛选行组件，支持金/银/铜彩色光圈标记前三名
- **新增 `src/hooks/useWaterfallColumns.ts`**：ResizeObserver 驱动的响应式列数计算（宽度 < 540px → 2 列，< 900px → 3 列，< 1280px → 4 列，< 1728px → 5 列，< 2200px → 6 列，>= 2200px → 7 列）
- **新增 `src/hooks/useInViewport.ts`**：IntersectionObserver 视口懒挂载，卡片未滚动到时不请求封面图
- **新增 `src/components/showcase/waterfall.ts`**：提取 `distributeToColumns` 和 `getAspectRatio` 为共享工具函数
- **修改 `src/pages/PortfolioShowcasePage.tsx`**：
  - 集成 `useWaterfallColumns` 替代硬编码的 `isMobile ? 2 : 4`
  - 新增 `listSubmissionCreators` 调用和创作者筛选状态管理
  - 集成 `CreatorFilterRow` 组件
  - 增强极光背景（`.showcase-aurora` CSS 类）
  - 首屏 PAGE_SIZE 从 24 改为 18
  - 图片加 `inView` 条件和 `decoding="async"`
- **修改 `src/components/showcase/ShowcaseGallery.tsx`**：同上逻辑，PAGE_SIZE 从 20 改为 12
- **修改 `src/components/showcase/LiteraryCard.tsx`**：集成 `useInViewport` 钩子
- **修改 `src/styles/motion.css`**：新增 `.showcase-aurora` 和 `showcaseAuroraDrift` / `showcaseAuroraBreathe` 动画
- **修改 `src/services/real/submissions.ts`**：
  - `listPublicSubmissions` 新增 `ownerUserId` 参数
  - 新增 `listSubmissionCreators` 函数和 `SubmissionCreator` 接口
- **修改 `src/services/api.ts`**：新增 `creators: () => '/api/submissions/public/creators'` 路由

### 后端（prd-api）

- **修改 `SubmissionsController.cs`**：
  - `ListPublicSubmissions` 新增 `ownerUserId` 查询参数和 MongoDB 过滤
  - 新增 `ListPublicSubmissionCreators` 端点（`GET /api/submissions/public/creators`），

https://claude.ai/code/session_0186VGMyjo55pjFgW8NxmEwT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches both frontend rendering/perf (ResizeObserver/IntersectionObserver-driven layouts and lazy image loading) and backend query endpoints/filters for public submissions, so regressions could impact showcase loading, pagination, or filtering behavior.
> 
> **Overview**
> Upgrades the作品广场（`ShowcaseGallery` + `PortfolioShowcasePage`）to use a **container-width driven masonry grid** via `useWaterfallColumns` (supports ultrawide monitors) and extracts shared waterfall helpers into `components/showcase/waterfall.ts`.
> 
> Adds a **creator avatar filter row** (`CreatorFilterRow`) with shared state/race-guard logic (`useCreatorFilter`), wiring it into public submission listing via an `ownerUserId` query param; empty states are adjusted to distinguish “no results” vs “no submissions”.
> 
> Improves perceived performance/UX by **viewport-gated cover image loading** (`useInViewport` + `decoding="async"`), reducing initial page sizes, and adding an animated `.showcase-aurora` background with `prefers-reduced-motion` fallbacks.
> 
> Backend/API support is extended with `GET /api/submissions/public` filtering by `ownerUserId` and a new `GET /api/submissions/public/creators` aggregation endpoint, plus corresponding `prd-admin` service methods/routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9cd41fe860327095fee604974ba89be61ec017a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->