### PR TITLE
refactor: 更新中心改用 serve-stale-while-revalidate 缓存策略

### DIFF
--- a/changelogs/2026-05-27_changelog-backend-swr.md
+++ b/changelogs/2026-05-27_changelog-backend-swr.md
@@ -1,3 +1,3 @@
 | perf | prd-api | 更新中心读取改为 serve-stale-while-revalidate：缓存陈旧时先返回旧值再后台静默刷新、按 key 去重防惊群、保留期 24h，生产冷启动不再卡 GitHub 拉取 |
 | perf | prd-api | 更新中心新增启动预热（ChangelogCacheWarmer），首个用户请求前先把历史发布/待发布拉好放进缓存 |
-| feat | prd-api | 更新中心 GET 端点下发 Cache-Control: private, max-age=60, stale-while-revalidate=86400，浏览器跨标签页/会话即时命中并后台校验 |
+| feat | prd-api | 更新中心 GET 端点下发 Cache-Control: private, no-cache（freshness-first）：浏览器每次向后端校验，杜绝「迟迟不更新」；秒开由前端 sessionStorage 首屏 + 后端内存缓存 ms 级响应兜底 |

--- a/changelogs/2026-05-27_changelog-backend-swr.md
+++ b/changelogs/2026-05-27_changelog-backend-swr.md
@@ -1,0 +1,3 @@
+| perf | prd-api | 更新中心读取改为 serve-stale-while-revalidate：缓存陈旧时先返回旧值再后台静默刷新、按 key 去重防惊群、保留期 24h，生产冷启动不再卡 GitHub 拉取 |
+| perf | prd-api | 更新中心新增启动预热（ChangelogCacheWarmer），首个用户请求前先把历史发布/待发布拉好放进缓存 |
+| feat | prd-api | 更新中心 GET 端点下发 Cache-Control: private, max-age=60, stale-while-revalidate=86400，浏览器跨标签页/会话即时命中并后台校验 |

--- a/changelogs/2026-05-27_changelog-swr-cache.md
+++ b/changelogs/2026-05-27_changelog-swr-cache.md
@@ -1,0 +1,1 @@
+| perf | prd-admin | 更新中心历史发布改用 stale-while-revalidate：releases/currentWeek 持久化到 sessionStorage，进页面先渲染缓存再后台静默刷新，消除每次打开都显示「正在加载历史发布」的转圈 |

