### PR TITLE
评审 Agent 三层兜底 + 一次性通过率口径修正

### DIFF
--- a/changelogs/2026-05-27_review-agent-anti-gaming.md
+++ b/changelogs/2026-05-27_review-agent-anti-gaming.md
@@ -1,0 +1,4 @@
+| feat | prd-api | 产品评审 Agent 加入三层兜底（evidence gate / 数据密度封顶 / summary 一致性闸），杜绝 LLM 把非清单维度全填满凑 99 分的钻空子路径 |
+| refactor | prd-api | 评审默认权重调整：清单维度 30→20，10 分按 +2 平均分摊到 consistency/problem_quality/user_value/feasibility/testability 五个高风险维度 |
+| feat | prd-admin | 评审结果页新增「系统兜底调整记录」展示区，触发 guardrail 时显示原分→新分及调整原因 |
+| test | prd-api | 新增 ReviewAgentScoringGuardrailsTests 覆盖三层兜底的触发与不触发场景 |

--- a/changelogs/2026-05-27_review-agent-anti-gaming.md
+++ b/changelogs/2026-05-27_review-agent-anti-gaming.md
@@ -1,4 +1,10 @@
 | feat | prd-api | 产品评审 Agent 加入三层兜底（evidence gate / 数据密度封顶 / summary 一致性闸），杜绝 LLM 把非清单维度全填满凑 99 分的钻空子路径 |
 | refactor | prd-api | 评审默认权重调整：清单维度 30→20，10 分按 +2 平均分摊到 consistency/problem_quality/user_value/feasibility/testability 五个高风险维度 |
+| fix | prd-api | 评审 prompt：清单维度 Description 把 "得分 = 30 × ..." 改为 "MaxScore × ..."，与新 MaxScore=20 对齐，不再误导 LLM |
+| fix | prd-api | evidence 正则收紧 \d → \d{2,}，章节匹配允许中间空格，长度门槛 30→15 + 强标记，既挡单数字钻空子又不误伤简洁高密度评语 |
+| fix | prd-api | CountDataPoints 用 \d{2,}(?![%％]) 避免 "80%" 被同时计入两条正则，L2 阈值不再被高估撑过 |
+| fix | prd-api | L3 关键词清单移除歧义词「标杆级水平」，避免误伤褒义 summary「达到行业标杆级水平」；新增「未达标杆/未到标杆」等明确负面词 |
+| fix | prd-api | ApplyScoringGuardrails 防御 DB 自定义维度配置出现重复 Key，改用 GroupBy 避免抛 ArgumentException |
+| feat | prd-api | ReviewDimensionScore 增加 OriginalScore 字段，记录被 guardrail 调整前的 LLM 原始分，便于审计 |
 | feat | prd-admin | 评审结果页新增「系统兜底调整记录」展示区，触发 guardrail 时显示原分→新分及调整原因 |
-| test | prd-api | 新增 ReviewAgentScoringGuardrailsTests 覆盖三层兜底的触发与不触发场景 |
+| test | prd-api | ReviewAgentScoringGuardrailsTests 新增 8 条测试覆盖单数字钻空子防御、简洁高密度评语、百分比不重复计数、褒义标杆级表述、重复 Key 容错、OriginalScore 记录、L2→L3 跌破门槛等场景 |

--- a/changelogs/2026-05-27_review-agent-first-pass-rate-fix.md
+++ b/changelogs/2026-05-27_review-agent-first-pass-rate-fix.md
@@ -1,0 +1,9 @@
+| feat | prd-api | 产品评审 Agent 新增「未通过救机会」端点 POST /submissions/{id}/reupload-on-failure，每方案仅 1 次替换附件重评 |
+| feat | prd-api | 新增 GET /submissions/{id}/results 返回该 submission 完整评审历史 |
+| fix | prd-api | rerun/reupload 路径不再删除旧 ReviewResult，保留为评审历史 |
+| fix | prd-api | LLM 网关 Error 后的"重新评审"重跑改用新字段 ErrorRetryCount，不污染 RerunCount，避免系统故障被错算成用户重评 |
+| refactor | prd-api | 排行榜重写：先按 (submitterId, title) 聚到「方案桶」再统计；新公式「一次性通过率」= 一次过方案数 / 总方案数（非"通过的方案中无重评的占比"，修复永远 100% 的旧 bug） |
+| feat | prd-admin | 评审结果页未通过状态新增「重新上传方案（剩 1 次救机会）」按钮 |
+| feat | prd-admin | 评审结果页新增「评审历史」折叠区，列出该 submission 的所有评审记录（得分/通过状态/时间/兜底次数） |
+| docs | prd-admin | 排行榜文案说明改为"按方案标题去重 + 系统故障重跑不计入用户重评" |
+| test | prd-api | 新增 ReviewAgentLeaderboardTests 10 条单测覆盖一次过判定/桶级通过判定/同标题去重/跨用户隔离/F-2 ErrorRetryCount 不污染 RerunCount/张三全月示例端到端 |

