### PR TITLE
优化排行榜聚合性能 + 修正缺陷口径 + 作品热度排序

### DIFF
--- a/changelogs/2026-05-17_gallery-stats.md
+++ b/changelogs/2026-05-17_gallery-stats.md
@@ -1,0 +1,5 @@
+| feat | prd-api | 作品广场改为热度排序（带时间衰减）+ _id 稳定 tiebreaker，消除翻页重复、新作品自然冒泡 |
+| perf | prd-api | Executive 排行榜/团队页改为 MongoDB 服务端 $group 聚合，消除全集合 Find 进内存 + per-user N+1 |
+| fix | prd-api | 修正缺陷"已解决"口径：未解决缺陷不再被计入解决数 |
+| feat | prd-admin | Executive 统计页缺陷三列合并为单列「缺陷」（提交+解决），每个指标列加问号说明 tooltip（口径/怎么+1/排除异常，文案后端下发） |
+| test | prd-api | 新增作品广场热度公式单元测试 + Executive 排行榜聚合交叉验证集成测试 |

--- a/changelogs/2026-05-17_gallery-stats.md
+++ b/changelogs/2026-05-17_gallery-stats.md
@@ -2,4 +2,5 @@
 | perf | prd-api | Executive 排行榜/团队页改为 MongoDB 服务端 $group 聚合，消除全集合 Find 进内存 + per-user N+1 |
 | fix | prd-api | 修正缺陷"已解决"口径：未解决缺陷不再被计入解决数 |
 | feat | prd-admin | Executive 统计页缺陷三列合并为单列「缺陷」（提交+解决），每个指标列加问号说明 tooltip（口径/怎么+1/排除异常，文案后端下发） |
+| fix | prd-api | 作品广场热度分基准时间按 10 分钟取桶，修复偏移分页跨请求 $$NOW 漂移导致的边界作品重复/漏项 |
 | test | prd-api | 新增作品广场热度公式单元测试 + Executive 排行榜聚合交叉验证集成测试 |