--- a/prd-admin/src/stores/__tests__/changelogStore.swr.test.ts
+++ b/prd-admin/src/stores/__tests__/changelogStore.swr.test.ts
@@ -1,0 +1,121 @@
+/**
+ * 更新中心 stale-while-revalidate 行为回归测试
+ *
+ * 历史背景：releases / currentWeek 之前只活在内存里（persist 仅存 lastSeenAt），
+ * 每次新会话打开「更新日志」都从 null 起步、强制走一次后端 + 显示「正在加载历史发布…」，
+ * 体感「每次打开都很慢」。改造后：
+ *   1. 无缓存 → 显示 loading 并拉取（旧行为保留）
+ *   2. 有缓存 → 不翻 loading 标志，后台静默刷新（不再闪 loading）
+ *   3. 有缓存 + 刷新失败 → 保留旧数据、不写 error
+ */
+
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+vi.mock('@/services', () => ({
+  getCurrentWeekChangelog: vi.fn(),
+  getChangelogReleases: vi.fn(),
+}));
+
+import { getChangelogReleases, getCurrentWeekChangelog, type ReleasesView, type CurrentWeekView } from '@/services';
+import { useChangelogStore } from '../changelogStore';
+
+const makeReleases = (source: ReleasesView['source']): ReleasesView => ({
+  dataSourceAvailable: true,
+  source,
+  fetchedAt: new Date().toISOString(),
+  releases: [],
+});
+
+const makeCurrentWeek = (source: CurrentWeekView['source']): CurrentWeekView => ({
+  weekStart: '2026-05-25',
+  weekEnd: '2026-05-27',
+  dataSourceAvailable: true,
+  source,
+  fetchedAt: new Date().toISOString(),
+  fragments: [],
+});
+
+describe('changelogStore: stale-while-revalidate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useChangelogStore.setState({
+      currentWeek: null,
+      releases: null,
+      loadingCurrent: false,
+      loadingReleases: false,
+      error: null,
+    });
+  });
+
+  it('无缓存时 loadReleases 显示 loading 并写入数据', async () => {
+    let resolveFn!: (v: unknown) => void;
+    (getChangelogReleases as Mock).mockReturnValue(new Promise((r) => { resolveFn = r; }));
+
+    const p = useChangelogStore.getState().loadReleases(20);
+    // 无缓存：拉取过程中 loading 为 true
+    expect(useChangelogStore.getState().loadingReleases).toBe(true);
+
+    resolveFn({ success: true, data: makeReleases('github') });
+    await p;
+
+    expect(useChangelogStore.getState().loadingReleases).toBe(false);
+    expect(useChangelogStore.getState().releases?.source).toBe('github');
+  });
+
+  it('有缓存时 loadReleases 后台静默刷新，全程不翻 loading', async () => {
+    useChangelogStore.setState({ releases: makeReleases('local') });
+
+    let resolveFn!: (v: unknown) => void;
+    (getChangelogReleases as Mock).mockReturnValue(new Promise((r) => { resolveFn = r; }));
+
+    const p = useChangelogStore.getState().loadReleases(20);
+    // 有缓存：刷新过程中 loading 始终为 false（页面不会闪「正在加载」）
+    expect(useChangelogStore.getState().loadingReleases).toBe(false);
+    // 仍展示旧数据
+    expect(useChangelogStore.getState().releases?.source).toBe('local');
+
+    resolveFn({ success: true, data: makeReleases('github') });
+    await p;
+
+    // 后台刷新完成后数据被更新
+    expect(useChangelogStore.getState().releases?.source).toBe('github');
+    expect(useChangelogStore.getState().loadingReleases).toBe(false);
+  });
+
+  it('有缓存时后台刷新失败：保留旧数据且不写 error', async () => {
+    useChangelogStore.setState({ releases: makeReleases('local') });
+    (getChangelogReleases as Mock).mockResolvedValue({ success: false, error: { message: '网络错误' } });
+
+    await useChangelogStore.getState().loadReleases(20);
+
+    expect(useChangelogStore.getState().releases?.source).toBe('local');
+    expect(useChangelogStore.getState().error).toBeNull();
+    expect(useChangelogStore.getState().loadingReleases).toBe(false);
+  });
+
+  it('无缓存时 loadReleases 失败会写 error', async () => {
+    (getChangelogReleases as Mock).mockResolvedValue({ success: false, error: { message: '网络错误' } });
+
+    await useChangelogStore.getState().loadReleases(20);
+
+    expect(useChangelogStore.getState().error).toBe('网络错误');
+    expect(useChangelogStore.getState().releases).toBeNull();
+  });
+
+  it('有缓存时 loadCurrentWeek 后台静默刷新，全程不翻 loading', async () => {
+    useChangelogStore.setState({ currentWeek: makeCurrentWeek('local') });
+
+    let resolveFn!: (v: unknown) => void;
+    (getCurrentWeekChangelog as Mock).mockReturnValue(new Promise((r) => { resolveFn = r; }));
+
+    const p = useChangelogStore.getState().loadCurrentWeek();
+    expect(useChangelogStore.getState().loadingCurrent).toBe(false);
+    expect(useChangelogStore.getState().currentWeek?.source).toBe('local');
+
+    resolveFn({ success: true, data: makeCurrentWeek('github') });
+    await p;
+
+    expect(useChangelogStore.getState().currentWeek?.source).toBe('github');
+    expect(useChangelogStore.getState().loadingCurrent).toBe(false);
+  });
+});

