### PR TITLE
每日熵减计划 2026-W22 — 补技能表 + manifest 登记 5 条 changelog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -430,6 +430,7 @@ python3 .claude/skills/cds/cli/cdscli.py --human preview-url
 |------|--------|-------------|
 | **technical-documentation** | — | 输入文档需求 → Diátaxis 工作流 + 8 种模板（Spec/Architecture/Runbook/API/Quick Start/How-to/FAQ/Tutorial） |
 | **ui-ux-pro-max** | — | 输入设计需求 → 67 种风格 + 96 种配色 + 57 种字体搭配，支持 13 种技术栈 |
+| **product-document-generator** | — | 输入产品需求 → 按工程版 1+N 主-子文档模板或敏捷版模板生成/补全符合 AI 开发要求的产品文档（Part A 价值层 + Part B 功能层两阶段） |
 
 ### 元技能
 

--- a/changelogs/.entropy-manifest.yml
+++ b/changelogs/.entropy-manifest.yml
@@ -165,3 +165,8 @@ processed:
   - 2026-05-26_web-observability.md
   - 2026-05-27_changelog-backend-swr.md
   - 2026-05-27_changelog-swr-cache.md
+  - 2026-05-22_ccas-agent-v0.md
+  - 2026-05-23_project-route-agent.md
+  - 2026-05-26_project-route-agent-admin-md-upload.md
+  - 2026-05-26_project-route-agent-branch-fallback.md
+  - 2026-05-26_project-route-agent-by-repo-grouping.md


### PR DESCRIPTION
自动生成的每日熵减 PR。

## 修复项

- **D4 技能表补缺**：`CLAUDE.md` 文档写作技能分类新增 `product-document-generator` 条目（对应 `.claude/skills/product-document-generator/`）
- **D6 manifest 登记**：将 5 条未处理 changelog 写入 `changelogs/.entropy-manifest.yml`：
  - `2026-05-22_ccas-agent-v0.md`（赋码采集智能体 v0）
  - `2026-05-23_project-route-agent.md`（项目路由智能体）
  - `2026-05-26_project-route-agent-admin-md-upload.md`
  - `2026-05-26_project-route-agent-branch-fallback.md`
  - `2026-05-26_project-route-agent-by-repo-grouping.md`

## 跳过项（diff 核验通过后安全跳过）

- D1：无命名违规
- D2：index.yml 无缺失/幽灵
- D3：guide.list 幽灵均位于历史变更记录表（合法引用，非文档链接）
- D4 幽灵 `pnpm`：来自行内粗体文本，非技能表行


---
_Generated by [Claude Code](https://claude.ai/code/session_011xMMerNBAjSYq41YvcZMKE)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> 仅文档与 manifest 元数据更新，不涉及运行时或业务代码。
> 
> **Overview**
> **每日熵减例行维护**：在 `CLAUDE.md` 的「文档写作与设计技能」表中补登记 **`product-document-generator`**（输入产品需求 → 工程版 1+N / 敏捷版模板，Part A 价值层 + Part B 功能层），与仓库内已有技能目录对齐。
> 
> 同时在 **`changelogs/.entropy-manifest.yml`** 的 `processed` 列表末尾登记 5 条此前未入账的 changelog 碎片（赋码采集智能体 v0、项目路由智能体及其 admin 上传 / 分支回退 / 按仓库分组相关记录），供 `daily-entropy-plan` 后续扫描不再重复处理。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f06262dc98b9d504d7b50f07dfc21fd769b3464c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->