### PR TITLE
fix(prd-api): 修复网页托管「替换网页不生效」——SiteUrl 追加版本指纹

### DIFF
--- a/changelogs/2026-05-29_web-hosting-replace-cache-bust.md
+++ b/changelogs/2026-05-29_web-hosting-replace-cache-bust.md
@@ -1,3 +1,4 @@
 | fix | prd-api | 修复网页托管「替换网页不生效」——SiteUrl 追加 ?v={UpdatedAt.Ticks} 版本指纹，内容不变命中缓存、重新上传击穿缓存 |
 | feat | prd-api | IAssetStorage.UploadToKeyAsync 支持 Cache-Control，网页托管对象设 public, max-age=3600 |
 | fix | prd-api | 缓存指纹改用 ContentVersion（仅创建/重传变化），改标题/可见性等元数据不再误击穿 PDF 缓存 |
+| fix | prd-api | ContentVersion 去掉 UtcNow 初始化器（老文档每次读都变）+ 读取侧回退 CreatedAt，老分享 PDF 缓存稳定 |

--- a/changelogs/2026-05-29_web-hosting-replace-cache-bust.md
+++ b/changelogs/2026-05-29_web-hosting-replace-cache-bust.md
@@ -1,0 +1,2 @@
+| fix | prd-api | 修复网页托管「替换网页不生效」——SiteUrl 追加 ?v={UpdatedAt.Ticks} 版本指纹，内容不变命中缓存、重新上传击穿缓存 |
+| feat | prd-api | IAssetStorage.UploadToKeyAsync 支持 Cache-Control，网页托管对象设 public, max-age=3600 |

--- a/changelogs/2026-05-29_web-hosting-replace-cache-bust.md
+++ b/changelogs/2026-05-29_web-hosting-replace-cache-bust.md
@@ -1,2 +1,3 @@
 | fix | prd-api | 修复网页托管「替换网页不生效」——SiteUrl 追加 ?v={UpdatedAt.Ticks} 版本指纹，内容不变命中缓存、重新上传击穿缓存 |
 | feat | prd-api | IAssetStorage.UploadToKeyAsync 支持 Cache-Control，网页托管对象设 public, max-age=3600 |
+| fix | prd-api | 缓存指纹改用 ContentVersion（仅创建/重传变化），改标题/可见性等元数据不再误击穿 PDF 缓存 |

--- a/prd-api/src/PrdAgent.Core/Models/WebPage.cs
+++ b/prd-api/src/PrdAgent.Core/Models/WebPage.cs
@@ -91,6 +91,14 @@ public class HostedSite
 
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// 内容版本时间戳：仅在创建 / 重新上传（内容真正变化）时更新，
+    /// 元数据改动（改标题、改可见性、改共享团队）不动它。
+    /// 用作 SiteUrl / pdfAssetUrl 的 ?v= 缓存指纹，确保"内容不变命中缓存、重新上传击穿缓存"。
+    /// 老数据缺该字段时反序列化为 default(DateTime)，?v 取一个稳定值，照常命中缓存（向后兼容）。
+    /// </summary>
+    public DateTime ContentVersion { get; set; } = DateTime.UtcNow;
 }
 
 /// <summary>站点文件清单项</summary>

--- a/prd-api/src/PrdAgent.Core/Models/WebPage.cs
+++ b/prd-api/src/PrdAgent.Core/Models/WebPage.cs
@@ -96,9 +96,13 @@ public class HostedSite
     /// 内容版本时间戳：仅在创建 / 重新上传（内容真正变化）时更新，
     /// 元数据改动（改标题、改可见性、改共享团队）不动它。
     /// 用作 SiteUrl / pdfAssetUrl 的 ?v= 缓存指纹，确保"内容不变命中缓存、重新上传击穿缓存"。
-    /// 老数据缺该字段时反序列化为 default(DateTime)，?v 取一个稳定值，照常命中缓存（向后兼容）。
+    ///
+    /// 注意：**禁止**给这里加 `= DateTime.UtcNow` 初始化器。Mongo 反序列化老文档（无此字段）
+    /// 时会保留初始化器的值——若为 UtcNow，则每次读取都得到当前时间，?v 每次都变，
+    /// 反而把缓存击穿（Codex PR #686 P2 抓到）。保持默认 default(DateTime) 才是确定值；
+    /// 所有创建路径都会显式赋 now，老文档则在读取侧回退到 CreatedAt（见 TryBuildPdfAssetUrl）。
     /// </summary>
-    public DateTime ContentVersion { get; set; } = DateTime.UtcNow;
+    public DateTime ContentVersion { get; set; }
 }
 
 /// <summary>站点文件清单项</summary>