--- a/prd-admin/src/stores/changelogStore.ts
+++ b/prd-admin/src/stores/changelogStore.ts
@@ -85,31 +85,36 @@ export const useChangelogStore = create<ChangelogState>()(
       error: null,
       lastSeenAt: null,
 
+      // stale-while-revalidate：有 sessionStorage 缓存时立即渲染旧数据并后台静默刷新
+      //（不翻 loadingCurrent，避免每次打开都闪 loading）；无缓存时才显示 loading。
       loadCurrentWeek: async (force?: boolean) => {
         const { loadingCurrent, currentWeek } = get();
-        if (loadingCurrent) return;
-        // 已有缓存 + 非强制：跳过（前端层面避免无谓往返）
-        if (currentWeek && !force) return;
-        set({ loadingCurrent: true, error: null });
+        if (loadingCurrent) return; // 冷加载去重（多个组件并发触发时）
+        const hasCache = currentWeek != null;
+        if (!hasCache) set({ loadingCurrent: true, error: null });
         // force 透传到后端：force=true 会绕过后端 IMemoryCache，从 local/GitHub 重新拉取
         const res = await getCurrentWeekChangelog(force === true);
         if (res.success) {
           set({ currentWeek: res.data, loadingCurrent: false });
-        } else {
+        } else if (!hasCache) {
           set({ loadingCurrent: false, error: res.error?.message || '加载待发布更新失败' });
+        } else {
+          set({ loadingCurrent: false }); // 后台刷新失败：保留旧数据，不打扰
         }
       },
 
       loadReleases: async (limit = 20, force?: boolean) => {
         const { loadingReleases, releases } = get();
         if (loadingReleases) return;
-        if (releases && !force) return;
-        set({ loadingReleases: true, error: null });
+        const hasCache = releases != null;
+        if (!hasCache) set({ loadingReleases: true, error: null });
         const res = await getChangelogReleases(limit, force === true);
         if (res.success) {
           set({ releases: res.data, loadingReleases: false });
-        } else {
+        } else if (!hasCache) {
           set({ loadingReleases: false, error: res.error?.message || '加载历史发布失败' });
+        } else {
+          set({ loadingReleases: false }); // 后台刷新失败：保留旧数据
         }
       },
 
@@ -121,8 +126,20 @@ export const useChangelogStore = create<ChangelogState>()(
       name: 'changelog-store',
       // 严格遵守 no-localstorage 规则
       storage: createJSONStorage(() => sessionStorage),
-      // 只持久化 lastSeenAt；数据每次会话重新拉取
-      partialize: (s) => ({ lastSeenAt: s.lastSeenAt }),
+      // v1 起一并持久化 releases / currentWeek：进页面先渲染缓存，后台静默刷新，
+      // 消除「每次打开都转圈」。sessionStorage 随标签页关闭清空，跨会话仍会冷拉一次。
+      version: 1,
+      // 旧版本（v0，只存 lastSeenAt）升级时：保留 lastSeenAt，数据字段重置为 null（首次进入冷拉一次）。
+      migrate: (persisted) => ({
+        lastSeenAt: (persisted as { lastSeenAt?: string | null } | null)?.lastSeenAt ?? null,
+        releases: null,
+        currentWeek: null,
+      }),
+      partialize: (s) => ({
+        lastSeenAt: s.lastSeenAt,
+        releases: s.releases,
+        currentWeek: s.currentWeek,
+      }),
     }
   )
 );

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ChangelogController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ChangelogController.cs
@@ -56,6 +56,7 @@ public class ChangelogController : ControllerBase
     public async Task<IActionResult> GetCurrentWeek([FromQuery] bool force = false)
     {
         var view = await _reader.GetCurrentWeekAsync(force).ConfigureAwait(false);
+        if (!force) SetClientCacheHeaders();
         return Ok(ApiResponse<CurrentWeekDto>.Ok(MapCurrentWeek(view)));
     }
 
@@ -69,6 +70,7 @@ public class ChangelogController : ControllerBase
     {
         if (limit <= 0 || limit > 100) limit = 20;
         var view = await _reader.GetReleasesAsync(limit, force).ConfigureAwait(false);
+        if (!force) SetClientCacheHeaders();
         return Ok(ApiResponse<ReleasesDto>.Ok(MapReleases(view)));
     }
 
@@ -80,7 +82,20 @@ public class ChangelogController : ControllerBase
     {
         if (limit <= 0 || limit > 1000) limit = 1000;
         var view = await _reader.GetGitHubLogsAsync(limit, force).ConfigureAwait(false);
+        if (!force) SetClientCacheHeaders();
         return Ok(ApiResponse<GitHubLogsDto>.Ok(MapGitHubLogs(view)));
+    }
+
+    /// <summary>
+    /// 浏览器客户端缓存（stale-while-revalidate, RFC 5861）：
+    ///  - 60s 内：浏览器直接用本地缓存，零网络（跨标签页/会话也命中，比 sessionStorage 更广）
+    ///  - 60s~1 天：先用缓存即时渲染、同时后台校验刷新（用户不等待）
+    /// 内容对所有登录用户一致且非敏感，故用 private（仅浏览器缓存，不进共享 CDN）。
+    /// force=true（手动刷新）不下发缓存头，确保拿到最新。
+    /// </summary>
+    private void SetClientCacheHeaders()
+    {
+        Response.Headers["Cache-Control"] = "private, max-age=60, stale-while-revalidate=86400";
     }
 
     /// <summary>

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ChangelogController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ChangelogController.cs
@@ -87,15 +87,16 @@ public class ChangelogController : ControllerBase
     }
 
     /// <summary>
-    /// 浏览器客户端缓存（stale-while-revalidate, RFC 5861）：
-    ///  - 60s 内：浏览器直接用本地缓存，零网络（跨标签页/会话也命中，比 sessionStorage 更广）
-    ///  - 60s~1 天：先用缓存即时渲染、同时后台校验刷新（用户不等待）
-    /// 内容对所有登录用户一致且非敏感，故用 private（仅浏览器缓存，不进共享 CDN）。
-    /// force=true（手动刷新）不下发缓存头，确保拿到最新。
+    /// 浏览器缓存策略：freshness-first。`no-cache` = 浏览器可存但每次使用前必须向后端校验，
+    /// 因此永远不会拿到「浏览器层面的陈旧副本」——杜绝「迟迟不更新」。
+    /// 速度由两层兜底，不靠浏览器缓存：
+    ///   1) 前端 sessionStorage 立即首屏渲染（不等网络），再后台拉取实时覆盖
+    ///   2) 后端 serve-stale-while-revalidate 内存缓存，校验请求 ms 级返回（不打 GitHub）
+    /// 这样既保持「秒开」又保证「所见即最新」。force=true（手动刷新）连后端缓存一并绕过。
     /// </summary>
     private void SetClientCacheHeaders()
     {
-        Response.Headers["Cache-Control"] = "private, max-age=60, stale-while-revalidate=86400";
+        Response.Headers["Cache-Control"] = "private, no-cache";
     }
 
     /// <summary>

