### PR TITLE
修复视觉创作画布占位卡死：后端对账 + SSE 流结束状态查询

### DIFF
--- a/changelogs/2026-05-24_visual-agent-canvas-reconcile.md
+++ b/changelogs/2026-05-24_visual-agent-canvas-reconcile.md
@@ -8,3 +8,4 @@
 | fix | prd-admin | runId 立即落盘改为保存成功后才更新已存标记，失败时让 debounce 重试，避免误判已存导致 runId 永不落库 |
 | fix | prd-admin | SSE 流结束查询到 run 已失败/取消时展示真实失败原因，不再一律误报"超时" |
 | fix | prd-admin | 加载/看门狗对账增加 workspace 切换防串台守卫，避免异步响应套到别的 workspace 画布 |
+| fix | prd-admin | 看门狗恢复对 runId 占位的直查 run 同步（修复 SSE 掉线但 worker 已成功时 server 已 done、对账扫不到导致本地永久转圈的 desync），无 runId 孤儿仍走 workspace 对账 |

--- a/changelogs/2026-05-24_visual-agent-canvas-reconcile.md
+++ b/changelogs/2026-05-24_visual-agent-canvas-reconcile.md
@@ -4,3 +4,7 @@
 | fix | prd-admin | 拿到 runId 后立即持久化画布（不等 debounce），避免关页/切走导致占位丢失 runId 成为孤儿 |
 | fix | prd-admin | 看门狗改走 workspace 级对账（覆盖无 runId 占位）+ 阈值 120s 降到 45s；加载即对账修复历史卡死占位 |
 | fix | prd-admin | 视觉创作三处生图 SSE 订阅补齐 maxAttempts=20（原默认 10，慢任务过早放弃） |
+| fix | prd-admin | 画布本地序列化器补齐 runId 往返持久化（此前 canvasToPersistedV1/persistedV1ToCanvas 从不存取 runId，是占位丢 runId 成孤儿的真正根因） |
+| fix | prd-admin | runId 立即落盘改为保存成功后才更新已存标记，失败时让 debounce 重试，避免误判已存导致 runId 永不落库 |
+| fix | prd-admin | SSE 流结束查询到 run 已失败/取消时展示真实失败原因，不再一律误报"超时" |
+| fix | prd-admin | 加载/看门狗对账增加 workspace 切换防串台守卫，避免异步响应套到别的 workspace 画布 |

--- a/changelogs/2026-05-24_visual-agent-canvas-reconcile.md
+++ b/changelogs/2026-05-24_visual-agent-canvas-reconcile.md
@@ -1,0 +1,6 @@
+| fix | prd-api | 生图失败/取消时回填画布占位为 error（原先只在成功路径回填，失败的 run 让画布永远停在 running 转圈） |
+| feat | prd-api | 新增画布对账接口 POST /api/visual-agent/image-master/workspaces/{id}/canvas/reconcile：按 run.TargetCanvasKey 反查真实结果修复卡死占位，不依赖前端 runId，可拯救历史孤儿 |
+| fix | prd-admin | 视觉创作 SSE 流结束不再盲目标 error：先查后端真实状态，成功则回填、仍在跑则保留占位，避免慢任务被代理 EOF 误判 |
+| fix | prd-admin | 拿到 runId 后立即持久化画布（不等 debounce），避免关页/切走导致占位丢失 runId 成为孤儿 |
+| fix | prd-admin | 看门狗改走 workspace 级对账（覆盖无 runId 占位）+ 阈值 120s 降到 45s；加载即对账修复历史卡死占位 |
+| fix | prd-admin | 视觉创作三处生图 SSE 订阅补齐 maxAttempts=20（原默认 10，慢任务过早放弃） |

--- a/changelogs/2026-05-24_visual-agent-canvas-reconcile.md
+++ b/changelogs/2026-05-24_visual-agent-canvas-reconcile.md
@@ -9,3 +9,5 @@
 | fix | prd-admin | SSE 流结束查询到 run 已失败/取消时展示真实失败原因，不再一律误报"超时" |
 | fix | prd-admin | 加载/看门狗对账增加 workspace 切换防串台守卫，避免异步响应套到别的 workspace 画布 |
 | fix | prd-admin | 看门狗恢复对 runId 占位的直查 run 同步（修复 SSE 掉线但 worker 已成功时 server 已 done、对账扫不到导致本地永久转圈的 desync），无 runId 孤儿仍走 workspace 对账 |
+| fix | prd-admin | 看门狗直查 run 的回填条件放宽到"running 或无图 error"：transient 误标 error 后 run 实际成功也能从 error 翻回 done（原先只 heal running 会卡 error 直到刷新） |
+| fix | prd-admin | runId 立即落盘抽成统一 helper，快捷操作 / 草图两条生图路径也复用（原先只主生成路径补 runId） |

