### PR TITLE
每日熵减计划 2026-W22 — 补齐 spec.pa-agent-savage-iter-v2 索引 + changelog manifest 入库

### DIFF
--- a/changelogs/.entropy-manifest.yml
+++ b/changelogs/.entropy-manifest.yml
@@ -155,3 +155,8 @@ processed:
   - 2026-05-25_share-visibility-yellow.md
   - 2026-05-26_risk-gate-opaque-red.md
   - 2026-05-26_tip-reminder-expiry.md
+  - 2026-05-26_pa-agent-savage-iter-v2.md
+  - 2026-05-26_pa-agent-ue-revamp.md
+  - 2026-05-27_library-share-reader.md
+  - 2026-05-27_pa-agent-theme-typography.md
+  - 2026-05-27_review-agent-anti-gaming.md

--- a/doc/guide.list.directory.md
+++ b/doc/guide.list.directory.md
@@ -45,6 +45,9 @@
 - [毒舌秘书：PA Agent 最小可行升级方案](spec.pa-agent-savage-upgrade) `spec.pa-agent-savage-upgrade`
   > PA Agent 升级为毒舌秘书的最小可行方案，1-2 天内可上线，保留架构只改产品灵魂
 
+- [毒舌秘书 v2 迭代升级方案](spec.pa-agent-savage-iter-v2) `spec.pa-agent-savage-iter-v2`
+  > 毒舌秘书 PA Agent v2 阶段迭代升级方案
+
 - [周报 Agent 产品需求文档](spec.report-agent) `spec.report-agent`
   > 周报 Agent v1.0 的产品需求文档
 

--- a/doc/index.yml
+++ b/doc/index.yml
@@ -33,6 +33,7 @@ docs:
   spec.defect-agent: 缺陷管理 Agent 产品方案
   spec.pa-agent: 私人执行助理（PA Agent）产品方案
   spec.pa-agent-savage-upgrade: 毒舌秘书 PA Agent 最小可行升级方案
+  spec.pa-agent-savage-iter-v2: 毒舌秘书 v2 迭代升级方案
   spec.report-agent: 周报 Agent 产品需求文档
   spec.report-agent.v2: 周报 Agent v2.0 产品需求文档
   spec.report-agent-phase5: 周报 Agent Phase 5 用户故事


### PR DESCRIPTION
自动生成的每日熵减 PR。

## 修复项

- **D2 index.yml 补缺（1 项）**：`spec.pa-agent-savage-iter-v2` — 毒舌秘书 v2 迭代升级方案
- **D3 guide.list 补缺（1 项）**：`spec.pa-agent-savage-iter-v2` — 在毒舌秘书升级方案条目后追加
- **D6 changelog manifest 入库（5 条）**：
  - `2026-05-26_pa-agent-savage-iter-v2.md`
  - `2026-05-26_pa-agent-ue-revamp.md`
  - `2026-05-27_library-share-reader.md`
  - `2026-05-27_pa-agent-theme-typography.md`
  - `2026-05-27_review-agent-anti-gaming.md`

## 跳过项（diff 核验判断为误报）

- **D3 GHOST_GUIDE（21 项）**：guide.list.directory.md 底部变更记录区（历史文档名）和元信息行中的引用，均有注释说明（如 2026-05-03 归档记录、2026-03-15 移除记录），并非悬空条目
- **D4 GHOST_SKILL_TABLE: pnpm**：`**pnpm**` 是 CLAUDE.md 规则正文中的加粗词，不是技能目录名

https://claude.ai/code/session_016fmb1JS5YRPJ3xMA6Z4XbV

---
_Generated by [Claude Code](https://claude.ai/code/session_016fmb1JS5YRPJ3xMA6Z4XbV)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and manifest-only edits with no runtime, auth, or data-path impact.
> 
> **Overview**
> This PR is **daily entropy reduction** for documentation metadata only—no application code changes.
> 
> It registers **`spec.pa-agent-savage-iter-v2`** (毒舌秘书 v2 迭代升级方案) in **`doc/index.yml`** and adds the matching entry in **`doc/guide.list.directory.md`** immediately after the savage-upgrade spec, so doc-sync and external index consumers can resolve the spec.
> 
> It also appends **five** changelog filenames to **`changelogs/.entropy-manifest.yml`** as processed (`pa-agent-savage-iter-v2`, `pa-agent-ue-revamp`, `library-share-reader`, `pa-agent-theme-typography`, `review-agent-anti-gaming`), so the daily-entropy workflow stops re-flagging those fragments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc4ea9d2fdd573def5c614c1af3c70e131c46412. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->