--- a/prd-api/src/PrdAgent.Api/Program.cs
+++ b/prd-api/src/PrdAgent.Api/Program.cs
@@ -152,6 +152,8 @@ builder.Services.AddMemoryCache();
 builder.Services.AddSingleton<PrdAgent.Core.Interfaces.IAppSettingsService, PrdAgent.Infrastructure.Services.AppSettingsService>();
 // 更新中心：从仓库 changelogs/ 与 CHANGELOG.md 解析代码级周报
 builder.Services.AddSingleton<PrdAgent.Infrastructure.Services.Changelog.IChangelogReader, PrdAgent.Infrastructure.Services.Changelog.ChangelogReader>();
+// 启动预热更新中心缓存，配合 serve-stale-while-revalidate 让用户不必等冷启动拉取
+builder.Services.AddHostedService<PrdAgent.Infrastructure.Services.Changelog.ChangelogCacheWarmer>();
 // 周报海报 AI 向导:读取数据源 + 调 LLM 生成结构化页面
 builder.Services.AddScoped<PrdAgent.Infrastructure.Services.Poster.IPosterAutopilotService, PrdAgent.Infrastructure.Services.Poster.PosterAutopilotService>();
 builder.Services.AddSingleton<PrdAgent.Core.Interfaces.ISystemPromptService, PrdAgent.Infrastructure.Services.SystemPromptService>();

--- a/prd-api/src/PrdAgent.Infrastructure/Services/Changelog/ChangelogCacheWarmer.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/Changelog/ChangelogCacheWarmer.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace PrdAgent.Infrastructure.Services.Changelog;
+
+/// <summary>
+/// 启动预热更新中心缓存：在第一个用户请求到达前，先把「历史发布 / 待发布」拉好放进缓存。
+/// 配合 ChangelogReader 的 serve-stale-while-revalidate，让用户几乎永远不必等冷启动拉取
+/// （生产镜像无本地源时，冷启动那一次 GitHub 拉取被挪到这里后台完成，用户无感）。
+/// 预热失败不阻断启动：懒加载路径仍会在首个请求时拉取。
+/// </summary>
+public sealed class ChangelogCacheWarmer : BackgroundService
+{
+    private readonly IChangelogReader _reader;
+    private readonly ILogger<ChangelogCacheWarmer> _logger;
+
+    public ChangelogCacheWarmer(IChangelogReader reader, ILogger<ChangelogCacheWarmer> logger)
+    {
+        _reader = reader;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            await _reader.GetCurrentWeekAsync().ConfigureAwait(false);
+            await _reader.GetReleasesAsync(20).ConfigureAwait(false);
+            _logger.LogInformation("[Changelog] 启动预热完成（current-week + releases）");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "[Changelog] 启动预热失败（退回懒加载，不影响服务启动）");
+        }
+    }
+}

--- a/prd-api/src/PrdAgent.Infrastructure/Services/Changelog/ChangelogReader.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/Changelog/ChangelogReader.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Globalization;
 using System.Net.Http;
 using System.Diagnostics;
@@ -150,9 +151,18 @@ public sealed class ChangelogReader : IChangelogReader
     private const string CacheKeyCurrentWeek = "changelog:current-week";
     private const string CacheKeyReleases = "changelog:releases";
     private const string CacheKeyGitHubLogs = "changelog:github-logs";
-    private static readonly TimeSpan LocalCacheTtl = TimeSpan.FromMinutes(5);
 