--- a/prd-api/src/PrdAgent.Infrastructure/Services/AssetStorage/CloudflareR2Storage.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/AssetStorage/CloudflareR2Storage.cs
@@ -204,10 +204,10 @@ public sealed class CloudflareR2Storage : IAssetStorage, IDisposable
         }
     }
 
-    public async Task UploadToKeyAsync(string key, byte[] bytes, string? contentType, CancellationToken ct)
+    public async Task UploadToKeyAsync(string key, byte[] bytes, string? contentType, CancellationToken ct, string? cacheControl = null)
     {
         ThrowIfDisposed();
-        await UploadBytesInternalAsync(NormalizeKey(key), bytes, contentType, ct).ConfigureAwait(false);
+        await UploadBytesInternalAsync(NormalizeKey(key), bytes, contentType, ct, cacheControl).ConfigureAwait(false);
     }
 
     public string BuildUrlForKey(string key)
@@ -249,7 +249,7 @@ public sealed class CloudflareR2Storage : IAssetStorage, IDisposable
 
     // ========================== Private ==========================
 
-    private async Task UploadBytesInternalAsync(string key, byte[] bytes, string? contentType, CancellationToken ct)
+    private async Task UploadBytesInternalAsync(string key, byte[] bytes, string? contentType, CancellationToken ct, string? cacheControl = null)
     {
         if (bytes == null || bytes.Length == 0) throw new ArgumentException("bytes empty", nameof(bytes));
         var putReq = new PutObjectRequest
@@ -260,6 +260,8 @@ public sealed class CloudflareR2Storage : IAssetStorage, IDisposable
             ContentType = (contentType ?? string.Empty).Trim(),
             DisablePayloadSigning = true, // R2 推荐
         };
+        var cc = (cacheControl ?? string.Empty).Trim();
+        if (!string.IsNullOrWhiteSpace(cc)) putReq.Headers.CacheControl = cc;
         await _s3.PutObjectAsync(putReq, ct).ConfigureAwait(false);
     }
 

--- a/prd-api/src/PrdAgent.Infrastructure/Services/AssetStorage/IAssetStorage.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/AssetStorage/IAssetStorage.cs
@@ -44,8 +44,11 @@ public interface IAssetStorage
     /// <summary>
     /// 上传 bytes 到指定的自定义 key（绕过 SHA256 去重，用于站点托管等场景）。
     /// key 需包含完整路径（含 prefix），可通过 BuildSiteKey 生成。
+    /// cacheControl 可选：设置对象的 Cache-Control 响应头（如 "public, max-age=3600"）。
+    /// 网页托管场景配合 SiteUrl 上的 ?v={UpdatedAt} 版本指纹使用：内容不变 → URL 不变 → 命中缓存；
+    /// 重新上传 → UpdatedAt 变化 → URL 变化 → 击穿缓存。
     /// </summary>
-    Task UploadToKeyAsync(string key, byte[] bytes, string? contentType, CancellationToken ct);
+    Task UploadToKeyAsync(string key, byte[] bytes, string? contentType, CancellationToken ct, string? cacheControl = null);
 
     /// <summary>
     /// 根据 key 构建公开访问 URL。

--- a/prd-api/src/PrdAgent.Infrastructure/Services/AssetStorage/LocalAssetStorage.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/AssetStorage/LocalAssetStorage.cs
@@ -152,8 +152,9 @@ public class LocalAssetStorage : IAssetStorage
         return Task.FromResult(File.Exists(filePath));
     }
 
-    public async Task UploadToKeyAsync(string key, byte[] bytes, string? contentType, CancellationToken ct)
+    public async Task UploadToKeyAsync(string key, byte[] bytes, string? contentType, CancellationToken ct, string? cacheControl = null)
     {
+        // 本地存储无对象级 Cache-Control 概念，cacheControl 仅在 COS/R2 生效，这里忽略。
         var filePath = Path.Combine(_baseDir, key.Replace('/', Path.DirectorySeparatorChar));
         var dir = Path.GetDirectoryName(filePath);
         if (dir != null) Directory.CreateDirectory(dir);

--- a/prd-api/src/PrdAgent.Infrastructure/Services/AssetStorage/RegistryAssetStorage.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/AssetStorage/RegistryAssetStorage.cs
@@ -98,9 +98,9 @@ public sealed class RegistryAssetStorage : IAssetStorage
         return await _inner.ExistsAsync(key, ct);
     }
 
-    public async Task UploadToKeyAsync(string key, byte[] bytes, string? contentType, CancellationToken ct)
+    public async Task UploadToKeyAsync(string key, byte[] bytes, string? contentType, CancellationToken ct, string? cacheControl = null)
     {
-        await _inner.UploadToKeyAsync(key, bytes, contentType, ct);
+        await _inner.UploadToKeyAsync(key, bytes, contentType, ct, cacheControl);
         var url = _inner.BuildUrlForKey(key);
         await LogRegistryAsync("write", key, null, url, InferDomainFromKey(key), InferTypeFromKey(key), contentType, bytes.Length);
     }

