### PR TITLE
每日熵减计划 2026-W22 — changelog manifest 登记 2 条新碎片

### DIFF
--- a/changelogs/.entropy-manifest.yml
+++ b/changelogs/.entropy-manifest.yml
@@ -153,3 +153,5 @@ processed:
   - 2026-05-25_knowledge-base-share-and-ux.md
   - 2026-05-25_reprocess-bugbot-fixes.md
   - 2026-05-25_share-visibility-yellow.md
+  - 2026-05-26_risk-gate-opaque-red.md
+  - 2026-05-26_tip-reminder-expiry.md


### PR DESCRIPTION
自动生成的每日熵减 PR。

## 修复项
- changelog manifest 补缺：登记 2 条今日新 changelog（`2026-05-26_risk-gate-opaque-red.md`、`2026-05-26_tip-reminder-expiry.md`）

## 跳过项（diff 核验未通过 / 确认为误报）
- D3 幽灵条目（19 个）：全部为 guide.list.directory.md 变更历史表中的历史删除/重命名记录，属于合法历史归档，不删除
- D4 幽灵（`pnpm`）：CLAUDE.md 中 `**pnpm**` 是包管理器规则粗体文本，非技能名，跳过
- D1/D2：无违规，无需修复

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4GX4uTk3SYiwnMAC74hq8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest-only metadata update with no runtime or security impact.
> 
> **Overview**
> Registers two new changelog fragments in **`changelogs/.entropy-manifest.yml`** so daily entropy processing treats them as already handled: **`2026-05-26_risk-gate-opaque-red.md`** and **`2026-05-26_tip-reminder-expiry.md`**.
> 
> No application, API, or UI code changes—manifest bookkeeping only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adc47ea43b8ff41b891a79d7f33edf5d8e6720ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->