### PR TITLE
每日熵减计划 2026-W21 — D6 入库 5 条 changelog + D3 幽灵扫描验证

### DIFF
--- a/changelogs/.entropy-manifest.yml
+++ b/changelogs/.entropy-manifest.yml
@@ -66,3 +66,8 @@ processed:
   - 2026-05-10_pa-agent-appcaller-startup-sync.md
   - 2026-05-10_pa-agent-llm-binding-fix.md
   - 2026-05-10_pa-agent-merge-from-main.md
+  - 2026-05-10_pa-agent-prompt-format-fix.md
+  - 2026-05-10_pa-agent-savage-secretary.md
+  - 2026-05-13_streaming-text-maxtailchars.md
+  - 2026-05-13_streaming-text-unify-batch1.md
+  - 2026-05-13_streaming-text-unify-batch2.md

--- a/doc/rule.streaming-text.md
+++ b/doc/rule.streaming-text.md
@@ -184,6 +184,14 @@ const polishStream = useAiPreviewStream({
 - 批次二 (中等): AlignmentPanel, WorkflowChatPanel, DailyLogPolishPopover, QuickCreateWizard, SseTypingBlock 内部
 - 批次三 (收尾): WeeklyPoster TypingPanel, SseStreamPanel 文档对齐
 
+## 变更记录
+
+| 日期 | 说明 |
+|------|------|
+| 2026-05-13 批次一 | 新增 StreamingText 组件；Arena / 工作流 / PR Review SummaryPanel 接入；新增 `/_dev/streaming-text-lab` 演示场 |
+| 2026-05-13 批次二 | AlignmentPanel / DailyLogPolishPopover / ToolDetail / literary-agent / QuickCreateWizard / SseTypingBlock 接入；新增第 5 条 thinking 块禁裸文本强制规则 |
+| 2026-05-13 | 新增 `maxTailChars` prop — 通用尾部窗口，token key 用绝对 offset 防止滑窗闪烁；修复 EmergenceNode 因全文 span 堆积导致父节点被挤飞问题 |
+
 ## 相关
 
 - `prd-admin/src/components/streaming/StreamingText.tsx` 实现

--- a/doc/spec.pa-agent-savage-upgrade.md
+++ b/doc/spec.pa-agent-savage-upgrade.md
@@ -233,6 +233,7 @@ PA Agent 的全部技术基础设施**保留**：
 | 版本 | 日期 | 说明 |
 |------|------|------|
 | v1.0 落地版 | 2026-05-10 | 首版：剥离 emoji 后落地于本仓库；五条信条、验收用例、四象限毒舌一句完整保留 |
+| v1.1 | 2026-05-10 | 修复 System Prompt 注入用户姓名：弃用 `string.Format`，改用 `__PA_USER_DISPLAY_NAME__` 占位符 Replace，避免与 JSON 示例花括号冲突导致 `FormatException` |
 
 ---
 


### PR DESCRIPTION
自动生成的每日熵减 PR。

## 修复项

- **D1 命名违规**：0 项（全部合规）
- **D2 index.yml**：补缺 0 / 删幽灵 0
- **D3 guide.list.directory.md**：扫描到 23 条幽灵引用，经核验全部来自文件底部「变更历史表格」中的历史操作记录（已删除/重命名文件的审计痕迹），删除会损坏审计历史，跳过
- **D4 CLAUDE.md 技能表**：`**pnpm**` 误报（规则正文引用，非技能表条目），跳过
- **D6 changelog 入库**：5 条已入库
  - `2026-05-10_pa-agent-prompt-format-fix.md` → 追加至 `spec.pa-agent-savage-upgrade` 修订记录 v1.1
  - `2026-05-10_pa-agent-savage-secretary.md` → 同上（已含 v1.0 首版记录）
  - `2026-05-13_streaming-text-maxtailchars.md` → 追加至 `rule.streaming-text` 变更记录
  - `2026-05-13_streaming-text-unify-batch1.md` → 同上（批次一）
  - `2026-05-13_streaming-text-unify-batch2.md` → 同上（批次二）

## 跳过项（diff 核验未通过）

- D3 guide.list.directory 23 条幽灵：全部位于变更历史区域，属历史审计记录，不删除
- D4 pnpm：非技能表条目，正则误报

## 改动文件

- `doc/spec.pa-agent-savage-upgrade.md`：修订记录补 v1.1 prompt-format-fix
- `doc/rule.streaming-text.md`：新增变更记录章节（3 行）
- `changelogs/.entropy-manifest.yml`：标记 5 条已处理

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrpCLKGXe2mqGSWfWdU1vg)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and manifest-only updates with no runtime, auth, or API behavior changes.
> 
> **Overview**
> **Daily entropy reduction (D6)** marks five changelog entries as processed in `changelogs/.entropy-manifest.yml` and folds their substance into living docs instead of leaving orphan changelogs.
> 
> **`doc/rule.streaming-text.md`** gains a **变更记录** table: batch-one/batch-two StreamingText rollouts, the thinking-block “no bare text” rule, and the **`maxTailChars`** tail-window fix (offset keys to stop slide-window flicker / EmergenceNode layout blow-up).
> 
> **`doc/spec.pa-agent-savage-upgrade.md`** adds revision **v1.1**: PA Agent system prompt user-name injection switched from `string.Format` to `__PA_USER_DISPLAY_NAME__` **Replace** so JSON example braces no longer trigger **`FormatException`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 290fe2eca5388f5109cfa8b40e2581ecbf110dac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->