--- a/prd-api/src/PrdAgent.Infrastructure/Services/AssetStorage/TencentCosStorage.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/AssetStorage/TencentCosStorage.cs
@@ -76,7 +76,7 @@ public sealed class TencentCosStorage : IAssetStorage, IDisposable
     /// <summary>
     /// 上传 bytes 到指定 key（可选设置 Content-Type）。
     /// </summary>
-    public async Task UploadBytesAsync(string key, byte[] bytes, string? contentType, CancellationToken ct)
+    public async Task UploadBytesAsync(string key, byte[] bytes, string? contentType, CancellationToken ct, string? cacheControl = null)
     {
         ThrowIfDisposed();
         var k = NormalizeKey(key);
@@ -85,6 +85,7 @@ public sealed class TencentCosStorage : IAssetStorage, IDisposable
         await using var ms = new MemoryStream(bytes, writable: false);
         var req = new PutObjectRequest(_bucket, k, ms);
         TrySetContentType(req, contentType);
+        TrySetHeader(req, "Cache-Control", cacheControl);
         ct.ThrowIfCancellationRequested();
         await Task.Run(() => _cos.PutObject(req), ct).ConfigureAwait(false);
     }
@@ -459,9 +460,9 @@ public sealed class TencentCosStorage : IAssetStorage, IDisposable
         return BuildPublicUrl(key);
     }
 
-    public async Task UploadToKeyAsync(string key, byte[] bytes, string? contentType, CancellationToken ct)
+    public async Task UploadToKeyAsync(string key, byte[] bytes, string? contentType, CancellationToken ct, string? cacheControl = null)
     {
-        await UploadBytesAsync(key, bytes, contentType, ct).ConfigureAwait(false);
+        await UploadBytesAsync(key, bytes, contentType, ct, cacheControl).ConfigureAwait(false);
     }
 
     public string BuildUrlForKey(string key)
@@ -531,9 +532,12 @@ public sealed class TencentCosStorage : IAssetStorage, IDisposable
     }
 
     private static void TrySetContentType(object request, string? contentType)
+        => TrySetHeader(request, "Content-Type", contentType);
+
+    private static void TrySetHeader(object request, string headerName, string? headerValue)
     {
-        var ct = (contentType ?? string.Empty).Trim();
-        if (string.IsNullOrWhiteSpace(ct)) return;
+        var value = (headerValue ?? string.Empty).Trim();
+        if (string.IsNullOrWhiteSpace(value)) return;
         try
         {
             var t = request.GetType();
@@ -545,7 +549,7 @@ public sealed class TencentCosStorage : IAssetStorage, IDisposable
                     m.GetParameters()[1].ParameterType == typeof(string));
             if (mi != null)
             {
-                mi.Invoke(request, new object[] { "Content-Type", ct });
+                mi.Invoke(request, new object[] { headerName, value });
             }
         }
         catch

--- a/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
@@ -26,6 +26,21 @@ public class HostedSiteService : IHostedSiteService
     private const long MaxExtractedSize = 500L * 1024 * 1024; // 500MB
     private const int MaxFileCount = 500;
 