--- a/prd-admin/src/pages/ai-chat/AdvancedVisualAgentTab.tsx
+++ b/prd-admin/src/pages/ai-chat/AdvancedVisualAgentTab.tsx
@@ -21,6 +21,7 @@ import * as Popover from '@radix-ui/react-popover';
 import {
   deleteVisualAgentWorkspaceAsset,
   createWorkspaceImageGenRun,
+  reconcileVisualAgentWorkspaceCanvas,
   generateVisualAgentWorkspaceTitle,
   getVisualAgentWorkspaceDetail,
   listVisualAgentWorkspaceMessages,
@@ -65,7 +66,7 @@ import { resolveImageRefs, buildRequestText } from '@/lib/imageRefResolver';
 import type { CanvasImageItem as ContractCanvasItem, ChipRef } from '@/lib/imageRefContract';
 import { moveUp, moveDown, bringToFront, sendToBack } from '@/lib/canvasLayerUtils';
 import { assignMissingRefIds, getMaxRefId } from '@/lib/visualAgentCanvasPersist';
-import type { ImageAsset, VisualAgentCanvas, VisualAgentWorkspace } from '@/services/contracts/visualAgent';
+import type { ImageAsset, ReconcileCanvasItem, VisualAgentCanvas, VisualAgentWorkspace } from '@/services/contracts/visualAgent';
 import type { Model } from '@/types/admin';
 import {
   ArrowUpToLine,
@@ -486,6 +487,45 @@ function persistedV1ToCanvas(
   }
   // 还原时不应无故少一张；用与持久化一致的上限（MAX_PERSIST_ELEMENTS）
   return { canvas: out.slice(0, MAX_PERSIST_ELEMENTS), missingAssets, localOnlyImages };
+}
+
+/**
+ * 把后端画布对账结果按 key 局部应用到本地画布。
+ * 只动被对账命中的元素，绝不整盘覆盖，避免清掉用户正在进行的位置/选区编辑。
+ */
+function applyReconcileReport(
+  reconciled: ReconcileCanvasItem[],
+  setCanvas: (updater: (prev: CanvasImageItem[]) => CanvasImageItem[]) => void,
+) {
+  for (const r of reconciled) {
+    if (r.action === 'recovered' && r.src) {
+      const src = r.src;
+      setCanvas((prev) =>
+        prev.map((x) =>
+          x.key === r.key
+            ? {
+                ...x,
+                status: 'done' as const,
+                kind: 'image' as const,
+                src,
+                originalSrc: r.originalSrc || src,
+                assetId: r.assetId || x.assetId,
+                sha256: r.sha256 || x.sha256,
+                originalSha256: r.originalSha256 || x.originalSha256,
+                syncStatus: 'synced' as const,
+                syncError: null,
+              }
+            : x
+        )
+      );
+    } else if (r.action === 'marked-error' || r.action === 'already-error') {
+      const msg = r.errorMessage || '生成失败';
+      setCanvas((prev) =>
+        prev.map((x) => (x.key === r.key && x.status === 'running' ? { ...x, status: 'error' as const, errorMessage: msg } : x))
+      );
+    }
+    // in-progress / no-run：后端仍在处理或无对应 run，保留占位
+  }
 }
 
 type UiMsg = {
@@ -2491,52 +2531,19 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
           const refIdChanged = assignMissingRefIds(restored.canvas);
           applyCanvasFocus(restored.canvas);
 
-          // 同步 running 状态的元素：查询后端实际状态
-          const runningElements = restored.canvas.filter((el) => el.status === 'running' && el.runId);
-          if (runningElements.length > 0) {
-            void (async () => {
-              for (const el of runningElements) {
-                try {
-                  const res = await getImageGenRun({ runId: el.runId!, includeItems: true, includeImages: true });
-                  if (!res.success || !res.data?.run) continue;
-                  const run = res.data.run;
-                  if (run.status === 'Failed' || run.status === 'Cancelled') {
-                    // 后端已失败，更新前端状态
-                    setCanvas((prev) =>
-                      prev.map((x) =>
-                        x.key === el.key
-                          ? { ...x, status: 'error', errorMessage: run.status === 'Failed' ? '生成失败（后端）' : '已取消' }
-                          : x
-                      )
-                    );
-                  } else if (run.status === 'Completed') {
-                    // 后端已完成，尝试获取图片 URL
-                    const item = res.data.items?.find((it) => it.url);
-                    if (item?.url) {
-                      setCanvas((prev) =>
-                        prev.map((x) =>
-                          x.key === el.key
-                            ? { ...x, status: 'done', src: item.url!, kind: 'image' }
-                            : x
-                        )
-                      );
-                    } else {
-                      // 完成但没有 URL，标记为错误
-                      setCanvas((prev) =>
-                        prev.map((x) =>
-                          x.key === el.key
-                            ? { ...x, status: 'error', errorMessage: '生成完成但无图片 URL' }
-                            : x
-                        )
-                      );
-                    }
-                  }
-                  // 如果是 Queued/Running，保持 running 状态，用户可以等待或重试
-                } catch {
-                  // 查询失败，保持原状态
+          // 加载即对账：修复历史上 runId 未落库 / 后端失败未回填导致的卡死占位（running / 无图 error）。
+          // 走 workspace 级对账（按 TargetCanvasKey 反查），不依赖前端持久化的 runId。
+          const hasStuck = restored.canvas.some((el) => el.status === 'running' || (el.status === 'error' && !el.src));
+          if (hasStuck && workspaceId) {
+            void reconcileVisualAgentWorkspaceCanvas({ id: workspaceId, dryRun: false })
+              .then((res) => {
+                if (res.success && res.data?.reconciled?.length) {
+                  applyReconcileReport(res.data.reconciled, setCanvas);
                 }
-              }
-            })();
+              })
+              .catch(() => {
+                // 对账失败：watchdog 会再试
+              });
           }
 
           if (restored.missingAssets > 0 || restored.localOnlyImages > 0) {
@@ -2600,58 +2607,45 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
     };
   }, [focusStage, pushMsg, setViewport, workspaceId]);
 
-  // Watchdog：定期检查画布上卡住的 running 项目，自动恢复或标记失败
+  // 画布对账兜底：按 run.TargetCanvasKey 反查真实结果，修复 running / 无图 error 的卡死占位。
+  // 关键：后端按"画布元素 id == TargetCanvasKey"匹配，不依赖前端 runId，
+  // 因此能拯救历史上 runId 未落库的孤儿占位（详见 backend ReconcileWorkspaceCanvas）。
+  const reconcileStuckCanvas = useCallback(async () => {
+    const wid = workspaceId;
+    if (!wid) return;
+    const items = canvasRef.current ?? [];
+    const hasStuck = items.some((el) => el.status === 'running' || (el.status === 'error' && !el.src));
+    if (!hasStuck) return;
+    try {
+      const res = await reconcileVisualAgentWorkspaceCanvas({ id: wid, dryRun: false });
+      if (res.success && res.data?.reconciled?.length) {
+        applyReconcileReport(res.data.reconciled, setCanvas);
+      }
+    } catch {
+      // 对账失败：下次 watchdog / 下次加载再试
+    }
+  }, [workspaceId]);
+
+  const reconcileStuckCanvasRef = useRef(reconcileStuckCanvas);
+  useEffect(() => {
+    reconcileStuckCanvasRef.current = reconcileStuckCanvas;
+  }, [reconcileStuckCanvas]);
+
+  // Watchdog：定期检查画布上卡住的 running / 无图 error 占位，统一走 workspace 级对账自动恢复或标记失败
   useEffect(() => {
     const WATCHDOG_INTERVAL = 15_000; // 每 15 秒检查一次
-    const STALE_THRESHOLD = 120_000; // running 超过 2 分钟视为可能卡住
+    const STALE_THRESHOLD = 45_000; // 占位超过 45 秒未出结果即触发对账（旧值 120s 过长）
 
     const tid = window.setInterval(() => {
       const items = canvasRef.current;
-      const staleRunning = items.filter(
-        (el) => el.status === 'running' && el.runId && el.createdAt && Date.now() - el.createdAt > STALE_THRESHOLD
+      const stale = items.some(
+        (el) =>
+          (el.status === 'running' || (el.status === 'error' && !el.src)) &&
+          el.createdAt &&
+          Date.now() - el.createdAt > STALE_THRESHOLD
       );
-      if (staleRunning.length === 0) return;
-
-      // 逐个查询后端实际状态
-      for (const el of staleRunning) {
-        void getImageGenRun({ runId: el.runId!, includeItems: true, includeImages: true })
-          .then((res) => {
-            if (!res.success || !res.data?.run) return;
-            const run = res.data.run;
-            if (run.status === 'Completed') {
-              const item = res.data.items?.find((it) => it.url);
-              if (item?.url) {
-                setCanvas((prev) =>
-                  prev.map((x) =>
-                    x.key === el.key && x.status === 'running'
-                      ? { ...x, status: 'done', src: item.url!, kind: 'image', originalSrc: item.url!, syncStatus: 'synced' as const }
-                      : x
-                  )
-                );
-              } else {
-                setCanvas((prev) =>
-                  prev.map((x) =>
-                    x.key === el.key && x.status === 'running'
-                      ? { ...x, status: 'error', errorMessage: '生成完成但无图片数据' }
-                      : x
-                  )
-                );
-              }
-            } else if (run.status === 'Failed' || run.status === 'Cancelled') {
-              setCanvas((prev) =>
-                prev.map((x) =>
-                  x.key === el.key && x.status === 'running'
-                    ? { ...x, status: 'error', errorMessage: run.status === 'Failed' ? '生成失败' : '已取消' }
-                    : x
-                )
-              );
-            }
-            // Queued/Running：后端仍在处理，继续等待
-          })
-          .catch(() => {
-            // 查询失败，不做处理，下次 watchdog 再试
-          });
-      }
+      if (!stale) return;
+      void reconcileStuckCanvasRef.current();
     }, WATCHDOG_INTERVAL);
 
     return () => window.clearInterval(tid);
@@ -3877,10 +3871,34 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
       // 保存 runId 到画布元素，用于刷新页面后同步状态
       setCanvas((prev) => prev.map((x) => (x.key === key ? { ...x, runId } : x)));
 
+      // 立即持久化含 runId 的画布（不等 debounce）：避免拿到 runId 后用户立刻关页/切走，
+      // 导致占位落库时缺 runId 而无法被刷新恢复。注：对账兜底按 TargetCanvasKey 反查不依赖此项，
+      // 但补上 runId 能让 watchdog/刷新走更快的 in-session 路径。
+      void (async () => {
+        try {
+          const next = (canvasRef.current ?? []).map((x) => (x.key === key ? { ...x, runId } : x));
+          const built = canvasToPersistedV1(next);
+          const json = JSON.stringify(built.state);
+          if (json !== lastSavedJsonRef.current) {
+            lastSavedJsonRef.current = json;
+            lastSaveAtRef.current = Date.now();
+            await saveVisualAgentWorkspaceCanvas({
+              id: workspaceId,
+              schemaVersion: PERSIST_SCHEMA_VERSION,
+              payloadJson: json,
+              idempotencyKey: `runIdSave_${key}_${runId}`,
+            });
+          }
+        } catch {
+          // 立即保存失败不阻断生成；debounce 自动保存仍会兜底
+        }
+      })();
+
       // 可选：订阅进度并实时替换（关闭页面也没关系，服务端会最终回填）
       const ac = new AbortController();
       streamImageGenRunWithRetry({
         runId,
+        maxAttempts: 20,
         signal: ac.signal,
         onEvent: (evt) => {
           const data = String(evt.data ?? '').trim();
@@ -3963,9 +3981,35 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
             triggerDefectFlash();
           }
         },
-      }).then(() => {
-        // SSE 流结束后，检查该图片是否还在 running 状态
-        // 如果是，说明服务端没有返回最终状态，需要标记为 error
+      }).then(async () => {
+        // SSE 流"结束"≠生成失败：代理 EOF / 重试耗尽都会走到这里，而后端（服务器权威）可能仍在生成。
+        // 因此不再盲目标 error，先查后端真实状态：成功→回填图；仍在跑→保留占位交给看门狗/对账；确认失败/查不到→才标 error。
+        if ((canvasRef.current.find((x) => x.key === key)?.status) !== 'running') return;
+        try {
+          const res = await getImageGenRun({ runId, includeItems: true, includeImages: true });
+          if (res.success && res.data?.run) {
+            const run = res.data.run;
+            if (run.status === 'Completed') {
+              const it = res.data.items?.find((i) => i.url);
+              if (it?.url) {
+                const u = it.url;
+                setCanvas((prev) =>
+                  prev.map((x) =>
+                    x.key === key && x.status === 'running'
+                      ? { ...x, status: 'done', kind: 'image', src: u, originalSrc: u, syncStatus: 'synced' as const }
+                      : x
+                  )
+                );
+                return;
+              }
+            } else if (run.status === 'Queued' || run.status === 'Running') {
+              // 后端仍在跑：保留 running，交给看门狗/对账
+              return;
+            }
+          }
+        } catch {
+          // 查询失败：按超时处理（下方标 error），用户可重试，watchdog 也会再兜
+        }
         setCanvas((prev) => {
           const item = prev.find((x) => x.key === key);
           if (item && item.status === 'running') {
@@ -4150,6 +4194,7 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
         const ac = new AbortController();
         void streamImageGenRunWithRetry({
           runId,
+          maxAttempts: 20,
           signal: ac.signal,
           onEvent: (evt) => {
             const data = String(evt.data ?? '').trim();
@@ -4190,7 +4235,33 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
               pushMsg('Assistant', buildGenErrorContent({ msg, refSrc: refSrc || undefined, prompt, runId, modelPool: modelPoolName }));
             }
           },
-        }).then(() => {
+        }).then(async () => {
+          // SSE 流结束先查后端真实状态，避免代理 EOF / 重试耗尽时误标 error（后端可能仍在生成）。
+          if ((canvasRef.current.find((x) => x.key === key)?.status) !== 'running') return;
+          try {
+            const res = await getImageGenRun({ runId, includeItems: true, includeImages: true });
+            if (res.success && res.data?.run) {
+              const run = res.data.run;
+              if (run.status === 'Completed') {
+                const it = res.data.items?.find((i) => i.url);
+                if (it?.url) {
+                  const u = it.url;
+                  setCanvas((prev) =>
+                    prev.map((x) =>
+                      x.key === key && x.status === 'running'
+                        ? { ...x, status: 'done', kind: 'image', src: u, originalSrc: u, syncStatus: 'synced' as const }
+                        : x
+                    )
+                  );
+                  return;
+                }
+              } else if (run.status === 'Queued' || run.status === 'Running') {
+                return;
+              }
+            }
+          } catch {
+            // 查询失败：按超时处理
+          }
           setCanvas((prev) => {
             const item = prev.find((x) => x.key === key);
             if (item && item.status === 'running') {
@@ -8914,6 +8985,7 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
             const sketchAc = new AbortController();
             void streamImageGenRunWithRetry({
               runId,
+              maxAttempts: 20,
               signal: sketchAc.signal,
               onEvent: (evt) => {
                 const evData = String(evt.data ?? '').trim();
@@ -8952,7 +9024,31 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
                   pushMsg('Assistant', buildGenErrorContent({ msg, refSrc, prompt: desc.trim(), runId, modelPool: modelPoolName }));
                 }
               },
-            }).then(() => {
+            }).then(async () => {
+              // SSE 流结束先查后端真实状态，避免代理 EOF / 重试耗尽时误标 error（后端可能仍在生成）。
+              if ((canvasRef.current.find(x => x.key === genKey)?.status) !== 'running') return;
+              try {
+                const res = await getImageGenRun({ runId, includeItems: true, includeImages: true });
+                if (res.success && res.data?.run) {
+                  const run = res.data.run;
+                  if (run.status === 'Completed') {
+                    const it = res.data.items?.find(i => i.url);
+                    if (it?.url) {
+                      const u = it.url;
+                      setCanvas(prev => prev.map(x =>
+                        x.key === genKey && x.status === 'running'
+                          ? { ...x, status: 'done' as const, kind: 'image' as const, src: u, originalSrc: u, syncStatus: 'synced' as const }
+                          : x
+                      ));
+                      return;
+                    }
+                  } else if (run.status === 'Queued' || run.status === 'Running') {
+                    return;
+                  }
+                }
+              } catch {
+                // 查询失败：按超时处理
+              }
               setCanvas(prev => {
                 const item = prev.find(x => x.key === genKey);
                 if (item && item.status === 'running') {

--- a/prd-admin/src/pages/ai-chat/AdvancedVisualAgentTab.tsx
+++ b/prd-admin/src/pages/ai-chat/AdvancedVisualAgentTab.tsx
@@ -2646,21 +2646,72 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
     reconcileStuckCanvasRef.current = reconcileStuckCanvas;
   }, [reconcileStuckCanvas]);
 
-  // Watchdog：定期检查画布上卡住的 running / 无图 error 占位，统一走 workspace 级对账自动恢复或标记失败
+  // Watchdog：定期检查画布上卡住的 running / 无图 error 占位并自动恢复。
+  // 两条路径缺一不可：
+  //  A) 有 runId 的占位 → 直查 run 状态同步本地。覆盖"SSE 掉线但 worker 已成功"的 desync：
+  //     此时 server 画布已是 done，workspace 对账只扫 server 端仍卡死的元素、扫不到它，
+  //     必须靠直查 run 把本地从 running 拉成 done（否则本地永远转圈）。
+  //  B) 无 runId 的占位（历史孤儿）→ 走 workspace 级对账（按 TargetCanvasKey 反查）。
   useEffect(() => {
     const WATCHDOG_INTERVAL = 15_000; // 每 15 秒检查一次
-    const STALE_THRESHOLD = 45_000; // 占位超过 45 秒未出结果即触发对账（旧值 120s 过长）
+    const STALE_THRESHOLD = 45_000; // 占位超过 45 秒未出结果即触发恢复（旧值 120s 过长）
 
     const tid = window.setInterval(() => {
       const items = canvasRef.current;
-      const stale = items.some(
+      const stale = items.filter(
         (el) =>
           (el.status === 'running' || (el.status === 'error' && !el.src)) &&
           el.createdAt &&
           Date.now() - el.createdAt > STALE_THRESHOLD
       );
-      if (!stale) return;
-      void reconcileStuckCanvasRef.current();
+      if (stale.length === 0) return;
+
+      const wid0 = workspaceIdRef.current;
+
+      // A) 有 runId 的卡死元素：直查 run 真实状态，同步本地（覆盖 SSE 掉线 desync）
+      for (const el of stale) {
+        if (!el.runId) continue;
+        const runId = el.runId;
+        const key = el.key;
+        void getImageGenRun({ runId, includeItems: true, includeImages: true })
+          .then((res) => {
+            if (workspaceIdRef.current !== wid0) return; // 防串台：已切换 workspace
+            if (!res.success || !res.data?.run) return;
+            const run = res.data.run;
+            if (run.status === 'Completed') {
+              const it = res.data.items?.find((i) => i.url);
+              if (it?.url) {
+                const u = it.url;
+                setCanvas((prev) =>
+                  prev.map((x) =>
+                    x.key === key && x.status === 'running'
+                      ? { ...x, status: 'done', kind: 'image', src: u, originalSrc: u, syncStatus: 'synced' as const }
+                      : x
+                  )
+                );
+              } else {
+                setCanvas((prev) =>
+                  prev.map((x) => (x.key === key && x.status === 'running' ? { ...x, status: 'error', errorMessage: '生成完成但无图片数据' } : x))
+                );
+              }
+            } else if (run.status === 'Failed' || run.status === 'Cancelled') {
+              const errItem = res.data.items?.find((i) => i.errorMessage);
+              const msg = run.status === 'Cancelled' ? '已取消' : (errItem?.errorMessage || '生成失败');
+              setCanvas((prev) =>
+                prev.map((x) => (x.key === key && x.status === 'running' ? { ...x, status: 'error', errorMessage: msg } : x))
+              );
+            }
+            // Queued/Running：后端仍在处理，保留占位
+          })
+          .catch(() => {
+            // 查询失败，下次 watchdog 再试
+          });
+      }
+
+      // B) 无 runId 的卡死元素（历史孤儿）→ workspace 级对账
+      if (stale.some((el) => !el.runId)) {
+        void reconcileStuckCanvasRef.current();
+      }
     }, WATCHDOG_INTERVAL);
 
     return () => window.clearInterval(tid);

--- a/prd-admin/src/pages/ai-chat/AdvancedVisualAgentTab.tsx
+++ b/prd-admin/src/pages/ai-chat/AdvancedVisualAgentTab.tsx
@@ -228,6 +228,8 @@ type PersistedCanvasElementV1 =
       hidden?: boolean;
       /** 占位状态：running 表示生成中，后端会回填 */
       status?: 'running' | 'error';
+      /** 占位元素关联的后端生图 runId，持久化以便刷新后快速对账（SSOT 仍是后端 run.TargetCanvasKey） */
+      runId?: string;
       /** 图片引用 ID，用于消息中的 @imgN 引用，持久化保存 */
       refId?: number;
       ext?: Record<string, unknown>;
@@ -345,6 +347,8 @@ function canvasToPersistedV1(items: CanvasImageItem[]): { state: PersistedCanvas
         naturalH: it.naturalH,
         // 保存占位状态，以便后端回填时能找到目标元素
         status: isPlaceholder ? (it.status as 'running' | 'error') : undefined,
+        // 持久化 runId（仅占位元素）：避免关页/刷新后丢失，导致占位无法被对账/看门狗恢复
+        runId: isPlaceholder && it.runId ? String(it.runId).trim() || undefined : undefined,
         // 持久化 refId
         refId: typeof it.refId === 'number' && it.refId > 0 ? it.refId : undefined,
         ext: {},
@@ -420,6 +424,8 @@ function persistedV1ToCanvas(
         src,
         // 恢复占位状态：running 表示后端仍在生成中
         status: isPlaceholder ? el.status! : 'done',
+        // 恢复持久化的 runId（占位元素），供 in-session 看门狗/刷新走快速路径
+        runId: isPlaceholder && el.runId ? String(el.runId).trim() || undefined : undefined,
         kind: 'image',
         syncStatus: src.startsWith('/api/visual-agent/image-master/assets/file/') || /^https?:\/\//i.test(src) ? 'synced' : 'pending',
         syncError: null,
@@ -2535,8 +2541,11 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
           // 走 workspace 级对账（按 TargetCanvasKey 反查），不依赖前端持久化的 runId。
           const hasStuck = restored.canvas.some((el) => el.status === 'running' || (el.status === 'error' && !el.src));
           if (hasStuck && workspaceId) {
-            void reconcileVisualAgentWorkspaceCanvas({ id: workspaceId, dryRun: false })
+            const reconcileWid = workspaceId;
+            void reconcileVisualAgentWorkspaceCanvas({ id: reconcileWid, dryRun: false })
               .then((res) => {
+                // 防串台：响应回来时若已切换 workspace / 卸载，丢弃，避免把别的 workspace 的对账结果套到当前画布
+                if (cancelled || workspaceId !== reconcileWid) return;
                 if (res.success && res.data?.reconciled?.length) {
                   applyReconcileReport(res.data.reconciled, setCanvas);
                 }
@@ -2607,6 +2616,10 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
     };
   }, [focusStage, pushMsg, setViewport, workspaceId]);
 
+  // 当前 workspaceId 的最新值引用：供异步回调判断是否已切换 workspace（防串台）
+  const workspaceIdRef = useRef(workspaceId);
+  workspaceIdRef.current = workspaceId;
+
   // 画布对账兜底：按 run.TargetCanvasKey 反查真实结果，修复 running / 无图 error 的卡死占位。
   // 关键：后端按"画布元素 id == TargetCanvasKey"匹配，不依赖前端 runId，
   // 因此能拯救历史上 runId 未落库的孤儿占位（详见 backend ReconcileWorkspaceCanvas）。
@@ -2618,6 +2631,8 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
     if (!hasStuck) return;
     try {
       const res = await reconcileVisualAgentWorkspaceCanvas({ id: wid, dryRun: false });
+      // 防串台：响应回来时若已切换 workspace，丢弃，避免把别的 workspace 的对账结果套到当前画布
+      if (workspaceIdRef.current !== wid) return;
       if (res.success && res.data?.reconciled?.length) {
         applyReconcileReport(res.data.reconciled, setCanvas);
       }
@@ -3880,14 +3895,18 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
           const built = canvasToPersistedV1(next);
           const json = JSON.stringify(built.state);
           if (json !== lastSavedJsonRef.current) {
-            lastSavedJsonRef.current = json;
-            lastSaveAtRef.current = Date.now();
-            await saveVisualAgentWorkspaceCanvas({
+            const r = await saveVisualAgentWorkspaceCanvas({
               id: workspaceId,
               schemaVersion: PERSIST_SCHEMA_VERSION,
               payloadJson: json,
               idempotencyKey: `runIdSave_${key}_${runId}`,
             });
+            // 仅在保存成功后才更新已存标记：失败则保持旧标记，让 debounce 自动保存重试，
+            // 避免"标记已存但实际没存进 runId"导致刷新后占位再次成孤儿。
+            if (r.success) {
+              lastSavedJsonRef.current = json;
+              lastSaveAtRef.current = Date.now();
+            }
           }
         } catch {
           // 立即保存失败不阻断生成；debounce 自动保存仍会兜底
@@ -3985,6 +4004,8 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
         // SSE 流"结束"≠生成失败：代理 EOF / 重试耗尽都会走到这里，而后端（服务器权威）可能仍在生成。
         // 因此不再盲目标 error，先查后端真实状态：成功→回填图；仍在跑→保留占位交给看门狗/对账；确认失败/查不到→才标 error。
         if ((canvasRef.current.find((x) => x.key === key)?.status) !== 'running') return;
+        // 默认按"超时/连接中断"处理；若后端能给出真实失败原因，则覆盖为真实原因（不再一律显示超时）。
+        let failMsg = '生成超时或连接中断，请重试';
         try {
           const res = await getImageGenRun({ runId, includeItems: true, includeImages: true });
           if (res.success && res.data?.run) {
@@ -4002,23 +4023,28 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
                 );
                 return;
               }
+              failMsg = '生成完成但无图片数据，请重试';
             } else if (run.status === 'Queued' || run.status === 'Running') {
               // 后端仍在跑：保留 running，交给看门狗/对账
               return;
+            } else if (run.status === 'Failed' || run.status === 'Cancelled') {
+              // surface 真实失败原因，而不是误报"超时"
+              const errItem = res.data.items?.find((i) => i.errorMessage);
+              failMsg = run.status === 'Cancelled' ? '已取消' : (errItem?.errorMessage || '生成失败');
             }
           }
         } catch {
-          // 查询失败：按超时处理（下方标 error），用户可重试，watchdog 也会再兜
+          // 查询失败：沿用默认超时文案
         }
         setCanvas((prev) => {
           const item = prev.find((x) => x.key === key);
           if (item && item.status === 'running') {
-            pushMsg('Assistant', buildGenErrorContent({ msg: '生成超时或连接中断，请重试', refSrc: refSrc || undefined, prompt: displayPrompt || undefined, runId, modelPool: pickedModel?.name || pickedModel?.modelName || '', imageRefShas }));
+            pushMsg('Assistant', buildGenErrorContent({ msg: failMsg, refSrc: refSrc || undefined, prompt: displayPrompt || undefined, runId, modelPool: pickedModel?.name || pickedModel?.modelName || '', imageRefShas }));
             triggerDefectFlash();
           }
           return prev.map((x) =>
             x.key === key && x.status === 'running'
-              ? { ...x, status: 'error', errorMessage: '生成超时或连接中断，请重试' }
+              ? { ...x, status: 'error', errorMessage: failMsg }
               : x
           );
         });
@@ -4238,6 +4264,7 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
         }).then(async () => {
           // SSE 流结束先查后端真实状态，避免代理 EOF / 重试耗尽时误标 error（后端可能仍在生成）。
           if ((canvasRef.current.find((x) => x.key === key)?.status) !== 'running') return;
+          let failMsg = '生成超时或连接中断，请重试';
           try {
             const res = await getImageGenRun({ runId, includeItems: true, includeImages: true });
             if (res.success && res.data?.run) {
@@ -4255,21 +4282,25 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
                   );
                   return;
                 }
+                failMsg = '生成完成但无图片数据，请重试';
               } else if (run.status === 'Queued' || run.status === 'Running') {
                 return;
+              } else if (run.status === 'Failed' || run.status === 'Cancelled') {
+                const errItem = res.data.items?.find((i) => i.errorMessage);
+                failMsg = run.status === 'Cancelled' ? '已取消' : (errItem?.errorMessage || '生成失败');
               }
             }
           } catch {
-            // 查询失败：按超时处理
+            // 查询失败：沿用默认超时文案
           }
           setCanvas((prev) => {
             const item = prev.find((x) => x.key === key);
             if (item && item.status === 'running') {
-              pushMsg('Assistant', buildGenErrorContent({ msg: '生成超时或连接中断，请重试', refSrc: refSrc || undefined, prompt, modelPool: modelPoolName }));
+              pushMsg('Assistant', buildGenErrorContent({ msg: failMsg, refSrc: refSrc || undefined, prompt, modelPool: modelPoolName }));
             }
             return prev.map((x) =>
               x.key === key && x.status === 'running'
-                ? { ...x, status: 'error', errorMessage: '生成超时或连接中断，请重试' }
+                ? { ...x, status: 'error', errorMessage: failMsg }
                 : x
             );
           });
@@ -9027,6 +9058,7 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
             }).then(async () => {
               // SSE 流结束先查后端真实状态，避免代理 EOF / 重试耗尽时误标 error（后端可能仍在生成）。
               if ((canvasRef.current.find(x => x.key === genKey)?.status) !== 'running') return;
+              let failMsg = '生成超时或连接中断，请重试';
               try {
                 const res = await getImageGenRun({ runId, includeItems: true, includeImages: true });
                 if (res.success && res.data?.run) {
@@ -9042,21 +9074,25 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
                       ));
                       return;
                     }
+                    failMsg = '生成完成但无图片数据，请重试';
                   } else if (run.status === 'Queued' || run.status === 'Running') {
                     return;
+                  } else if (run.status === 'Failed' || run.status === 'Cancelled') {
+                    const errItem = res.data.items?.find(i => i.errorMessage);
+                    failMsg = run.status === 'Cancelled' ? '已取消' : (errItem?.errorMessage || '生成失败');
                   }
                 }
               } catch {
-                // 查询失败：按超时处理
+                // 查询失败：沿用默认超时文案
               }
               setCanvas(prev => {
                 const item = prev.find(x => x.key === genKey);
                 if (item && item.status === 'running') {
-                  pushMsg('Assistant', buildGenErrorContent({ msg: '生成超时或连接中断，请重试', refSrc, prompt: desc.trim(), modelPool: modelPoolName }));
+                  pushMsg('Assistant', buildGenErrorContent({ msg: failMsg, refSrc, prompt: desc.trim(), modelPool: modelPoolName }));
                 }
                 return prev.map(x =>
                   x.key === genKey && x.status === 'running'
-                    ? { ...x, status: 'error' as const, errorMessage: '生成超时或连接中断，请重试' }
+                    ? { ...x, status: 'error' as const, errorMessage: failMsg }
                     : x
                 );
               });

--- a/prd-admin/src/pages/ai-chat/AdvancedVisualAgentTab.tsx
+++ b/prd-admin/src/pages/ai-chat/AdvancedVisualAgentTab.tsx
@@ -2620,6 +2620,36 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
   const workspaceIdRef = useRef(workspaceId);
   workspaceIdRef.current = workspaceId;
 
+  // 拿到 runId 后立即把含 runId 的画布落盘（不等 debounce）：避免用户在 debounce 刷盘前关页/切走，
+  // 导致占位落库缺 runId。三条生图路径（主生成 / 快捷操作 / 草图）统一复用，避免只在主路径补 runId。
+  const persistRunIdImmediately = useCallback(
+    (key: string, runId: string) => {
+      void (async () => {
+        try {
+          const next = (canvasRef.current ?? []).map((x) => (x.key === key ? { ...x, runId } : x));
+          const built = canvasToPersistedV1(next);
+          const json = JSON.stringify(built.state);
+          if (json !== lastSavedJsonRef.current) {
+            const r = await saveVisualAgentWorkspaceCanvas({
+              id: workspaceId,
+              schemaVersion: PERSIST_SCHEMA_VERSION,
+              payloadJson: json,
+              idempotencyKey: `runIdSave_${key}_${runId}`,
+            });
+            // 仅保存成功才更新已存标记：失败保留旧标记让 debounce 重试，避免误判已存导致 runId 永不落库。
+            if (r.success) {
+              lastSavedJsonRef.current = json;
+              lastSaveAtRef.current = Date.now();
+            }
+          }
+        } catch {
+          // 立即保存失败不阻断生成；debounce 自动保存仍会兜底
+        }
+      })();
+    },
+    [workspaceId]
+  );
+
   // 画布对账兜底：按 run.TargetCanvasKey 反查真实结果，修复 running / 无图 error 的卡死占位。
   // 关键：后端按"画布元素 id == TargetCanvasKey"匹配，不依赖前端 runId，
   // 因此能拯救历史上 runId 未落库的孤儿占位（详见 backend ReconcileWorkspaceCanvas）。
@@ -2668,7 +2698,10 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
 
       const wid0 = workspaceIdRef.current;
 
-      // A) 有 runId 的卡死元素：直查 run 真实状态，同步本地（覆盖 SSE 掉线 desync）
+      // A) 有 runId 的卡死元素：直查 run 真实状态，同步本地（覆盖 SSE 掉线 desync）。
+      //    healable 同时含 running 与"无图 error"：transient SSE/查询失败可能把仍在生成的占位误标 error，
+      //    待 run 实际 Completed 时必须能从 error 翻回 done，否则会卡在 error 直到刷新。
+      const healable = (x: CanvasImageItem) => x.status === 'running' || (x.status === 'error' && !x.src);
       for (const el of stale) {
         if (!el.runId) continue;
         const runId = el.runId;
@@ -2684,8 +2717,8 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
                 const u = it.url;
                 setCanvas((prev) =>
                   prev.map((x) =>
-                    x.key === key && x.status === 'running'
-                      ? { ...x, status: 'done', kind: 'image', src: u, originalSrc: u, syncStatus: 'synced' as const }
+                    x.key === key && healable(x)
+                      ? { ...x, status: 'done', kind: 'image', src: u, originalSrc: u, syncStatus: 'synced' as const, syncError: null }
                       : x
                   )
                 );
@@ -3936,33 +3969,8 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
 
       // 保存 runId 到画布元素，用于刷新页面后同步状态
       setCanvas((prev) => prev.map((x) => (x.key === key ? { ...x, runId } : x)));
-
-      // 立即持久化含 runId 的画布（不等 debounce）：避免拿到 runId 后用户立刻关页/切走，
-      // 导致占位落库时缺 runId 而无法被刷新恢复。注：对账兜底按 TargetCanvasKey 反查不依赖此项，
-      // 但补上 runId 能让 watchdog/刷新走更快的 in-session 路径。
-      void (async () => {
-        try {
-          const next = (canvasRef.current ?? []).map((x) => (x.key === key ? { ...x, runId } : x));
-          const built = canvasToPersistedV1(next);
-          const json = JSON.stringify(built.state);
-          if (json !== lastSavedJsonRef.current) {
-            const r = await saveVisualAgentWorkspaceCanvas({
-              id: workspaceId,
-              schemaVersion: PERSIST_SCHEMA_VERSION,
-              payloadJson: json,
-              idempotencyKey: `runIdSave_${key}_${runId}`,
-            });
-            // 仅在保存成功后才更新已存标记：失败则保持旧标记，让 debounce 自动保存重试，
-            // 避免"标记已存但实际没存进 runId"导致刷新后占位再次成孤儿。
-            if (r.success) {
-              lastSavedJsonRef.current = json;
-              lastSaveAtRef.current = Date.now();
-            }
-          }
-        } catch {
-          // 立即保存失败不阻断生成；debounce 自动保存仍会兜底
-        }
-      })();
+      // 立即落盘含 runId 的画布（不等 debounce），三条生图路径统一复用
+      persistRunIdImmediately(key, runId);
 
       // 可选：订阅进度并实时替换（关闭页面也没关系，服务端会最终回填）
       const ac = new AbortController();
@@ -4266,6 +4274,7 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
         }
         const modelPoolName = pickedModel?.name || pickedModel?.modelName || '';
         setCanvas((prev) => prev.map((x) => (x.key === key ? { ...x, runId } : x)));
+        persistRunIdImmediately(key, runId);
 
         // 订阅 SSE 流
         const ac = new AbortController();
@@ -4362,7 +4371,7 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
         pushMsg('Assistant', buildGenErrorContent({ msg, refSrc: refSrc || undefined, prompt }));
       }
     },
-    [effectiveModel, imageGenSize, workspaceId, setSelectionWithoutChip, pushMsg],
+    [effectiveModel, imageGenSize, workspaceId, setSelectionWithoutChip, pushMsg, persistRunIdImmediately],
   );
 
   /** 快捷操作栏：点击内置/DIY 操作 */
@@ -9064,6 +9073,7 @@ export default function AdvancedVisualAgentTab(props: { workspaceId: string; ini
             // 订阅 Run 事件流
             const runId = runRes.data.runId;
             setCanvas(prev => prev.map(x => x.key === genKey ? { ...x, runId } : x));
+            persistRunIdImmediately(genKey, runId);
             const sketchAc = new AbortController();
             void streamImageGenRunWithRetry({
               runId,

--- a/prd-admin/src/services/api.ts
+++ b/prd-admin/src/services/api.ts
@@ -342,6 +342,7 @@ export const api = {
         viewport: (id: string) => `/api/visual-agent/image-master/workspaces/${id}/viewport`,
         messages: (id: string) => `/api/visual-agent/image-master/workspaces/${id}/messages`,
         canvas: (id: string) => `/api/visual-agent/image-master/workspaces/${id}/canvas`,
+        canvasReconcile: (id: string) => `/api/visual-agent/image-master/workspaces/${id}/canvas/reconcile`,
         assets: (id: string) => `/api/visual-agent/image-master/workspaces/${id}/assets`,
         asset: (id: string, assetId: string) => `/api/visual-agent/image-master/workspaces/${id}/assets/${assetId}`,
         imageGenRuns: (id: string) => `/api/visual-agent/image-master/workspaces/${id}/image-gen/runs`,

--- a/prd-admin/src/services/contracts/visualAgent.ts
+++ b/prd-admin/src/services/contracts/visualAgent.ts
@@ -214,6 +214,25 @@ export type CreateWorkspaceImageGenRunContract = (args: {
   idempotencyKey?: string;
 }) => Promise<ApiResponse<{ runId: string }>>;
 
+/** 画布对账：按 run.TargetCanvasKey 反查真实结果，修复 running/无图 error 的卡死占位（不依赖前端 runId） */
+export type ReconcileCanvasItem = {
+  key: string;
+  action: 'recovered' | 'marked-error' | 'already-error' | 'in-progress' | 'no-run';
+  runId?: string;
+  runStatus?: string;
+  src?: string | null;
+  assetId?: string | null;
+  sha256?: string | null;
+  originalSrc?: string | null;
+  originalSha256?: string | null;
+  prompt?: string | null;
+  errorMessage?: string | null;
+};
+
+export type ReconcileWorkspaceCanvasContract = (args: { id: string; dryRun?: boolean }) => Promise<
+  ApiResponse<{ reconciled: ReconcileCanvasItem[]; updated: boolean; dryRun?: boolean; conflict?: boolean }>
+>;
+
 export type DeleteVisualAgentWorkspaceAssetContract = (input: { id: string; assetId: string }) => Promise<ApiResponse<{ deleted: boolean }>>;
 
 export type RefreshVisualAgentWorkspaceCoverContract = (input: { id: string; limit?: number; idempotencyKey?: string }) => Promise<

--- a/prd-admin/src/services/index.ts
+++ b/prd-admin/src/services/index.ts
@@ -113,6 +113,7 @@ import type {
   DeleteVisualAgentWorkspaceAssetContract,
   UpdateVisualAgentWorkspaceContract,
   CreateWorkspaceImageGenRunContract,
+  ReconcileWorkspaceCanvasContract,
 } from '@/services/contracts/visualAgent';
 import type {
   CreateDesktopAssetKeyContract,
@@ -384,6 +385,7 @@ import {
   deleteVisualAgentWorkspaceAssetReal,
   updateVisualAgentWorkspaceReal,
   createWorkspaceImageGenRunReal,
+  reconcileVisualAgentWorkspaceCanvasReal,
   generateArticleMarkersReal,
   extractArticleMarkersReal,
   exportArticleReal,
@@ -975,6 +977,7 @@ export const saveVisualAgentWorkspaceViewport: SaveVisualAgentWorkspaceViewportC
 export const uploadVisualAgentWorkspaceAsset: UploadVisualAgentWorkspaceAssetContract = withAuth(uploadVisualAgentWorkspaceAssetReal);
 export const deleteVisualAgentWorkspaceAsset: DeleteVisualAgentWorkspaceAssetContract = withAuth(deleteVisualAgentWorkspaceAssetReal);
 export const createWorkspaceImageGenRun: CreateWorkspaceImageGenRunContract = withAuth(createWorkspaceImageGenRunReal);
+export const reconcileVisualAgentWorkspaceCanvas: ReconcileWorkspaceCanvasContract = withAuth(reconcileVisualAgentWorkspaceCanvasReal);
 export const refreshVisualAgentWorkspaceCover: RefreshVisualAgentWorkspaceCoverContract = withAuth(refreshVisualAgentWorkspaceCoverReal);
 
 export const generateVisualAgentWorkspaceTitle = generateVisualAgentWorkspaceTitleReal;

--- a/prd-admin/src/services/real/visualAgent.ts
+++ b/prd-admin/src/services/real/visualAgent.ts
@@ -24,6 +24,7 @@ import type {
   RefreshVisualAgentWorkspaceCoverContract,
   UploadImageAssetContract,
   CreateWorkspaceImageGenRunContract,
+  ReconcileWorkspaceCanvasContract,
   ImageAsset,
   VisualAgentCanvas,
   VisualAgentMessage,
@@ -258,6 +259,13 @@ export const createWorkspaceImageGenRunReal: CreateWorkspaceImageGenRunContract 
     method: 'POST',
     headers,
     body: input,
+  });
+};
+
+export const reconcileVisualAgentWorkspaceCanvasReal: ReconcileWorkspaceCanvasContract = async ({ id, dryRun }) => {
+  const qs = dryRun ? '?dryRun=true' : '';
+  return await apiRequest(`${api.visualAgent.imageMaster.workspaces.canvasReconcile(encodeURIComponent(id))}${qs}`, {
+    method: 'POST',
   });
 };
 

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ImageMasterController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ImageMasterController.cs
@@ -1142,6 +1142,146 @@ public class ImageMasterController : ControllerBase
         return Ok(ApiResponse<object>.Ok(payload));
     }
 
+    private static string ReadCanvasStr(JsonObject o, string key)
+    {
+        var v = o[key];
+        if (v is JsonValue jv && jv.TryGetValue<string>(out var s)) return (s ?? string.Empty).Trim();
+        return string.Empty;
+    }
+
+    /// <summary>
+    /// 画布对账兜底：扫描画布上仍停在 running / 无图 error 的占位元素，按 image_gen_runs 的 TargetCanvasKey
+    /// 反查真实结果，修复"后端已生成或已失败、但画布占位卡死"的状态。
+    /// 关键：按"画布元素 id == run.TargetCanvasKey"匹配，不依赖前端持久化 runId，
+    /// 因此能拯救历史上 runId 未落库的孤儿占位。dryRun=true 时只报告不落库。
+    /// </summary>
+    [HttpPost("workspaces/{id}/canvas/reconcile")]
+    public async Task<IActionResult> ReconcileWorkspaceCanvas(string id, [FromQuery] bool dryRun = false, CancellationToken ct = default)
+    {
+        var adminId = GetAdminId();
+        var wid = (id ?? string.Empty).Trim();
+        if (string.IsNullOrWhiteSpace(wid)) return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "id 不能为空"));
+
+        var ws = await GetWorkspaceIfAllowedAsync(wid, adminId, ct);
+        if (ws == null) return NotFound(ApiResponse<object>.Fail("WORKSPACE_NOT_FOUND", "Workspace 不存在"));
+        if (ws.OwnerUserId == "__FORBIDDEN__") return StatusCode(StatusCodes.Status403Forbidden, ApiResponse<object>.Fail(ErrorCodes.PERMISSION_DENIED, "无权限"));
+
+        // OCC 重试：对账期间 Worker 可能也在写画布
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            var canvas = await _db.ImageMasterCanvases
+                .Find(x => x.WorkspaceId == wid)
+                .SortByDescending(x => x.UpdatedAt).ThenByDescending(x => x.CreatedAt)
+                .FirstOrDefaultAsync(ct);
+            if (canvas == null || string.IsNullOrWhiteSpace((canvas.PayloadJson ?? string.Empty).Trim()))
+                return Ok(ApiResponse<object>.Ok(new { reconciled = Array.Empty<object>(), updated = false, dryRun }));
+
+            JsonNode? root;
+            try { root = JsonNode.Parse(canvas.PayloadJson); } catch { return Ok(ApiResponse<object>.Ok(new { reconciled = Array.Empty<object>(), updated = false, dryRun })); }
+            var elements = root?["elements"] as JsonArray;
+            if (elements == null) return Ok(ApiResponse<object>.Ok(new { reconciled = Array.Empty<object>(), updated = false, dryRun }));
+
+            var report = new List<object>();
+            var mutated = false;
+
+            foreach (var n in elements)
+            {
+                if (n is not JsonObject o) continue;
+                var status = ReadCanvasStr(o, "status");
+                var hasSrc = !string.IsNullOrWhiteSpace(ReadCanvasStr(o, "src"));
+                // 卡死占位：running，或 error 但没图（error 也可能其实后端已成功）
+                var isStuck = status == "running" || (status == "error" && !hasSrc);
+                if (!isStuck) continue;
+
+                var key = ReadCanvasStr(o, "id");
+                if (string.IsNullOrWhiteSpace(key)) key = ReadCanvasStr(o, "key");
+                if (string.IsNullOrWhiteSpace(key)) continue;
+
+                var run = await _db.ImageGenRuns
+                    .Find(x => x.OwnerAdminId == adminId && x.WorkspaceId == wid && x.TargetCanvasKey == key)
+                    .SortByDescending(x => x.CreatedAt)
+                    .FirstOrDefaultAsync(ct);
+                if (run == null) { report.Add(new { key, action = "no-run" }); continue; }
+
+                if (run.Status == ImageGenRunStatus.Completed)
+                {
+                    var item = await _db.ImageGenRunItems
+                        .Find(x => x.RunId == run.Id && x.OwnerAdminId == adminId && x.Status == ImageGenRunItemStatus.Done && x.Url != null && x.Url != "")
+                        .SortBy(x => x.ItemIndex).ThenBy(x => x.ImageIndex)
+                        .FirstOrDefaultAsync(ct);
+                    if (item != null && !string.IsNullOrWhiteSpace(item.Url))
+                    {
+                        var asset = await _db.ImageAssets
+                            .Find(x => x.WorkspaceId == wid && (x.Url == item.Url || x.OriginalUrl == item.Url))
+                            .FirstOrDefaultAsync(ct);
+                        o["kind"] = "image";
+                        o["status"] = "done";
+                        o["syncStatus"] = "synced";
+                        o["syncError"] = null;
+                        o["src"] = item.Url;
+                        if (asset != null)
+                        {
+                            o["assetId"] = asset.Id;
+                            o["sha256"] = asset.Sha256;
+                            if (!string.IsNullOrWhiteSpace(asset.OriginalUrl)) o["originalSrc"] = asset.OriginalUrl;
+                            if (!string.IsNullOrWhiteSpace(asset.OriginalSha256)) o["originalSha256"] = asset.OriginalSha256;
+                        }
+                        if (!string.IsNullOrWhiteSpace(item.Prompt)) o["prompt"] = item.Prompt;
+                        mutated = true;
+                        report.Add(new
+                        {
+                            key,
+                            action = "recovered",
+                            runId = run.Id,
+                            src = item.Url,
+                            assetId = asset?.Id,
+                            sha256 = asset?.Sha256,
+                            originalSrc = asset?.OriginalUrl,
+                            originalSha256 = asset?.OriginalSha256,
+                            prompt = item.Prompt
+                        });
+                    }
+                    else
+                    {
+                        if (status != "error") { o["status"] = "error"; o["errorMessage"] = "生成完成但无图片数据"; mutated = true; }
+                        report.Add(new { key, action = "marked-error", runId = run.Id, errorMessage = "生成完成但无图片数据" });
+                    }
+                }
+                else if (run.Status is ImageGenRunStatus.Failed or ImageGenRunStatus.Cancelled)
+                {
+                    var failItem = await _db.ImageGenRunItems
+                        .Find(x => x.RunId == run.Id && x.OwnerAdminId == adminId && x.ErrorMessage != null && x.ErrorMessage != "")
+                        .FirstOrDefaultAsync(ct);
+                    var msg = run.Status == ImageGenRunStatus.Cancelled
+                        ? "已取消"
+                        : (string.IsNullOrWhiteSpace(failItem?.ErrorMessage) ? "生成失败" : failItem!.ErrorMessage!);
+                    if (status != "error") { o["status"] = "error"; o["errorMessage"] = msg; o["syncStatus"] = "failed"; mutated = true; }
+                    report.Add(new { key, action = status == "error" ? "already-error" : "marked-error", runId = run.Id, runStatus = run.Status.ToString(), errorMessage = msg });
+                }
+                else
+                {
+                    // Queued / Running：后端仍在处理，保留占位
+                    report.Add(new { key, action = "in-progress", runId = run.Id, runStatus = run.Status.ToString() });
+                }
+            }
+
+            if (!mutated || dryRun)
+                return Ok(ApiResponse<object>.Ok(new { reconciled = report, updated = false, dryRun }));
+
+            var newJson = root!.ToJsonString(new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+            var nowTs = DateTime.UtcNow;
+            var updRes = await _db.ImageMasterCanvases.UpdateOneAsync(
+                x => x.Id == canvas.Id && x.UpdatedAt == canvas.UpdatedAt,
+                Builders<ImageMasterCanvas>.Update.Set(x => x.PayloadJson, newJson).Set(x => x.UpdatedAt, nowTs),
+                cancellationToken: ct);
+            if (updRes.ModifiedCount > 0)
+                return Ok(ApiResponse<object>.Ok(new { reconciled = report, updated = true, dryRun = false }));
+            // OCC 冲突 → 重试整轮
+        }
+
+        return Ok(ApiResponse<object>.Ok(new { reconciled = Array.Empty<object>(), updated = false, conflict = true }));
+    }
+
     [HttpPost("workspaces/{id}/assets")]
     public async Task<IActionResult> UploadWorkspaceAsset(string id, [FromBody] UploadAssetRequest request, CancellationToken ct)
     {

--- a/prd-api/src/PrdAgent.Api/Services/ImageGenRunWorker.cs
+++ b/prd-api/src/PrdAgent.Api/Services/ImageGenRunWorker.cs
@@ -704,6 +704,21 @@ public class ImageGenRunWorker : BackgroundService
             status = nextStatus.ToString(),
             endedAt = DateTime.UtcNow
         }, ct);
+
+        // 兜底：失败/取消时把对应画布占位从 running 翻成 error（成功路径已由 TryPatchWorkspaceCanvasAsync 回填）。
+        // 否则后端失败但画布元素永远停在 running，前端"预计 1024×1024"占位永久转圈，且看门狗/对账之外没有第二道闸。
+        if (nextStatus is ImageGenRunStatus.Failed or ImageGenRunStatus.Cancelled
+            && !string.IsNullOrWhiteSpace(run.WorkspaceId)
+            && !string.IsNullOrWhiteSpace(run.TargetCanvasKey))
+        {
+            var errItem = await _db.ImageGenRunItems
+                .Find(x => x.RunId == run.Id && x.ErrorMessage != null && x.ErrorMessage != "")
+                .FirstOrDefaultAsync(ct);
+            var errMsg = nextStatus == ImageGenRunStatus.Cancelled
+                ? "已取消"
+                : (string.IsNullOrWhiteSpace(errItem?.ErrorMessage) ? "生成失败" : errItem!.ErrorMessage!);
+            await TryMarkWorkspaceCanvasErrorAsync(run, errMsg, ct);
+        }
     }
 
     private static string ResolveSize(ImageGenRun run, ImageGenRunPlanItem planItem)
@@ -1157,6 +1172,56 @@ public class ImageGenRunWorker : BackgroundService
             }
 
             var nextJson = root.ToJsonString(new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+            var now = DateTime.UtcNow;
+            var res = await _db.ImageMasterCanvases.UpdateOneAsync(
+                x => x.Id == canvas.Id && x.UpdatedAt == canvas.UpdatedAt,
+                Builders<ImageMasterCanvas>.Update.Set(x => x.PayloadJson, nextJson).Set(x => x.UpdatedAt, now),
+                cancellationToken: ct);
+            if (res.ModifiedCount > 0) return;
+        }
+    }
+
+    /// <summary>
+    /// 失败/取消兜底：把 TargetCanvasKey 对应的画布占位元素从 running 翻成 error。
+    /// 只动仍是占位（无 src 且非 done）的元素，绝不覆盖已成功回填的图片。
+    /// </summary>
+    private async Task TryMarkWorkspaceCanvasErrorAsync(ImageGenRun run, string errorMessage, CancellationToken ct)
+    {
+        var wid = (run.WorkspaceId ?? string.Empty).Trim();
+        var key = (run.TargetCanvasKey ?? string.Empty).Trim();
+        if (string.IsNullOrWhiteSpace(wid) || string.IsNullOrWhiteSpace(key)) return;
+
+        for (var attempt = 0; attempt < 5; attempt++)
+        {
+            var canvas = await _db.ImageMasterCanvases.Find(x => x.WorkspaceId == wid).FirstOrDefaultAsync(ct);
+            if (canvas == null) return;
+            var raw = (canvas.PayloadJson ?? string.Empty).Trim();
+            if (string.IsNullOrWhiteSpace(raw)) return;
+
+            JsonNode? root;
+            try { root = JsonNode.Parse(raw); } catch { return; }
+            var elements = root?["elements"] as JsonArray;
+            if (elements == null) return;
+
+            JsonObject? target = null;
+            foreach (var n in elements)
+            {
+                if (n is not JsonObject o) continue;
+                var k = (o["id"]?.GetValue<string>() ?? o["key"]?.GetValue<string>() ?? string.Empty).Trim();
+                if (string.Equals(k, key, StringComparison.Ordinal)) { target = o; break; }
+            }
+            // 元素已被删除：不复活；已成功（done 或有 src）：不覆盖。
+            if (target == null) return;
+            var st = (target["status"]?.GetValue<string>() ?? string.Empty).Trim();
+            var hasSrc = !string.IsNullOrWhiteSpace(target["src"]?.GetValue<string>());
+            if (st == "done" || hasSrc) return;
+            if (st == "error") return; // 已是 error，无需重复写
+
+            target["status"] = "error";
+            target["errorMessage"] = string.IsNullOrWhiteSpace(errorMessage) ? "生成失败" : errorMessage;
+            target["syncStatus"] = "failed";
+
+            var nextJson = root!.ToJsonString(new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
             var now = DateTime.UtcNow;
             var res = await _db.ImageMasterCanvases.UpdateOneAsync(
                 x => x.Id == canvas.Id && x.UpdatedAt == canvas.UpdatedAt,


### PR DESCRIPTION
## 摘要

修复视觉创作中生图占位元素永久停留在 running 或无图 error 状态的问题。通过新增后端画布对账接口、改进 SSE 流结束处理逻辑、以及优化看门狗机制，确保卡死占位能被及时恢复或标记失败。

## 改动 diff

### 后端（prd-api）
- **新增对账接口** `POST /api/visual-agent/image-master/workspaces/{id}/canvas/reconcile`：按 `run.TargetCanvasKey` 反查真实结果，修复 running/无图 error 的卡死占位，不依赖前端 runId，可拯救历史孤儿占位
- **失败/取消兜底** `ImageGenRunWorker.cs`：生图失败或取消时自动把对应画布占位从 running 翻成 error（原先只在成功路径回填，失败的 run 让画布永远停在 running 转圈）
- **OCC 重试机制**：对账期间 Worker 可能并发写画布，使用乐观并发控制重试

### 前端（prd-admin）
- **新增对账应用函数** `applyReconcileReport()`：局部应用后端对账结果到本地画布，只动被对账命中的元素，绝不整盘覆盖
- **SSE 流结束改进**：不再盲目标 error，先查后端真实状态，成功则回填、仍在跑则保留占位，避免慢任务被代理 EOF 误判
- **立即持久化 runId**：拿到 runId 后立即保存画布（不等 debounce），避免关页/切走导致占位丢失 runId 成为孤儿
- **看门狗升级**：改走 workspace 级对账（覆盖无 runId 占位）+ 阈值从 120s 降到 45s，更快触发恢复
- **页面加载对账**：恢复历史画布时若检测到卡死占位，立即触发一次对账

### 类型定义（prd-admin）
- 新增 `ReconcileCanvasItem` 类型：对账结果项，包含 action（recovered/marked-error/already-error/in-progress/no-run）、src、assetId、sha256 等字段
- 新增 `ReconcileWorkspaceCanvasContract` 类型：对账接口契约

### 更新记录
- `changelogs/2026-05-24_visual-agent-canvas-reconcile.md`：记录本次改动的 5 条 fix/feat

## 关键实现细节

1. **后端对账不依赖 runId**：按 `run.TargetCanvasKey`（画布元素 id）反查，能拯救历史上 runId 未落库的孤儿占位
2. **SSE 流结束三段论**：流结束 ≠ 生成失败，先查后端权威状态，再决定回填/保留/标错
3. **立即保存 runId**：避免用户关页/切走时占位丢失 runId，导致刷新后无法被看门狗恢复
4. **看门狗走对账**：统一走 workspace 级对账，覆盖所有卡死占

https://claude.ai/code/session_01DvfXHdBdUjv7CS15upvkx3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches image-gen worker canvas writes and a new mutating reconcile API on user workspaces; incorrect matching or OCC races could mis-label placeholders, but scope is limited to visual-agent canvas state.
> 
> **Overview**
> Fixes visual-agent canvas placeholders that stay **running** or **error without an image** by aligning client, worker, and a new server-side reconcile path around **run `TargetCanvasKey`** (not only frontend `runId`).
> 
> **Backend:** Adds `POST .../workspaces/{id}/canvas/reconcile` to scan stuck elements, look up the latest `image_gen_runs` by `TargetCanvasKey`, and patch the stored canvas (recover done images or mark real failures). `ImageGenRunWorker` now marks the matching placeholder **error** on failed/cancelled runs, mirroring the existing success backfill.
> 
> **Frontend:** Persists **`runId`** in canvas v1 serialize/restore, saves it **immediately** after create (shared helper on main/quick/sketch paths), and applies reconcile reports **locally** without replacing the whole canvas. On load and on a **45s** watchdog, reconciles orphans and **directly polls** runs when `runId` exists (including healing transient **error** back to **done**). When SSE ends, it **queries run status** before labeling timeout, keeps **running** if still queued/running, and raises **`maxAttempts` to 20** on all three streams. Guards async reconcile/poll results when the **workspace** changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d82cfd319392796851942aeb3f7b8ba312d9e2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->