-    private static readonly TimeSpan GitHubLogsCacheTtl = TimeSpan.FromMinutes(2);
+    // serve-stale-while-revalidate（业界通行做法，见 web.dev / RFC 5861 / .NET HybridCache 防击穿）：
+    //  - 新鲜期（GetFreshWindow，默认 5 分钟）内：直接返回缓存，不刷新
+    //  - 新鲜期过后、保留期（StaleKeepWindow，24 小时）内：先返回旧值、再后台静默刷新（用户不等待）
+    //  - 保留期作为 IMemoryCache 绝对过期时间，超过才真正丢弃，下一次请求才同步拉取
+    // 这样除了「首次启动且尚未预热」这一种情况外，用户几乎永远不会卡在 GitHub/磁盘拉取上。
+    private static readonly TimeSpan StaleKeepWindow = TimeSpan.FromHours(24);
+
+    // 按 cacheKey 串行化「真实拉取」，避免缓存过期瞬间并发请求同时打满 GitHub（惊群/stampede）
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _fetchLocks = new();
+    // 标记某个 cacheKey 是否已有后台刷新在跑，避免重复刷新
+    private readonly ConcurrentDictionary<string, byte> _refreshing = new();
 
     // 文件名格式：YYYY-MM-DD_<short>.md
     private static readonly Regex FragmentFileNameRegex =
@@ -188,40 +198,138 @@ public sealed class ChangelogReader : IChangelogReader
         _logger = logger;
     }
 
-    // ── 公共 API ──────────────────────────────────────────────────────
+    // ── 公共 API（均走 serve-stale-while-revalidate） ─────────────────
 
-    public async Task<CurrentWeekView> GetCurrentWeekAsync(bool force = false)
+    public Task<CurrentWeekView> GetCurrentWeekAsync(bool force = false) =>
+        GetWithSwrAsync(CacheKeyCurrentWeek, force, FetchCurrentWeekAsync, v => v.DataSourceAvailable);
+
+    public Task<ReleasesView> GetReleasesAsync(int limit, bool force = false)
     {
-        if (!force && _cache.TryGetValue(CacheKeyCurrentWeek, out CurrentWeekView? cached) && cached != null)
+        var cacheKey = $"{CacheKeyReleases}:{limit}";
+        return GetWithSwrAsync(cacheKey, force, () => FetchReleasesAsync(limit), v => v.DataSourceAvailable);
+    }
+
+    public Task<GitHubLogsView> GetGitHubLogsAsync(int limit, bool force = false)
+    {
+        if (limit <= 0 || limit > 1000) limit = 1000;
+        var cacheKey = $"{CacheKeyGitHubLogs}:{limit}";
+        return GetWithSwrAsync(cacheKey, force, () => FetchGitHubLogsAsync(limit), v => v.DataSourceAvailable);
+    }
+
+    // ── serve-stale-while-revalidate 核心 ─────────────────────────────
+
+    private sealed class CacheEntry<T>
+    {
+        public required T Value { get; init; }
+        public required DateTime FetchedAt { get; init; }
+    }
+
+    /// <summary>
+    /// 通用 SWR 读取：新鲜直接返回；陈旧先返回旧值再后台刷新；无缓存则同步拉取（按 key 去重）。
+    /// </summary>
+    private async Task<T> GetWithSwrAsync<T>(
+        string cacheKey,
+        bool force,
+        Func<Task<T>> fetch,
+        Func<T, bool> usable) where T : class
+    {
+        if (!force && _cache.TryGetValue(cacheKey, out CacheEntry<T>? entry) && entry != null)
         {
-            return cached;
+            if (DateTime.UtcNow - entry.FetchedAt <= GetFreshWindow())
+            {
+                return entry.Value; // 新鲜：直接返回
+            }
+            TriggerBackgroundRefresh(cacheKey, fetch, usable); // 陈旧：先返回旧值 + 后台刷新
+            return entry.Value;
         }
 
-        // 1) 本地优先（dev 快路径）
-        // 注意：只要本地有 changelogs/ 目录就用本地（即使本周空），不向 GitHub 兜底
+        // 无缓存或强制刷新：必须同步拉取，按 key 串行去重避免惊群
+        return await FetchCoalescedAsync(cacheKey, force, fetch, usable).ConfigureAwait(false);
+    }
+
+    private async Task<T> FetchCoalescedAsync<T>(
+        string cacheKey,
+        bool force,
+        Func<Task<T>> fetch,
+        Func<T, bool> usable) where T : class
+    {
+        var gate = _fetchLocks.GetOrAdd(cacheKey, _ => new SemaphoreSlim(1, 1));
+        await gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            // double-check：等锁期间别的请求可能已填好新鲜缓存
+            if (!force && _cache.TryGetValue(cacheKey, out CacheEntry<T>? entry) && entry != null
+                && DateTime.UtcNow - entry.FetchedAt <= GetFreshWindow())
+            {
+                return entry.Value;
+            }
+
+            var fresh = await fetch().ConfigureAwait(false);
+            if (usable(fresh))
+            {
+                _cache.Set(cacheKey, new CacheEntry<T> { Value = fresh, FetchedAt = DateTime.UtcNow }, StaleKeepWindow);
+                return fresh;
+            }
+
+            // 拉取失败：保留期内若仍有旧值则继续用旧值，否则返回不可用结果（DataSourceAvailable=false）
+            if (_cache.TryGetValue(cacheKey, out CacheEntry<T>? stale) && stale != null)
+            {
+                return stale.Value;
+            }
+            return fresh;
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    private void TriggerBackgroundRefresh<T>(
+        string cacheKey,
+        Func<Task<T>> fetch,
+        Func<T, bool> usable) where T : class
+    {
+        if (!_refreshing.TryAdd(cacheKey, 1)) return; // 已有同 key 后台刷新在跑
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                var fresh = await fetch().ConfigureAwait(false);
+                if (usable(fresh))
+                {
+                    _cache.Set(cacheKey, new CacheEntry<T> { Value = fresh, FetchedAt = DateTime.UtcNow }, StaleKeepWindow);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "[Changelog] 后台刷新失败 key={Key}（继续沿用旧值）", cacheKey);
+            }
+            finally
+            {
+                _refreshing.TryRemove(cacheKey, out _);
+            }
+        });
+    }
+
+    // ── 真实拉取（本地优先 → GitHub 兜底），供 SWR 包装调用 ─────────────
+
+    private async Task<CurrentWeekView> FetchCurrentWeekAsync()
+    {
+        // 本地优先：只要有 changelogs/ 目录就用本地（即使本周空），不向 GitHub 兜底
         var localView = BuildCurrentWeekViewFromLocal();
-        if (localView.DataSourceAvailable)
-        {
-            _cache.Set(CacheKeyCurrentWeek, localView, LocalCacheTtl);
-            return localView;
-        }
+        if (localView.DataSourceAvailable) return localView;
 
-        // 2) GitHub 兜底（生产 Docker 等无本地源场景）
+        // GitHub 兜底（生产 Docker 等无本地源场景）
         try
         {
             var githubView = await BuildCurrentWeekViewFromGitHubAsync().ConfigureAwait(false);
-            if (githubView.DataSourceAvailable)
-            {
-                _cache.Set(CacheKeyCurrentWeek, githubView, GetGitHubCacheTtl());
-                return githubView;
-            }
+            if (githubView.DataSourceAvailable) return githubView;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "[Changelog] GitHub 拉取本周更新失败");
         }
 
