### PR TITLE
知识库分享落地页改用深色阅读器 + 修复文档再加工进度卡死

### DIFF
--- a/changelogs/2026-05-27_library-share-reader.md
+++ b/changelogs/2026-05-27_library-share-reader.md
@@ -1,0 +1,1 @@
+| feat | prd-admin | 知识库分享落地页(/s/lib/:token)改用深色极简阅读器 LibraryShareReader(窄/宽栏 + 卡片式 + 全屏 + 目录 TOC + 树内搜索 + KaTeX 数学 + 代码高亮),数据层沿用 main 的 token 门禁匿名端点,支持整库/单篇两种分享范围 |

--- a/changelogs/2026-05-27_library-share-reader.md
+++ b/changelogs/2026-05-27_library-share-reader.md
@@ -1,1 +1,3 @@
 | feat | prd-admin | 知识库分享落地页(/s/lib/:token)改用深色极简阅读器 LibraryShareReader(窄/宽栏 + 卡片式 + 全屏 + 目录 TOC + 树内搜索 + KaTeX 数学 + 代码高亮),数据层沿用 main 的 token 门禁匿名端点,支持整库/单篇两种分享范围 |
+| fix | prd-api | 修复知识库「文档再加工」进度卡死:Worker 启动兜底回收上一个容器残留的 Running 任务并标记失败,避免重新部署/崩溃后前端进度条永远卡在「调用 LLM N%」(server-authority #5) |
+| fix | prd-api | 修复「文档再加工」LLM 调用未设 LlmRequestContext 导致用量/配额挂不到用户:在 ContentReprocessProcessor 调用前用 run.UserId 开 BeginScope(llm-gateway.md) |

--- a/prd-admin/src/pages/library/LibraryShareReader.tsx
+++ b/prd-admin/src/pages/library/LibraryShareReader.tsx
@@ -1,0 +1,1225 @@
+/**
+ * LibraryShareReader — 智识殿堂专属文档阅读器（极简深色风格）
+ *
+ * 独立于 DocBrowser。专门为「智识殿堂」分享落地页的阅读体验设计，
+ * 对齐网页托管分享页 ShareViewPage 的深色极简观感：
+ *  - 左侧：深色文件树侧栏
+ *  - 右侧：MarkdownViewer 用深色高对比 prose 样式
+ *  - 图片/视频/音频/PDF 预览
+ *
+ * 只读，没有编辑/上传/删除/拖拽等写操作。
+ */
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
+import remarkMath from 'remark-math';
+import rehypeKatex from 'rehype-katex';
+import 'katex/dist/katex.min.css';
+import GithubSlugger from 'github-slugger';
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import { toast } from '@/lib/toast';
+import {
+  FolderOpen,
+  FolderClosed,
+  Star,
+  Pin,
+  ChevronRight,
+  ChevronDown,
+  BookOpen,
+  Search,
+  Type,
+  FileText,
+  Maximize2,
+  Minimize2,
+} from 'lucide-react';
+import type { DocumentEntry } from '@/services/contracts/documentStore';
+import { getFileTypeConfig } from '@/lib/fileTypeRegistry';
+import type { FilePreviewKind } from '@/lib/fileTypeRegistry';
+import { MapSectionLoader } from '@/components/ui/VideoLoader';
+import { useViewTracking } from '@/lib/useViewTracking';
+
+// ── slug 辅助 ──
+function childrenToText(children: unknown): string {
+  if (children == null) return '';
+  if (typeof children === 'string') return children;
+  if (Array.isArray(children)) return children.map(childrenToText).join('');
+  if (typeof children === 'object' && children !== null && 'props' in children) {
+    const props = (children as { props?: { children?: unknown } }).props;
+    return childrenToText(props?.children);
+  }
+  return '';
+}
+
+function normalizeHeadingText(raw: string): string {
+  return String(raw || '')
+    .replace(/\s+#+\s*$/, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+// 链接类型判定结果
+type ResolvedLink =
+  | { kind: 'anchor'; hash: string }                             // 页内锚点
+  | { kind: 'entry'; entryId: string; hash?: string }            // 同知识库内的文档引用
+  | { kind: 'route'; path: string }                              // 其他 SPA 路由（/library/xxx、/... 等）
+  | { kind: 'external'; href: string }                           // 外链（新标签页）
+  | { kind: 'unresolved'; href: string };                        // 相对路径但在 entries 里找不到
+
+/**
+ * 尝试把相对路径的 "文档名" 映射到知识库里的某个 entry。
+ * 支持的匹配规则（按优先级）：
+ *   1. entry.title 完全等于 name（含或不含 .md）
+ *   2. entry.metadata.github_path 末段等于 name
+ *   3. entry.title 去掉扩展名后等于 name 去掉扩展名
+ * 找不到返回 undefined。
+ */
+function findEntryByRelativeName(
+  name: string,
+  entries: DocumentEntry[],
+): DocumentEntry | undefined {
+  const cleaned = name.trim().replace(/^\.\//, '');
+  if (!cleaned) return undefined;
+  const withMd = cleaned.endsWith('.md') ? cleaned : `${cleaned}.md`;
+  const withoutMd = cleaned.replace(/\.md$/i, '');
+
+  // 规则 1：title 直接等于
+  let hit = entries.find(
+    (e) => !e.isFolder && (e.title === cleaned || e.title === withMd || e.title === withoutMd),
+  );
+  if (hit) return hit;
+
+  // 规则 2：github_path 末段等于
+  hit = entries.find((e) => {
+    if (e.isFolder) return false;
+    const ghPath = e.metadata?.github_path;
+    if (!ghPath) return false;
+    const base = ghPath.split('/').pop() ?? '';
+    return base === cleaned || base === withMd;
+  });
+  if (hit) return hit;
+
+  // 规则 3：去扩展名比对 title
+  hit = entries.find((e) => {
+    if (e.isFolder) return false;
+    const titleBase = e.title.replace(/\.[^.]+$/, '');
+    return titleBase === withoutMd;
+  });
+  return hit;
+}
+
+/**
+ * 根据 href 判断应该怎么处理这个链接。
+ *
+ * - `#xxx`                 → 页内锚点
+ * - `https://foo.bar/...`  → 外链
+ * - `/library/...`         → SPA 路由（走 react-router navigate）
+ * - `design.visual-agent`  → 相对文档引用，尝试在 entries 里找，找不到就算 unresolved
+ * - `./design.visual-agent.md` 同上
+ * - `/some/absolute/path`  → 如果是站内路由白名单就走 route，否则 unresolved（防止误跳 /library/{name}）
+ */
+function resolveLink(
+  href: string | undefined,
+  entries: DocumentEntry[],
+): ResolvedLink {
+  if (!href) return { kind: 'external', href: '' };
+
+  // 页内锚点
+  if (href.startsWith('#')) return { kind: 'anchor', hash: href.slice(1) };
+
+  // 协议开头 → 判断同源还是外链
+  if (/^[a-z][a-z0-9+.-]*:/i.test(href)) {
+    try {
+      const url = new URL(href);
+      if (url.origin !== window.location.origin) {
+        return { kind: 'external', href };
+      }
+      // 同源绝对 URL：按路由处理，保留 hash
+      return { kind: 'route', path: url.pathname + url.search + url.hash };
+    } catch {
+      return { kind: 'external', href };
+    }
+  }
+
+  // 绝对路径 /library/xxx 或其他 SPA 路由：允许
+  if (href.startsWith('/') && !href.startsWith('//')) {
+    return { kind: 'route', path: href };
+  }
+
+  // 相对路径：只能是"同知识库内的文档引用"。从 href 里把纯文档名抠出来（去掉 query 和 hash）
+  const qMark = href.indexOf('?');
+  const hMark = href.indexOf('#');
+  const firstSep = [qMark, hMark].filter((i) => i >= 0).sort((a, b) => a - b)[0] ?? href.length;
+  const namePart = href.slice(0, firstSep);
+  const hashPart = hMark >= 0 ? href.slice(hMark + 1) : undefined;
+
+  const hit = findEntryByRelativeName(namePart, entries);
+  if (hit) {
+    return { kind: 'entry', entryId: hit.id, hash: hashPart };
+  }
+
+  return { kind: 'unresolved', href };
+}
+
+export type LibraryShareReaderPreview = {
+  text: string | null;
+  fileUrl: string | null;
+  contentType: string;
+};
+
+type Props = {
+  entries: DocumentEntry[];
+  primaryEntryId?: string;
+  pinnedEntryIds?: string[];
+  loadContent: (entryId: string) => Promise<LibraryShareReaderPreview | null>;
+};
+
+export function LibraryShareReader({
+  entries,
+  primaryEntryId,
+  pinnedEntryIds = [],
+  loadContent,
+}: Props) {
+  const navigate = useNavigate();
+  const [selectedId, setSelectedId] = useState<string | undefined>(primaryEntryId);
+  const [preview, setPreview] = useState<LibraryShareReaderPreview | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [loadedId, setLoadedId] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [search, setSearch] = useState('');
+  const [useContentTitle, setUseContentTitle] = useState(true);
+  const [fullscreen, setFullscreen] = useState(false);
+  const [readWidth, setReadWidth] = useState<'narrow' | 'wide'>(
+    () => (sessionStorage.getItem('library-share-read-width') === 'wide' ? 'wide' : 'narrow'));
+  const [cardMode, setCardMode] = useState<boolean>(
+    () => sessionStorage.getItem('library-share-card-mode') === '1');
+  const contentScrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => { sessionStorage.setItem('library-share-read-width', readWidth); }, [readWidth]);
+  useEffect(() => { sessionStorage.setItem('library-share-card-mode', cardMode ? '1' : '0'); }, [cardMode]);
+
+  const pinnedSet = useMemo(() => new Set(pinnedEntryIds), [pinnedEntryIds]);
+
+  // 批次 C：智识殿堂访问埋点（只对非文件夹的选中条目生效）
+  const trackedEntryId = useMemo(() => {
+    if (!selectedId) return null;
+    const e = entries.find(x => x.id === selectedId);
+    return e && !e.isFolder ? selectedId : null;
+  }, [selectedId, entries]);
+  useViewTracking(trackedEntryId);
+
+  // 从 entry.summary 提取正文第一行作为"正文标题"
+  const contentFirstLines = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const e of entries) {
+      if (e.isFolder || !e.summary) continue;
+      const line = e.summary.split('\n').find((l) => l.trim());
+      if (line) map.set(e.id, line.replace(/^#+\s*/, '').trim());
+    }
+    return map;
+  }, [entries]);
+
+  const getDisplayTitle = useCallback(
+    (entry: DocumentEntry): string => {
+      if (entry.isFolder) return entry.title;
+      if (!useContentTitle) return entry.title;
+      return contentFirstLines.get(entry.id) ?? entry.title;
+    },
+    [useContentTitle, contentFirstLines],
+  );
+
+  // 全屏时锁定 body 滚动 + 监听 ESC 退出
+  useEffect(() => {
+    if (!fullscreen) return;
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setFullscreen(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => {
+      document.body.style.overflow = prevOverflow;
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [fullscreen]);
+
+  // 构建树（过滤掉 github_directory）
+  const { roots, childrenMap } = useMemo(() => {
+    const visible = entries.filter((e) => e.sourceType !== 'github_directory');
+    const cMap = new Map<string, DocumentEntry[]>();
+    const rs: DocumentEntry[] = [];
+    for (const e of visible) {
+      if (!e.parentId) {
+        rs.push(e);
+      } else {
+        const arr = cMap.get(e.parentId) ?? [];
+        arr.push(e);
+        cMap.set(e.parentId, arr);
+      }
+    }
+    const sortFn = (a: DocumentEntry, b: DocumentEntry) => {
+      if (a.id === primaryEntryId) return -1;
+      if (b.id === primaryEntryId) return 1;
+      const ap = pinnedSet.has(a.id), bp = pinnedSet.has(b.id);
+      if (ap !== bp) return ap ? -1 : 1;
+      if (a.isFolder !== b.isFolder) return a.isFolder ? -1 : 1;
+      return a.title.localeCompare(b.title);
+    };
+    rs.sort(sortFn);
+    for (const [, arr] of cMap) arr.sort(sortFn);
+    return { roots: rs, childrenMap: cMap };
+  }, [entries, primaryEntryId, pinnedSet]);
+
+  // 搜索过滤：匹配标题 + 正文第一行（只隐藏未命中的文件，祖先文件夹保留）
+  const { filteredRoots, filteredChildrenMap } = useMemo(() => {
+    if (!search.trim()) return { filteredRoots: roots, filteredChildrenMap: childrenMap };
+    const kw = search.toLowerCase();
+    const entryMap = new Map(entries.map((e) => [e.id, e]));
+    const matchIds = new Set<string>();
+    for (const e of entries) {
+      if (e.sourceType === 'github_directory' || e.isFolder) continue;
+      const titleMatch = e.title.toLowerCase().includes(kw);
+      const firstLineMatch = contentFirstLines.get(e.id)?.toLowerCase().includes(kw) ?? false;
+      const summaryMatch = e.summary?.toLowerCase().includes(kw) ?? false;
+      if (titleMatch || firstLineMatch || summaryMatch) {
+        matchIds.add(e.id);
+        let cur = entryMap.get(e.parentId ?? '');
+        while (cur) {
+          matchIds.add(cur.id);
+          cur = entryMap.get(cur.parentId ?? '');
+        }
+      }
+    }
+    const fRoots = roots.filter((e) => matchIds.has(e.id));
+    const fMap = new Map<string, DocumentEntry[]>();
+    for (const [parentId, kids] of childrenMap) {
+      const kept = kids.filter((k) => matchIds.has(k.id));
+      if (kept.length > 0) fMap.set(parentId, kept);
+    }
+    return { filteredRoots: fRoots, filteredChildrenMap: fMap };
+  }, [search, roots, childrenMap, entries, contentFirstLines]);
+
+  // 初始默认展开根级所有文件夹 + 主文档的父链
+  useEffect(() => {
+    const toOpen = new Set<string>();
+    // 展开所有根级文件夹
+    for (const r of roots) {
+      if (r.isFolder) toOpen.add(r.id);
+    }
+    // 展开主文档所在的祖先链
+    if (primaryEntryId) {
+      const entryMap = new Map(entries.map((e) => [e.id, e]));
+      let cur = entryMap.get(primaryEntryId);
+      while (cur?.parentId) {
+        toOpen.add(cur.parentId);
+        cur = entryMap.get(cur.parentId);
+      }
+    }
+    setExpanded(toOpen);
+    if (primaryEntryId && !selectedId) setSelectedId(primaryEntryId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [primaryEntryId, roots.length]);
+
+  // 搜索时自动展开所有文件夹
+  useEffect(() => {
+    if (search.trim()) {
+      const allFolderIds = entries.filter((e) => e.isFolder).map((e) => e.id);
+      setExpanded(new Set(allFolderIds));
+    }
+  }, [search, entries]);
+
+  // 加载内容
+  useEffect(() => {
+    if (!selectedId || selectedId === loadedId) return;
+    const entry = entries.find((e) => e.id === selectedId);
+    if (!entry || entry.isFolder) return;
+    setLoading(true);
+    setPreview(null);
+    loadContent(selectedId)
+      .then((p) => {
+        setPreview(p);
+        setLoadedId(selectedId);
+      })
+      .finally(() => setLoading(false));
+  }, [selectedId, loadContent, loadedId, entries]);
+
+  // 内容加载完成后，若 URL 带 hash 则 scroll 到对应 heading
+  useEffect(() => {
+    if (loading || !preview?.text) return;
+    const rawHash = window.location.hash;
+    if (!rawHash || rawHash.length < 2) return;
+    const id = decodeURIComponent(rawHash.slice(1));
+    // 等一轮 markdown 渲染完成
+    const timer = window.setTimeout(() => {
+      const target = document.getElementById(id);
+      if (target) {
+        target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    }, 120);
+    return () => window.clearTimeout(timer);
+  }, [loading, preview?.text, loadedId]);
+
+  // 监听 hashchange：用户点文档内的锚点链接时，SPA 内 scroll
+  useEffect(() => {
+    const onHashChange = () => {
+      const rawHash = window.location.hash;
+      if (!rawHash || rawHash.length < 2) return;
+      const id = decodeURIComponent(rawHash.slice(1));
+      const target = document.getElementById(id);
+      if (target) target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    };
+    window.addEventListener('hashchange', onHashChange);
+    return () => window.removeEventListener('hashchange', onHashChange);
+  }, []);
+
+  // 切换选中文档时，默认清除 URL 上的旧 hash（避免旧 hash 把新文档 scroll 到错的位置）。
+  // 来自相对路径文档引用（带 hash 的跳转）时，调用方会在切换后自行 replaceState 新 hash。
+  const handleSelectEntry = useCallback((id: string, keepHash = false) => {
+    setSelectedId(id);
+    if (!keepHash && window.location.hash) {
+      const { pathname, search } = window.location;
+      window.history.replaceState(null, '', pathname + search);
+    }
+  }, []);
+
+  const toggleFolder = useCallback((id: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  return (
+    <div
+      className="flex overflow-hidden relative"
+      style={{
+        background: '#0f1014',
+        borderRadius: 0,
+        border: 'none',
+        boxShadow: 'none',
+        fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, system-ui, sans-serif',
+        ...(fullscreen
+          ? {
+              position: 'fixed',
+              top: 0,
+              left: 0,
+              right: 0,
+              bottom: 0,
+              width: '100vw',
+              height: '100vh',
+              zIndex: 9999,
+            }
+          : {
+              height: '100%',
+            }),
+      }}
+    >
+      {/* 右上角浮动阅读控制：宽窄 / 卡片 / 全屏 */}
+      <div className="absolute" style={{ top: 14, right: 14, zIndex: 30, display: 'flex', alignItems: 'center', gap: 6 }}>
+        {/* 宽窄分段 */}
+        <div style={{ display: 'flex', borderRadius: 9, overflow: 'hidden', border: '1px solid rgba(255,255,255,0.1)' }}>
+          {(['narrow', 'wide'] as const).map((w) => (
+            <button
+              key={w}
+              onClick={() => setReadWidth(w)}
+              title={w === 'narrow' ? '窄栏阅读' : '宽屏阅读'}
+              className="cursor-pointer transition-colors"
+              style={{
+                padding: '6px 10px', border: 'none', fontSize: 12, lineHeight: 1,
+                background: readWidth === w ? 'rgba(59,130,246,0.22)' : 'rgba(255,255,255,0.04)',
+                color: readWidth === w ? 'rgba(147,197,253,0.95)' : 'rgba(255,255,255,0.55)',
+              }}
+            >
+              {w === 'narrow' ? '窄' : '宽'}
+            </button>
+          ))}
+        </div>
+        {/* 卡片式 */}
+        <button
+          onClick={() => setCardMode((v) => !v)}
+          title={cardMode ? '关闭卡片式' : '卡片式阅读'}
+          className="cursor-pointer transition-colors"
+          style={{
+            padding: '6px 10px', borderRadius: 9, fontSize: 12, lineHeight: 1,
+            background: cardMode ? 'rgba(59,130,246,0.22)' : 'rgba(255,255,255,0.04)',
+            border: `1px solid ${cardMode ? 'rgba(59,130,246,0.4)' : 'rgba(255,255,255,0.1)'}`,
+            color: cardMode ? 'rgba(147,197,253,0.95)' : 'rgba(255,255,255,0.55)',
+          }}
+        >
+          卡片
+        </button>
+        {/* 全屏 */}
+        <button
+          onClick={() => setFullscreen((f) => !f)}
+          title={fullscreen ? '退出全屏 (ESC)' : '全屏阅读'}
+          aria-label={fullscreen ? '退出全屏' : '全屏阅读'}
+          className="transition-colors cursor-pointer"
+          style={{
+            width: 32, height: 32, borderRadius: 9,
+            background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.1)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+          }}
+        >
+          {fullscreen ? (
+            <Minimize2 size={16} strokeWidth={2.2} style={{ color: 'rgba(255,255,255,0.7)' }} />
+          ) : (
+            <Maximize2 size={16} strokeWidth={2.2} style={{ color: 'rgba(255,255,255,0.7)' }} />
+          )}
+        </button>
+      </div>
+
+      {/* 左侧文件树 */}
+      <div
+        className="w-[280px] flex-shrink-0 flex flex-col overflow-hidden"
+        style={{
+          background: 'rgba(255,255,255,0.02)',
+          borderRight: '1px solid rgba(255,255,255,0.06)',
+        }}
+      >
+        <div
+          className="px-4 py-3.5 flex items-center gap-2"
+          style={{ borderBottom: '1px solid rgba(255,255,255,0.06)' }}
+        >
+          <BookOpen size={15} style={{ color: 'rgba(255,255,255,0.5)' }} strokeWidth={2} />
+          <div className="text-[13px] font-semibold flex-1" style={{ color: 'rgba(255,255,255,0.8)' }}>
+            目录
+          </div>
+          {/* 标题模式切换：文件名 ↔ 正文第一行 */}
+          <button
+            onClick={() => setUseContentTitle((v) => !v)}
+            className="flex items-center gap-1 text-[11px] font-medium px-2 py-1 rounded-md cursor-pointer transition-colors"
+            style={{
+              background: 'rgba(255,255,255,0.05)',
+              border: '1px solid rgba(255,255,255,0.1)',
+              color: 'rgba(255,255,255,0.55)',
+            }}
+            title={useContentTitle ? '当前：正文标题，点击切换文件名' : '当前：文件名，点击切换正文标题'}
+          >
+            {useContentTitle ? <FileText size={11} strokeWidth={2.2} /> : <Type size={11} strokeWidth={2.2} />}
+            {useContentTitle ? '正文' : '文件'}
+          </button>
+        </div>
+
+        {/* 搜索框 */}
+        <div
+          className="px-3 py-3"
+          style={{ borderBottom: '1px solid rgba(255,255,255,0.06)' }}
+        >
+          <div className="relative">
+            <Search
+              size={13}
+              strokeWidth={2.4}
+              className="absolute left-3 top-1/2 -translate-y-1/2"
+              style={{ color: 'rgba(255,255,255,0.35)' }}
+            />
+            <input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="搜索标题或正文..."
+              className="w-full h-9 pl-8 pr-3 rounded-lg text-[12px] outline-none placeholder:text-white/30"
+              style={{
+                background: 'rgba(255,255,255,0.04)',
+                border: '1px solid rgba(255,255,255,0.1)',
+                color: 'rgba(255,255,255,0.9)',
+              }}
+            />
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-y-auto py-3 px-2">
+          {filteredRoots.length === 0 ? (
+            <div className="px-3 py-6 text-center text-[12px]" style={{ color: 'rgba(255,255,255,0.4)' }}>
+              {search.trim() ? '没有找到匹配的文档' : '这个知识库还是空的'}
+            </div>
+          ) : (
+            filteredRoots.map((entry) => (
+              <TreeNode
+                key={entry.id}
+                entry={entry}
+                childrenMap={search.trim() ? filteredChildrenMap : childrenMap}
+                depth={0}
+                selectedId={selectedId}
+                primaryEntryId={primaryEntryId}
+                pinnedSet={pinnedSet}
+                expanded={expanded}
+                getDisplayTitle={getDisplayTitle}
+                onToggle={toggleFolder}
+                onSelect={handleSelectEntry}
+              />
+            ))
+          )}
+        </div>
+      </div>
+
+      {/* 右侧内容区 */}
+      <div ref={contentScrollRef} className="flex-1 min-w-0 overflow-y-auto">
+        {!selectedId ? (
+          <EmptyRight />
+        ) : loading ? (
+          <div className="flex items-center justify-center h-full">
+            <MapSectionLoader text="翻开书页..." />
+          </div>
+        ) : (
+          <ContentArea
+            entry={entries.find((e) => e.id === selectedId)}
+            preview={preview}
+            entries={entries}
+            onSelectEntry={handleSelectEntry}
+            navigate={navigate}
+            readWidth={readWidth}
+            cardMode={cardMode}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── TreeNode ──
+
+function TreeNode({
+  entry,
+  childrenMap,
+  depth,
+  selectedId,
+  primaryEntryId,
+  pinnedSet,
+  expanded,
+  getDisplayTitle,
+  onToggle,
+  onSelect,
+}: {
+  entry: DocumentEntry;
+  childrenMap: Map<string, DocumentEntry[]>;
+  depth: number;
+  selectedId?: string;
+  primaryEntryId?: string;
+  pinnedSet: Set<string>;
+  expanded: Set<string>;
+  getDisplayTitle: (entry: DocumentEntry) => string;
+  onToggle: (id: string) => void;
+  onSelect: (id: string) => void;
+}) {
+  const isFolder = entry.isFolder;
+  const isOpen = expanded.has(entry.id);
+  const isSelected = entry.id === selectedId;
+  const isPrimary = entry.id === primaryEntryId;
+  const isPinned = pinnedSet.has(entry.id);
+  const children = childrenMap.get(entry.id) ?? [];
+
+  const cfg = !isFolder ? getFileTypeConfig(entry.title, entry.contentType) : null;
+  const FileIcon = cfg?.icon;
+
+  return (
+    <>
+      <button
+        onClick={() => (isFolder ? onToggle(entry.id) : onSelect(entry.id))}
+        className="w-full text-left flex items-center gap-1.5 py-1.5 transition-colors hover:bg-white/[0.04]"
+        style={{
+          paddingLeft: `${8 + depth * 14}px`,
+          paddingRight: 8,
+          marginBottom: 2,
+          borderRadius: 8,
+          background: isSelected && !isFolder ? 'rgba(59,130,246,0.15)' : 'transparent',
+          border: isSelected && !isFolder ? '1px solid rgba(59,130,246,0.3)' : '1px solid transparent',
+          cursor: 'pointer',
+        }}
+      >
+        {isFolder ? (
+          <span className="flex-shrink-0 w-4 flex items-center justify-center">
+            {isOpen ? (
+              <ChevronDown size={12} strokeWidth={2.4} style={{ color: 'rgba(255,255,255,0.4)' }} />
+            ) : (
+              <ChevronRight size={12} strokeWidth={2.4} style={{ color: 'rgba(255,255,255,0.4)' }} />
+            )}
+          </span>
+        ) : null}
+
+        {isFolder ? (
+          isOpen ? (
+            <FolderOpen size={15} strokeWidth={2} style={{ color: 'rgba(255,255,255,0.5)' }} />
+          ) : (
+            <FolderClosed size={15} strokeWidth={2} style={{ color: 'rgba(255,255,255,0.5)' }} />
+          )
+        ) : isPrimary ? (
+          <Star size={14} strokeWidth={2} fill="#f59e0b" style={{ color: '#f59e0b' }} />
+        ) : isPinned ? (
+          <Pin size={14} strokeWidth={2} style={{ color: '#60a5fa' }} />
+        ) : FileIcon ? (
+          <FileIcon size={14} strokeWidth={2} style={{ color: cfg!.color }} />
+        ) : null}
+
+        <span
+          className="flex-1 truncate text-[12px]"
+          style={{
+            color: isSelected && !isFolder ? '#fff' : 'rgba(255,255,255,0.72)',
+            fontWeight: isFolder ? 600 : isSelected ? 600 : 400,
+          }}
+        >
+          {getDisplayTitle(entry)}
+        </span>
+
+        {isPrimary && (
+          <span
+            className="text-[9px] px-1.5 py-0.5 rounded flex-shrink-0 font-semibold"
+            style={{
+              background: 'rgba(245,158,11,0.15)',
+              border: '1px solid rgba(245,158,11,0.4)',
+              color: '#fbbf24',
+            }}
+          >
+            主
+          </span>
+        )}
+        {isPinned && !isPrimary && (
+          <span
+            className="text-[9px] px-1.5 py-0.5 rounded flex-shrink-0 font-semibold"
+            style={{
+              background: 'rgba(96,165,250,0.15)',
+              border: '1px solid rgba(96,165,250,0.4)',
+              color: '#93c5fd',
+            }}
+          >
+            置顶
+          </span>
+        )}
+      </button>
+
+      {isFolder && isOpen &&
+        children.map((child) => (
+          <TreeNode
+            key={child.id}
+            entry={child}
+            childrenMap={childrenMap}
+            depth={depth + 1}
+            selectedId={selectedId}
+            primaryEntryId={primaryEntryId}
+            pinnedSet={pinnedSet}
+            expanded={expanded}
+            getDisplayTitle={getDisplayTitle}
+            onToggle={onToggle}
+            onSelect={onSelect}
+          />
+        ))}
+    </>
+  );
+}
+
+// ── 内容区（支持 text/image/video/audio/pdf） ──
+
+function ContentArea({
+  entry,
+  preview,
+  entries,
+  onSelectEntry,
+  navigate,
+  readWidth,
+  cardMode,
+}: {
+  entry?: DocumentEntry;
+  preview: LibraryShareReaderPreview | null;
+  entries: DocumentEntry[];
+  onSelectEntry: (id: string) => void;
+  navigate: ReturnType<typeof useNavigate>;
+  readWidth: 'narrow' | 'wide';
+  cardMode: boolean;
+}) {
+  if (!entry) return <EmptyRight />;
+  if (entry.isFolder) {
+    return (
+      <div className="h-full flex items-center justify-center">
+        <p className="text-[14px]" style={{ color: 'rgba(255,255,255,0.4)' }}>
+          点击左侧的文档开始阅读
+        </p>
+      </div>
+    );
+  }
+
+  const cfg = getFileTypeConfig(entry.title, entry.contentType);
+  const kind: FilePreviewKind = cfg.preview;
+  const text = preview?.text ?? null;
+  const fileUrl = preview?.fileUrl ?? null;
+
+  return (
+    <div className={`px-6 md:px-8 py-7 ${readWidth === 'wide' ? 'max-w-5xl' : 'max-w-3xl'} mx-auto`}>
+     <div
+       style={cardMode ? {
+         background: 'rgba(255,255,255,0.03)',
+         border: '1px solid rgba(255,255,255,0.07)',
+         borderRadius: 16,
+         padding: '24px 28px',
+       } : undefined}
+     >
+      {/* 标题 */}
+      <div className="mb-6 pb-4" style={{ borderBottom: '1px solid rgba(255,255,255,0.08)' }}>
+        <h1 className="text-[28px] font-bold leading-tight" style={{ color: '#fff' }}>
+          {entry.title}
+        </h1>
+      </div>
+
+      {kind === 'image' && fileUrl ? (
+        <div className="flex justify-center py-4">
+          <img
+            src={fileUrl}
+            alt={entry.title}
+            className="max-w-full rounded-xl"
+            style={{
+              border: '1px solid rgba(255,255,255,0.1)',
+              maxHeight: '70vh',
+            }}
+          />
+        </div>
+      ) : kind === 'video' && fileUrl ? (
+        <div className="flex justify-center py-4">
+          <video
+            src={fileUrl}
+            controls
+            className="max-w-full rounded-xl"
+            style={{ border: '1px solid rgba(255,255,255,0.1)' }}
+          />
+        </div>
+      ) : kind === 'audio' && fileUrl ? (
+        <div className="py-4">
+          <audio src={fileUrl} controls className="w-full" />
+        </div>
+      ) : kind === 'pdf' && fileUrl ? (
+        <iframe
+          src={fileUrl}
+          title={entry.title}
+          className="w-full rounded-xl"
+          style={{
+            height: '78vh',
+            border: '1px solid rgba(255,255,255,0.1)',
+          }}
+        />
+      ) : text ? (
+        <DocMarkdown
+          content={text}
+          entries={entries}
+          onSelectEntry={onSelectEntry}
+          navigate={navigate}
+        />
+      ) : fileUrl ? (
+        <div className="text-center py-16">
+          <cfg.icon
+            size={48}
+            strokeWidth={2}
+            style={{ color: cfg.color, margin: '0 auto 16px' }}
+          />
+          <p className="text-[14px] mb-4" style={{ color: 'rgba(255,255,255,0.7)' }}>
+            {cfg.label} 文件不支持在线预览
+          </p>
+          <a
+            href={fileUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center px-5 py-2.5 rounded-lg text-[13px] font-medium transition-colors"
+            style={{
+              background: 'rgba(59,130,246,0.15)',
+              border: '1px solid rgba(59,130,246,0.3)',
+              color: 'rgba(96,165,250,0.95)',
+            }}
+          >
+            下载文件
+          </a>
+        </div>
+      ) : (
+        <div className="text-center py-16">
+          <p className="text-[14px]" style={{ color: 'rgba(255,255,255,0.4)' }}>
+            这一页还是空白的
+          </p>
+        </div>
+      )}
+     </div>
+    </div>
+  );
+}
+
+function EmptyRight() {
+  return (
+    <div className="h-full flex flex-col items-center justify-center p-8">
+      <div
+        className="w-16 h-16 rounded-2xl flex items-center justify-center mb-5"
+        style={{
+          background: 'rgba(255,255,255,0.04)',
+          border: '1px solid rgba(255,255,255,0.08)',
+        }}
+      >
+        <BookOpen size={28} strokeWidth={2} style={{ color: 'rgba(255,255,255,0.5)' }} />
+      </div>
+      <p className="text-[16px] font-semibold mb-2" style={{ color: 'rgba(255,255,255,0.85)' }}>
+        选择一篇文档开始阅读
+      </p>
+      <p className="text-[13px]" style={{ color: 'rgba(255,255,255,0.4)' }}>
+        从左侧目录点击任意文档
+      </p>
+    </div>
+  );
+}
+
+// ── Markdown Viewer（深色高对比 prose 主题）──
+
+function DocMarkdown({
+  content,
+  entries,
+  onSelectEntry,
+  navigate,
+}: {
+  content: string;
+  entries: DocumentEntry[];
+  onSelectEntry: (id: string) => void;
+  navigate: ReturnType<typeof useNavigate>;
+}) {
+  // 为每次渲染创建新 slugger（确保同一标题首次出现得到干净 slug）
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const slugger = useMemo(() => new GithubSlugger(), [content]);
+
+  // heading 组件生成带 id 的标签，与 PrdPreviewPage 的策略一致
+  const headingComponents = useMemo(() => {
+    const makeHeading = (Tag: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6') => {
+      return ({ children }: { children?: React.ReactNode }) => {
+        const text = normalizeHeadingText(childrenToText(children));
+        const id = text ? slugger.slug(text) : undefined;
+        const baseStyle: React.CSSProperties = { color: '#fff' };
+        if (Tag === 'h1') {
+          return (
+            <h1
+              id={id}
+              className="text-[26px] font-bold mt-8 mb-4 pb-3 scroll-mt-24"
+              style={{
+                ...baseStyle,
+                borderBottom: '1px solid rgba(255,255,255,0.1)',
+              }}
+            >
+              {children}
+            </h1>
+          );
+        }
+        if (Tag === 'h2') {
+          return (
+            <h2
+              id={id}
+              className="text-[21px] font-bold mt-6 mb-3 scroll-mt-24"
+              style={baseStyle}
+            >
+              {children}
+            </h2>
+          );
+        }
+        if (Tag === 'h3') {
+          return (
+            <h3
+              id={id}
+              className="text-[17px] font-bold mt-5 mb-2 scroll-mt-24"
+              style={baseStyle}
+            >
+              {children}
+            </h3>
+          );
+        }
+        if (Tag === 'h4') {
+          return (
+            <h4 id={id} className="text-[16px] font-bold mt-4 mb-2 scroll-mt-24" style={baseStyle}>
+              {children}
+            </h4>
+          );
+        }
+        if (Tag === 'h5') {
+          return (
+            <h5 id={id} className="text-[15px] font-bold mt-3 mb-1.5 scroll-mt-24" style={baseStyle}>
+              {children}
+            </h5>
+          );
+        }
+        return (
+          <h6 id={id} className="text-[14px] font-bold mt-3 mb-1.5 scroll-mt-24" style={baseStyle}>
+            {children}
+          </h6>
+        );
+      };
+    };
+    return {
+      h1: makeHeading('h1'),
+      h2: makeHeading('h2'),
+      h3: makeHeading('h3'),
+      h4: makeHeading('h4'),
+      h5: makeHeading('h5'),
+      h6: makeHeading('h6'),
+    };
+  }, [slugger]);
+
+  return (
+    <div
+      className="max-w-none text-[15px] leading-[1.8]"
+      style={{ color: 'rgba(255,255,255,0.85)' }}
+    >
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm, remarkBreaks, remarkMath]}
+        rehypePlugins={[rehypeKatex]}
+        components={{
+          ...headingComponents,
+          p: ({ children }) => (
+            <p
+              className="my-3 whitespace-pre-wrap break-words"
+              style={{ color: 'rgba(255,255,255,0.72)' }}
+            >
+              {children}
+            </p>
+          ),
+          a: ({ href, children }) => {
+            const resolved = resolveLink(href, entries);
+
+            // 外链：新标签页
+            if (resolved.kind === 'external') {
+              return (
+                <a
+                  href={resolved.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-medium underline decoration-1 underline-offset-4"
+                  style={{ color: '#60a5fa' }}
+                >
+                  {children}
+                </a>
+              );
+            }
+
+            // 找不到目标的相对路径：灰显 + 禁用点击 + tooltip
+            if (resolved.kind === 'unresolved') {
+              return (
+                <span
+                  className="font-medium decoration-1 underline-offset-4"
+                  style={{
+                    color: 'rgba(255,255,255,0.3)',
+                    textDecoration: 'line-through wavy',
+                    cursor: 'not-allowed',
+                  }}
+                  title={`未在本知识库中找到该文档：${resolved.href}`}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    toast.warning('链接无效', `未找到文档：${resolved.href}`);
+                  }}
+                >
+                  {children}
+                </span>
+              );
+            }
+
+            return (
+              <a
+                href={href}
+                className="font-medium underline decoration-1 underline-offset-4"
+                style={{ color: '#60a5fa' }}
+                onClick={(e) => {
+                  e.preventDefault();
+                  if (resolved.kind === 'anchor') {
+                    // 页内锚点：scroll 到对应 heading
+                    const id = decodeURIComponent(resolved.hash);
+                    const target = document.getElementById(id);
+                    if (target) {
+                      target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                      window.history.replaceState(
+                        null,
+                        '',
+                        `${window.location.pathname}${window.location.search}#${id}`,
+                      );
+                    } else {
+                      toast.warning('未找到章节', `#${id}`);
+                    }
+                  } else if (resolved.kind === 'entry') {
+                    // 相对路径命中知识库内的文档：先写 hash，再切换 entry，避免 handleSelectEntry 把 hash 清掉
+                    if (resolved.hash) {
+                      window.history.replaceState(
+                        null,
+                        '',
+                        `${window.location.pathname}${window.location.search}#${resolved.hash}`,
+                      );
+                      onSelectEntry(resolved.entryId);
+                    } else {
+                      onSelectEntry(resolved.entryId);
+                    }
+                  } else if (resolved.kind === 'route') {
+                    // 站内其他路由（如 /library/{其他知识库 ID}）：react-router 导航
+                    navigate(resolved.path);
+                  }
+                }}
+              >
+                {children}
+              </a>
+            );
+          },
+          ul: ({ children, className }) => {
+            // 任务列表（GFM）：ul 会带 "contains-task-list" class
+            const isTaskList = className?.includes('contains-task-list');
+            return (
+              <ul
+                className={`${isTaskList ? 'list-none pl-2' : 'list-disc pl-6'} my-3 space-y-1`}
+                style={{ color: 'rgba(255,255,255,0.72)' }}
+              >
+                {children}
+              </ul>
+            );
+          },
+          ol: ({ children }) => (
+            <ol
+              className="list-decimal pl-6 my-3 space-y-1"
+              style={{ color: 'rgba(255,255,255,0.72)' }}
+            >
+              {children}
+            </ol>
+          ),
+          li: ({ children, className }) => {
+            const isTaskItem = className?.includes('task-list-item');
+            return (
+              <li className={`text-[15px] ${isTaskItem ? 'flex items-start gap-2' : ''}`} style={{ color: 'rgba(255,255,255,0.72)' }}>
+                {children}
+              </li>
+            );
+          },
+          blockquote: ({ children }) => (
+            <blockquote
+              className="my-4 pl-4 py-2 pr-4 rounded-r-lg"
+              style={{
+                borderLeft: '3px solid rgba(96,165,250,0.5)',
+                background: 'rgba(255,255,255,0.03)',
+                color: 'rgba(255,255,255,0.6)',
+              }}
+            >
+              {children}
+            </blockquote>
+          ),
+          table: ({ children }) => (
+            <div
+              className="my-5 overflow-x-auto rounded-lg"
+              style={{
+                background: 'rgba(255,255,255,0.02)',
+                border: '1px solid rgba(255,255,255,0.1)',
+              }}
+            >
+              <table className="w-full text-[13px]">{children}</table>
+            </div>
+          ),
+          th: ({ children }) => (
+            <th
+              className="px-4 py-2.5 text-left font-semibold"
+              style={{
+                background: 'rgba(255,255,255,0.04)',
+                borderBottom: '1px solid rgba(255,255,255,0.12)',
+                color: '#fff',
+              }}
+            >
+              {children}
+            </th>
+          ),
+          td: ({ children }) => (
+            <td
+              className="px-4 py-2.5"
+              style={{
+                borderBottom: '1px solid rgba(255,255,255,0.06)',
+                color: 'rgba(255,255,255,0.72)',
+              }}
+            >
+              {children}
+            </td>
+          ),
+          code: ({ className, children, ...props }) => {
+            const match = /language-(\w+)/.exec(className || '');
+            const text = String(children ?? '').replace(/\n$/, '');
+            // 块级判断：有 language- 类名 或 内容包含换行（兼容未指定语言的 fenced code block）
+            const isBlock = !!match || text.includes('\n');
+            if (!isBlock) {
+              return (
+                <code
+                  className="px-1.5 py-0.5 rounded text-[13px] font-mono"
+                  style={{
+                    background: 'rgba(255,255,255,0.08)',
+                    color: '#e6c07b',
+                  }}
+                  {...props}
+                >
+                  {children}
+                </code>
+              );
+            }
+            // 块级且指定了语言 → 走 Prism 高亮
+            if (match) {
+              return (
+                <div
+                  className="my-4 rounded-lg overflow-hidden"
+                  style={{
+                    background: '#0d0d0f',
+                    border: '1px solid rgba(255,255,255,0.08)',
+                  }}
+                >
+                  <SyntaxHighlighter
+                    style={oneDark}
+                    language={match[1]}
+                    PreTag="div"
+                    customStyle={{
+                      margin: 0,
+                      padding: '16px',
+                      fontSize: '13px',
+                      background: 'transparent',
+                      border: 'none',
+                    }}
+                  >
+                    {text}
+                  </SyntaxHighlighter>
+                </div>
+              );
+            }
+            // 块级但无语言 → 纯 <pre><code>，避免 Prism 对 ASCII 框图加 token 背景
+            return (
+              <div
+                className="my-4 rounded-lg overflow-x-auto"
+                style={{
+                  background: '#0d0d0f',
+                  border: '1px solid rgba(255,255,255,0.08)',
+                }}
+              >
+                <pre
+                  style={{
+                    margin: 0,
+                    padding: '16px',
+                    fontSize: '13px',
+                    lineHeight: 1.6,
+                    color: 'rgba(255,255,255,0.8)',
+                    fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+                    background: 'transparent',
+                    whiteSpace: 'pre',
+                  }}
+                >
+                  {text}
+                </pre>
+              </div>
+            );
+          },
+          pre: ({ children }) => <>{children}</>,
+          hr: () => (
+            <hr
+              className="my-6"
+              style={{ border: 'none', borderTop: '1px solid rgba(255,255,255,0.1)' }}
+            />
+          ),
+          img: ({ src, alt }) => (
+            <img
+              src={src}
+              alt={alt || ''}
+              className="max-w-full rounded-lg my-4"
+              style={{
+                border: '1px solid rgba(255,255,255,0.1)',
+                maxHeight: 500,
+              }}
+            />
+          ),
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/prd-admin/src/pages/library/LibraryShareViewPage.tsx
+++ b/prd-admin/src/pages/library/LibraryShareViewPage.tsx
@@ -3,17 +3,20 @@
  *
  * 路径：/s/lib/:token （统一分享路由，对齐 /s/wp/、/s/skill/）
  *
- * 与 LibraryStoreDetailPage 同源（复用 LibraryDocReader + claymorphism 外壳），
- * 区别在于数据走 token 门禁的匿名端点，可展示「私有库的分享」，且支持两种范围：
+ * 数据层走 main 的 token 门禁匿名端点（getDocStoreShareView / listDocStoreShareEntries /
+ * getDocStoreShareEntryContent），可展示「私有库的分享」，支持两种范围：
  *   - 整库分享（entryId 为空）：文件树 + 全部文档只读浏览
  *   - 单篇分享（entryId 非空）：只展示那一篇
+ *
+ * 呈现采用极简深色风（对齐网页托管分享页 ShareViewPage 的观感）：
+ *   #0a0a0a 深色壳 + 玻璃顶栏（作者 + 标题）+ 低饱和简介条 + 深色阅读器。
  * 全屏渲染，不依赖登录。
  */
 import { useEffect, useState, useCallback } from 'react';
-import { useParams } from 'react-router-dom';
-import { BookOpen, Eye, Library, FileText, AlertCircle } from 'lucide-react';
-import { LibraryDocReader } from './LibraryDocReader';
-import type { LibraryDocReaderPreview } from './LibraryDocReader';
+import { useNavigate, useParams } from 'react-router-dom';
+import { ArrowRight, ShieldCheck, BookOpen, AlertCircle, Eye, FileText } from 'lucide-react';
+import { LibraryShareReader } from './LibraryShareReader';
+import type { LibraryShareReaderPreview } from './LibraryShareReader';
 import {
   getDocStoreShareView,
   listDocStoreShareEntries,
@@ -22,27 +25,12 @@ import {
 import type { DocStoreShareView, DocumentEntry } from '@/services/contracts/documentStore';
 import { MapSectionLoader } from '@/components/ui/VideoLoader';
 
-function useFredokaFonts() {
-  useEffect(() => {
-    const id = 'library-claymorphism-fonts';
-    if (document.getElementById(id)) return;
-    const link = document.createElement('link');
-    link.id = id;
-    link.rel = 'stylesheet';
-    link.href = 'https://fonts.googleapis.com/css2?family=Fredoka:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&display=swap';
-    document.head.appendChild(link);
-  }, []);
-}
-
-const BG = {
-  background: '#FEF3C7',
-  fontFamily: "'Nunito', system-ui, sans-serif",
-  color: '#1E1B4B',
-} as const;
+const PAGE_BG = '#0a0a0a';
+const SANS = '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
 
 export function LibraryShareViewPage() {
   const { token } = useParams<{ token: string }>();
-  useFredokaFonts();
+  const navigate = useNavigate();
 
   const [view, setView] = useState<DocStoreShareView | null>(null);
   const [entries, setEntries] = useState<DocumentEntry[]>([]);
@@ -67,7 +55,7 @@ export function LibraryShareViewPage() {
     return () => { mounted = false; };
   }, [token]);
 
-  const loadContent = useCallback(async (entryId: string): Promise<LibraryDocReaderPreview | null> => {
+  const loadContent = useCallback(async (entryId: string): Promise<LibraryShareReaderPreview | null> => {
     if (!token) return null;
     const res = await getDocStoreShareEntryContent(token, entryId);
     if (!res.success) return null;
@@ -80,7 +68,7 @@ export function LibraryShareViewPage() {
 
   if (loading) {
     return (
-      <div className="min-h-screen flex items-center justify-center" style={BG}>
+      <div style={{ height: '100vh', background: PAGE_BG, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
         <MapSectionLoader text="正在打开分享..." />
       </div>
     );
@@ -88,126 +76,112 @@ export function LibraryShareViewPage() {
 
   if (error || !view) {
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center gap-5 px-6 text-center" style={BG}>
-        <div
-          className="w-20 h-20 rounded-3xl flex items-center justify-center"
-          style={{ background: '#FEF3C7', border: '4px solid #1E1B4B', boxShadow: '6px 6px 0 #1E1B4B' }}
-        >
-          <AlertCircle size={32} style={{ color: '#DC2626' }} strokeWidth={2.5} />
+      <div style={{ height: '100vh', background: PAGE_BG, fontFamily: SANS, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 18 }}>
+        <div style={{
+          width: 64, height: 64, borderRadius: '50%',
+          background: 'rgba(239, 68, 68, 0.15)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+        }}>
+          <AlertCircle size={30} color="rgba(239, 68, 68, 0.9)" />
         </div>
-        <p className="text-[16px] font-semibold" style={{ color: '#64748B' }}>
+        <p style={{ color: 'rgba(255,255,255,0.6)', fontSize: 15, margin: 0 }}>
           {error ?? '分享链接不存在或已撤销'}
         </p>
+        <button
+          onClick={() => navigate('/library')}
+          style={{
+            display: 'flex', alignItems: 'center', gap: 6,
+            padding: '8px 16px', borderRadius: 8, border: '1px solid rgba(255,255,255,0.12)',
+            background: 'rgba(255,255,255,0.06)', color: 'rgba(255,255,255,0.85)',
+            fontSize: 13, cursor: 'pointer',
+          }}
+        >
+          去智识殿堂逛逛 <ArrowRight size={14} />
+        </button>
       </div>
     );
   }
 
+  const store = view.store;
   const isSingleDoc = Boolean(view.entryId);
-  const headerTitle = isSingleDoc ? (view.entryTitle ?? view.store.name) : view.store.name;
+  const title = isSingleDoc ? (view.entryTitle ?? store.name) : (view.title || store.name);
+  const desc = view.description || store.description;
+  const hasMeta = Boolean(desc) || (!isSingleDoc && store.documentCount > 0) || store.viewCount > 0;
 
   return (
-    <div className="min-h-screen w-full overflow-y-auto" style={BG}>
-      {/* 顶部悬浮 Navbar */}
-      <nav className="z-50 px-4 md:px-6" style={{ position: 'fixed', top: 24, left: 0, right: 0 }}>
-        <div
-          className="max-w-6xl mx-auto rounded-[28px] px-5 md:px-6 py-3 flex items-center gap-4"
-          style={{ background: '#FFFFFF', border: '4px solid #1E1B4B', boxShadow: '0 6px 0 #1E1B4B' }}
-        >
-          <div
-            className="w-11 h-11 rounded-2xl flex items-center justify-center flex-shrink-0"
-            style={{ background: '#FECACA', border: '3px solid #1E1B4B', boxShadow: '0 3px 0 #1E1B4B' }}
-          >
-            <BookOpen size={20} style={{ color: '#DC2626' }} strokeWidth={2.8} />
-          </div>
-          <span
-            className="text-[18px] md:text-[20px] font-black hidden sm:inline"
-            style={{ fontFamily: "'Fredoka', sans-serif", color: '#1E1B4B' }}
-          >
-            智识殿堂
+    <div style={{ height: '100vh', display: 'flex', flexDirection: 'column', background: PAGE_BG, fontFamily: SANS }}>
+      {/* 顶栏：深色玻璃（借鉴网页托管 ShareViewPage） */}
+      <div style={{
+        padding: '10px 16px',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 16,
+        background: 'rgba(17, 17, 17, 0.85)',
+        backdropFilter: 'blur(12px)',
+        WebkitBackdropFilter: 'blur(12px)',
+        borderBottom: '1px solid rgba(255,255,255,0.06)',
+        flexShrink: 0,
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
+          <ShieldCheck size={14} color="rgba(34, 197, 94, 0.8)" style={{ flexShrink: 0 }} />
+          {view.createdByName && (
+            <span style={{ color: 'rgba(34, 197, 94, 0.9)', fontSize: 13, fontWeight: 600, flexShrink: 0 }}>
+              {view.createdByName}
+            </span>
+          )}
+          <span style={{
+            color: '#fff', fontSize: 14, fontWeight: 500,
+            whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', minWidth: 0,
+          }}>
+            {view.createdByName ? `分享给你的「${title}」` : title}
           </span>
-          <div
-            className="flex-1 text-center text-[13px] md:text-[14px] font-bold truncate hidden md:block"
-            style={{ color: '#64748B' }}
+          <span
+            className="hidden sm:inline-flex"
+            style={{
+              alignItems: 'center', gap: 4, flexShrink: 0,
+              padding: '2px 8px', borderRadius: 999,
+              background: 'rgba(255,255,255,0.06)', color: 'rgba(255,255,255,0.45)',
+              fontSize: 11, fontWeight: 600,
+            }}
           >
-            分享 · <span style={{ color: '#1E1B4B' }}>{headerTitle}</span>
-          </div>
+            {isSingleDoc ? <><FileText size={11} /> 单篇</> : <><BookOpen size={11} /> 知识库</>}
+          </span>
         </div>
-      </nav>
+      </div>
 
-      {/* Hero 头部 */}
-      <section className="relative pt-32 pb-8 px-6">
-        <div className="max-w-6xl mx-auto">
-          <div
-            className="p-8 rounded-[32px] relative"
-            style={{ background: '#FFFFFF', border: '4px solid #1E1B4B', boxShadow: '8px 8px 0 #1E1B4B' }}
-          >
-            <div className="flex flex-col md:flex-row items-start gap-6">
-              <div
-                className="w-24 h-24 rounded-3xl flex items-center justify-center flex-shrink-0"
-                style={{ background: '#FEF3C7', border: '4px solid #F59E0B', boxShadow: '0 5px 0 #D97706' }}
-              >
-                {isSingleDoc
-                  ? <FileText size={42} style={{ color: '#D97706' }} strokeWidth={2.5} />
-                  : <Library size={42} style={{ color: '#D97706' }} strokeWidth={2.5} />}
-              </div>
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2 mb-3 flex-wrap">
-                  <span
-                    className="inline-flex items-center gap-1 px-3 py-1 rounded-full text-[11px] font-bold"
-                    style={{ background: '#D1FAE5', border: '2.5px solid #10B981', boxShadow: '0 2px 0 #059669', color: '#064E3B' }}
-                  >
-                    {isSingleDoc ? 'SHARED DOCUMENT' : 'SHARED LIBRARY'}
-                  </span>
-                  {!isSingleDoc && (
-                    <span className="text-[12px] font-bold" style={{ color: '#64748B' }}>
-                      · {view.store.documentCount} 篇文档
-                    </span>
-                  )}
-                </div>
-                <h1
-                  className="text-[32px] md:text-[44px] font-bold leading-tight mb-3"
-                  style={{ fontFamily: "'Fredoka', sans-serif", color: '#1E1B4B' }}
-                >
-                  {headerTitle}
-                </h1>
-                {view.description && (
-                  <p className="text-[15px] mb-5 max-w-3xl font-medium" style={{ color: '#475569', lineHeight: 1.6 }}>
-                    {view.description}
-                  </p>
-                )}
-                <div className="flex items-center gap-4 flex-wrap text-[12px] font-semibold" style={{ color: '#64748B' }}>
-                  {view.createdByName && (
-                    <span className="flex items-center gap-2">
-                      <div
-                        className="w-8 h-8 rounded-full flex items-center justify-center text-[12px] font-bold"
-                        style={{ background: '#FCE7F3', border: '2px solid #EC4899', color: '#831843' }}
-                      >
-                        {view.createdByName.charAt(0)}
-                      </div>
-                      <span style={{ color: '#1E1B4B' }}>{view.createdByName}</span>
-                    </span>
-                  )}
-                  <span className="flex items-center gap-1.5">
-                    <Eye size={13} strokeWidth={2.8} /> {view.store.viewCount} 次浏览
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
+      {/* 简介条：低饱和度，不抢阅读 */}
+      {hasMeta && (
+        <div style={{
+          padding: '8px 16px',
+          display: 'flex', alignItems: 'center', gap: 14, flexWrap: 'wrap',
+          background: 'rgba(255,255,255,0.012)',
+          borderBottom: '1px solid rgba(255,255,255,0.05)',
+          flexShrink: 0,
+          fontSize: 12,
+          color: 'rgba(255,255,255,0.4)',
+        }}>
+          <BookOpen size={12} style={{ flexShrink: 0 }} />
+          {desc && (
+            <span style={{ color: 'rgba(255,255,255,0.55)', maxWidth: 640, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {desc}
+            </span>
+          )}
+          {!isSingleDoc && <span>{store.documentCount} 篇文档</span>}
+          <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+            <Eye size={12} /> {store.viewCount} 次浏览
+          </span>
         </div>
-      </section>
+      )}
 
-      {/* 文档阅读器 */}
-      <section className="relative px-6 pb-16">
-        <div className="max-w-6xl mx-auto" style={{ height: 'calc(100vh - 320px)', minHeight: 560 }}>
-          <LibraryDocReader
-            entries={entries}
-            primaryEntryId={view.entryId ?? view.store.primaryEntryId}
-            pinnedEntryIds={view.store.pinnedEntryIds ?? []}
-            loadContent={loadContent}
-          />
-        </div>
-      </section>
+      {/* 阅读器填满剩余高度（深色） */}
+      <div style={{ flex: 1, minHeight: 0 }}>
+        <LibraryShareReader
+          entries={entries}
+          primaryEntryId={view.entryId ?? store.primaryEntryId}
+          pinnedEntryIds={store.pinnedEntryIds ?? []}
+          loadContent={loadContent}
+        />
+      </div>
     </div>
   );
 }

--- a/prd-api/src/PrdAgent.Api/Services/ContentReprocessProcessor.cs
+++ b/prd-api/src/PrdAgent.Api/Services/ContentReprocessProcessor.cs
@@ -20,15 +20,18 @@ public class ContentReprocessProcessor
 {
     private readonly ILlmGateway _llmGateway;
     private readonly IDocumentService _documentService;
+    private readonly ILLMRequestContextAccessor _llmCtx;
     private readonly ILogger<ContentReprocessProcessor> _logger;
 
     public ContentReprocessProcessor(
         ILlmGateway llmGateway,
         IDocumentService documentService,
+        ILLMRequestContextAccessor llmCtx,
         ILogger<ContentReprocessProcessor> logger)
     {
         _llmGateway = llmGateway;
         _documentService = documentService;
+        _llmCtx = llmCtx;
         _logger = logger;
     }
 
@@ -81,6 +84,20 @@ public class ContentReprocessProcessor
         await UpdateProgressAsync(db, runStore, run, 15, "调用 LLM");
 
         // 3) 流式调用
+        // Worker 场景必须显式开 LlmRequestContext，UserId 从 run.UserId 取——否则
+        // Gateway 日志/配额/账单挂不到用户头上（llm-gateway.md：日志会打 "UserId 为空"）。
+        using var _ctxScope = _llmCtx.BeginScope(new LlmRequestContext(
+            RequestId: Guid.NewGuid().ToString("N"),
+            GroupId: null,
+            SessionId: null,
+            UserId: run.UserId,
+            ViewRole: null,
+            DocumentChars: sourceContent.Length,
+            DocumentHash: null,
+            SystemPromptRedacted: "doc-store-reprocess",
+            RequestType: "chat",
+            AppCallerCode: AppCallerRegistry.DocumentStoreAgent.Reprocess.Generate));
+
         var client = _llmGateway.CreateClient(
             AppCallerRegistry.DocumentStoreAgent.Reprocess.Generate,
             ModelTypes.Chat,

--- a/prd-api/src/PrdAgent.Api/Services/DocumentStoreAgentWorker.cs
+++ b/prd-api/src/PrdAgent.Api/Services/DocumentStoreAgentWorker.cs
@@ -34,6 +34,32 @@ public class DocumentStoreAgentWorker : BackgroundService
     {
         _logger.LogInformation("[doc-store-agent] Worker started");
 
+        // 启动兜底回收：上一个容器异常退出（重新部署 / 崩溃 / SIGKILL）时，正在处理的
+        // run 会残留为 Running 状态——此刻已没有任何 worker 在跑它，但前端 getAgentRun
+        // 永远拿到非终态、SSE 续传也收不到 done/error，进度卡片就卡死在「调用 LLM N%」。
+        // 这里把所有残留 Running 标记为失败，让前端刷新后自愈为「加工失败」（server-authority #5）。
+        // 注意：只回收 Running，Queued 留给正常拾取流程，不误杀未开始的任务。
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<MongoDbContext>();
+            var recovered = await db.DocumentStoreAgentRuns.UpdateManyAsync(
+                r => r.Status == DocumentStoreRunStatus.Running,
+                Builders<DocumentStoreAgentRun>.Update
+                    .Set(r => r.Status, DocumentStoreRunStatus.Failed)
+                    .Set(r => r.ErrorMessage, "服务重启，任务被中断")
+                    .Set(r => r.EndedAt, DateTime.UtcNow),
+                cancellationToken: CancellationToken.None);
+            if (recovered.ModifiedCount > 0)
+                _logger.LogWarning(
+                    "[doc-store-agent] 启动兜底：{Count} 个残留 Running 任务标记为失败",
+                    recovered.ModifiedCount);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[doc-store-agent] 启动兜底回收失败");
+        }
+
         try
         {
             while (!stoppingToken.IsCancellationRequested)


### PR DESCRIPTION
## 摘要

1. **分享融合(阅读页部分)**:把知识库分享落地页 `/s/lib/:token` 的呈现换成深色极简阅读器,**嫁接到 main #666 的分享基座**——路由不动、数据层沿用 main 的干净 token 门禁端点,只换渲染。main 的右键单篇分享照常工作。
2. **修复用户实测踩到的 bug**:文档再加工进度卡片在重新部署/重启后**永久卡死在「调用 LLM N%」**。根因是 Worker 缺启动兜底,残留 `Running` 任务无人收尾 → 前端 `getAgentRun` 永远拿非终态。

## 改动 diff

- `prd-admin/src/pages/library/LibraryShareReader.tsx`(新增):深色整页阅读器,窄/宽栏 + 卡片式 + 全屏 + 目录 TOC + 树内搜索 + KaTeX + 代码高亮;纯呈现组件,数据全走 props
- `prd-admin/src/pages/library/LibraryShareViewPage.tsx`(重写):深色外壳 + 上述阅读器,数据层用 main 的 `getDocStoreShareView` / `listDocStoreShareEntries` / `getDocStoreShareEntryContent`,支持整库/单篇两种分享范围
- `prd-api/.../DocumentStoreAgentWorker.cs`:启动时把残留 `Running` 任务标记失败(只回收 Running,不动 Queued),刷新后自愈为「加工失败」(server-authority #5)。该兜底同时保护字幕生成任务(共用同一 Worker)
- `prd-api/.../ContentReprocessProcessor.cs`:调 LLM 前用 `run.UserId` 开 `LlmRequestContext` 作用域,修日志「UserId 为空」、用量/配额挂不到用户(llm-gateway.md)。字幕处理器走 `GatewayRequestContext` 本就传了 UserId,无需改
- `changelogs/2026-05-27_library-share-reader.md`:changelog 碎片

## 测试

- [x] `pnpm tsc --noEmit` 通过、改动文件 `eslint` 零告警
- [x] C# 经 CDS 远端编译:0 个 `error CS`;api 运行时 `version-check` HTTP 200
- [x] CDS 日志验证再加工后端链路正常(成功生成内容、建新条目);Worker 已用新兜底代码重启
- [ ] 真人刷新预览域名确认卡死卡片自愈为「加工失败」+ 新发再加工端到端跑通

https://claude.ai/code/session_0165Bq5x3ho814CCgN2CWnY3

---
_Generated by [Claude Code](https://claude.ai/code/session_0165Bq5x3ho814CCgN2CWnY3)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> 前端为大型新阅读器组件，行为面较广；API 侧启动时批量将 Running 标失败可能误伤极短窗口内仍有效的任务，但只影响异常重启场景且优于永久卡死。
> 
> **Overview**
> 知识库分享落地页 `/s/lib/:token` 从 claymorphism + `LibraryDocReader` 改为深色极简壳 + 新组件 **`LibraryShareReader`**：路由与 token 匿名接口不变，只换呈现。阅读器提供侧栏目录、树内搜索、窄/宽栏与卡片式、全屏、KaTeX/代码高亮、相对链接与锚点跳转，以及媒体/PDF 预览。
> 
> 后端修复「文档再加工」：`DocumentStoreAgentWorker` 启动时将残留的 **`Running`** 任务标为失败，避免部署/崩溃后进度永远卡在「调用 LLM」；`ContentReprocessProcessor` 在调 LLM 前用 **`run.UserId`** 开启 **`LlmRequestContext`**，使用量/配额归属用户。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c8d997f297f7aba40d61171487fcc7300384a6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->