### PR TITLE
每日熵减计划 2026-W21 — CDS changelog 入库 5 条

### DIFF
--- a/changelogs/.entropy-manifest.yml
+++ b/changelogs/.entropy-manifest.yml
@@ -36,3 +36,8 @@ processed:
   - 2026-05-13_cds-light-icon-contrast.md
   - 2026-05-13_cds-light-shape-backdrop.md
   - 2026-05-13_cds-map-authorize-flow.md
+  - 2026-05-13_cds-nacos-icon-legibility.md
+  - 2026-05-13_cds-preview-asset-mime.md
+  - 2026-05-13_cds-preview-error-state.md
+  - 2026-05-13_cds-project-switcher-name.md
+  - 2026-05-13_cds-rail-shiny-logo.md

--- a/doc/design.cds.md
+++ b/doc/design.cds.md
@@ -507,3 +507,8 @@ target: `http://localhost:${process.env.VITE_API_PORT || 5000}`
 | fix | cds | 分支列表首屏快路径跳过 worktree git log，进一步缩短首屏等待 |
 | fix | cds | 扩大提交实时流记录点击热区，并为提交标签增加状态图标 |
 | fix | cds | 优化提交实时流面板信息密度，折叠态显示最新分支与精确更新时间 |
+| fix | cds | 将项目卡片 Nacos 单字母标识改为更清晰的 Na 专用标识 |
+| fix | cds | 修复预览等待页误把模块资源请求返回为 HTML 导致 MIME 报错的问题 |
+| fix | cds | 修复失败分支访问预览页会反复触发自动部署的问题，并同步失败服务与错误信息到分支卡片 |
+| fix | cds | 统一分支页项目切换器显示口径，优先展示项目名并保留 slug 辅助识别 |
+| fix | cds | 使用 React Bits ShinyText 优化左侧 CDS 标识，加入克制的银白扫光动效 |


### PR DESCRIPTION
自动生成的每日熵减 PR。

## 修复项

- **D6 changelog 入库（5 条）**：将 2026-05-13 的 5 条 CDS 修复记录录入 `design.cds.md` 近期变更记录（§13），并更新 `changelogs/.entropy-manifest.yml` 标记已处理。
  - `cds-nacos-icon-legibility`：Nacos 标识由单字母改为 Na
  - `cds-preview-asset-mime`：修复预览等待页 MIME 报错
  - `cds-preview-error-state`：修复失败分支预览页反复触发自动部署
  - `cds-project-switcher-name`：统一项目切换器显示口径
  - `cds-rail-shiny-logo`：CDS 标识加入银白扫光动效

## 跳过项（diff 核验通过，无删除行）

- D1：无命名规范违规
- D2：index.yml 双向一致，无欠款
- D3：guide.list 幽灵条目均在变更历史区（历史记录），非主列表条目，安全跳过
- D4：`**pnpm**` 出现在规则文本中非技能表行，假阳性，跳过

## 改动文件

- `doc/design.cds.md`：§13 追加 5 行（纯追加，无删除）
- `changelogs/.entropy-manifest.yml`：追加 5 条已处理记录（纯追加，无删除）

https://claude.ai/code/session_01AStS952YQH5s2PoyQXKwMG

---
_Generated by [Claude Code](https://claude.ai/code/session_01AStS952YQH5s2PoyQXKwMG)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only appends changelog/manifest entries; no runtime code or behavior changes. Risk is limited to documentation accuracy/consistency.
> 
> **Overview**
> Updates CDS documentation changelog by appending **5 new 2026-05-13 fix entries** to `doc/design.cds.md` (Nacos icon legibility, preview asset MIME handling, preview error-state auto-deploy loop, project switcher naming, and sidebar logo shimmer effect).
> 
> Marks the corresponding changelog fragments as processed by adding them to `changelogs/.entropy-manifest.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4144a2f09940c24ba91b15201fbfb384efbdbe1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->