### PR TITLE
fix(cds): 显示 commit SHA 短哈希，完整值移入 tooltip

### DIFF
--- a/cds/src/widget-script.ts
+++ b/cds/src/widget-script.ts
@@ -520,7 +520,7 @@ export function buildWidgetScript(branchId: string, branchName: string): string 
         h+='<span style="font-size:11px;color:#8b949e">状态: </span>';
         h+='<span class="cds-status-dot'+statusBlink+'" style="background:'+statusColor+'"></span>';
         h+='<span style="font-size:11px;color:'+statusColor+';font-style:italic;font-weight:600">'+branchStatus+'</span>';
-        if(commitSha)h+='<span class="cds-commit-sha">'+commitSha+'</span>';
+        if(commitSha)h+='<span class="cds-commit-sha" title="'+commitSha+'">'+shortSha(commitSha)+'</span>';
         h+='</div>';
         if(commitMsg)h+='<div class="cds-commit-msg" title="'+commitMsg.replace(/"/g,'&quot;')+'">'+commitMsg+'</div>';
         // Deploy mode selectors
@@ -607,7 +607,7 @@ export function buildWidgetScript(branchId: string, branchName: string): string 
     h+='<div class="cds-badge-main">';
     h+='<span class="cds-badge-icon">'+(syncState.visible&&syncState.phase==='syncing'?ICON_REFRESH:ICON_BRANCH)+'</span>';
     h+='<span class="cds-branch">'+BRANCH_NAME+'</span>';
-    if(commitSha)h+='<span class="cds-sha" title="'+commitSha+'">'+commitSha+'</span>';
+    if(commitSha)h+='<span class="cds-sha" title="'+commitSha+'">'+shortSha(commitSha)+'</span>';
     if(syncState.visible){
       var syncChipClass='cds-sync-chip'+(syncState.phase==='done'?' done':syncState.phase==='error'?' error':'');
       h+='<span class="'+syncChipClass+'" title="'+syncLabelText().replace(/"/g,'&quot;')+'">';

--- a/changelogs/2026-05-29_cds-widget-short-sha.md
+++ b/changelogs/2026-05-29_cds-widget-short-sha.md
@@ -1,0 +1,1 @@
+| fix | cds | 预览页左下角 widget 的 commit id 恢复显示 7 位短哈希（复用 shortSha()，完整 SHA 移入 title tooltip） |


### PR DESCRIPTION
## 摘要
优化 CDS widget 中 commit SHA 的显示方式，改为显示 7 位短哈希，完整 SHA 值通过 title tooltip 提供，提升界面紧凑性。

## 改动 diff
- `cds/src/widget-script.ts`：两处调用 `shortSha()` 函数缩短 commit SHA 显示
  - 第 523 行：widget 详情区域的 commit SHA 显示
  - 第 610 行：widget badge 区域的 commit SHA 显示
  - 两处均保留完整 SHA 在 `title` 属性中作为 tooltip
- `changelogs/2026-05-29_cds-widget-short-sha.md`：新增 changelog 碎片记录本次修复

## 实现细节
- 复用现有 `shortSha()` 函数（已在项目中定义），无需新增依赖
- 保持向后兼容：用户悬停时仍可看到完整 SHA，不影响功能
- 两个显示位置保持一致的处理方式

https://claude.ai/code/session_017pytkuiCE6sP3BUZwrecN2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change in injected widget markup; full SHA remains available on hover.
> 
> **Overview**
> The preview-page CDS widget now shows a **7-character commit hash** in the expanded status row and on the collapsed badge, instead of the full SHA. **Full SHA** stays on the `title` tooltip via existing `shortSha()`; no new helpers.
> 
> A changelog fragment records the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f5d20dac9b54bff3a8bc581736d3c55ad9d4428. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->