### PR TITLE
fix(prd-admin): 修复 AI 百宝箱知识库上传无效（FileList 被 value 清空）

### DIFF
--- a/changelogs/2026-05-25_fix-kb-upload-filelist.md
+++ b/changelogs/2026-05-25_fix-kb-upload-filelist.md
@@ -1,0 +1,1 @@
+| fix | prd-admin | 修复 AI 百宝箱知识库上传无效：handleKnowledgeFileSelect 在 e.target.value='' 之后才 Array.from(files)，而 value 清空会就地清空 live FileList，导致上传循环拿到空数组、文件不入列表也不上传。改为清空前先快照成数组（QuickCreateWizard + ToolEditor 两处） |

--- a/prd-admin/src/pages/ai-toolbox/components/QuickCreateWizard.tsx
+++ b/prd-admin/src/pages/ai-toolbox/components/QuickCreateWizard.tsx
@@ -628,12 +628,14 @@ export function QuickCreateWizard() {
   const kbUploadSessionRef = useRef(0);
 
   const handleKnowledgeFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = e.target.files;
-    if (!files) return;
+    // e.target.files 是 live FileList，必须先快照成数组；e.target.value='' 会就地清空它
+    const fileList = e.target.files;
+    if (!fileList || fileList.length === 0) return;
+    const files = Array.from(fileList);
     e.target.value = '';
 
     const session = kbUploadSessionRef.current;
-    for (const file of Array.from(files)) {
+    for (const file of files) {
       const tempId = Math.random().toString(36).slice(2, 11);
       setKnowledgeFiles(prev => [...prev, {
         id: tempId,

--- a/prd-admin/src/pages/ai-toolbox/components/ToolEditor.tsx
+++ b/prd-admin/src/pages/ai-toolbox/components/ToolEditor.tsx
@@ -286,11 +286,13 @@ export function ToolEditor() {
   };
 
   const handleKnowledgeFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = e.target.files;
-    if (!files) return;
+    // e.target.files 是 live FileList，必须先快照成数组；e.target.value='' 会就地清空它
+    const fileList = e.target.files;
+    if (!fileList || fileList.length === 0) return;
+    const files = Array.from(fileList);
     e.target.value = '';
 
-    for (const file of Array.from(files)) {
+    for (const file of files) {
       const tempId = Math.random().toString(36).slice(2, 11);
       const entry = {
         id: tempId,


### PR DESCRIPTION
## 摘要

真人验收发现：AI 百宝箱给智能体加知识库，文件选完后列表始终为空、不发上传请求、`knowledgeBaseIds` 一直是 `[]`、对话也命中不了知识库。根因是 `handleKnowledgeFileSelect` 在清空 `e.target.value` **之后**才 `Array.from(files)`，而清 value 会就地清空 `e.target.files` 这个 live FileList，导致上传循环拿到空数组。修复：清 value 前先快照成数组。

## 根因

```js
const files = e.target.files;   // live FileList 引用（len=1）
e.target.value = '';            // 清空 input → 把上面这个 live FileList 一并清空
for (const file of Array.from(files))  // 此时 files 已空 → 循环不执行 → 不上传、不入列表
```

`e.target.files` 是活引用，清 `value` 会连它清空。隔离测试坐实：清 value 后 `Array.from` 拿到 **0** 个；先快照再清拿到 **1** 个。

## 改动 diff

- `prd-admin/src/pages/ai-toolbox/components/QuickCreateWizard.tsx`：`handleKnowledgeFileSelect` 改为清 `value` 前先 `const files = Array.from(fileList)`
- `prd-admin/src/pages/ai-toolbox/components/ToolEditor.tsx`：同款 bug 同款修（完整模式编辑器）
- `changelogs/2026-05-25_fix-kb-upload-filelist.md`：changelog 碎片

## 测试

- [x] `pnpm tsc --noEmit` 通过
- [x] `pnpm lint` 改动文件零新增告警
- [x] 真机复现 bug（Playwright + 真实 filechooser，main 预览）：`input.files` 始终 0、无 `POST /api/v1/attachments` —— 与用户报告一字不差
- [x] 真机验证修复（Playwright，fix 分支预览，端到端）：
  - `POST /api/v1/attachments` → 200
  - 文件进入列表、徽章显示「1 个文件」
  - 保存后后端 `knowledgeBaseIds = ["16ddde89-..."]`（非空）
  - 对话命中知识库：问「每人一桶水预先打满」能答出文档原意 + 特征词 `FIX_VERIFY_PROBE_5577`
- [x] 隔离逻辑对比：清 value 后 Array.from=0（bug）vs 先 Array.from 再清=1（fix）

## 备注

验证过程中发现一个**与本 fix 无关**的 CDS 服务缺陷（重部署 running 分支时把拆旧容器的 docker kill 误报为部署失败 exitCode=137），已另立 issue #667 交由 CDS 维护方处理。

---
_Generated by [Claude Code](https://claude.ai/code/session_011Uc8viBGcTNrMZ9zw1MCnc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized client-side fix in two change handlers; no auth, API contract, or persistence logic changes beyond restoring intended upload behavior.
> 
> **Overview**
> **AI 百宝箱**里给智能体加知识库时，选文件后列表一直为空、也不会调附件上传，是因为 `handleKnowledgeFileSelect` 先执行了 `e.target.value = ''`，浏览器会就地清空 **live** `FileList`，后面再 `Array.from(files)` 得到空数组，上传循环根本不跑。
> 
> 本 PR 在 **快速创建向导**（`QuickCreateWizard.tsx`）和 **完整编辑器**（`ToolEditor.tsx`）两处统一改为：在清空 input 之前用 `Array.from(fileList)` 快照文件，再清 `value` 并遍历快照上传。附带一条 `changelogs` 记录说明根因与修复点。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09e48b234f336eb2cc0533a72310b14d840fc257. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->