### PR TITLE
feat(web-hosting): 新增评论能力 - 站点评论 CRUD + owner 开关

### DIFF
--- a/changelogs/2026-05-30_web-hosting-comments.md
+++ b/changelogs/2026-05-30_web-hosting-comments.md
@@ -1,2 +1,3 @@
 | feat | prd-api | 网页托管新增评论能力：站点评论 CRUD + owner 开关（hosted_site_comments 集合 + HostedSite.CommentsEnabled），分享页/站内双入口，复用分享可见性+密码门禁 |
 | feat | prd-admin | 网页托管评论 UI：分享页 CommentsSection 访客读/登录评，站点卡「评论管理」按钮打开预览弹窗内嵌评论面板 + 允许评论开关 |
+| fix | prd-api | 修复评论功能 CDS 编译失败：补齐 HostedSiteService 6 个评论方法实现 + AddCommentRequest 改名避免与 PmAgent 重名 |

--- a/changelogs/2026-05-30_web-hosting-comments.md
+++ b/changelogs/2026-05-30_web-hosting-comments.md
@@ -1,0 +1,2 @@
+| feat | prd-api | 网页托管新增评论能力：站点评论 CRUD + owner 开关（hosted_site_comments 集合 + HostedSite.CommentsEnabled），分享页/站内双入口，复用分享可见性+密码门禁 |
+| feat | prd-admin | 网页托管评论 UI：分享页 CommentsSection 访客读/登录评，站点卡「评论管理」按钮打开预览弹窗内嵌评论面板 + 允许评论开关 |

--- a/changelogs/2026-05-31_web-hosting-site-comments.md
+++ b/changelogs/2026-05-31_web-hosting-site-comments.md
@@ -1,3 +1,4 @@
-| feat | prd-admin | 站点分享页评论改右下角浮动按钮 + 右侧滑出抽屉，访客不必下滚即可评论 |
+| feat | prd-admin | 站点分享页评论入口移到顶栏「评论 N」按钮 + 右侧滑出抽屉，PPT/全屏页无需滚动、不遮挡页面控件，并实时展示评论数 |
+| feat | prd-api | 有人评论站点时通知站点 owner（系统通知，自评不通知，每条评论幂等一次） |
 | fix | prd-admin | 站点评论入口对团队 viewer 角色开放（去掉 canShare gate），「允许访客评论」开关仅 owner/editor 可见 |
 | fix | prd-api | 豁免站点维度评论路由（{siteId}/comments 列表+发表、{siteId}/comments-enabled 开关）的 WebPagesWrite 权限闸门，改由 service 层自鉴权（成员可读/评、owner/editor 可改开关），修复团队 viewer/editor 被中间件提前 403 |

--- a/changelogs/2026-05-31_web-hosting-site-comments.md
+++ b/changelogs/2026-05-31_web-hosting-site-comments.md
@@ -1,3 +1,3 @@
 | feat | prd-admin | 站点分享页评论改右下角浮动按钮 + 右侧滑出抽屉，访客不必下滚即可评论 |
 | fix | prd-admin | 站点评论入口对团队 viewer 角色开放（去掉 canShare gate），「允许访客评论」开关仅 owner/editor 可见 |
-| fix | prd-api | 豁免 POST/GET /api/web-pages/{siteId}/comments 的 WebPagesWrite 权限闸门，团队 viewer 成员可读/可评（service 层 GetByIdAsync 自鉴权），保留 comments-enabled 开关写权限 |
+| fix | prd-api | 豁免站点维度评论路由（{siteId}/comments 列表+发表、{siteId}/comments-enabled 开关）的 WebPagesWrite 权限闸门，改由 service 层自鉴权（成员可读/评、owner/editor 可改开关），修复团队 viewer/editor 被中间件提前 403 |

--- a/changelogs/2026-05-31_web-hosting-site-comments.md
+++ b/changelogs/2026-05-31_web-hosting-site-comments.md
@@ -1,0 +1,3 @@
+| feat | prd-admin | 站点分享页评论改右下角浮动按钮 + 右侧滑出抽屉，访客不必下滚即可评论 |
+| fix | prd-admin | 站点评论入口对团队 viewer 角色开放（去掉 canShare gate），「允许访客评论」开关仅 owner/editor 可见 |
+| fix | prd-api | 豁免 POST/GET /api/web-pages/{siteId}/comments 的 WebPagesWrite 权限闸门，团队 viewer 成员可读/可评（service 层 GetByIdAsync 自鉴权），保留 comments-enabled 开关写权限 |

--- a/doc/debt.web-hosting-comments.md
+++ b/doc/debt.web-hosting-comments.md
@@ -25,12 +25,14 @@
 - 删：评论作者本人 或 站点 owner。
 - 开关：仅 owner / editor 可切换 `CommentsEnabled`（默认 true，存量站点反序列化为 true）。
 
-## 验收状态（2026-05-30）
+## 验收状态（2026-05-31 已通过）
 
-- 前端：`pnpm tsc --noEmit` 0 error、`pnpm lint` 改动文件 0 告警（已自测通过）。
-- 后端 C#：本地无 dotnet SDK，依赖 CDS 远端编译验证。**截至交付，CDS 分支 `claude-fervent-meitner-lcue8` 持续 `building` 近 30 分钟，预览域名 `/api/v` 恒 503，deploy 触发返回 HTTP 500（git 操作成功但部署链路失败）** —— 属 CDS 构建侧外部阻塞，非本次代码可自解。
-- 视觉验收（create-visual-test-to-kb）**未执行**：(a) 预览未就绪；(b) `MAP_ACCEPT_PASS` 登录密码 env 缺失，harness 无法走真人登录路径发表评论。两者均为外部不可自产输入。
-- 待 CDS 构建绿灯 + 提供登录密码后，按既定 driver（登录 → 点「网页托管」→ 站点卡「评论管理」→ 截图；分享页评论区双主题）补跑视觉验收并归档。
+- 前端：`pnpm tsc --noEmit` 0 error、`pnpm lint` 改动文件 0 告警。
+- 后端：CDS 远端编译——期间修复 3 轮真实编译错误（接口未实现 CS0535×6、`AddCommentRequest` 与 PmAgent 重名 CS0101、前端评论入口未接线 TS6133），最终 deploy 流水线全绿、L1/L2/L3 探针 200。
+- API E2E（灰度直连，AI 密钥 impersonate）：列表/发表/再查/开关/关闭后发表 403/重开/删除 8 条用例全过；存量站点 `commentsEnabled` 反序列化为 true。
+- 视觉验收：Playwright 真人路径 10 张截图（站点卡评论管理弹窗发表/开关 + 分享页访客只读 + 登录可评）全部通过，已归档知识库并自查可打开。
+- 报告分享链：https://fervent-meitner-lcue8-claude-prd-agent.miduo.org/s/lib/ftDV5mobkfHt?entry=7f3cdff238d640448019536ba23f75a7
+- 早前「CDS building 30 分钟」判断有误：实为容器构建失败进入 error 态（CDS proxy 把 error 也包成 `status` JSON 返回 200，误导了轮询）；真正根因是编译错误，看 `branch logs --profile api-prd-agent` 才暴露。
 
 ## 关联
 

--- a/doc/debt.web-hosting-comments.md
+++ b/doc/debt.web-hosting-comments.md
@@ -25,6 +25,13 @@
 - 删：评论作者本人 或 站点 owner。
 - 开关：仅 owner / editor 可切换 `CommentsEnabled`（默认 true，存量站点反序列化为 true）。
 
+## 验收状态（2026-05-30）
+
+- 前端：`pnpm tsc --noEmit` 0 error、`pnpm lint` 改动文件 0 告警（已自测通过）。
+- 后端 C#：本地无 dotnet SDK，依赖 CDS 远端编译验证。**截至交付，CDS 分支 `claude-fervent-meitner-lcue8` 持续 `building` 近 30 分钟，预览域名 `/api/v` 恒 503，deploy 触发返回 HTTP 500（git 操作成功但部署链路失败）** —— 属 CDS 构建侧外部阻塞，非本次代码可自解。
+- 视觉验收（create-visual-test-to-kb）**未执行**：(a) 预览未就绪；(b) `MAP_ACCEPT_PASS` 登录密码 env 缺失，harness 无法走真人登录路径发表评论。两者均为外部不可自产输入。
+- 待 CDS 构建绿灯 + 提供登录密码后，按既定 driver（登录 → 点「网页托管」→ 站点卡「评论管理」→ 截图；分享页评论区双主题）补跑视觉验收并归档。
+
 ## 关联
 
 - 后端：`HostedSiteComment.cs`、`HostedSiteService.cs`（评论段）、`WebPagesController.cs`（评论端点）、`IHostedSiteService.cs`（DTO）

--- a/doc/debt.web-hosting-comments.md
+++ b/doc/debt.web-hosting-comments.md
@@ -1,0 +1,31 @@
+# debt.web-hosting-comments
+
+> 类型：debt（工程债务台账） | 模块：网页托管评论 | 状态：active | 更新：2026-05-30
+
+## 背景
+
+为「网页托管允许被评论」落地的评论能力，记录本次交付的已知边界与后续可补项。
+
+## 已知边界（本次交付未做，刻意留尾）
+
+| 项 | 现状 | 后续可补 |
+|----|------|---------|
+| 评论回复/盖楼 | 仅平铺单层评论，无 `ParentCommentId` | 如需讨论串，仿 `ReportComment.ParentCommentId` 扩展 |
+| 评论编辑 | 仅支持发表 / 删除（软删 `IsDeleted`），不支持编辑 | 加 `PUT comments/{id}`，仿 ReportComment 编辑路径 |
+| 实时推送 | 发表后本地乐观插入，不走 SSE；他人评论需刷新 | 复用 `GET /api/branches/stream` 模式做评论流 |
+| 防刷 | 评论无独立速率限制（仅借分享 view 门禁） | 如遇滥用，加 per-user / per-site 滑动窗口（仿 `EnforceShareAccessAsync`） |
+| 通知 | owner 不会收到「有人评论了你的站点」通知 | 接 `admin_notifications` 或团队活动流 |
+| 合集分享评论 | 合集分享（多站点）评论只挂到 `sites[0]` 首个站点 | 如需逐站点评论，前端按 site 分区 + 后端按 siteId 查询 |
+| 索引 | `hosted_site_comments` 未建索引（遵守 no-auto-index 规则） | DBA 手动建 `(siteId, createdAt)` 复合索引，写入 `doc/guide.mongodb-indexes.md` |
+
+## 权限模型（已实现）
+
+- 读：站内路径走 `GetByIdAsync`（owner / 团队成员）；分享路径走分享可见性 + 密码门禁（owner-only / logged-in / public）。访客未登录也可读公开分享评论。
+- 写：恒需登录。站内路径需对站点有访问权；分享路径需过门禁 + 站点 `CommentsEnabled`。
+- 删：评论作者本人 或 站点 owner。
+- 开关：仅 owner / editor 可切换 `CommentsEnabled`（默认 true，存量站点反序列化为 true）。
+
+## 关联
+
+- 后端：`HostedSiteComment.cs`、`HostedSiteService.cs`（评论段）、`WebPagesController.cs`（评论端点）、`IHostedSiteService.cs`（DTO）
+- 前端：`components/web-hosting/CommentsSection.tsx`、`components/web-hosting/SitePreviewModal.tsx`、`pages/SharedSitePage.tsx`、`services/real/webPages.ts`

--- a/doc/guide.mongodb-indexes.md
+++ b/doc/guide.mongodb-indexes.md
@@ -1113,6 +1113,17 @@ db.web_page_share_links.createIndex(
 )
 ```
 
+### hosted_site_comments
+
+```js
+// 评论面板按 站点 + 未删 + 时间倒序 加载（站内/分享公开读都走这条）；
+// 共享集合跨多站点后无此复合索引会全表扫 + 内存排序（PR #694）。
+db.hosted_site_comments.createIndex(
+  { "SiteId": 1, "IsDeleted": 1, "CreatedAt": -1 },
+  { name: "idx_hosted_site_comments_site_deleted_created" }
+)
+```
+
 ### share_view_logs
 
 ```js

--- a/prd-admin/src/components/web-hosting/CommentsSection.tsx
+++ b/prd-admin/src/components/web-hosting/CommentsSection.tsx
@@ -41,12 +41,24 @@ export default function CommentsSection(props: Props) {
 
   // 防竞态：token/password/siteId/登录态变化时旧请求回来不得覆盖新结果（Cursor learned rule）
   const fetchIdRef = useRef(0);
+  // 组件卸载后所有在途请求都作废（避免卸载后 setState / onStateLoaded 拿 stale 值回写父组件，Cursor high）
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      fetchIdRef.current++; // 让在途请求的 myId 失配，彻底丢弃
+    };
+  }, []);
 
   const mode = props.mode;
   const token = (props as { token?: string }).token;
   const password = (props as { password?: string }).password;
   const siteId = (props as { siteId?: string }).siteId;
-  const onStateLoaded = props.onStateLoaded;
+  // onStateLoaded 走 ref：父级每次 render 传新内联函数也不污染 load 的依赖，
+  // 避免 iframe onLoad 等无关 modal 重渲染触发评论列表重新拉取 + loading 闪烁（Cursor medium）
+  const onStateLoadedRef = useRef(props.onStateLoaded);
+  onStateLoadedRef.current = props.onStateLoaded;
 
   const load = useCallback(async () => {
     const myId = ++fetchIdRef.current;
@@ -56,22 +68,22 @@ export default function CommentsSection(props: Props) {
       const res = mode === 'share'
         ? await listShareComments(token!, password)
         : await listSiteComments(siteId!);
-      if (myId !== fetchIdRef.current) return; // 过期响应，丢弃
+      if (myId !== fetchIdRef.current || !mountedRef.current) return; // 过期/已卸载，丢弃
       if (res.success && res.data) {
         setComments(res.data.comments);
         setCommentsEnabled(res.data.commentsEnabled);
         setCanComment(res.data.canComment);
-        onStateLoaded?.(res.data.commentsEnabled);
+        onStateLoadedRef.current?.(res.data.commentsEnabled);
       } else {
         setError(res.error?.message || '加载评论失败');
       }
     } catch {
-      if (myId !== fetchIdRef.current) return;
+      if (myId !== fetchIdRef.current || !mountedRef.current) return;
       setError('网络错误，无法加载评论');
     } finally {
-      if (myId === fetchIdRef.current) setLoading(false);
+      if (myId === fetchIdRef.current && mountedRef.current) setLoading(false);
     }
-  }, [mode, token, password, siteId, onStateLoaded]);
+  }, [mode, token, password, siteId]);
 
   // isAuthenticated / authToken 纳入依赖：登录态就绪（含 persist rehydration）后重新拉取，
   // 让已登录用户拿到 canComment=true 的发表 UI，不必手动刷新。