--- a/prd-admin/src/pages/review-agent/ReviewAgentResultPage.tsx
+++ b/prd-admin/src/pages/review-agent/ReviewAgentResultPage.tsx
@@ -175,6 +175,7 @@ export function ReviewAgentResultPage() {
   const [summary, setSummary] = useState('');
   const [totalScore, setTotalScore] = useState<number | null>(null);
   const [isPassed, setIsPassed] = useState<boolean | null>(null);
+  const [adjustmentLog, setAdjustmentLog] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const [dimConfigs, setDimConfigs] = useState<ReviewDimensionConfig[]>([]);
   const [expandedDims, setExpandedDims] = useState<Set<string>>(new Set());
@@ -209,6 +210,7 @@ export function ReviewAgentResultPage() {
         setSummary(res.data.result.summary);
         setTotalScore(res.data.result.totalScore);
         setIsPassed(res.data.result.isPassed);
+        setAdjustmentLog(res.data.result.adjustmentLog ?? []);
         // 默认展开所有维度
         setExpandedDims(new Set(res.data.result.dimensionScores.map((d: { key: string }) => d.key)));
       }
@@ -238,10 +240,15 @@ export function ReviewAgentResultPage() {
     },
     onEvent: {
       result: (data: unknown) => {
-        const d = data as { totalScore: number; isPassed: boolean; summary: string };
+        const d = data as { totalScore: number; isPassed: boolean; summary: string; adjustmentLog?: string[] };
         setTotalScore(d.totalScore);
         setIsPassed(d.isPassed);
         setSummary(d.summary);
+        if (Array.isArray(d.adjustmentLog)) setAdjustmentLog(d.adjustmentLog);
+      },
+      adjustment_log: (data: unknown) => {
+        const d = data as { entries?: string[] };
+        if (Array.isArray(d.entries)) setAdjustmentLog(d.entries);
       },
     },
     onDone: () => {
@@ -275,6 +282,7 @@ export function ReviewAgentResultPage() {
         setSummary('');
         setTotalScore(null);
         setIsPassed(null);
+        setAdjustmentLog([]);
         setExpandedDims(new Set());
         setStreaming(true);
         setSubmission(prev => prev ? { ...prev, status: 'Queued', resultId: undefined } : prev);
@@ -306,6 +314,7 @@ export function ReviewAgentResultPage() {
       setSummary('');
       setTotalScore(null);
       setIsPassed(null);
+      setAdjustmentLog([]);
       setExpandedDims(new Set());
       setStreaming(true);
       setSubmission(prev => prev ? {
@@ -542,6 +551,24 @@ export function ReviewAgentResultPage() {
               );
             })}
           </div>
+        </div>
+      )}
+
+      {/* 系统兜底调整记录（三层 guardrails 触发后才出现） */}
+      {adjustmentLog.length > 0 && !isRunning && (
+        <div className="mb-6 bg-amber-500/5 border border-amber-500/20 rounded-xl p-5">
+          <h2 className="text-sm font-medium text-amber-300/90 mb-3 flex items-center gap-2">
+            <AlertTriangle className="w-4 h-4" />
+            系统兜底调整记录
+            <span className="text-[11px] text-amber-300/60 font-normal">
+              （LLM 原始打分被三层 guardrail 调整，明细如下）
+            </span>
+          </h2>
+          <ul className="space-y-1.5 text-[13px] text-amber-100/80 leading-relaxed">
+            {adjustmentLog.map((entry, idx) => (
+              <li key={idx} className="font-mono whitespace-pre-wrap">{entry}</li>
+            ))}
+          </ul>
         </div>
       )}
 

--- a/prd-admin/src/pages/review-agent/ReviewAgentResultPage.tsx
+++ b/prd-admin/src/pages/review-agent/ReviewAgentResultPage.tsx
@@ -5,7 +5,7 @@ import { MapSpinner } from '@/components/ui/VideoLoader';
 import { useSseStream } from '@/lib/useSseStream';
 import { SsePhaseBar } from '@/components/sse/SsePhaseBar';
 import { SseTypingBlock } from '@/components/sse/SseTypingBlock';
-import { getReviewSubmission, getReviewResultStreamUrl, rerunReviewSubmission, getReviewDimensions } from '@/services';
+import { getReviewSubmission, getReviewResultStreamUrl, rerunReviewSubmission, getReviewDimensions, reuploadReviewOnFailure, getReviewSubmissionResults } from '@/services';
 import type { ReviewSubmission, ReviewResult, ReviewDimensionScore, ReviewDimensionConfig, DimensionCheckItemResult } from '@/services';
 import { reuploadReviewSubmission } from '@/services/real/reviewAgent';
 import { uploadAttachment } from '@/services/real/aiToolbox';
@@ -186,6 +186,9 @@ export function ReviewAgentResultPage() {
   const [reuploading, setReuploading] = useState(false);
   const [reuploadError, setReuploadError] = useState<string | null>(null);
   const reuploadInputRef = useRef<HTMLInputElement>(null);
+  const reuploadOnFailureInputRef = useRef<HTMLInputElement>(null);
+  const [resultHistory, setResultHistory] = useState<ReviewResult[]>([]);
+  const [showHistory, setShowHistory] = useState(false);
 
   const authUser = useAuthStore(s => s.user);
   const permissions = useAuthStore(s => s.permissions);
@@ -197,6 +200,11 @@ export function ReviewAgentResultPage() {
   );
   const canAppeal = isOwner && canAppealLocal(submission);
   const canReupload = isOwner && submission?.appealStatus === 'Approved';
+  // 未通过救机会：Done + 未通过 + RerunCount=0（每方案仅 1 次）
+  const canReuploadOnFailure = isOwner
+    && submission?.status === 'Done'
+    && submission?.isPassed === false
+    && (submission?.rerunCount ?? 0) === 0;
   const hasAppealRecord = !!submission?.latestAppealId;
 
   const loadData = useCallback(async () => {
@@ -291,6 +299,53 @@ export function ReviewAgentResultPage() {
     } finally {
       setRerunning(false);
     }
+  }
+
+  async function handleReuploadOnFailureFile(file: File) {
+    if (!id || reuploading) return;
+    setReuploading(true);
+    setReuploadError(null);
+    try {
+      const up = await uploadAttachment(file);
+      if (!up.success || !up.data) {
+        setReuploadError(up.error?.message ?? '文件上传失败');
+        return;
+      }
+      const res = await reuploadReviewOnFailure(id, up.data.attachmentId);
+      if (!res.success) {
+        setReuploadError(res.error?.message ?? '替换失败');
+        return;
+      }
+      // 重置本地评审展示，触发新一轮 SSE。RerunCount 在后端 +1，前端同步更新。
+      setResult(null);
+      setDimensionScores([]);
+      setSummary('');
+      setTotalScore(null);
+      setIsPassed(null);
+      setAdjustmentLog([]);
+      setExpandedDims(new Set());
+      setStreaming(true);
+      setSubmission(prev => prev ? {
+        ...prev,
+        status: 'Queued',
+        resultId: undefined,
+        isPassed: undefined,
+        completedAt: undefined,
+        rerunCount: (prev.rerunCount ?? 0) + 1,
+        attachmentId: up.data!.attachmentId,
+        fileName: file.name,
+      } : prev);
+      sse.start({ url: getReviewResultStreamUrl(id!) });
+    } finally {
+      setReuploading(false);
+      if (reuploadOnFailureInputRef.current) reuploadOnFailureInputRef.current.value = '';
+    }
+  }
+
+  async function loadResultHistory() {
+    if (!id) return;
+    const res = await getReviewSubmissionResults(id);
+    if (res.success && res.data) setResultHistory(res.data.results);
   }
 
   async function handleReuploadFile(file: File) {
@@ -432,8 +487,30 @@ export function ReviewAgentResultPage() {
       </div>
 
       {/* 申诉操作行（仅在相关状态下展示） */}
-      {(canAppeal || canReupload || hasAppealRecord) && (
+      {(canAppeal || canReupload || canReuploadOnFailure || hasAppealRecord) && (
         <div className="flex flex-wrap items-center gap-2 mb-6">
+          {canReuploadOnFailure && (
+            <>
+              <input
+                ref={reuploadOnFailureInputRef}
+                type="file"
+                accept=".md,.markdown,text/markdown,text/plain"
+                style={{ display: 'none' }}
+                onChange={e => {
+                  const f = e.target.files?.[0];
+                  if (f) handleReuploadOnFailureFile(f);
+                }}
+              />
+              <button
+                onClick={() => reuploadOnFailureInputRef.current?.click()}
+                disabled={reuploading}
+                title="未通过的方案可重新上传文件再评审一次（每方案仅 1 次机会）"
+                className="flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-amber-600 hover:bg-amber-500 text-white transition-colors disabled:opacity-50"
+              >
+                <Upload className="w-3.5 h-3.5" /> {reuploading ? '上传中...' : '重新上传方案（剩 1 次救机会）'}
+              </button>
+            </>
+          )}
           {canAppeal && (
             <button
               onClick={() => setShowAppealDialog(true)}
@@ -551,6 +628,52 @@ export function ReviewAgentResultPage() {
               );
             })}
           </div>
+        </div>
+      )}
+
+      {/* 评审历史（含被重传/重跑覆盖之前的旧结果），按需折叠展开 */}
+      {isDone && !isRunning && (
+        <div className="mb-6 bg-white/3 border border-white/8 rounded-xl">
+          <button
+            onClick={() => {
+              const next = !showHistory;
+              setShowHistory(next);
+              if (next && resultHistory.length === 0) loadResultHistory();
+            }}
+            className="w-full flex items-center justify-between px-5 py-3 text-sm text-white/70 hover:text-white transition-colors"
+          >
+            <span className="flex items-center gap-2">
+              <ClockIcon className="w-4 h-4" />
+              评审历史 {resultHistory.length > 0 && <span className="text-xs text-white/40">（共 {resultHistory.length} 次）</span>}
+            </span>
+            {showHistory ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
+          </button>
+          {showHistory && (
+            <div className="px-5 pb-4 border-t border-white/5">
+              {resultHistory.length === 0 ? (
+                <div className="text-xs text-white/40 py-3">仅本次评审，无更早历史。</div>
+              ) : (
+                <ul className="space-y-2 mt-3">
+                  {resultHistory.map((r, i) => (
+                    <li key={r.id} className="flex items-center gap-3 text-xs">
+                      <span className="text-white/40 tabular-nums w-12">#{resultHistory.length - i}</span>
+                      <span className={`tabular-nums font-medium ${r.isPassed ? 'text-emerald-400' : 'text-orange-400'}`}>
+                        {r.totalScore}分
+                      </span>
+                      <span className={`flex items-center gap-1 ${r.isPassed ? 'text-emerald-400/80' : 'text-orange-400/80'}`}>
+                        {r.isPassed ? <CheckCircle className="w-3 h-3" /> : <XCircle className="w-3 h-3" />}
+                        {r.isPassed ? '通过' : '未通过'}
+                      </span>
+                      <span className="text-white/40">{new Date(r.scoredAt).toLocaleString('zh-CN')}</span>
+                      {r.adjustmentLog && r.adjustmentLog.length > 0 && (
+                        <span className="text-amber-400/60">（系统兜底 {r.adjustmentLog.length} 项）</span>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
         </div>
       )}
 

--- a/prd-admin/src/pages/review-agent/ReviewAgentResultPage.tsx
+++ b/prd-admin/src/pages/review-agent/ReviewAgentResultPage.tsx
@@ -514,6 +514,7 @@ export function ReviewAgentResultPage() {
           {canAppeal && (
             <button
               onClick={() => setShowAppealDialog(true)}
+              title="认为 AI 评分有误，提交人工复核（与「重新上传方案」不同：申诉走人审，重传是改写方案后再 AI 评）"
               className="flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white transition-colors"
             >
               <Megaphone className="w-3.5 h-3.5" /> 我要申诉

--- a/prd-admin/src/pages/review-agent/components/ReviewLeaderboardView.tsx
+++ b/prd-admin/src/pages/review-agent/components/ReviewLeaderboardView.tsx
@@ -239,7 +239,7 @@ export function ReviewLeaderboardView({ groupBy }: Props) {
             label="一次性通过率"
             value={formatPct(summary.totalFirstTimePassRate)}
             progress={summary.totalFirstTimePassRate ?? 0}
-            hint="通过的方案中，从未重审的占比"
+            hint="一次提交即通过、未触发重传救机会的方案占比（按方案标题去重）"
           />
         </div>
       )}
@@ -322,9 +322,11 @@ export function ReviewLeaderboardView({ groupBy }: Props) {
         </div>
       )}
 
-      {/* 历史数据近似值提示 */}
+      {/* 统计口径说明 */}
       <p className="text-[11px] text-white/30 leading-relaxed">
-        说明：「一次性通过率」= 通过的方案中从未触发「重新评审」的占比；2026-05-13 之前的历史数据未追踪 rerun 次数，统计为近似值。
+        说明：方案按「提交人 + 标题」去重，同标题的多次提交视为同一方案。
+        「一次性通过率」= 一次提交即通过、且未使用「重新上传方案」救机会的方案数 / 该用户在此期间的方案总数；
+        系统故障导致的「重新评审」不计入用户重评。
       </p>
     </div>
   );

--- a/prd-admin/src/services/index.ts
+++ b/prd-admin/src/services/index.ts
@@ -1757,6 +1757,8 @@ export {
   getAllSubmissions as getAllReviewSubmissions,
   getSubmission as getReviewSubmission,
   rerunSubmission as rerunReviewSubmission,
+  reuploadOnFailure as reuploadReviewOnFailure,
+  getSubmissionResults as getReviewSubmissionResults,
   getResultStreamUrl as getReviewResultStreamUrl,
   getSubmitters as getReviewSubmitters,
   listReviewWebhooks,

--- a/prd-admin/src/services/real/reviewAgent.ts
+++ b/prd-admin/src/services/real/reviewAgent.ts
@@ -158,6 +158,26 @@ export async function rerunSubmission(id: string): Promise<ApiResponse<{ message
   return apiRequest(`/api/review-agent/submissions/${id}/rerun`, { method: 'POST' });
 }
 
+/**
+ * 未通过救机会：替换附件并触发重新评审。仅当 isPassed=false 且 RerunCount=0 时可调用。
+ */
+export async function reuploadOnFailure(
+  id: string,
+  attachmentId: string
+): Promise<ApiResponse<{ message: string }>> {
+  return apiRequest(`/api/review-agent/submissions/${encodeURIComponent(id)}/reupload-on-failure`, {
+    method: 'POST',
+    body: { attachmentId },
+  });
+}
+
+/** 获取该 submission 的所有评审历史（按时间倒序） */
+export async function getSubmissionResults(
+  id: string
+): Promise<ApiResponse<{ results: ReviewResult[] }>> {
+  return apiRequest(`/api/review-agent/submissions/${encodeURIComponent(id)}/results`);
+}
+
 export interface LeaderboardItem {
   rank: number;
   key: string;

--- a/prd-admin/src/services/real/reviewAgent.ts
+++ b/prd-admin/src/services/real/reviewAgent.ts
@@ -50,6 +50,8 @@ export interface ReviewDimensionScore {
   score: number;
   maxScore: number;
   comment: string;
+  /** LLM 原始分（调整前）。仅当被系统兜底调整时填充，否则为 null/undefined */
+  originalScore?: number | null;
   /** 子检查项判断结果（清单类维度使用） */
   items?: DimensionCheckItemResult[] | null;
 }

--- a/prd-admin/src/services/real/reviewAgent.ts
+++ b/prd-admin/src/services/real/reviewAgent.ts
@@ -84,6 +84,8 @@ export interface ReviewResult {
   summary: string;
   fullMarkdown: string;
   parseError?: string;
+  /** 系统三层兜底（evidence gate / 数据密度封顶 / summary 一致性闸）的调整日志，空数组表示未触发任何调整 */
+  adjustmentLog?: string[];
   scoredAt: string;
 }
 

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ReviewAgentController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ReviewAgentController.cs
@@ -339,6 +339,7 @@ public class ReviewAgentController : ControllerBase
                 IsPassed = x.IsPassed,
                 RerunCount = x.RerunCount,
                 AppealStatus = x.AppealStatus,
+                AppealResolvedAt = x.AppealResolvedAt,
             })
             .ToListAsync(ct);
 
@@ -456,6 +457,10 @@ public class ReviewAgentController : ControllerBase
                 var hasAnyPass = rows.Any(r => r.IsPassed == true && r.AppealStatus != AppealStatuses.Approved);
                 var hasAnyFail = rows.Any(r => r.IsPassed == false && r.AppealStatus != AppealStatuses.Approved);
                 var hasAppealApproved = rows.Any(r => r.AppealStatus == AppealStatuses.Approved);
+                // 该桶是否走过任何申诉通道（含已驳回 / 已通过 / 处理中 + 历史 AppealResolvedAt 非空）
+                // 申诉链路本身就意味着用户对该方案折腾过一轮，不应算"一次过"
+                var hasAppealHistory = rows.Any(r =>
+                    !string.IsNullOrEmpty(r.AppealStatus) || r.AppealResolvedAt != null);
 
                 return new ProposalBucket
                 {
@@ -466,11 +471,12 @@ public class ReviewAgentController : ControllerBase
                     IsBucketPassed = hasAnyPass,
                     IsBucketFailed = !hasAnyPass && hasAnyFail,
                     IsBucketAppealApproved = !hasAnyPass && hasAppealApproved,
-                    // 一次过：只 1 条 sub + IsPassed=true + RerunCount=0 + 非申诉成功
+                    // 一次过：只 1 条 sub + IsPassed=true + RerunCount=0 + 从未走过申诉
+                    // （申诉成功后 reupload 路径会把 RerunCount 清零，不加申诉历史判定会被错算成一次过）
                     IsFirstPass = submissionCount == 1
                                   && first.IsPassed == true
                                   && first.RerunCount == 0
-                                  && first.AppealStatus != AppealStatuses.Approved,
+                                  && !hasAppealHistory,
                 };
             })
             .ToList();
@@ -510,6 +516,19 @@ public class ReviewAgentController : ControllerBase
         return (startUtc, endUtcExclusive);
     }
 
+    // ──────────────────────────────────────────────
+    // 状态门槛 helper（提取以便守卫测试）
+    // ──────────────────────────────────────────────
+
+    /// <summary>系统故障恢复用的「重新评审」：仅 Error 状态可用，其他状态拒绝</summary>
+    internal static bool CanUseSystemRerun(ReviewSubmission s) => s.Status == ReviewStatuses.Error;
+
+    /// <summary>「未通过救机会」：仅 Done + IsPassed=false + RerunCount=0 三个条件齐备才可用</summary>
+    internal static bool CanReuploadOnFailure(ReviewSubmission s) =>
+        s.Status == ReviewStatuses.Done
+        && s.IsPassed == false
+        && s.RerunCount < 1;
+
     /// <summary>排行榜聚合中间投影类型（避免匿名类型在 LINQ Project 表达式树中的限制）</summary>
     internal class LeaderboardRow
     {
@@ -519,6 +538,8 @@ public class ReviewAgentController : ControllerBase
         public bool? IsPassed { get; set; }
         public int RerunCount { get; set; }
         public string? AppealStatus { get; set; }
+        /// <summary>申诉受理时间（任一非空）= 该方案桶走过申诉通道，不应算"一次过"</summary>
+        public DateTime? AppealResolvedAt { get; set; }
     }
 
     /// <summary>
@@ -568,7 +589,7 @@ public class ReviewAgentController : ControllerBase
             return StatusCode(403, ApiResponse<object>.Fail(ErrorCodes.PERMISSION_DENIED, "无权限操作该提交"));
 
         // 仅允许 Error 状态触发"重新评审"（系统故障恢复）；未通过应走 reupload-on-failure
-        if (submission.Status != ReviewStatuses.Error)
+        if (!CanUseSystemRerun(submission))
             return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT,
                 "仅在评审过程出错时才能使用「重新评审」；如评审未通过，请使用「重新上传方案」（一次救机会）"));
 
@@ -604,10 +625,11 @@ public class ReviewAgentController : ControllerBase
             return StatusCode(403, ApiResponse<object>.Fail(ErrorCodes.PERMISSION_DENIED, "仅本人可重新上传方案"));
 
         // 状态门槛：评审完成 + 未通过 + 没用过救机会
-        if (submission.Status != ReviewStatuses.Done || submission.IsPassed != false)
-            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "仅在评审完成且未通过时可使用救机会"));
-        if (submission.RerunCount >= 1)
-            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "本方案的救机会已用完（每个方案仅 1 次）"));
+        if (!CanReuploadOnFailure(submission))
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT,
+                submission.RerunCount >= 1
+                    ? "本方案的救机会已用完（每个方案仅 1 次）"
+                    : "仅在评审完成且未通过时可使用救机会"));
 
         if (string.IsNullOrWhiteSpace(req?.AttachmentId))
             return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "attachmentId 不能为空"));

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ReviewAgentController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ReviewAgentController.cs
@@ -1058,17 +1058,24 @@ public class ReviewAgentController : ControllerBase
             // 否则进入下一轮重试
         }
 
+        // ── 三层兜底（Guardrails）：抵御 LLM 把非清单维度全填满凑高分 + summary 自相矛盾的钻空子路径 ──
+        var adjustmentLog = ApplyScoringGuardrails(dimensionScores, dims, content, summary);
+
         var totalScore = dimensionScores.Sum(d => d.Score);
         var isPassed = totalScore >= 80;
 
         // 在 summary 末尾追加权威结论，避免 LLM 文字与系统派生分数错位时误导用户
         // （企微/钉钉 webhook 通知也读这个 summary，保证三处文案对齐）
         var conclusionLine = $"[系统结论] 最终得分 {totalScore}/100，{(isPassed ? "已通过" : "未通过")}。";
+        if (adjustmentLog.Count > 0)
+        {
+            conclusionLine += $" 系统兜底已触发 {adjustmentLog.Count} 项调整（详见报告）。";
+        }
         summary = string.IsNullOrWhiteSpace(summary)
             ? conclusionLine
             : summary.TrimEnd() + "\n\n" + conclusionLine;
 
-        // 推送分项结果
+        // 推送分项结果（已应用 evidence gate）
         foreach (var dimScore in dimensionScores)
         {
             try
@@ -1076,6 +1083,13 @@ public class ReviewAgentController : ControllerBase
                 await WriteSseEventAsync("dimension_score", dimScore);
             }
             catch (ObjectDisposedException) { break; }
+        }
+
+        // 推送兜底调整日志（前端展示「系统调整记录」区）
+        if (adjustmentLog.Count > 0)
+        {
+            try { await WriteSseEventAsync("adjustment_log", new { entries = adjustmentLog }); }
+            catch (ObjectDisposedException) { /* 客户端已断开 */ }
         }
 
         // 保存结果
@@ -1088,6 +1102,7 @@ public class ReviewAgentController : ControllerBase
             Summary = summary,
             FullMarkdown = llmOutput,
             ParseError = parseError,
+            AdjustmentLog = adjustmentLog,
         };
 
         await _db.ReviewResults.InsertOneAsync(result, cancellationToken: CancellationToken.None);
