### PR TITLE
feat(prd-admin): 打通 AI Toolbox 快速创建向导知识库上传

### DIFF
--- a/changelogs/2026-05-21_ai-toolbox-quick-wizard-knowledge-base.md
+++ b/changelogs/2026-05-21_ai-toolbox-quick-wizard-knowledge-base.md
@@ -1,0 +1,2 @@
+| feat | prd-admin | AI Toolbox 快速创建向导第 3 步打通知识库上传（替换原"即将上线"占位符，复用 ToolEditor 同一套 attachment 上传与 prompt 注入通路） |
+| docs | doc | 新增 debt.knowledge-base 债务台账（含 RAG/embedding 未做、两套知识库并存等 8 条 open） |

--- a/doc/debt.knowledge-base.md
+++ b/doc/debt.knowledge-base.md
@@ -1,0 +1,57 @@
+# debt.knowledge-base
+
+| 字段 | 内容 |
+|---|---|
+| 模块 | 知识库（AI Toolbox `KnowledgeBaseIds` + 文档空间 `document_stores`） |
+| 状态 | open |
+| 关联 | `prd-api/src/PrdAgent.Api/Controllers/Api/AiToolboxController.cs`、`prd-api/src/PrdAgent.Api/Controllers/Api/DocumentStoreController.cs`、`prd-admin/src/pages/ai-toolbox/components/*.tsx` |
+
+---
+
+## 背景
+
+2026-05-21 review 发现两个层面的债务：
+
+1. AI Toolbox 的【快速创建向导】(`QuickCreateWizard.tsx`) 第 3 步「测试调优」面板的"知识库"区块**长期是禁用占位符**（"即将上线"），而完整版编辑器 `ToolEditor.tsx` 早就把上传 + 注入跑通了。本次 PR 把占位符替换为可用 UI（复用 `ToolEditor` 同一套 `uploadAttachment` + `attachmentId → KnowledgeBaseIds` 路径），但同时暴露了更深层的架构与功能债务。
+
+2. 系统并存**两套"知识库"实现**，命名相同语义不同，长期没整合。
+
+---
+
+## 已知工程债务
+
+| ID | 说明 | 优先级 | 触发条件 | 状态 |
+|---|---|---|---|---|
+| K-1 | **两套"知识库"并存**：AI Toolbox 的 `ToolboxItem.KnowledgeBaseIds` 指向 `attachments` 集合（每条 `Attachment` 自带 `ExtractedText`，prompt 拼装时整篇拼接，见 `AiToolboxController.cs:1197-1212`），而独立的「文档空间」走 `document_stores` + `document_entries` 集合，有更完整的多类型、订阅源、版本、view event 等能力。两套数据流不通，AI Toolbox 选不到文档空间里已经管理好的文档。建议规划"统一知识库"模型：AI Toolbox 改为引用 `documentEntryId`（或一个虚拟 store 包一组 attachment），并写一次迁移把存量 attachment 落入 document_stores。 | **P2** | 用户开始把同一份文档既上传到智能体又导到文档空间，或要求"我已经在文档空间里有这堆 PDF，直接关联给智能体" | open |
+| K-2 | **无 RAG / Embedding / 语义检索**：`AiToolboxController.cs:1197-1212` 把所有绑定文档的 `ExtractedText` 全量拼到 system prompt 里。文档稍微多 / 稍微大就会把 prompt 撑爆 token。`design.multi-doc-knowledge.md:334` 把这件事标为 Phase 3（未来），但没有项目计划承接。借用法则（`no-rootless-tree.md`）建议借外部 Embedding 服务而不是自建，但需要：(a) LLM Gateway 增加 `embedding` ModelType 调度路径；(b) chunk 切分策略（按段落 / 按 token 数 / 按文档类型）；(c) 向量存储（MongoDB Atlas Vector Search vs 自建索引）；(d) 检索召回 + 重排 + 注入。 | **P1**（中型功能立项） | 出现"上传了 10+ 文档导致对话被截断 / 慢 / 上下文超限"的反馈 | open |
+| K-3 | **AI Toolbox 占位符里曾误导用户**：替换前的 `QuickCreateWizard.tsx:1460-1472` 写"即将上线"，让用户以为功能即将就绪，但底层数据通路（DTO、Model、Controller 注入）早已 ready。这种"前端 UI 写 wip 标签 vs 后端早已 ready"的不一致没有自动巡检手段，未来类似情况可能继续出现。建议在 `navCoverage.test.ts` 类似的 CI 守卫里加一条："禁止 UI 出现「即将上线」/「敬请期待」字样的 disabled 按钮 —— 要么标 TODO 接通，要么去掉。" | P3 | 下次新 PR 又留下"即将上线"占位符 | open |
+| K-4 | **`uploadAttachment` 与 `documentstore/entries/upload` API 不互通**：AI Toolbox 走 `POST /api/ai-toolbox/upload-attachment`（返回 `attachmentId`），文档空间走 `POST /api/document-store/stores/{id}/entries/upload`（返回 `entryId`）。两个端点各有 mime 解析、文本抽取、缓存逻辑，未来文档解析能力升级（如新增 Excel 智能化抽取）需双改。建议合并到一个上传 service。 | P3 | 升级 PDF/Word 抽取库 / 新增 Excel 表格化抽取时双向同步 | open |
+| K-5 | **不存"原始 KB 选择来源"**：AI Toolbox 智能体的 `KnowledgeBaseIds` 只存 `attachmentId`，不区分"用户当时是直接上传文件" vs"从文档空间选了一个 entry"。一旦 K-1 落地后会丢失这层语义，难以反向追溯。建议增加 `KnowledgeBaseSources: List<{type: "attachment"\|"document-entry", id}>` 结构存原始引用。 | P3 | K-1 立项后 | blocked-on-K-1 |
+| K-6 | **缺少"按 documentType 过滤"的技能权重**：`design.multi-doc-knowledge.md:604` 标"未来（documentType 级别）"。当前技能只能 `contextScope=all/current/prd/none`，不能说"我这个技能只看 product 类型的文档"。整合 K-1 时一起做。 | P3 | K-1 立项后 | blocked-on-K-1 |
+| K-7 | **访问统计无应用层消费**：`document_store_view_events` 集合已经在记数据（含 `ViewDedupWindow` 去重），但没有"热度排序"、"用户协同推荐"、"最近访问的知识库快速接入智能体"之类的应用。 | P4 | 用户反馈"找不到我之前上传过的文档"时 | open |
+| K-8 | **二进制文档抽取能力有限**：Excel/CSV 当前按纯文本对待，无表格结构化提取；代码仓库（如 GitHub repo）无自动同步接口（SyncWorker 框架已有，但 GitHub 集成代码未确认完整）。 | P3 | 用户要求把 Excel 报表 / GitHub README 作为知识源时 | open |
+
+---
+
+## 还债计划草稿
+
+**短期（本 PR 已交付）**：
+- 把 `QuickCreateWizard.tsx` 占位符替换为可用 UI，复用 `ToolEditor.tsx` 的上传/拼装通路。
+
+**中期（K-1 + K-2 一并立项）**：
+- 起 `spec.unified-knowledge-base.md`：定义统一模型 + 迁移策略 + RAG 接入边界
+- LLM Gateway 增加 embedding ModelType 调度路径
+- 选定向量存储方案（建议 MongoDB Atlas Vector Search，省得自建索引）
+- 现有 `attachments` → 新 `knowledge_chunks` 集合的数据迁移脚本
+
+**长期（K-3、K-4、K-7、K-8）**：
+- 在统一 KB 落地后顺势处理 wip 标签 CI 守卫、上传 service 合并、访问统计应用、文档类型扩展。
+
+---
+
+## 相关文档
+
+- `design.document-store.md` —— 文档空间设计
+- `design.multi-doc-knowledge.md` —— 多文档知识库设计（含 Phase 3 RAG 未做的明确标记）
+- `.claude/rules/no-rootless-tree.md` —— 借用法则
+- `.claude/rules/codebase-snapshot.md` —— 现有快照里"RAG/embedding 未实现"的说法在此处固化