-        // 3) 都失败：返回空视图（不缓存，下次重试）
         return new CurrentWeekView
         {
             WeekStart = ComputeWeekStart(),
@@ -232,31 +340,15 @@ public sealed class ChangelogReader : IChangelogReader
         };
     }
 
-    public async Task<ReleasesView> GetReleasesAsync(int limit, bool force = false)
+    private async Task<ReleasesView> FetchReleasesAsync(int limit)
     {
-        var cacheKey = $"{CacheKeyReleases}:{limit}";
-        if (!force && _cache.TryGetValue(cacheKey, out ReleasesView? cached) && cached != null)
-        {
-            return cached;
-        }
-
-        // 1) 本地优先
         var localView = BuildReleasesViewFromLocal(limit);
-        if (localView.DataSourceAvailable)
-        {
-            _cache.Set(cacheKey, localView, LocalCacheTtl);
-            return localView;
-        }
+        if (localView.DataSourceAvailable) return localView;
 
-        // 2) GitHub 兜底
         try
         {
             var githubView = await BuildReleasesViewFromGitHubAsync(limit).ConfigureAwait(false);
-            if (githubView.DataSourceAvailable)
-            {
-                _cache.Set(cacheKey, githubView, GetGitHubCacheTtl());
-                return githubView;
-            }
+            if (githubView.DataSourceAvailable) return githubView;
         }
         catch (Exception ex)
         {
@@ -271,30 +363,15 @@ public sealed class ChangelogReader : IChangelogReader
         };
     }
 
