### PR TITLE
优化 AI 资讯与更新中心外网拉取性能，实现真 serve-stale-while-revalidate

### DIFF
--- a/changelogs/2026-06-03_changelog-ainews-loading-perf.md
+++ b/changelogs/2026-06-03_changelog-ainews-loading-perf.md
@@ -1,0 +1,3 @@
+| perf | prd-api | 更新中心「待发布」GitHub 兜底逐文件拉取限并发(8)，避免数百碎片打爆连接池/限速导致冷缓存首屏长时间转圈 |
+| perf | prd-api | AI 大事资讯改真 serve-stale-while-revalidate + 后台每 4 分钟预热，用户访问路径不再每 5 分钟同步阻塞外网拉取 |
+| feat | prd-api | 更新中心/AI 大事成功路径补计时日志(elapsed/files/failures/rateRemaining)，让外网拉取卡顿可被检测 |

--- a/prd-api/src/PrdAgent.Api/Program.cs
+++ b/prd-api/src/PrdAgent.Api/Program.cs
@@ -299,6 +299,8 @@ builder.Services.AddHttpClient("AiNews", c =>
 // Scoped：AiNewsService 依赖 Scoped 的 ILlmGateway（一句话解读），故不能是 Singleton；
 // 内存缓存走注入的单例 IMemoryCache，资讯流缓存不受 scoped 影响。
 builder.Services.AddScoped<PrdAgent.Core.Interfaces.IAiNewsService, PrdAgent.Infrastructure.Services.AiNewsService>();
+// 后台每 4 分钟预热「AI 大事」缓存，让用户访问路径永不同步等外网（卡顿排查 2026-06-03）。
+builder.Services.AddHostedService<PrdAgent.Infrastructure.Services.AiNewsCacheWarmer>();
 
 // 知识库 Agent 后台执行器（字幕生成 + 文档再加工，复用 DoubaoStreamAsrService 和 ILlmGateway）
 builder.Services.AddHttpClient("DocStoreAgent");

--- a/prd-api/src/PrdAgent.Core/Interfaces/IAiNewsService.cs
+++ b/prd-api/src/PrdAgent.Core/Interfaces/IAiNewsService.cs
@@ -11,6 +11,12 @@ public interface IAiNewsService
     Task<AiNewsFeed> GetLatestAsync(CancellationToken ct = default);
 
     /// <summary>
+    /// 强制拉取上游并刷新新鲜/陈旧两层缓存（供启动预热器与定时刷新调用）。
+    /// 让缓存常驻新鲜，用户访问路径永不同步等外网。
+    /// </summary>
+    Task<AiNewsFeed> RefreshAndCacheAsync(CancellationToken ct = default);
+
+    /// <summary>
     /// 为指定资讯 id 生成 / 读取「一句话 AI 解读」。命中缓存直接返回，未命中批量调 LLM 生成并落库。
     /// 返回 id -> commentary 的映射（仅含成功生成或已缓存的条目）。
     /// </summary>

--- a/prd-api/src/PrdAgent.Infrastructure/Services/AiNewsCacheWarmer.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/AiNewsCacheWarmer.cs
@@ -1,0 +1,64 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using PrdAgent.Core.Interfaces;
+
+namespace PrdAgent.Infrastructure.Services;
+
+/// <summary>
+/// 「AI 大事」资讯缓存预热 + 定时刷新。
+///
+/// 背景（卡顿排查 2026-06-03）：AiNewsService 的新鲜缓存只有 5 分钟，旧实现「过期即同步阻塞拉外网」，
+/// 于是每过 5 分钟、或容器冷启动后，第一个访问的用户都要同步等一次 GitHub Pages 拉取（最长顶到 8s 超时）→ 转圈。
+///
+/// 本预热器在后台每 4 分钟（小于 FreshTtl=5min）刷一次缓存，让新鲜缓存常驻，
+/// 用户访问路径永远命中缓存、永不同步等外网。失败不阻断启动，也不影响用户（仍有 stale 兜底）。
+///
+/// IAiNewsService 是 Scoped（依赖 Scoped 的 ILlmGateway），故每次刷新都开一个 DI scope。
+/// </summary>
+public sealed class AiNewsCacheWarmer : BackgroundService
+{
+    private static readonly TimeSpan RefreshInterval = TimeSpan.FromMinutes(4);
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<AiNewsCacheWarmer> _logger;
+
+    public AiNewsCacheWarmer(IServiceScopeFactory scopeFactory, ILogger<AiNewsCacheWarmer> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // 启动即预热一次，再进入定时循环。
+        await RefreshOnceAsync(stoppingToken).ConfigureAwait(false);
+
+        using var timer = new PeriodicTimer(RefreshInterval);
+        try
+        {
+            while (await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false))
+            {
+                await RefreshOnceAsync(stoppingToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // 正常停机，忽略。
+        }
+    }
+
+    private async Task RefreshOnceAsync(CancellationToken ct)
+    {
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var svc = scope.ServiceProvider.GetRequiredService<IAiNewsService>();
+            await svc.RefreshAndCacheAsync(ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "[AiNews] 后台预热刷新失败（退回懒加载 + stale 兜底，不影响服务）");
+        }
+    }
+}

--- a/prd-api/src/PrdAgent.Infrastructure/Services/AiNewsService.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/AiNewsService.cs
@@ -99,6 +99,20 @@ public class AiNewsService : IAiNewsService
         }
         catch (Exception ex)
         {
+            // 拉取期间可能有并发刷新（预热器 / 其他请求）已写入 stale，失败后再读一次，
+            // 能用旧值就别给空降级（保留旧实现的兜底，避免冷路径漏掉这次 stale）。
+            if (_cache.TryGetValue<AiNewsFeed>(StaleKey, out var stale) && stale != null)
+            {
+                _logger.LogWarning(ex, "[AiNews] 冷缓存同步拉取失败，回退到并发刷新写入的 stale 缓存");
+                return new AiNewsFeed
+                {
+                    Items = stale.Items,
+                    Total = stale.Total,
+                    GeneratedAt = stale.GeneratedAt,
+                    Degraded = false,
+                    Stale = true,
+                };
+            }
             _logger.LogWarning(ex, "[AiNews] 冷缓存同步拉取失败且无 stale 可回退");
             return new AiNewsFeed { Degraded = true };
         }