+    // 网页托管对象的 Cache-Control。配合 SiteUrl 上的 ?v={UpdatedAt.Ticks} 版本指纹形成
+    // 「内容指纹缓存」：内容不变 → URL 不变 → 命中浏览器/CDN 缓存（满足"没更新就用缓存"）；
+    // 重新上传 → UpdatedAt 变化 → ?v 变化 → URL 变化 → 击穿缓存拿到新内容。
+    // max-age=3600 是兜底——万一某些 CDN 配置忽略查询串，最长 1 小时后也会回源刷新。
+    private const string SiteCacheControl = "public, max-age=3600";
+
+    // 给入口 URL 追加版本指纹。version 取站点的 UpdatedAt：只在重新上传时变化，
+    // 因此"没更新"的站点 URL 恒定可缓存，符合用户要求。
+    internal static string AppendVersion(string url, DateTime version)
+    {
+        if (string.IsNullOrWhiteSpace(url)) return url;
+        var sep = url.Contains('?') ? '&' : '?';
+        return $"{url}{sep}v={version.Ticks}";
+    }
+
     private static readonly HashSet<string> BlockedExtensions = new(StringComparer.OrdinalIgnoreCase)
     {
         ".exe", ".dll", ".sh", ".bat", ".cmd", ".ps1", ".msi", ".com", ".scr", ".pif",
@@ -116,9 +131,10 @@ public class HostedSiteService : IHostedSiteService
         CancellationToken ct)
     {
         var siteId = Guid.NewGuid().ToString("N");
+        var now = DateTime.UtcNow;
         var rewritten = RewriteAbsolutePathsInHtml(htmlBytes, "index.html");
         var cosKey = _storage.BuildSiteKey(siteId, "index.html");
-        await _storage.UploadToKeyAsync(cosKey, rewritten, "text/html; charset=utf-8", CancellationToken.None);
+        await _storage.UploadToKeyAsync(cosKey, rewritten, "text/html; charset=utf-8", CancellationToken.None, SiteCacheControl);
 
         var site = new HostedSite
         {
@@ -128,7 +144,9 @@ public class HostedSiteService : IHostedSiteService
             SourceType = "upload",
             CosPrefix = $"web-hosting/sites/{siteId}/",
             EntryFile = "index.html",
-            SiteUrl = _storage.BuildUrlForKey(cosKey),
+            SiteUrl = AppendVersion(_storage.BuildUrlForKey(cosKey), now),
+            CreatedAt = now,
+            UpdatedAt = now,
             Files = new List<HostedSiteFile>
             {
                 new() { Path = "index.html", CosKey = cosKey, Size = rewritten.Length, MimeType = "text/html" }
@@ -153,12 +171,13 @@ public class HostedSiteService : IHostedSiteService
         CancellationToken ct = default)
     {
         var siteId = Guid.NewGuid().ToString("N");
+        var now = DateTime.UtcNow;
         var result = await ExtractAndUploadZip(siteId, zipBytes);
         if (result.Error != null)
             throw new InvalidOperationException(result.Error);
 
         var cosPrefix = $"web-hosting/sites/{siteId}/";
-        var siteUrl = _storage.BuildUrlForKey(_storage.BuildSiteKey(siteId, result.EntryFile));
+        var siteUrl = AppendVersion(_storage.BuildUrlForKey(_storage.BuildSiteKey(siteId, result.EntryFile)), now);
 
         var site = new HostedSite
         {
@@ -169,6 +188,8 @@ public class HostedSiteService : IHostedSiteService
             CosPrefix = cosPrefix,
             EntryFile = result.EntryFile,
             SiteUrl = siteUrl,
+            CreatedAt = now,
+            UpdatedAt = now,
             Files = result.Files,
             TotalSize = result.TotalSize,
             Tags = tags ?? new(),
@@ -192,11 +213,12 @@ public class HostedSiteService : IHostedSiteService
         CancellationToken ct)
     {
         var siteId = Guid.NewGuid().ToString("N");
+        var now = DateTime.UtcNow;
         var htmlBytes = RewriteAbsolutePathsInHtml(
             System.Text.Encoding.UTF8.GetBytes(htmlContent), "index.html");
 
         var cosKey = _storage.BuildSiteKey(siteId, "index.html");
-        await _storage.UploadToKeyAsync(cosKey, htmlBytes, "text/html; charset=utf-8", CancellationToken.None);
+        await _storage.UploadToKeyAsync(cosKey, htmlBytes, "text/html; charset=utf-8", CancellationToken.None, SiteCacheControl);
 
         var site = new HostedSite
         {
@@ -207,7 +229,9 @@ public class HostedSiteService : IHostedSiteService
             SourceRef = sourceRef?.Trim(),
             CosPrefix = $"web-hosting/sites/{siteId}/",
             EntryFile = "index.html",
-            SiteUrl = _storage.BuildUrlForKey(cosKey),
+            SiteUrl = AppendVersion(_storage.BuildUrlForKey(cosKey), now),
+            CreatedAt = now,
+            UpdatedAt = now,
             Files = new List<HostedSiteFile>
             {
                 new() { Path = "index.html", CosKey = cosKey, Size = htmlBytes.Length, MimeType = "text/html" }
@@ -271,7 +295,7 @@ public class HostedSiteService : IHostedSiteService
         {
             var rewritten = RewriteAbsolutePathsInHtml(fileBytes, "index.html");
             var cosKey = _storage.BuildSiteKey(siteId, "index.html");
-            await _storage.UploadToKeyAsync(cosKey, rewritten, "text/html; charset=utf-8", CancellationToken.None);
+            await _storage.UploadToKeyAsync(cosKey, rewritten, "text/html; charset=utf-8", CancellationToken.None, SiteCacheControl);
             siteFiles = new List<HostedSiteFile>
             {
                 new() { Path = "index.html", CosKey = cosKey, Size = rewritten.Length, MimeType = "text/html" }
@@ -284,8 +308,12 @@ public class HostedSiteService : IHostedSiteService
             throw new InvalidOperationException("仅支持 .html/.htm/.zip 文件");
         }
 
-        // siteId 前缀保持不变 → SiteUrl 稳定，既有书签 / 公开主页 / 知识库引用不会 404
-        var siteUrl = _storage.BuildUrlForKey(_storage.BuildSiteKey(siteId, entryFile));
+        // siteId 前缀保持不变 → COS key 稳定，既有书签 / 公开主页 / 知识库引用不会 404。
+        // 但 index.html 是原地覆盖（同 key），URL 字符串若也保持不变，浏览器/CDN 会继续吐
+        // 旧缓存 →「替换网页不生效」。因此在 URL 上追加 ?v={UpdatedAt.Ticks} 版本指纹：
+        // 重新上传 → UpdatedAt 变化 → URL 变化 → 击穿缓存；没有重新上传则 URL 恒定 → 命中缓存。
+        var now = DateTime.UtcNow;
+        var siteUrl = AppendVersion(_storage.BuildUrlForKey(_storage.BuildSiteKey(siteId, entryFile)), now);
 
         // wrappedAssetType 必须显式覆盖（包括清空）：
         // - 用户把 PDF 重传到原 HTML 站，应写入 "pdf" 让分享/缩略走 PDF 路径
@@ -301,7 +329,7 @@ public class HostedSiteService : IHostedSiteService
                 .Set(x => x.Files, siteFiles)
                 .Set(x => x.TotalSize, totalSize)
                 .Set(x => x.WrappedAssetType, normalizedType)
-                .Set(x => x.UpdatedAt, DateTime.UtcNow),
+                .Set(x => x.UpdatedAt, now),
             cancellationToken: ct);
 
         // 清理旧文件中不再被新文件集复用的 key。同 key（如 index.html）已被新内容
@@ -1090,7 +1118,9 @@ public class HostedSiteService : IHostedSiteService
     // 只看 marker，不依赖 ZIP 文件形状——避免把"用户上传的 custom landing.html + report.pdf"
     // 这种 2 文件普通 ZIP 误判为包装站（Codex P2 反复抓到，PR #612）。
     private string? TryBuildPdfAssetUrl(HostedSite site)
-        => IsPdfWrapperSite(site, out var pdf) ? _storage.BuildUrlForKey(pdf!.CosKey) : null;
+        => IsPdfWrapperSite(site, out var pdf)
+            ? AppendVersion(_storage.BuildUrlForKey(pdf!.CosKey), site.UpdatedAt)
+            : null;
 
     public static bool IsPdfWrapperSite(HostedSite site, out HostedSiteFile? pdf)
     {
@@ -1614,7 +1644,7 @@ public class HostedSiteService : IHostedSiteService
 
                 var cosKey = _storage.BuildSiteKey(siteId, relativePath);
                 await _storage.UploadToKeyAsync(cosKey, entryBytes,
-                    mimeType == "text/html" ? "text/html; charset=utf-8" : mimeType, CancellationToken.None);
+                    mimeType == "text/html" ? "text/html; charset=utf-8" : mimeType, CancellationToken.None, SiteCacheControl);
 
                 files.Add(new HostedSiteFile
                 {

--- a/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
@@ -32,8 +32,9 @@ public class HostedSiteService : IHostedSiteService
     // max-age=3600 是兜底——万一某些 CDN 配置忽略查询串，最长 1 小时后也会回源刷新。
     private const string SiteCacheControl = "public, max-age=3600";
 
-    // 给入口 URL 追加版本指纹。version 取站点的 UpdatedAt：只在重新上传时变化，
-    // 因此"没更新"的站点 URL 恒定可缓存，符合用户要求。
+    // 给入口 URL 追加版本指纹。version 取站点的 ContentVersion：只在创建 / 重新上传
+    // （内容真正变化）时改变；改标题、改可见性等元数据操作不动它。因此"没更新"的站点
+    // URL 恒定可缓存，符合用户要求"没更新还要缓存"。
     internal static string AppendVersion(string url, DateTime version)
     {
         if (string.IsNullOrWhiteSpace(url)) return url;
@@ -147,6 +148,7 @@ public class HostedSiteService : IHostedSiteService
             SiteUrl = AppendVersion(_storage.BuildUrlForKey(cosKey), now),
             CreatedAt = now,
             UpdatedAt = now,
+            ContentVersion = now,
             Files = new List<HostedSiteFile>
             {
                 new() { Path = "index.html", CosKey = cosKey, Size = rewritten.Length, MimeType = "text/html" }
@@ -190,6 +192,7 @@ public class HostedSiteService : IHostedSiteService
             SiteUrl = siteUrl,
             CreatedAt = now,
             UpdatedAt = now,
+            ContentVersion = now,
             Files = result.Files,
             TotalSize = result.TotalSize,
             Tags = tags ?? new(),
@@ -232,6 +235,7 @@ public class HostedSiteService : IHostedSiteService
             SiteUrl = AppendVersion(_storage.BuildUrlForKey(cosKey), now),
             CreatedAt = now,
             UpdatedAt = now,
+            ContentVersion = now,
             Files = new List<HostedSiteFile>
             {
                 new() { Path = "index.html", CosKey = cosKey, Size = htmlBytes.Length, MimeType = "text/html" }
@@ -329,7 +333,8 @@ public class HostedSiteService : IHostedSiteService
                 .Set(x => x.Files, siteFiles)
                 .Set(x => x.TotalSize, totalSize)
                 .Set(x => x.WrappedAssetType, normalizedType)
-                .Set(x => x.UpdatedAt, now),
+                .Set(x => x.UpdatedAt, now)
+                .Set(x => x.ContentVersion, now),
             cancellationToken: ct);
 
         // 清理旧文件中不再被新文件集复用的 key。同 key（如 index.html）已被新内容
@@ -1119,7 +1124,7 @@ public class HostedSiteService : IHostedSiteService
     // 这种 2 文件普通 ZIP 误判为包装站（Codex P2 反复抓到，PR #612）。
     private string? TryBuildPdfAssetUrl(HostedSite site)
         => IsPdfWrapperSite(site, out var pdf)
-            ? AppendVersion(_storage.BuildUrlForKey(pdf!.CosKey), site.UpdatedAt)
+            ? AppendVersion(_storage.BuildUrlForKey(pdf!.CosKey), site.ContentVersion)
             : null;
 
     public static bool IsPdfWrapperSite(HostedSite site, out HostedSiteFile? pdf)
@@ -1530,6 +1535,8 @@ public class HostedSiteService : IHostedSiteService
                 CosPrefix = original.CosPrefix,
                 EntryFile = original.EntryFile,
                 SiteUrl = original.SiteUrl,
+                // 复用原站 COS 文件，内容版本也照搬，保证 pdfAssetUrl 的 ?v 与原站一致（缓存命中）
+                ContentVersion = original.ContentVersion,
                 Files = original.Files.Select(f => new HostedSiteFile
                 {
                     Path = f.Path,

--- a/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
@@ -1124,8 +1124,14 @@ public class HostedSiteService : IHostedSiteService
     // 这种 2 文件普通 ZIP 误判为包装站（Codex P2 反复抓到，PR #612）。
     private string? TryBuildPdfAssetUrl(HostedSite site)
         => IsPdfWrapperSite(site, out var pdf)
-            ? AppendVersion(_storage.BuildUrlForKey(pdf!.CosKey), site.ContentVersion)
+            ? AppendVersion(_storage.BuildUrlForKey(pdf!.CosKey), EffectiveContentVersion(site))
             : null;
+
+    // 计算缓存指纹用的内容版本：老文档无 ContentVersion（default）时回退到 CreatedAt
+    // （创建后恒定不变）→ 保证 ?v 稳定、缓存命中。禁止回退到 UpdatedAt，那会被
+    // 改标题 / 改可见性等元数据操作顶变，导致没改内容却击穿缓存。
+    internal static DateTime EffectiveContentVersion(HostedSite site)
+        => site.ContentVersion == default ? site.CreatedAt : site.ContentVersion;
 
     public static bool IsPdfWrapperSite(HostedSite site, out HostedSiteFile? pdf)
     {

--- a/prd-api/tests/PrdAgent.Api.Tests/Services/WatermarkTestHelpers.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Services/WatermarkTestHelpers.cs
@@ -55,7 +55,7 @@ public sealed class NullAssetStorage : IAssetStorage
         return null;
     }
 
-    public Task UploadToKeyAsync(string key, byte[] bytes, string? contentType, CancellationToken ct)
+    public Task UploadToKeyAsync(string key, byte[] bytes, string? contentType, CancellationToken ct, string? cacheControl = null)
     {
         return Task.CompletedTask;
     }

--- a/prd-api/tests/PrdAgent.Tests/HostedSiteVersionFingerprintTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/HostedSiteVersionFingerprintTests.cs
@@ -1,0 +1,63 @@
+using PrdAgent.Infrastructure.Services;
+using Xunit;
+
+namespace PrdAgent.Tests;
+
+/// <summary>
+/// 网页托管「替换网页不生效」回归守护。
+///
+/// 根因：reupload 把 index.html 原地覆盖到同一个 COS key，SiteUrl 字符串不变，
+/// 浏览器/CDN 继续吐旧缓存 → 用户以为"替换没生效"，缓存过期后又忽然好了（无法稳定复现）。
+///
+/// 修复：SiteUrl 追加 ?v={UpdatedAt.Ticks} 版本指纹。
+/// - 内容没更新 → UpdatedAt 不变 → URL 恒定 → 命中缓存（满足"没更新还要缓存"）
+/// - 重新上传 → UpdatedAt 变化 → URL 变化 → 击穿缓存
+///
+/// 本测试直接验证 <see cref="HostedSiteService.AppendVersion"/> 的这两条性质。
+/// </summary>
+public class HostedSiteVersionFingerprintTests
+{
+    private const string BaseUrl = "https://cdn.example.com/web-hosting/sites/abc/index.html";
+
+    [Fact]
+    public void SameVersion_ProducesStableUrl_SoUnchangedSiteStaysCached()
+    {
+        var v = new DateTime(2026, 5, 26, 1, 2, 3, DateTimeKind.Utc);
+        var a = HostedSiteService.AppendVersion(BaseUrl, v);
+        var b = HostedSiteService.AppendVersion(BaseUrl, v);
+
+        // 没更新 → 版本相同 → URL 完全一致 → 浏览器/CDN 命中缓存
+        Assert.Equal(a, b);
+        Assert.Contains($"v={v.Ticks}", a);
+    }
+
+    [Fact]
+    public void NewVersion_BustsCache_SoReuploadTakesEffect()
+    {
+        var older = HostedSiteService.AppendVersion(BaseUrl, new DateTime(2026, 5, 26, 0, 0, 0, DateTimeKind.Utc));
+        var newer = HostedSiteService.AppendVersion(BaseUrl, new DateTime(2026, 5, 26, 0, 0, 1, DateTimeKind.Utc));
+
+        // 重新上传 → UpdatedAt 前进 → URL 必须不同，否则缓存击不穿
+        Assert.NotEqual(older, newer);
+    }
+
+    [Fact]
+    public void AppendsWithAmpersand_WhenUrlAlreadyHasQuery()
+    {
+        var url = "https://cdn.example.com/x/index.html?foo=bar";
+        var result = HostedSiteService.AppendVersion(url, new DateTime(2026, 5, 26, 0, 0, 0, DateTimeKind.Utc));
+
+        Assert.Contains("?foo=bar", result);
+        Assert.Contains("&v=", result);
+        Assert.DoesNotContain("?v=", result);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void EmptyUrl_ReturnedUntouched(string? url)
+    {
+        var result = HostedSiteService.AppendVersion(url!, DateTime.UtcNow);
+        Assert.Equal(url, result);
+    }
+}

--- a/prd-api/tests/PrdAgent.Tests/HostedSiteVersionFingerprintTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/HostedSiteVersionFingerprintTests.cs
@@ -1,3 +1,4 @@
+using PrdAgent.Core.Models;
 using PrdAgent.Infrastructure.Services;
 using Xunit;
 
@@ -59,5 +60,40 @@ public class HostedSiteVersionFingerprintTests
     {
         var result = HostedSiteService.AppendVersion(url!, DateTime.UtcNow);
         Assert.Equal(url, result);
+    }
+
+    // ── EffectiveContentVersion：老文档（无 ContentVersion）必须有确定且稳定的回退 ──
+    // 守护 Codex PR #686 P2：ContentVersion 不能带 = DateTime.UtcNow 初始化器，
+    // 否则反序列化老文档时每次读取都得到当前时间，?v 每次变 → 缓存被击穿。
+
+    [Fact]
+    public void EffectiveContentVersion_NewSite_UsesContentVersion()
+    {
+        var content = new DateTime(2026, 5, 26, 3, 0, 0, DateTimeKind.Utc);
+        var site = new HostedSite { CreatedAt = new DateTime(2026, 1, 1), ContentVersion = content };
+        Assert.Equal(content, HostedSiteService.EffectiveContentVersion(site));
+    }
+
+    [Fact]
+    public void EffectiveContentVersion_LegacySite_FallsBackToCreatedAt_AndIsStable()
+    {
+        var created = new DateTime(2026, 2, 2, 8, 0, 0, DateTimeKind.Utc);
+        // 模拟老文档：Mongo 反序列化后 ContentVersion 为 default(DateTime)
+        var site = new HostedSite { CreatedAt = created };
+        Assert.Equal(default, site.ContentVersion);
+
+        var v1 = HostedSiteService.EffectiveContentVersion(site);
+        var v2 = HostedSiteService.EffectiveContentVersion(site);
+        // 两次读取必须一致（稳定），且等于 CreatedAt（不是 UpdatedAt、不是当前时间）
+        Assert.Equal(created, v1);
+        Assert.Equal(v1, v2);
+    }
+
+    [Fact]
+    public void ContentVersion_HasNoUtcNowInitializer_SoDefaultIsDeterministic()
+    {
+        // 直接 new 出来不显式赋值 → 必须是 default(DateTime)，而非 DateTime.UtcNow。
+        // 这正是 Codex 评审要求：禁止给 ContentVersion 加 = DateTime.UtcNow 初始化器。
+        Assert.Equal(default, new HostedSite().ContentVersion);
     }
 }


### PR DESCRIPTION
## 摘要

修复网页托管重新上传网页后浏览器/CDN 继续吐旧缓存导致"替换不生效"的问题。通过在 SiteUrl 追加 `?v={UpdatedAt.Ticks}` 版本指纹，实现"内容不变命中缓存、重新上传击穿缓存"的双重目标。

## 改动 diff

- `prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs`：
  - 新增 `AppendVersion()` 方法，为 URL 追加版本指纹
  - 新增 `SiteCacheControl` 常量（`public, max-age=3600`）
  - 在 `CreateFromHtmlAsync`、`CreateFromZipAsync`、`CreateFromContentAsync`、`ReuploadAsync` 中应用版本指纹
  - 在 `TryBuildPdfAssetUrl()` 中为 PDF 资源 URL 追加版本指纹
  - 所有 HTML 上传调用传入 `SiteCacheControl` 参数

- `prd-api/src/PrdAgent.Infrastructure/Services/AssetStorage/IAssetStorage.cs`：
  - `UploadToKeyAsync` 签名新增可选参数 `cacheControl`

- `prd-api/src/PrdAgent.Infrastructure/Services/AssetStorage/TencentCosStorage.cs`：
  - `UploadBytesAsync` 和 `UploadToKeyAsync` 支持 `cacheControl` 参数
  - 重构 `TrySetContentType` 为通用 `TrySetHeader` 方法，支持设置任意响应头

- `prd-api/src/PrdAgent.Infrastructure/Services/AssetStorage/CloudflareR2Storage.cs`：
  - `UploadToKeyAsync` 和 `UploadBytesInternalAsync` 支持 `cacheControl` 参数
  - 将 `cacheControl` 映射到 S3 PutObjectRequest 的 `Headers.CacheControl`

- `prd-api/src/PrdAgent.Infrastructure/Services/AssetStorage/LocalAssetStorage.cs` 和 `RegistryAssetStorage.cs`：
  - 更新 `UploadToKeyAsync` 签名以支持 `cacheControl` 参数（本地存储忽略该参数）

- `prd-api/tests/PrdAgent.Tests/HostedSiteVersionFingerprintTests.cs`（新增）：
  - 4 个单元测试验证版本指纹逻辑：
    - 相同版本产生稳定 URL（命中缓存）
    - 新版本产生不同 URL（击穿缓存）
    - 已有查询参数时用 `&` 追加
    - 空 URL 原样返回

- `prd-api/tests/PrdAgent.Api.Tests/Services/WatermarkTestHelpers.cs`：
  - 更新 mock 实现以支持新的 `cacheControl` 参数

- `changelogs/2026-05-29_web-hosting-replace-cache-bust.md`（新增）：
  - 记录本次修复和功能增强

## 实现细节

**版本指纹机制**：
- 每次创建或重新上传站点时，记录当前时间为 `UpdatedAt`
- 在入口 URL 后追加 `?v={UpdatedAt.

https://claude.ai/code/session_01DKa8k9RFzaYzya5zHQPqqg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes public CDN URL shape and cache headers for all hosted sites; low security impact but users with bookmarked unversioned URLs may see stale content until re-upload or migration.
> 
> **Overview**
> Fixes **web hosting re-uploads** where the same COS object key was overwritten but **entry URLs stayed identical**, so browsers/CDNs kept serving stale HTML/PDF.
> 
> **Cache-busting URLs:** `HostedSiteService` appends `?v={ticks}` (via `AppendVersion`) to `SiteUrl` on create/reupload and to **PDF wrapper** `pdfAssetUrl`. The fingerprint uses **`ContentVersion`** (updated only when content changes), not `UpdatedAt`, so title/visibility edits do not invalidate cache. Legacy sites without `ContentVersion` use **`EffectiveContentVersion`** (`CreatedAt` fallback); the model field has **no `UtcNow` initializer** so Mongo reads stay stable.
> 
> **Object caching:** Hosted uploads pass **`public, max-age=3600`** through a new optional **`cacheControl`** on `IAssetStorage.UploadToKeyAsync` (Tencent COS, R2, registry; local ignores). Saved-share copies preserve **`ContentVersion`** for consistent `?v` with the source site.
> 
> Regression tests cover stable vs busted URLs, query-string joining, and legacy version behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 667ca3a705456e5e0690a6d4e4b97b88115cd8d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->