-    public async Task<GitHubLogsView> GetGitHubLogsAsync(int limit, bool force = false)
+    private async Task<GitHubLogsView> FetchGitHubLogsAsync(int limit)
     {
-        if (limit <= 0 || limit > 1000) limit = 1000;
-        var cacheKey = $"{CacheKeyGitHubLogs}:{limit}";
-        if (!force && _cache.TryGetValue(cacheKey, out GitHubLogsView? cached) && cached != null)
-        {
-            return cached;
-        }
-
         var localView = await BuildGitHubLogsViewFromLocalAsync(limit).ConfigureAwait(false);
-        if (localView.DataSourceAvailable)
-        {
-            _cache.Set(cacheKey, localView, LocalCacheTtl);
-            return localView;
-        }
+        if (localView.DataSourceAvailable) return localView;
 
         try
         {
             var githubView = await BuildGitHubLogsViewFromGitHubAsync(limit).ConfigureAwait(false);
-            if (githubView.DataSourceAvailable)
-            {
-                _cache.Set(cacheKey, githubView, GetGitHubCacheTtl());
-                return githubView;
-            }
+            if (githubView.DataSourceAvailable) return githubView;
         }
         catch (Exception ex)
         {
@@ -486,7 +563,11 @@ public sealed class ChangelogReader : IChangelogReader
     private string GetGitHubRawBase() => (_config["Changelog:GitHubRawBase"] ?? "https://raw.githubusercontent.com").TrimEnd('/');
     private string? GetGitHubToken() => _config["Changelog:GitHubToken"];
 
-    private TimeSpan GetGitHubCacheTtl()
+    /// <summary>
+    /// 缓存「新鲜期」：此窗口内直接返回缓存、不触发刷新。可由 Changelog:CacheTtlMinutes /
+    /// CacheTtlHours 配置覆盖，默认 5 分钟。超过新鲜期后走 stale-while-revalidate（先旧值后台刷新）。
+    /// </summary>
+    private TimeSpan GetFreshWindow()
     {
         var minutes = _config.GetValue<int?>("Changelog:CacheTtlMinutes");
         if (minutes.HasValue && minutes.Value > 0)

--- a/prd-api/tests/PrdAgent.Tests/ChangelogReaderSwrTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/ChangelogReaderSwrTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using PrdAgent.Infrastructure.Services.Changelog;
+using Xunit;
+
+namespace PrdAgent.Tests;
+
+/// <summary>
+/// ChangelogReader 的 serve-stale-while-revalidate 行为回归测试。
+/// 用临时目录作为本地源（含 changelogs/ + CHANGELOG.md），不触网。
+/// 覆盖：本地解析正确 + 新鲜期内命中缓存（同实例，不重读文件）+ force 绕过缓存重读。
+/// </summary>
+public sealed class ChangelogReaderSwrTests : IDisposable
+{
+    private readonly string _root;
+
+    public ChangelogReaderSwrTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "changelog-swr-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(_root, "changelogs"));
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort */ }
+    }
+
+    private void WriteChangelog(string body) => File.WriteAllText(Path.Combine(_root, "CHANGELOG.md"), body);
+
+    private ChangelogReader CreateReader()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new System.Collections.Generic.Dictionary<string, string?>
+            {
+                ["Changelog:RootPath"] = _root,
+            })
+            .Build();
+
+        return new ChangelogReader(
+            new MemoryCache(new MemoryCacheOptions()),
+            config,
+            new FakeHostEnvironment(),
+            new FakeHttpClientFactory(),
+            NullLogger<ChangelogReader>.Instance);
+    }
+
+    private const string OneRelease =
+        "# Changelog\n\n## [1.0.0] - 2026-05-01\n\n### 2026-05-01\n\n| feat | prd-admin | 初始版本 |\n";
+
+    private const string TwoReleases =
+        "# Changelog\n\n## [2.0.0] - 2026-05-20\n\n### 2026-05-20\n\n| feat | prd-api | 新增缓存 |\n\n" +
+        "## [1.0.0] - 2026-05-01\n\n### 2026-05-01\n\n| feat | prd-admin | 初始版本 |\n";
+
+    [Fact]
+    public async Task GetReleases_ParsesLocalChangelog()
+    {
+        WriteChangelog(OneRelease);
+        var reader = CreateReader();
+
+        var view = await reader.GetReleasesAsync(20);
+
+        Assert.True(view.DataSourceAvailable);
+        Assert.Equal("local", view.Source);
+        Assert.Single(view.Releases);
+        Assert.Equal("1.0.0", view.Releases[0].Version);
+        Assert.Single(view.Releases[0].Days.SelectMany(d => d.Entries));
+    }
+
+    [Fact]
+    public async Task GetReleases_FreshWindow_ReturnsCachedInstance_WithoutRereadingFile()
+    {
+        WriteChangelog(OneRelease);
+        var reader = CreateReader();
+
+        var first = await reader.GetReleasesAsync(20);
+        // 新鲜期内（默认 5 分钟）即便文件被改写，非 force 仍返回同一缓存实例
+        WriteChangelog(TwoReleases);
+        var second = await reader.GetReleasesAsync(20);
+
+        Assert.Same(first, second);
+        Assert.Single(second.Releases); // 仍是旧值（1 个版本），证明走了缓存而非重读
+    }
+
+    [Fact]
+    public async Task GetReleases_Force_BypassesCacheAndRereads()
+    {
+        WriteChangelog(OneRelease);
+        var reader = CreateReader();
+
+        var cached = await reader.GetReleasesAsync(20);
+        Assert.Single(cached.Releases);
+
+        WriteChangelog(TwoReleases);
+        var forced = await reader.GetReleasesAsync(20, force: true);
+
+        Assert.NotSame(cached, forced);
+        Assert.Equal(2, forced.Releases.Count); // force 重读拿到 2 个版本
+
+        // force 之后新值进缓存：再次非 force 读到的是刷新后的 2 个版本
+        var afterForce = await reader.GetReleasesAsync(20);
+        Assert.Equal(2, afterForce.Releases.Count);
+    }
+
+    private sealed class FakeHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = "Development";
+        public string ApplicationName { get; set; } = "PrdAgent.Tests";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+
+    private sealed class FakeHttpClientFactory : IHttpClientFactory
+    {
+        // 本地源可用时不会被调用；仅为满足构造函数依赖
+        public HttpClient CreateClient(string name) => new HttpClient();
+    }
+}