@@ -1124,7 +1139,7 @@ public class ReviewAgentController : ControllerBase
         // 推送最终结果
         try
         {
-            await WriteSseEventAsync("result", new { totalScore, isPassed, summary });
+            await WriteSseEventAsync("result", new { totalScore, isPassed, summary, adjustmentLog });
             await WriteSseEventAsync("done", new { });
         }
         catch (ObjectDisposedException) { /* 客户端已断开，忽略 */ }
@@ -1145,6 +1160,145 @@ public class ReviewAgentController : ControllerBase
         var raw = BitConverter.ToInt32(hash, 0);
         // & 0x7FFFFFFF 保证非负，避免 Math.Abs(int.MinValue) 溢出
         return raw & 0x7FFFFFFF;
+    }
+
+    // ──────────────────────────────────────────────
+    // 三层兜底（Guardrails）：抵御 LLM 钻空子的硬规则
+    // ──────────────────────────────────────────────
+
+    /// <summary>
+    /// 应用系统级三层兜底，按顺序：
+    /// L1 evidence gate：非清单维度若 LLM 给到 MaxScore × 0.9 以上，要求 Comment 必须 ≥ 30 字且含具体证据（数字/百分比/引用/章节名），否则该维度降至 floor(MaxScore × 0.89)。
+    /// L2 数据密度封顶：方案原文「数字/百分比/链接/章节引用」总出现 &lt; 5 处时，整体高分维度（≥ 0.9 得分率）按 0.89 封顶。
+    /// L3 summary 一致性闸：summary 出现明确降级关键词（"75-89"/"未达 90+"/"合格区间"/"有改进空间"），但总分 ≥ 90 时，整体高分维度按 0.89 封顶。
+    /// 注意：清单类维度（Items != null）由系统按 truth table 强制重算，不在本兜底覆盖范围。
+    /// </summary>
+    /// <returns>触发的调整日志条目（≥ 0 条）</returns>
+    internal static List<string> ApplyScoringGuardrails(
+        List<ReviewDimensionScore> dimensionScores,
+        List<ReviewDimensionConfig> dims,
+        string proposalContent,
+        string summary)
+    {
+        var log = new List<string>();
+        var dimConfigMap = dims.ToDictionary(d => d.Key);
+
+        // L1：逐维度 evidence gate
+        foreach (var score in dimensionScores)
+        {
+            if (!dimConfigMap.TryGetValue(score.Key, out var cfg)) continue;
+            // 清单维度跳过：由 truth table 强制重算，不需要 evidence gate
+            if (cfg.Items != null && cfg.Items.Count > 0) continue;
+            // 仅对「得分率 ≥ 90%」的维度强制要求证据
+            var threshold90 = (int)Math.Ceiling(score.MaxScore * 0.9);
+            if (score.Score < threshold90) continue;
+
+            if (!HasSufficientEvidence(score.Comment))
+            {
+                var capped = (int)Math.Floor(score.MaxScore * 0.89);
+                log.Add(
+                    $"[L1 证据闸] 维度「{score.Name}」原 {score.Score}/{score.MaxScore} → 调整为 {capped}/{score.MaxScore}：" +
+                    $"得分率 ≥90% 但 LLM 评语未提供具体证据（数字/百分比/引用/原文章节），按 89% 封顶。");
+                score.Score = capped;
+                score.Comment = (string.IsNullOrWhiteSpace(score.Comment) ? "" : score.Comment.TrimEnd() + " ") +
+                                "[系统提示] 因高分缺乏具体证据，已按 89% 封顶。";
+            }
+        }
+
+        // L2：数据密度封顶（基于方案原文统计）
+        var dataDensity = CountDataPoints(proposalContent);
+        if (dataDensity < 5)
+        {
+            CapHighScoringDimensions(dimensionScores, dimConfigMap, log,
+                $"[L2 数据密度] 方案原文具体数据/链接/章节引用仅 {dataDensity} 处（要求 ≥ 5），所有得分率 ≥90% 的非清单维度按 89% 封顶。");
+        }
+
+        // L3：summary 与总分一致性闸
+        var totalScoreNow = dimensionScores.Sum(d => d.Score);
+        var totalMax = dimensionScores.Sum(d => d.MaxScore);
+        if (totalMax > 0 && (double)totalScoreNow / totalMax >= 0.9 && SummaryContainsDowngradeKeyword(summary))
+        {
+            CapHighScoringDimensions(dimensionScores, dimConfigMap, log,
+                "[L3 一致性闸] summary 出现明确降级表述（如「未达 90+」「合格区间」「有改进空间」）但总分 ≥90%，所有得分率 ≥90% 的非清单维度按 89% 封顶。");
+        }
+
+        return log;
+    }
+
+    /// <summary>
+    /// 判断 LLM 评语是否含「具体证据」：长度 ≥ 30 且含数字/百分比/章节引用/书名号/方括号引用 任一线索。
+    /// 纯定性形容词（"完整""清晰""凝练"）不视为证据。
+    /// </summary>
+    internal static bool HasSufficientEvidence(string? comment)
+    {
+        if (string.IsNullOrWhiteSpace(comment)) return false;
+        var trimmed = comment.Trim();
+        if (trimmed.Length < 30) return false;
+        // 至少含一种具体证据线索
+        return System.Text.RegularExpressions.Regex.IsMatch(
+            trimmed,
+            @"\d|[%％]|第[一-龥\d]+[章节段条]|《[^》]+》|「[^」]+」|\[[^\]]+\]|http[s]?://");
+    }
+
+    /// <summary>
+    /// 数据密度统计：扫方案原文「数字串(≥2 位) / 百分比 / URL / 章节引用 / 书名号引用」总出现次数。
+    /// 阈值 5 是保守估计：1000 字以上的产品方案普遍能轻松达标，达不到说明确实空话占多数。
+    /// </summary>
+    internal static int CountDataPoints(string content)
+    {
+        if (string.IsNullOrWhiteSpace(content)) return 0;
+        var count = 0;
+        // 数字串（≥ 2 位连续数字，避免误算单个数字如"3 个"）
+        count += System.Text.RegularExpressions.Regex.Matches(content, @"\d{2,}").Count;
+        // 百分比
+        count += System.Text.RegularExpressions.Regex.Matches(content, @"\d+[%％]").Count;
+        // URL
+        count += System.Text.RegularExpressions.Regex.Matches(content, @"http[s]?://[^\s一-龥]+").Count;
+        // 章节引用
+        count += System.Text.RegularExpressions.Regex.Matches(content, @"第[一-龥\d]+[章节段条]").Count;
+        // 书名号引用
+        count += System.Text.RegularExpressions.Regex.Matches(content, @"《[^》]{1,40}》").Count;
+        return count;
+    }
+
+    /// <summary>
+    /// 检测 summary 是否含明确的「降级」关键词。命中即视为 LLM 自己承认"未达 90+"。
+    /// </summary>
+    internal static bool SummaryContainsDowngradeKeyword(string? summary)
+    {
+        if (string.IsNullOrWhiteSpace(summary)) return false;
+        string[] keywords = { "75-89", "75 - 89", "75 至 89", "未达 90", "未达到 90", "未达90", "未达到90",
+                              "合格区间", "标杆级水平", "有改进空间", "未达标杆", "未达行业" };
+        return keywords.Any(k => summary.Contains(k, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// 把所有非清单维度中「得分率 ≥ 90%」的项一律压到 floor(MaxScore × 0.89)。
+    /// 触发时先写 reason 主条目，再逐条记录被压的维度；未触发任何维度不写 log。
+    /// </summary>
+    private static void CapHighScoringDimensions(
+        List<ReviewDimensionScore> dimensionScores,
+        Dictionary<string, ReviewDimensionConfig> dimConfigMap,
+        List<string> log,
+        string reason)
+    {
+        var subEntries = new List<string>();
+        foreach (var score in dimensionScores)
+        {
+            if (!dimConfigMap.TryGetValue(score.Key, out var cfg)) continue;
+            if (cfg.Items != null && cfg.Items.Count > 0) continue; // 清单维度跳过
+            var threshold90 = (int)Math.Ceiling(score.MaxScore * 0.9);
+            if (score.Score < threshold90) continue;
+
+            var capped = (int)Math.Floor(score.MaxScore * 0.89);
+            subEntries.Add($"  └ 维度「{score.Name}」{score.Score}/{score.MaxScore} → {capped}/{score.MaxScore}");
+            score.Score = capped;
+        }
+        if (subEntries.Count > 0)
+        {
+            log.Add(reason);
+            log.AddRange(subEntries);
+        }
     }
 
     /// <summary>

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ReviewAgentController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ReviewAgentController.cs
@@ -293,8 +293,11 @@ public class ReviewAgentController : ControllerBase
     }
 
     /// <summary>
-    /// 排行榜 — 按自然月区间聚合，支持按提交人或方案两种维度统计：
-    /// 评审数量 / 通过率 / 一次性通过率（首次评审就通过且未 rerun 的占比）
+    /// 排行榜 — 按自然月区间聚合，先把 submission 按 (SubmitterId, Title) 聚到「方案桶」，
+    /// 再按 submitter / document 维度展示。
+    /// 「一次性通过率」= 该用户的「一次过方案桶」/「方案桶总数」；
+    /// 一次过 = 桶里只 1 条 sub + IsPassed=true + RerunCount=0（不含 ErrorRetryCount，系统故障重跑不归咎用户）。
+    /// 「通过率」= 桶级最终通过的数量（桶内任一 sub IsPassed=true 视为通过） / 已落定的方案桶数。
     /// </summary>
     [HttpGet("leaderboard")]
     public async Task<IActionResult> GetLeaderboard(
@@ -326,7 +329,6 @@ public class ReviewAgentController : ControllerBase
             Builders<ReviewSubmission>.Filter.Lt(x => x.CompletedAt, endUtcExclusive)
         );
 
-        // 数据量当前在百级，未来到千级也是毫秒级，直接拉取后内存聚合更直观
         var docs = await _db.ReviewSubmissions
             .Find(filter)
             .Project(x => new LeaderboardRow
@@ -340,78 +342,151 @@ public class ReviewAgentController : ControllerBase
             })
             .ToListAsync(ct);
 
-        IEnumerable<IGrouping<string, LeaderboardRow>> grouped = groupBy == "document"
-            ? docs.GroupBy(x => $"{x.SubmitterId}|{x.Title}")
-            : docs.GroupBy(x => x.SubmitterId);
+        var buckets = AggregateProposalBuckets(docs);
 
-        // 申诉成功语义：该条评审「不计入通过、不计入未通过」（视为待重审），但仍计入总评审数。
-        // 通过率公式 = 有效通过 / (有效通过 + 有效未通过)，分母排除申诉成功的。
-        var items = grouped
-            .Select(g =>
-            {
-                var first = g.First();
-                var totalCount = g.Count();
-                var appealApprovedCount = g.Count(x => x.AppealStatus == AppealStatuses.Approved);
-                var effectivelyPassed = g.Count(x => x.IsPassed == true && x.AppealStatus != AppealStatuses.Approved);
-                var effectivelyFailed = g.Count(x => x.IsPassed == false && x.AppealStatus != AppealStatuses.Approved);
-                var ratedTotal = effectivelyPassed + effectivelyFailed; // 已落定（不含申诉成功）
-                var firstTimePassedCount = g.Count(x => x.IsPassed == true && x.RerunCount == 0 && x.AppealStatus != AppealStatuses.Approved);
-                return new
+        IEnumerable<dynamic> items;
+        if (groupBy == "document")
+        {
+            // 每个方案桶 = 一行
+            items = buckets
+                .OrderByDescending(b => b.SubmissionCount)
+                .ThenByDescending(b => b.IsBucketPassed)
+                .Select((b, i) => new
                 {
-                    key = g.Key,
-                    name = groupBy == "document" ? first.Title : first.SubmitterName,
-                    submitterId = first.SubmitterId,
-                    submitterName = first.SubmitterName,
-                    totalCount,
-                    passedCount = effectivelyPassed,
-                    appealApprovedCount,
-                    passRate = ratedTotal > 0 ? (double)effectivelyPassed / ratedTotal : 0d,
-                    firstTimePassedCount,
-                    // passedCount=0 时 N/A（前端显示「— 无通过」），避免 NaN
-                    firstTimePassRate = effectivelyPassed > 0 ? (double?)firstTimePassedCount / effectivelyPassed : null,
-                };
-            })
-            .OrderByDescending(x => x.totalCount)
-            .ThenByDescending(x => x.passRate)
-            .Select((x, i) => new
-            {
-                rank = i + 1,
-                x.key,
-                x.name,
-                x.submitterId,
-                x.submitterName,
-                x.totalCount,
-                x.passedCount,
-                x.appealApprovedCount,
-                x.passRate,
-                x.firstTimePassedCount,
-                x.firstTimePassRate,
-            })
-            .ToList();
+                    rank = i + 1,
+                    key = $"{b.SubmitterId}|{b.Title}",
+                    name = b.Title,
+                    submitterId = b.SubmitterId,
+                    submitterName = b.SubmitterName,
+                    totalCount = b.SubmissionCount,       // 该方案被提交了几次
+                    passedCount = b.IsBucketPassed ? 1 : 0,
+                    appealApprovedCount = b.IsBucketAppealApproved ? 1 : 0,
+                    passRate = b.IsBucketPassed ? 1d : 0d,
+                    firstTimePassedCount = b.IsFirstPass ? 1 : 0,
+                    firstTimePassRate = (double?)(b.IsFirstPass ? 1d : 0d),
+                });
+        }
+        else
+        {
+            // submitter 维度：把方案桶按 SubmitterId 二次聚合
+            items = buckets
+                .GroupBy(b => b.SubmitterId)
+                .Select(g =>
+                {
+                    var total = g.Count();
+                    var passed = g.Count(b => b.IsBucketPassed);
+                    var failed = g.Count(b => b.IsBucketFailed);
+                    var appealed = g.Count(b => b.IsBucketAppealApproved);
+                    var ratedTotal = passed + failed;
+                    var firstPassCount = g.Count(b => b.IsFirstPass);
+                    return new
+                    {
+                        key = g.Key,
+                        name = g.First().SubmitterName,
+                        submitterId = g.Key,
+                        submitterName = g.First().SubmitterName,
+                        totalCount = total,        // 方案桶数（按标题去重）
+                        passedCount = passed,
+                        appealApprovedCount = appealed,
+                        passRate = ratedTotal > 0 ? (double)passed / ratedTotal : 0d,
+                        firstTimePassedCount = firstPassCount,
+                        // 一次性通过率 = 一次过方案数 / 总方案数（用户给的口径）
+                        firstTimePassRate = total > 0 ? (double?)firstPassCount / total : null,
+                    };
+                })
+                .OrderByDescending(x => x.totalCount)
+                .ThenByDescending(x => x.passRate)
+                .Select((x, i) => new
+                {
+                    rank = i + 1,
+                    x.key,
+                    x.name,
+                    x.submitterId,
+                    x.submitterName,
+                    x.totalCount,
+                    x.passedCount,
+                    x.appealApprovedCount,
+                    x.passRate,
+                    x.firstTimePassedCount,
+                    x.firstTimePassRate,
+                });
+        }
 
