### PR TITLE
feat(prd-admin): 作品广场卡片增加 Masonry 入场动效与占位优化

### DIFF
--- a/changelogs/2026-05-21_showcase-masonry-anim.md
+++ b/changelogs/2026-05-21_showcase-masonry-anim.md
@@ -1,1 +1,2 @@
 | feat | prd-admin | 作品广场卡片增加 reactbits Masonry 风格入场动效（位移 + 缩放 + 模糊淡入 + 列内 stagger） |
+| fix | prd-admin | 作品广场有封面卡片占位底从纯黑改为彩色渐变 + 加载呼吸占位，避免图片懒加载前闪黑 |

--- a/changelogs/2026-05-21_showcase-masonry-anim.md
+++ b/changelogs/2026-05-21_showcase-masonry-anim.md
@@ -1,0 +1,1 @@
+| feat | prd-admin | 作品广场卡片增加 reactbits Masonry 风格入场动效（位移 + 缩放 + 模糊淡入 + 列内 stagger） |

--- a/prd-admin/src/components/showcase/ShowcaseGallery.tsx
+++ b/prd-admin/src/components/showcase/ShowcaseGallery.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { motion } from 'motion/react';
 import { Eye, BookOpen, X } from 'lucide-react';
 import { MapSpinner } from '@/components/ui/VideoLoader';
 import { SubmissionDetailModal } from './SubmissionDetailModal';
@@ -435,21 +436,33 @@ export function ShowcaseGallery() {
         </div>
       )}
 
-      {/* Waterfall layout — natural aspect ratio cards */}
+      {/* Waterfall layout — natural aspect ratio cards
+          入场动效参考 reactbits.dev/components/masonry：位移 + 缩放 + 模糊淡入 + 顺序 stagger */}
       {!loading && items.length > 0 && (
         <>
           <div style={{ display: 'flex', gap, alignItems: 'flex-start' }}>
             {columns.map((col, colIdx) => (
               <div key={colIdx} style={{ flex: 1, display: 'flex', flexDirection: 'column', gap }}>
-                {col.map((item) => (
-                  <ShowcaseCard
+                {col.map((item, rowIdx) => (
+                  <motion.div
                     key={item.id}
-                    item={item}
-                    onLikeToggle={handleLikeToggle}
-                    onClick={() => setSelectedId(item.id)}
-                    isAdmin={isAdmin}
-                    onAdminWithdraw={handleAdminWithdraw}
-                  />
+                    initial={{ opacity: 0, y: 80, scale: 0.86, filter: 'blur(12px)' }}
+                    whileInView={{ opacity: 1, y: 0, scale: 1, filter: 'blur(0px)' }}
+                    viewport={{ once: true, margin: '0px 0px -10% 0px' }}
+                    transition={{
+                      duration: 0.65,
+                      ease: [0.22, 1, 0.36, 1],
+                      delay: Math.min(rowIdx * 0.08 + colIdx * 0.04, 0.6),
+                    }}
+                  >
+                    <ShowcaseCard
+                      item={item}
+                      onLikeToggle={handleLikeToggle}
+                      onClick={() => setSelectedId(item.id)}
+                      isAdmin={isAdmin}
+                      onAdminWithdraw={handleAdminWithdraw}
+                    />
+                  </motion.div>
                 ))}
               </div>
             ))}

--- a/prd-admin/src/components/showcase/ShowcaseGallery.tsx
+++ b/prd-admin/src/components/showcase/ShowcaseGallery.tsx
@@ -102,9 +102,15 @@ function ShowcaseCard({
         className="relative w-full overflow-hidden rounded-xl transition-all duration-300 group-hover:shadow-xl group-hover:shadow-black/30 group-hover:scale-[1.02]"
         style={{
           aspectRatio: getAspectRatio(item),
-          background: hasCover ? '#0a0a0f' : getFallbackGradient(item.id),
+          // 始终用彩色渐变占位（即使有封面），封面图懒加载后在渐变之上淡入，
+          // 避免下载完成前闪一块纯黑。
+          background: getFallbackGradient(item.id),
         }}
       >
+        {/* 封面图未加载完成时的轻微呼吸感占位（仅在已进入视口、图片还没 onLoad 时显示） */}
+        {hasCover && inView && !imgLoaded && (
+          <div className="absolute inset-0 animate-pulse" style={{ background: 'rgba(255,255,255,0.04)' }} />
+        )}
         {/* Cover image — only requested once the card nears the viewport */}
         {item.coverUrl && !imgError && inView && (
           <img


### PR DESCRIPTION
## 摘要

为作品广场（ShowcaseGallery）的卡片增加 Framer Motion 驱动的 Masonry 风格入场动效，同时优化有封面卡片的占位体验，避免图片懒加载前出现纯黑闪烁。

## 改动 diff

- `prd-admin/src/components/showcase/ShowcaseGallery.tsx`：
  - 新增 `motion` 库导入（Framer Motion）
  - 将卡片背景从条件判断改为始终使用彩色渐变占位
  - 新增加载中呼吸感占位层（仅在已进入视口、图片未加载时显示）
  - 用 `motion.div` 包装每张卡片，实现位移 + 缩放 + 模糊淡入 + 列内 stagger 的入场动效
  - 动效参数：初始状态 `opacity: 0, y: 80, scale: 0.86, filter: blur(12px)`，缓动曲线 `[0.22, 1, 0.36, 1]`，延迟基于行列索引计算（`rowIdx * 0.08 + colIdx * 0.04`，最大 0.6s）

- `changelogs/2026-05-21_showcase-masonry-anim.md`：新增 changelog 碎片，记录本次 feat 与 fix

## 实现细节

1. **入场动效**：参考 reactbits.dev/components/masonry 的设计，使用 Framer Motion 的 `whileInView` 触发器，当卡片进入视口时（margin: -10%）执行动效，`once: true` 确保仅执行一次

2. **占位优化**：
   - 移除了条件判断 `hasCover ? '#0a0a0f' : getFallbackGradient(item.id)`，改为始终使用彩色渐变
   - 新增 `animate-pulse` 呼吸感占位层，仅在 `hasCover && inView && !imgLoaded` 时显示，避免纯黑背景闪烁

3. **Stagger 策略**：延迟计算为 `Math.min(rowIdx * 0.08 + colIdx * 0.04, 0.6)`，使得同列卡片按行顺序错开，同时不同列也有微妙的时间差，形成自然的瀑布流入场感

## 测试

- [x] pnpm tsc --noEmit 通过
- [x] pnpm lint 本文件零新增告警
- [ ] 真人通过预览域名验收（待部署后）

https://claude.ai/code/session_011deVxLyhNcYLzcqxRqBgCR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to animation and image placeholders in `ShowcaseGallery`; main risk is minor performance/regression in rendering/scroll behavior due to added `motion` wrappers and viewport triggers.
> 
> **Overview**
> Adds Masonry-style *in-view enter animations* to Showcase gallery cards (translate/scale/blur fade-in with per-column stagger) by wrapping each card in `motion.div`.
> 
> Improves cover loading placeholders by always rendering a colorful gradient background (removing the solid-black fallback) and showing a subtle pulsing overlay until the cover image finishes loading, reducing black flash during lazy-load. Updates the changelog to record the new animation and placeholder fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9ff4b7b10fe9ec5994b39cc8ece1b76ad9308d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->