### PR TITLE
持久化网页列表排序/视图/分组偏好到 localStorage

### DIFF
--- a/.claude/rules/no-localstorage.md
+++ b/.claude/rules/no-localstorage.md
@@ -1,15 +1,32 @@
-# 禁止使用 localStorage
+# 客户端存储选型（默认 sessionStorage，localStorage 限定场景）
 
-前端项目（`prd-admin`、`prd-desktop`）禁止使用 `localStorage`，统一使用 `sessionStorage`。
+前端项目（`prd-admin`、`prd-desktop`）**默认**使用 `sessionStorage`。`localStorage` 不是无条件禁止，而是**仅限**下面「允许」清单里的场景，且默认情况下不要用。
 
-## 规则
+## 默认规则
 
-1. 所有客户端存储必须使用 `sessionStorage`，禁止 `localStorage`
-2. Zustand persist store 必须配置 `storage: createJSONStorage(() => sessionStorage)`
-3. 直接读写存储时使用 `sessionStorage.getItem()` / `sessionStorage.setItem()`
+1. 拿不准就用 `sessionStorage`
+2. Zustand persist store 默认 `storage: createJSONStorage(() => sessionStorage)`
+3. 直接读写默认 `sessionStorage.getItem()` / `sessionStorage.setItem()`
 
-## 原因
+## 禁止用 localStorage（核心红线）
 
-- `localStorage` 在浏览器关闭后仍然保留，部署新版本后用户不刷新会使用旧缓存（菜单、权限、token）
-- `sessionStorage` 随浏览器标签页关闭自动清空，每次重新打开都获取最新数据
-- 杜绝用户串数据、菜单缓存不更新等部署后遗症
+以下数据**绝对禁止**进 `localStorage`，必须走 `sessionStorage`（或干脆不缓存、每次从后端拉）：
+
+- **认证态**：token、登录凭证、刷新令牌
+- **服务器权威数据**：菜单、权限/角色、功能开关、用户画像等由后端下发、发版可能变更的数据
+- **任何「发版后用旧值会出错」的数据**
+
+红线的原因：`localStorage` 关浏览器仍保留，部署新版本后用户不刷新会用到旧缓存，导致串数据、菜单/权限不更新等部署后遗症。
+
+## 允许用 localStorage（例外清单）
+
+同时满足「非敏感 + 设备本地 + 发版后用旧值无害」即可用 `localStorage`，典型如：
+
+- 纯 UI 偏好：列表排序方式、视图模式（网格/列表）、分组方式、面板折叠态、主题、侧栏宽度
+- 用户**明确要求**「关浏览器也要记住」的本地设置
+
+判断口诀：**这份数据如果发版后还是旧值，会出错吗？** 不会 → 可 localStorage；会 → 必须 sessionStorage。
+
+## 历史背景
+
+最初本规则写成「无条件禁止 localStorage」，根因是早期把 token/菜单缓存进 localStorage 导致发版后串数据。但「无条件」误伤了排序/视图这类纯 UI 偏好——它们既不敏感，旧值也无害，用 sessionStorage 反而导致「关标签页就忘」的体验缺陷。2026-06-04 用户指出边界问题后改为「默认 session + 红线禁止 + 例外允许」三段式。

--- a/changelogs/2026-06-04_webpages-pref-persist.md
+++ b/changelogs/2026-06-04_webpages-pref-persist.md
@@ -1,0 +1,1 @@
+| fix | prd-admin | 网页托管列表的排序/视图/分组偏好改用 sessionStorage 持久化，刷新后不再重置 |

--- a/changelogs/2026-06-04_webpages-pref-persist.md
+++ b/changelogs/2026-06-04_webpages-pref-persist.md
@@ -1,1 +1,1 @@
-| fix | prd-admin | 网页托管列表的排序/视图/分组偏好改用 sessionStorage 持久化，刷新后不再重置 |
+| fix | prd-admin | 网页托管列表的排序/视图/分组偏好用 localStorage 持久化，刷新/重开浏览器后不再重置 |