--- a/prd-api/src/PrdAgent.Infrastructure/Services/AiNewsService.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/AiNewsService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Net;
 using System.Text;
 using System.Text.Json;
@@ -64,36 +65,77 @@ public class AiNewsService : IAiNewsService
         _llmRequestContext = llmRequestContext;
     }
 
+    // 后台刷新去重哨兵。AiNewsService 是 Scoped（每请求新实例），故用 static 跨实例去重，
+    // 保证同一时刻最多一个后台拉取，避免 stale 期间每个请求都甩一个 FetchAsync。
+    private static int _refreshing;
+
     public async Task<AiNewsFeed> GetLatestAsync(CancellationToken ct = default)
     {
+        // 真 serve-stale-while-revalidate（之前是「过期即同步阻塞拉外网」，每 5 分钟第一个用户必卡）：
+        // 1) 新鲜命中 → 立即返回
         if (_cache.TryGetValue<AiNewsFeed>(CacheKey, out var fresh) && fresh != null)
         {
             return fresh;
         }
 
+        // 2) 有 stale（6h 内拉成功过）→ 立即返回旧值 + 后台静默刷新，用户永不阻塞在外网拉取上
+        if (_cache.TryGetValue<AiNewsFeed>(StaleKey, out var stale) && stale != null)
+        {
+            TriggerBackgroundRefresh();
+            return new AiNewsFeed
+            {
+                Items = stale.Items,
+                Total = stale.Total,
+                GeneratedAt = stale.GeneratedAt,
+                Degraded = false,
+                Stale = true,
+            };
+        }
+
+        // 3) 彻底冷（首次启动 / 超 6h 没人访问且预热器也没拉到）→ 只能同步拉一次
         try
         {
-            var feed = await FetchAsync(ct);
-            _cache.Set(CacheKey, feed, FreshTtl);
-            _cache.Set(StaleKey, feed, StaleTtl);
-            return feed;
+            return await RefreshAndCacheAsync(ct);
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "[AiNews] 拉取上游资讯失败，尝试回退 stale 缓存");
-            if (_cache.TryGetValue<AiNewsFeed>(StaleKey, out var stale) && stale != null)
-            {
-                return new AiNewsFeed
-                {
-                    Items = stale.Items,
-                    Total = stale.Total,
-                    GeneratedAt = stale.GeneratedAt,
-                    Degraded = false,
-                    Stale = true,
-                };
-            }
+            _logger.LogWarning(ex, "[AiNews] 冷缓存同步拉取失败且无 stale 可回退");
             return new AiNewsFeed { Degraded = true };
         }
