### PR TITLE
每日熵减计划 2026-W20 — 删除重复文档条目 + 补录5条changelog

### DIFF
--- a/changelogs/.entropy-manifest.yml
+++ b/changelogs/.entropy-manifest.yml
@@ -31,3 +31,8 @@ processed:
   - 2026-05-13_cds-branch-list-skip-gitlog.md
   - 2026-05-13_cds-commit-inbox-click-target.md
   - 2026-05-13_cds-commit-inbox-density.md
+  - 2026-05-13_cds-commit-inbox-hierarchy.md
+  - 2026-05-13_cds-forwarder-asset-mime.md
+  - 2026-05-13_cds-light-icon-contrast.md
+  - 2026-05-13_cds-light-shape-backdrop.md
+  - 2026-05-13_cds-map-authorize-flow.md

--- a/doc/guide.list.directory.md
+++ b/doc/guide.list.directory.md
@@ -1,6 +1,6 @@
 # MAP 平台文档索引 · 指南
 
-> 最后更新：2026-05-14
+> 最后更新：2026-05-17
 >
 > 本文件是 `doc/` 目录的结构化索引，供外部同步工具（语雀、Confluence 等）消费。
 > 元数据定义见 `doc/index.yml`，命名规范见 `doc/rule.doc-naming.md`。
@@ -208,9 +208,6 @@
 
 - [周报管理 Agent 架构设计](design.report-agent) `design.report-agent`
   > 周报 Agent 的完整架构：团队管理、AI 生成、数据源采集
-
-- [产品评审员技术设计文档](design.review-agent) `design.review-agent`
-  > ReviewAgent 的完整技术设计：状态机、LLM 集成、SSE 协议
 
 - [系统涌现：从基础组件到协同智能](design.system-emergence) `design.system-emergence`
   > MAP 平台从基础能力到协同智能的涌现机制说明


### PR DESCRIPTION
自动生成的每日熵减 PR。

## 修复项

- **D3 guide.list.directory.md**：删除 `design.review-agent` 重复条目（第 212-213 行的较短版本，完整版保留在第 128-130 行）；更新最后更新日期至 2026-05-17
- **D6 changelog manifest**：补录 5 条 2026-05-13 未处理 changelog 入库
  - cds-commit-inbox-hierarchy（分支提交面板信息层级优化）
  - cds-forwarder-asset-mime（forwarder 异常时资源请求 MIME 类型修复）
  - cds-light-icon-contrast（浅色模式图标对比度提升）
  - cds-light-shape-backdrop（浅色模式部署面板背景修复）
  - cds-map-authorize-flow（MAP-CDS 地址授权流新功能，feat + 12 项 fix）

## 跳过项

- D1（命名违规）：无
- D2（index.yml）：无
- D4（CLAUDE.md 技能表）：`pnpm` 为规则正文粗体，非技能表条目，跳过
- D3 ghost 引用：大部分为"变更历史"表中的合法历史记录，跳过

---
_Generated by [Claude Code](https://claude.ai/code/session_017EtHsuNk5j1188eLUbyBhQ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation/manifest-only edits with no runtime code changes; main risk is minor doc sync tooling or indexing discrepancies if an entry was removed incorrectly.
> 
> **Overview**
> Updates documentation metadata only.
> 
> `doc/guide.list.directory.md` bumps the *last updated* date to `2026-05-17` and removes a duplicate `design.review-agent` entry so the guide index lists it once. `changelogs/.entropy-manifest.yml` backfills **5** additional `2026-05-13` changelog fragments as processed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3544b6c0b6e5bbcf79daebcddcc4d4097fc0ff06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->