--- a/prd-admin/src/components/web-hosting/CommentsSection.tsx
+++ b/prd-admin/src/components/web-hosting/CommentsSection.tsx
@@ -117,10 +117,12 @@ export default function CommentsSection(props: Props) {
   };
 
   const handleDelete = async (commentId: string) => {
-    const reqId = fetchIdRef.current;
     const res = await deleteSiteComment(commentId);
-    if (reqId !== fetchIdRef.current) return; // 删除在途时线程已切换，late 响应不动新线程的列表
+    if (!mountedRef.current) return;
     if (res.success) {
+      // 按 commentId 精确过滤：id 全局唯一，无论期间是否有并发 load 切了线程，
+      // "从当前列表移除这一条"永远是正确操作。不能用 fetchIdRef 守卫——那会在并发 load
+      // 撞号时把已成功的服务端删除丢掉、评论残留到下次刷新（Cursor medium）。
       setComments((prev) => prev.filter((c) => c.id !== commentId));
     } else {
       setError(res.error?.message || '删除失败');

--- a/prd-admin/src/components/web-hosting/CommentsSection.tsx
+++ b/prd-admin/src/components/web-hosting/CommentsSection.tsx
@@ -179,9 +179,13 @@ export default function CommentsSection(props: Props) {
         {loading ? (
           <MapSectionLoader text="正在加载评论…" />
         ) : comments.length === 0 ? (
-          <div className="text-center py-8 text-sm text-white/30">
-            还没有评论，来发表第一条吧
-          </div>
+          // 仅在"加载成功但确实没有评论"时显示空状态；加载失败已由上方 error 提示，
+          // 不能再叠一句"还没有评论"让用户误以为是成功的空列表（Cursor low）。
+          !error && (
+            <div className="text-center py-8 text-sm text-white/30">
+              还没有评论，来发表第一条吧
+            </div>
+          )
         ) : (
           <ul className="space-y-3">
             {comments.map((c) => (

--- a/prd-admin/src/components/web-hosting/CommentsSection.tsx
+++ b/prd-admin/src/components/web-hosting/CommentsSection.tsx
@@ -1,0 +1,197 @@
+import { useState, useEffect, useCallback } from 'react';
+import { MessageSquare, Send, Trash2, Lock } from 'lucide-react';
+import { MapSpinner, MapSectionLoader } from '../ui/VideoLoader';
+import { getUserAvatarUrl } from '../../lib/avatar';
+import { useAuthStore } from '../../stores/authStore';
+import {
+  listShareComments, addShareComment,
+  listSiteComments, addSiteComment,
+  deleteSiteComment,
+  type HostedSiteCommentDto,
+} from '../../services/real/webPages';
+
+/**
+ * 托管站点评论区 —— 在分享页 / 站点预览下展示评论列表 + 发表入口。
+ *
+ * 两种数据来源（discriminated by mode）：
+ * - mode='share'：经分享 token 读写（公开访问路径，读不需登录、写需登录）
+ * - mode='site' ：经 siteId 读写（owner / 团队成员视角，恒需登录）
+ *
+ * 走 prd-admin 暗色面板配色（与 SharedSitePage / SitePreviewModal 一致）。
+ */
+type Props =
+  | { mode: 'share'; token: string; password?: string; siteId?: never }
+  | { mode: 'site'; siteId: string; token?: never; password?: never };
+
+export default function CommentsSection(props: Props) {
+  const { isAuthenticated } = useAuthStore();
+  const [loading, setLoading] = useState(true);
+  const [comments, setComments] = useState<HostedSiteCommentDto[]>([]);
+  const [commentsEnabled, setCommentsEnabled] = useState(true);
+  const [canComment, setCanComment] = useState(false);
+  const [draft, setDraft] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = props.mode === 'share'
+        ? await listShareComments(props.token, props.password)
+        : await listSiteComments(props.siteId);
+      if (res.success && res.data) {
+        setComments(res.data.comments);
+        setCommentsEnabled(res.data.commentsEnabled);
+        setCanComment(res.data.canComment);
+      } else {
+        setError(res.error?.message || '加载评论失败');
+      }
+    } catch {
+      setError('网络错误，无法加载评论');
+    } finally {
+      setLoading(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.mode, (props as { token?: string }).token, (props as { password?: string }).password, (props as { siteId?: string }).siteId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleSubmit = async () => {
+    const content = draft.trim();
+    if (!content || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = props.mode === 'share'
+        ? await addShareComment(props.token, content, props.password)
+        : await addSiteComment(props.siteId, content);
+      if (res.success && res.data) {
+        setComments((prev) => [res.data!, ...prev]);
+        setDraft('');
+      } else {
+        setError(res.error?.message || '发表失败');
+      }
+    } catch {
+      setError('网络错误，发表失败');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDelete = async (commentId: string) => {
+    const res = await deleteSiteComment(commentId);
+    if (res.success) {
+      setComments((prev) => prev.filter((c) => c.id !== commentId));
+    } else {
+      setError(res.error?.message || '删除失败');
+    }
+  };
+
+  return (
+    <section className="rounded-xl border border-white/10 bg-white/[0.03]">
+      <header className="flex items-center gap-2 px-4 py-3 border-b border-white/10">
+        <MessageSquare className="w-4 h-4 text-white/50" />
+        <h2 className="text-sm font-semibold text-white">评论</h2>
+        <span className="text-xs text-white/40">{comments.length}</span>
+      </header>
+
+      <div className="p-4 space-y-4">
+        {/* 发表区 */}
+        {!commentsEnabled ? (
+          <div className="flex items-center gap-2 text-sm text-white/40 py-1">
+            <Lock className="w-4 h-4" />
+            该站点已关闭评论
+          </div>
+        ) : !isAuthenticated ? (
+          <div className="flex items-center gap-2 text-sm text-white/40 py-1">
+            <Lock className="w-4 h-4" />
+            登录后即可发表评论
+          </div>
+        ) : canComment ? (
+          <div className="flex flex-col gap-2">
+            <textarea
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              placeholder="写下你的评论…"
+              rows={3}
+              maxLength={2000}
+              className="w-full px-3 py-2 rounded-lg bg-white/5 border border-white/10 text-sm text-white placeholder-white/30 resize-none focus:outline-none focus:border-blue-500/50"
+            />
+            <div className="flex items-center justify-between">
+              <span className="text-[11px] text-white/30">{draft.length}/2000</span>
+              <button
+                onClick={handleSubmit}
+                disabled={!draft.trim() || submitting}
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                {submitting ? <MapSpinner size={14} /> : <Send className="w-3.5 h-3.5" />}
+                发表
+              </button>
+            </div>
+          </div>
+        ) : null}
+
+        {error && <p className="text-sm text-red-400">{error}</p>}
+
+        {/* 列表区 */}
+        {loading ? (
+          <MapSectionLoader text="正在加载评论…" />
+        ) : comments.length === 0 ? (
+          <div className="text-center py-8 text-sm text-white/30">
+            还没有评论，来发表第一条吧
+          </div>
+        ) : (
+          <ul className="space-y-3">
+            {comments.map((c) => (
+              <li key={c.id} className="flex gap-3">
+                <Avatar name={c.authorName} fileName={c.authorAvatarFileName} />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium text-white/90 truncate">{c.authorName}</span>
+                    <span className="text-[11px] text-white/30">{formatTime(c.createdAt)}</span>
+                    {c.canDelete && (
+                      <button
+                        onClick={() => handleDelete(c.id)}
+                        title="删除评论"
+                        className="ml-auto text-white/30 hover:text-red-400 transition-colors"
+                      >
+                        <Trash2 className="w-3.5 h-3.5" />
+                      </button>
+                    )}
+                  </div>
+                  <p className="text-sm text-white/70 mt-0.5 whitespace-pre-wrap break-words">{c.content}</p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function Avatar({ name, fileName }: { name: string; fileName?: string }) {
+  // getUserAvatarUrl 永远返回有效 URL（缺头像时回退内置 data-uri），无需额外兜底分支
+  const url = getUserAvatarUrl({ avatarFileName: fileName, displayName: name });
+  return (
+    <img
+      src={url}
+      alt={name}
+      className="w-8 h-8 rounded-full object-cover shrink-0 bg-white/10"
+    />
+  );
+}
+
+function formatTime(iso: string): string {
+  const d = new Date(iso);
+  const now = Date.now();
+  const diff = Math.floor((now - d.getTime()) / 1000);
+  if (diff < 60) return '刚刚';
+  if (diff < 3600) return `${Math.floor(diff / 60)} 分钟前`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)} 小时前`;
+  if (diff < 86400 * 30) return `${Math.floor(diff / 86400)} 天前`;
+  return d.toLocaleDateString('zh-CN');
+}

--- a/prd-admin/src/components/web-hosting/CommentsSection.tsx
+++ b/prd-admin/src/components/web-hosting/CommentsSection.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { MessageSquare, Send, Trash2, Lock } from 'lucide-react';
 import { MapSpinner, MapSectionLoader } from '../ui/VideoLoader';
 import { getUserAvatarUrl } from '../../lib/avatar';
@@ -17,14 +17,16 @@ import {
  * - mode='share'：经分享 token 读写（公开访问路径，读不需登录、写需登录）
  * - mode='site' ：经 siteId 读写（owner / 团队成员视角，恒需登录）
  *
- * 走 prd-admin 暗色面板配色（与 SharedSitePage / SitePreviewModal 一致）。
+ * 走 prd-admin 暗色面板配色（与 ShareViewPage / SitePreviewModal 一致）。
  */
 type Props =
   | { mode: 'share'; token: string; password?: string; siteId?: never }
   | { mode: 'site'; siteId: string; token?: never; password?: never };
 
 export default function CommentsSection(props: Props) {
-  const { isAuthenticated } = useAuthStore();
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  // 鉴权 token：persist rehydration 后才有值；纳入 load 依赖，避免首帧匿名拉取后 canComment 卡 false
+  const authToken = useAuthStore((s) => s.token);
   const [loading, setLoading] = useState(true);
   const [comments, setComments] = useState<HostedSiteCommentDto[]>([]);
   const [commentsEnabled, setCommentsEnabled] = useState(true);
@@ -33,13 +35,23 @@ export default function CommentsSection(props: Props) {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // 防竞态：token/password/siteId/登录态变化时旧请求回来不得覆盖新结果（Cursor learned rule）
+  const fetchIdRef = useRef(0);
+
+  const mode = props.mode;
+  const token = (props as { token?: string }).token;
+  const password = (props as { password?: string }).password;
+  const siteId = (props as { siteId?: string }).siteId;
+
   const load = useCallback(async () => {
+    const myId = ++fetchIdRef.current;
     setLoading(true);
     setError(null);
     try {
-      const res = props.mode === 'share'
-        ? await listShareComments(props.token, props.password)
-        : await listSiteComments(props.siteId);
+      const res = mode === 'share'
+        ? await listShareComments(token!, password)
+        : await listSiteComments(siteId!);
+      if (myId !== fetchIdRef.current) return; // 过期响应，丢弃
       if (res.success && res.data) {
         setComments(res.data.comments);
         setCommentsEnabled(res.data.commentsEnabled);
@@ -48,16 +60,18 @@ export default function CommentsSection(props: Props) {
         setError(res.error?.message || '加载评论失败');
       }
     } catch {
+      if (myId !== fetchIdRef.current) return;
       setError('网络错误，无法加载评论');
     } finally {
-      setLoading(false);
+      if (myId === fetchIdRef.current) setLoading(false);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.mode, (props as { token?: string }).token, (props as { password?: string }).password, (props as { siteId?: string }).siteId]);
+  }, [mode, token, password, siteId]);
 
+  // isAuthenticated / authToken 纳入依赖：登录态就绪（含 persist rehydration）后重新拉取，
+  // 让已登录用户拿到 canComment=true 的发表 UI，不必手动刷新。
   useEffect(() => {
-    load();
-  }, [load]);
+    void load();
+  }, [load, isAuthenticated, authToken]);
 
   const handleSubmit = async () => {
     const content = draft.trim();
@@ -65,9 +79,9 @@ export default function CommentsSection(props: Props) {
     setSubmitting(true);
     setError(null);
     try {
-      const res = props.mode === 'share'
-        ? await addShareComment(props.token, content, props.password)
-        : await addSiteComment(props.siteId, content);
+      const res = mode === 'share'
+        ? await addShareComment(token!, content, password)
+        : await addSiteComment(siteId!, content);
       if (res.success && res.data) {
         setComments((prev) => [res.data!, ...prev]);
         setDraft('');

--- a/prd-admin/src/components/web-hosting/CommentsSection.tsx
+++ b/prd-admin/src/components/web-hosting/CommentsSection.tsx
@@ -45,10 +45,9 @@ export default function CommentsSection(props: Props) {
   const mountedRef = useRef(true);
   useEffect(() => {
     mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-      fetchIdRef.current++; // 让在途请求的 myId 失配，彻底丢弃
-    };
+    // 卸载只翻 mountedRef：所有在途 handler（load/submit/delete）都已用 !mountedRef.current 兜底丢弃，
+    // 无需再动 fetchIdRef（动它会触发 react-hooks/exhaustive-deps 的 ref-in-cleanup 告警）。
+    return () => { mountedRef.current = false; };
   }, []);
 
   const mode = props.mode;
@@ -94,25 +93,26 @@ export default function CommentsSection(props: Props) {
   const handleSubmit = async () => {
     const content = draft.trim();
     if (!content || submitting) return;
-    const reqId = fetchIdRef.current; // 锁定当前线程，回来后变了就丢弃（防串线程，Cursor learned rule）
     setSubmitting(true);
     setError(null);
     try {
       const res = mode === 'share'
         ? await addShareComment(token!, content, password)
         : await addSiteComment(siteId!, content);
-      if (reqId !== fetchIdRef.current) return; // token/siteId/password/登录态已变，结果作废
+      if (!mountedRef.current) return;
       if (res.success && res.data) {
-        setComments((prev) => [res.data!, ...prev]);
         setDraft('');
+        // 发表成功后用 load() 重新拉取作为唯一真相：load 在 server commit 之后发起、自带 fetchId/mounted
+        // 守卫，因此新评论必然出现，且不会被"提交前发起、提交后才返回"的并发 reload 覆盖（Cursor medium）。
+        // 不再做乐观 prepend —— 乐观更新与并发 reload 的竞态正是这一系列 bug 的根源。
+        await load();
       } else {
         setError(res.error?.message || '发表失败');
       }
     } catch {
-      if (reqId !== fetchIdRef.current) return;
-      setError('网络错误，发表失败');
+      if (mountedRef.current) setError('网络错误，发表失败');
     } finally {
-      if (reqId === fetchIdRef.current) setSubmitting(false);
+      if (mountedRef.current) setSubmitting(false);
     }
   };
 

--- a/prd-admin/src/components/web-hosting/CommentsSection.tsx
+++ b/prd-admin/src/components/web-hosting/CommentsSection.tsx
@@ -25,6 +25,8 @@ type Props = (
 ) & {
   /** 服务端权威 commentsEnabled 拉到后回传，供父级（预览弹窗开关）与 stale site 快照对齐 */
   onStateLoaded?: (commentsEnabled: boolean) => void;
+  /** 评论数变化时回传（含首次加载、发表、删除），供父级在顶栏按钮等处展示「评论 N」 */
+  onCountChange?: (count: number) => void;
 };
 
 export default function CommentsSection(props: Props) {
@@ -58,6 +60,13 @@ export default function CommentsSection(props: Props) {
   // 避免 iframe onLoad 等无关 modal 重渲染触发评论列表重新拉取 + loading 闪烁（Cursor medium）
   const onStateLoadedRef = useRef(props.onStateLoaded);
   onStateLoadedRef.current = props.onStateLoaded;
+  // 走 ref 同理：父级内联函数每次 render 都换新引用，不该污染下面 effect 的依赖
+  const onCountChangeRef = useRef(props.onCountChange);
+  onCountChangeRef.current = props.onCountChange;
+  // 评论数变化（首次加载 / 乐观插入 / 删除 / 对账）回传父级，顶栏「评论 N」实时同步
+  useEffect(() => {
+    onCountChangeRef.current?.(comments.length);
+  }, [comments.length]);
 
   // silent=true：后台对账刷新，不翻 loading（否则全屏 section loader 会盖掉刚乐观插入的评论，
   // 让发表后的新评论"闪没"，慢/失败的刷新更像没发成功，Cursor medium）。

--- a/prd-admin/src/components/web-hosting/CommentsSection.tsx
+++ b/prd-admin/src/components/web-hosting/CommentsSection.tsx
@@ -101,10 +101,13 @@ export default function CommentsSection(props: Props) {
         : await addSiteComment(siteId!, content);
       if (!mountedRef.current) return;
       if (res.success && res.data) {
+        const created = res.data;
         setDraft('');
-        // 发表成功后用 load() 重新拉取作为唯一真相：load 在 server commit 之后发起、自带 fetchId/mounted
-        // 守卫，因此新评论必然出现，且不会被"提交前发起、提交后才返回"的并发 reload 覆盖（Cursor medium）。
-        // 不再做乐观 prepend —— 乐观更新与并发 reload 的竞态正是这一系列 bug 的根源。
+        // 1) 乐观插入（按 id 去重）：服务端已落库，立即上屏 —— 即使下面 load() 失败，评论也已可见，
+        //    用户不会以为没发出去而重复提交导致重复评论（Cursor medium: refresh fail → duplicate）。
+        setComments((prev) => (prev.some((c) => c.id === created.id) ? prev : [created, ...prev]));
+        // 2) 再 load() 对账拿服务端真相（含他人新评论 / 准确时间戳）。best-effort：失败也无妨，
+        //    乐观插入已兜底；若并发 reload 漏掉本条，本次 load 会补正。
         await load();
       } else {
         setError(res.error?.message || '发表失败');

--- a/prd-admin/src/components/web-hosting/CommentsSection.tsx
+++ b/prd-admin/src/components/web-hosting/CommentsSection.tsx
@@ -59,9 +59,11 @@ export default function CommentsSection(props: Props) {
   const onStateLoadedRef = useRef(props.onStateLoaded);
   onStateLoadedRef.current = props.onStateLoaded;
 
-  const load = useCallback(async () => {
+  // silent=true：后台对账刷新，不翻 loading（否则全屏 section loader 会盖掉刚乐观插入的评论，
+  // 让发表后的新评论"闪没"，慢/失败的刷新更像没发成功，Cursor medium）。
+  const load = useCallback(async (silent = false) => {
     const myId = ++fetchIdRef.current;
-    setLoading(true);
+    if (!silent) setLoading(true);
     setError(null);
     try {
       const res = mode === 'share'
@@ -73,14 +75,15 @@ export default function CommentsSection(props: Props) {
         setCommentsEnabled(res.data.commentsEnabled);
         setCanComment(res.data.canComment);
         onStateLoadedRef.current?.(res.data.commentsEnabled);
-      } else {
+      } else if (!silent) {
+        // 后台刷新失败保持静默：乐观插入的评论仍在屏上，不该用错误提示打断（发表已成功）
         setError(res.error?.message || '加载评论失败');
       }
     } catch {
       if (myId !== fetchIdRef.current || !mountedRef.current) return;
-      setError('网络错误，无法加载评论');
+      if (!silent) setError('网络错误，无法加载评论');
     } finally {
-      if (myId === fetchIdRef.current && mountedRef.current) setLoading(false);
+      if (myId === fetchIdRef.current && mountedRef.current && !silent) setLoading(false);
     }
   }, [mode, token, password, siteId]);
 
@@ -106,9 +109,9 @@ export default function CommentsSection(props: Props) {
         // 1) 乐观插入（按 id 去重）：服务端已落库，立即上屏 —— 即使下面 load() 失败，评论也已可见，
         //    用户不会以为没发出去而重复提交导致重复评论（Cursor medium: refresh fail → duplicate）。
         setComments((prev) => (prev.some((c) => c.id === created.id) ? prev : [created, ...prev]));
-        // 2) 再 load() 对账拿服务端真相（含他人新评论 / 准确时间戳）。best-effort：失败也无妨，
-        //    乐观插入已兜底；若并发 reload 漏掉本条，本次 load 会补正。
-        await load();
+        // 2) 再静默 load() 对账拿服务端真相（含他人新评论 / 准确时间戳）。silent=不翻 loading，
+        //    乐观插入的评论全程留在屏上；best-effort：失败也无妨，乐观插入已兜底。
+        await load(true);
       } else {
         setError(res.error?.message || '发表失败');
       }

--- a/prd-admin/src/components/web-hosting/CommentsSection.tsx
+++ b/prd-admin/src/components/web-hosting/CommentsSection.tsx
@@ -19,9 +19,13 @@ import {
  *
  * 走 prd-admin 暗色面板配色（与 ShareViewPage / SitePreviewModal 一致）。
  */
-type Props =
+type Props = (
   | { mode: 'share'; token: string; password?: string; siteId?: never }
-  | { mode: 'site'; siteId: string; token?: never; password?: never };
+  | { mode: 'site'; siteId: string; token?: never; password?: never }
+) & {
+  /** 服务端权威 commentsEnabled 拉到后回传，供父级（预览弹窗开关）与 stale site 快照对齐 */
+  onStateLoaded?: (commentsEnabled: boolean) => void;
+};
 
 export default function CommentsSection(props: Props) {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
@@ -42,6 +46,7 @@ export default function CommentsSection(props: Props) {
   const token = (props as { token?: string }).token;
   const password = (props as { password?: string }).password;
   const siteId = (props as { siteId?: string }).siteId;
+  const onStateLoaded = props.onStateLoaded;
 
   const load = useCallback(async () => {
     const myId = ++fetchIdRef.current;
@@ -56,6 +61,7 @@ export default function CommentsSection(props: Props) {
         setComments(res.data.comments);
         setCommentsEnabled(res.data.commentsEnabled);
         setCanComment(res.data.canComment);
+        onStateLoaded?.(res.data.commentsEnabled);
       } else {
         setError(res.error?.message || '加载评论失败');
       }
@@ -65,7 +71,7 @@ export default function CommentsSection(props: Props) {
     } finally {
       if (myId === fetchIdRef.current) setLoading(false);
     }
-  }, [mode, token, password, siteId]);
+  }, [mode, token, password, siteId, onStateLoaded]);
 
   // isAuthenticated / authToken 纳入依赖：登录态就绪（含 persist rehydration）后重新拉取，
   // 让已登录用户拿到 canComment=true 的发表 UI，不必手动刷新。
@@ -76,12 +82,14 @@ export default function CommentsSection(props: Props) {
   const handleSubmit = async () => {
     const content = draft.trim();
     if (!content || submitting) return;
+    const reqId = fetchIdRef.current; // 锁定当前线程，回来后变了就丢弃（防串线程，Cursor learned rule）
     setSubmitting(true);
     setError(null);
     try {
       const res = mode === 'share'
         ? await addShareComment(token!, content, password)
         : await addSiteComment(siteId!, content);
+      if (reqId !== fetchIdRef.current) return; // token/siteId/password/登录态已变，结果作废
       if (res.success && res.data) {
         setComments((prev) => [res.data!, ...prev]);
         setDraft('');
@@ -89,14 +97,17 @@ export default function CommentsSection(props: Props) {
         setError(res.error?.message || '发表失败');
       }
     } catch {
+      if (reqId !== fetchIdRef.current) return;
       setError('网络错误，发表失败');
     } finally {
-      setSubmitting(false);
+      if (reqId === fetchIdRef.current) setSubmitting(false);
     }
   };
 
   const handleDelete = async (commentId: string) => {
+    const reqId = fetchIdRef.current;
     const res = await deleteSiteComment(commentId);
+    if (reqId !== fetchIdRef.current) return; // 删除在途时线程已切换，late 响应不动新线程的列表
     if (res.success) {
       setComments((prev) => prev.filter((c) => c.id !== commentId));
     } else {

--- a/prd-admin/src/components/web-hosting/SitePreviewModal.tsx
+++ b/prd-admin/src/components/web-hosting/SitePreviewModal.tsx
@@ -10,13 +10,15 @@ interface Props {
   onClose: () => void;
   /** 评论开关变更后回传给父组件，避免关闭再打开时从 stale site.commentsEnabled 重新初始化 */
   onCommentsEnabledChange?: (siteId: string, enabled: boolean) => void;
+  /** 是否可改「允许访客评论」开关（仅 owner/editor）。viewer 角色只读评论、不显示开关 */
+  canToggleComments?: boolean;
 }
 
 /**
  * 站点预览模态框 —— 在 iframe 中加载站点入口 URL，右侧可展开评论面板
  * 遵循 frontend-modal.md 三硬约束: inline style 高度 + createPortal + min-h-0
  */
-export default function SitePreviewModal({ site, onClose, onCommentsEnabledChange }: Props) {
+export default function SitePreviewModal({ site, onClose, onCommentsEnabledChange, canToggleComments = true }: Props) {
   const [loading, setLoading] = useState(true);
   const [errored, setErrored] = useState(false);
   const [showComments, setShowComments] = useState(false);
@@ -144,7 +146,8 @@ export default function SitePreviewModal({ site, onClose, onCommentsEnabledChang
             <aside
               className="w-[360px] shrink-0 border-l border-white/10 flex flex-col min-h-0 bg-[#0f1014]"
             >
-              {/* 允许评论开关 */}
+              {/* 允许评论开关：仅 owner/editor 显示（viewer 无权改，显示了点不动反而困惑） */}
+              {canToggleComments && (
               <div className="flex items-center justify-between gap-2 px-4 py-3 border-b border-white/10 shrink-0">
                 <span className="text-xs text-white/60">允许访客评论</span>
                 <button
@@ -163,6 +166,7 @@ export default function SitePreviewModal({ site, onClose, onCommentsEnabledChang
                   />
                 </button>
               </div>
+              )}
               <div
                 className="flex-1 min-h-0 overflow-y-auto p-3"
                 style={{ overscrollBehavior: 'contain' }}

--- a/prd-admin/src/components/web-hosting/SitePreviewModal.tsx
+++ b/prd-admin/src/components/web-hosting/SitePreviewModal.tsx
@@ -8,13 +8,15 @@ import CommentsSection from './CommentsSection';
 interface Props {
   site: HostedSite;
   onClose: () => void;
+  /** 评论开关变更后回传给父组件，避免关闭再打开时从 stale site.commentsEnabled 重新初始化 */
+  onCommentsEnabledChange?: (siteId: string, enabled: boolean) => void;
 }
 
 /**
  * 站点预览模态框 —— 在 iframe 中加载站点入口 URL，右侧可展开评论面板
  * 遵循 frontend-modal.md 三硬约束: inline style 高度 + createPortal + min-h-0
  */
-export default function SitePreviewModal({ site, onClose }: Props) {
+export default function SitePreviewModal({ site, onClose, onCommentsEnabledChange }: Props) {
   const [loading, setLoading] = useState(true);
   const [errored, setErrored] = useState(false);
   const [showComments, setShowComments] = useState(false);
@@ -50,7 +52,11 @@ export default function SitePreviewModal({ site, onClose }: Props) {
     const next = !commentsEnabled;
     setTogglingComments(true);
     const res = await setSiteCommentsEnabled(site.id, next);
-    if (res.success) setCommentsEnabled(next);
+    if (res.success) {
+      setCommentsEnabled(next);
+      // 回传父组件，更新其持有的 site 快照（修复关闭再打开开关回退到旧值）
+      onCommentsEnabledChange?.(site.id, next);
+    }
     setTogglingComments(false);
   };
 
@@ -99,8 +105,8 @@ export default function SitePreviewModal({ site, onClose }: Props) {
 
         {/* 主体：iframe + 可选评论面板 */}
         <div className="flex-1 min-h-0 flex">
-          {/* iframe 容器 */}
-          <div className="flex-1 min-w-0 relative bg-white">
+          {/* iframe 容器（底色用面板深色，避免站点白底加载瞬间在暗色后台里突兀闪白） */}
+          <div className="flex-1 min-w-0 relative bg-[#0f1014]">
             {loading && (
               <div className="absolute inset-0 flex items-center justify-center bg-[#0f1014]">
                 <Loader2 className="w-8 h-8 animate-spin text-white/40" />
@@ -122,7 +128,12 @@ export default function SitePreviewModal({ site, onClose }: Props) {
               ref={iframeRef}
               src={site.siteUrl}
               className="w-full h-full"
-              onLoad={() => setLoading(false)}
+              onLoad={() => {
+                // iframe 成功加载：清 loading 同时清 errored
+                // 修复"超时已置 errored，但站点随后加载成功，错误遮罩却一直盖住"（Cursor medium）
+                setLoading(false);
+                setErrored(false);
+              }}
               sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-modals"
               title={site.title}
             />

--- a/prd-admin/src/components/web-hosting/SitePreviewModal.tsx
+++ b/prd-admin/src/components/web-hosting/SitePreviewModal.tsx
@@ -167,8 +167,19 @@ export default function SitePreviewModal({ site, onClose, onCommentsEnabledChang
                 className="flex-1 min-h-0 overflow-y-auto p-3"
                 style={{ overscrollBehavior: 'contain' }}
               >
-                {/* key 随开关变化，强制刷新评论区的 commentsEnabled 态 */}
-                <CommentsSection key={String(commentsEnabled)} mode="site" siteId={site.id} />
+                {/* key 随开关变化，强制刷新评论区的 commentsEnabled 态；
+                    onStateLoaded 用服务端权威值回填开关，消除"开关 ON 但面板显示已关闭"的 stale 偏差（Cursor medium） */}
+                <CommentsSection
+                  key={String(commentsEnabled)}
+                  mode="site"
+                  siteId={site.id}
+                  onStateLoaded={(serverEnabled) => {
+                    if (serverEnabled !== commentsEnabled) {
+                      setCommentsEnabled(serverEnabled);
+                      onCommentsEnabledChange?.(site.id, serverEnabled);
+                    }
+                  }}
+                />
               </div>
             </aside>
           )}

--- a/prd-admin/src/components/web-hosting/SitePreviewModal.tsx
+++ b/prd-admin/src/components/web-hosting/SitePreviewModal.tsx
@@ -1,0 +1,170 @@
+import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { X, ExternalLink, Loader2, FileWarning, MessageSquare } from 'lucide-react';
+import type { HostedSite } from '../../services/real/webPages';
+import { setSiteCommentsEnabled } from '../../services/real/webPages';
+import CommentsSection from './CommentsSection';
+
+interface Props {
+  site: HostedSite;
+  onClose: () => void;
+}
+
+/**
+ * 站点预览模态框 —— 在 iframe 中加载站点入口 URL，右侧可展开评论面板
+ * 遵循 frontend-modal.md 三硬约束: inline style 高度 + createPortal + min-h-0
+ */
+export default function SitePreviewModal({ site, onClose }: Props) {
+  const [loading, setLoading] = useState(true);
+  const [errored, setErrored] = useState(false);
+  const [showComments, setShowComments] = useState(false);
+  const [commentsEnabled, setCommentsEnabled] = useState(site.commentsEnabled !== false);
+  const [togglingComments, setTogglingComments] = useState(false);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [onClose]);
+
+  // 加载超时检测 (10s 未触发 onLoad 视为可能失败)
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setLoading((prev) => {
+        if (prev) setErrored(true);
+        return false;
+      });
+    }, 10000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  const handleOpenExternal = () => {
+    window.open(site.siteUrl, '_blank');
+  };
+
+  const handleToggleCommentsEnabled = async () => {
+    if (togglingComments) return;
+    const next = !commentsEnabled;
+    setTogglingComments(true);
+    const res = await setSiteCommentsEnabled(site.id, next);
+    if (res.success) setCommentsEnabled(next);
+    setTogglingComments(false);
+  };
+
+  const modal = (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 backdrop-blur-sm p-4"
+      onClick={onClose}
+    >
+      <div
+        className="relative flex flex-col rounded-xl border border-white/10 bg-[#0f1014] shadow-2xl"
+        style={{ width: '90vw', height: '90vh', maxWidth: '1400px' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* 头部 */}
+        <div className="flex items-center justify-between gap-3 px-4 py-3 border-b border-white/10 shrink-0">
+          <div className="min-w-0 flex-1">
+            <h3 className="text-sm font-semibold text-white truncate">{site.title}</h3>
+            <p className="text-xs text-white/40 truncate">{site.siteUrl}</p>
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            <button
+              onClick={() => setShowComments((v) => !v)}
+              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs transition-colors ${
+                showComments ? 'bg-blue-600/80 text-white' : 'bg-white/5 hover:bg-white/10 text-white/70'
+              }`}
+            >
+              <MessageSquare className="w-3.5 h-3.5" />
+              评论
+            </button>
+            <button
+              onClick={handleOpenExternal}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-white/5 hover:bg-white/10 text-white/70 text-xs transition-colors"
+            >
+              <ExternalLink className="w-3.5 h-3.5" />
+              新窗口打开
+            </button>
+            <button
+              onClick={onClose}
+              className="flex items-center justify-center w-8 h-8 rounded-lg bg-white/5 hover:bg-white/10 text-white/70 transition-colors"
+              title="关闭"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+
+        {/* 主体：iframe + 可选评论面板 */}
+        <div className="flex-1 min-h-0 flex">
+          {/* iframe 容器 */}
+          <div className="flex-1 min-w-0 relative bg-white">
+            {loading && (
+              <div className="absolute inset-0 flex items-center justify-center bg-[#0f1014]">
+                <Loader2 className="w-8 h-8 animate-spin text-white/40" />
+              </div>
+            )}
+            {errored && (
+              <div className="absolute inset-0 flex flex-col items-center justify-center bg-[#0f1014] gap-3">
+                <FileWarning className="w-12 h-12 text-amber-400/70" />
+                <p className="text-sm text-white/60">站点加载超时或失败</p>
+                <button
+                  onClick={handleOpenExternal}
+                  className="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-white text-sm"
+                >
+                  在新窗口打开
+                </button>
+              </div>
+            )}
+            <iframe
+              ref={iframeRef}
+              src={site.siteUrl}
+              className="w-full h-full"
+              onLoad={() => setLoading(false)}
+              sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-modals"
+              title={site.title}
+            />
+          </div>
+
+          {/* 评论面板 */}
+          {showComments && (
+            <aside
+              className="w-[360px] shrink-0 border-l border-white/10 flex flex-col min-h-0 bg-[#0f1014]"
+            >
+              {/* 允许评论开关 */}
+              <div className="flex items-center justify-between gap-2 px-4 py-3 border-b border-white/10 shrink-0">
+                <span className="text-xs text-white/60">允许访客评论</span>
+                <button
+                  onClick={handleToggleCommentsEnabled}
+                  disabled={togglingComments}
+                  role="switch"
+                  aria-checked={commentsEnabled}
+                  className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors disabled:opacity-50 ${
+                    commentsEnabled ? 'bg-blue-600' : 'bg-white/15'
+                  }`}
+                >
+                  <span
+                    className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                      commentsEnabled ? 'translate-x-4' : 'translate-x-0.5'
+                    }`}
+                  />
+                </button>
+              </div>
+              <div
+                className="flex-1 min-h-0 overflow-y-auto p-3"
+                style={{ overscrollBehavior: 'contain' }}
+              >
+                {/* key 随开关变化，强制刷新评论区的 commentsEnabled 态 */}
+                <CommentsSection key={String(commentsEnabled)} mode="site" siteId={site.id} />
+              </div>
+            </aside>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+
+  return createPortal(modal, document.body);
+}

--- a/prd-admin/src/pages/ShareViewPage.tsx
+++ b/prd-admin/src/pages/ShareViewPage.tsx
@@ -6,6 +6,7 @@ import { useAuthStore } from '@/stores/authStore';
 import { Lock, ExternalLink, FileCode2, Eye, EyeOff, AlertCircle, ShieldCheck, Unlock, Download, Check, LogIn } from 'lucide-react';
 import { BlackHoleVortex } from '@/components/effects/BlackHoleVortex';
 import { BlurText } from '@/components/reactbits';
+import CommentsSection from '@/components/web-hosting/CommentsSection';
 
 function fmtSize(b: number) {
   if (b < 1024) return `${b} B`;

--- a/prd-admin/src/pages/ShareViewPage.tsx
+++ b/prd-admin/src/pages/ShareViewPage.tsx
@@ -393,6 +393,14 @@ export default function ShareViewPage({ tokenOverride }: ShareViewPageProps = {}
           style={{ flex: 1, border: 'none', width: '100%' }}
           sandbox={site.pdfAssetUrl ? undefined : 'allow-scripts allow-same-origin allow-popups allow-forms'}
         />
+        {/* 评论区：iframe 下方可滚动区，访客可读、登录后可评（token 必有） */}
+        {token && (
+          <div style={{ flexShrink: 0, maxHeight: '40vh', overflowY: 'auto', overscrollBehavior: 'contain', background: '#0a0a0a', borderTop: '1px solid rgba(255,255,255,0.06)' }}>
+            <div style={{ maxWidth: 820, margin: '0 auto', padding: '16px' }}>
+              <CommentsSection mode="share" token={token} password={password || undefined} />
+            </div>
+          </div>
+        )}
       </div>
     );
   }

--- a/prd-admin/src/pages/ShareViewPage.tsx
+++ b/prd-admin/src/pages/ShareViewPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useRef, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { viewSiteShare, saveSharedSite } from '@/services';
 import type { ShareViewData } from '@/services';
+import { listShareComments } from '@/services/real/webPages';
 import { useAuthStore } from '@/stores/authStore';
 import { Lock, ExternalLink, FileCode2, Eye, EyeOff, AlertCircle, ShieldCheck, Unlock, Download, Check, LogIn, MessageSquare, X } from 'lucide-react';
 import { BlackHoleVortex } from '@/components/effects/BlackHoleVortex';
@@ -37,8 +38,10 @@ export default function ShareViewPage({ tokenOverride }: ShareViewPageProps = {}
   const inputRef = useRef<HTMLInputElement>(null);
   const [saving, setSaving] = useState(false);
   const [saveStatus, setSaveStatus] = useState<'idle' | 'saved' | 'already'>('idle');
-  // 评论抽屉：单站点分享页右下角浮动「评论」按钮打开（避免只在 iframe 下方、需往下滚才看见）
+  // 评论抽屉：由顶栏「评论 N」按钮打开（PPT/全屏页无滚动条，评论不能放底部）
   const [showComments, setShowComments] = useState(false);
+  // 顶栏按钮上展示的评论数。初始拉一次，抽屉打开后由 CommentsSection 的 onCountChange 接管实时同步
+  const [commentCount, setCommentCount] = useState<number | null>(null);
 
   const handleSave = useCallback(async () => {
     if (!token) return;
@@ -90,6 +93,16 @@ export default function ShareViewPage({ tokenOverride }: ShareViewPageProps = {}
     fetchShare();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [token]);
+
+  // 顶栏「评论 N」初始计数：单站点分享 + token 就绪后拉一次（抽屉打开后由 onCountChange 接管）
+  useEffect(() => {
+    if (!token || !data || data.sites.length !== 1) return;
+    let alive = true;
+    listShareComments(token, password || undefined)
+      .then((res) => { if (alive && res.success && res.data) setCommentCount(res.data.comments.length); })
+      .catch(() => {});
+    return () => { alive = false; };
+  }, [token, password, data]);
 
   const handlePasswordSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -383,6 +396,17 @@ export default function ShareViewPage({ tokenOverride }: ShareViewPageProps = {}
               <ExternalLink size={12} />
               新窗口打开
             </a>
+            {/* 评论入口放在顶栏（MAP 自己的 chrome）：PPT/全屏页无滚动条，底部放评论区不可达；
+                浮动按钮又会盖住 PPT 右下角的翻页控件。顶栏按钮零侵入页面布局，点击从右侧抽屉打开。 */}
+            {token && (
+              <button
+                onClick={() => setShowComments(true)}
+                style={{ display: 'flex', alignItems: 'center', gap: 4, padding: 0, border: 'none', background: 'transparent', color: '#3b82f6', fontSize: 13, cursor: 'pointer' }}
+              >
+                <MessageSquare size={12} />
+                评论{commentCount != null && commentCount > 0 ? ` ${commentCount}` : ''}
+              </button>
+            )}
           </div>
         </div>
         {/* Iframe
@@ -396,66 +420,44 @@ export default function ShareViewPage({ tokenOverride }: ShareViewPageProps = {}
           sandbox={site.pdfAssetUrl ? undefined : 'allow-scripts allow-same-origin allow-popups allow-forms'}
         />
 
-        {/* 评论：右下角浮动按钮 + 右侧滑出抽屉。访客一眼可见入口，不必往下滚（token 必有） */}
-        {token && (
+        {/* 评论：右侧滑出抽屉（由顶栏「评论」按钮打开）。不占页面布局、不盖 PPT 控件（token 必有） */}
+        {token && showComments && (
           <>
-            {!showComments && (
-              <button
-                onClick={() => setShowComments(true)}
-                title="评论"
-                style={{
-                  position: 'fixed', right: 20, bottom: 20, zIndex: 50,
-                  display: 'flex', alignItems: 'center', gap: 8,
-                  padding: '12px 18px', borderRadius: 9999, border: 'none', cursor: 'pointer',
-                  background: 'rgba(59, 130, 246, 0.95)', color: '#fff',
-                  fontSize: 14, fontWeight: 600,
-                  boxShadow: '0 8px 24px rgba(0,0,0,0.4)',
-                  backdropFilter: 'blur(8px)', WebkitBackdropFilter: 'blur(8px)',
-                }}
-              >
-                <MessageSquare size={16} />
-                评论
-              </button>
-            )}
-            {showComments && (
-              <>
-                {/* 遮罩：点击关闭 */}
-                <div
+            {/* 遮罩：点击关闭 */}
+            <div
+              onClick={() => setShowComments(false)}
+              style={{ position: 'fixed', inset: 0, zIndex: 60, background: 'rgba(0,0,0,0.4)' }}
+            />
+            {/* 右侧抽屉 */}
+            <aside
+              style={{
+                position: 'fixed', top: 0, right: 0, bottom: 0, zIndex: 61,
+                width: 'min(420px, 92vw)', display: 'flex', flexDirection: 'column',
+                background: '#0f1014', borderLeft: '1px solid rgba(255,255,255,0.1)',
+                boxShadow: '-12px 0 40px rgba(0,0,0,0.5)',
+              }}
+            >
+              <div style={{
+                display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                padding: '12px 16px', borderBottom: '1px solid rgba(255,255,255,0.08)', flexShrink: 0,
+              }}>
+                <span style={{ color: '#fff', fontSize: 14, fontWeight: 600 }}>评论</span>
+                <button
                   onClick={() => setShowComments(false)}
-                  style={{ position: 'fixed', inset: 0, zIndex: 60, background: 'rgba(0,0,0,0.4)' }}
-                />
-                {/* 右侧抽屉 */}
-                <aside
+                  title="关闭"
                   style={{
-                    position: 'fixed', top: 0, right: 0, bottom: 0, zIndex: 61,
-                    width: 'min(420px, 92vw)', display: 'flex', flexDirection: 'column',
-                    background: '#0f1014', borderLeft: '1px solid rgba(255,255,255,0.1)',
-                    boxShadow: '-12px 0 40px rgba(0,0,0,0.5)',
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    width: 28, height: 28, borderRadius: 8, border: 'none', cursor: 'pointer',
+                    background: 'rgba(255,255,255,0.06)', color: 'rgba(255,255,255,0.7)',
                   }}
                 >
-                  <div style={{
-                    display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-                    padding: '12px 16px', borderBottom: '1px solid rgba(255,255,255,0.08)', flexShrink: 0,
-                  }}>
-                    <span style={{ color: '#fff', fontSize: 14, fontWeight: 600 }}>评论</span>
-                    <button
-                      onClick={() => setShowComments(false)}
-                      title="关闭"
-                      style={{
-                        display: 'flex', alignItems: 'center', justifyContent: 'center',
-                        width: 28, height: 28, borderRadius: 8, border: 'none', cursor: 'pointer',
-                        background: 'rgba(255,255,255,0.06)', color: 'rgba(255,255,255,0.7)',
-                      }}
-                    >
-                      <X size={16} />
-                    </button>
-                  </div>
-                  <div style={{ flex: 1, minHeight: 0, overflowY: 'auto', overscrollBehavior: 'contain', padding: 16 }}>
-                    <CommentsSection mode="share" token={token} password={password || undefined} />
-                  </div>
-                </aside>
-              </>
-            )}
+                  <X size={16} />
+                </button>
+              </div>
+              <div style={{ flex: 1, minHeight: 0, overflowY: 'auto', overscrollBehavior: 'contain', padding: 16 }}>
+                <CommentsSection mode="share" token={token} password={password || undefined} onCountChange={setCommentCount} />
+              </div>
+            </aside>
           </>
         )}
       </div>

--- a/prd-admin/src/pages/ShareViewPage.tsx
+++ b/prd-admin/src/pages/ShareViewPage.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { viewSiteShare, saveSharedSite } from '@/services';
 import type { ShareViewData } from '@/services';
 import { useAuthStore } from '@/stores/authStore';
-import { Lock, ExternalLink, FileCode2, Eye, EyeOff, AlertCircle, ShieldCheck, Unlock, Download, Check, LogIn } from 'lucide-react';
+import { Lock, ExternalLink, FileCode2, Eye, EyeOff, AlertCircle, ShieldCheck, Unlock, Download, Check, LogIn, MessageSquare, X } from 'lucide-react';
 import { BlackHoleVortex } from '@/components/effects/BlackHoleVortex';
 import { BlurText } from '@/components/reactbits';
 import CommentsSection from '@/components/web-hosting/CommentsSection';
@@ -37,6 +37,8 @@ export default function ShareViewPage({ tokenOverride }: ShareViewPageProps = {}
   const inputRef = useRef<HTMLInputElement>(null);
   const [saving, setSaving] = useState(false);
   const [saveStatus, setSaveStatus] = useState<'idle' | 'saved' | 'already'>('idle');
+  // 评论抽屉：单站点分享页右下角浮动「评论」按钮打开（避免只在 iframe 下方、需往下滚才看见）
+  const [showComments, setShowComments] = useState(false);
 
   const handleSave = useCallback(async () => {
     if (!token) return;
@@ -393,13 +395,68 @@ export default function ShareViewPage({ tokenOverride }: ShareViewPageProps = {}
           style={{ flex: 1, border: 'none', width: '100%' }}
           sandbox={site.pdfAssetUrl ? undefined : 'allow-scripts allow-same-origin allow-popups allow-forms'}
         />
-        {/* 评论区：iframe 下方可滚动区，访客可读、登录后可评（token 必有） */}
+
+        {/* 评论：右下角浮动按钮 + 右侧滑出抽屉。访客一眼可见入口，不必往下滚（token 必有） */}
         {token && (
-          <div style={{ flexShrink: 0, maxHeight: '40vh', overflowY: 'auto', overscrollBehavior: 'contain', background: '#0a0a0a', borderTop: '1px solid rgba(255,255,255,0.06)' }}>
-            <div style={{ maxWidth: 820, margin: '0 auto', padding: '16px' }}>
-              <CommentsSection mode="share" token={token} password={password || undefined} />
-            </div>
-          </div>
+          <>
+            {!showComments && (
+              <button
+                onClick={() => setShowComments(true)}
+                title="评论"
+                style={{
+                  position: 'fixed', right: 20, bottom: 20, zIndex: 50,
+                  display: 'flex', alignItems: 'center', gap: 8,
+                  padding: '12px 18px', borderRadius: 9999, border: 'none', cursor: 'pointer',
+                  background: 'rgba(59, 130, 246, 0.95)', color: '#fff',
+                  fontSize: 14, fontWeight: 600,
+                  boxShadow: '0 8px 24px rgba(0,0,0,0.4)',
+                  backdropFilter: 'blur(8px)', WebkitBackdropFilter: 'blur(8px)',
+                }}
+              >
+                <MessageSquare size={16} />
+                评论
+              </button>
+            )}
+            {showComments && (
+              <>
+                {/* 遮罩：点击关闭 */}
+                <div
+                  onClick={() => setShowComments(false)}
+                  style={{ position: 'fixed', inset: 0, zIndex: 60, background: 'rgba(0,0,0,0.4)' }}
+                />
+                {/* 右侧抽屉 */}
+                <aside
+                  style={{
+                    position: 'fixed', top: 0, right: 0, bottom: 0, zIndex: 61,
+                    width: 'min(420px, 92vw)', display: 'flex', flexDirection: 'column',
+                    background: '#0f1014', borderLeft: '1px solid rgba(255,255,255,0.1)',
+                    boxShadow: '-12px 0 40px rgba(0,0,0,0.5)',
+                  }}
+                >
+                  <div style={{
+                    display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                    padding: '12px 16px', borderBottom: '1px solid rgba(255,255,255,0.08)', flexShrink: 0,
+                  }}>
+                    <span style={{ color: '#fff', fontSize: 14, fontWeight: 600 }}>评论</span>
+                    <button
+                      onClick={() => setShowComments(false)}
+                      title="关闭"
+                      style={{
+                        display: 'flex', alignItems: 'center', justifyContent: 'center',
+                        width: 28, height: 28, borderRadius: 8, border: 'none', cursor: 'pointer',
+                        background: 'rgba(255,255,255,0.06)', color: 'rgba(255,255,255,0.7)',
+                      }}
+                    >
+                      <X size={16} />
+                    </button>
+                  </div>
+                  <div style={{ flex: 1, minHeight: 0, overflowY: 'auto', overscrollBehavior: 'contain', padding: 16 }}>
+                    <CommentsSection mode="share" token={token} password={password || undefined} />
+                  </div>
+                </aside>
+              </>
+            )}
+          </>
         )}
       </div>
     );

--- a/prd-admin/src/pages/WebPagesPage.tsx
+++ b/prd-admin/src/pages/WebPagesPage.tsx
@@ -532,7 +532,7 @@ export default function WebPagesPage() {
             onReplaceFile={(file) => setReplaceTarget({ site, file })}
             onViewers={() => setViewersTarget({ siteId: site.id, siteTitle: site.title })}
             onMove={() => setMovingSite(site)}
-            onComments={siteCaps(site).canShare ? () => setCommentSite(site) : undefined}
+            onComments={() => setCommentSite(site)}
           />
         ))}
       </div>
@@ -551,7 +551,7 @@ export default function WebPagesPage() {
             onShare={() => handleShare(site.id)}
             onCancelShare={() => cancelShareForSite(site.id)}
             onQrCode={() => setQrSite(site)}
-            onComments={siteCaps(site).canShare ? () => setCommentSite(site) : undefined}
+            onComments={() => setCommentSite(site)}
           />
         ))}
       </div>
@@ -953,6 +953,7 @@ export default function WebPagesPage() {
         <SitePreviewModal
           site={commentSite}
           onClose={() => setCommentSite(null)}
+          canToggleComments={siteCaps(commentSite).canEdit}
           onCommentsEnabledChange={(sid, enabled) => {
             // 同步父组件持有的 site 快照 + 列表，避免关闭再开开关回退到旧值
             setCommentSite((prev) => (prev && prev.id === sid ? { ...prev, commentsEnabled: enabled } : prev));

--- a/prd-admin/src/pages/WebPagesPage.tsx
+++ b/prd-admin/src/pages/WebPagesPage.tsx
@@ -81,6 +81,7 @@ import {
   User,
   FolderInput,
   BarChart3,
+  MessageSquare,
   Plus,
 } from 'lucide-react';
 import { QRCodeSVG } from 'qrcode.react';

--- a/prd-admin/src/pages/WebPagesPage.tsx
+++ b/prd-admin/src/pages/WebPagesPage.tsx
@@ -950,7 +950,15 @@ export default function WebPagesPage() {
 
       {/* 评论管理：站点预览 iframe + 评论面板 + 允许评论开关 */}
       {commentSite && (
-        <SitePreviewModal site={commentSite} onClose={() => setCommentSite(null)} />
+        <SitePreviewModal
+          site={commentSite}
+          onClose={() => setCommentSite(null)}
+          onCommentsEnabledChange={(sid, enabled) => {
+            // 同步父组件持有的 site 快照 + 列表，避免关闭再开开关回退到旧值
+            setCommentSite((prev) => (prev && prev.id === sid ? { ...prev, commentsEnabled: enabled } : prev));
+            setSites((prev) => prev.map((x) => (x.id === sid ? { ...x, commentsEnabled: enabled } : x)));
+          }}
+        />
       )}
 
       {movingSite && (
@@ -1563,6 +1571,7 @@ function SiteListItem({ site, selected, shared, caps, onSelect, onEdit, onDelete
   onShare: () => void;
   onCancelShare: () => void;
   onQrCode: () => void;
+  onComments?: () => void;
 }) {
   const c = caps ?? { canEdit: true, canDelete: true, canShare: true, canSetVisibility: true };
   const isPublic = site.visibility === 'public';

--- a/prd-admin/src/pages/WebPagesPage.tsx
+++ b/prd-admin/src/pages/WebPagesPage.tsx
@@ -273,6 +273,8 @@ export default function WebPagesPage() {
   const [replaceTarget, setReplaceTarget] = useState<{ site: HostedSite; file: File } | null>(null);
   const [replacing, setReplacing] = useState(false);
   const [viewersTarget, setViewersTarget] = useState<{ siteId: string; siteTitle: string } | null>(null);
+  // 评论管理：点击站点卡「评论」按钮打开预览 + 评论面板（owner 可发表/删除 + 允许评论开关）
+  const [commentSite, setCommentSite] = useState<HostedSite | null>(null);
 
   // ─── Load ───
 
@@ -529,6 +531,7 @@ export default function WebPagesPage() {
             onReplaceFile={(file) => setReplaceTarget({ site, file })}
             onViewers={() => setViewersTarget({ siteId: site.id, siteTitle: site.title })}
             onMove={() => setMovingSite(site)}
+            onComments={siteCaps(site).canShare ? () => setCommentSite(site) : undefined}
           />
         ))}
       </div>
@@ -547,6 +550,7 @@ export default function WebPagesPage() {
             onShare={() => handleShare(site.id)}
             onCancelShare={() => cancelShareForSite(site.id)}
             onQrCode={() => setQrSite(site)}
+            onComments={siteCaps(site).canShare ? () => setCommentSite(site) : undefined}
           />
         ))}
       </div>
@@ -941,6 +945,11 @@ export default function WebPagesPage() {
           siteTitle={viewersTarget.siteTitle}
           onClose={() => setViewersTarget(null)}
         />
+      )}
+
+      {/* 评论管理：站点预览 iframe + 评论面板 + 允许评论开关 */}
+      {commentSite && (
+        <SitePreviewModal site={commentSite} onClose={() => setCommentSite(null)} />
       )}
 
       {movingSite && (
@@ -1430,6 +1439,9 @@ function SiteCard({ site, selected, fresh, shared, caps, ownerCard, onSelect, on
                 onClick={onTransferToLibrary}
               />
             )}
+            {onComments && (
+              <IconAction icon={<MessageSquare size={12} />} label="评论管理" onClick={onComments} />
+            )}
             {onViewers && (
               <IconAction icon={<Eye size={12} />} label="访客" onClick={onViewers} />
             )}
@@ -1539,7 +1551,7 @@ function IconAction({
 
 // ─── List View ───
 
-function SiteListItem({ site, selected, shared, caps, onSelect, onEdit, onDelete, onShare, onCancelShare, onQrCode }: {
+function SiteListItem({ site, selected, shared, caps, onSelect, onEdit, onDelete, onShare, onCancelShare, onQrCode, onComments }: {
   site: HostedSite;
   selected: boolean;
   shared?: boolean;
@@ -1652,6 +1664,11 @@ function SiteListItem({ site, selected, shared, caps, onSelect, onEdit, onDelete
         <button onClick={onQrCode} className="p-1 rounded hover:bg-[var(--bg-hover)]" title="二维码">
           <QrCode size={14} style={{ color: 'var(--text-muted)' }} />
         </button>
+        {onComments && (
+          <button onClick={onComments} className="p-1 rounded hover:bg-[var(--bg-hover)]" title="评论管理">
+            <MessageSquare size={14} style={{ color: 'var(--text-muted)' }} />
+          </button>
+        )}
         {c.canEdit && (
           <button onClick={onEdit} className="p-1 rounded hover:bg-[var(--bg-hover)]">
             <Edit3 size={14} style={{ color: 'var(--text-muted)' }} />

--- a/prd-admin/src/pages/WebPagesPage.tsx
+++ b/prd-admin/src/pages/WebPagesPage.tsx
@@ -39,6 +39,7 @@ import { useTeamStore } from '@/stores/teamStore';
 import { recordSiteView } from '@/services/real/webAnalytics';
 import { SiteViewersDrawer } from '@/components/web-hosting/SiteViewersDrawer';
 import { ShareAnalyticsDrawer } from '@/components/web-hosting/ShareAnalyticsDrawer';
+import SitePreviewModal from '@/components/web-hosting/SitePreviewModal';
 import { createPortal } from 'react-dom';
 import type { DocumentStore } from '@/services/contracts/documentStore';
 import { ShareDock, useDockDrag } from '@/components/share-dock';
@@ -1222,7 +1223,7 @@ function TransferToLibraryDialog({ site, onClose }: { site: HostedSite; onClose:
   );
 }
 
-function SiteCard({ site, selected, fresh, shared, caps, ownerCard, onSelect, onTogglePublic, onEdit, onDelete, onShare, onCancelShare, onQrCode, onTransferToLibrary, onReplaceFile, onViewers, onMove }: {
+function SiteCard({ site, selected, fresh, shared, caps, ownerCard, onSelect, onTogglePublic, onEdit, onDelete, onShare, onCancelShare, onQrCode, onTransferToLibrary, onReplaceFile, onViewers, onMove, onComments }: {
   site: HostedSite;
   selected: boolean;
   fresh?: boolean;
@@ -1240,6 +1241,7 @@ function SiteCard({ site, selected, fresh, shared, caps, ownerCard, onSelect, on
   onTransferToLibrary: () => void;
   onReplaceFile: (file: File) => void;
   onMove?: () => void;
+  onComments?: () => void;
 }) {
   const c = caps ?? { canEdit: true, canDelete: true, canShare: true, canSetVisibility: true };
   const isPublic = site.visibility === 'public';

--- a/prd-admin/src/services/real/webPages.ts
+++ b/prd-admin/src/services/real/webPages.ts
@@ -37,6 +37,8 @@ export interface HostedSite {
   visibility?: 'private' | 'public';
   /** 首次设为 public 的时间 */
   publishedAt?: string | null;
+  /** 是否允许被评论（默认 true，owner 可关闭） */
+  commentsEnabled?: boolean;
   createdAt: string;
   updatedAt: string;
 }
@@ -397,4 +399,76 @@ export async function getShareAnalytics(rangeDays = 7, siteId?: string): Promise
   const params = new URLSearchParams({ rangeDays: String(rangeDays) });
   if (siteId) params.set('siteId', siteId);
   return apiRequest(`/api/web-pages/shares/analytics?${params.toString()}`);
+}
+
+// ─── 评论 ───
+
+export interface HostedSiteCommentDto {
+  id: string;
+  siteId: string;
+  content: string;
+  authorUserId: string;
+  authorName: string;
+  authorAvatarFileName?: string;
+  createdAt: string;
+  canDelete: boolean;
+}
+
+export interface SiteCommentsResult {
+  siteId: string;
+  commentsEnabled: boolean;
+  canComment: boolean;
+  comments: HostedSiteCommentDto[];
+}
+
+/** 切换站点是否允许评论（仅 owner / editor 可调） */
+export async function setSiteCommentsEnabled(siteId: string, enabled: boolean): Promise<ApiResponse<{ id: string; commentsEnabled: boolean }>> {
+  return apiRequest(`/api/web-pages/${encodeURIComponent(siteId)}/comments-enabled`, {
+    method: 'PATCH',
+    body: { enabled },
+  });
+}
+
+/** 列出某站点评论（owner / 团队成员视角，需登录） */
+export async function listSiteComments(siteId: string): Promise<ApiResponse<SiteCommentsResult>> {
+  return apiRequest(`/api/web-pages/${encodeURIComponent(siteId)}/comments`);
+}
+
+/** 在某站点发表评论（owner / 团队成员视角，需登录） */
+export async function addSiteComment(siteId: string, content: string): Promise<ApiResponse<HostedSiteCommentDto>> {
+  return apiRequest(`/api/web-pages/${encodeURIComponent(siteId)}/comments`, {
+    method: 'POST',
+    body: { content },
+  });
+}
+
+/** 经分享链接列出评论（无需登录即可读）。走 raw fetch（公开端点 + 可选携带 token 识别身份） */
+export async function listShareComments(token: string, password?: string): Promise<ApiResponse<SiteCommentsResult>> {
+  const q = password ? `?password=${encodeURIComponent(password)}` : '';
+  const url = joinUrl(getApiBaseUrl(), `/api/web-pages/shares/view/${encodeURIComponent(token)}/comments${q}`);
+  const headers: Record<string, string> = { Accept: 'application/json' };
+  const authToken = useAuthStore.getState().token;
+  if (authToken) headers.Authorization = `Bearer ${authToken}`;
+  try {
+    const res = await fetch(url, { headers });
+    return (await res.json()) as ApiResponse<SiteCommentsResult>;
+  } catch {
+    return { success: false, data: null as never, error: { code: 'NETWORK_ERROR', message: '网络请求失败' } };
+  }
+}
+
+/** 经分享链接发表评论（需登录） */
+export async function addShareComment(token: string, content: string, password?: string): Promise<ApiResponse<HostedSiteCommentDto>> {
+  const q = password ? `?password=${encodeURIComponent(password)}` : '';
+  return apiRequest(`/api/web-pages/shares/view/${encodeURIComponent(token)}/comments${q}`, {
+    method: 'POST',
+    body: { content },
+  });
+}
+
+/** 删除评论（作者本人或站点 owner） */
+export async function deleteSiteComment(commentId: string): Promise<ApiResponse<{ deleted: boolean }>> {
+  return apiRequest(`/api/web-pages/comments/${encodeURIComponent(commentId)}`, {
+    method: 'DELETE',
+  });
 }

--- a/prd-admin/src/services/real/webPages.ts
+++ b/prd-admin/src/services/real/webPages.ts
@@ -419,6 +419,8 @@ export interface SiteCommentsResult {
   commentsEnabled: boolean;
   canComment: boolean;
   comments: HostedSiteCommentDto[];
+  /** 429 限流时后端返回的重试秒数（正常读取为 undefined） */
+  retryAfterSeconds?: number;
 }
 
 /** 切换站点是否允许评论（仅 owner / editor 可调） */

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/WebPagesController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/WebPagesController.cs
@@ -723,6 +723,94 @@ public class WebPagesController : ControllerBase
 
         return Ok(ApiResponse<object>.Ok(new { saved = true, siteCount = result.Sites.Count }));
     }
+
+    // ─────────────────────────────────────────────
+    // 评论
+    // ─────────────────────────────────────────────
+
+    /// <summary>切换站点是否允许评论（仅 owner / editor 可调）</summary>
+    [HttpPatch("{id}/comments-enabled")]
+    public async Task<IActionResult> SetCommentsEnabled(string id, [FromBody] SetCommentsEnabledRequest req)
+    {
+        var updated = await _siteService.SetCommentsEnabledAsync(id, GetUserId(), req.Enabled);
+        if (updated == null)
+            return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "站点不存在或无权限"));
+        return Ok(ApiResponse<object>.Ok(new { id = updated.Id, commentsEnabled = updated.CommentsEnabled }));
+    }
+
+    /// <summary>列出某站点的评论（owner / 团队成员视角，需登录）</summary>
+    [HttpGet("{siteId}/comments")]
+    public async Task<IActionResult> ListSiteComments(string siteId)
+    {
+        var result = await _siteService.ListCommentsBySiteAsync(siteId, GetUserId());
+        if (result == null)
+            return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "站点不存在或无权访问"));
+        return Ok(ApiResponse<object>.Ok(result));
+    }
+
+    /// <summary>在某站点发表评论（owner / 团队成员视角，需登录）</summary>
+    [HttpPost("{siteId}/comments")]
+    public async Task<IActionResult> AddSiteComment(string siteId, [FromBody] AddCommentRequest req)
+    {
+        var result = await _siteService.AddCommentBySiteAsync(
+            siteId, GetUserId(), GetDisplayName(), await GetAvatarFileNameAsync(GetUserId()), req.Content ?? string.Empty);
+        return MapAddCommentResult(result);
+    }
+
+    /// <summary>经分享链接列出评论（公开访问，无需登录即可读）</summary>
+    [HttpGet("shares/view/{token}/comments")]
+    [AllowAnonymous]
+    public async Task<IActionResult> ListShareComments(string token, [FromQuery] string? password)
+    {
+        var viewerUserId = User.Identity?.IsAuthenticated == true ? GetUserId() : null;
+        var result = await _siteService.ListCommentsByShareAsync(token, password, viewerUserId);
+        if (result.Error != null)
+            return MapCommentError(result.Error, result.HttpStatus, result.ErrorCode);
+        return Ok(ApiResponse<object>.Ok(result));
+    }
+
+    /// <summary>经分享链接发表评论（需登录）</summary>
+    [HttpPost("shares/view/{token}/comments")]
+    public async Task<IActionResult> AddShareComment(string token, [FromQuery] string? password, [FromBody] AddCommentRequest req)
+    {
+        var userId = GetUserId();
+        var ip = HttpContext.Connection.RemoteIpAddress?.ToString();
+        var result = await _siteService.AddCommentByShareAsync(
+            token, password, userId, GetDisplayName(), await GetAvatarFileNameAsync(userId), req.Content ?? string.Empty, ip);
+        return MapAddCommentResult(result);
+    }
+
+    /// <summary>删除评论（作者本人或站点 owner）</summary>
+    [HttpDelete("comments/{commentId}")]
+    public async Task<IActionResult> DeleteComment(string commentId)
+    {
+        var ok = await _siteService.DeleteCommentAsync(commentId, GetUserId());
+        if (!ok)
+            return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "评论不存在或无权删除"));
+        return Ok(ApiResponse<object>.Ok(new { deleted = true }));
+    }
+
+    private async Task<string?> GetAvatarFileNameAsync(string userId)
+    {
+        var user = await _db.Users.Find(u => u.UserId == userId).FirstOrDefaultAsync();
+        return user?.AvatarFileName;
+    }
+
+    private IActionResult MapAddCommentResult(AddCommentResult result)
+    {
+        if (result.Error != null)
+            return MapCommentError(result.Error, result.HttpStatus, result.ErrorCode);
+        return Ok(ApiResponse<object>.Ok(result.Comment));
+    }
+
+    private IActionResult MapCommentError(string error, int httpStatus, string? errorCode)
+        => httpStatus switch
+        {
+            401 => Unauthorized(ApiResponse<object>.Fail(ErrorCodes.UNAUTHORIZED, error)),
+            403 => StatusCode(403, ApiResponse<object>.Fail(errorCode ?? "FORBIDDEN", error)),
+            400 => BadRequest(ApiResponse<object>.Fail(errorCode ?? ErrorCodes.INVALID_FORMAT, error)),
+            _ => NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, error)),
+        };
 }
 
 // ─────────────────────────────────────────────
@@ -792,4 +880,16 @@ public class RenewShareRequest
 {
     /// <summary>续期天数（1-365）</summary>
     public int ExtendDays { get; set; } = 30;
+}
+
+public class SetCommentsEnabledRequest
+{
+    /// <summary>true = 允许评论 | false = 关闭评论</summary>
+    public bool Enabled { get; set; }
+}
+
+public class AddCommentRequest
+{
+    /// <summary>评论正文（1-2000 字）</summary>
+    public string? Content { get; set; }
 }

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/WebPagesController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/WebPagesController.cs
@@ -750,7 +750,7 @@ public class WebPagesController : ControllerBase
 
     /// <summary>在某站点发表评论（owner / 团队成员视角，需登录）</summary>
     [HttpPost("{siteId}/comments")]
-    public async Task<IActionResult> AddSiteComment(string siteId, [FromBody] AddCommentRequest req)
+    public async Task<IActionResult> AddSiteComment(string siteId, [FromBody] AddSiteCommentRequest req)
     {
         var result = await _siteService.AddCommentBySiteAsync(
             siteId, GetUserId(), GetDisplayName(), await GetAvatarFileNameAsync(GetUserId()), req.Content ?? string.Empty);
@@ -771,7 +771,7 @@ public class WebPagesController : ControllerBase
 
     /// <summary>经分享链接发表评论（需登录）</summary>
     [HttpPost("shares/view/{token}/comments")]
-    public async Task<IActionResult> AddShareComment(string token, [FromQuery] string? password, [FromBody] AddCommentRequest req)
+    public async Task<IActionResult> AddShareComment(string token, [FromQuery] string? password, [FromBody] AddSiteCommentRequest req)
     {
         var userId = GetUserId();
         var ip = HttpContext.Connection.RemoteIpAddress?.ToString();
@@ -888,7 +888,7 @@ public class SetCommentsEnabledRequest
     public bool Enabled { get; set; }
 }
 
-public class AddCommentRequest
+public class AddSiteCommentRequest
 {
     /// <summary>评论正文（1-2000 字）</summary>
     public string? Content { get; set; }

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/WebPagesController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/WebPagesController.cs
@@ -765,7 +765,7 @@ public class WebPagesController : ControllerBase
         var viewerUserId = User.Identity?.IsAuthenticated == true ? GetUserId() : null;
         var result = await _siteService.ListCommentsByShareAsync(token, password, viewerUserId);
         if (result.Error != null)
-            return MapCommentError(result.Error, result.HttpStatus, result.ErrorCode);
+            return MapCommentError(result.Error, result.HttpStatus, result.ErrorCode, result.RetryAfterSeconds);
         return Ok(ApiResponse<object>.Ok(result));
     }
 
@@ -799,18 +799,28 @@ public class WebPagesController : ControllerBase
     private IActionResult MapAddCommentResult(AddCommentResult result)
     {
         if (result.Error != null)
-            return MapCommentError(result.Error, result.HttpStatus, result.ErrorCode);
+            return MapCommentError(result.Error, result.HttpStatus, result.ErrorCode, result.RetryAfterSeconds);
         return Ok(ApiResponse<object>.Ok(result.Comment));
     }
 
-    private IActionResult MapCommentError(string error, int httpStatus, string? errorCode)
-        => httpStatus switch
+    private IActionResult MapCommentError(string error, int httpStatus, string? errorCode, int? retryAfterSeconds = null)
+    {
+        // 429 限流：与 ViewShare 一致，回 Retry-After 头 + RATE_LIMITED，让客户端倒计时重试，
+        // 不能 fall through 成 404 把"临时限流的受密码保护分享"误报成"不存在"（Codex P2）。
+        if (httpStatus == 429)
+        {
+            if (retryAfterSeconds is { } ra && ra > 0)
+                Response.Headers["Retry-After"] = ra.ToString();
+            return StatusCode(429, ApiResponse<object>.Fail("RATE_LIMITED", error));
+        }
+        return httpStatus switch
         {
             401 => Unauthorized(ApiResponse<object>.Fail(ErrorCodes.UNAUTHORIZED, error)),
             403 => StatusCode(403, ApiResponse<object>.Fail(errorCode ?? "FORBIDDEN", error)),
             400 => BadRequest(ApiResponse<object>.Fail(errorCode ?? ErrorCodes.INVALID_FORMAT, error)),
             _ => NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, error)),
         };
+    }
 }
 
 // ─────────────────────────────────────────────

--- a/prd-api/src/PrdAgent.Core/Interfaces/IHostedSiteService.cs
+++ b/prd-api/src/PrdAgent.Core/Interfaces/IHostedSiteService.cs
@@ -206,8 +206,10 @@ public class SiteCommentsResult
     public List<HostedSiteCommentDto> Comments { get; set; } = new();
     public string? Error { get; set; }
     public int HttpStatus { get; set; } = 200;
-    /// <summary>错误码：not_found / expired / VISIBILITY_DENIED / UNAUTHORIZED</summary>
+    /// <summary>错误码：not_found / expired / VISIBILITY_DENIED / UNAUTHORIZED / rate_limited</summary>
     public string? ErrorCode { get; set; }
+    /// <summary>HttpStatus = 429 时填充，告知前端 N 秒后再试</summary>
+    public int? RetryAfterSeconds { get; set; }
 }
 
 public class AddCommentResult
@@ -216,6 +218,8 @@ public class AddCommentResult
     public string? Error { get; set; }
     public int HttpStatus { get; set; } = 200;
     public string? ErrorCode { get; set; }
+    /// <summary>HttpStatus = 429 时填充，告知前端 N 秒后再试</summary>
+    public int? RetryAfterSeconds { get; set; }
 }
 
 public class TagCountResult

--- a/prd-api/src/PrdAgent.Core/Interfaces/IHostedSiteService.cs
+++ b/prd-api/src/PrdAgent.Core/Interfaces/IHostedSiteService.cs
@@ -151,6 +151,71 @@ public interface IHostedSiteService
     /// 由 WebPageVisibilityBackfillService 在启动时调用一次。
     /// </summary>
     Task<int> BackfillShareVisibilityAsync(CancellationToken ct = default);
+
+    // ── 评论 ──
+
+    /// <summary>切换站点是否允许评论（仅 owner / editor 可调）。返回更新后的站点；无权或不存在返回 null。</summary>
+    Task<HostedSite?> SetCommentsEnabledAsync(string siteId, string userId, bool enabled, CancellationToken ct = default);
+
+    /// <summary>
+    /// 直连 siteId 列出评论（owner / 有访问权的团队成员视角）。
+    /// 校验 viewer 对站点的访问权（与 GetByIdAsync 同款 owner/team 规则）；无权或不存在返回 null。
+    /// </summary>
+    Task<SiteCommentsResult?> ListCommentsBySiteAsync(string siteId, string viewerUserId, CancellationToken ct = default);
+
+    /// <summary>
+    /// 经分享链接列出评论（公开访问路径）。校验分享访问门（撤销 / 过期 / 可见性 / 密码）。
+    /// 通过后返回分享首个站点的评论；门禁不过时 Result.Error 非空。
+    /// </summary>
+    Task<SiteCommentsResult> ListCommentsByShareAsync(string token, string? password, string? viewerUserId, CancellationToken ct = default);
+
+    /// <summary>直连 siteId 发表评论（需 viewer 对站点有访问权）。站点不存在 / 无权 / 评论关闭时 Error 非空。</summary>
+    Task<AddCommentResult> AddCommentBySiteAsync(
+        string siteId, string authorUserId, string authorName, string? avatarFileName,
+        string content, CancellationToken ct = default);
+
+    /// <summary>经分享链接发表评论（公开路径，需登录）。校验分享访问门 + 评论开关；通过后插入。</summary>
+    Task<AddCommentResult> AddCommentByShareAsync(
+        string token, string? password,
+        string authorUserId, string authorName, string? avatarFileName,
+        string content, string? ipAddress, CancellationToken ct = default);
+
+    /// <summary>删除评论（作者本人或站点 owner）。无权 / 不存在返回 false。</summary>
+    Task<bool> DeleteCommentAsync(string commentId, string userId, CancellationToken ct = default);
+}
+
+public class HostedSiteCommentDto
+{
+    public string Id { get; set; } = string.Empty;
+    public string SiteId { get; set; } = string.Empty;
+    public string Content { get; set; } = string.Empty;
+    public string AuthorUserId { get; set; } = string.Empty;
+    public string AuthorName { get; set; } = "用户";
+    public string? AuthorAvatarFileName { get; set; }
+    public DateTime CreatedAt { get; set; }
+    /// <summary>当前 viewer 是否可删除本评论（作者本人或站点 owner）</summary>
+    public bool CanDelete { get; set; }
+}
+
+public class SiteCommentsResult
+{
+    public string SiteId { get; set; } = string.Empty;
+    public bool CommentsEnabled { get; set; } = true;
+    /// <summary>当前 viewer 是否可发表（已登录 + 评论开启）</summary>
+    public bool CanComment { get; set; }
+    public List<HostedSiteCommentDto> Comments { get; set; } = new();
+    public string? Error { get; set; }
+    public int HttpStatus { get; set; } = 200;
+    /// <summary>错误码：not_found / expired / VISIBILITY_DENIED / UNAUTHORIZED</summary>
+    public string? ErrorCode { get; set; }
+}
+
+public class AddCommentResult
+{
+    public HostedSiteCommentDto? Comment { get; set; }
+    public string? Error { get; set; }
+    public int HttpStatus { get; set; } = 200;
+    public string? ErrorCode { get; set; }
 }
 
 public class TagCountResult

--- a/prd-api/src/PrdAgent.Core/Models/HostedSiteComment.cs
+++ b/prd-api/src/PrdAgent.Core/Models/HostedSiteComment.cs
@@ -1,0 +1,45 @@
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace PrdAgent.Core.Models;
+
+/// <summary>
+/// 托管站点评论 —— 访客在分享页 / 站点详情上对某个托管站点发表的评论。
+///
+/// 评论恒以 SiteId 维度组织（一个站点的所有评论聚在一起），不区分来自哪条分享链接，
+/// 但保留 ShareToken 快照便于追溯"这条评论是从哪个分享链接进来发的"。
+///
+/// BsonIgnoreExtraElements: 与 hosted_sites 同样的 schema drift 常态防御，
+/// 避免后续加字段时反序列化老文档抛 FormatException。
+/// </summary>
+[BsonIgnoreExtraElements]
+public class HostedSiteComment
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString("N");
+
+    /// <summary>被评论的站点 ID</summary>
+    public string SiteId { get; set; } = string.Empty;
+
+    /// <summary>评论来源的分享 Token 快照（经分享页发表时记录；站内/owner 视角发表为 null）</summary>
+    public string? ShareToken { get; set; }
+
+    /// <summary>评论作者用户 ID（发表必须登录，恒非空）</summary>
+    public string AuthorUserId { get; set; } = string.Empty;
+
+    /// <summary>作者显示名称快照（发表当时的昵称，避免改名后历史评论错位）</summary>
+    public string AuthorName { get; set; } = "用户";
+
+    /// <summary>作者头像文件名快照（用于前端渲染头像，可为空）</summary>
+    public string? AuthorAvatarFileName { get; set; }
+
+    /// <summary>评论正文</summary>
+    public string Content { get; set; } = string.Empty;
+
+    /// <summary>软删除标记（删除不抹除记录，便于审计）</summary>
+    public bool IsDeleted { get; set; }
+
+    /// <summary>发表来源 IP（审计用，前端不展示）</summary>
+    public string? IpAddress { get; set; }
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/prd-api/src/PrdAgent.Core/Models/WebPage.cs
+++ b/prd-api/src/PrdAgent.Core/Models/WebPage.cs
@@ -89,6 +89,15 @@ public class HostedSite
     /// <summary>首次设为 public 的时间（用于公开页排序）</summary>
     public DateTime? PublishedAt { get; set; }
 
+    /// <summary>
+    /// 是否允许被评论。默认 true（站点天然开放评论），owner 可在站点上关闭。
+    ///
+    /// 注意：默认值刻意为 true —— Mongo 反序列化老文档（无此字段）时保留初始化器的值，
+    /// 因此存量站点会被识别为"允许评论"，符合"网页托管允许被评论"的发布预期。
+    /// owner 关闭后写入 false，下游 ListComments / AddComment 据此放行或拒绝。
+    /// </summary>
+    public bool CommentsEnabled { get; set; } = true;
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 

--- a/prd-api/src/PrdAgent.Infrastructure/Database/MongoDbContext.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Database/MongoDbContext.cs
@@ -296,6 +296,7 @@ public class MongoDbContext
 
     // 网页访客痕迹 + 自定义分类
     public IMongoCollection<SiteViewEvent> SiteViewEvents => _database.GetCollection<SiteViewEvent>("site_view_events");
+    public IMongoCollection<HostedSiteComment> HostedSiteComments => _database.GetCollection<HostedSiteComment>("hosted_site_comments");
     public IMongoCollection<WebFolder> WebFolders => _database.GetCollection<WebFolder>("web_folders");
 
     // Emergence Explorer 涌现探索器

--- a/prd-api/src/PrdAgent.Infrastructure/Database/MongoDbContext.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Database/MongoDbContext.cs
@@ -1534,6 +1534,14 @@ public class MongoDbContext
             Builders<ShareViewLog>.IndexKeys.Ascending(x => x.ShareToken).Descending(x => x.ViewedAt),
             new CreateIndexOptions { Name = "idx_share_view_logs_token_viewed" }));
 
+        // HostedSiteComments：评论按 站点 + 未删 + 时间倒序 查（站内/分享评论面板每次加载都走这条）。
+        // 共享集合跨多站点后无此索引会全表扫 + 内存排序（Codex P2）。CreateIndexes 不执行，
+        // 仅作 DBA 手建参考，落地见 doc/guide.mongodb-indexes.md。
+        HostedSiteComments.Indexes.CreateOne(new CreateIndexModel<HostedSiteComment>(
+            Builders<HostedSiteComment>.IndexKeys
+                .Ascending(x => x.SiteId).Ascending(x => x.IsDeleted).Descending(x => x.CreatedAt),
+            new CreateIndexOptions { Name = "idx_hosted_site_comments_site_deleted_created" }));
+
         // ========== 统一短链 ==========
         // ShortLinks：按 Seq 唯一（对外 URL 主键）
         try

--- a/prd-api/src/PrdAgent.Infrastructure/Services/AdminControllerScanner.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/AdminControllerScanner.cs
@@ -36,15 +36,17 @@ public sealed class AdminControllerScanner : IAdminControllerScanner
         "/api/document-store/public/",
     };
 
-    // 站点维度评论的「列表 + 发表」路由：/api/web-pages/{siteId}/comments
-    // siteId 在路径中段，无法用 PublicRoutes 的 StartsWith 前缀命中。
-    // ListCommentsBySiteAsync/AddCommentBySiteAsync 经 GetByIdAsync 自行鉴权（owner + 团队成员，
-    // 含 viewer 角色均可读/评），若仍套用 AdminPermissionMiddleware 的 WebPagesWrite 写权限，
-    // 团队 viewer 成员从面板发表评论会被提前拦成 403（Codex P2）。这里只豁免「权限检查」，
-    // [Authorize] 仍要求登录，业务层 access check 仍在，故是登录态 + 业务层鉴权。
-    // 注意：$ 锚点确保只命中 .../comments，不会误伤 {id}/comments-enabled（owner/editor 专属开关，需保留写权限）。
+    // 站点维度评论相关路由（siteId 在路径中段，无法用 PublicRoutes 的 StartsWith 前缀命中）：
+    //   - /api/web-pages/{siteId}/comments          列表(GET) + 发表(POST)
+    //   - /api/web-pages/{siteId}/comments-enabled  评论开关(PATCH)
+    // 这三条都在 service 层自行鉴权，不依赖全局 WebPagesWrite 管理权限：
+    //   - ListCommentsBySiteAsync/AddCommentBySiteAsync 经 GetByIdAsync 校验（owner + 团队成员，含 viewer 可读/评）
+    //   - SetCommentsEnabledAsync 显式只放行 owner/editor（其余返回 null → 404）
+    // 若仍套用 AdminPermissionMiddleware 的 WebPagesWrite 闸门，团队 viewer 发表评论 / 团队 editor 改开关
+    // 会在 service 鉴权前被中间件提前拦成 403（Codex P2，两轮）。这里只豁免「管理权限检查」，
+    // [Authorize] 仍要求登录，业务层 owner/editor/成员鉴权仍在，故是登录态 + 业务层鉴权。
     private static readonly Regex SiteCommentRoute = new(
-        @"^/api/web-pages/[^/]+/comments/?$",
+        @"^/api/web-pages/[^/]+/comments(-enabled)?/?$",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     public AdminControllerScanner(ILogger<AdminControllerScanner> logger, Assembly? controllerAssembly = null)

--- a/prd-api/src/PrdAgent.Infrastructure/Services/AdminControllerScanner.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/AdminControllerScanner.cs
@@ -27,6 +27,10 @@ public sealed class AdminControllerScanner : IAdminControllerScanner
         "/api/authz/menu-catalog",
         "/api/dashboard/notifications",
         "/api/web-pages/shares/view/",
+        // 评论删除：作者本人/站点 owner 可删（DeleteCommentAsync 内做 author/owner 校验）。
+        // 经分享页发表评论的普通登录用户没有 WebPagesWrite 权限，若不豁免会被 AdminPermissionMiddleware
+        // 提前拦成 403（Codex P2）。这里只豁免「权限检查」，[Authorize] 仍要求登录，故仍是登录态 + 业务层鉴权。
+        "/api/web-pages/comments/",
         // 知识库公开端点（智识殿堂浏览/详情/分享）
         "/api/document-store/public/",
     };

--- a/prd-api/src/PrdAgent.Infrastructure/Services/AdminControllerScanner.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/AdminControllerScanner.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -34,6 +35,17 @@ public sealed class AdminControllerScanner : IAdminControllerScanner
         // 知识库公开端点（智识殿堂浏览/详情/分享）
         "/api/document-store/public/",
     };
+
+    // 站点维度评论的「列表 + 发表」路由：/api/web-pages/{siteId}/comments
+    // siteId 在路径中段，无法用 PublicRoutes 的 StartsWith 前缀命中。
+    // ListCommentsBySiteAsync/AddCommentBySiteAsync 经 GetByIdAsync 自行鉴权（owner + 团队成员，
+    // 含 viewer 角色均可读/评），若仍套用 AdminPermissionMiddleware 的 WebPagesWrite 写权限，
+    // 团队 viewer 成员从面板发表评论会被提前拦成 403（Codex P2）。这里只豁免「权限检查」，
+    // [Authorize] 仍要求登录，业务层 access check 仍在，故是登录态 + 业务层鉴权。
+    // 注意：$ 锚点确保只命中 .../comments，不会误伤 {id}/comments-enabled（owner/editor 专属开关，需保留写权限）。
+    private static readonly Regex SiteCommentRoute = new(
+        @"^/api/web-pages/[^/]+/comments/?$",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     public AdminControllerScanner(ILogger<AdminControllerScanner> logger, Assembly? controllerAssembly = null)
     {
@@ -166,6 +178,11 @@ public sealed class AdminControllerScanner : IAdminControllerScanner
             {
                 return true;
             }
+        }
+        // 站点维度评论列表/发表（siteId 在路径中段，前缀匹配命中不了）
+        if (SiteCommentRoute.IsMatch(path))
+        {
+            return true;
         }
         return false;
     }

--- a/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
@@ -1776,7 +1776,7 @@ public class HostedSiteService : IHostedSiteService
     {
         var (sites, err) = await ResolveShareForCommentAsync(token, password, viewerUserId, ct);
         if (err != null)
-            return new SiteCommentsResult { Error = err.Value.Error, HttpStatus = err.Value.HttpStatus, ErrorCode = err.Value.ErrorCode };
+            return new SiteCommentsResult { Error = err.Value.Error, HttpStatus = err.Value.HttpStatus, ErrorCode = err.Value.ErrorCode, RetryAfterSeconds = err.Value.RetryAfter };
         if (sites.Count == 0)
             return new SiteCommentsResult { Error = "分享内无可评论站点", HttpStatus = 404, ErrorCode = "not_found" };
 
@@ -1813,7 +1813,7 @@ public class HostedSiteService : IHostedSiteService
 
         var (sites, err) = await ResolveShareForCommentAsync(token, password, authorUserId, ct);
         if (err != null)
-            return new AddCommentResult { Error = err.Value.Error, HttpStatus = err.Value.HttpStatus, ErrorCode = err.Value.ErrorCode };
+            return new AddCommentResult { Error = err.Value.Error, HttpStatus = err.Value.HttpStatus, ErrorCode = err.Value.ErrorCode, RetryAfterSeconds = err.Value.RetryAfter };
         if (sites.Count == 0)
             return new AddCommentResult { Error = "分享内无可评论站点", HttpStatus = 404, ErrorCode = "not_found" };
 
@@ -1913,20 +1913,20 @@ public class HostedSiteService : IHostedSiteService
     /// 评论专用分享门禁：撤销 / 过期 / 可见性 / 密码。复用 EnforceShareVisibilityAsync（与 ViewShareAsync 同款）；
     /// 密码仅校验不动滑动窗口（防爆破由 view 端点承担）。通过后内联解析分享目标站点。
     /// </summary>
-    private async Task<(List<HostedSite> Sites, (string Error, int HttpStatus, string ErrorCode)? Err)>
+    private async Task<(List<HostedSite> Sites, (string Error, int HttpStatus, string ErrorCode, int? RetryAfter)? Err)>
         ResolveShareForCommentAsync(string token, string? password, string? viewerUserId, CancellationToken ct)
     {
         var empty = new List<HostedSite>();
         var share = await _db.WebPageShareLinks.Find(x => x.Token == token).FirstOrDefaultAsync(ct);
         if (share == null || share.IsRevoked)
-            return (empty, ("分享链接不存在", 404, "not_found"));
+            return (empty, ("分享链接不存在", 404, "not_found", null));
 
         if (share.ExpiresAt.HasValue && share.ExpiresAt.Value < DateTime.UtcNow)
-            return (empty, ("分享链接已过期", 400, "expired"));
+            return (empty, ("分享链接已过期", 400, "expired", null));
 
         var visForbid = await EnforceShareVisibilityAsync(share, viewerUserId, ct);
         if (visForbid is { } vf)
-            return (empty, (vf.Error, vf.HttpStatus, vf.ErrorCode));
+            return (empty, (vf.Error, vf.HttpStatus, vf.ErrorCode, null));
 
         // 密码门控：复用 ViewShareAsync 同款 EnforceShareAccessAsync —— 它内置滑动窗口速率限制
         // （10 次/分钟）+ 持久化 RecentAttempts + 恒时比对。直接手写比对会绕过防爆破（Codex P1）。
@@ -1934,13 +1934,17 @@ public class HostedSiteService : IHostedSiteService
         if (gate is { } g)
         {
             var code = g.HttpStatus == 429 ? "rate_limited" : "UNAUTHORIZED";
-            return (empty, (g.Error, g.HttpStatus, code));
+            return (empty, (g.Error, g.HttpStatus, code, g.RetryAfter));
         }
 
         var siteIds = new List<string>(share.SiteIds ?? new List<string>());
         if (share.SiteId != null && !siteIds.Contains(share.SiteId))
             siteIds.Insert(0, share.SiteId);
-        var sites = await _db.HostedSites.Find(x => siteIds.Contains(x.Id)).ToListAsync(ct);
+        var fetched = await _db.HostedSites.Find(x => siteIds.Contains(x.Id)).ToListAsync(ct);
+        // Mongo Find 不保证返回顺序 == siteIds 顺序；调用方取 sites[0] 作为"分享首站点"挂评论，
+        // 必须按 share 定义的 siteIds 顺序重排，否则多站点合集分享会把评论挂到错误站点（Cursor medium）。
+        var byId = fetched.ToDictionary(s => s.Id);
+        var sites = siteIds.Where(byId.ContainsKey).Select(id => byId[id]).ToList();
         return (sites, null);
     }
 

--- a/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
@@ -1781,7 +1781,7 @@ public class HostedSiteService : IHostedSiteService
             return new SiteCommentsResult { Error = "分享内无可评论站点", HttpStatus = 404, ErrorCode = "not_found" };
 
         var site = sites[0];
-        var comments = await LoadCommentDtosAsync(site, viewerUserId, ct);
+        var comments = await LoadCommentDtosAsync(site, viewerUserId, ct, maskUserId: true);
         return new SiteCommentsResult
         {
             SiteId = site.Id,
@@ -1886,7 +1886,7 @@ public class HostedSiteService : IHostedSiteService
         };
     }
 
-    private async Task<List<HostedSiteCommentDto>> LoadCommentDtosAsync(HostedSite site, string? viewerUserId, CancellationToken ct)
+    private async Task<List<HostedSiteCommentDto>> LoadCommentDtosAsync(HostedSite site, string? viewerUserId, CancellationToken ct, bool maskUserId = false)
     {
         var comments = await _db.HostedSiteComments
             .Find(c => c.SiteId == site.Id && !c.IsDeleted)
@@ -1900,7 +1900,8 @@ public class HostedSiteService : IHostedSiteService
             Id = c.Id,
             SiteId = c.SiteId,
             Content = c.Content,
-            AuthorUserId = c.AuthorUserId,
+            // 公开分享读取路径下抹掉内部 UserId，避免向匿名访客泄露账号标识（Codex P2）；CanDelete 已由服务端算好
+            AuthorUserId = maskUserId ? string.Empty : c.AuthorUserId,
             AuthorName = c.AuthorName,
             AuthorAvatarFileName = c.AuthorAvatarFileName,
             CreatedAt = c.CreatedAt,

--- a/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
@@ -1927,16 +1927,13 @@ public class HostedSiteService : IHostedSiteService
         if (visForbid is { } vf)
             return (empty, (vf.Error, vf.HttpStatus, vf.ErrorCode));
 
-        if (share.AccessLevel == "password")
+        // 密码门控：复用 ViewShareAsync 同款 EnforceShareAccessAsync —— 它内置滑动窗口速率限制
+        // （10 次/分钟）+ 持久化 RecentAttempts + 恒时比对。直接手写比对会绕过防爆破（Codex P1）。
+        var gate = await EnforceShareAccessAsync(share, password, ct);
+        if (gate is { } g)
         {
-            var provided = (password ?? string.Empty).Trim();
-            if (string.IsNullOrEmpty(provided))
-                return (empty, ("需要访问密码", 401, "UNAUTHORIZED"));
-            bool ok = !string.IsNullOrEmpty(share.PasswordHash) && !string.IsNullOrEmpty(share.PasswordSalt)
-                ? _sharePwd.Verify(provided, share.PasswordHash, share.PasswordSalt)
-                : _sharePwd.ConstantTimeStringEquals(provided, share.Password ?? string.Empty);
-            if (!ok)
-                return (empty, ("密码错误", 401, "UNAUTHORIZED"));
+            var code = g.HttpStatus == 429 ? "rate_limited" : "UNAUTHORIZED";
+            return (empty, (g.Error, g.HttpStatus, code));
         }
 
         var siteIds = new List<string>(share.SiteIds ?? new List<string>());

--- a/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
@@ -1870,6 +1870,32 @@ public class HostedSiteService : IHostedSiteService
         };
         await _db.HostedSiteComments.InsertOneAsync(comment, cancellationToken: ct);
 
+        // 通知站点 owner：有人评论了你的站点。自评不通知；Key 幂等保证每条评论只产生一条系统通知（用户要求「1 次」）。
+        // best-effort + CancellationToken.None：通知失败不得影响评论本身，也不随客户端断开取消（server-authority）。
+        if (!string.IsNullOrWhiteSpace(site.OwnerUserId) && site.OwnerUserId != authorUserId)
+        {
+            try
+            {
+                var preview = trimmed.Length > 40 ? trimmed[..40] + "…" : trimmed;
+                await _db.AdminNotifications.InsertOneAsync(new AdminNotification
+                {
+                    Key = $"hosted-comment:{comment.Id}",
+                    TargetUserId = site.OwnerUserId,
+                    Title = $"{comment.AuthorName} 评论了你的站点「{site.Title}」",
+                    Message = preview,
+                    Level = "info",
+                    Source = "web-hosting",
+                    ActionLabel = "查看",
+                    ActionUrl = "/web-pages",
+                    ActionKind = "navigate",
+                }, cancellationToken: CancellationToken.None);
+            }
+            catch
+            {
+                // 通知是 best-effort，失败静默（评论已落库成功）
+            }
+        }
+
         return new AddCommentResult
         {
             Comment = new HostedSiteCommentDto

--- a/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
@@ -1732,6 +1732,220 @@ public class HostedSiteService : IHostedSiteService
         return System.Text.Encoding.UTF8.GetBytes(html);
     }
 
+    // ─────────────────────────────────────────────
+    // 评论
+    // ─────────────────────────────────────────────
+
+    public async Task<HostedSite?> SetCommentsEnabledAsync(string siteId, string userId, bool enabled, CancellationToken ct = default)
+    {
+        var site = await _db.HostedSites.Find(s => s.Id == siteId).FirstOrDefaultAsync(ct);
+        if (site == null) return null;
+
+        // 仅 owner / editor 可改评论开关（viewer / 非成员不行）
+        var role = site.OwnerUserId == userId ? "owner" : await ResolveSiteRoleAsync(site, userId, ct);
+        if (role != "owner" && role != "editor") return null;
+
+        await _db.HostedSites.UpdateOneAsync(
+            s => s.Id == siteId,
+            Builders<HostedSite>.Update
+                .Set(s => s.CommentsEnabled, enabled)
+                .Set(s => s.UpdatedAt, DateTime.UtcNow),
+            cancellationToken: ct);
+
+        site.CommentsEnabled = enabled;
+        return site;
+    }
+
+    public async Task<SiteCommentsResult?> ListCommentsBySiteAsync(string siteId, string viewerUserId, CancellationToken ct = default)
+    {
+        // GetByIdAsync 已封装 "owner 本人 / 团队成员" 访问校验
+        var site = await GetByIdAsync(siteId, viewerUserId, ct);
+        if (site == null) return null;
+
+        var comments = await LoadCommentDtosAsync(site, viewerUserId, ct);
+        return new SiteCommentsResult
+        {
+            SiteId = site.Id,
+            CommentsEnabled = site.CommentsEnabled,
+            CanComment = !string.IsNullOrWhiteSpace(viewerUserId) && site.CommentsEnabled,
+            Comments = comments,
+        };
+    }
+
+    public async Task<SiteCommentsResult> ListCommentsByShareAsync(string token, string? password, string? viewerUserId, CancellationToken ct = default)
+    {
+        var (sites, err) = await ResolveShareForCommentAsync(token, password, viewerUserId, ct);
+        if (err != null)
+            return new SiteCommentsResult { Error = err.Value.Error, HttpStatus = err.Value.HttpStatus, ErrorCode = err.Value.ErrorCode };
+        if (sites.Count == 0)
+            return new SiteCommentsResult { Error = "分享内无可评论站点", HttpStatus = 404, ErrorCode = "not_found" };
+
+        var site = sites[0];
+        var comments = await LoadCommentDtosAsync(site, viewerUserId, ct);
+        return new SiteCommentsResult
+        {
+            SiteId = site.Id,
+            CommentsEnabled = site.CommentsEnabled,
+            // 公开分享下发表评论必须登录（viewerUserId 非空）且站点开启评论
+            CanComment = !string.IsNullOrWhiteSpace(viewerUserId) && site.CommentsEnabled,
+            Comments = comments,
+        };
+    }
+
+    public async Task<AddCommentResult> AddCommentBySiteAsync(
+        string siteId, string authorUserId, string authorName, string? avatarFileName,
+        string content, CancellationToken ct = default)
+    {
+        var site = await GetByIdAsync(siteId, authorUserId, ct);
+        if (site == null)
+            return new AddCommentResult { Error = "站点不存在或无权访问", HttpStatus = 404, ErrorCode = "not_found" };
+
+        return await InsertCommentAsync(site, authorUserId, authorName, avatarFileName, content, shareToken: null, ipAddress: null, ct);
+    }
+
+    public async Task<AddCommentResult> AddCommentByShareAsync(
+        string token, string? password,
+        string authorUserId, string authorName, string? avatarFileName,
+        string content, string? ipAddress, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(authorUserId))
+            return new AddCommentResult { Error = "请登录后发表评论", HttpStatus = 401, ErrorCode = "UNAUTHORIZED" };
+
+        var (sites, err) = await ResolveShareForCommentAsync(token, password, authorUserId, ct);
+        if (err != null)
+            return new AddCommentResult { Error = err.Value.Error, HttpStatus = err.Value.HttpStatus, ErrorCode = err.Value.ErrorCode };
+        if (sites.Count == 0)
+            return new AddCommentResult { Error = "分享内无可评论站点", HttpStatus = 404, ErrorCode = "not_found" };
+
+        return await InsertCommentAsync(sites[0], authorUserId, authorName, avatarFileName, content, shareToken: token, ipAddress, ct);
+    }
+
+    public async Task<bool> DeleteCommentAsync(string commentId, string userId, CancellationToken ct = default)
+    {
+        var comment = await _db.HostedSiteComments.Find(c => c.Id == commentId && !c.IsDeleted).FirstOrDefaultAsync(ct);
+        if (comment == null) return false;
+
+        // 作者本人，或被评论站点的 owner，可删除
+        bool canDelete = comment.AuthorUserId == userId;
+        if (!canDelete)
+        {
+            var site = await _db.HostedSites.Find(s => s.Id == comment.SiteId).FirstOrDefaultAsync(ct);
+            canDelete = site != null && site.OwnerUserId == userId;
+        }
+        if (!canDelete) return false;
+
+        await _db.HostedSiteComments.UpdateOneAsync(
+            c => c.Id == commentId,
+            Builders<HostedSiteComment>.Update
+                .Set(c => c.IsDeleted, true)
+                .Set(c => c.UpdatedAt, DateTime.UtcNow),
+            cancellationToken: ct);
+        return true;
+    }
+
+    // ── 评论内部辅助 ──
+
+    private async Task<AddCommentResult> InsertCommentAsync(
+        HostedSite site, string authorUserId, string authorName, string? avatarFileName,
+        string content, string? shareToken, string? ipAddress, CancellationToken ct)
+    {
+        if (!site.CommentsEnabled)
+            return new AddCommentResult { Error = "该站点已关闭评论", HttpStatus = 403, ErrorCode = "COMMENTS_DISABLED" };
+
+        var trimmed = (content ?? string.Empty).Trim();
+        if (trimmed.Length == 0)
+            return new AddCommentResult { Error = "评论内容不能为空", HttpStatus = 400, ErrorCode = "invalid" };
+        if (trimmed.Length > 2000)
+            return new AddCommentResult { Error = "评论内容不能超过 2000 字", HttpStatus = 400, ErrorCode = "invalid" };
+
+        var comment = new HostedSiteComment
+        {
+            SiteId = site.Id,
+            ShareToken = shareToken,
+            AuthorUserId = authorUserId,
+            AuthorName = string.IsNullOrWhiteSpace(authorName) ? "用户" : authorName,
+            AuthorAvatarFileName = avatarFileName,
+            Content = trimmed,
+            IpAddress = ipAddress,
+        };
+        await _db.HostedSiteComments.InsertOneAsync(comment, cancellationToken: ct);
+
+        return new AddCommentResult
+        {
+            Comment = new HostedSiteCommentDto
+            {
+                Id = comment.Id,
+                SiteId = comment.SiteId,
+                Content = comment.Content,
+                AuthorUserId = comment.AuthorUserId,
+                AuthorName = comment.AuthorName,
+                AuthorAvatarFileName = comment.AuthorAvatarFileName,
+                CreatedAt = comment.CreatedAt,
+                CanDelete = true,
+            },
+        };
+    }
+
+    private async Task<List<HostedSiteCommentDto>> LoadCommentDtosAsync(HostedSite site, string? viewerUserId, CancellationToken ct)
+    {
+        var comments = await _db.HostedSiteComments
+            .Find(c => c.SiteId == site.Id && !c.IsDeleted)
+            .SortByDescending(c => c.CreatedAt)
+            .Limit(500)
+            .ToListAsync(ct);
+
+        bool viewerIsOwner = !string.IsNullOrWhiteSpace(viewerUserId) && site.OwnerUserId == viewerUserId;
+        return comments.Select(c => new HostedSiteCommentDto
+        {
+            Id = c.Id,
+            SiteId = c.SiteId,
+            Content = c.Content,
+            AuthorUserId = c.AuthorUserId,
+            AuthorName = c.AuthorName,
+            AuthorAvatarFileName = c.AuthorAvatarFileName,
+            CreatedAt = c.CreatedAt,
+            CanDelete = viewerIsOwner || (!string.IsNullOrWhiteSpace(viewerUserId) && c.AuthorUserId == viewerUserId),
+        }).ToList();
+    }
+
+    /// <summary>
+    /// 评论专用分享门禁：撤销 / 过期 / 可见性 / 密码。复用 EnforceShareVisibilityAsync（与 ViewShareAsync 同款）；
+    /// 密码仅校验不动滑动窗口（防爆破由 view 端点承担）。通过后内联解析分享目标站点。
+    /// </summary>
+    private async Task<(List<HostedSite> Sites, (string Error, int HttpStatus, string ErrorCode)? Err)>
+        ResolveShareForCommentAsync(string token, string? password, string? viewerUserId, CancellationToken ct)
+    {
+        var empty = new List<HostedSite>();
+        var share = await _db.WebPageShareLinks.Find(x => x.Token == token).FirstOrDefaultAsync(ct);
+        if (share == null || share.IsRevoked)
+            return (empty, ("分享链接不存在", 404, "not_found"));
+
+        if (share.ExpiresAt.HasValue && share.ExpiresAt.Value < DateTime.UtcNow)
+            return (empty, ("分享链接已过期", 400, "expired"));
+
+        var visForbid = await EnforceShareVisibilityAsync(share, viewerUserId, ct);
+        if (visForbid is { } vf)
+            return (empty, (vf.Error, vf.HttpStatus, vf.ErrorCode));
+
+        if (share.AccessLevel == "password")
+        {
+            var provided = (password ?? string.Empty).Trim();
+            if (string.IsNullOrEmpty(provided))
+                return (empty, ("需要访问密码", 401, "UNAUTHORIZED"));
+            bool ok = !string.IsNullOrEmpty(share.PasswordHash) && !string.IsNullOrEmpty(share.PasswordSalt)
+                ? _sharePwd.Verify(provided, share.PasswordHash, share.PasswordSalt)
+                : _sharePwd.ConstantTimeStringEquals(provided, share.Password ?? string.Empty);
+            if (!ok)
+                return (empty, ("密码错误", 401, "UNAUTHORIZED"));
+        }
+
+        var siteIds = new List<string>(share.SiteIds ?? new List<string>());
+        if (share.SiteId != null && !siteIds.Contains(share.SiteId))
+            siteIds.Insert(0, share.SiteId);
+        var sites = await _db.HostedSites.Find(x => siteIds.Contains(x.Id)).ToListAsync(ct);
+        return (sites, null);
+    }
+
     private sealed class ZipExtractResult
     {
         public List<HostedSiteFile> Files { get; set; } = new();

--- a/prd-api/tests/PrdAgent.Tests/SiteCommentRouteExemptionTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/SiteCommentRouteExemptionTests.cs
@@ -8,13 +8,13 @@ namespace PrdAgent.Tests;
 /// <summary>
 /// 守护 <see cref="AdminControllerScanner"/> 对站点维度评论路由的权限豁免（Codex P2）。
 ///
-/// 契约：<c>POST/GET /api/web-pages/{siteId}/comments</c> 由 service 层
-/// (ListCommentsBySiteAsync / AddCommentBySiteAsync 经 GetByIdAsync) 自行鉴权，
-/// 团队成员（含 viewer 角色）可读/可评，因此必须从 AdminPermissionMiddleware 的
-/// WebPagesWrite 写权限闸门豁免，否则 viewer 从面板发表评论会被提前 403。
+/// 契约：以下三条站点维度评论路由由 service 层自行鉴权，不依赖全局 WebPagesWrite，
+/// 因此必须从 AdminPermissionMiddleware 的写权限闸门豁免（否则中间件在 service 鉴权前 403）：
+///   - <c>GET/POST /api/web-pages/{siteId}/comments</c>          经 GetByIdAsync 校验（owner + 团队成员，含 viewer 可读/可评）
+///   - <c>PATCH /api/web-pages/{siteId}/comments-enabled</c>     SetCommentsEnabledAsync 显式只放行 owner/editor
 ///
-/// 边界：豁免正则用 <c>$</c> 锚定，**不得**误伤 owner/editor 专属的
-/// <c>{id}/comments-enabled</c> 开关（必须保留写权限）。本测试同时锁定这条反向边界。
+/// 边界：豁免正则用 <c>$</c> 锚定，**不得**误伤站点其它写操作（如 publish / 删除站点本体）。
+/// 本测试同时锁定正向豁免与反向不豁免。
 /// </summary>
 public class SiteCommentRouteExemptionTests
 {
@@ -30,13 +30,15 @@ public class SiteCommentRouteExemptionTests
     // 站点评论列表/发表：必须豁免（含尾斜杠）
     [InlineData("/api/web-pages/148d0c6d730444c1800ccdbb4a918a5f/comments", true)]
     [InlineData("/api/web-pages/148d0c6d730444c1800ccdbb4a918a5f/comments/", true)]
+    // 评论开关：service 层只放行 owner/editor，同样豁免管理权限闸门（Codex P2 第二轮）
+    [InlineData("/api/web-pages/148d0c6d730444c1800ccdbb4a918a5f/comments-enabled", true)]
+    [InlineData("/api/web-pages/148d0c6d730444c1800ccdbb4a918a5f/comments-enabled/", true)]
     // 既有公开前缀：保持豁免
     [InlineData("/api/web-pages/comments/some-comment-id", true)]
     [InlineData("/api/web-pages/shares/view/tok123/comments", true)]
-    // 反向边界：owner/editor 专属开关绝不能被误豁免
-    [InlineData("/api/web-pages/148d0c6d730444c1800ccdbb4a918a5f/comments-enabled", false)]
-    // 普通站点写操作不豁免
+    // 反向边界：站点本体写操作不豁免
     [InlineData("/api/web-pages/148d0c6d730444c1800ccdbb4a918a5f", false)]
+    [InlineData("/api/web-pages/148d0c6d730444c1800ccdbb4a918a5f/publish", false)]
     public void IsPublicRoute_SiteCommentExemption_RespectsBoundaries(string path, bool expected)
     {
         Assert.Equal(expected, IsPublicRoute(path));

--- a/prd-api/tests/PrdAgent.Tests/SiteCommentRouteExemptionTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/SiteCommentRouteExemptionTests.cs
@@ -1,0 +1,44 @@
+using System.Reflection;
+using Microsoft.Extensions.Logging.Abstractions;
+using PrdAgent.Infrastructure.Services;
+using Xunit;
+
+namespace PrdAgent.Tests;
+
+/// <summary>
+/// 守护 <see cref="AdminControllerScanner"/> 对站点维度评论路由的权限豁免（Codex P2）。
+///
+/// 契约：<c>POST/GET /api/web-pages/{siteId}/comments</c> 由 service 层
+/// (ListCommentsBySiteAsync / AddCommentBySiteAsync 经 GetByIdAsync) 自行鉴权，
+/// 团队成员（含 viewer 角色）可读/可评，因此必须从 AdminPermissionMiddleware 的
+/// WebPagesWrite 写权限闸门豁免，否则 viewer 从面板发表评论会被提前 403。
+///
+/// 边界：豁免正则用 <c>$</c> 锚定，**不得**误伤 owner/editor 专属的
+/// <c>{id}/comments-enabled</c> 开关（必须保留写权限）。本测试同时锁定这条反向边界。
+/// </summary>
+public class SiteCommentRouteExemptionTests
+{
+    private static bool IsPublicRoute(string path)
+    {
+        var scanner = new AdminControllerScanner(NullLogger<AdminControllerScanner>.Instance);
+        var method = typeof(AdminControllerScanner).GetMethod(
+            "IsPublicRoute", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        return (bool)method.Invoke(scanner, new object[] { path })!;
+    }
+
+    [Theory]
+    // 站点评论列表/发表：必须豁免（含尾斜杠）
+    [InlineData("/api/web-pages/148d0c6d730444c1800ccdbb4a918a5f/comments", true)]
+    [InlineData("/api/web-pages/148d0c6d730444c1800ccdbb4a918a5f/comments/", true)]
+    // 既有公开前缀：保持豁免
+    [InlineData("/api/web-pages/comments/some-comment-id", true)]
+    [InlineData("/api/web-pages/shares/view/tok123/comments", true)]
+    // 反向边界：owner/editor 专属开关绝不能被误豁免
+    [InlineData("/api/web-pages/148d0c6d730444c1800ccdbb4a918a5f/comments-enabled", false)]
+    // 普通站点写操作不豁免
+    [InlineData("/api/web-pages/148d0c6d730444c1800ccdbb4a918a5f", false)]
+    public void IsPublicRoute_SiteCommentExemption_RespectsBoundaries(string path, bool expected)
+    {
+        Assert.Equal(expected, IsPublicRoute(path));
+    }
+}


### PR DESCRIPTION
## 摘要

为网页托管站点新增评论功能，支持访客在分享页和站内发表评论，owner 可管理评论开关。实现了完整的评论 CRUD 操作、权限控制和分享链接门禁集成。

## 改动 diff

### 后端 (prd-api/)
- `PrdAgent.Core/Models/HostedSiteComment.cs`：新增评论实体模型，包含软删除、IP 审计、作者快照等字段
- `PrdAgent.Core/Models/WebPage.cs`：HostedSite 新增 `CommentsEnabled` 字段（默认 true），控制站点是否允许评论
- `PrdAgent.Core/Interfaces/IHostedSiteService.cs`：新增评论相关接口定义和 DTO（HostedSiteCommentDto、SiteCommentsResult、AddCommentResult）
- `PrdAgent.Infrastructure/Services/HostedSiteService.cs`：实现评论核心逻辑
  - `SetCommentsEnabledAsync`：owner/editor 切换评论开关
  - `ListCommentsBySiteAsync`：站内路径列出评论（需访问权）
  - `ListCommentsByShareAsync`：分享路径列出评论（复用分享门禁）
  - `AddCommentBySiteAsync` / `AddCommentByShareAsync`：发表评论（需登录 + 评论开启）
  - `DeleteCommentAsync`：删除评论（作者本人或 owner）
  - `ResolveShareForCommentAsync`：评论专用分享门禁（撤销/过期/可见性/密码）
- `PrdAgent.Api/Controllers/Api/WebPagesController.cs`：新增 5 个评论端点
  - `PATCH /{id}/comments-enabled`：切换评论开关
  - `GET /{siteId}/comments`：列出站点评论
  - `POST /{siteId}/comments`：发表站点评论
  - `GET /shares/view/{token}/comments`：列出分享评论（AllowAnonymous）
  - `POST /shares/view/{token}/comments`：发表分享评论
  - `DELETE /comments/{commentId}`：删除评论
- `PrdAgent.Infrastructure/Database/MongoDbContext.cs`：注册 HostedSiteComments 集合

### 前端 (prd-admin/)
- `src/components/web-hosting/CommentsSection.tsx`：评论区组件（新增）
  - 支持两种模式：分享页（mode='share'）和站内（mode='site'）
  - 访客可读公开分享评论，登录后可发表
  - owner 可删除任意评论，访客可删除自己的评论
  - 暗色面板配色，遵循 prd-admin 设计规范
- `src/components/web-hosting/SitePreviewModal.tsx`：站点预览弹窗（新增）
  - iframe 加载站点，右侧可展开评论面板
  - owner 可通过开关控制是否允许评论
  - 支持新窗口打开、加载超时检测
- `src/pages/WebPagesPage.tsx`：站点卡新增「评论」按钮，点击打开预览弹窗
- `src/pages/ShareViewPage.tsx`：分享页集成 CommentsSection 组件
- `src/services/real/webPages.ts`：新增评论相关 API 调

https://claude.ai/code/session_01AkBmzHMM56VxBj3xwWvV8p

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth middleware exemptions, share password/rate-limit paths, and new public-ish read APIs; misconfiguration could widen write access, though service-layer checks and tests mitigate this.
> 
> **Overview**
> Adds **hosted site comments** end-to-end: new `hosted_site_comments` storage, `HostedSite.CommentsEnabled` (default on for legacy docs), and API routes for list/post/delete plus share-token read paths that reuse share visibility and password gates.
> 
> **Backend:** `HostedSiteService` implements comment CRUD, share resolution (ordered first site for multi-site shares), soft delete, owner notifications (idempotent, skip self-comment), and masks `AuthorUserId` on public share reads. `AdminControllerScanner` exempts site-scoped comment routes and delete from `WebPagesWrite` so team viewers/editors are authorized in the service layer; unit tests lock that regex. Mongo index definition documented for `(SiteId, IsDeleted, CreatedAt)`.
> 
> **Frontend:** New `CommentsSection` (share vs site modes, optimistic post, race-safe loads) and `SitePreviewModal` (iframe + optional “allow comments” toggle for owner/editor). Web hosting list gets **评论管理**; share view moves comments to a top-bar **评论 N** + right drawer with live count. Team viewers can open comments without `canShare`; toggle remains editor/owner-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d98349a54c401655e125ccb2269ad9244539e84f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->