+    }
+
+    /// <summary>拉取上游并写入新鲜/陈旧两层缓存。供冷路径、后台刷新、预热器共用。</summary>
+    public async Task<AiNewsFeed> RefreshAndCacheAsync(CancellationToken ct = default)
+    {
+        var sw = Stopwatch.StartNew();
+        var feed = await FetchAsync(ct);
+        sw.Stop();
+        _cache.Set(CacheKey, feed, FreshTtl);
+        _cache.Set(StaleKey, feed, StaleTtl);
+        // 成功路径计时日志：以前成功零日志，「慢但成功」无法检测。此行让外网拉取耗时可见。
+        _logger.LogInformation("[AiNews] 上游资讯拉取完成 items={Items} elapsed={Elapsed}ms", feed.Total, sw.ElapsedMilliseconds);
+        return feed;
+    }
+
+    private void TriggerBackgroundRefresh()
+    {
+        if (Interlocked.CompareExchange(ref _refreshing, 1, 0) != 0) return; // 已有刷新在跑，跳过
+        // 后台刷新与请求生命周期解耦（server-authority：客户端断开不取消），仅用单例依赖。
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await RefreshAndCacheAsync(CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "[AiNews] 后台刷新失败（继续沿用 stale 缓存）");
+            }
+            finally
+            {
+                Interlocked.Exchange(ref _refreshing, 0);
+            }
+        });
     }
 
     public async Task<Dictionary<string, string>> EnrichCommentaryAsync(

--- a/prd-api/src/PrdAgent.Infrastructure/Services/AiNewsService.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/AiNewsService.cs
@@ -101,14 +101,14 @@ public class AiNewsService : IAiNewsService
         {
             // 拉取期间可能有并发刷新（预热器 / 其他请求）已写入 stale，失败后再读一次，
             // 能用旧值就别给空降级（保留旧实现的兜底，避免冷路径漏掉这次 stale）。
-            if (_cache.TryGetValue<AiNewsFeed>(StaleKey, out var stale) && stale != null)
+            if (_cache.TryGetValue<AiNewsFeed>(StaleKey, out var staleAfterFail) && staleAfterFail != null)
             {
                 _logger.LogWarning(ex, "[AiNews] 冷缓存同步拉取失败，回退到并发刷新写入的 stale 缓存");
                 return new AiNewsFeed
                 {
-                    Items = stale.Items,
-                    Total = stale.Total,
-                    GeneratedAt = stale.GeneratedAt,
+                    Items = staleAfterFail.Items,
+                    Total = staleAfterFail.Total,
+                    GeneratedAt = staleAfterFail.GeneratedAt,
                     Degraded = false,
                     Stale = true,
                 };

--- a/prd-api/src/PrdAgent.Infrastructure/Services/Changelog/ChangelogReader.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/Changelog/ChangelogReader.cs
@@ -152,6 +152,10 @@ public sealed class ChangelogReader : IChangelogReader
     private const string CacheKeyReleases = "changelog:releases";
     private const string CacheKeyGitHubLogs = "changelog:github-logs";
 
+    // 「待发布」碎片走 GitHub raw 逐文件拉取，碎片数可能达数百个。限并发避免上百个
+    // 并发连接打爆连接池 / 触发限速导致冷缓存首屏长时间转圈（卡顿排查 2026-06-03）。
+    private const int MaxGitHubFetchConcurrency = 8;
+
     // serve-stale-while-revalidate（业界通行做法，见 web.dev / RFC 5861 / .NET HybridCache 防击穿）：
     //  - 新鲜期（GetFreshWindow，默认 5 分钟）内：直接返回缓存，不刷新
     //  - 新鲜期过后、保留期（StaleKeepWindow，24 小时）内：先返回旧值、再后台静默刷新（用户不等待）
@@ -750,10 +754,19 @@ public sealed class ChangelogReader : IChangelogReader
         {
             using var req = CreateGitHubApiRequest(HttpMethod.Get, url);
             using var resp = await client.SendAsync(req).ConfigureAwait(false);
+            var rateRemaining = resp.Headers.TryGetValues("X-RateLimit-Remaining", out var rl)
+                ? rl.FirstOrDefault() : null;
             if (!resp.IsSuccessStatusCode)
             {
-                _logger.LogWarning("[Changelog] GitHub Contents API 失败 {Url} status={Status}", url, (int)resp.StatusCode);
+                // 403 + remaining=0 即匿名限速打爆（未配 Changelog:GitHubToken）。明确暴露，便于检测。
+                _logger.LogWarning(
+                    "[Changelog] GitHub Contents API 失败 {Url} status={Status} rateRemaining={RateRemaining}",
+                    url, (int)resp.StatusCode, rateRemaining ?? "n/a");
                 return new List<string>();
+            }
+            if (rateRemaining != null)
+            {
+                _logger.LogInformation("[Changelog] GitHub Contents API 配额剩余 rateRemaining={RateRemaining}", rateRemaining);
             }
 
             var json = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -816,19 +829,36 @@ public sealed class ChangelogReader : IChangelogReader
             filtered.Add((name, date.Value));
         }
 
-        // 并行下载本周内的碎片文件（数量很少，最多 7-10 个）
+        // 「待发布」展示所有未合并进 CHANGELOG.md 的碎片，数量可能达数百个（已发布 0 / 待发布 768
+        // 即没人跑 assemble-changelog 合并）。每个碎片走一次 raw 拉取，必须限并发（见 MaxGitHubFetchConcurrency），
+        // 否则上百个并发连接会打爆连接池 / 触发限速，冷缓存首屏长时间转圈。
+        var sw = Stopwatch.StartNew();
+        var gate = new SemaphoreSlim(MaxGitHubFetchConcurrency, MaxGitHubFetchConcurrency);
+        var failures = 0;
         var tasks = filtered.Select(async f =>
         {
-            var content = await FetchRawFileAsync(client, $"changelogs/{f.name}").ConfigureAwait(false);
-            if (string.IsNullOrEmpty(content)) return null;
-            var entries = ParseTableRows(content);
-            if (entries.Count == 0) return null;
-            return new ChangelogFragment
+            await gate.WaitAsync().ConfigureAwait(false);
+            try
             {
-                FileName = f.name,
-                Date = f.date,
-                Entries = entries,
-            };
+                var content = await FetchRawFileAsync(client, $"changelogs/{f.name}").ConfigureAwait(false);
+                if (string.IsNullOrEmpty(content))
+                {
+                    Interlocked.Increment(ref failures);
+                    return null;
+                }
+                var entries = ParseTableRows(content);
+                if (entries.Count == 0) return null;
+                return new ChangelogFragment
+                {
+                    FileName = f.name,
+                    Date = f.date,
+                    Entries = entries,
+                };
+            }
+            finally
+            {
+                gate.Release();
+            }
         }).ToList();
 
         var results = await Task.WhenAll(tasks).ConfigureAwait(false);
@@ -836,6 +866,11 @@ public sealed class ChangelogReader : IChangelogReader
         {
             if (fragment != null) AddCurrentWeekEntries(view, fragment.FileName, fragment.Date, fragment.Entries);
         }
+        sw.Stop();
+        // 成功路径计时日志：以前只在失败时记日志，「慢但成功」零痕迹无法检测。此行让卡顿可见。
+        _logger.LogInformation(
+            "[Changelog] GitHub 待发布拉取完成 files={Files} failures={Failures} concurrency={Concurrency} elapsed={Elapsed}ms",
+            filtered.Count, failures, MaxGitHubFetchConcurrency, sw.ElapsedMilliseconds);
 
         view.Fragments = SortFragments(view.Fragments);
         ApplyUnreleasedDateRange(view);


### PR DESCRIPTION
## 摘要

解决 AI 资讯与更新中心因同步阻塞外网拉取导致的用户卡顿问题（卡顿排查 2026-06-03）。通过后台预热 + 限并发 + 完整日志，让用户访问路径永不同步等待外网，冷缓存首屏不再转圈。

## 改动 diff

### AI 资讯服务（AiNewsService）
- 实现真 serve-stale-while-revalidate 策略：新鲜命中直接返回 → 有陈旧值立即返回旧值并后台静默刷新 → 彻底冷才同步拉一次
- 新增 `RefreshAndCacheAsync()` 公开方法供预热器与后台刷新调用
- 新增 `TriggerBackgroundRefresh()` 后台刷新机制，用 `static int _refreshing` 哨兵保证同一时刻最多一个后台拉取
- 补充成功路径计时日志，让外网拉取耗时可被检测

### AI 资讯缓存预热器（AiNewsCacheWarmer）
- 新增 `BackgroundService` 实现，启动即预热一次，后续每 4 分钟（小于 FreshTtl=5min）刷新一次
- 每次刷新开一个 DI scope 获取 Scoped 的 IAiNewsService
- 失败不阻断启动，用户仍有 stale 兜底

### 更新中心 GitHub 拉取（ChangelogReader）
- 「待发布」碎片拉取限并发为 8，避免数百碎片打爆连接池 / 触发限速
- 补充 GitHub API 配额日志（`X-RateLimit-Remaining`），便于检测匿名限速
- 补充成功路径计时日志（files / failures / concurrency / elapsed），让卡顿可见

### 接口与注册
- `IAiNewsService` 新增 `RefreshAndCacheAsync()` 方法签名
- `Program.cs` 注册 `AiNewsCacheWarmer` 为 `HostedService`

### 更新记录
- `changelogs/2026-06-03_changelog-ainews-loading-perf.md`：记录性能优化与日志补充

## 测试
- [x] `dotnet build --no-restore` 通过（零 error CS*）
- [x] 逻辑验证：后台预热 + stale 回退 + 限并发机制符合设计
- [x] 日志补充：成功路径计时日志完整，便于监控卡顿

## 已知边界
- 后台刷新与请求生命周期解耦（server-authority），客户端断开不取消后台任务
- 预热器失败不影响用户（仍有 stale 兜底），但应监控日志确保预热正常运行

https://claude.ai/code/session_01N6TEcXuYweezEk5FF5ufsH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance and caching behavior only; failures still fall back to stale data and existing SWR patterns. Background refresh uses CancellationToken.None by design.
> 
> **Overview**
> Fixes user-visible loading stalls when **AI 大事** and the update center hit cold or expired caches and blocked on outbound GitHub fetches.
> 
> **AI 大事 (`AiNewsService`)** no longer synchronously refetches when the 5-minute fresh cache expires. It returns stale data immediately and kicks off a deduplicated background refresh via new **`RefreshAndCacheAsync`**. Only a fully cold cache still blocks once. A new **`AiNewsCacheWarmer`** hosted service warms the cache at startup and every 4 minutes. Successful upstream pulls log elapsed time.
> 
> **更新中心 (`ChangelogReader`)** caps parallel GitHub raw fetches for unreleased changelog fragments at **8** (instead of unbounded parallel downloads). It adds **`X-RateLimit-Remaining`** on Contents API responses and completion logs (files, failures, elapsed).
> 
> Changelog fragment documents the perf/observability changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59a2915b179892207ca1dfd8193bb20f19219f7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->