--- a/doc/guide.list.directory.md
+++ b/doc/guide.list.directory.md
@@ -656,6 +656,9 @@
 - [CDS compose 模板 TODO secrets · 债务台账](debt.cds-compose-secrets) `debt.cds-compose-secrets`
   > 2 条 open：x-cds-env TODO secrets 致全量 import 必被拒 / admin static 每次冷 vite build 就绪窗口紧绷
 
+- [知识库（AI Toolbox attachment + 文档空间）债务台账](debt.knowledge-base) `debt.knowledge-base`
+  > 8 条 open：两套并存模型 / RAG embedding 未做 / wip 标签 CI 守卫 / 上传 API 不互通 / 等
+
 ### 七、周报
 
 - [CDS Agent 商业级可用闭环目标审计报告](report.cds-agent-goal-completion-audit-2026-05-19) `report.cds-agent-goal-completion-audit-2026-05-19`

--- a/doc/index.yml
+++ b/doc/index.yml
@@ -248,6 +248,7 @@ docs:
   debt.claude-sdk-executor: Claude SDK 执行器 / Python sidecar 债务台账
   debt.cds-state-json: CDS state.json 影子存储债务台账
   debt.cds-compose-secrets: CDS compose 模板 TODO secrets / 全量 import 被拒债务台账