-        var summaryTotal = docs.Count;
-        var summaryAppealApproved = docs.Count(x => x.AppealStatus == AppealStatuses.Approved);
-        var summaryEffectivePassed = docs.Count(x => x.IsPassed == true && x.AppealStatus != AppealStatuses.Approved);
-        var summaryEffectiveFailed = docs.Count(x => x.IsPassed == false && x.AppealStatus != AppealStatuses.Approved);
-        var summaryRatedTotal = summaryEffectivePassed + summaryEffectiveFailed;
-        var summaryFirstTimePassed = docs.Count(x => x.IsPassed == true && x.RerunCount == 0 && x.AppealStatus != AppealStatuses.Approved);
+        var itemsList = items.ToList();
+
+        // 总览：所有方案桶聚合（不分 submitter）
+        var summaryTotal = buckets.Count;
+        var summaryPassed = buckets.Count(b => b.IsBucketPassed);
+        var summaryFailed = buckets.Count(b => b.IsBucketFailed);
+        var summaryAppealed = buckets.Count(b => b.IsBucketAppealApproved);
+        var summaryRated = summaryPassed + summaryFailed;
+        var summaryFirstPass = buckets.Count(b => b.IsFirstPass);
         var summary = new
         {
             totalCount = summaryTotal,
-            totalPassedCount = summaryEffectivePassed,
-            totalAppealApprovedCount = summaryAppealApproved,
-            totalPassRate = summaryRatedTotal > 0 ? (double)summaryEffectivePassed / summaryRatedTotal : 0d,
-            totalFirstTimePassedCount = summaryFirstTimePassed,
-            totalFirstTimePassRate = summaryEffectivePassed > 0 ? (double?)summaryFirstTimePassed / summaryEffectivePassed : null,
+            totalPassedCount = summaryPassed,
+            totalAppealApprovedCount = summaryAppealed,
+            totalPassRate = summaryRated > 0 ? (double)summaryPassed / summaryRated : 0d,
+            totalFirstTimePassedCount = summaryFirstPass,
+            totalFirstTimePassRate = summaryTotal > 0 ? (double?)summaryFirstPass / summaryTotal : null,
         };
 
         return Ok(ApiResponse<object>.Ok(new
         {
-            items,
+            items = itemsList,
             summary,
             period = new { startMonth, endMonth },
             groupBy,
         }));
+    }
+
+    /// <summary>
+    /// 把 submission 平表按 (SubmitterId, Title) 聚合到「方案桶」。
+    /// 同一用户同标题的多次提交视为同一方案，反映 Z 口径"一次性通过率"语义。
+    /// </summary>
+    internal static List<ProposalBucket> AggregateProposalBuckets(IEnumerable<LeaderboardRow> docs)
+    {
+        return docs
+            .GroupBy(x => $"{x.SubmitterId}|{x.Title}")
+            .Select(g =>
+            {
+                var rows = g.ToList();
+                var first = rows[0];
+                var submissionCount = rows.Count;
+                var hasAnyPass = rows.Any(r => r.IsPassed == true && r.AppealStatus != AppealStatuses.Approved);
+                var hasAnyFail = rows.Any(r => r.IsPassed == false && r.AppealStatus != AppealStatuses.Approved);
+                var hasAppealApproved = rows.Any(r => r.AppealStatus == AppealStatuses.Approved);
+
+                return new ProposalBucket
+                {
+                    SubmitterId = first.SubmitterId,
+                    SubmitterName = first.SubmitterName,
+                    Title = first.Title,
+                    SubmissionCount = submissionCount,
+                    IsBucketPassed = hasAnyPass,
+                    IsBucketFailed = !hasAnyPass && hasAnyFail,
+                    IsBucketAppealApproved = !hasAnyPass && hasAppealApproved,
+                    // 一次过：只 1 条 sub + IsPassed=true + RerunCount=0 + 非申诉成功
+                    IsFirstPass = submissionCount == 1
+                                  && first.IsPassed == true
+                                  && first.RerunCount == 0
+                                  && first.AppealStatus != AppealStatuses.Approved,
+                };
+            })
+            .ToList();
+    }
+
+    /// <summary>排行榜方案桶：把同一用户同标题的多次提交聚合为一份方案的统计结果。</summary>
+    internal class ProposalBucket
+    {
+        public string SubmitterId { get; set; } = string.Empty;
+        public string SubmitterName { get; set; } = string.Empty;
+        public string Title { get; set; } = string.Empty;
+        public int SubmissionCount { get; set; }
+        public bool IsBucketPassed { get; set; }
+        public bool IsBucketFailed { get; set; }
+        public bool IsBucketAppealApproved { get; set; }
+        public bool IsFirstPass { get; set; }
     }
 
     /// <summary>解析 YYYY-MM 区间为 UTC 起止（end 为下个月 1 号 0 点，半开区间）</summary>
@@ -436,7 +511,7 @@ public class ReviewAgentController : ControllerBase
     }
 
     /// <summary>排行榜聚合中间投影类型（避免匿名类型在 LINQ Project 表达式树中的限制）</summary>
-    private class LeaderboardRow
+    internal class LeaderboardRow
     {
         public string SubmitterId { get; set; } = string.Empty;
         public string SubmitterName { get; set; } = string.Empty;
@@ -478,7 +553,8 @@ public class ReviewAgentController : ControllerBase
     }
 
     /// <summary>
-    /// 重新评审 — 清除旧结果，重置为 Queued 状态，触发重跑
+    /// 系统故障重跑 — 仅限 Error 状态使用（LLM 网关失败等）。保留旧 ReviewResult 作为历史，仅累加 ErrorRetryCount。
+    /// 不影响 RerunCount（系统故障不归咎用户，不计入一次性通过率统计）。
     /// </summary>
     [HttpPost("submissions/{id}/rerun")]
     public async Task<IActionResult> RerunSubmission(string id, CancellationToken ct)
@@ -491,11 +567,12 @@ public class ReviewAgentController : ControllerBase
         if (submission.SubmitterId != userId && !HasViewAllPermission())
             return StatusCode(403, ApiResponse<object>.Fail(ErrorCodes.PERMISSION_DENIED, "无权限操作该提交"));
 
-        // 删除旧结果
-        if (!string.IsNullOrEmpty(submission.ResultId))
-            await _db.ReviewResults.DeleteOneAsync(x => x.Id == submission.ResultId, CancellationToken.None);
+        // 仅允许 Error 状态触发"重新评审"（系统故障恢复）；未通过应走 reupload-on-failure
+        if (submission.Status != ReviewStatuses.Error)
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT,
+                "仅在评审过程出错时才能使用「重新评审」；如评审未通过，请使用「重新上传方案」（一次救机会）"));
 
-        // 重置状态 + 累加 RerunCount（一次性通过率统计依赖此字段）
+        // 不删旧 ReviewResult（保留为历史，详情页会展示评审历史）
         await _db.ReviewSubmissions.UpdateOneAsync(
             x => x.Id == id,
             Builders<ReviewSubmission>.Update
@@ -505,10 +582,81 @@ public class ReviewAgentController : ControllerBase
                 .Unset(x => x.CompletedAt)
                 .Unset(x => x.StartedAt)
                 .Unset(x => x.ErrorMessage)
-                .Inc(x => x.RerunCount, 1),
+                .Inc(x => x.ErrorRetryCount, 1),
             cancellationToken: CancellationToken.None);
 
         return Ok(ApiResponse<object>.Ok(new { message = "已重置，请刷新页面重新评审" }));
+    }
+
+    /// <summary>
+    /// 未通过救机会 — 仅在 Done + IsPassed=false + RerunCount=0 时可用。替换附件、累加 RerunCount=1、状态置 Queued。
+    /// 保留旧 ReviewResult 作为历史。每个 submission 仅允许 1 次（RerunCount 上限 1）。
+    /// </summary>
+    [HttpPost("submissions/{id}/reupload-on-failure")]
+    public async Task<IActionResult> ReuploadOnFailure(string id, [FromBody] ReuploadRequest req, CancellationToken ct)
+    {
+        var userId = GetUserId();
+        var submission = await _db.ReviewSubmissions.Find(x => x.Id == id).FirstOrDefaultAsync(ct);
+        if (submission == null)
+            return NotFound(ApiResponse<object>.Fail(ErrorCodes.DOCUMENT_NOT_FOUND, "提交记录不存在"));
+
+        if (submission.SubmitterId != userId)
+            return StatusCode(403, ApiResponse<object>.Fail(ErrorCodes.PERMISSION_DENIED, "仅本人可重新上传方案"));
+
+        // 状态门槛：评审完成 + 未通过 + 没用过救机会
+        if (submission.Status != ReviewStatuses.Done || submission.IsPassed != false)
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "仅在评审完成且未通过时可使用救机会"));
+        if (submission.RerunCount >= 1)
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "本方案的救机会已用完（每个方案仅 1 次）"));
+
+        if (string.IsNullOrWhiteSpace(req?.AttachmentId))
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "attachmentId 不能为空"));
+
+        var attachment = await _db.Attachments.Find(x => x.AttachmentId == req.AttachmentId).FirstOrDefaultAsync(ct);
+        if (attachment == null)
+            return NotFound(ApiResponse<object>.Fail(ErrorCodes.DOCUMENT_NOT_FOUND, "附件不存在"));
+        if (string.IsNullOrWhiteSpace(attachment.ExtractedText))
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "无法从文件中提取文本内容，请确认上传的是有效的 Markdown 文件"));
+
+        // 不删旧 ReviewResult，保留为历史
+        await _db.ReviewSubmissions.UpdateOneAsync(
+            x => x.Id == id,
+            Builders<ReviewSubmission>.Update
+                .Set(x => x.AttachmentId, req.AttachmentId)
+                .Set(x => x.FileName, attachment.FileName)
+                .Set(x => x.ExtractedContent, attachment.ExtractedText)
+                .Set(x => x.Status, ReviewStatuses.Queued)
+                .Unset(x => x.ResultId)
+                .Unset(x => x.IsPassed)
+                .Unset(x => x.CompletedAt)
+                .Unset(x => x.StartedAt)
+                .Unset(x => x.ErrorMessage)
+                .Inc(x => x.RerunCount, 1),
+            cancellationToken: CancellationToken.None);
+
+        return Ok(ApiResponse<object>.Ok(new { message = "已替换附件，请刷新页面重新评审" }));
+    }
+
+    /// <summary>
+    /// 获取某 submission 的所有评审历史（含被 reupload-on-failure / Error 重跑覆盖前的历史结果），按时间倒序。
+    /// </summary>
+    [HttpGet("submissions/{id}/results")]
+    public async Task<IActionResult> GetSubmissionResults(string id, CancellationToken ct)
+    {
+        var userId = GetUserId();
+        var submission = await _db.ReviewSubmissions.Find(x => x.Id == id).FirstOrDefaultAsync(ct);
+        if (submission == null)
+            return NotFound(ApiResponse<object>.Fail(ErrorCodes.DOCUMENT_NOT_FOUND, "提交记录不存在"));
+
+        if (submission.SubmitterId != userId && !HasViewAllPermission())
+            return StatusCode(403, ApiResponse<object>.Fail(ErrorCodes.PERMISSION_DENIED, "无权限查看该提交"));
+
+        var results = await _db.ReviewResults
+            .Find(x => x.SubmissionId == id)
+            .SortByDescending(x => x.ScoredAt)
+            .ToListAsync(ct);
+
+        return Ok(ApiResponse<object>.Ok(new { results }));
     }
 
     // ──────────────────────────────────────────────
@@ -739,10 +887,7 @@ public class ReviewAgentController : ControllerBase
         if (string.IsNullOrWhiteSpace(attachment.ExtractedText))
             return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "无法从文件中提取文本内容，请确认上传的是有效的 Markdown 文件"));
 
