### PR TITLE
每日熵减计划 2026-W21 — index/guide.list 补缺 + changelog manifest 入库

### DIFF
--- a/changelogs/.entropy-manifest.yml
+++ b/changelogs/.entropy-manifest.yml
@@ -56,3 +56,8 @@ processed:
   - 2026-05-13_poster-list-perf-and-badge.md
   - 2026-05-13_reprocess-button-order.md
   - 2026-05-13_resource-preview.md
+  - 2026-05-13_review-scoring-consistency.md
+  - 2026-05-13_short-link-admin.md
+  - 2026-05-13_short-share-links.md
+  - 2026-05-13_streaming-text-followup-r2.md
+  - 2026-05-13_streaming-text-general-capability.md

--- a/doc/guide.list.directory.md
+++ b/doc/guide.list.directory.md
@@ -1,6 +1,6 @@
 # MAP 平台文档索引 · 指南
 
-> 最后更新：2026-05-17
+> 最后更新：2026-05-22
 >
 > 本文件是 `doc/` 目录的结构化索引，供外部同步工具（语雀、Confluence 等）消费。
 > 元数据定义见 `doc/index.yml`，命名规范见 `doc/rule.doc-naming.md`。
@@ -280,6 +280,9 @@
 
 - [CDS Railway 式部署向导设计](design.cds-railway-onboarding-flow) `design.cds-railway-onboarding-flow`
   > 从 Railway 首次部署路径抽象 CDS 一键部署、运行环境选择、基础设施创建和可观察性闭环
+
+- [缺陷分享与 Agent 技能修复架构](design.defect-agent-share-skill-architecture) `design.defect-agent-share-skill-architecture`
+  > 缺陷分享中心、外部 Agent 技能接入与修复报告闭环的架构设计
 
 ### 三、指南
 
@@ -659,6 +662,9 @@
 - [知识库（AI Toolbox attachment + 文档空间）债务台账](debt.knowledge-base) `debt.knowledge-base`
   > 8 条 open：两套并存模型 / RAG embedding 未做 / wip 标签 CI 守卫 / 上传 API 不互通 / 等
 
+- [分享链接安全债务台账](debt.share-link-security) `debt.share-link-security`
+  > 分享链接系统的已知安全边界与待补项
+
 ### 七、周报
 
 - [CDS Agent 商业级可用闭环目标审计报告](report.cds-agent-goal-completion-audit-2026-05-19) `report.cds-agent-goal-completion-audit-2026-05-19`
@@ -784,12 +790,16 @@
 - [文档技能评测·documentation-writer 样本输出](report.skill-eval-sample-diataxis) `report.skill-eval-sample-diataxis`
   > 评测报告引用的 skill 原始输出样本（Diátaxis 四象限类）
 
+- [CDS Mongo 日志拆分事故复盘（2026-05-23）](report.cds-mongo-log-split-incident-2026-05-23) `report.cds-mongo-log-split-incident-2026-05-23`
+  > CDS 控制面 cds-master 崩溃导致 502 的事故根因分析与复盘
+
 ---
 
 ## 变更历史
 
 | 日期 | 操作 | 文件名 | 中文标题 |
 | :--- | :--- | :--- | :--- |
+| 2026-05-22 | 新增 | `design.defect-agent-share-skill-architecture` `debt.share-link-security` `report.cds-mongo-log-split-incident-2026-05-23` | 缺陷分享架构设计、分享链接安全债务台账、CDS Mongo 事故复盘 |
 | 2026-05-15 | 新增 | `design.cds-agent-runtime-architecture` | CDS Agent 运行时架构设计 |
 | 2026-05-15 | 新增 | `report.cds-agent-workbench-2026-05-15` `guide.cds-agent-workbench-reproduce` `guide.cds-agent-next-agent-testing` | CDS Agent A10 完成复盘、复现教程、下一代测试与涌现建议 |
 | 2026-05-14 | 新增 | `guide.cds-agent-workbench` `guide.cds-agent-admin` `design.cds-agent-api` `guide.cds-agent-runbook` | CDS Agent 完全可用文档闭环 |

--- a/doc/index.yml
+++ b/doc/index.yml
@@ -250,6 +250,7 @@ docs:
   debt.cds-state-json: CDS state.json 影子存储债务台账
   debt.cds-compose-secrets: CDS compose 模板 TODO secrets / 全量 import 被拒债务台账
   debt.knowledge-base: 知识库（AI Toolbox attachment + 文档空间）债务台账
+  debt.share-link-security: 分享链接安全债务台账
 
   # ── 七、周报（降序：最新在前）──
   report.cds-agent-goal-completion-audit-2026-05-19: CDS Agent 商业级可用闭环目标审计报告
@@ -293,3 +294,4 @@ docs:
   report.skill-eval-sample-user-guide: 文档技能评测·user-guide-writing 样本输出
   report.skill-eval-sample-technical: 文档技能评测·technical-writing 样本输出
   report.skill-eval-sample-diataxis: 文档技能评测·documentation-writer（Diátaxis）样本输出
+  report.cds-mongo-log-split-incident-2026-05-23: CDS Mongo 日志拆分事故复盘（2026-05-23）


### PR DESCRIPTION
自动生成的每日熵减 PR。

## 修复项

- **D1 命名违规**：0 项（全部规范）
- **D2 index.yml 补缺**：2 项
  - `debt.share-link-security`：分享链接安全债务台账
  - `report.cds-mongo-log-split-incident-2026-05-23`：CDS Mongo 日志拆分事故复盘
- **D2 index.yml 幽灵**：0 项
- **D3 guide.list 补缺**：3 项
  - `design.defect-agent-share-skill-architecture`：缺陷分享与 Agent 技能修复架构
  - `debt.share-link-security`：分享链接安全债务台账
  - `report.cds-mongo-log-split-incident-2026-05-23`：CDS Mongo 日志拆分事故复盘
- **D3 guide.list 幽灵**：检出的 23 条均为变更历史表格中的历史引用，非实际文档列表条目，已跳过
- **D4 CLAUDE.md 技能表**：`pnpm` 为规则文本强调标记（非技能条目），跳过
- **D6 changelog 入库**：5 条（2026-05-13 review-scoring / short-link-admin / short-share-links / streaming-text-followup-r2 / streaming-text-general-capability）

## 跳过项

- D3 ghost：23 条均在变更历史表格中，有据可查非孤儿
- D4 ghost `pnpm`：规则文本强调，非技能目录条目
- D6 changelog 设计文档追加：5 条均为代码 fix/feat 记录，无对应 design 文档章节可追加

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEC8qZbUVTqqW517hEWHuS)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only updates: adds missing index/list entries and marks additional changelog fragments as processed, with no runtime code changes.
> 
> **Overview**
> Updates documentation metadata to close gaps between the doc catalog and directory listing.
> 
> `doc/index.yml` and `doc/guide.list.directory.md` add the missing entries for `design.defect-agent-share-skill-architecture`, `debt.share-link-security`, and `report.cds-mongo-log-split-incident-2026-05-23` (including a changelog/history row and refreshed last-updated date). `changelogs/.entropy-manifest.yml` records five additional `2026-05-13_*` changelog fragments as processed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8bdd7179b0b0aad0afb5f65ca5da4d3df9448d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->