--- a/prd-admin/src/components/ui/Tooltip.tsx
+++ b/prd-admin/src/components/ui/Tooltip.tsx
@@ -44,30 +44,33 @@ export function Tooltip({
         <TooltipPrimitive.Trigger asChild>
           {triggerContent}
         </TooltipPrimitive.Trigger>
-        <TooltipPrimitive.Content
-          side={side}
-          align={align}
-          sideOffset={8}
-          alignOffset={-6}
-          className="rounded-[12px] px-3 py-2 text-xs"
-          style={{
-            ...glassTooltip,
-            color: 'rgba(255,255,255,0.95)',
-            maxWidth: 240,
-            userSelect: 'none',
-            zIndex: 9999,
-            animation: 'tooltipFloat 0.3s cubic-bezier(0.16, 1, 0.3, 1)',
-            fontWeight: 500,
-            lineHeight: 1.4,
-          }}
-        >
-          {content}
-          <TooltipPrimitive.Arrow
-            width={12}
-            height={6}
-            style={{ fill: 'rgba(20, 20, 24, 0.95)' }}
-          />
-        </TooltipPrimitive.Content>
+        <TooltipPrimitive.Portal>
+          <TooltipPrimitive.Content
+            side={side}
+            align={align}
+            sideOffset={8}
+            alignOffset={-6}
+            collisionPadding={12}
+            className="rounded-[12px] px-3 py-2 text-xs"
+            style={{
+              ...glassTooltip,
+              color: 'rgba(255,255,255,0.95)',
+              maxWidth: 240,
+              userSelect: 'none',
+              zIndex: 9999,
+              animation: 'tooltipFloat 0.3s cubic-bezier(0.16, 1, 0.3, 1)',
+              fontWeight: 500,
+              lineHeight: 1.4,
+            }}
+          >
+            {content}
+            <TooltipPrimitive.Arrow
+              width={12}
+              height={6}
+              style={{ fill: 'rgba(20, 20, 24, 0.95)' }}
+            />
+          </TooltipPrimitive.Content>
+        </TooltipPrimitive.Portal>
         <style>{`
           @keyframes tooltipFloat {
             0% { opacity: 0; transform: translateY(4px) scale(0.96); }

--- a/prd-admin/src/pages/ExecutiveDashboardPage.tsx
+++ b/prd-admin/src/pages/ExecutiveDashboardPage.tsx
@@ -26,6 +26,7 @@ import type {
   ExecutiveAgentStat,
   ExecutiveModelStat,
   ExecutiveLeaderboard,
+  LeaderboardDimension,
 } from '@/services/contracts/executive';
 import type { EChartsOption } from 'echarts';
 import { resolveAvatarUrl } from '@/lib/avatar';
@@ -301,6 +302,25 @@ function InfoTip({ tip }: { tip: string }) {
   );
 }
 
+/** 排行榜列头的问号说明：口径/怎么+1/排除异常，文案全部由后端下发（SSOT） */
+function DimHelp({ dim }: { dim: LeaderboardDimension }) {
+  if (!dim.description && !dim.howToIncrease && !dim.anomalyNote) return null;
+  const content = (
+    <div className="flex flex-col gap-1 text-left" style={{ maxWidth: 220, fontWeight: 400 }}>
+      {dim.description && <div>{dim.description}</div>}
+      {dim.howToIncrease && <div style={{ opacity: 0.85 }}>怎么 +1：{dim.howToIncrease}</div>}
+      {dim.anomalyNote && <div style={{ opacity: 0.65 }}>口径：{dim.anomalyNote}</div>}
+    </div>
+  );
+  return (
+    <Tooltip content={content} side="top">
+      <span onClick={(e) => e.stopPropagation()} className="inline-flex cursor-help">
+        <Info size={11} style={{ color: D.text3, opacity: 0.55, flexShrink: 0 }} />
+      </span>
+    </Tooltip>
+  );
+}
+
 /** 从 ROLE_META 提取主色调，供排行榜使用 */
 const ROLE_COLORS: Record<string, string> = new Proxy({} as Record<string, string>, {
   get: (_, key: string) => getRoleMeta(key).color,
@@ -379,12 +399,10 @@ const DIMENSION_META: Record<string, { icon: typeof Bot; color: string; barColor
   'prd-agent':        { icon: MessageSquare, color: D.primary,  barColor: hexAlpha(D.primary, 0.5),   short: 'PRD' },
   'visual-agent':     { icon: Image,         color: D.primary,  barColor: hexAlpha(D.primary, 0.45),  short: '视觉' },
   'literary-agent':   { icon: MessageSquare, color: D.primary,  barColor: hexAlpha(D.primary, 0.4),   short: '文学' },
-  'defect-agent':     { icon: Bug,           color: D.primary,  barColor: hexAlpha(D.primary, 0.5),   short: '缺陷' },
   'ai-toolbox':       { icon: Zap,           color: D.primary,  barColor: hexAlpha(D.primary, 0.4),   short: '工具箱' },
   'report-agent':     { icon: FileText,      color: D.primary,  barColor: hexAlpha(D.primary, 0.4),   short: '周报' },
   'video-agent':      { icon: Activity,      color: D.primary,  barColor: hexAlpha(D.primary, 0.4),   short: '视频' },
-  'defects-created':    { icon: Bug,           color: D.danger,   barColor: hexAlpha(D.danger, 0.35),   short: '提缺陷' },
-  'defects-resolved':   { icon: Bug,           color: D.success,  barColor: hexAlpha(D.success, 0.35),  short: '解缺陷' },
+  'defects':            { icon: Bug,           color: D.primary,  barColor: hexAlpha(D.primary, 0.5),   short: '缺陷' },
   'images':             { icon: Image,         color: D.primary,  barColor: hexAlpha(D.primary, 0.4),   short: '图片合计' },
   'image-gen-visual':   { icon: Image,         color: D.primary,  barColor: hexAlpha(D.primary, 0.45),  short: '视觉生图' },
   'image-gen-literary': { icon: Image,         color: D.primary,  barColor: hexAlpha(D.primary, 0.4),   short: '文学配图' },
@@ -524,7 +542,11 @@ function TeamInsightsTab({ leaderboard, loading }: { leaderboard: ExecutiveLeade
                       style={{ color: sortKey === dim.key ? D.primary : D.text3, verticalAlign: 'middle' }}
                       onClick={() => toggleSort(dim.key)}
                     >
-                      <span className="inline-flex items-center justify-center gap-1 w-full">{meta?.short ?? dim.name} <SortIcon col={dim.key} /></span>
+                      <span className="inline-flex items-center justify-center gap-1 w-full">
+                        {meta?.short ?? dim.name}
+                        <DimHelp dim={dim} />
+                        <SortIcon col={dim.key} />
+                      </span>
                       <div className="text-[9px] font-normal" style={{ color: D.text3, opacity: 0.7 }}>权重 {weightPct}%</div>
                     </th>
                   );
@@ -588,13 +610,21 @@ function TeamInsightsTab({ leaderboard, loading }: { leaderboard: ExecutiveLeade
                       const totalDays = Math.min(data?.totalDays ?? 1, 30);
                       const pct = Math.min((raw / Math.max(1, totalDays)) * 100, 100);
                       const isLastCol = dimIdx === allDims.length - 1;
+                      const sub = dim.subValues?.[user.userId];
+                      const numberEl = (
+                        <span className="tabular-nums font-bold text-[11px]" style={{ color: raw > 0 ? D.text2 : D.text3 }}>
+                          {raw.toLocaleString()}
+                        </span>
+                      );
 
                       return (
                         <td key={dim.key} className="py-2.5 px-2" style={{ verticalAlign: 'middle', borderRadius: isTop3 && isLastCol ? '0 8px 8px 0' : undefined }}>
                           <div className="flex flex-col items-center gap-0.5" style={{ minWidth: 40 }}>
-                            <span className="tabular-nums font-bold text-[11px]" style={{ color: raw > 0 ? D.text2 : D.text3 }}>
-                              {raw.toLocaleString()}
-                            </span>
+                            {sub && raw > 0 ? (
+                              <Tooltip content={`提交 ${sub.created} 个 · 解决 ${sub.resolved} 个`} side="top">
+                                {numberEl}
+                              </Tooltip>
+                            ) : numberEl}
                             <div className="w-full h-1.5 rounded-full overflow-hidden" style={{ background: 'rgba(255,255,255,0.04)' }}>
                               <div className="h-full rounded-full" style={{ width: `${pct}%`, background: meta?.barColor ?? 'rgba(255,255,255,0.12)' }} />
                             </div>

--- a/prd-admin/src/pages/ExecutiveDashboardPage.tsx
+++ b/prd-admin/src/pages/ExecutiveDashboardPage.tsx
@@ -520,13 +520,7 @@ function TeamInsightsTab({ leaderboard, loading }: { leaderboard: ExecutiveLeade
       <DashCard>
         <SectionTitle>综合排行榜</SectionTitle>
         <div className="overflow-x-auto">
-          <table className="w-full text-[12px]" style={{ borderCollapse: 'separate', borderSpacing: 0, tableLayout: 'fixed' }}>
-            <colgroup>
-              <col style={{ width: 40 }} />
-              <col style={{ width: 184 }} />
-              <col style={{ width: 88 }} />
-              {allDims.map(d => <col key={d.key} style={{ width: 112 }} />)}
-            </colgroup>
+          <table className="w-full text-[12px]" style={{ borderCollapse: 'separate', borderSpacing: 0 }}>
             <thead>
               <tr style={{ borderBottom: `1px solid ${D.border}` }}>
                 <th className="text-left py-2.5 pr-2 font-medium w-8" style={{ color: D.text3, verticalAlign: 'middle' }}>#</th>
@@ -544,7 +538,7 @@ function TeamInsightsTab({ leaderboard, loading }: { leaderboard: ExecutiveLeade
                     <th
                       key={dim.key}
                       className="text-center py-2.5 px-2 font-medium cursor-pointer select-none whitespace-nowrap"
-                      style={{ color: sortKey === dim.key ? D.primary : D.text3, verticalAlign: 'middle' }}
+                      style={{ color: sortKey === dim.key ? D.primary : D.text3, verticalAlign: 'middle', width: 96, minWidth: 96 }}
                       onClick={() => toggleSort(dim.key)}
                     >
                       <span className="inline-flex items-center justify-center gap-1 w-full">
@@ -622,7 +616,7 @@ function TeamInsightsTab({ leaderboard, loading }: { leaderboard: ExecutiveLeade
                       );
 
                       return (
-                        <td key={dim.key} className="py-2.5 px-2" style={{ verticalAlign: 'middle', borderRadius: isTop3 && isLastCol ? '0 8px 8px 0' : undefined }}>
+                        <td key={dim.key} className="py-2.5 px-2" style={{ verticalAlign: 'middle', width: 96, minWidth: 96, borderRadius: isTop3 && isLastCol ? '0 8px 8px 0' : undefined }}>
                           <div className="flex flex-col items-center gap-0.5" style={{ minWidth: 40 }}>
                             {sub && raw > 0 ? (
                               <Tooltip content={`提交 ${sub.created} 个 · 解决 ${sub.resolved} 个`} side="top">

--- a/prd-admin/src/pages/ExecutiveDashboardPage.tsx
+++ b/prd-admin/src/pages/ExecutiveDashboardPage.tsx
@@ -461,7 +461,6 @@ function TeamInsightsTab({ leaderboard, loading }: { leaderboard: ExecutiveLeade
 
   const { dimensions: allDims } = data;
   const scored = computeScores(data);
-  const weightPct = allDims.length > 0 ? (100 / allDims.length).toFixed(1) : '0';
 
   const tableSorted = [...scored].sort((a, b) => {
     let va: number, vb: number;
@@ -521,7 +520,13 @@ function TeamInsightsTab({ leaderboard, loading }: { leaderboard: ExecutiveLeade
       <DashCard>
         <SectionTitle>综合排行榜</SectionTitle>
         <div className="overflow-x-auto">
-          <table className="w-full text-[12px]" style={{ borderCollapse: 'separate', borderSpacing: 0 }}>
+          <table className="w-full text-[12px]" style={{ borderCollapse: 'separate', borderSpacing: 0, tableLayout: 'fixed' }}>
+            <colgroup>
+              <col style={{ width: 40 }} />
+              <col style={{ width: 184 }} />
+              <col style={{ width: 88 }} />
+              {allDims.map(d => <col key={d.key} style={{ width: 112 }} />)}
+            </colgroup>
             <thead>
               <tr style={{ borderBottom: `1px solid ${D.border}` }}>
                 <th className="text-left py-2.5 pr-2 font-medium w-8" style={{ color: D.text3, verticalAlign: 'middle' }}>#</th>
@@ -547,7 +552,6 @@ function TeamInsightsTab({ leaderboard, loading }: { leaderboard: ExecutiveLeade
                         <DimHelp dim={dim} />
                         <SortIcon col={dim.key} />
                       </span>
-                      <div className="text-[9px] font-normal" style={{ color: D.text3, opacity: 0.7 }}>权重 {weightPct}%</div>
                     </th>
                   );
                 })}
@@ -575,18 +579,18 @@ function TeamInsightsTab({ leaderboard, loading }: { leaderboard: ExecutiveLeade
                       )}
                     </td>
                     <td className="py-2.5 pr-4" style={{ verticalAlign: 'middle' }}>
-                      <div className="flex items-center gap-2">
+                      <div className="flex items-center gap-2 min-w-0">
                         {user.avatarFileName ? (
-                          <UserAvatar src={resolveAvatarUrl({ avatarFileName: user.avatarFileName })} className="w-6 h-6 rounded-full object-cover ring-1 ring-white/5" />
+                          <UserAvatar src={resolveAvatarUrl({ avatarFileName: user.avatarFileName })} className="w-6 h-6 rounded-full object-cover ring-1 ring-white/5 flex-shrink-0" />
                         ) : (
-                          <div className="w-6 h-6 rounded-full flex items-center justify-center text-[10px] font-bold"
+                          <div className="w-6 h-6 rounded-full flex items-center justify-center text-[10px] font-bold flex-shrink-0"
                             style={{ background: `${roleColor}22`, color: roleColor }}>
                             {user.displayName[0]}
                           </div>
                         )}
-                        <div>
-                          <div className="text-[12px] font-medium" style={{ color: D.text1 }}>{user.displayName}</div>
-                          <div className="text-[9px] font-medium" style={{ color: roleColor }}>{getRoleMeta(user.role).label}</div>
+                        <div className="min-w-0">
+                          <div className="text-[12px] font-medium truncate" style={{ color: D.text1 }}>{user.displayName}</div>
+                          <div className="text-[9px] font-medium truncate" style={{ color: roleColor }}>{getRoleMeta(user.role).label}</div>
                         </div>
                       </div>
                     </td>

--- a/prd-admin/src/services/contracts/executive.ts
+++ b/prd-admin/src/services/contracts/executive.ts
@@ -75,8 +75,16 @@ export type LeaderboardUser = {
 export type LeaderboardDimension = {
   key: string;
   name: string;
-  category: 'agent' | 'activity';
+  category: 'agent' | 'activity' | 'image';
   values: Record<string, number>;
+  /** 口径说明（怎么算的）—— 后端单一来源，前端直接渲染 */
+  description?: string;
+  /** 怎么操作会让这一项 +1 */
+  howToIncrease?: string;
+  /** 排除了哪些异常/奇异数据 */
+  anomalyNote?: string;
+  /** 缺陷列专用：每个用户的提交/解决拆解 */
+  subValues?: Record<string, { created: number; resolved: number }>;
 };
 
 export type ExecutiveLeaderboard = {

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ExecutiveController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ExecutiveController.cs
@@ -1,6 +1,8 @@
 using System.Linq.Expressions;
+using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using MongoDB.Bson;
 using MongoDB.Driver;
 using PrdAgent.Core.Models;
 using PrdAgent.Infrastructure.Database;
@@ -492,9 +494,11 @@ public class ExecutiveController : ControllerBase
             { "/api/video-agent/", "video-agent" },
         };
 
+        var aggOpts = new AggregateOptions { AllowDiskUse = true };
+
         // LLM 维度：服务端按 {AppCallerCode,UserId} 分组（基数 = 不同 appcaller×用户，
         // 远小于日志条数），再在内存做 NormalizeAppKey 归一。不再把整张 llmrequestlogs 拉回。
-        var llmGroups = await _db.LlmRequestLogs.Aggregate()
+        var llmGroups = await _db.LlmRequestLogs.Aggregate(aggOpts)
             .Match(l => l.StartedAt >= periodStart && l.AppCallerCode != null && l.UserId != null)
             .Group(l => new { l.AppCallerCode, l.UserId },
                    g => new { g.Key.AppCallerCode, g.Key.UserId, C = g.Count() })
@@ -511,26 +515,60 @@ public class ExecutiveController : ControllerBase
             inner[row.UserId] = inner.GetValueOrDefault(row.UserId) + row.C;
         }
 
-        // API 维度（写操作）：服务端按 {Path,UserId} 分组，再在内存做路由前缀→appKey 映射。
-        var apiGroups = await _db.ApiRequestLogs.Aggregate()
-            .Match(l => l.StartedAt >= periodStart && l.Method != "GET"
-                        && l.StatusCode >= 200 && l.StatusCode < 400)
-            .Group(l => new { l.Path, l.UserId },
-                   g => new { g.Key.Path, g.Key.UserId, C = g.Count() })
+        // API 维度（写操作）：Path 含资源 GUID（如 /api/prd-agent/sessions/{guid}/messages），
+        // 若按原始 Path 分组基数≈文档数，既失去聚合意义又会撞 $group 100MB 内存上限。
+        // 改为在管道内用 $switch 把 Path 前缀直接归一成 appKey，再按 {appKey,UserId} 分组，
+        // 基数收敛到 ≈7×用户数（与 LLM 维度同量级）。
+        var apiPrefixRegex = "^(" + string.Join("|", agentRoutePrefixes.Keys.Select(Regex.Escape)) + ")";
+        var switchBranches = new BsonArray(agentRoutePrefixes.Select(kv => new BsonDocument
+        {
+            { "case", new BsonDocument("$regexMatch", new BsonDocument
+                {
+                    { "input", "$Path" },
+                    { "regex", "^" + Regex.Escape(kv.Key) },
+                    { "options", "i" },
+                }) },
+            { "then", kv.Value },
+        }));
+
+        var apiPipeline = new BsonDocument[]
+        {
+            new("$match", new BsonDocument
+            {
+                { "StartedAt", new BsonDocument("$gte", periodStart) },
+                { "Method", new BsonDocument("$ne", "GET") },
+                { "StatusCode", new BsonDocument { { "$gte", 200 }, { "$lt", 400 } } },
+                { "UserId", new BsonDocument("$nin", new BsonArray { BsonNull.Value, "anonymous" }) },
+                { "Path", new BsonRegularExpression(apiPrefixRegex, "i") },
+            }),
+            new("$set", new BsonDocument("_ak", new BsonDocument("$switch", new BsonDocument
+            {
+                { "branches", switchBranches },
+                { "default", BsonNull.Value },
+            }))),
+            new("$match", new BsonDocument("_ak", new BsonDocument("$ne", BsonNull.Value))),
+            new("$group", new BsonDocument
+            {
+                { "_id", new BsonDocument { { "ak", "$_ak" }, { "u", "$UserId" } } },
+                { "c", new BsonDocument("$sum", 1) },
+            }),
+        };
+
+        var apiGroups = await _db.ApiRequestLogs
+            .Aggregate<BsonDocument>(apiPipeline, aggOpts)
             .ToListAsync();
 
         var apiAgentUserCounts = new Dictionary<string, Dictionary<string, int>>();
         foreach (var row in apiGroups)
         {
-            if (row.UserId == null || row.UserId == "anonymous" || !userIds.Contains(row.UserId)) continue;
-            string? matchedKey = null;
-            foreach (var kv in agentRoutePrefixes)
-                if (row.Path != null && row.Path.StartsWith(kv.Key, StringComparison.OrdinalIgnoreCase))
-                { matchedKey = kv.Value; break; }
-            if (matchedKey == null) continue;
+            var id = row["_id"].AsBsonDocument;
+            var matchedKey = id["ak"].AsString;
+            var uid = id["u"].IsString ? id["u"].AsString : null;
+            if (string.IsNullOrEmpty(uid) || !userIds.Contains(uid)) continue;
+            var c = row["c"].ToInt32();
             if (!apiAgentUserCounts.TryGetValue(matchedKey, out var inner))
                 apiAgentUserCounts[matchedKey] = inner = new Dictionary<string, int>();
-            inner[row.UserId] = inner.GetValueOrDefault(row.UserId) + row.C;
+            inner[uid] = inner.GetValueOrDefault(uid) + c;
         }
 
         // 合并两个数据源

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ExecutiveController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ExecutiveController.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using MongoDB.Driver;
@@ -54,6 +55,62 @@ public class ExecutiveController : ControllerBase
     public ExecutiveController(MongoDbContext db)
     {
         _db = db;
+    }
+
+    /// <summary>
+    /// 服务端聚合：$match + $group by 用户字段 → { userId: count }。
+    /// 关键点：分组在 MongoDB 内完成，只把 (userId,count) 拉回，
+    /// 不再 Find().ToListAsync() 把整个大集合搬进内存。
+    /// </summary>
+    private static async Task<Dictionary<string, int>> CountByUserAsync<T>(
+        IMongoCollection<T> col,
+        Expression<Func<T, bool>> match,
+        Expression<Func<T, string?>> userKey,
+        HashSet<string> userIds)
+    {
+        var grouped = await col.Aggregate()
+            .Match(match)
+            .Group(userKey, g => new { Uid = g.Key, C = g.Count() })
+            .ToListAsync();
+
+        var dict = new Dictionary<string, int>();
+        foreach (var row in grouped)
+        {
+            if (string.IsNullOrEmpty(row.Uid) || !userIds.Contains(row.Uid)) continue;
+            dict[row.Uid] = row.C;
+        }
+        return dict;
+    }
+
+    /// <summary>
+    /// 维度口径元数据（SSOT）：前端问号 tooltip 直接渲染这些文案，
+    /// 不在前端硬编码。desc=怎么算的 / how=怎么操作会+1 / anomaly=排除了什么异常。
+    /// </summary>
+    private static readonly Dictionary<string, (string Desc, string How, string Anomaly)> DimMeta =
+        new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["prd-agent"]          = ("PRD 解读 Agent 的使用次数（LLM 对话 + 写操作合计）", "在 PRD 解读中发起对话或执行操作", "已排除 Bot 账号与匿名请求"),
+        ["visual-agent"]       = ("视觉创作 Agent 的使用次数（LLM + 写操作合计）", "在视觉创作中生成或编辑作品", "已排除 Bot 账号与匿名请求"),
+        ["literary-agent"]     = ("文学创作 Agent 的使用次数（LLM + 写操作合计）", "在文学创作中发起创作", "已排除 Bot 账号与匿名请求"),
+        ["ai-toolbox"]         = ("AI 百宝箱使用次数：工作流执行、教程邮件等百宝箱内工具的调用", "在百宝箱中运行工作流或使用其中的工具", "已排除 Bot 账号与匿名请求"),
+        ["report-agent"]       = ("周报 Agent 的使用次数（LLM + 写操作合计）", "在周报中生成或提交周报", "已排除 Bot 账号与匿名请求"),
+        ["video-agent"]        = ("视频 Agent 的使用次数（LLM + 写操作合计）", "在视频生成中发起任务", "已排除 Bot 账号与匿名请求"),
+        ["defects"]            = ("真实缺陷贡献 = 你提交的缺陷数 + 你解决的缺陷数", "在缺陷管理中提交新缺陷，或把缺陷标记为已解决", "只统计真实提交/解决；未解决的缺陷不计入解决数，已排除 Bot 账号"),
+        ["images"]             = ("名下生成的图片总数（所有来源合计）", "在视觉或文学创作中生成图片", "已排除 Bot 账号"),
+        ["image-gen-visual"]   = ("视觉创作 AI 生图的成功次数", "在视觉创作中成功生成图片", "只统计成功完成的生图，失败或排队中的不计入"),
+        ["image-gen-literary"] = ("文学创作配图的成功次数", "在文学创作中成功生成配图", "只统计成功完成的生图"),
+        ["image-upload"]       = ("上传的参考图数量", "在创作中上传参考图", "只统计参考图（input_image），不含生成结果"),
+        ["workflows"]          = ("触发的工作流执行次数", "在百宝箱中运行工作流", "已排除 Bot 账号"),
+        ["arena"]              = ("模型竞技场的对战次数", "在模型竞技场发起对战", "已排除 Bot 账号"),
+    };
+
+    private static object MakeDim(string key, string name, string category,
+        Dictionary<string, int> values, object? subValues = null)
+    {
+        DimMeta.TryGetValue(key, out var m);
+        if (subValues == null)
+            return new { key, name, category, values, description = m.Desc ?? "", howToIncrease = m.How ?? "", anomalyNote = m.Anomaly ?? "" };
+        return new { key, name, category, values, description = m.Desc ?? "", howToIncrease = m.How ?? "", anomalyNote = m.Anomaly ?? "", subValues };
     }
 
     /// <summary>
@@ -186,53 +243,39 @@ public class ExecutiveController : ControllerBase
         var periodStart = days > 0 ? DateTime.UtcNow.Date.AddDays(-days + 1) : DateTime.MinValue;
 
         var users = await _db.Users.Find(_ => true).ToListAsync();
-        var result = new List<object>();
+        var humanUsers = users.Where(u => u.UserType != UserType.Bot).ToList();
+        var userIds = humanUsers.Select(u => u.UserId).ToHashSet();
 
-        foreach (var user in users)
+        // 每个指标一次服务端 $group，彻底消除原来的 per-user N+1（用户数 × 5 次查询）
+        var messagesByUser = await CountByUserAsync(_db.Messages,
+            m => m.Timestamp >= periodStart, m => m.SenderId, userIds);
+        var sessionsByUser = await CountByUserAsync(_db.Sessions,
+            s => s.CreatedAt >= periodStart, s => s.OwnerUserId, userIds);
+        var defectsCreatedByUser = await CountByUserAsync(_db.DefectReports,
+            d => d.CreatedAt >= periodStart, d => d.ReporterId, userIds);
+        // 口径修正：未解决的缺陷 ResolvedById/ResolvedAt 为 null，原 `ResolvedAt >= MinValue`
+        // 在 days=0 时会把未解决缺陷也算进"已解决"。显式要求 ResolvedById/ResolvedAt 非空。
+        var defectsResolvedByUser = await CountByUserAsync(_db.DefectReports,
+            d => d.ResolvedById != null && d.ResolvedAt != null && d.ResolvedAt >= periodStart,
+            d => d.ResolvedById, userIds);
+        var imageRunsByUser = await CountByUserAsync(_db.ImageGenRuns,
+            r => r.CreatedAt >= periodStart, r => r.OwnerAdminId, userIds);
+
+        var result = humanUsers.Select(user => (object)new
         {
-            if (user.UserType == UserType.Bot) continue;
-
-            // 消息数 + Token
-            var msgFilter = Builders<Message>.Filter.Eq(m => m.SenderId, user.UserId) &
-                            Builders<Message>.Filter.Gte(m => m.Timestamp, periodStart);
-            var userMessages = await _db.Messages.CountDocumentsAsync(msgFilter);
-
-            // 助手消息的 Token (用户发的消息产生的助手回复)
-            var assistantTokenFilter = Builders<Message>.Filter.Gte(m => m.Timestamp, periodStart) &
-                                       Builders<Message>.Filter.Eq(m => m.Role, MessageRole.Assistant) &
-                                       Builders<Message>.Filter.Ne(m => m.TokenUsage, null);
-            // 通过 session 关联用户 — 简化处理：取所有助手消息
-            // 更精确的做法需要 session->owner 关联，这里先按消息数反映活跃度
-
-            // 会话数
-            var sessionCount = await _db.Sessions.CountDocumentsAsync(s => s.OwnerUserId == user.UserId && s.CreatedAt >= periodStart);
-
-            // 缺陷
-            var defectsCreated = await _db.DefectReports.CountDocumentsAsync(d => d.ReporterId == user.UserId && d.CreatedAt >= periodStart);
-            var defectsResolved = await _db.DefectReports.CountDocumentsAsync(d => d.ResolvedById == user.UserId && d.ResolvedAt >= periodStart);
-
-            // 图片生成
-            var imageRuns = await _db.ImageGenRuns.CountDocumentsAsync(r => r.OwnerAdminId == user.UserId && r.CreatedAt >= periodStart);
-
-            // 活跃天数 (简化: 取 LastActiveAt)
-            var isActive = user.LastActiveAt >= periodStart;
-
-            result.Add(new
-            {
-                userId = user.UserId,
-                username = user.Username,
-                displayName = user.DisplayName ?? user.Username,
-                role = user.Role.ToString(),
-                avatarFileName = user.AvatarFileName,
-                lastActiveAt = user.LastActiveAt,
-                isActive,
-                messages = userMessages,
-                sessions = sessionCount,
-                defectsCreated,
-                defectsResolved,
-                imageRuns,
-            });
-        }
+            userId = user.UserId,
+            username = user.Username,
+            displayName = user.DisplayName ?? user.Username,
+            role = user.Role.ToString(),
+            avatarFileName = user.AvatarFileName,
+            lastActiveAt = user.LastActiveAt,
+            isActive = user.LastActiveAt >= periodStart,
+            messages = messagesByUser.GetValueOrDefault(user.UserId),
+            sessions = sessionsByUser.GetValueOrDefault(user.UserId),
+            defectsCreated = defectsCreatedByUser.GetValueOrDefault(user.UserId),
+            defectsResolved = defectsResolvedByUser.GetValueOrDefault(user.UserId),
+            imageRuns = imageRunsByUser.GetValueOrDefault(user.UserId),
+        }).ToList();
 
         var sorted = result.OrderByDescending(u => ((dynamic)u).messages).ToList();
         return Ok(ApiResponse<object>.Ok(sorted));
@@ -449,42 +492,46 @@ public class ExecutiveController : ControllerBase
             { "/api/video-agent/", "video-agent" },
         };
 
-        // LLM 维度
-        var logs = await _db.LlmRequestLogs
-            .Find(l => l.StartedAt >= periodStart && l.AppCallerCode != null && l.UserId != null)
-            .Project(l => new { l.UserId, l.AppCallerCode })
+        // LLM 维度：服务端按 {AppCallerCode,UserId} 分组（基数 = 不同 appcaller×用户，
+        // 远小于日志条数），再在内存做 NormalizeAppKey 归一。不再把整张 llmrequestlogs 拉回。
+        var llmGroups = await _db.LlmRequestLogs.Aggregate()
+            .Match(l => l.StartedAt >= periodStart && l.AppCallerCode != null && l.UserId != null)
+            .Group(l => new { l.AppCallerCode, l.UserId },
+                   g => new { g.Key.AppCallerCode, g.Key.UserId, C = g.Count() })
             .ToListAsync();
 
-        var llmAgentUserCounts = logs
-            .Where(l => l.UserId != null && userIds.Contains(l.UserId))
-            .GroupBy(l => NormalizeAppKey(l.AppCallerCode ?? ""))
-            .Where(g => !string.IsNullOrEmpty(g.Key))
-            .ToDictionary(
-                g => g.Key,
-                g => g.GroupBy(x => x.UserId!).ToDictionary(ug => ug.Key, ug => ug.Count())
-            );
+        var llmAgentUserCounts = new Dictionary<string, Dictionary<string, int>>();
+        foreach (var row in llmGroups)
+        {
+            if (row.UserId == null || !userIds.Contains(row.UserId)) continue;
+            var appKey = NormalizeAppKey(row.AppCallerCode ?? "");
+            if (string.IsNullOrEmpty(appKey)) continue;
+            if (!llmAgentUserCounts.TryGetValue(appKey, out var inner))
+                llmAgentUserCounts[appKey] = inner = new Dictionary<string, int>();
+            inner[row.UserId] = inner.GetValueOrDefault(row.UserId) + row.C;
+        }
 
-        // API 维度 (写操作)
-        var apiLogsForLb = await _db.ApiRequestLogs
-            .Find(l => l.StartedAt >= periodStart && l.Method != "GET"
+        // API 维度（写操作）：服务端按 {Path,UserId} 分组，再在内存做路由前缀→appKey 映射。
+        var apiGroups = await _db.ApiRequestLogs.Aggregate()
+            .Match(l => l.StartedAt >= periodStart && l.Method != "GET"
                         && l.StatusCode >= 200 && l.StatusCode < 400)
-            .Project(l => new { l.Path, l.UserId })
+            .Group(l => new { l.Path, l.UserId },
+                   g => new { g.Key.Path, g.Key.UserId, C = g.Count() })
             .ToListAsync();
 
-        var apiAgentUserCounts = apiLogsForLb
-            .Select(l =>
-            {
-                foreach (var kv in agentRoutePrefixes)
-                    if (l.Path.StartsWith(kv.Key, StringComparison.OrdinalIgnoreCase))
-                        return new { AppKey = kv.Value, l.UserId };
-                return null;
-            })
-            .Where(x => x != null && x.UserId != null && x.UserId != "anonymous" && userIds.Contains(x.UserId))
-            .GroupBy(x => x!.AppKey)
-            .ToDictionary(
-                g => g.Key,
-                g => g.GroupBy(x => x!.UserId!).ToDictionary(ug => ug.Key, ug => ug.Count())
-            );
+        var apiAgentUserCounts = new Dictionary<string, Dictionary<string, int>>();
+        foreach (var row in apiGroups)
+        {
+            if (row.UserId == null || row.UserId == "anonymous" || !userIds.Contains(row.UserId)) continue;
+            string? matchedKey = null;
+            foreach (var kv in agentRoutePrefixes)
+                if (row.Path != null && row.Path.StartsWith(kv.Key, StringComparison.OrdinalIgnoreCase))
+                { matchedKey = kv.Value; break; }
+            if (matchedKey == null) continue;
+            if (!apiAgentUserCounts.TryGetValue(matchedKey, out var inner))
+                apiAgentUserCounts[matchedKey] = inner = new Dictionary<string, int>();
+            inner[row.UserId] = inner.GetValueOrDefault(row.UserId) + row.C;
+        }
 
         // 合并两个数据源
         var agentUserCounts = new Dictionary<string, Dictionary<string, int>>();
@@ -502,89 +549,28 @@ public class ExecutiveController : ControllerBase
             agentUserCounts[appKey] = merged;
         }
 
-        // --- 缺陷提交 ---
-        var dcItems = await _db.DefectReports
-            .Find(d => d.CreatedAt >= periodStart)
-            .Project(d => new { d.ReporterId })
-            .ToListAsync();
-        var defectsCreatedByUser = dcItems
-            .Where(d => d.ReporterId != null && userIds.Contains(d.ReporterId))
-            .GroupBy(d => d.ReporterId!)
-            .ToDictionary(g => g.Key, g => g.Count());
-
-        // --- 缺陷解决 ---
-        var drItems = await _db.DefectReports
-            .Find(d => d.ResolvedAt >= periodStart)
-            .Project(d => new { d.ResolvedById })
-            .ToListAsync();
-        var defectsResolvedByUser = drItems
-            .Where(d => d.ResolvedById != null && userIds.Contains(d.ResolvedById))
-            .GroupBy(d => d.ResolvedById!)
-            .ToDictionary(g => g.Key, g => g.Count());
-
-        // --- 图片生成（合计，所有来源）---
-        var imgItems = await _db.ImageAssets
-            .Find(r => r.CreatedAt >= periodStart)
-            .Project(r => new { r.OwnerUserId })
-            .ToListAsync();
-        var imageByUser = imgItems
-            .Where(r => !string.IsNullOrEmpty(r.OwnerUserId) && userIds.Contains(r.OwnerUserId))
-            .GroupBy(r => r.OwnerUserId)
-            .ToDictionary(g => g.Key, g => g.Count());
-
-        // --- 视觉创作 AI 生图（image_gen_runs AppKey=visual-agent, Completed）---
-        var visualGenItems = await _db.ImageGenRuns
-            .Find(r => r.CreatedAt >= periodStart
-                    && r.AppKey == "visual-agent"
-                    && r.Status == ImageGenRunStatus.Completed)
-            .Project(r => new { r.OwnerAdminId })
-            .ToListAsync();
-        var visualGenByUser = visualGenItems
-            .Where(r => !string.IsNullOrEmpty(r.OwnerAdminId) && userIds.Contains(r.OwnerAdminId))
-            .GroupBy(r => r.OwnerAdminId)
-            .ToDictionary(g => g.Key, g => g.Count());
-
-        // --- 文学创作配图（image_gen_runs AppKey=literary-agent, Completed）---
-        var literaryGenItems = await _db.ImageGenRuns
-            .Find(r => r.CreatedAt >= periodStart
-                    && r.AppKey == "literary-agent"
-                    && r.Status == ImageGenRunStatus.Completed)
-            .Project(r => new { r.OwnerAdminId })
-            .ToListAsync();
-        var literaryGenByUser = literaryGenItems
-            .Where(r => !string.IsNullOrEmpty(r.OwnerAdminId) && userIds.Contains(r.OwnerAdminId))
-            .GroupBy(r => r.OwnerAdminId)
-            .ToDictionary(g => g.Key, g => g.Count());
-
-        // --- 上传参考图（upload_artifacts Kind=input_image）---
-        var uploadItems = await _db.UploadArtifacts
-            .Find(r => r.CreatedAt >= periodStart && r.Kind == "input_image")
-            .Project(r => new { r.CreatedByAdminId })
-            .ToListAsync();
-        var uploadByUser = uploadItems
-            .Where(r => !string.IsNullOrEmpty(r.CreatedByAdminId) && userIds.Contains(r.CreatedByAdminId))
-            .GroupBy(r => r.CreatedByAdminId)
-            .ToDictionary(g => g.Key, g => g.Count());
-
-        // --- 工作流执行 ---
-        var wfItems = await _db.WorkflowExecutions
-            .Find(w => w.CreatedAt >= periodStart)
-            .Project(w => new { w.TriggeredBy })
-            .ToListAsync();
-        var workflowByUser = wfItems
-            .Where(w => !string.IsNullOrEmpty(w.TriggeredBy) && userIds.Contains(w.TriggeredBy))
-            .GroupBy(w => w.TriggeredBy!)
-            .ToDictionary(g => g.Key, g => g.Count());
-
-        // --- 竞技场对战 ---
-        var arenaItems = await _db.ArenaBattles
-            .Find(a => a.CreatedAt >= periodStart)
-            .Project(a => new { a.UserId })
-            .ToListAsync();
-        var arenaByUser = arenaItems
-            .Where(a => !string.IsNullOrEmpty(a.UserId) && userIds.Contains(a.UserId))
-            .GroupBy(a => a.UserId)
-            .ToDictionary(g => g.Key, g => g.Count());
+        // --- 各活动维度：全部走服务端 $group，不再 Find().ToListAsync() 全量进内存 ---
+        var defectsCreatedByUser = await CountByUserAsync(_db.DefectReports,
+            d => d.CreatedAt >= periodStart, d => d.ReporterId, userIds);
+        // 口径修正：未解决缺陷 ResolvedById/ResolvedAt 为 null。原 `ResolvedAt >= periodStart`
+        // 在 days=0(periodStart=MinValue) 时会把未解决缺陷也算进"已解决"。显式要求非空。
+        var defectsResolvedByUser = await CountByUserAsync(_db.DefectReports,
+            d => d.ResolvedById != null && d.ResolvedAt != null && d.ResolvedAt >= periodStart,
+            d => d.ResolvedById, userIds);
+        var imageByUser = await CountByUserAsync(_db.ImageAssets,
+            r => r.CreatedAt >= periodStart, r => r.OwnerUserId, userIds);
+        var visualGenByUser = await CountByUserAsync(_db.ImageGenRuns,
+            r => r.CreatedAt >= periodStart && r.AppKey == "visual-agent" && r.Status == ImageGenRunStatus.Completed,
+            r => r.OwnerAdminId, userIds);
+        var literaryGenByUser = await CountByUserAsync(_db.ImageGenRuns,
+            r => r.CreatedAt >= periodStart && r.AppKey == "literary-agent" && r.Status == ImageGenRunStatus.Completed,
+            r => r.OwnerAdminId, userIds);
+        var uploadByUser = await CountByUserAsync(_db.UploadArtifacts,
+            r => r.CreatedAt >= periodStart && r.Kind == "input_image", r => r.CreatedByAdminId, userIds);
+        var workflowByUser = await CountByUserAsync(_db.WorkflowExecutions,
+            w => w.CreatedAt >= periodStart, w => w.TriggeredBy, userIds);
+        var arenaByUser = await CountByUserAsync(_db.ArenaBattles,
+            a => a.CreatedAt >= periodStart, a => a.UserId, userIds);
 
         // 用户列表 (按活跃度排序)
         var userList = humanUsers
@@ -601,24 +587,34 @@ public class ExecutiveController : ControllerBase
             })
             .ToList();
 
-        // 构建维度
-        var knownAgents = new[] { "prd-agent", "visual-agent", "literary-agent", "defect-agent", "ai-toolbox", "report-agent", "video-agent" };
+        // 构建维度。缺陷三列（defect-agent LLM 调用 / 缺陷提交 / 缺陷解决）合并为
+        // 单列「缺陷」= 真实提交数 + 解决数；defect-agent 不再单列（口径混乱）。
+        var knownAgents = new[] { "prd-agent", "visual-agent", "literary-agent", "ai-toolbox", "report-agent", "video-agent" };
         var dimensions = new List<object>();
 
         foreach (var appKey in knownAgents)
         {
             agentUserCounts.TryGetValue(appKey, out var vals);
-            dimensions.Add(new { key = appKey, name = ResolveAgentName(appKey), category = "agent", values = vals ?? new Dictionary<string, int>() });
+            dimensions.Add(MakeDim(appKey, ResolveAgentName(appKey), "agent", vals ?? new Dictionary<string, int>()));
         }
 
-        dimensions.Add(new { key = "defects-created", name = "缺陷提交", category = "activity", values = defectsCreatedByUser });
-        dimensions.Add(new { key = "defects-resolved", name = "缺陷解决", category = "activity", values = defectsResolvedByUser });
-        dimensions.Add(new { key = "images", name = "图片合计", category = "activity", values = imageByUser });
-        dimensions.Add(new { key = "image-gen-visual", name = "视觉生图", category = "image", values = visualGenByUser });
-        dimensions.Add(new { key = "image-gen-literary", name = "文学配图", category = "image", values = literaryGenByUser });
-        dimensions.Add(new { key = "image-upload", name = "上传参考图", category = "image", values = uploadByUser });
-        dimensions.Add(new { key = "workflows", name = "工作流执行", category = "activity", values = workflowByUser });
-        dimensions.Add(new { key = "arena", name = "竞技场对战", category = "activity", values = arenaByUser });
+        // 缺陷合并：values = 提交 + 解决；subValues 给 tooltip 拆解显示
+        var defectValues = new Dictionary<string, int>();
+        var defectSub = new Dictionary<string, object>();
+        foreach (var uid in defectsCreatedByUser.Keys.Union(defectsResolvedByUser.Keys))
+        {
+            var c = defectsCreatedByUser.GetValueOrDefault(uid);
+            var r = defectsResolvedByUser.GetValueOrDefault(uid);
+            defectValues[uid] = c + r;
+            defectSub[uid] = new { created = c, resolved = r };
+        }
+        dimensions.Add(MakeDim("defects", "缺陷", "activity", defectValues, defectSub));
+        dimensions.Add(MakeDim("images", "图片合计", "activity", imageByUser));
+        dimensions.Add(MakeDim("image-gen-visual", "视觉生图", "image", visualGenByUser));
+        dimensions.Add(MakeDim("image-gen-literary", "文学配图", "image", literaryGenByUser));
+        dimensions.Add(MakeDim("image-upload", "上传参考图", "image", uploadByUser));
+        dimensions.Add(MakeDim("workflows", "工作流执行", "activity", workflowByUser));
+        dimensions.Add(MakeDim("arena", "竞技场对战", "activity", arenaByUser));
 
         // 计算实际天数: days>0 时等于 days; days=0 时从最早的 LLM 日志到今天
         int totalDays;

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/SubmissionsController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/SubmissionsController.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using MongoDB.Bson;
 using MongoDB.Driver;
+using PrdAgent.Core.Helpers;
 using PrdAgent.Core.Models;
 using PrdAgent.Infrastructure.Database;
 using PrdAgent.Infrastructure.Services.AssetStorage;
@@ -211,14 +213,49 @@ public class SubmissionsController : ControllerBase
             filter &= Builders<Submission>.Filter.Eq(x => x.ContentType, contentType);
 
         var total = await _db.Submissions.CountDocumentsAsync(filter);
-        var sort = Builders<Submission>.Sort
-            .Descending(x => x.LikeCount)
-            .Descending(x => x.CreatedAt);
+
+        // 热度排序（带时间衰减），公式权威定义见 PrdAgent.Core.Helpers.GalleryRanking。
+        // ageHours = max(0, (NOW - CreatedAt) / 3600000ms)
+        // hot      = (LikeCount*LikeWeight + ViewCount) / pow(ageHours + 2, Gravity)
+        // 末尾按 _id desc 做稳定且唯一的 tiebreaker —— 彻底消除分页重复。
+        var matchDoc = filter.Render(new RenderArgs<Submission>(
+            _db.Submissions.DocumentSerializer,
+            _db.Submissions.Settings.SerializerRegistry));
+
+        var ageHoursExpr = new BsonDocument("$max", new BsonArray
+        {
+            0.0,
+            new BsonDocument("$divide", new BsonArray
+            {
+                new BsonDocument("$subtract", new BsonArray { "$$NOW", "$CreatedAt" }),
+                3600000.0,
+            }),
+        });
+
+        var pipeline = new[]
+        {
+            new BsonDocument("$match", matchDoc),
+            new BsonDocument("$set", new BsonDocument("_hot", new BsonDocument("$divide", new BsonArray
+            {
+                new BsonDocument("$add", new BsonArray
+                {
+                    new BsonDocument("$multiply", new BsonArray { "$LikeCount", GalleryRanking.LikeWeight }),
+                    "$ViewCount",
+                }),
+                new BsonDocument("$pow", new BsonArray
+                {
+                    new BsonDocument("$add", new BsonArray { ageHoursExpr, 2.0 }),
+                    GalleryRanking.Gravity,
+                }),
+            }))),
+            new BsonDocument("$sort", new BsonDocument { { "_hot", -1 }, { "_id", -1 } }),
+            new BsonDocument("$skip", skip),
+            new BsonDocument("$limit", limit),
+            new BsonDocument("$unset", "_hot"),
+        };
+
         var items = await _db.Submissions
-            .Find(filter)
-            .Sort(sort)
-            .Skip(skip)
-            .Limit(limit)
+            .Aggregate<Submission>(pipeline)
             .ToListAsync();
 
         // 查询当前用户是否已点赞

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/SubmissionsController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/SubmissionsController.cs
@@ -215,19 +215,31 @@ public class SubmissionsController : ControllerBase
         var total = await _db.Submissions.CountDocumentsAsync(filter);
 
         // 热度排序（带时间衰减），公式权威定义见 PrdAgent.Core.Helpers.GalleryRanking。
-        // ageHours = max(0, (NOW - CreatedAt) / 3600000ms)
+        // ageHours = max(0, (refNow - CreatedAt) / 3600000ms)
         // hot      = (LikeCount*LikeWeight + ViewCount) / pow(ageHours + 2, Gravity)
-        // 末尾按 _id desc 做稳定且唯一的 tiebreaker —— 彻底消除分页重复。
+        // 末尾按 _id desc 做稳定且唯一的 tiebreaker。
+        //
+        // refNow 不直接用 $$NOW：偏移分页（$skip/$limit）下，第 1 页与第 2 页若不是
+        // 同一瞬间发起，$$NOW 不同 → 时间衰减分被不同基准重算 → 边界作品在两页间漂移，
+        // 仍会出现重复/漏项。把基准时间按 10 分钟取桶（$dateTrunc），同一 10 分钟窗口内
+        // 所有翻页请求使用完全相同的基准 → 分页稳定；排名每 10 分钟刷新一次。
         var matchDoc = filter.Render(new RenderArgs<Submission>(
             _db.Submissions.DocumentSerializer,
             _db.Submissions.Settings.SerializerRegistry));
+
+        var refNowExpr = new BsonDocument("$dateTrunc", new BsonDocument
+        {
+            { "date", "$$NOW" },
+            { "unit", "minute" },
+            { "binSize", 10 },
+        });
 
         var ageHoursExpr = new BsonDocument("$max", new BsonArray
         {
             0.0,
             new BsonDocument("$divide", new BsonArray
             {
-                new BsonDocument("$subtract", new BsonArray { "$$NOW", "$CreatedAt" }),
+                new BsonDocument("$subtract", new BsonArray { refNowExpr, "$CreatedAt" }),
                 3600000.0,
             }),
         });

--- a/prd-api/src/PrdAgent.Core/Helpers/GalleryRanking.cs
+++ b/prd-api/src/PrdAgent.Core/Helpers/GalleryRanking.cs
@@ -1,0 +1,37 @@
+namespace PrdAgent.Core.Helpers;
+
+/// <summary>
+/// 作品广场热度排序公式（带时间衰减）。
+///
+/// 原排序是「点赞数 desc → 创建时间 desc」，老爆款永远霸榜，新作品永远沉底，
+/// 且分页缺稳定 tiebreaker 导致翻页重复。改为热度分 + 时间衰减后，新作品自然冒泡，
+/// 旧作品随时间退场。MongoDB 聚合管道里用等价表达式实现，本类是该公式的
+/// 唯一权威定义 + 单元测试锚点（SubmissionsController 的管道必须与此一致）。
+///
+/// 公式（HN/Reddit 风格柔和衰减）：
+///   hot = (likeCount * LikeWeight + viewCount) / pow(ageHours + 2, Gravity)
+/// </summary>
+public static class GalleryRanking
+{
+    /// <summary>点赞相对浏览的权重（1 个赞 ≈ 3 次浏览）</summary>
+    public const double LikeWeight = 3.0;
+
+    /// <summary>时间衰减指数，越大旧作品掉得越快</summary>
+    public const double Gravity = 1.5;
+
+    /// <summary>
+    /// 计算热度分。ageHours 为作品已发布的小时数（负数按 0 处理，防止未来时间刷分）。
+    /// </summary>
+    public static double HotScore(int likeCount, int viewCount, double ageHours)
+    {
+        if (ageHours < 0) ageHours = 0;
+        var engagement = likeCount * LikeWeight + viewCount;
+        return engagement / Math.Pow(ageHours + 2.0, Gravity);
+    }
+
+    /// <summary>
+    /// 计算热度分（按创建时间与当前时间推导 ageHours）。
+    /// </summary>
+    public static double HotScore(int likeCount, int viewCount, DateTime createdAtUtc, DateTime nowUtc)
+        => HotScore(likeCount, viewCount, (nowUtc - createdAtUtc).TotalHours);
+}

--- a/prd-api/tests/PrdAgent.Api.Tests/Integration/ExecutiveLeaderboardCrossValidationTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Integration/ExecutiveLeaderboardCrossValidationTests.cs
@@ -1,0 +1,232 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Driver;
+using PrdAgent.Core.Models;
+using PrdAgent.Infrastructure.Database;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PrdAgent.Api.Tests.Integration;
+
+/// <summary>
+/// Executive 排行榜「服务端聚合重构」的交叉验证测试。
+///
+/// 用户明确要求："别把数据搞错了，注意交叉验证测试代码"。
+/// 本测试用一条**独立的暴力重算路径**（直接 Find + 内存分组）重算每个维度的
+/// per-user 计数，再与重构后的 `/api/executive/leaderboard` 端点（服务端 $group）
+/// 输出逐用户比对，证明"新聚合 == 独立重算"。
+///
+/// 同时锁定本次口径修正：未解决的缺陷不得计入"解决数"。
+///
+/// 需要：真实 MongoDB + AI_ACCESS_KEY。CI 跳过（Category=Integration），CDS 灰度跑。
+///   cd prd-api
+///   dotnet test --filter "FullyQualifiedName~ExecutiveLeaderboardCrossValidationTests" --logger "console;verbosity=detailed"
+/// </summary>
+[Collection("Integration")]
+[Trait("Category", TestCategories.Integration)]
+public class ExecutiveLeaderboardCrossValidationTests
+    : IClassFixture<WebApplicationFactory<Program>>, IAsyncLifetime
+{
+    private readonly WebApplicationFactory<Program> _factory;
+    private readonly ITestOutputHelper _output;
+    private string? _aiAccessKey;
+
+    public ExecutiveLeaderboardCrossValidationTests(WebApplicationFactory<Program> factory, ITestOutputHelper output)
+    {
+        _factory = factory;
+        _output = output;
+    }
+
+    private void Log(string m) => _output.WriteLine(m);
+
+    public Task InitializeAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var config = scope.ServiceProvider.GetRequiredService<IConfiguration>();
+        _aiAccessKey = (config["AI_ACCESS_KEY"] ?? "").Trim();
+        Log(string.IsNullOrWhiteSpace(_aiAccessKey)
+            ? "[Init] AI_ACCESS_KEY 未配置，测试将跳过"
+            : "[Init] AI_ACCESS_KEY found");
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private HttpClient CreateClient(string impersonate)
+    {
+        var c = _factory.CreateClient();
+        c.DefaultRequestHeaders.Add("X-AI-Access-Key", _aiAccessKey);
+        c.DefaultRequestHeaders.Add("X-AI-Impersonate", impersonate);
+        return c;
+    }
+
+    private bool Ready => !string.IsNullOrWhiteSpace(_aiAccessKey);
+
+    // 独立复刻 NormalizeAppKey（故意独立实现，作为交叉验证的"另一双眼"）
+    private static readonly Dictionary<string, string> Aliases = new(StringComparer.OrdinalIgnoreCase)
+    {
+        { "prd-agent-desktop", "prd-agent" }, { "prd-agent-web", "prd-agent" },
+        { "open-platform-agent", "open-platform" }, { "workflow-agent", "ai-toolbox" },
+        { "tutorial-email", "ai-toolbox" },
+    };
+    private static readonly HashSet<string> KnownKeys = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "prd-agent", "visual-agent", "literary-agent", "defect-agent",
+        "ai-toolbox", "open-platform", "report-agent", "video-agent",
+    };
+    private static string NormalizeAppKey(string code)
+    {
+        var dot = code.IndexOf('.');
+        var key = dot > 0 ? code[..dot] : code;
+        if (Aliases.TryGetValue(key, out var n)) key = n;
+        if (!KnownKeys.Contains(key)) key = "admin";
+        return key;
+    }
+
+    [Fact]
+    public async Task Leaderboard_AggregationMatches_IndependentRecompute_AllTime()
+    {
+        if (!Ready) { Log("[Skip] 无 AI_ACCESS_KEY"); return; }
+
+        var client = CreateClient("admin");
+        var resp = await client.GetAsync("/api/executive/leaderboard?days=0");
+        if (resp.StatusCode == HttpStatusCode.Forbidden || resp.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            client = CreateClient("root");
+            resp = await client.GetAsync("/api/executive/leaderboard?days=0");
+        }
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var data = body.GetProperty("data");
+        var dims = data.GetProperty("dimensions");
+
+        // 端点返回：dimensionKey -> { userId -> count }
+        var endpoint = new Dictionary<string, Dictionary<string, int>>();
+        foreach (var d in dims.EnumerateArray())
+        {
+            var key = d.GetProperty("key").GetString()!;
+            var vals = new Dictionary<string, int>();
+            foreach (var kv in d.GetProperty("values").EnumerateObject())
+                vals[kv.Name] = kv.Value.GetInt32();
+            endpoint[key] = vals;
+        }
+
+        // ── 独立暴力重算（all-time: periodStart = MinValue）──
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MongoDbContext>();
+        var start = DateTime.MinValue;
+
+        var users = await db.Users.Find(_ => true).ToListAsync();
+        var userIds = users.Where(u => u.UserType != UserType.Bot).Select(u => u.UserId).ToHashSet();
+
+        // 缺陷：提交 + 解决（口径修正：仅 ResolvedById/ResolvedAt 非空才算解决）
+        var allDefects = await db.DefectReports.Find(_ => true).ToListAsync();
+        var refDefects = new Dictionary<string, int>();
+        foreach (var grp in allDefects.Where(d => userIds.Contains(d.ReporterId))
+                                      .GroupBy(d => d.ReporterId))
+            refDefects[grp.Key] = grp.Count();
+        foreach (var d in allDefects.Where(d => d.ResolvedById != null
+                                             && d.ResolvedAt != null
+                                             && userIds.Contains(d.ResolvedById!)))
+            refDefects[d.ResolvedById!] = refDefects.GetValueOrDefault(d.ResolvedById!) + 1;
+
+        AssertDimEquals("defects", refDefects, endpoint);
+
+        // 图片合计
+        var imgs = await db.ImageAssets.Find(_ => true).Project(r => new { r.OwnerUserId }).ToListAsync();
+        AssertDimEquals("images", GroupCount(imgs.Select(x => x.OwnerUserId), userIds), endpoint);
+
+        // 视觉生图 / 文学配图（仅 Completed）
+        var gens = await db.ImageGenRuns
+            .Find(r => r.Status == ImageGenRunStatus.Completed)
+            .Project(r => new { r.OwnerAdminId, r.AppKey }).ToListAsync();
+        AssertDimEquals("image-gen-visual",
+            GroupCount(gens.Where(x => x.AppKey == "visual-agent").Select(x => x.OwnerAdminId), userIds), endpoint);
+        AssertDimEquals("image-gen-literary",
+            GroupCount(gens.Where(x => x.AppKey == "literary-agent").Select(x => x.OwnerAdminId), userIds), endpoint);
+
+        // 上传参考图
+        var ups = await db.UploadArtifacts.Find(r => r.Kind == "input_image")
+            .Project(r => new { r.CreatedByAdminId }).ToListAsync();
+        AssertDimEquals("image-upload", GroupCount(ups.Select(x => x.CreatedByAdminId), userIds), endpoint);
+
+        // 工作流执行
+        var wfs = await db.WorkflowExecutions.Find(_ => true).Project(w => new { w.TriggeredBy }).ToListAsync();
+        AssertDimEquals("workflows", GroupCount(wfs.Select(x => x.TriggeredBy), userIds), endpoint);
+
+        // 竞技场
+        var ars = await db.ArenaBattles.Find(_ => true).Project(a => new { a.UserId }).ToListAsync();
+        AssertDimEquals("arena", GroupCount(ars.Select(x => x.UserId), userIds), endpoint);
+
+        // Agent 维度（LLM + API 合并；defect-agent 已不再单列）
+        var llm = await db.LlmRequestLogs
+            .Find(l => l.AppCallerCode != null && l.UserId != null)
+            .Project(l => new { l.AppCallerCode, l.UserId }).ToListAsync();
+        var api = await db.ApiRequestLogs
+            .Find(l => l.Method != "GET" && l.StatusCode >= 200 && l.StatusCode < 400)
+            .Project(l => new { l.Path, l.UserId }).ToListAsync();
+
+        var prefixes = new Dictionary<string, string>
+        {
+            { "/api/prd-agent/", "prd-agent" }, { "/api/visual-agent/", "visual-agent" },
+            { "/api/literary-agent/", "literary-agent" }, { "/api/defect-agent/", "defect-agent" },
+            { "/api/ai-toolbox/", "ai-toolbox" }, { "/api/report-agent/", "report-agent" },
+            { "/api/video-agent/", "video-agent" },
+        };
+        var refAgents = new Dictionary<string, Dictionary<string, int>>();
+        foreach (var l in llm.Where(x => x.UserId != null && userIds.Contains(x.UserId!)))
+        {
+            var k = NormalizeAppKey(l.AppCallerCode ?? "");
+            if (string.IsNullOrEmpty(k)) continue;
+            var inner = refAgents.TryGetValue(k, out var i) ? i : (refAgents[k] = new());
+            inner[l.UserId!] = inner.GetValueOrDefault(l.UserId!) + 1;
+        }
+        foreach (var l in api.Where(x => x.UserId != null && x.UserId != "anonymous" && userIds.Contains(x.UserId!)))
+        {
+            string? k = null;
+            foreach (var p in prefixes)
+                if (l.Path != null && l.Path.StartsWith(p.Key, StringComparison.OrdinalIgnoreCase)) { k = p.Value; break; }
+            if (k == null) continue;
+            var inner = refAgents.TryGetValue(k, out var i) ? i : (refAgents[k] = new());
+            inner[l.UserId!] = inner.GetValueOrDefault(l.UserId!) + 1;
+        }
+
+        foreach (var appKey in new[] { "prd-agent", "visual-agent", "literary-agent", "ai-toolbox", "report-agent", "video-agent" })
+            AssertDimEquals(appKey, refAgents.GetValueOrDefault(appKey) ?? new(), endpoint);
+
+        // defect-agent 不应再作为单列出现
+        Assert.False(endpoint.ContainsKey("defect-agent"), "defect-agent 应已合并进「缺陷」列");
+        Assert.False(endpoint.ContainsKey("defects-created"), "提缺陷列应已合并");
+        Assert.False(endpoint.ContainsKey("defects-resolved"), "解缺陷列应已合并");
+    }
+
+    private static Dictionary<string, int> GroupCount(IEnumerable<string?> ids, HashSet<string> userIds)
+    {
+        var d = new Dictionary<string, int>();
+        foreach (var id in ids)
+            if (!string.IsNullOrEmpty(id) && userIds.Contains(id))
+                d[id] = d.GetValueOrDefault(id) + 1;
+        return d;
+    }
+
+    private void AssertDimEquals(string key,
+        Dictionary<string, int> expected,
+        Dictionary<string, Dictionary<string, int>> endpoint)
+    {
+        Assert.True(endpoint.TryGetValue(key, out var actual), $"端点缺少维度 {key}");
+        // 只比对非零项（双方都不写 0 项）
+        var expectedNz = expected.Where(kv => kv.Value > 0).ToDictionary(kv => kv.Key, kv => kv.Value);
+        foreach (var (uid, cnt) in expectedNz)
+            Assert.True(actual!.TryGetValue(uid, out var a) && a == cnt,
+                $"[{key}] 用户 {uid}: 期望 {cnt}, 实际 {(actual!.TryGetValue(uid, out var x) ? x : 0)}");
+        foreach (var (uid, cnt) in actual!.Where(kv => kv.Value > 0))
+            Assert.True(expectedNz.TryGetValue(uid, out var e) && e == cnt,
+                $"[{key}] 端点多出用户 {uid}={cnt}（独立重算无此值）");
+        Log($"[OK] 维度 {key} 交叉验证通过（{expectedNz.Count} 个非零用户）");
+    }
+}

--- a/prd-api/tests/PrdAgent.Tests/GalleryRankingTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GalleryRankingTests.cs
@@ -1,0 +1,76 @@
+using PrdAgent.Core.Helpers;
+using Xunit;
+
+namespace PrdAgent.Tests;
+
+/// <summary>
+/// 作品广场热度排序公式测试（CI 可运行，纯函数无需 Mongo）。
+///
+/// 这是 SubmissionsController 聚合管道排序的权威公式锚点：
+/// 管道里的 (LikeCount*LikeWeight + ViewCount) / pow(ageHours+2, Gravity)
+/// 必须与 GalleryRanking.HotScore 行为一致。
+/// </summary>
+public class GalleryRankingTests
+{
+    [Fact]
+    public void NewWork_WithFewerLikes_CanOutrank_OldViralWork()
+    {
+        // 老爆款：100 赞，发布 30 天前（720 小时）
+        var oldViral = GalleryRanking.HotScore(likeCount: 100, viewCount: 500, ageHours: 720);
+        // 新作品：10 赞，刚发布 1 小时
+        var freshWork = GalleryRanking.HotScore(likeCount: 10, viewCount: 20, ageHours: 1);
+
+        Assert.True(freshWork > oldViral,
+            $"新作品应能冒泡到老爆款之上 (fresh={freshWork}, oldViral={oldViral})");
+    }
+
+    [Fact]
+    public void SameEngagement_OlderWork_ScoresLower()
+    {
+        var younger = GalleryRanking.HotScore(50, 100, ageHours: 2);
+        var older = GalleryRanking.HotScore(50, 100, ageHours: 200);
+
+        Assert.True(younger > older, "相同互动量下，越旧的作品热度越低（时间衰减单调）");
+    }
+
+    [Fact]
+    public void MoreLikes_SameAge_ScoresHigher()
+    {
+        var low = GalleryRanking.HotScore(5, 0, ageHours: 10);
+        var high = GalleryRanking.HotScore(50, 0, ageHours: 10);
+
+        Assert.True(high > low, "同龄作品点赞越多热度越高");
+    }
+
+    [Fact]
+    public void LikeIsWeightedHeavierThanView()
+    {
+        // 1 个赞应当显著重于 1 次浏览（LikeWeight = 3）
+        var oneLike = GalleryRanking.HotScore(likeCount: 1, viewCount: 0, ageHours: 5);
+        var oneView = GalleryRanking.HotScore(likeCount: 0, viewCount: 1, ageHours: 5);
+
+        Assert.Equal(GalleryRanking.LikeWeight, oneLike / oneView, precision: 6);
+    }
+
+    [Fact]
+    public void NegativeAge_IsClampedToZero_NoFutureBoost()
+    {
+        // 未来时间（负 ageHours）不应刷出更高分，按 0 处理
+        var future = GalleryRanking.HotScore(10, 10, ageHours: -100);
+        var atZero = GalleryRanking.HotScore(10, 10, ageHours: 0);
+
+        Assert.Equal(atZero, future, precision: 9);
+    }
+
+    [Fact]
+    public void DateTimeOverload_MatchesAgeHoursOverload()
+    {
+        var now = new DateTime(2026, 5, 17, 12, 0, 0, DateTimeKind.Utc);
+        var createdAt = now.AddHours(-48);
+
+        var viaDate = GalleryRanking.HotScore(20, 40, createdAt, now);
+        var viaHours = GalleryRanking.HotScore(20, 40, ageHours: 48);
+
+        Assert.Equal(viaHours, viaDate, precision: 9);
+    }
+}


### PR DESCRIPTION
## 摘要

本 PR 包含三个主要改进：
1. **Executive 排行榜性能优化**：将全集合 Find 进内存改为 MongoDB 服务端 $group 聚合，消除 per-user N+1 查询
2. **缺陷统计口径修正**：未解决的缺陷（ResolvedById/ResolvedAt 为 null）不再被计入"已解决"数
3. **作品广场热度排序**：引入时间衰减公式，新作品自然冒泡，消除翻页重复

## 改动 diff

### 后端（prd-api）

- **ExecutiveController.cs**
  - 新增 `CountByUserAsync<T>()` 通用方法：服务端 $group 聚合，返回 per-user 计数字典
  - 新增 `DimMeta` 静态字典：维度元数据（口径说明、怎么+1、排除异常），前端直接渲染，消除硬编码
  - 新增 `MakeDim()` 方法：构建维度对象，自动填充元数据
  - `GetTeam()` 端点：改为 5 次服务端 $group（消除原来的 per-user 5 次 CountDocumentsAsync）
  - `GetLeaderboard()` 端点：
    - LLM 维度改为服务端 $group by {AppCallerCode, UserId}，再在内存做 NormalizeAppKey 映射
    - API 维度改为服务端 $group by {Path, UserId}，再在内存做路由前缀匹配
    - 缺陷、图片、工作流、竞技场等 8 个维度全部改为 CountByUserAsync
    - 缺陷"已解决"口径修正：显式要求 `ResolvedById != null && ResolvedAt != null`
    - 移除 defect-agent 单列，缺陷改为单列（提交数 + 解决数合计）

- **SubmissionsController.cs**
  - `ListPublicSubmissions()` 改为 MongoDB 聚合管道热度排序
  - 新增 $set 阶段计算 `_hot` 字段：`(LikeCount*3 + ViewCount) / pow(ageHours+2, 1.5)`
  - 新增 $sort 阶段：`{_hot: -1, _id: -1}`（热度 desc + _id desc 稳定 tiebreaker）
  - 消除原来的"点赞 desc → 创建时间 desc"导致的老爆款永霸榜问题

- **GalleryRanking.cs**（新增）
  - 热度排序公式权威定义：`HotScore(likeCount, viewCount, ageHours)`
  - 常数：`LikeWeight = 3.0`（1 赞 ≈ 3 次浏览）、`Gravity = 1.5`（时间衰减指数）
  - 两个重载：按 ageHours 或按 DateTime 计算

### 前端（prd-admin）

- **ExecutiveDashboardPage.tsx**
  - 新增 `DimHelp()` 组件：渲染维度问号 tooltip，展示后端下发的 description/howToIncrease/anomalyNote
  - 更新 `DIMENSION_META`：移除 defect

https://claude.ai/code/session_016hqCqftLr75jea1QTty6sa

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes production ranking/leaderboard business logic and replaces multiple queries with MongoDB aggregation pipelines, which can affect correctness and performance if edge cases or index coverage differ.
> 
> **Overview**
> **Executive dashboard stats are reworked for correctness and scale.** The API now computes team/leaderboard per-user metrics via MongoDB `$match/$group` aggregations (including API-path normalization in-pipeline) instead of in-memory scans and per-user N+1 queries, and fixes defect “resolved” counts to exclude unresolved items.
> 
> **Leaderboard dimensions and UI are updated.** The backend now returns per-dimension help text (description/how-to/anomaly notes) and merges defect-related columns into a single `defects` dimension with per-user `subValues`; the admin dashboard renders these as “?” tooltips and shows defect submit/resolve breakdown on hover.
> 
> **Public gallery ranking changes.** `ListPublicSubmissions` switches from like/time sorting to a time-decayed hot score (bucketed reference time + `_id` tiebreaker to prevent cross-request pagination drift), backed by a new `GalleryRanking` helper and added unit/integration tests (including cross-validation of the new leaderboard aggregations).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e982be5fabf6418502e398225322e31fdf47b685. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->