-        // 删除旧 ReviewResult（如有）
-        if (!string.IsNullOrEmpty(submission.ResultId))
-            await _db.ReviewResults.DeleteOneAsync(x => x.Id == submission.ResultId, CancellationToken.None);
-
+        // 不删旧 ReviewResult，保留为评审历史
         await _db.ReviewSubmissions.UpdateOneAsync(
             x => x.Id == id,
             Builders<ReviewSubmission>.Update
@@ -750,7 +895,7 @@ public class ReviewAgentController : ControllerBase
                 .Set(x => x.FileName, attachment.FileName)
                 .Set(x => x.ExtractedContent, attachment.ExtractedText)
                 .Set(x => x.Status, ReviewStatuses.Queued)
-                .Set(x => x.RerunCount, 0)  // 重新上传 = 新一次方案的「首次评审」，RerunCount 清零
+                .Set(x => x.RerunCount, 0)  // 申诉成功后重新上传 = 该方案的"新一轮首次评审"，RerunCount 清零
                 .Unset(x => x.ResultId)
                 .Unset(x => x.IsPassed)
                 .Unset(x => x.CompletedAt)

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ReviewAgentController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ReviewAgentController.cs
@@ -1168,9 +1168,9 @@ public class ReviewAgentController : ControllerBase
 
     /// <summary>
     /// 应用系统级三层兜底，按顺序：
-    /// L1 evidence gate：非清单维度若 LLM 给到 MaxScore × 0.9 以上，要求 Comment 必须 ≥ 30 字且含具体证据（数字/百分比/引用/章节名），否则该维度降至 floor(MaxScore × 0.89)。
+    /// L1 evidence gate：非清单维度若 LLM 给到 MaxScore × 0.9 以上，要求 Comment 必须 ≥ 15 字且含至少 1 个强标记（≥2 位数字/百分比/章节引用/书名号/直角引号/方括号/URL），否则该维度降至 floor(MaxScore × 0.89)。
     /// L2 数据密度封顶：方案原文「数字/百分比/链接/章节引用」总出现 &lt; 5 处时，整体高分维度（≥ 0.9 得分率）按 0.89 封顶。
-    /// L3 summary 一致性闸：summary 出现明确降级关键词（"75-89"/"未达 90+"/"合格区间"/"有改进空间"），但总分 ≥ 90 时，整体高分维度按 0.89 封顶。
+    /// L3 summary 一致性闸：summary 出现明确降级关键词（"75-89"/"未达 90"/"合格区间"/"未达标杆"/"有改进空间"），但总分 ≥ 90 时，整体高分维度按 0.89 封顶。L1/L2 已把总分压到 90% 以下时本闸自动失效（设计正确：不重复打压）。
     /// 注意：清单类维度（Items != null）由系统按 truth table 强制重算，不在本兜底覆盖范围。
     /// </summary>
     /// <returns>触发的调整日志条目（≥ 0 条）</returns>
@@ -1181,7 +1181,8 @@ public class ReviewAgentController : ControllerBase
         string summary)
     {
         var log = new List<string>();
-        var dimConfigMap = dims.ToDictionary(d => d.Key);
+        // 防御 DB 自定义配置出现重复 Key（UpdateDimensions 未做唯一性校验）—— 取第一条避免抛 ArgumentException
+        var dimConfigMap = dims.GroupBy(d => d.Key).ToDictionary(g => g.Key, g => g.First());
 
         // L1：逐维度 evidence gate
         foreach (var score in dimensionScores)
@@ -1199,6 +1200,7 @@ public class ReviewAgentController : ControllerBase
                 log.Add(
                     $"[L1 证据闸] 维度「{score.Name}」原 {score.Score}/{score.MaxScore} → 调整为 {capped}/{score.MaxScore}：" +
                     $"得分率 ≥90% 但 LLM 评语未提供具体证据（数字/百分比/引用/原文章节），按 89% 封顶。");
+                score.OriginalScore ??= score.Score;
                 score.Score = capped;
                 score.Comment = (string.IsNullOrWhiteSpace(score.Comment) ? "" : score.Comment.TrimEnd() + " ") +
                                 "[系统提示] 因高分缺乏具体证据，已按 89% 封顶。";
@@ -1214,6 +1216,8 @@ public class ReviewAgentController : ControllerBase
         }
 
         // L3：summary 与总分一致性闸
+        // 注：若 L1/L2 已把高分维度压低、total/max 跌破 0.9，则 L3 门槛自动失效，
+        // 这是设计上正确的行为（summary 的降级措辞此时与总分一致，没有矛盾）。
         var totalScoreNow = dimensionScores.Sum(d => d.Score);
         var totalMax = dimensionScores.Sum(d => d.MaxScore);
         if (totalMax > 0 && (double)totalScoreNow / totalMax >= 0.9 && SummaryContainsDowngradeKeyword(summary))
@@ -1226,36 +1230,42 @@ public class ReviewAgentController : ControllerBase
     }
 
     /// <summary>
-    /// 判断 LLM 评语是否含「具体证据」：长度 ≥ 30 且含数字/百分比/章节引用/书名号/方括号引用 任一线索。
-    /// 纯定性形容词（"完整""清晰""凝练"）不视为证据。
+    /// 「具体证据」线索的正则：≥2 位连续数字（排除单数字凑数）、百分比、章节引用（允许中间空格）、
+    /// 书名号 / 直角引号 / 方括号 / URL。纯定性形容词（"完整""清晰""凝练"）不视为证据。
+    /// </summary>
+    private static readonly System.Text.RegularExpressions.Regex EvidenceMarkerRegex = new(
+        @"\d{2,}|\d+[%％]|第\s?[一-龥\d]+\s?[章节段条]|《[^》]+》|「[^」]+」|\[[^\]]+\]|http[s]?://",
+        System.Text.RegularExpressions.RegexOptions.Compiled);
+
+    /// <summary>
+    /// 判断 LLM 评语是否含「具体证据」：长度 ≥ 15 字 且 含至少 1 个强标记
+    /// （≥2 位数字 / 百分比 / 章节引用 / 书名号 / 直角引号 / 方括号 / URL）。
+    /// 长度门槛防纯空话；强标记正则（不含单 `\d`）防 "整体不错…综合判断 1" 这类单数字钻空子。
     /// </summary>
     internal static bool HasSufficientEvidence(string? comment)
     {
         if (string.IsNullOrWhiteSpace(comment)) return false;
         var trimmed = comment.Trim();
-        if (trimmed.Length < 30) return false;
-        // 至少含一种具体证据线索
-        return System.Text.RegularExpressions.Regex.IsMatch(
-            trimmed,
-            @"\d|[%％]|第[一-龥\d]+[章节段条]|《[^》]+》|「[^」]+」|\[[^\]]+\]|http[s]?://");
+        if (trimmed.Length < 15) return false;
+        return EvidenceMarkerRegex.IsMatch(trimmed);
     }
 
     /// <summary>
-    /// 数据密度统计：扫方案原文「数字串(≥2 位) / 百分比 / URL / 章节引用 / 书名号引用」总出现次数。
+    /// 数据密度统计：扫方案原文「数字串(≥2 位非百分比) / 百分比 / URL / 章节引用 / 书名号引用」总出现次数。
     /// 阈值 5 是保守估计：1000 字以上的产品方案普遍能轻松达标，达不到说明确实空话占多数。
     /// </summary>
     internal static int CountDataPoints(string content)
     {
         if (string.IsNullOrWhiteSpace(content)) return 0;
         var count = 0;
-        // 数字串（≥ 2 位连续数字，避免误算单个数字如"3 个"）
-        count += System.Text.RegularExpressions.Regex.Matches(content, @"\d{2,}").Count;
+        // 数字串（≥ 2 位连续数字，且不跟百分号，避免与下一条 \d+% 重复计数）
+        count += System.Text.RegularExpressions.Regex.Matches(content, @"\d{2,}(?![%％])").Count;
         // 百分比
         count += System.Text.RegularExpressions.Regex.Matches(content, @"\d+[%％]").Count;
         // URL
         count += System.Text.RegularExpressions.Regex.Matches(content, @"http[s]?://[^\s一-龥]+").Count;
-        // 章节引用
-        count += System.Text.RegularExpressions.Regex.Matches(content, @"第[一-龥\d]+[章节段条]").Count;
+        // 章节引用（允许"第 3 章"这种带空格写法）
+        count += System.Text.RegularExpressions.Regex.Matches(content, @"第\s?[一-龥\d]+\s?[章节段条]").Count;
         // 书名号引用
         count += System.Text.RegularExpressions.Regex.Matches(content, @"《[^》]{1,40}》").Count;
         return count;
@@ -1263,12 +1273,13 @@ public class ReviewAgentController : ControllerBase
 
     /// <summary>
     /// 检测 summary 是否含明确的「降级」关键词。命中即视为 LLM 自己承认"未达 90+"。
+    /// 关键词清单只保留**单义负面**表述；像"标杆级水平"这种褒贬双向的词不放入（会误伤"达到行业标杆级水平"褒义高分）。
     /// </summary>
     internal static bool SummaryContainsDowngradeKeyword(string? summary)
     {
         if (string.IsNullOrWhiteSpace(summary)) return false;
         string[] keywords = { "75-89", "75 - 89", "75 至 89", "未达 90", "未达到 90", "未达90", "未达到90",
-                              "合格区间", "标杆级水平", "有改进空间", "未达标杆", "未达行业" };
+                              "合格区间", "未达标杆", "未达到标杆", "未到标杆", "未达行业", "有改进空间" };
         return keywords.Any(k => summary.Contains(k, StringComparison.OrdinalIgnoreCase));
     }
 
@@ -1292,6 +1303,7 @@ public class ReviewAgentController : ControllerBase
 
             var capped = (int)Math.Floor(score.MaxScore * 0.89);
             subEntries.Add($"  └ 维度「{score.Name}」{score.Score}/{score.MaxScore} → {capped}/{score.MaxScore}");
+            score.OriginalScore ??= score.Score;
             score.Score = capped;
         }
         if (subEntries.Count > 0)

--- a/prd-api/src/PrdAgent.Core/Models/ReviewDimensionConfig.cs
+++ b/prd-api/src/PrdAgent.Core/Models/ReviewDimensionConfig.cs
@@ -54,9 +54,12 @@ public class DimensionCheckItem
 
 /// <summary>
 /// 系统默认评审维度（数据库无配置时使用）
