### PR TITLE
每日熵减计划 2026-W22 — changelog 入库 + web-hosting 变更记录

### DIFF
--- a/changelogs/.entropy-manifest.yml
+++ b/changelogs/.entropy-manifest.yml
@@ -160,3 +160,8 @@ processed:
   - 2026-05-27_library-share-reader.md
   - 2026-05-27_pa-agent-theme-typography.md
   - 2026-05-27_review-agent-anti-gaming.md
+  - 2026-05-25_team-feature.md
+  - 2026-05-26_web-hosting-roles.md
+  - 2026-05-26_web-observability.md
+  - 2026-05-27_changelog-backend-swr.md
+  - 2026-05-27_changelog-swr-cache.md

--- a/doc/design.web-hosting.md
+++ b/doc/design.web-hosting.md
@@ -372,3 +372,27 @@ public class VideoGenRunWorker
 | 团队协作 | 站点共享给团队成员（非匿名分享） | 团队/Group 权限体系 |
 | 模板市场 | 站点模板发布到海鲜市场 | `IForkable` + `CONFIG_TYPE_REGISTRY` 集成 |
 | 在线编辑器 | 浏览器内编辑 HTML/CSS/JS | Monaco Editor 集成 |
+
+---
+
+## 变更记录（2026-05）
+
+### 团队共享与协作角色（2026-05-25/26）
+
+- 新增 `SharedTeamIds` 字段，网页托管与知识库均支持分享到团队；owner-or-member 双路径过滤放宽，全员可编辑共享站点
+- 新增团队作用域顶部「我的/团队」切换栏 + 「管理团队」面板（成员/邀请/活动日志），卡片显示成员归属头像昵称
+- 团队共享细分 owner / editor / viewer 三角色：viewer 只读、editor 可编辑/重传/建分享、删除收敛到文件夹 owner 或站点创建者
+- 新增 `WebHostingPermission` 纯策略类（角色继承解析 + 跨团队取最宽松 + 能力矩阵）
+- 团队管理面板新增成员「网页托管角色」选择器；网页托管团队视图按角色隐藏对应操作入口
+
+### 访客审计与可观测性（2026-05-26）
+
+- 新增 `SiteViewEvent` 记录登录访客 ID 快照；`WebPageAnalyticsController`（record-view + owner 查访客名单，owner 或团队成员可见）
+- 新增高级权限 `web-pages.viewAll` + `AdminWebPagesController`：跨用户查看全部托管网页、阅读量与访客记录
+- 前端：卡片「访客」抽屉、工具栏「文件夹」管理器、访问即记录访客；新增「全部网页（高级）」审计页 `/admin-web-pages`
+- 新增 `data-tour-id` 锚点（文件夹按钮/阅读量/卡片）+ 入库 onboarding 小技巧，进页面即可弹出教学 Tour
+
+### 文件夹绑生成器（2026-05-26）
+
+- 新增 `WebFolder + WebFolderController/Service`：给文件夹绑定 Markdown 模板一键生成网页/知识库条目
+- 「分类」概念并入既有「文件夹」（Folder）：`WebCategory→WebFolder`，消除分类与文件夹双概念冗余


### PR DESCRIPTION
自动生成的每日熵减 PR。

## 修复项

- **D6 changelog 入库**：登记 5 条未处理 changelog 到 `.entropy-manifest.yml`
  - `2026-05-25_team-feature.md`（团队协作子系统）
  - `2026-05-26_web-hosting-roles.md`（网页托管三角色权限）
  - `2026-05-26_web-observability.md`（访客审计 + 文件夹绑生成器）
  - `2026-05-27_changelog-backend-swr.md`（更新中心 SWR 后端缓存）
  - `2026-05-27_changelog-swr-cache.md`（更新中心前端 SWR 缓存）
- **design.web-hosting.md 追加变更记录**：将上述 3 条 web-hosting 相关 changelog 归档到设计文档，补录团队共享/访客审计/文件夹绑生成器三节

## 扫描结果

| 维度 | 结果 |
|------|------|
| D1 命名违规 | 0 项 |
| D2 index.yml 双向 | 0 项 |
| D3 guide.list 双向 | 19 项幽灵均为历史记录正文，非实际列表条目，跳过 |
| D4 技能表双向 | `pnpm` 误匹配，跳过 |
| D6 changelog 入库 | 5 条，全部处理 |

## 跳过项

- D3 幽灵：所有 19 项均通过 `grep -n "^\- .*\`xxx\`"` 验证为历史 changelog 表记录，无实际列表引用
- D4 `pnpm`：CLAUDE.md「pnpm Only」文本误匹配，非真实幽灵技能目录

---
_Generated by [Claude Code](https://claude.ai/code/session_01RtSwh6aF4M2WFVa6AEK8Y5)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to manifest and design doc; no runtime, auth, or data-path changes.
> 
> **Overview**
> This PR is **documentation and entropy housekeeping** only—no application code changes.
> 
> It **registers five changelog fragments** in `changelogs/.entropy-manifest.yml` as processed (team feature, web-hosting roles, web observability, and two changelog SWR cache entries), so daily entropy planning treats them as handled.
> 
> It also **appends a 2026-05 change log** to `doc/design.web-hosting.md` that documents already-shipped web-hosting work: team sharing with owner/editor/viewer roles, visitor analytics and admin audit surfaces, and folder-bound Markdown generation (`WebCategory` → `WebFolder`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b006b9485dd2f685c109283b0072102040f6ba0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->