### PR TITLE
每日熵减计划 2026-W21 — spec.pa-agent-savage-upgrade 索引补缺 + PA Agent changelog 入库

### DIFF
--- a/changelogs/.entropy-manifest.yml
+++ b/changelogs/.entropy-manifest.yml
@@ -61,3 +61,8 @@ processed:
   - 2026-05-13_short-share-links.md
   - 2026-05-13_streaming-text-followup-r2.md
   - 2026-05-13_streaming-text-general-capability.md
+  - 2026-04-18_pa-agent.md
+  - 2026-05-10_pa-agent-appcaller-chat-pick.md
+  - 2026-05-10_pa-agent-appcaller-startup-sync.md
+  - 2026-05-10_pa-agent-llm-binding-fix.md
+  - 2026-05-10_pa-agent-merge-from-main.md

--- a/doc/guide.list.directory.md
+++ b/doc/guide.list.directory.md
@@ -42,6 +42,9 @@
 - [私人执行助理（PA Agent）产品方案](spec.pa-agent) `spec.pa-agent`
   > PA Agent 产品定位、Phase 1 能力与路线图，可独立下载评审
 
+- [毒舌秘书：PA Agent 最小可行升级方案](spec.pa-agent-savage-upgrade) `spec.pa-agent-savage-upgrade`
+  > PA Agent 升级为毒舌秘书的最小可行方案，1-2 天内可上线，保留架构只改产品灵魂
+
 - [周报 Agent 产品需求文档](spec.report-agent) `spec.report-agent`
   > 周报 Agent v1.0 的产品需求文档
 

--- a/doc/index.yml
+++ b/doc/index.yml
@@ -32,6 +32,7 @@ docs:
   spec.marketplace: 海鲜市场（Configuration Marketplace）
   spec.defect-agent: 缺陷管理 Agent 产品方案
   spec.pa-agent: 私人执行助理（PA Agent）产品方案
+  spec.pa-agent-savage-upgrade: 毒舌秘书 PA Agent 最小可行升级方案
   spec.report-agent: 周报 Agent 产品需求文档
   spec.report-agent.v2: 周报 Agent v2.0 产品需求文档
   spec.report-agent-phase5: 周报 Agent Phase 5 用户故事


### PR DESCRIPTION
自动生成的每日熵减 PR。

## 修复项

- **D2 index.yml 补缺 1 项**：`spec.pa-agent-savage-upgrade`（毒舌秘书 PA Agent 最小可行升级方案）
- **D3 guide.list 补缺 1 项**：同上，追加到「一、产品规格」区块
- **D6 changelog 入库 5 条**：
  - `2026-04-18_pa-agent.md`
  - `2026-05-10_pa-agent-appcaller-chat-pick.md`
  - `2026-05-10_pa-agent-appcaller-startup-sync.md`
  - `2026-05-10_pa-agent-llm-binding-fix.md`
  - `2026-05-10_pa-agent-merge-from-main.md`

## 跳过项（扫描误报，无需操作）

- D3 幽灵条目：均位于变更历史表格的历史引用行，非主列表真实引用，不删
- D4 `pnpm` 幽灵：CLAUDE.md 规则正文加粗字符，非技能表条目，不删

## 变更文件

- `doc/index.yml` — +1 行
- `doc/guide.list.directory.md` — +3 行
- `changelogs/.entropy-manifest.yml` — +5 行

---
_Generated by [Claude Code](https://claude.ai/code/session_013QETzMGoKj16R4REUhz3Av)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes: updates doc indexes and a changelog processing manifest with no runtime/code-path impact.
> 
> **Overview**
> Adds the missing `spec.pa-agent-savage-upgrade` entry to the documentation indexes (`doc/index.yml` and `doc/guide.list.directory.md`) so it appears in the Product Specs list.
> 
> Registers five PA Agent changelog fragments in `changelogs/.entropy-manifest.yml` as processed, ensuring they’re tracked by the changelog ingestion workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eda50a2519ddfb967169d8c8a835b012778bab4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->