-/// 总分 100。「全局规则检查清单」30 + 「文档规范完整性」8 + 「内在自洽性」14 + 「问题陈述质量」11
-///        + 「用户价值清晰度」10 + 「实现思路可行性」10 + 「需求可测试性」7 + 「表达质量与凝练度」10。
-/// 2026-05-21 调整：表达质量与凝练度 4→10、文档规范完整性 14→8（释放 6 分权重给反堆砌主战场，对抗"分数虚高 / 用户为分数堆砌文字"问题）。
+/// 总分 100。「全局规则检查清单」20 + 「文档规范完整性」8 + 「内在自洽性」16 + 「问题陈述质量」13
+///        + 「用户价值清晰度」12 + 「实现思路可行性」12 + 「需求可测试性」9 + 「表达质量与凝练度」10。
+/// 2026-05-21 调整：表达质量与凝练度 4→10、文档规范完整性 14→8（释放 6 分权重给反堆砌主战场）。
+/// 2026-05-27 调整：清单维度 30→20，10 分按 +2 平均分摊到 consistency/problem_quality/user_value/feasibility/testability 五个高风险维度，
+///   配合系统级三层兜底（evidence gate / 数据密度封顶 / summary 一致性闸），杜绝 LLM 把 70 分自填维度全填满凑 99 的钻空子路径。
+/// 注意：本默认配置仅在 review_dimension_configs 集合为空时生效；线上若已存在 DB 自定义配置，需管理员通过「评审维度配置」UI 手动同步权重。
 /// </summary>
 public static class DefaultReviewDimensions
 {
@@ -66,7 +69,7 @@ public static class DefaultReviewDimensions
         {
             Key = "global_rules_checklist",
             Name = "全局规则检查清单",
-            MaxScore = 30,
+            MaxScore = 20,
             Description = "检查方案是否考虑到米多平台的硬性业务/技术规则。对每个检查项做二段判断：① 方案是否涉及该规则？② 若涉及，方案是否已明确写出对应设计？只有「涉及=是 且 覆盖=否」才算未通过，涉及=否直接视为通过。得分 = 30 × 通过项数 / 总项数（向下取整）。",
             OrderIndex = 1,
             Items = new List<DimensionCheckItem>
@@ -135,7 +138,7 @@ public static class DefaultReviewDimensions
         {
             Key = "consistency",
             Name = "内在自洽性",
-            MaxScore = 14,
+            MaxScore = 16,
             Description = "评估整篇方案的逻辑闭环：项目目的→现状问题→用户诉求→实现思路是否形成完整链条；各章节描述是否互相支撑，有无矛盾；问题陈述的\"问题\"是否与\"需求\"对应；实现思路是否能解决所提出的问题。",
             OrderIndex = 3,
         },
@@ -143,7 +146,7 @@ public static class DefaultReviewDimensions
         {
             Key = "problem_quality",
             Name = "问题陈述质量",
-            MaxScore = 11,
+            MaxScore = 13,
             Description = "评估现状背景与问题陈述章节的质量：现状描述是否具体清晰（非泛泛而谈）；问题陈述是否指向根因（非表面症状）；需求描述是否明确可执行（用户期望达到的效果是否可验证）。",
             OrderIndex = 4,
         },
@@ -151,7 +154,7 @@ public static class DefaultReviewDimensions
         {
             Key = "user_value",
             Name = "用户价值清晰度",
-            MaxScore = 10,
+            MaxScore = 12,
             Description = "评估用户价值的阐述质量：项目目的中3个核心要点是否完整涵盖商业目标与客户价值；用户范围章节中核心用户角色是否明确列举；每个角色的核心诉求是否简明扼要且真实反映用户需要。",
             OrderIndex = 5,
         },
@@ -159,7 +162,7 @@ public static class DefaultReviewDimensions
         {
             Key = "feasibility",
             Name = "实现思路可行性",
-            MaxScore = 10,
+            MaxScore = 12,
             Description = "评估实现思路章节的质量：是否明确了'结构归母'（功能归属的产品模块/系统）；整体设计思路是否合理，分要点阐述是否具体；是否有明显的技术或业务风险盲点；方案是否在系统现有能力范围内可实现。",
             OrderIndex = 6,
         },
@@ -167,7 +170,7 @@ public static class DefaultReviewDimensions
         {
             Key = "testability",
             Name = "需求可测试性",
-            MaxScore = 7,
+            MaxScore = 9,
             Description = "评估需求是否可被验证和测试：需求描述是否有明确的完成标准；是否可以从需求推导出验收测试用例；描述中是否有可量化的指标或清晰的成功/失败判断条件。",
             OrderIndex = 7,
         },

--- a/prd-api/src/PrdAgent.Core/Models/ReviewDimensionConfig.cs
+++ b/prd-api/src/PrdAgent.Core/Models/ReviewDimensionConfig.cs
@@ -70,7 +70,7 @@ public static class DefaultReviewDimensions
             Key = "global_rules_checklist",
             Name = "全局规则检查清单",
             MaxScore = 20,
-            Description = "检查方案是否考虑到米多平台的硬性业务/技术规则。对每个检查项做二段判断：① 方案是否涉及该规则？② 若涉及，方案是否已明确写出对应设计？只有「涉及=是 且 覆盖=否」才算未通过，涉及=否直接视为通过。得分 = 30 × 通过项数 / 总项数（向下取整）。",
+            Description = "检查方案是否考虑到米多平台的硬性业务/技术规则。对每个检查项做二段判断：① 方案是否涉及该规则？② 若涉及，方案是否已明确写出对应设计？只有「涉及=是 且 覆盖=否」才算未通过，涉及=否直接视为通过。得分 = MaxScore × 通过项数 / 总项数（向下取整）。",
             OrderIndex = 1,
             Items = new List<DimensionCheckItem>
             {

--- a/prd-api/src/PrdAgent.Core/Models/ReviewResult.cs
+++ b/prd-api/src/PrdAgent.Core/Models/ReviewResult.cs
@@ -28,6 +28,13 @@ public class ReviewResult
     /// <summary>解析错误信息（为空表示解析成功）</summary>
     public string? ParseError { get; set; }
 
+    /// <summary>
+    /// 系统兜底调整日志。记录三层 guardrail（evidence gate / 数据密度封顶 / summary 一致性闸）
+    /// 触发后的调整原文，便于用户/审计追踪「LLM 给了 X 分，系统按规则 Y 改为 Z 分」。
+    /// 空列表表示 LLM 原始打分未被系统调整。
+    /// </summary>
+    public List<string> AdjustmentLog { get; set; } = new();
+
     public DateTime ScoredAt { get; set; } = DateTime.UtcNow;
 }
 

--- a/prd-api/src/PrdAgent.Core/Models/ReviewResult.cs
+++ b/prd-api/src/PrdAgent.Core/Models/ReviewResult.cs
@@ -47,11 +47,17 @@ public class ReviewDimensionScore
     /// <summary>维度名称快照</summary>
     public string Name { get; set; } = string.Empty;
 
-    /// <summary>实得分</summary>
+    /// <summary>实得分（可能被系统兜底调整覆盖；调整前的 LLM 原始分见 OriginalScore）</summary>
     public int Score { get; set; }
 
     /// <summary>满分</summary>
     public int MaxScore { get; set; }
+
+    /// <summary>
+    /// LLM 原始分（清单维度为系统派生前的 LLM 自填值）。仅当被 guardrail 调整时填充，
+    /// 未调整时为 null。用于审计「LLM 给了多少 / 系统改了多少」。
+    /// </summary>
+    public int? OriginalScore { get; set; }
 
     /// <summary>AI 评语（该维度的具体评价）</summary>
     public string Comment { get; set; } = string.Empty;

--- a/prd-api/src/PrdAgent.Core/Models/ReviewSubmission.cs
+++ b/prd-api/src/PrdAgent.Core/Models/ReviewSubmission.cs
@@ -40,8 +40,18 @@ public class ReviewSubmission
     public DateTime? StartedAt { get; set; }
     public DateTime? CompletedAt { get; set; }
 
-    /// <summary>该提交被「重新评审」的次数；0 表示从未 rerun。用于一次性通过率统计。</summary>
+    /// <summary>
+    /// 该提交被用户「重新上传方案救机会」的次数；语义 = 用户主动改/换内容的次数。
+    /// 0 = 首次提交从未折腾过；≥1 = 用户至少救过一次。一次性通过率统计依赖此字段。
+    /// 注意：不含 LLM 网关 Error 后的"重新评审"重跑（那是系统恢复，不归咎用户），见 ErrorRetryCount。
+    /// </summary>
     public int RerunCount { get; set; } = 0;
+
+    /// <summary>
+    /// LLM 网关 Error 后用户点「重新评审」触发的系统重跑次数；与用户方案质量无关，仅用于运维统计。
+    /// 一次性通过率公式不消费此字段。
+    /// </summary>
+    public int ErrorRetryCount { get; set; } = 0;
 
     /// <summary>申诉状态：null（未申诉）/ Pending / Approved / Rejected</summary>
     public string? AppealStatus { get; set; }

--- a/prd-api/tests/PrdAgent.Api.Tests/Controllers/ReviewAgentLeaderboardTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Controllers/ReviewAgentLeaderboardTests.cs
@@ -12,7 +12,8 @@ namespace PrdAgent.Api.Tests.Controllers;
 public class ReviewAgentLeaderboardTests
 {
     private static ReviewAgentController.LeaderboardRow Row(
-        string title, bool? passed, int rerun, string? appeal = null, string submitter = "u1")
+        string title, bool? passed, int rerun, string? appeal = null, string submitter = "u1",
+        DateTime? appealResolvedAt = null)
         => new()
         {
             SubmitterId = submitter,
@@ -21,6 +22,7 @@ public class ReviewAgentLeaderboardTests
             IsPassed = passed,
             RerunCount = rerun,
             AppealStatus = appeal,
+            AppealResolvedAt = appealResolvedAt,
         };
 
     [Fact]
@@ -176,5 +178,49 @@ public class ReviewAgentLeaderboardTests
     {
         var buckets = ReviewAgentController.AggregateProposalBuckets(Array.Empty<ReviewAgentController.LeaderboardRow>());
         buckets.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Bucket_申诉成功后重传通过_不算一次过_防止RerunCount被清零导致误判()
+    {
+        // Finding 1 修复：reupload-after-appeal 路径会把 RerunCount 清零，
+        // 但 AppealResolvedAt 非空，应据此判定"该方案折腾过申诉链路"，IsFirstPass=false
+        var rows = new[]
+        {
+            Row(
+                title: "方案 X：申诉通过后重传",
+                passed: true,
+                rerun: 0,                                   // ← 被清零
+                appeal: null,                               // ← 走完 reupload 后 AppealStatus 被 Unset
+                appealResolvedAt: DateTime.UtcNow.AddDays(-1)), // ← 但历史时间戳保留
+        };
+
+        var bucket = ReviewAgentController.AggregateProposalBuckets(rows).Single();
+        bucket.IsBucketPassed.ShouldBeTrue();
+        bucket.IsFirstPass.ShouldBeFalse();  // ✓ Finding 1 关键断言：申诉历史 → 非一次过
+    }
+
+    [Fact]
+    public void Bucket_申诉处理中_不算一次过()
+    {
+        // 用户提交、未通过、正在申诉中（AppealStatus=Pending），即便 RerunCount=0 也不应算"一次过"
+        var rows = new[]
+        {
+            Row("方案 Y", passed: false, rerun: 0, appeal: AppealStatuses.Pending),
+        };
+        var bucket = ReviewAgentController.AggregateProposalBuckets(rows).Single();
+        bucket.IsFirstPass.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Bucket_申诉被驳回_不算一次过()
+    {
+        // 申诉被驳回 + 评审仍未通过：明显非一次过
+        var rows = new[]
+        {
+            Row("方案 Z", passed: false, rerun: 0, appeal: AppealStatuses.Rejected),
+        };
+        var bucket = ReviewAgentController.AggregateProposalBuckets(rows).Single();
+        bucket.IsFirstPass.ShouldBeFalse();
     }
 }

--- a/prd-api/tests/PrdAgent.Api.Tests/Controllers/ReviewAgentLeaderboardTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Controllers/ReviewAgentLeaderboardTests.cs
@@ -1,0 +1,180 @@
+using PrdAgent.Api.Controllers.Api;
+using PrdAgent.Core.Models;
+using Shouldly;
+using Xunit;
+
+namespace PrdAgent.Api.Tests.Controllers;
+
+/// <summary>
+/// 排行榜「方案桶」聚合 + 「一次性通过率」公式（口径 Z）单元测试。
+/// 模拟用户提出的张三 5 月度 6 方案场景。
+/// </summary>
+public class ReviewAgentLeaderboardTests
+{
+    private static ReviewAgentController.LeaderboardRow Row(
+        string title, bool? passed, int rerun, string? appeal = null, string submitter = "u1")
+        => new()
+        {
+            SubmitterId = submitter,
+            SubmitterName = submitter == "u1" ? "张三" : "李四",
+            Title = title,
+            IsPassed = passed,
+            RerunCount = rerun,
+            AppealStatus = appeal,
+        };
+
+    [Fact]
+    public void Bucket_单次通过且未重传_算一次过()
+    {
+        var buckets = ReviewAgentController.AggregateProposalBuckets(new[]
+        {
+            Row("方案A：互动营销", passed: true, rerun: 0),
+        });
+
+        var b = buckets.Single();
+        b.SubmissionCount.ShouldBe(1);
+        b.IsBucketPassed.ShouldBeTrue();
+        b.IsFirstPass.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Bucket_单次未通过_不算一次过_算桶级失败()
+    {
+        var buckets = ReviewAgentController.AggregateProposalBuckets(new[]
+        {
+            Row("方案B：积分体系", passed: false, rerun: 0),
+        });
+
+        var b = buckets.Single();
+        b.IsBucketPassed.ShouldBeFalse();
+        b.IsBucketFailed.ShouldBeTrue();
+        b.IsFirstPass.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Bucket_救活成功_RerunCount1_算桶级通过但非一次过()
+    {
+        var buckets = ReviewAgentController.AggregateProposalBuckets(new[]
+        {
+            Row("方案C：分销返利", passed: true, rerun: 1),
+        });
+
+        var b = buckets.Single();
+        b.IsBucketPassed.ShouldBeTrue();
+        b.IsFirstPass.ShouldBeFalse();    // RerunCount>0
+    }
+
+    [Fact]
+    public void Bucket_救机会用尽仍未通过_桶级失败()
+    {
+        var buckets = ReviewAgentController.AggregateProposalBuckets(new[]
+        {
+            Row("方案D：会员等级", passed: false, rerun: 1),
+        });
+
+        var b = buckets.Single();
+        b.IsBucketFailed.ShouldBeTrue();
+        b.IsFirstPass.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Bucket_用户新建同标题再过_2条submission_算桶级通过但非一次过()
+    {
+        var buckets = ReviewAgentController.AggregateProposalBuckets(new[]
+        {
+            Row("方案E：抽奖活动", passed: false, rerun: 0),
+            Row("方案E：抽奖活动", passed: true, rerun: 0), // 用户新建同标题第二份
+        });
+
+        var b = buckets.Single(); // 按 title 去重，仍是 1 个桶
+        b.SubmissionCount.ShouldBe(2);
+        b.IsBucketPassed.ShouldBeTrue();
+        b.IsFirstPass.ShouldBeFalse();    // submissionCount>1
+    }
+
+    [Fact]
+    public void Bucket_F2语义_Error重跑通过_RerunCount0_算一次过()
+    {
+        // 关键：F-2 设计下 ErrorRetryCount 不污染 RerunCount
+        // LLM 网关 Error 重跑通过的方案，RerunCount 仍为 0，应算"一次过"
+        var buckets = ReviewAgentController.AggregateProposalBuckets(new[]
+        {
+            Row("方案F：渠道分润", passed: true, rerun: 0), // 系统故障重跑过，但 RerunCount=0
+        });
+
+        var b = buckets.Single();
+        b.IsBucketPassed.ShouldBeTrue();
+        b.IsFirstPass.ShouldBeTrue();    // ✓ F-2 关键断言
+    }
+
+    [Fact]
+    public void Bucket_张三全月6方案_一次性通过率符合预期()
+    {
+        // 复现用户给的"张三 5 月度 6 方案"场景，验证全链路 Z 口径正确
+        var rows = new[]
+        {
+            // A：1 sub 通过 → 一次过
+            Row("方案A：互动营销", passed: true, rerun: 0),
+            // B：1 sub 未通过放弃
+            Row("方案B：积分体系", passed: false, rerun: 0),
+            // C：1 sub 救活成功
+            Row("方案C：分销返利", passed: true, rerun: 1),
+            // D：1 sub 救失败
+            Row("方案D：会员等级", passed: false, rerun: 1),
+            // E：2 sub 同标题，第二个通过
+            Row("方案E：抽奖活动", passed: false, rerun: 0),
+            Row("方案E：抽奖活动", passed: true, rerun: 0),
+            // F：1 sub Error 重跑通过，RerunCount 仍 0
+            Row("方案F：渠道分润", passed: true, rerun: 0),
+        };
+
+        var buckets = ReviewAgentController.AggregateProposalBuckets(rows);
+
+        buckets.Count.ShouldBe(6);  // 按 (submitter,title) 去重 → 6 个方案
+        var firstPassCount = buckets.Count(b => b.IsFirstPass);
+        var passedCount = buckets.Count(b => b.IsBucketPassed);
+
+        // 一次过 = A + F = 2 / 6 ≈ 33.3%
+        firstPassCount.ShouldBe(2);
+        // 最终通过的方案桶 = A + C + E + F = 4 / 6 ≈ 66.7%
+        passedCount.ShouldBe(4);
+
+        ((double)firstPassCount / buckets.Count).ShouldBe(2d / 6d, 0.0001);
+    }
+
+    [Fact]
+    public void Bucket_申诉成功的方案桶_不算通过也不算失败()
+    {
+        var buckets = ReviewAgentController.AggregateProposalBuckets(new[]
+        {
+            Row("方案 X", passed: false, rerun: 0, appeal: AppealStatuses.Approved),
+        });
+
+        var b = buckets.Single();
+        b.IsBucketPassed.ShouldBeFalse();
+        b.IsBucketFailed.ShouldBeFalse();
+        b.IsBucketAppealApproved.ShouldBeTrue();
+        b.IsFirstPass.ShouldBeFalse();    // 申诉成功不算一次过
+    }
+
+    [Fact]
+    public void Bucket_跨用户同标题_分到不同桶()
+    {
+        var buckets = ReviewAgentController.AggregateProposalBuckets(new[]
+        {
+            Row("方案A：互动营销", passed: true, rerun: 0, submitter: "u1"),
+            Row("方案A：互动营销", passed: false, rerun: 0, submitter: "u2"),
+        });
+
+        buckets.Count.ShouldBe(2);
+        buckets.Single(b => b.SubmitterId == "u1").IsFirstPass.ShouldBeTrue();
+        buckets.Single(b => b.SubmitterId == "u2").IsFirstPass.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Bucket_空输入_返回空列表()
+    {
+        var buckets = ReviewAgentController.AggregateProposalBuckets(Array.Empty<ReviewAgentController.LeaderboardRow>());
+        buckets.ShouldBeEmpty();
+    }
+}

--- a/prd-api/tests/PrdAgent.Api.Tests/Controllers/ReviewAgentScoringGuardrailsTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Controllers/ReviewAgentScoringGuardrailsTests.cs
@@ -69,6 +69,21 @@ public class ReviewAgentScoringGuardrailsTests
     }
 
     [Fact]
+    public void HasSufficientEvidence_LLM单数字凑数钻空子_无效()
+    {
+        // 30+ 字 + 一个孤零零的 "1" —— 之前 \d 单数字会过关，现在 \d{2,} 拦下
+        var comment = "整体表现非常优秀，所有维度都得到了应得的分数，本次评审基于综合判断 1。";
+        ReviewAgentController.HasSufficientEvidence(comment).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void HasSufficientEvidence_简洁高密度短评语_视为有证据()
+    {
+        // Finding D 修复：长度仅 16 字但含 2 个强标记，不应被误伤
+        ReviewAgentController.HasSufficientEvidence("覆盖 40 应用 80% 成功率，归母清晰。").ShouldBeTrue();
+    }
+
+    [Fact]
     public void HasSufficientEvidence_含数字_视为有证据()
     {
         ReviewAgentController.HasSufficientEvidence("方案中 40 个应用的量化数据支撑，逻辑闭环清晰。").ShouldBeTrue();
@@ -125,6 +140,15 @@ public class ReviewAgentScoringGuardrailsTests
         ReviewAgentController.CountDataPoints(content).ShouldBeGreaterThanOrEqualTo(5);
     }
 
+    [Fact]
+    public void CountDataPoints_百分比不被重复计数()
+    {
+        // Finding C 修复：之前 "80%" 既匹配 \d{2,} 又匹配 \d+[%]，被计 2 次
+        // 现在 \d{2,}(?![%％]) 排除百分号后续，"80%" 只计 1
+        ReviewAgentController.CountDataPoints("覆盖率 80%").ShouldBe(1);
+        ReviewAgentController.CountDataPoints("成功率 80%，失败率 20%").ShouldBe(2);
+    }
+
     // ── SummaryContainsDowngradeKeyword ─────────────────────────
 
     [Fact]
@@ -146,6 +170,21 @@ public class ReviewAgentScoringGuardrailsTests
     public void SummaryContainsDowngradeKeyword_有改进空间_命中()
     {
         ReviewAgentController.SummaryContainsDowngradeKeyword("方案整体不错，但仍有改进空间。").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SummaryContainsDowngradeKeyword_褒义标杆级表述_不命中()
+    {
+        // Finding B 修复：之前 "标杆级水平" 子串匹配会误伤褒义高分 summary
+        // 现在关键词清单只保留单义负面词，褒义不应触发
+        ReviewAgentController.SummaryContainsDowngradeKeyword(
+            "方案达到行业标杆级水平，凝练扎实，数据充分，可立即对外发布。").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SummaryContainsDowngradeKeyword_明确未达标杆_命中()
+    {
+        ReviewAgentController.SummaryContainsDowngradeKeyword("方案未达标杆级水平，仍需打磨。").ShouldBeTrue();
     }
 
     // ── ApplyScoringGuardrails 集成场景 ─────────────────────────
@@ -226,6 +265,57 @@ public class ReviewAgentScoringGuardrailsTests
         var total = scores.Sum(s => s.Score);
         var max = scores.Sum(s => s.MaxScore);
         ((double)total / max).ShouldBeLessThan(0.9);
+    }
+
+    [Fact]
+    public void Guardrail_L1触发时记录OriginalScore()
+    {
+        // Finding H：被调整的维度必须留下原始分供审计
+        var dims = BuildDims();
+        var scores = BuildAllMaxScores("整体表现优秀，内容完整、思路清晰、表达凝练，可立即指导落地实施。质量上乘。");
+        var content = string.Join(" ", Enumerable.Repeat("第 1 章引用 40 个应用 80% 覆盖率《规范 v2》", 5));
+        var summary = "方案凝练扎实，数据充分。";
+
+        ReviewAgentController.ApplyScoringGuardrails(scores, dims, content, summary);
+
+        // 非清单维度被压时 OriginalScore 应保留原满分值
+        var consistency = scores.First(s => s.Key == "consistency");
+        consistency.OriginalScore.ShouldBe(16);
+        consistency.Score.ShouldBeLessThan(16);
+
+        // 清单维度未被本兜底调整，OriginalScore 保持 null
+        var checklist = scores.First(s => s.Key == "global_rules_checklist");
+        checklist.OriginalScore.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Guardrail_DB配置出现重复Key_不抛异常()
+    {
+        // Finding F：UpdateDimensions 未校验 Key 唯一性，guardrail 必须能容错
+        var dims = BuildDims();
+        dims.Add(new ReviewDimensionConfig { Key = "consistency", Name = "重复键", MaxScore = 16 });
+        var scores = BuildAllMaxScores();
+        var summary = "整体合格";
+
+        Should.NotThrow(() => ReviewAgentController.ApplyScoringGuardrails(scores, dims, "短方案", summary));
+    }
+
+    [Fact]
+    public void Guardrail_L2命中后L3因总分跌破90门槛而不再触发()
+    {
+        // L2 把所有高分维度压到 89%，total/max 降到 0.88 < 0.9，L3 门槛失效
+        // 这是设计上正确的行为：summary 的降级措辞此时与系统打分一致，没有矛盾，不需要再压
+        var dims = BuildDims();
+        var scores = BuildAllMaxScores(
+            "方案覆盖 40 个应用，给出 80% 的能力清单，引用《互动营销规范 v2》，第 3 章实现思路明确归母。");
+        var content = "本次改造旨在优化产品体验。"; // L2 触发
+        var summary = "总体落在 75-89 合格区间上沿，未达到 90+ 水平。"; // L3 关键词命中
+
+        var log = ReviewAgentController.ApplyScoringGuardrails(scores, dims, content, summary);
+
+        log.ShouldContain(e => e.Contains("L2 数据密度"));
+        // L3 门槛失效，不应产生 L3 日志条目（设计正确：避免在已经合理的得分上重复打压）
+        log.ShouldNotContain(e => e.Contains("L3 一致性闸"));
     }
 
     [Fact]

--- a/prd-api/tests/PrdAgent.Api.Tests/Controllers/ReviewAgentScoringGuardrailsTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Controllers/ReviewAgentScoringGuardrailsTests.cs
@@ -1,0 +1,255 @@
+using PrdAgent.Api.Controllers.Api;
+using PrdAgent.Core.Models;
+using Shouldly;
+using Xunit;
+
+namespace PrdAgent.Api.Tests.Controllers;
+
+/// <summary>
+/// 三层兜底（Guardrails）单元测试：抵御 LLM 把非清单维度全填满凑高分 + summary 自相矛盾的钻空子路径。
+/// </summary>
+public class ReviewAgentScoringGuardrailsTests
+{
+    /// <summary>构造一个简化的"7 个非清单维度 + 1 个清单维度"配置，权重与最新默认对齐。</summary>
+    private static List<ReviewDimensionConfig> BuildDims()
+    {
+        return new List<ReviewDimensionConfig>
+        {
+            new() { Key = "global_rules_checklist", Name = "全局规则检查清单", MaxScore = 20,
+                    Items = new List<DimensionCheckItem> { new() { Id = "x", Text = "x" } } },
+            new() { Key = "template_compliance", Name = "文档规范完整性", MaxScore = 8 },
+            new() { Key = "consistency", Name = "内在自洽性", MaxScore = 16 },
+            new() { Key = "problem_quality", Name = "问题陈述质量", MaxScore = 13 },
+            new() { Key = "user_value", Name = "用户价值清晰度", MaxScore = 12 },
+            new() { Key = "feasibility", Name = "实现思路可行性", MaxScore = 12 },
+            new() { Key = "testability", Name = "需求可测试性", MaxScore = 9 },
+            new() { Key = "expression", Name = "表达质量与凝练度", MaxScore = 10 },
+        };
+    }
+
+    /// <summary>构造一份「LLM 全填满分」的打分（清单 20 + 非清单 80 = 100）。</summary>
+    private static List<ReviewDimensionScore> BuildAllMaxScores(string commentForNonChecklist = "整体表现优秀，内容完整、思路清晰、表达凝练。")
+    {
+        return new List<ReviewDimensionScore>
+        {
+            new() { Key = "global_rules_checklist", Name = "全局规则检查清单", Score = 20, MaxScore = 20,
+                    Comment = "清单已系统派生", Items = new List<DimensionCheckItemResult>() },
+            new() { Key = "template_compliance", Name = "文档规范完整性", Score = 8, MaxScore = 8, Comment = commentForNonChecklist },
+            new() { Key = "consistency", Name = "内在自洽性", Score = 16, MaxScore = 16, Comment = commentForNonChecklist },
+            new() { Key = "problem_quality", Name = "问题陈述质量", Score = 13, MaxScore = 13, Comment = commentForNonChecklist },
+            new() { Key = "user_value", Name = "用户价值清晰度", Score = 12, MaxScore = 12, Comment = commentForNonChecklist },
+            new() { Key = "feasibility", Name = "实现思路可行性", Score = 12, MaxScore = 12, Comment = commentForNonChecklist },
+            new() { Key = "testability", Name = "需求可测试性", Score = 9, MaxScore = 9, Comment = commentForNonChecklist },
+            new() { Key = "expression", Name = "表达质量与凝练度", Score = 10, MaxScore = 10, Comment = commentForNonChecklist },
+        };
+    }
+
+    // ── HasSufficientEvidence ───────────────────────────────────
+
+    [Fact]
+    public void HasSufficientEvidence_空评语_视为无证据()
+    {
+        ReviewAgentController.HasSufficientEvidence(null).ShouldBeFalse();
+        ReviewAgentController.HasSufficientEvidence("").ShouldBeFalse();
+        ReviewAgentController.HasSufficientEvidence("   ").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void HasSufficientEvidence_短评语_视为无证据()
+    {
+        ReviewAgentController.HasSufficientEvidence("内容完整，思路清晰。").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void HasSufficientEvidence_长评语但纯定性形容_视为无证据()
+    {
+        // 长度足够但通篇空话套话，无任何具体数字/引用
+        var comment = "整体表现优秀，内容完整、思路清晰、表达凝练，可立即指导落地实施。质量上乘。";
+        ReviewAgentController.HasSufficientEvidence(comment).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void HasSufficientEvidence_含数字_视为有证据()
+    {
+        ReviewAgentController.HasSufficientEvidence("方案中 40 个应用的量化数据支撑，逻辑闭环清晰。").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void HasSufficientEvidence_含百分比_视为有证据()
+    {
+        ReviewAgentController.HasSufficientEvidence("覆盖了 80% 的核心场景，剩余 20% 已标注后续迭代。").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void HasSufficientEvidence_含章节引用_视为有证据()
+    {
+        ReviewAgentController.HasSufficientEvidence("第 3 章实现思路明确指出归母模块，与项目目的形成闭环。").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void HasSufficientEvidence_含书名号引用_视为有证据()
+    {
+        ReviewAgentController.HasSufficientEvidence("方案引用《互动营销规范 v2》明确边界，可执行性强。").ShouldBeTrue();
+    }
+
+    // ── CountDataPoints ─────────────────────────────────────────
+
+    [Fact]
+    public void CountDataPoints_空白原文_为零()
+    {
+        ReviewAgentController.CountDataPoints("").ShouldBe(0);
+        ReviewAgentController.CountDataPoints("   ").ShouldBe(0);
+    }
+
+    [Fact]
+    public void CountDataPoints_单数字不计_两位数及以上才计()
+    {
+        // "3 个" 中的 "3" 是单数字（< 2 位），按设计不计入
+        ReviewAgentController.CountDataPoints("方案有 3 个应用").ShouldBe(0);
+        // "40" 是两位数，计 1 次
+        ReviewAgentController.CountDataPoints("方案覆盖 40 个应用").ShouldBe(1);
+    }
+
+    [Fact]
+    public void CountDataPoints_典型空话方案_低于五处()
+    {
+        var content = "本次改造旨在优化产品体验，提升用户满意度。我们将通过技术手段实现这一目标，确保项目顺利落地。";
+        ReviewAgentController.CountDataPoints(content).ShouldBeLessThan(5);
+    }
+
+    [Fact]
+    public void CountDataPoints_扎实方案_达到阈值()
+    {
+        var content = "P95 首屏加载从 3200ms 降至 1500ms（监控来源 https://dashboard.example/perf），" +
+                      "覆盖 12 个核心场景，第 3 章详细阐述方案，引用《性能规范 v2》。Safari 兼容性下降 0.8%。";
+        ReviewAgentController.CountDataPoints(content).ShouldBeGreaterThanOrEqualTo(5);
+    }
+
+    // ── SummaryContainsDowngradeKeyword ─────────────────────────
+
+    [Fact]
+    public void SummaryContainsDowngradeKeyword_匹配截图原文_命中()
+    {
+        // 用户截图里出现的原话
+        var summary = "总体落在 75-89 合格区间上沿，因缺乏行业级洞察和非显而易见的数据分析，未达到 90+ 标杆级水平。";
+        ReviewAgentController.SummaryContainsDowngradeKeyword(summary).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SummaryContainsDowngradeKeyword_仅含正面评价_不命中()
+    {
+        var summary = "方案凝练扎实，数据充分，论证完整，可立即指导落地实施。";
+        ReviewAgentController.SummaryContainsDowngradeKeyword(summary).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SummaryContainsDowngradeKeyword_有改进空间_命中()
+    {
+        ReviewAgentController.SummaryContainsDowngradeKeyword("方案整体不错，但仍有改进空间。").ShouldBeTrue();
+    }
+
+    // ── ApplyScoringGuardrails 集成场景 ─────────────────────────
+
+    [Fact]
+    public void Guardrail_L1_LLM全填满分但评语空洞_所有非清单维度被压到89()
+    {
+        var dims = BuildDims();
+        var scores = BuildAllMaxScores("整体表现优秀，内容完整、思路清晰、表达凝练，可立即指导落地实施。质量上乘。");
+        // 给一份「数据密度足够 + summary 无降级关键词」的原文和 summary，确保 L2/L3 不会同时触发，单独验 L1
+        var content = string.Join(" ", Enumerable.Repeat("第 1 章引用 40 个应用 80% 覆盖率《规范 v2》", 5));
+        var summary = "方案凝练扎实，数据充分，论证完整。";
+
+        var log = ReviewAgentController.ApplyScoringGuardrails(scores, dims, content, summary);
+
+        log.ShouldNotBeEmpty();
+        log.ShouldContain(e => e.Contains("L1 证据闸"));
+
+        // 所有非清单维度都应被压（得分率原 100% → 89%）
+        scores.First(s => s.Key == "consistency").Score.ShouldBe((int)System.Math.Floor(16 * 0.89));      // 14
+        scores.First(s => s.Key == "problem_quality").Score.ShouldBe((int)System.Math.Floor(13 * 0.89)); // 11
+        scores.First(s => s.Key == "feasibility").Score.ShouldBe((int)System.Math.Floor(12 * 0.89));     // 10
+        scores.First(s => s.Key == "testability").Score.ShouldBe((int)System.Math.Floor(9 * 0.89));      // 8
+
+        // 清单维度不被本兜底覆盖
+        scores.First(s => s.Key == "global_rules_checklist").Score.ShouldBe(20);
+
+        // 总分不再是 100：被压到合理范围内
+        scores.Sum(s => s.Score).ShouldBeLessThan(100);
+    }
+
+    [Fact]
+    public void Guardrail_L1_评语有具体证据_不触发()
+    {
+        var dims = BuildDims();
+        var scores = BuildAllMaxScores(
+            "方案覆盖 40 个应用，给出 80% 的能力清单，引用《互动营销规范 v2》，第 3 章实现思路明确归母。");
+        var content = string.Join(" ", Enumerable.Repeat("第 1 章引用 40 个应用 80% 覆盖率《规范 v2》", 5));
+        var summary = "方案凝练扎实，数据充分。";
+
+        var log = ReviewAgentController.ApplyScoringGuardrails(scores, dims, content, summary);
+
+        // 不应有 L1 触发条目（所有维度评语都含具体证据）
+        log.ShouldNotContain(e => e.Contains("L1 证据闸"));
+        // 分数保持原状
+        scores.First(s => s.Key == "consistency").Score.ShouldBe(16);
+    }
+
+    [Fact]
+    public void Guardrail_L2_数据密度不足_所有高分非清单维度被压()
+    {
+        var dims = BuildDims();
+        var scores = BuildAllMaxScores(
+            "方案覆盖 40 个应用，给出 80% 的能力清单，引用《互动营销规范 v2》。"); // L1 不会触发
+        var content = "本次改造旨在优化产品体验。"; // 数据密度 = 0
+        var summary = "方案凝练扎实，数据充分。"; // L3 不触发
+
+        var log = ReviewAgentController.ApplyScoringGuardrails(scores, dims, content, summary);
+
+        log.ShouldContain(e => e.Contains("L2 数据密度"));
+        scores.First(s => s.Key == "consistency").Score.ShouldBe((int)System.Math.Floor(16 * 0.89));
+    }
+
+    [Fact]
+    public void Guardrail_L3_summary含降级关键词但分高_被压()
+    {
+        var dims = BuildDims();
+        // 评语含具体证据 → L1 不触发；原文数据密度高 → L2 不触发；仅 L3 触发
+        var scores = BuildAllMaxScores(
+            "方案覆盖 40 个应用，给出 80% 的能力清单，引用《互动营销规范 v2》，第 3 章实现思路明确归母。");
+        var content = string.Join(" ", Enumerable.Repeat("第 1 章 40 个应用 80% 《规范 v2》", 5));
+        var summary = "总体落在 75-89 合格区间上沿，未达到 90+ 标杆级水平。";
+
+        var log = ReviewAgentController.ApplyScoringGuardrails(scores, dims, content, summary);
+
+        log.ShouldContain(e => e.Contains("L3 一致性闸"));
+        // 总分被压：99/100 → 应显著低于 90
+        var total = scores.Sum(s => s.Score);
+        var max = scores.Sum(s => s.MaxScore);
+        ((double)total / max).ShouldBeLessThan(0.9);
+    }
+
+    [Fact]
+    public void Guardrail_无任何触发_日志为空()
+    {
+        var dims = BuildDims();
+        // 一份「合格区间」打分：得分率 75-89 之间，不触发任何兜底
+        var scores = new List<ReviewDimensionScore>
+        {
+            new() { Key = "global_rules_checklist", Name = "全局规则检查清单", Score = 16, MaxScore = 20,
+                    Items = new List<DimensionCheckItemResult>() },
+            new() { Key = "template_compliance", Name = "文档规范完整性", Score = 7, MaxScore = 8, Comment = "章节齐全" },
+            new() { Key = "consistency", Name = "内在自洽性", Score = 13, MaxScore = 16, Comment = "逻辑闭环基本到位" },
+            new() { Key = "problem_quality", Name = "问题陈述质量", Score = 10, MaxScore = 13, Comment = "问题描述清晰" },
+            new() { Key = "user_value", Name = "用户价值清晰度", Score = 10, MaxScore = 12, Comment = "用户角色明确" },
+            new() { Key = "feasibility", Name = "实现思路可行性", Score = 10, MaxScore = 12, Comment = "归母明确" },
+            new() { Key = "testability", Name = "需求可测试性", Score = 7, MaxScore = 9, Comment = "标准基本可验证" },
+            new() { Key = "expression", Name = "表达质量与凝练度", Score = 8, MaxScore = 10, Comment = "表达凝练" },
+        };
+        var content = "短方案";
+        var summary = "整体合格";
+
+        var log = ReviewAgentController.ApplyScoringGuardrails(scores, dims, content, summary);
+
+        log.ShouldBeEmpty();
+    }
+}

--- a/prd-api/tests/PrdAgent.Api.Tests/Controllers/ReviewAgentStateGuardsTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Controllers/ReviewAgentStateGuardsTests.cs
@@ -1,0 +1,74 @@
+using PrdAgent.Api.Controllers.Api;
+using PrdAgent.Core.Models;
+using Shouldly;
+using Xunit;
+
+namespace PrdAgent.Api.Tests.Controllers;
+
+/// <summary>
+/// 救机会 / 系统重跑端点的状态门槛守卫测试。
+/// 防止下次有人放宽条件（例如把 RerunSubmission 改回"任意状态都能调"）后没人发现。
+/// </summary>
+public class ReviewAgentStateGuardsTests
+{
+    private static ReviewSubmission Sub(string status, bool? isPassed = null, int rerun = 0)
+        => new() { Status = status, IsPassed = isPassed, RerunCount = rerun };
+
+    // ── CanUseSystemRerun (Error 状态独占) ──────────────────
+
+    [Fact]
+    public void SystemRerun_仅Error状态_允许()
+    {
+        ReviewAgentController.CanUseSystemRerun(Sub(ReviewStatuses.Error)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SystemRerun_Done状态_拒绝()
+    {
+        ReviewAgentController.CanUseSystemRerun(Sub(ReviewStatuses.Done, isPassed: false)).ShouldBeFalse();
+        ReviewAgentController.CanUseSystemRerun(Sub(ReviewStatuses.Done, isPassed: true)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SystemRerun_Queued_Running_拒绝()
+    {
+        ReviewAgentController.CanUseSystemRerun(Sub(ReviewStatuses.Queued)).ShouldBeFalse();
+        ReviewAgentController.CanUseSystemRerun(Sub(ReviewStatuses.Running)).ShouldBeFalse();
+    }
+
+    // ── CanReuploadOnFailure (Done + 未通过 + 救机会未用) ────
+
+    [Fact]
+    public void ReuploadOnFailure_Done未通过且未用救机会_允许()
+    {
+        ReviewAgentController.CanReuploadOnFailure(Sub(ReviewStatuses.Done, isPassed: false, rerun: 0)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ReuploadOnFailure_已通过_拒绝()
+    {
+        ReviewAgentController.CanReuploadOnFailure(Sub(ReviewStatuses.Done, isPassed: true, rerun: 0)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ReuploadOnFailure_救机会已用尽_拒绝()
+    {
+        ReviewAgentController.CanReuploadOnFailure(Sub(ReviewStatuses.Done, isPassed: false, rerun: 1)).ShouldBeFalse();
+        ReviewAgentController.CanReuploadOnFailure(Sub(ReviewStatuses.Done, isPassed: false, rerun: 2)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ReuploadOnFailure_非Done状态_拒绝()
+    {
+        ReviewAgentController.CanReuploadOnFailure(Sub(ReviewStatuses.Queued, isPassed: false)).ShouldBeFalse();
+        ReviewAgentController.CanReuploadOnFailure(Sub(ReviewStatuses.Running, isPassed: false)).ShouldBeFalse();
+        ReviewAgentController.CanReuploadOnFailure(Sub(ReviewStatuses.Error, isPassed: false)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ReuploadOnFailure_IsPassed为null_拒绝()
+    {
+        // 评审异常或刚提交，IsPassed 还没被赋值的 case
+        ReviewAgentController.CanReuploadOnFailure(Sub(ReviewStatuses.Done, isPassed: null)).ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
## 摘要

本 PR 为产品评审 Agent 加入三层系统兜底（evidence gate / 数据密度封顶 / summary 一致性闸），杜绝 LLM 把非清单维度全填满凑 99 分的钻空子路径。同时修正排行榜「一次性通过率」的口径定义，新增「未通过救机会」端点，区分系统故障重跑与用户主动救机会两条路径。

## 改动 diff

### 后端核心逻辑（prd-api/）

- **`ReviewAgentController.cs`**：
  - 新增 `ApplyScoringGuardrails()` 方法实现三层兜底逻辑（L1 证据闸、L2 数据密度封顶、L3 summary 一致性闸）
  - 新增 `HasSufficientEvidence()`、`CountDataPoints()`、`SummaryContainsDowngradeKeyword()` 三个守卫函数
  - 新增 `AggregateProposalBuckets()` 方法按 (SubmitterId, Title) 聚合方案桶，实现「一次性通过率」Z 口径
  - 新增 `ProposalBucket` 内部类和 `LeaderboardRow` 投影类
  - 新增 `CanUseSystemRerun()` 和 `CanReuploadOnFailure()` 状态门槛守卫
  - 修改 `GetLeaderboard()` 端点：从行级聚合改为桶级聚合，支持 document / submitter 两种维度
  - 修改 `RerunSubmission()` 端点：仅允许 Error 状态调用，改为累加 ErrorRetryCount 而非 RerunCount，保留旧 ReviewResult 作为历史
  - 新增 `ReuploadOnFailure()` 端点：未通过救机会，Done + 未通过 + RerunCount=0 时可用，每方案仅 1 次
  - 新增 `GetSubmissionResults()` 端点：返回该 submission 完整评审历史

- **`ReviewDimensionConfig.cs`**：
  - 调整默认权重：清单维度 30→20，10 分按 +2 平均分摊到 consistency/problem_quality/user_value/feasibility/testability 五个高风险维度

- **`ReviewSubmission.cs`**：
  - 新增 `ErrorRetryCount` 字段：系统故障重跑计数（不影响一次性通过率）
  - 修改 `RerunCount` 语义：仅计用户「重新上传方案救机会」的次数

- **`ReviewResult.cs`**：
  - 新增 `AdjustmentLog` 字段：记录三层兜底触发的调整原文，便于审计追踪

### 单元测试（prd-api/tests/）

- **`ReviewAgentScoringGuardrailsTests.cs`**（新增）：
  - 345 行测试覆盖三层兜底的 8 个 Finding 修复场景
  - 验证 L1 证据闸、L2 数据密度、L3 summary 一致性的触发条件与压分逻辑
  - 验证 OriginalScore 审计字段的保留

- **`ReviewAgentLeaderboardTests.cs`**（新增）：
  - 226 行测

https://claude.ai/code/session_013yN7rWFsCg4Zw68MeDL3Tv