### PR TITLE
每日熵减计划 2026-W21 — changelog manifest 补录 5 条

### DIFF
--- a/changelogs/.entropy-manifest.yml
+++ b/changelogs/.entropy-manifest.yml
@@ -41,3 +41,8 @@ processed:
   - 2026-05-13_cds-preview-error-state.md
   - 2026-05-13_cds-project-switcher-name.md
   - 2026-05-13_cds-rail-shiny-logo.md
+  - 2026-05-13_cds-shapegrid-panels.md
+  - 2026-05-13_cds-waiting-room-magic-rings.md
+  - 2026-05-13_cds-web-pnpm-build-approval.md
+  - 2026-05-13_changelog-tabs-rename.md
+  - 2026-05-13_dockdrag-defer-preventdefault.md


### PR DESCRIPTION
自动生成的每日熵减 PR。

## 修复项
- D6: changelog manifest 补录 5 个未处理碎片（2026-05-13）
  - `2026-05-13_cds-shapegrid-panels.md`
  - `2026-05-13_cds-waiting-room-magic-rings.md`
  - `2026-05-13_cds-web-pnpm-build-approval.md`
  - `2026-05-13_changelog-tabs-rename.md`
  - `2026-05-13_dockdrag-defer-preventdefault.md`

## 跳过项（diff 核验未通过 / 误报）
- D3 幽灵（20 项）：均来自 guide.list.directory.md 历史变更表格或散文行内引用（带 `.md` 后缀的幻象双重匹配），非实际文档列表条目，跳过删除
- D4 幽灵 `pnpm`：来自 CLAUDE.md 规则 #1 加粗文本强调，非技能目录引用，跳过

## 扫描摘要
| 维度 | 结果 |
|------|------|
| D1 命名违规 | 0 项 |
| D2 index.yml | 0 项 |
| D3 guide.list | 20 项误报（均为历史表/散文引用，未修改） |
| D4 CLAUDE.md 技能表 | 1 项误报（pnpm 文本强调，未修改） |
| D6 changelog manifest | 5 项已录入 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnpdRrrXnC1KJ2H8VGm2S2)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates a changelog tracking manifest and does not affect runtime code paths.
> 
> **Overview**
> Updates `changelogs/.entropy-manifest.yml` to **backfill five missing** `2026-05-13` changelog fragment filenames in the `processed` list so they’re tracked as handled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0c97771be7eafeecde6a8d73033cfc6da80821d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->