### PR DESCRIPTION
## 摘要

将更新中心（Changelog）的缓存策略从简单 TTL 改为 serve-stale-while-revalidate（SWR），实现"新鲜期内直接返回、过期后先返回旧值再后台静默刷新"。配合启动预热和前端 sessionStorage 持久化，消除生产冷启动卡 GitHub 拉取、用户每次打开都显示加载转圈的问题。

## 改动 diff

### 后端（prd-api）

- **ChangelogReader.cs**：
  - 移除固定 TTL（LocalCacheTtl / GitHubLogsCacheTtl），改为 24h 保留期 + 可配置新鲜期（默认 5 分钟）
  - 新增 `CacheEntry<T>` 包装类记录缓存时间戳
  - 实现通用 `GetWithSwrAsync<T>()` 核心逻辑：新鲜直接返回、陈旧先返回旧值再触发后台刷新、无缓存同步拉取
  - 新增 `FetchCoalescedAsync()` 按 cacheKey 串行化真实拉取，避免缓存过期瞬间并发请求打满 GitHub（防惊群）
  - 新增 `TriggerBackgroundRefresh()` 后台刷新，用 `ConcurrentDictionary<string, byte>` 标记去重，避免重复刷新
  - 将原 `GetCurrentWeekAsync / GetReleasesAsync / GetGitHubLogsAsync` 改为公共 API 入口，内部调用 `Fetch*Async()` 真实拉取方法
  - 重命名 `GetGitHubCacheTtl()` → `GetFreshWindow()`，语义更清晰

- **ChangelogCacheWarmer.cs**（新增）：
  - 启动预热服务，在第一个用户请求前后台拉取"待发布"和"历史发布"，填充缓存
  - 预热失败不阻断启动，懒加载路径仍会在首个请求时拉取

- **ChangelogController.cs**：
  - 非 force 请求时调用 `SetClientCacheHeaders()` 设置浏览器缓存头（`no-cache` 策略）
  - 浏览器缓存由前端 sessionStorage + 后端 SWR 两层兜底，不靠浏览器缓存保证新鲜度

- **Program.cs**：
  - 注册 `ChangelogCacheWarmer` 为后台服务

### 前端（prd-admin）

- **changelogStore.ts**：
  - 改造 `loadCurrentWeek()` / `loadReleases()` 为 SWR 模式：有缓存时不翻 `loadingCurrent / loadingReleases` 标志，后台静默刷新；无缓存时才显示 loading
  - 后台刷新失败时保留旧数据、不写 error，避免打扰用户
  - 升级 persist 配置：版本号改为 1，新增 `migrate()` 处理旧版本升级（保留 lastSeenAt，数据字段重置为 null）
  - 新增 `partialize()` 持久化 `releases / currentWeek` 到 sessionStorage（原仅存 lastSe

https://claude.ai/code/session_01R3Zja6uA8HJq9rhr5oxkSR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Caching semantics and client persistence changed for changelog reads; mis-tuned TTL or background refresh could briefly show stale content, but auth and data-mutation paths are untouched.
> 
> **Overview**
> Replaces the update center’s simple TTL caches with **serve-stale-while-revalidate** end-to-end so users see data immediately instead of waiting on GitHub or disk on every visit.
> 
> **Backend (`prd-api`)** — `ChangelogReader` now uses a configurable fresh window (default 5 minutes), a 24-hour stale retention window, per-key fetch coalescing, and deduplicated background refresh; stale entries are returned first while refresh runs. A new **`ChangelogCacheWarmer`** hosted service preloads current-week and releases before the first request. Changelog GET routes set **`Cache-Control: private, no-cache`** when `force` is false. **`ChangelogReaderSwrTests`** cover fresh-window caching and `force` bypass.
> 
> **Frontend (`prd-admin`)** — `changelogStore` persists **`releases` / `currentWeek`** in sessionStorage (persist v1 + migrate), shows loading only on cold load, silently revalidates when cached data exists, and keeps stale data on refresh failure. **`changelogStore.swr.test.ts`** locks in that behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7180ab66bae2fe38fa5c247e604e5bab68a8443d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->