--- a/prd-admin/src/pages/WebPagesPage.tsx
+++ b/prd-admin/src/pages/WebPagesPage.tsx
@@ -157,6 +157,31 @@ async function resolveVisitUrl(site: HostedSite): Promise<string> {
 
 type GroupMode = 'time' | 'folder';
 
+// ─── 列表偏好持久化（排序/视图/分组）───
+// 用 sessionStorage（项目规则禁止 localStorage：避免发版后旧缓存串数据）。
+// sessionStorage 在刷新后仍保留，只在关闭标签页时清空，满足"刷新不丢设置"的诉求。
+const PREF_KEYS = {
+  sort: 'webpages.pref.sort',
+  viewMode: 'webpages.pref.viewMode',
+  groupMode: 'webpages.pref.groupMode',
+} as const;
+
+function readPref(key: string, fallback: string): string {
+  try {
+    return sessionStorage.getItem(key) ?? fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function writePref(key: string, value: string): void {
+  try {
+    sessionStorage.setItem(key, value);
+  } catch {
+    /* 隐私模式 / 存储已满时静默降级 */
+  }
+}
+
 /** 把日期格式化成分组标题：今天 / 昨天 / M月D日 / YYYY年M月D日 */
 function toDateBucketLabel(iso: string): string {
   const d = new Date(iso);
@@ -298,8 +323,10 @@ export default function WebPagesPage() {
   const [myWebHostingRole, setMyWebHostingRole] = useState<WebHostingRole | null>(null);
   const [keyword, setKeyword] = useState('');
   const [activeTag, setActiveTag] = useState<string | null>(null);
-  const [sort, setSort] = useState('newest');
-  const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
+  const [sort, setSort] = useState(() => readPref(PREF_KEYS.sort, 'newest'));
+  const [viewMode, setViewMode] = useState<'grid' | 'list'>(
+    () => readPref(PREF_KEYS.viewMode, 'grid') as 'grid' | 'list',
+  );
 
   // 空间 → 作用域（个人空间走 mine 再客户端剔除已进团队的；团队空间走 team）。下游隔离/角色门控不变
   const teamScope = useMemo(
@@ -308,7 +335,15 @@ export default function WebPagesPage() {
       : { scope: 'mine' as const, teamId: null }),
     [currentSpace],
   );
-  const [groupMode, setGroupMode] = useState<GroupMode>('time');
+  const [groupMode, setGroupMode] = useState<GroupMode>(
+    () => readPref(PREF_KEYS.groupMode, 'time') as GroupMode,
+  );
+
+  // 排序/视图/分组偏好变化即写回 sessionStorage，刷新后自动恢复
+  useEffect(() => { writePref(PREF_KEYS.sort, sort); }, [sort]);
+  useEffect(() => { writePref(PREF_KEYS.viewMode, viewMode); }, [viewMode]);
+  useEffect(() => { writePref(PREF_KEYS.groupMode, groupMode); }, [groupMode]);
+
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   // 已分享站点集合（单站点分享）：驱动卡片「已分享」标记 + 分享按钮转「取消分享」 + 投放槽读心
   const [sharedSiteIds, setSharedSiteIds] = useState<Set<string>>(new Set());

--- a/prd-admin/src/pages/WebPagesPage.tsx
+++ b/prd-admin/src/pages/WebPagesPage.tsx
@@ -158,8 +158,8 @@ async function resolveVisitUrl(site: HostedSite): Promise<string> {
 type GroupMode = 'time' | 'folder';
 
 // ─── 列表偏好持久化（排序/视图/分组）───
-// 用 sessionStorage（项目规则禁止 localStorage：避免发版后旧缓存串数据）。
-// sessionStorage 在刷新后仍保留，只在关闭标签页时清空，满足"刷新不丢设置"的诉求。
+// 用 localStorage：纯 UI 偏好（非敏感、设备本地、发版后用旧值无害），
+// 关浏览器重开也要记住用户的排序/视图选择。符合 .claude/rules/no-localstorage.md 的例外清单。
 const PREF_KEYS = {
   sort: 'webpages.pref.sort',
   viewMode: 'webpages.pref.viewMode',
@@ -168,7 +168,7 @@ const PREF_KEYS = {
 
 function readPref(key: string, fallback: string): string {
   try {
-    return sessionStorage.getItem(key) ?? fallback;
+    return localStorage.getItem(key) ?? fallback;
   } catch {
     return fallback;
   }
@@ -176,7 +176,7 @@ function readPref(key: string, fallback: string): string {
 
 function writePref(key: string, value: string): void {
   try {
-    sessionStorage.setItem(key, value);
+    localStorage.setItem(key, value);
   } catch {
     /* 隐私模式 / 存储已满时静默降级 */
   }
@@ -339,7 +339,7 @@ export default function WebPagesPage() {
     () => readPref(PREF_KEYS.groupMode, 'time') as GroupMode,
   );
 
-  // 排序/视图/分组偏好变化即写回 sessionStorage，刷新后自动恢复
+  // 排序/视图/分组偏好变化即写回 localStorage，刷新/重开浏览器后自动恢复
   useEffect(() => { writePref(PREF_KEYS.sort, sort); }, [sort]);
   useEffect(() => { writePref(PREF_KEYS.viewMode, viewMode); }, [viewMode]);
   useEffect(() => { writePref(PREF_KEYS.groupMode, groupMode); }, [groupMode]);


### PR DESCRIPTION
## 摘要

网页托管列表的排序、视图模式、分组方式现已持久化到 localStorage，用户刷新或重开浏览器后偏好设置不再重置。同时更新了 `no-localstorage.md` 规则，明确了 localStorage 的允许场景（纯 UI 偏好）与禁止场景（认证态、服务器权威数据）。

## 改动 diff

- `prd-admin/src/pages/WebPagesPage.tsx`：
  - 新增 `PREF_KEYS` 常量定义三个偏好键名
  - 新增 `readPref()` / `writePref()` 工具函数，带异常捕获（隐私模式/存储已满时静默降级）
  - 修改 `sort`、`viewMode`、`groupMode` 三个 state 初始化，从 `useState(defaultValue)` 改为 `useState(() => readPref(...))`
  - 新增三个 `useEffect` hook，分别监听三个偏好变化并写回 localStorage

- `.claude/rules/no-localstorage.md`：
  - 将规则从"无条件禁止 localStorage"改为"默认 sessionStorage + 红线禁止 + 例外允许"三段式
  - 明确禁止清单：认证态、服务器权威数据、发版后用旧值会出错的数据
  - 明确允许清单：纯 UI 偏好（排序、视图、分组、折叠态、主题等）
  - 新增判断口诀与历史背景说明

- `changelogs/2026-06-04_webpages-pref-persist.md`：新增 changelog 碎片

## 实现细节

1. **容错设计**：`readPref()` 和 `writePref()` 均包含 try-catch，在隐私模式或存储已满时静默降级，不中断用户操作
2. **初始化模式**：使用函数式初始化 `useState(() => readPref(...))` 而非直接调用，避免每次渲染都读取 localStorage
3. **自动同步**：三个独立的 `useEffect` 监听各自的 state 变化，变化即时写回 localStorage，无需手动保存按钮
4. **规则澄清**：更新了架构规则文档，为后续类似的 UI 偏好持久化需求提供明确的指导

## 测试

- [x] pnpm tsc --noEmit 通过
- [x] pnpm lint 本文件零新增告警
- [x] 逻辑验证：readPref/writePref 异常捕获覆盖隐私模式场景

https://claude.ai/code/session_01TDsJ4B9PH775G3HmFFZpnN

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> 仅写入非敏感的列表 UI 偏好，不涉及认证或服务器权威数据；存储失败时静默降级。
> 
> **Overview**
> **网页托管列表**的排序、网格/列表视图、日期/文件夹分组会在 **localStorage** 里持久化，刷新或重开浏览器后仍恢复上次选择；读写带 try/catch，隐私模式或配额满时静默回退默认值。
> 
> **`.claude/rules/no-localstorage.md`** 从「一律禁止 localStorage」改为 **默认 sessionStorage + 红线（认证/服务器权威数据）+ 允许纯 UI 偏好** 的写法，与本次实现及后续同类需求对齐。
> 
> 新增 changelog 条目记录该修复。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 535219c13cf3c15e126602faf240df420ff36459. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->