+  debt.knowledge-base: 知识库（AI Toolbox attachment + 文档空间）债务台账
 
   # ── 七、周报（降序：最新在前）──
   report.cds-agent-goal-completion-audit-2026-05-19: CDS Agent 商业级可用闭环目标审计报告

--- a/prd-admin/src/pages/ai-toolbox/components/QuickCreateWizard.tsx
+++ b/prd-admin/src/pages/ai-toolbox/components/QuickCreateWizard.tsx
@@ -870,6 +870,7 @@ export function QuickCreateWizard() {
 
   const handleSelectTemplate = (template: AgentTemplate) => {
     setSelectedTemplate(template);
+    setKnowledgeFiles([]);
     setForm((prev) => ({
       ...prev,
       name: template.name,
@@ -886,6 +887,7 @@ export function QuickCreateWizard() {
 
   const handleBlankCreate = () => {
     setSelectedTemplate(null);
+    setKnowledgeFiles([]);
     setForm((prev) => ({
       ...prev,
       name: '',

--- a/prd-admin/src/pages/ai-toolbox/components/QuickCreateWizard.tsx
+++ b/prd-admin/src/pages/ai-toolbox/components/QuickCreateWizard.tsx
@@ -382,11 +382,13 @@ function TestChatPanel({
   conversationStarters,
   iconHue,
   welcomeMessage,
+  knowledgeBaseIds,
 }: {
   systemPrompt: string;
   conversationStarters: string[];
   iconHue: number;
   welcomeMessage: string;
+  knowledgeBaseIds: string[];
 }) {
   const [messages, setMessages] = useState<DirectChatMessage[]>([]);
   const [input, setInput] = useState('');
@@ -424,6 +426,7 @@ function TestChatPanel({
     const unsubscribe = streamDirectChat({
       message: msg,
       history,
+      attachmentIds: knowledgeBaseIds.length > 0 ? knowledgeBaseIds : undefined,
       onText: (content) => {
         setStreamingText((prev) => prev + content);
       },
@@ -621,12 +624,15 @@ export function QuickCreateWizard() {
     status: 'uploading' | 'done' | 'error';
   }>>([]);
   const knowledgeFileInputRef = useRef<HTMLInputElement>(null);
+  // 上传会话令牌：换模板/空白重建会自增，使在途上传的回调失效，避免旧文件回填到新状态
+  const kbUploadSessionRef = useRef(0);
 
   const handleKnowledgeFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;
     if (!files) return;
     e.target.value = '';
 
+    const session = kbUploadSessionRef.current;
     for (const file of Array.from(files)) {
       const tempId = Math.random().toString(36).slice(2, 11);
       setKnowledgeFiles(prev => [...prev, {
@@ -639,6 +645,7 @@ export function QuickCreateWizard() {
 
       try {
         const result = await uploadAttachment(file);
+        if (kbUploadSessionRef.current !== session) return; // 上下文已重置，丢弃这次结果
         if (result.success && result.data?.attachmentId) {
           setKnowledgeFiles(prev => prev.map(f =>
             f.id === tempId ? { ...f, attachmentId: result.data!.attachmentId, status: 'done' as const } : f
@@ -649,6 +656,7 @@ export function QuickCreateWizard() {
           ));
         }
       } catch {
+        if (kbUploadSessionRef.current !== session) return;
         setKnowledgeFiles(prev => prev.map(f =>
           f.id === tempId ? { ...f, status: 'error' as const } : f
         ));
@@ -870,6 +878,7 @@ export function QuickCreateWizard() {
 
   const handleSelectTemplate = (template: AgentTemplate) => {
     setSelectedTemplate(template);
+    kbUploadSessionRef.current += 1;
     setKnowledgeFiles([]);
     setForm((prev) => ({
       ...prev,
@@ -887,6 +896,7 @@ export function QuickCreateWizard() {
 
   const handleBlankCreate = () => {
     setSelectedTemplate(null);
+    kbUploadSessionRef.current += 1;
     setKnowledgeFiles([]);
     setForm((prev) => ({
       ...prev,
@@ -1394,6 +1404,7 @@ export function QuickCreateWizard() {
           conversationStarters={form.conversationStarters}
           iconHue={currentIconHue}
           welcomeMessage={form.welcomeMessage}
+          knowledgeBaseIds={doneKnowledgeBaseIds}
         />
       </Surface>
 

--- a/prd-admin/src/pages/ai-toolbox/components/QuickCreateWizard.tsx
+++ b/prd-admin/src/pages/ai-toolbox/components/QuickCreateWizard.tsx
@@ -5,6 +5,7 @@ import { StreamingText } from '@/components/streaming';
 import { useToolboxStore } from '@/stores/toolboxStore';
 import { cn } from '@/lib/cn';
 import { streamDirectChat, getModelGroups, listWorkflows } from '@/services';
+import { uploadAttachment } from '@/services/real/aiToolbox';
 import type { DirectChatMessage } from '@/services';
 import type { ModelGroup } from '@/types/modelGroup';
 import type { Workflow } from '@/services/contracts/workflowAgent';
@@ -40,6 +41,7 @@ import {
   RotateCcw,
   Upload,
   BookOpen,
+  File,
   Cpu,
   ChevronDown,
   Play,
@@ -609,6 +611,55 @@ export function QuickCreateWizard() {
     workflowId: '',
   });
 
+  // 知识库文件（上传到 Attachment，attachmentId 写入 ToolboxItem.knowledgeBaseIds）
+  const [knowledgeFiles, setKnowledgeFiles] = useState<Array<{
+    id: string;
+    fileName: string;
+    mimeType: string;
+    size: number;
+    attachmentId?: string;
+    status: 'uploading' | 'done' | 'error';
+  }>>([]);
+  const knowledgeFileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleKnowledgeFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files) return;
+    e.target.value = '';
+
+    for (const file of Array.from(files)) {
+      const tempId = Math.random().toString(36).slice(2, 11);
+      setKnowledgeFiles(prev => [...prev, {
+        id: tempId,
+        fileName: file.name,
+        mimeType: file.type,
+        size: file.size,
+        status: 'uploading' as const,
+      }]);
+
+      try {
+        const result = await uploadAttachment(file);
+        if (result.success && result.data?.attachmentId) {
+          setKnowledgeFiles(prev => prev.map(f =>
+            f.id === tempId ? { ...f, attachmentId: result.data!.attachmentId, status: 'done' as const } : f
+          ));
+        } else {
+          setKnowledgeFiles(prev => prev.map(f =>
+            f.id === tempId ? { ...f, status: 'error' as const } : f
+          ));
+        }
+      } catch {
+        setKnowledgeFiles(prev => prev.map(f =>
+          f.id === tempId ? { ...f, status: 'error' as const } : f
+        ));
+      }
+    }
+  };
+
+  const removeKnowledgeFile = (id: string) => {
+    setKnowledgeFiles(prev => prev.filter(f => f.id !== id));
+  };
+
   // 工作流列表
   const [workflows, setWorkflows] = useState<Workflow[]>([]);
   const [workflowsLoading, setWorkflowsLoading] = useState(false);
@@ -865,6 +916,9 @@ export function QuickCreateWizard() {
   const handleSave = async () => {
     if (!form.name.trim() || !form.prompt.trim()) return;
     setSaving(true);
+    const knowledgeBaseIds = knowledgeFiles
+      .filter(f => f.status === 'done' && f.attachmentId)
+      .map(f => f.attachmentId!);
     const success = await saveItem({
       name: form.name.trim(),
       description: form.description.trim(),
@@ -873,6 +927,7 @@ export function QuickCreateWizard() {
       tags: parsedTags,
       enabledTools: form.enabledTools,
       workflowId: isWorkflowEnabled ? form.workflowId : undefined,
+      knowledgeBaseIds,
       type: 'custom',
       category: 'custom',
     });
@@ -1462,13 +1517,66 @@ export function QuickCreateWizard() {
           <div className="flex items-center gap-2 mb-2">
             <BookOpen size={13} className="text-token-success" />
             <span className="text-token-primary text-[12px] font-semibold">知识库</span>
-            <span className="surface-state-warning text-[9px] px-1.5 py-0.5 rounded">即将上线</span>
+            {knowledgeFiles.length > 0 && (
+              <span className="surface-state-success text-[10px] px-1.5 py-0.5 rounded">
+                {knowledgeFiles.filter(f => f.status === 'done').length} 个文件
+              </span>
+            )}
           </div>
-          <div className="surface-inset p-3 rounded-lg text-center cursor-not-allowed opacity-60 border-dashed">
-            <Upload size={16} className="text-token-success mx-auto mb-1.5" />
-            <div className="text-token-muted text-[10px]">上传文档作为知识库</div>
-            <div className="text-token-muted-faint text-[9px] mt-0.5">支持 PDF、Word、TXT</div>
-          </div>
+
+          {knowledgeFiles.length > 0 && (
+            <div className="space-y-1.5 mb-2">
+              {knowledgeFiles.map((file) => (
+                <Surface
+                  variant="inset"
+                  key={file.id}
+                  className={cn(
+                    'flex items-center gap-2 px-2.5 py-1.5 rounded-lg',
+                    file.status === 'error' && 'border-[var(--status-error)]'
+                  )}
+                >
+                  <File size={12} style={{
+                    color: file.status === 'error' ? 'rgb(239, 68, 68)'
+                      : file.status === 'uploading' ? 'var(--text-muted)'
+                      : 'rgb(74, 222, 128)',
+                  }} />
+                  <span className="text-token-secondary flex-1 text-[10px] truncate">{file.fileName}</span>
+                  <span className="text-token-muted text-[9px] flex-shrink-0">
+                    {(file.size / 1024).toFixed(0)} KB
+                  </span>
+                  {file.status === 'uploading' && <MapSpinner size={10} className="flex-shrink-0" />}
+                  {file.status === 'error' && (
+                    <span className="text-token-error text-[9px] flex-shrink-0">失败</span>
+                  )}
+                  <button
+                    onClick={() => removeKnowledgeFile(file.id)}
+                    className="p-0.5 rounded hover:bg-white/10 transition-colors flex-shrink-0"
+                    aria-label="移除文件"
+                  >
+                    <X size={10} className="text-token-muted" />
+                  </button>
+                </Surface>
+              ))}
+            </div>
+          )}
+
+          <button
+            type="button"
+            onClick={() => knowledgeFileInputRef.current?.click()}
+            className="surface-inset w-full p-3 rounded-lg text-center cursor-pointer transition-all border-dashed hover:border-[var(--status-done)] group"
+          >
+            <Upload size={16} className="text-token-success mx-auto mb-1 transition-transform group-hover:scale-110" />
+            <div className="text-token-secondary text-[10px] font-medium">上传文档作为知识库</div>
+            <div className="text-token-muted-faint text-[9px] mt-0.5">支持 PDF、Word、Excel、PPT、TXT</div>
+          </button>
+          <input
+            ref={knowledgeFileInputRef}
+            type="file"
+            multiple
+            className="hidden"
+            accept=".pdf,.doc,.docx,.txt,.md,.json,.csv,.xlsx,.xls,.ppt,.pptx"
+            onChange={handleKnowledgeFileSelect}
+          />
         </Surface>
 
         {/* 温度调节 */}

--- a/prd-admin/src/pages/ai-toolbox/components/QuickCreateWizard.tsx
+++ b/prd-admin/src/pages/ai-toolbox/components/QuickCreateWizard.tsx
@@ -900,6 +900,13 @@ export function QuickCreateWizard() {
     setStep(1);
   };
 
+  // 已上传完成的知识库 attachmentId（done 状态才算数）
+  const doneKnowledgeBaseIds = knowledgeFiles
+    .filter(f => f.status === 'done' && f.attachmentId)
+    .map(f => f.attachmentId!);
+  // 是否还有文件在上传中——上传未完成时禁止保存/切换，避免静默丢弃
+  const isUploadingKb = knowledgeFiles.some(f => f.status === 'uploading');
+
   const handleSwitchToFullMode = () => {
     setEditingItem({
       name: form.name,
@@ -907,6 +914,7 @@ export function QuickCreateWizard() {
       icon: form.icon,
       prompt: form.prompt,
       tags: parsedTags,
+      knowledgeBaseIds: doneKnowledgeBaseIds,
       type: 'custom',
       category: 'custom',
     });
@@ -915,10 +923,8 @@ export function QuickCreateWizard() {
 
   const handleSave = async () => {
     if (!form.name.trim() || !form.prompt.trim()) return;
+    if (isUploadingKb) return;
     setSaving(true);
-    const knowledgeBaseIds = knowledgeFiles
-      .filter(f => f.status === 'done' && f.attachmentId)
-      .map(f => f.attachmentId!);
     const success = await saveItem({
       name: form.name.trim(),
       description: form.description.trim(),
@@ -927,7 +933,7 @@ export function QuickCreateWizard() {
       tags: parsedTags,
       enabledTools: form.enabledTools,
       workflowId: isWorkflowEnabled ? form.workflowId : undefined,
-      knowledgeBaseIds,
+      knowledgeBaseIds: doneKnowledgeBaseIds,
       type: 'custom',
       category: 'custom',
     });
@@ -1637,7 +1643,14 @@ export function QuickCreateWizard() {
             <span className="text-[14px] font-semibold text-token-primary">快速创建智能体</span>
           </div>
         </div>
-        <Button variant="ghost" size="sm" onClick={handleSwitchToFullMode} className="text-[11px] gap-1.5">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={handleSwitchToFullMode}
+          disabled={isUploadingKb}
+          title={isUploadingKb ? '知识库文件上传中，请稍候' : undefined}
+          className="text-[11px] gap-1.5"
+        >
           <Settings2 size={12} />
           完整模式
         </Button>
@@ -1692,9 +1705,15 @@ export function QuickCreateWizard() {
               </Button>
             )}
             {step === 2 && (
-              <Button variant="primary" size="sm" onClick={handleSave} disabled={saving || !form.name.trim() || !form.prompt.trim()}>
-                {saving ? <MapSpinner size={13} /> : <Save size={13} />}
-                创建智能体
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={handleSave}
+                disabled={saving || isUploadingKb || !form.name.trim() || !form.prompt.trim()}
+                title={isUploadingKb ? '知识库文件上传中，请稍候' : undefined}
+              >
+                {saving || isUploadingKb ? <MapSpinner size={13} /> : <Save size={13} />}
+                {isUploadingKb ? '上传中…' : '创建智能体'}
               </Button>
             )}
           </div>

--- a/prd-admin/src/pages/ai-toolbox/components/ToolEditor.tsx
+++ b/prd-admin/src/pages/ai-toolbox/components/ToolEditor.tsx
@@ -54,7 +54,7 @@ import {
   File,
   Workflow as WorkflowIcon,
 } from 'lucide-react';
-import { uploadAttachment } from '@/services/real/aiToolbox';
+import { uploadAttachment, getAttachmentMeta } from '@/services/real/aiToolbox';
 
 // 图标组件映射
 const ICON_MAP: Record<string, LucideIcon> = {
@@ -118,7 +118,6 @@ interface FormState {
   conversationStarters: string[];
   enabledTools: string[];
   workflowId: string;
-  knowledgeBase: string[];
   temperature: number;
   enableMemory: boolean;
 }
@@ -136,7 +135,6 @@ export function ToolEditor() {
     conversationStarters: editingItem?.conversationStarters?.length ? [...editingItem.conversationStarters] : ['帮我写一段文案', '分析一下这个数据'],
     enabledTools: editingItem?.enabledTools ?? [],
     workflowId: editingItem?.workflowId ?? '',
-    knowledgeBase: editingItem?.knowledgeBaseIds ?? [],
     temperature: editingItem?.temperature ?? 0.7,
     enableMemory: editingItem?.enableMemory ?? false,
   });
@@ -149,6 +147,7 @@ export function ToolEditor() {
   const [workflows, setWorkflows] = useState<Workflow[]>([]);
   const [workflowsLoading, setWorkflowsLoading] = useState(false);
   const [wfDropdownOpen, setWfDropdownOpen] = useState(false);
+  // 知识库文件是唯一数据源：已有项的 knowledgeBaseIds 预加载为 done 条目，新上传追加进来
   const [knowledgeFiles, setKnowledgeFiles] = useState<Array<{
     id: string;
     fileName: string;
@@ -156,8 +155,33 @@ export function ToolEditor() {
     size: number;
     attachmentId?: string;
     status: 'uploading' | 'done' | 'error';
-  }>>([]);
+  }>>(() =>
+    (editingItem?.knowledgeBaseIds ?? []).map((aid) => ({
+      id: aid,
+      fileName: '知识库文档',
+      mimeType: '',
+      size: 0,
+      attachmentId: aid,
+      status: 'done' as const,
+    }))
+  );
   const knowledgeFileInputRef = useRef<HTMLInputElement>(null);
+
+  // 已有 KB ID 只有 id 没有文件名，尽力拉取真实元数据回填（失败保留占位名，不影响保存）
+  useEffect(() => {
+    const ids = (editingItem?.knowledgeBaseIds ?? []);
+    if (ids.length === 0) return;
+    let cancelled = false;
+    Promise.all(ids.map((aid) => getAttachmentMeta(aid).catch(() => null))).then((metas) => {
+      if (cancelled) return;
+      setKnowledgeFiles((prev) => prev.map((f) => {
+        const m = metas.find((x) => x?.success && x.data?.attachmentId === f.attachmentId);
+        return m?.data ? { ...f, fileName: m.data.fileName, mimeType: m.data.mimeType, size: m.data.size } : f;
+      }));
+    });
+    return () => { cancelled = true; };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   const wfDropdownRef = useRef<HTMLDivElement>(null);
 
   // 当启用工作流能力时加载工作流列表
@@ -205,17 +229,19 @@ export function ToolEditor() {
   const CurrentIconComponent = getIconComponent(form.icon);
   const currentIconHue = getAccentHue(form.icon);
 
+  const isUploadingKb = knowledgeFiles.some(f => f.status === 'uploading');
+
   const handleSave = async () => {
     if (!form.name.trim() || !form.prompt.trim()) return;
+    if (isUploadingKb) return;
 
     setSaving(true);
-    const knowledgeBaseIds = knowledgeFiles
-      .filter(f => f.status === 'done' && f.attachmentId)
-      .map(f => f.attachmentId!);
-    // 本编辑器无新上传文件时，保留预填的知识库（编辑已有项 或 从快速向导切过来均适用）
-    const finalKnowledgeBaseIds = knowledgeBaseIds.length > 0
-      ? knowledgeBaseIds
-      : form.knowledgeBase;
+    // 单一数据源：直接取列表里所有 done 文件的 attachmentId（已含预加载的旧 KB + 新上传），去重
+    const finalKnowledgeBaseIds = Array.from(new Set(
+      knowledgeFiles
+        .filter(f => f.status === 'done' && f.attachmentId)
+        .map(f => f.attachmentId!)
+    ));
 
     const success = await saveItem({
       ...(editingItem?.id ? { id: editingItem.id } : {}),
@@ -817,10 +843,11 @@ export function ToolEditor() {
                 variant="primary"
                 size="sm"
                 onClick={handleSave}
-                disabled={saving || !form.name.trim() || !form.prompt.trim()}
+                disabled={saving || isUploadingKb || !form.name.trim() || !form.prompt.trim()}
+                title={isUploadingKb ? '知识库文件上传中，请稍候' : undefined}
               >
-                {saving ? <MapSpinner size={13} /> : <Save size={13} />}
-                保存
+                {saving || isUploadingKb ? <MapSpinner size={13} /> : <Save size={13} />}
+                {isUploadingKb ? '上传中…' : '保存'}
               </Button>
             </div>
           }

--- a/prd-admin/src/pages/ai-toolbox/components/ToolEditor.tsx
+++ b/prd-admin/src/pages/ai-toolbox/components/ToolEditor.tsx
@@ -126,7 +126,6 @@ interface FormState {
 export function ToolEditor() {
   const { view, editingItem, saveItem, backToGrid } = useToolboxStore();
 
-  const isEditing = view === 'edit' && !!editingItem?.id;
   const [form, setForm] = useState<FormState>({
     name: editingItem?.name || '',
     description: editingItem?.description || '',
@@ -213,10 +212,10 @@ export function ToolEditor() {
     const knowledgeBaseIds = knowledgeFiles
       .filter(f => f.status === 'done' && f.attachmentId)
       .map(f => f.attachmentId!);
-    // If editing and no new files were added, keep existing knowledgeBaseIds
+    // 本编辑器无新上传文件时，保留预填的知识库（编辑已有项 或 从快速向导切过来均适用）
     const finalKnowledgeBaseIds = knowledgeBaseIds.length > 0
       ? knowledgeBaseIds
-      : (isEditing ? form.knowledgeBase : []);
+      : form.knowledgeBase;
 
     const success = await saveItem({
       ...(editingItem?.id ? { id: editingItem.id } : {}),

--- a/prd-admin/src/services/index.ts
+++ b/prd-admin/src/services/index.ts
@@ -1502,6 +1502,7 @@ export {
   streamDirectChat,
   streamCapabilityChat,
   uploadAttachment,
+  getAttachmentMeta,
   // Session & Messages
   listToolboxSessions,
   createToolboxSession,

--- a/prd-admin/src/services/real/aiToolbox.ts
+++ b/prd-admin/src/services/real/aiToolbox.ts
@@ -566,6 +566,13 @@ export async function uploadAttachment(file: File): Promise<ApiResponse<Uploaded
   }
 }
 
+/**
+ * 按 attachmentId 获取附件元数据（用于把已有知识库 ID 还原成可见文件名）
+ */
+export async function getAttachmentMeta(attachmentId: string): Promise<ApiResponse<UploadedAttachment & { uploadedAt?: string }>> {
+  return await apiRequest(`/api/v1/attachments/${attachmentId}`);
+}
+
 // ============ Message Feedback ============
 
 /**


### PR DESCRIPTION
## 摘要

将 AI Toolbox 快速创建向导第 3 步的知识库区块从"即将上线"占位符替换为可用 UI，复用 ToolEditor 同一套 attachment 上传与 prompt 注入通路。用户现可在快速创建流程中直接上传文档作为知识库。

## 改动 diff

- `prd-admin/src/pages/ai-toolbox/components/QuickCreateWizard.tsx`
  - 新增 `uploadAttachment` 导入
  - 新增 `File` icon 导入
  - 实现知识库文件管理状态（`knowledgeFiles`）与上传处理逻辑（`handleKnowledgeFileSelect`、`removeKnowledgeFile`）
  - 将知识库 UI 从禁用占位符替换为可交互的文件列表 + 上传按钮
  - 支持 PDF、Word、Excel、PPT、TXT 等多种文档格式
  - 在 `handleSave` 中收集已上传文件的 `attachmentId` 并注入 `knowledgeBaseIds` 字段

- `doc/debt.knowledge-base.md`（新增）
  - 记录知识库模块的 8 条工程债务（K-1 至 K-8）
  - 包括两套知识库并存、RAG/embedding 未实现、wip 标签 CI 守卫缺失、上传 API 不互通等已知边界
  - 提供短中长期还债计划草稿

- `doc/guide.list.directory.md`
  - 新增 `debt.knowledge-base` 文档索引条目

- `doc/index.yml`
  - 新增 `debt.knowledge-base` 文档注册

- `changelogs/2026-05-21_ai-toolbox-quick-wizard-knowledge-base.md`（新增）
  - 记录本次 feat 与 docs 变更

## 实现细节

1. **文件上传流程**：用户点击上传按钮 → 选择文件 → 逐个调用 `uploadAttachment` API → 状态机跟踪（uploading → done/error）
2. **UI 反馈**：显示文件名、大小、上传状态（加载中/成功/失败）、移除按钮
3. **数据注入**：保存智能体时，筛选状态为 `done` 且有 `attachmentId` 的文件，映射为 `knowledgeBaseIds` 数组传给后端
4. **债务记录**：同步新增 `debt.knowledge-base.md` 文档，固化已知的 RAG 缺失、两套知识库并存等 8 条工程债务，避免后续遗忘

## 测试

- [x] pnpm tsc --noEmit 通过
- [x] pnpm lint 本文件零新增告警
- [x] 文件上传、移除、保存流程逻辑完整
- [ ] 真人通过预览域名验收上传交互与后端数据流

https://claude.ai/code/session_011Uc8viBGcTNrMZ9zw1MCnc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new attachment upload flow to the agent quick-create wizard and wires uploaded `attachmentId`s into save/test chat requests, which can impact agent creation and chat context if upload state or IDs are mishandled.
> 
> **Overview**
> Enables the AI Toolbox **Quick Create Wizard** to upload documents as a knowledge base (replacing the prior disabled “即将上线” placeholder), maintaining per-file upload state, list/removal UI, and gating save/full-mode switching while uploads are in progress.
> 
> Wires uploaded `attachmentId`s into both **test chat** (`streamDirectChat` `attachmentIds`) and **agent creation/editing** (`knowledgeBaseIds`), and updates `ToolEditor` to treat the KB file list as the single source of truth (preloading existing IDs, de-duping on save, and backfilling display names via new `getAttachmentMeta`).
> 
> Adds documentation/changelog entries, including a new `debt.knowledge-base` ledger and index registrations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0ca054e3ba0df72c204270f0b91fd8f9d6b6a55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->