### PR TITLE
知识库划词评论新增右侧批注栏与布局切换

### DIFF
--- a/.claude/skills/create-visual-test-to-kb/SKILL.md
+++ b/.claude/skills/create-visual-test-to-kb/SKILL.md
@@ -141,7 +141,22 @@ python3 $SKILL/scripts/archive_report.py --config $SKILL/acceptance.config.json 
 | `scripts/harness.mjs` | 模拟人类浏览器 helper(点击导航/截图/主题 + ZZ 画框 stepClick/stepShot/box) | 写 driver 时 |
 | `scripts/archive_report.py` | 配置驱动归档(上传/删图保URL/建条目/写正文校验/分享链/必给地址/可见性防漂移) | 归档时 |
 | `scripts/verify-open.mjs` | 归档后自查:headless 打开分享链断言报告渲染(标题+正文+截图);空/打不开 exit 2 | 归档后(强制) |
+| `scripts/read_comments.py` | 回读闭环:拉知识库最近批注(用户在验收文档上的划词/全文批注),按时间倒序,供复测 | 复测/收集反馈时 |
 | `acceptance.config.json` | 项目配置(预览域名/登录/文档空间API/库名/截图);跨仓库改这个 | 接新仓库时 |
+
+## 回读批注闭环(用户批注 → 智能体复测)
+
+知识库与本技能是双向的:技能把验收报告**写**进知识库;用户在那篇报告里**划词/框选文字批注**(或对整篇评论)留下反馈,验收智能体再把这些批注**读**回来做下一轮复测。最简实现是按需轮询(不是监听):
+
+```bash
+# 归档后,归档脚本会输出 storeId/entryId;隔段时间或被要求复测时拉一次最近批注
+python3 $SKILL/scripts/read_comments.py --config $SKILL/acceptance.config.json \
+  --store "验收报告" --entry <报告条目 entryId> --since <上次拉取时间ISO>
+```
+
+- 鉴权复用归档同一把 `MAP_DOC_STORE_KEY`(`document-store:write` 写蕴含读,可调读接口);后端 `GET /stores/{storeId}/recent-comments` 已做读权限校验,只返回该 key 可读库的批注。
+- 输出末尾 `COMMENTS_JSON: {...}` 供智能体解析:每条含 `entryTitle / selectedText(被批注原文) / content / authorDisplayName / createdAt / isWholeDocument / status`。智能体据此定位"用户对哪段不满意",针对性复测/修复,再走第 4 步重新归档(新 report_id)。
+- `--since` 做增量:只取上次拉取后的新批注,避免重复处理。监听式(webhook/SSE 主动推送)是后续增强,先用这条拉取路径跑通。
 
 ## 跨仓库复用
 

--- a/.claude/skills/create-visual-test-to-kb/scripts/read_comments.py
+++ b/.claude/skills/create-visual-test-to-kb/scripts/read_comments.py
@@ -18,7 +18,7 @@
 
 输出：先打印人类可读的批注清单，最后打印一行 `COMMENTS_JSON: {...}` 供智能体解析。
 """
-import argparse, json, os, subprocess, time, sys, urllib.parse, datetime
+import argparse, json, os, subprocess, time, sys, urllib.parse, datetime, re
 
 
 def parse_iso(s):
@@ -74,11 +74,14 @@ def resolve_store_id(H, base, store_arg, default_name):
     want = (store_arg or default_name or "").strip()
     if not want:
         raise SystemExit("未指定 --store，且 config.report.storeName 为空")
-    # 先按 id 直查（命中即返回）
-    direct = curl(H + [f"{base}/stores/{want}"])
-    if isinstance(direct, dict) and direct.get("success") and direct.get("data", {}).get("id"):
-        return direct["data"]["id"], direct["data"].get("name", want)
-    # 否则按名字在列表里找
+    # 仅当看起来像 store id（32 位十六进制 Guid）才按 id 直查；否则直接按名字查。
+    # 库名常含空格/中文（如「验收报告」「Acceptance Reports」），拼进 /stores/{want} 会是非法 URL，
+    # curl() 拿不到 JSON 会在回退到名字查找前就抛错（Codex P2）。
+    if re.fullmatch(r"[0-9a-fA-F]{32}", want):
+        direct = curl(H + [f"{base}/stores/{want}"])
+        if isinstance(direct, dict) and direct.get("success") and (direct.get("data") or {}).get("id"):
+            return direct["data"]["id"], direct["data"].get("name", want)
+    # 按名字在列表里找
     listed = curl(H + [f"{base}/stores?pageSize=100"])
     items = (listed.get("data") or {}).get("items") or []
     match = [s for s in items if s.get("name") == want]

--- a/.claude/skills/create-visual-test-to-kb/scripts/read_comments.py
+++ b/.claude/skills/create-visual-test-to-kb/scripts/read_comments.py
@@ -18,7 +18,21 @@
 
 输出：先打印人类可读的批注清单，最后打印一行 `COMMENTS_JSON: {...}` 供智能体解析。
 """
-import argparse, json, os, subprocess, time, sys, urllib.parse
+import argparse, json, os, subprocess, time, sys, urllib.parse, datetime
+
+
+def parse_iso(s):
+    """ISO-8601 → 统一为 UTC aware datetime；失败返回 None。容忍 'Z' 与带时区偏移。"""
+    if not s:
+        return None
+    s = s.strip().replace("Z", "+00:00")
+    try:
+        d = datetime.datetime.fromisoformat(s)
+    except Exception:
+        return None
+    if d.tzinfo is None:
+        d = d.replace(tzinfo=datetime.timezone.utc)
+    return d.astimezone(datetime.timezone.utc)
 
 
 def curl(args, retries=5):
@@ -102,7 +116,14 @@ def main():
             raise SystemExit(f"读取条目批注失败：{json.dumps(r, ensure_ascii=False)[:200]}")
         items = r["data"].get("items", [])
         if since:
-            items = [c for c in items if (c.get("createdAt") or "") > since]
+            # 解析为 datetime 再比较：since 可能带非 UTC 偏移（如 +08:00），与 API 的 UTC createdAt
+            # 直接做字符串字典序比较会误判（Codex P2）。解析失败才退回字符串比较，避免静默全丢。
+            since_dt = parse_iso(since)
+            if since_dt is not None:
+                items = [c for c in items
+                         if (parse_iso(c.get("createdAt")) or datetime.datetime.min.replace(tzinfo=datetime.timezone.utc)) > since_dt]
+            else:
+                items = [c for c in items if (c.get("createdAt") or "") > since]
         items.sort(key=lambda c: c.get("createdAt") or "", reverse=True)
         items = items[:limit]
     else:

--- a/.claude/skills/create-visual-test-to-kb/scripts/read_comments.py
+++ b/.claude/skills/create-visual-test-to-kb/scripts/read_comments.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""MAP 验收 · 回读知识库批注（验收智能体 ← 用户在验收文档上的划词/全文批注）。
+
+闭环的另一半：archive_report.py 把验收报告「写」进知识库；本脚本把用户在那篇报告上
+划词/框选留下的「批注」读回来，喂给验收智能体做下一轮复测。最简实现 = 按需轮询
+后端聚合接口 GET /api/document-store/stores/{storeId}/recent-comments（按时间倒序）。
+监听式（webhook/SSE 主动推送）留作后续，先用这条拉取路径跑通。
+
+用法：
+  python3 read_comments.py --config <acceptance.config.json> \
+    [--store "验收报告" | --store <storeId>] \
+    [--entry <entryId>]      # 只看某篇报告的批注
+    [--since 2026-06-05T00:00:00Z]  # 增量：只看此时间后的新批注
+    [--limit 50]
+
+鉴权与归档脚本一致：优先 MAP_DOC_STORE_KEY（document-store:write，写蕴含读，可调本读接口），
+未设回退 AI 超级密钥 + X-AI-Impersonate。base URL 走 config 的 previewUrlOverride 或 previewUrlCmd（cdscli）。
+
+输出：先打印人类可读的批注清单，最后打印一行 `COMMENTS_JSON: {...}` 供智能体解析。
+"""
+import argparse, json, os, subprocess, time, sys
+
+
+def curl(args, retries=5):
+    last = ""
+    for i in range(retries):
+        r = subprocess.run(["curl", "-s", "--max-time", "120"] + args, capture_output=True, text=True)
+        last = r.stdout
+        try:
+            return json.loads(r.stdout)
+        except Exception:
+            if i < retries - 1:
+                time.sleep(3 * (i + 1)); continue
+    print("RAW(重试后仍失败):", (last or "")[:200], file=sys.stderr)
+    raise RuntimeError("curl 返回非 JSON（多为预览环境 524/重启）")
+
+
+def preview_from_cmd(cmd):
+    out = subprocess.run(cmd, shell=True, capture_output=True, text=True).stdout
+    lines = [l.strip() for l in out.splitlines() if l.strip()]
+    return lines[-1] if lines else ""
+
+
+def build_auth(cfg):
+    """返回鉴权 header 列表，与 archive_report.run_doc_store 完全一致。"""
+    api = cfg["auth"]["api"]
+    agent_key_env = api.get("agentKeyEnv", "MAP_DOC_STORE_KEY")
+    agent_key = os.environ.get(agent_key_env, "").strip()
+    if agent_key:
+        print(f"  鉴权：AgentApiKey scope（{agent_key_env}，document-store:write⊇read）", file=sys.stderr)
+        return ["-H", f"Authorization: Bearer {agent_key}"]
+    key = os.environ[api["keyEnv"]]
+    imp = os.environ[api["impersonateEnv"]]
+    print("  鉴权：AI 超级密钥 + impersonate（建议改用 MAP_DOC_STORE_KEY scoped key）", file=sys.stderr)
+    return ["-H", f"{api['keyHeader']}: {key}", "-H", f"{api['impersonateHeader']}: {imp}"]
+
+
+def resolve_store_id(H, base, store_arg, default_name):
+    """store_arg 可为 storeId 或库名；为空时用 config 的 storeName。"""
+    want = (store_arg or default_name or "").strip()
+    if not want:
+        raise SystemExit("未指定 --store，且 config.report.storeName 为空")
+    # 先按 id 直查（命中即返回）
+    direct = curl(H + [f"{base}/stores/{want}"])
+    if isinstance(direct, dict) and direct.get("success") and direct.get("data", {}).get("id"):
+        return direct["data"]["id"], direct["data"].get("name", want)
+    # 否则按名字在列表里找
+    listed = curl(H + [f"{base}/stores?pageSize=100"])
+    items = (listed.get("data") or {}).get("items") or []
+    match = [s for s in items if s.get("name") == want]
+    if not match:
+        raise SystemExit(f"找不到知识库「{want}」（既不是有效 storeId，也没有同名库）")
+    return match[0]["id"], match[0]["name"]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--config", required=True)
+    ap.add_argument("--store", default="", help="知识库名或 storeId（缺省用 config.report.storeName）")
+    ap.add_argument("--entry", default="", help="只看某篇报告条目的批注（entryId）")
+    ap.add_argument("--since", default="", help="增量：只看此 ISO 时间后创建的批注")
+    ap.add_argument("--limit", type=int, default=50)
+    a = ap.parse_args()
+
+    cfg = json.load(open(a.config))
+    base_url = (cfg.get("previewUrlOverride") or "").strip() or preview_from_cmd(cfg["previewUrlCmd"])
+    if not base_url:
+        raise SystemExit("拿不到预览 base URL（previewUrlOverride 为空且 cdscli 无输出）")
+    base = base_url.rstrip("/") + cfg["report"]["apiBasePath"]
+    H = build_auth(cfg)
+
+    store_id, store_name = resolve_store_id(H, base, a.store, cfg["report"].get("storeName"))
+
+    qs = [f"limit={max(1, min(200, a.limit))}"]
+    if a.since.strip():
+        qs.append("since=" + a.since.strip())
+    url = f"{base}/stores/{store_id}/recent-comments?" + "&".join(qs)
+    res = curl(H + [url])
+    if not (isinstance(res, dict) and res.get("success")):
+        raise SystemExit(f"读取批注失败：{json.dumps(res, ensure_ascii=False)[:200]}")
+
+    items = res["data"].get("items", [])
+    if a.entry.strip():
+        items = [c for c in items if c.get("entryId") == a.entry.strip()]
+
+    # 人类可读清单
+    print(f"知识库「{store_name}」最近批注（{len(items)} 条）")
+    if not items:
+        print("  （暂无新批注）")
+    for c in items:
+        who = c.get("authorDisplayName") or "未知用户"
+        when = (c.get("createdAt") or "")[:19].replace("T", " ")
+        where = c.get("entryTitle") or c.get("entryId") or "?"
+        quote = (c.get("selectedText") or "").strip()
+        tag = "全文" if c.get("isWholeDocument") else (f"原文「{quote[:40]}」" if quote else "锚点")
+        flag = " [失锚]" if c.get("status") == "orphaned" else ""
+        print(f"  · [{where}] {who} · {when}{flag}\n      {tag} → {c.get('content','').strip()}")
+
+    # 机器可解析（验收智能体据此决定下一轮复测哪些点）
+    print("COMMENTS_JSON: " + json.dumps({
+        "storeId": store_id,
+        "storeName": store_name,
+        "count": len(items),
+        "items": items,
+    }, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/create-visual-test-to-kb/scripts/read_comments.py
+++ b/.claude/skills/create-visual-test-to-kb/scripts/read_comments.py
@@ -18,7 +18,7 @@
 
 输出：先打印人类可读的批注清单，最后打印一行 `COMMENTS_JSON: {...}` 供智能体解析。
 """
-import argparse, json, os, subprocess, time, sys
+import argparse, json, os, subprocess, time, sys, urllib.parse
 
 
 def curl(args, retries=5):
@@ -90,18 +90,31 @@ def main():
     H = build_auth(cfg)
 
     store_id, store_name = resolve_store_id(H, base, a.store, cfg["report"].get("storeName"))
+    limit = max(1, min(200, a.limit))
+    since = a.since.strip()
 
-    qs = [f"limit={max(1, min(200, a.limit))}"]
-    if a.since.strip():
-        qs.append("since=" + a.since.strip())
-    url = f"{base}/stores/{store_id}/recent-comments?" + "&".join(qs)
-    res = curl(H + [url])
-    if not (isinstance(res, dict) and res.get("success")):
-        raise SystemExit(f"读取批注失败：{json.dumps(res, ensure_ascii=False)[:200]}")
-
-    items = res["data"].get("items", [])
     if a.entry.strip():
-        items = [c for c in items if c.get("entryId") == a.entry.strip()]
+        # 「只看某篇报告」：直接用 per-entry 接口拿该条目全量评论，再客户端按 since/limit 截取。
+        # 不能走 store 级 recent-comments 再客户端过滤——store 很忙时前 N 条可能全是别的报告，
+        # 目标条目被挤出页就会“明明有评论却读不到”（Codex P2）。
+        r = curl(H + [f"{base}/entries/{a.entry.strip()}/inline-comments"])
+        if not (isinstance(r, dict) and r.get("success")):
+            raise SystemExit(f"读取条目批注失败：{json.dumps(r, ensure_ascii=False)[:200]}")
+        items = r["data"].get("items", [])
+        if since:
+            items = [c for c in items if (c.get("createdAt") or "") > since]
+        items.sort(key=lambda c: c.get("createdAt") or "", reverse=True)
+        items = items[:limit]
+    else:
+        qs = [f"limit={limit}"]
+        if since:
+            # since 含 ':' '+' 等字符，必须 URL 编码，否则网关/后端可能解析错（Bugbot Low）
+            qs.append("since=" + urllib.parse.quote(since, safe=""))
+        url = f"{base}/stores/{store_id}/recent-comments?" + "&".join(qs)
+        res = curl(H + [url])
+        if not (isinstance(res, dict) and res.get("success")):
+            raise SystemExit(f"读取批注失败：{json.dumps(res, ensure_ascii=False)[:200]}")
+        items = res["data"].get("items", [])
 
     # 人类可读清单
     print(f"知识库「{store_name}」最近批注（{len(items)} 条）")

--- a/changelogs/2026-06-05_kb-inline-comment-margin.md
+++ b/changelogs/2026-06-05_kb-inline-comment-margin.md
@@ -15,3 +15,5 @@
 | fix | prd-admin | 评论加载 effect 改以 entryId 为依赖，后台列表刷新（同一条目新数组引用）不再清掉正在写的就地浮层/草稿 |
 | fix | prd-admin | 评论删除按钮 stopPropagation，避免点删除冒泡到批注卡 root 误切换激活态 |
 | fix | prd-agent | read_comments.py --entry --since 改为解析 datetime 再比较，兼容带时区偏移的 ISO 时间 |
+| fix | prd-admin | 其它面板增删评论后自增 syncTick 驱动已打开的抽屉重拉，抽屉不再与正文数据脱节 |
+| fix | prd-agent | read_comments.py 仅对疑似 storeId（32位hex）做直查，含空格/中文的库名直接走名称查找，不再因非法URL报错 |

--- a/changelogs/2026-06-05_kb-inline-comment-margin.md
+++ b/changelogs/2026-06-05_kb-inline-comment-margin.md
@@ -5,3 +5,5 @@
 | fix | prd-admin | 修复批注牵引连线两个边界：高亮/卡片滚出正文可视区时不再画线（避免飞到窗口角/越过顶栏）；连线改连续 rAF 直接改 DOM，跟手不再延迟抖动 |
 | fix | prd-admin | 修复批注评审 5 项：composer 提交落到选区所属条目（切档不串档）、删除/激活滚动加 stale 守卫、激活用真实锚点滚动且取消激活不跳视口 |
 | fix | prd-agent | read_comments.py：--entry 改用 per-entry 接口拿全量（避免被 store 级 limit 挤出页）、since 查询 URL 编码 |
+| fix | prd-admin | 批注评审二轮：创建后乐观插入防 UI 滞留、删光分组清激活态防幽灵连线、只读访客不弹写入 composer、收起批注栏时点气泡自动重开 |
+| fix | prd-api | recent-comments 返回补 authorAvatar 字段，与 per-entry 接口对齐供 store 级轮询取头像 |

--- a/changelogs/2026-06-05_kb-inline-comment-margin.md
+++ b/changelogs/2026-06-05_kb-inline-comment-margin.md
@@ -18,3 +18,4 @@
 | fix | prd-admin | 其它面板增删评论后自增 syncTick 驱动已打开的抽屉重拉，抽屉不再与正文数据脱节 |
 | fix | prd-agent | read_comments.py 仅对疑似 storeId（32位hex）做直查，含空格/中文的库名直接走名称查找，不再因非法URL报错 |
 | fix | prd-admin | 抽屉内增删评论回调父级刷新（margin/overlay/计数反向同步）；抽屉 load 加 stale-response 守卫防旧响应覆盖 |
+| fix | prd-admin | 评论抽屉的删除按钮同样按库主/作者逐条判权（之前仍用 canCreate）；收起批注栏时点已激活气泡强制重开并保持激活 |

--- a/changelogs/2026-06-05_kb-inline-comment-margin.md
+++ b/changelogs/2026-06-05_kb-inline-comment-margin.md
@@ -10,3 +10,4 @@
 | fix | prd-admin | 批注评审三轮：连线不再用正文 bounds 误判右栏卡片致误隐藏、抽屉关闭同步 commentsCanCreate、margin/inline 删除按钮加二次确认 |
 | fix | prd-admin | 批注删除后 bump fetchId 作废在途刷新，防止删除前的服务器快照晚到把已删评论复活 |
 | fix | prd-admin | 批注栏/内联的回复改为落到该线程所属条目（base.entryId），防切档后回复写到别的文档 |
+| fix | prd-admin,prd-api | 批注删除按钮按「库主/作者」逐条判定权限（recent list 返回 isOwner+viewerUserId），公开库非作者读者不再看到删不掉的删除按钮 |

--- a/changelogs/2026-06-05_kb-inline-comment-margin.md
+++ b/changelogs/2026-06-05_kb-inline-comment-margin.md
@@ -7,3 +7,4 @@
 | fix | prd-agent | read_comments.py：--entry 改用 per-entry 接口拿全量（避免被 store 级 limit 挤出页）、since 查询 URL 编码 |
 | fix | prd-admin | 批注评审二轮：创建后乐观插入防 UI 滞留、删光分组清激活态防幽灵连线、只读访客不弹写入 composer、收起批注栏时点气泡自动重开 |
 | fix | prd-api | recent-comments 返回补 authorAvatar 字段，与 per-entry 接口对齐供 store 级轮询取头像 |
+| fix | prd-admin | 批注评审三轮：连线不再用正文 bounds 误判右栏卡片致误隐藏、抽屉关闭同步 commentsCanCreate、margin/inline 删除按钮加二次确认 |

--- a/changelogs/2026-06-05_kb-inline-comment-margin.md
+++ b/changelogs/2026-06-05_kb-inline-comment-margin.md
@@ -8,3 +8,4 @@
 | fix | prd-admin | 批注评审二轮：创建后乐观插入防 UI 滞留、删光分组清激活态防幽灵连线、只读访客不弹写入 composer、收起批注栏时点气泡自动重开 |
 | fix | prd-api | recent-comments 返回补 authorAvatar 字段，与 per-entry 接口对齐供 store 级轮询取头像 |
 | fix | prd-admin | 批注评审三轮：连线不再用正文 bounds 误判右栏卡片致误隐藏、抽屉关闭同步 commentsCanCreate、margin/inline 删除按钮加二次确认 |
+| fix | prd-admin | 批注删除后 bump fetchId 作废在途刷新，防止删除前的服务器快照晚到把已删评论复活 |

--- a/changelogs/2026-06-05_kb-inline-comment-margin.md
+++ b/changelogs/2026-06-05_kb-inline-comment-margin.md
@@ -2,3 +2,4 @@
 | feat | prd-admin | 划词评论支持「批注栏 / 内联」布局切换（右上角，个人偏好持久化），并改为选区就地输入（取代右侧抽屉） |
 | feat | prd-api | 新增知识库最近批注聚合接口 GET /api/document-store/stores/{storeId}/recent-comments（按时间倒序，供验收智能体回读用户在验收文档上的批注） |
 | feat | prd-admin | 知识库批注强关联：同色锚定（高亮下划线=卡片色条同色）+ 点气泡/卡片激活联动 + active-only 牵引连线 + 批注密集时折叠成一行 |
+| fix | prd-admin | 修复批注牵引连线两个边界：高亮/卡片滚出正文可视区时不再画线（避免飞到窗口角/越过顶栏）；连线改连续 rAF 直接改 DOM，跟手不再延迟抖动 |

--- a/changelogs/2026-06-05_kb-inline-comment-margin.md
+++ b/changelogs/2026-06-05_kb-inline-comment-margin.md
@@ -3,3 +3,5 @@
 | feat | prd-api | 新增知识库最近批注聚合接口 GET /api/document-store/stores/{storeId}/recent-comments（按时间倒序，供验收智能体回读用户在验收文档上的批注） |
 | feat | prd-admin | 知识库批注强关联：同色锚定（高亮下划线=卡片色条同色）+ 点气泡/卡片激活联动 + active-only 牵引连线 + 批注密集时折叠成一行 |
 | fix | prd-admin | 修复批注牵引连线两个边界：高亮/卡片滚出正文可视区时不再画线（避免飞到窗口角/越过顶栏）；连线改连续 rAF 直接改 DOM，跟手不再延迟抖动 |
+| fix | prd-admin | 修复批注评审 5 项：composer 提交落到选区所属条目（切档不串档）、删除/激活滚动加 stale 守卫、激活用真实锚点滚动且取消激活不跳视口 |
+| fix | prd-agent | read_comments.py：--entry 改用 per-entry 接口拿全量（避免被 store 级 limit 挤出页）、since 查询 URL 编码 |

--- a/changelogs/2026-06-05_kb-inline-comment-margin.md
+++ b/changelogs/2026-06-05_kb-inline-comment-margin.md
@@ -1,3 +1,4 @@
 | feat | prd-admin | 知识库划词评论新增「右侧批注栏」边读边看布局：评论卡片常驻正文右侧显示头像+名字+内容，与正文高亮 hover 联动 |
 | feat | prd-admin | 划词评论支持「批注栏 / 内联」布局切换（右上角，个人偏好持久化），并改为选区就地输入（取代右侧抽屉） |
 | feat | prd-api | 新增知识库最近批注聚合接口 GET /api/document-store/stores/{storeId}/recent-comments（按时间倒序，供验收智能体回读用户在验收文档上的批注） |
+| feat | prd-admin | 知识库批注强关联：同色锚定（高亮下划线=卡片色条同色）+ 点气泡/卡片激活联动 + active-only 牵引连线 + 批注密集时折叠成一行 |

--- a/changelogs/2026-06-05_kb-inline-comment-margin.md
+++ b/changelogs/2026-06-05_kb-inline-comment-margin.md
@@ -1,0 +1,3 @@
+| feat | prd-admin | 知识库划词评论新增「右侧批注栏」边读边看布局：评论卡片常驻正文右侧显示头像+名字+内容，与正文高亮 hover 联动 |
+| feat | prd-admin | 划词评论支持「批注栏 / 内联」布局切换（右上角，个人偏好持久化），并改为选区就地输入（取代右侧抽屉） |
+| feat | prd-api | 新增知识库最近批注聚合接口 GET /api/document-store/stores/{storeId}/recent-comments（按时间倒序，供验收智能体回读用户在验收文档上的批注） |

--- a/changelogs/2026-06-05_kb-inline-comment-margin.md
+++ b/changelogs/2026-06-05_kb-inline-comment-margin.md
@@ -9,3 +9,4 @@
 | fix | prd-api | recent-comments 返回补 authorAvatar 字段，与 per-entry 接口对齐供 store 级轮询取头像 |
 | fix | prd-admin | 批注评审三轮：连线不再用正文 bounds 误判右栏卡片致误隐藏、抽屉关闭同步 commentsCanCreate、margin/inline 删除按钮加二次确认 |
 | fix | prd-admin | 批注删除后 bump fetchId 作废在途刷新，防止删除前的服务器快照晚到把已删评论复活 |
+| fix | prd-admin | 批注栏/内联的回复改为落到该线程所属条目（base.entryId），防切档后回复写到别的文档 |

--- a/changelogs/2026-06-05_kb-inline-comment-margin.md
+++ b/changelogs/2026-06-05_kb-inline-comment-margin.md
@@ -17,3 +17,4 @@
 | fix | prd-agent | read_comments.py --entry --since 改为解析 datetime 再比较，兼容带时区偏移的 ISO 时间 |
 | fix | prd-admin | 其它面板增删评论后自增 syncTick 驱动已打开的抽屉重拉，抽屉不再与正文数据脱节 |
 | fix | prd-agent | read_comments.py 仅对疑似 storeId（32位hex）做直查，含空格/中文的库名直接走名称查找，不再因非法URL报错 |
+| fix | prd-admin | 抽屉内增删评论回调父级刷新（margin/overlay/计数反向同步）；抽屉 load 加 stale-response 守卫防旧响应覆盖 |

--- a/changelogs/2026-06-05_kb-inline-comment-margin.md
+++ b/changelogs/2026-06-05_kb-inline-comment-margin.md
@@ -12,3 +12,4 @@
 | fix | prd-admin | 批注栏/内联的回复改为落到该线程所属条目（base.entryId），防切档后回复写到别的文档 |
 | fix | prd-admin,prd-api | 批注删除按钮按「库主/作者」逐条判定权限（recent list 返回 isOwner+viewerUserId），公开库非作者读者不再看到删不掉的删除按钮 |
 | fix | prd-admin | 划词就地输入浮层跟随正文滚动平移，不再因滚动停在错误位置挡错内容 |
+| fix | prd-admin | 评论加载 effect 改以 entryId 为依赖，后台列表刷新（同一条目新数组引用）不再清掉正在写的就地浮层/草稿 |

--- a/changelogs/2026-06-05_kb-inline-comment-margin.md
+++ b/changelogs/2026-06-05_kb-inline-comment-margin.md
@@ -11,3 +11,4 @@
 | fix | prd-admin | 批注删除后 bump fetchId 作废在途刷新，防止删除前的服务器快照晚到把已删评论复活 |
 | fix | prd-admin | 批注栏/内联的回复改为落到该线程所属条目（base.entryId），防切档后回复写到别的文档 |
 | fix | prd-admin,prd-api | 批注删除按钮按「库主/作者」逐条判定权限（recent list 返回 isOwner+viewerUserId），公开库非作者读者不再看到删不掉的删除按钮 |
+| fix | prd-admin | 划词就地输入浮层跟随正文滚动平移，不再因滚动停在错误位置挡错内容 |

--- a/changelogs/2026-06-05_kb-inline-comment-margin.md
+++ b/changelogs/2026-06-05_kb-inline-comment-margin.md
@@ -13,3 +13,5 @@
 | fix | prd-admin,prd-api | 批注删除按钮按「库主/作者」逐条判定权限（recent list 返回 isOwner+viewerUserId），公开库非作者读者不再看到删不掉的删除按钮 |
 | fix | prd-admin | 划词就地输入浮层跟随正文滚动平移，不再因滚动停在错误位置挡错内容 |
 | fix | prd-admin | 评论加载 effect 改以 entryId 为依赖，后台列表刷新（同一条目新数组引用）不再清掉正在写的就地浮层/草稿 |
+| fix | prd-admin | 评论删除按钮 stopPropagation，避免点删除冒泡到批注卡 root 误切换激活态 |
+| fix | prd-agent | read_comments.py --entry --since 改为解析 datetime 再比较，兼容带时区偏移的 ISO 时间 |

--- a/doc/debt.kb-inline-comment.md
+++ b/doc/debt.kb-inline-comment.md
@@ -1,0 +1,30 @@
+# 知识库划词评论 · 债务台账
+
+> **版本**：v1.0 | **日期**：2026-06-05 | **状态**：维护中
+
+## 总览
+
+模块范围：`prd-admin/src/components/doc-browser/`（DocBrowser + InlineCommentOverlay/Margin/Composer + inlineCommentShared）、
+`prd-admin/src/stores/docReaderPrefsStore.ts`、
+`prd-api/.../DocumentStoreController.cs`（recent-comments 接口）、
+`.claude/skills/create-visual-test-to-kb/scripts/read_comments.py`（回读闭环）。
+
+本次落地了「边读边看」批注栏 + 批注栏/内联布局切换 + 划词就地输入 + 批注头像/名字显示 +
+后端最近批注聚合接口 + 验收技能回读脚本。以下为主动声明的已知边界。
+
+## 已知边界（待后续偿还）
+
+| # | 边界 | 现状 | 后续方向 |
+|---|------|------|----------|
+| 1 | 图片批注 | 仅文字锚点 + 全文评论；右键图片/框选图片区域批注未实现 | 新增 image-anchor 数据模型（坐标框）+ 前端图片框选交互 |
+| 2 | inline 布局展开卡片定位 | 绝对定位在高亮末行下方，可能与下方正文视觉重叠（MVP） | 改为 in-flow 占位插入，或碰撞规避 |
+| 3 | margin 批注栏卡片排序 | 按 createdAt 排序，非按锚点在正文中的垂直位置对齐（无 Docs 式连线） | 计算每组锚点 top，按位置排序 + 可选连线 |
+| 4 | 批注栏 ↔ TOC | 有评论时默认批注栏取代 TOC，「收起」临时切回；未做并存 | 评估窄屏并存 / 可拖拽分栏 |
+| 5 | 回读闭环 | read_comments.py 为按需轮询（GET recent-comments） | 监听式 webhook/SSE 主动推送 |
+| 6 | 布局偏好存储 | localStorage（设备本地，符合 no-localstorage 例外清单） | 如需跨设备同步，迁移到 user_preferences |
+
+## 相关
+
+- 设计：本次为增量交付，无独立 design 文档；交互 mock 见会话记录
+- 接口：`GET /api/document-store/stores/{storeId}/recent-comments?since=&limit=`
+- 鉴权：AgentApiKey `document-store:read`（write 蕴含 read），与归档脚本同一把 MAP_DOC_STORE_KEY

--- a/doc/debt.kb-inline-comment.md
+++ b/doc/debt.kb-inline-comment.md
@@ -22,6 +22,7 @@
 | 4 | 批注栏 ↔ TOC | 有评论时默认批注栏取代 TOC，「收起」临时切回；未做并存 | 评估窄屏并存 / 可拖拽分栏 |
 | 5 | 回读闭环 | read_comments.py 为按需轮询（GET recent-comments） | 监听式 webhook/SSE 主动推送 |
 | 6 | 布局偏好存储 | localStorage（设备本地，符合 no-localstorage 例外清单） | 如需跨设备同步，迁移到 user_preferences |
+| 7 | 同一短语多处分别评论 | 完全相同的选中文字在文档不同位置被分别评论时，按归一化文本合并为一张卡（两处的评论混在一起），正文只高亮其中一处，回复用首处偏移。**产品决定保持现状**（2026-06-06 用户拍板，低频场景）。group key = 归一化文本 是 overlay 高亮解析/连线/激活态共享的身份，按出现位置拆分属较大重构 | 如需精确区分：group key 带 contextBefore/offset，overlay 改为逐出现位置解析锚点 |
 
 ## 相关
 

--- a/doc/guide.list.directory.md
+++ b/doc/guide.list.directory.md
@@ -681,6 +681,8 @@
   > Phase 1 MVP 仅交付执行层；治理层（干系人/NPSS/奖金/盘点）待 Phase 2-3；Leader 职级强校验待 User 加字段
 - [视频生成 Agent · 债务台账](debt.video-agent) `debt.video-agent`
   > 4 条 open：OpenRouter CDN 7 天过期、混合渲染 ffmpeg normalize、直出心跳文案分级、成本预估 tooltip
+- [知识库划词评论（批注栏/内联 + 就地输入 + 回读闭环）· 债务台账](debt.kb-inline-comment) `debt.kb-inline-comment`
+  > 6 条边界：图片批注未做、inline 卡片定位 MVP、批注栏按时间非锚点排序、批注栏/TOC 互斥、回读为轮询、偏好走 localStorage
 
 - [工作流 Agent · 债务台账](debt.workflow-agent) `debt.workflow-agent`
   > 7 条 open：video-to-text asr 模式 ASR 池绑定 / maxItems 硬编码 / LlmRequestContext / 转写失败兜底 / ffmpeg 检测 / Play 后无返回 / count 与 maxItems 联动

--- a/doc/index.yml
+++ b/doc/index.yml
@@ -273,6 +273,7 @@ docs:
   debt.cds-tutorial: CDS 教程（示例工程 + 隔离知识库 + 评分/自愈）债务台账
   debt.cds-visual-deploy: CDS 绝对可视化一键部署 · 债务台账（已知边界 + 低边际 backlog + 独立 fixture demo 阻塞）
   debt.knowledge-base: 知识库（AI Toolbox attachment + 文档空间）债务台账
+  debt.kb-inline-comment: 知识库划词评论（批注栏/内联布局 + 就地输入 + 回读闭环）债务台账
   debt.web-hosting: 网页托管 · 债务台账（幻灯片翻页方向兼容垫片边界）
   debt.share-link-security: 分享链接安全债务台账
   debt.web-hosting-client-ip: 网页托管真实客户端 IP（XFF 解析）债务台账

--- a/prd-admin/src/components/doc-browser/DocBrowser.tsx
+++ b/prd-admin/src/components/doc-browser/DocBrowser.tsx
@@ -319,7 +319,7 @@ import { InlineCommentOverlay } from './InlineCommentOverlay';
 import { InlineCommentMargin } from './InlineCommentMargin';
 import { InlineCommentComposer } from './InlineCommentComposer';
 import { InlineCommentConnector } from './InlineCommentConnector';
-import { threadColor } from './inlineCommentShared';
+import { threadColor, groupKey } from './inlineCommentShared';
 import { useDocReaderPrefs } from '@/stores/docReaderPrefsStore';
 import { BulkActionBar } from './BulkActionBar';
 
@@ -1686,8 +1686,15 @@ export function DocBrowser({
     if (!targetId) return false;
     const res = await createInlineComment(targetId, input);
     if (res.success) {
-      // 仅当目标条目仍是当前正在看的条目才刷新列表，避免改到别的文档状态
-      if (targetId === trackedEntryForComments?.id) await refreshComments();
+      // 仅当目标条目仍是当前正在看的条目才更新本地状态，避免改到别的文档
+      if (targetId === trackedEntryForComments?.id) {
+        // 乐观插入：即使随后 refresh 拿到 success:false，新评论也立即可见，
+        // 不会出现“提交成功但列表/计数仍旧、要手动刷新才出现”（Bugbot Medium）
+        const created = res.data;
+        setInlineCommentItems((prev) => (prev.some((c) => c.id === created.id) ? prev : [...prev, created]));
+        setCommentCount((c) => c + 1);
+        await refreshComments(); // 与服务器对账：成功则覆盖为真值，失败则保留乐观结果
+      }
       return true;
     }
     toast.error('添加失败', res.error?.message);
@@ -1710,7 +1717,10 @@ export function DocBrowser({
   // 激活某条批注（点正文气泡或点批注卡）：仅 toggle 状态。滚动定位由下面的 effect 按真实锚点处理。
   const handleActivateComment = useCallback((key: string) => {
     setActiveCommentKey((prev) => (prev === key ? null : key));
-  }, []);
+    // margin 布局下若批注栏被收起（marginCollapsed），点气泡只 toggle 看不到内容；
+    // 重新展开批注栏，让激活的卡片可见（Codex P2：collapsed 时气泡要能露出可读评论面）
+    if (inlineCommentLayout === 'margin') setMarginCollapsed(false);
+  }, [inlineCommentLayout]);
 
   // 激活后把正文锚点滚到眼前：用 overlay 已按 findTextRange（去空白 + contextBefore 消歧）放置的
   // data-active-hl 元素，而非 raw indexOf（会被空白归一化/重复短语坑，Bugbot Medium）。
@@ -1723,6 +1733,19 @@ export function DocBrowser({
     });
     return () => cancelAnimationFrame(raf);
   }, [activeCommentKey]);
+
+  // 激活的分组若已不存在于当前评论列表（删光该处批注 / 刷新后消失）→ 清掉激活/hover，
+  // 避免连线层、hover 联动指向幽灵分组（Bugbot Low：active key survives deletion）
+  useEffect(() => {
+    if (!activeCommentKey) return;
+    const stillThere = inlineCommentItems.some(
+      (c) => !c.isWholeDocument && c.selectedText && groupKey(c.selectedText) === activeCommentKey,
+    );
+    if (!stillThere) {
+      setActiveCommentKey(null);
+      setHoveredCommentKey(null);
+    }
+  }, [inlineCommentItems, activeCommentKey]);
 
   // F1：仅当当前预览是文本类（Markdown/提取文本）时，给右侧 TOC 提供正文
   const tocContent = useMemo(() => {
@@ -2945,8 +2968,9 @@ export function DocBrowser({
                     <p className="text-[13px]">{selectedEntryData?.isFolder ? '这是一个目录' : '无法预览该文件'}</p>
                   </div>
                 )}
-                {/* 划词选中时的浮层"添加评论"按钮 */}
-                {liveSelection && !editMode && (
+                {/* 划词选中时的浮层"添加评论"按钮——仅有写权限时出现；只读访客（私有分享/匿名公开）不弹，
+                    避免写了提交才 403（Codex P2：read-only viewers 不该拿到写入框） */}
+                {liveSelection && !editMode && commentsCanCreate && (
                   <SelectionActionPopover
                     selection={liveSelection}
                     onAddComment={() => {

--- a/prd-admin/src/components/doc-browser/DocBrowser.tsx
+++ b/prd-admin/src/components/doc-browser/DocBrowser.tsx
@@ -1715,6 +1715,9 @@ export function DocBrowser({
     if (res.success) {
       // 慢删除可能在切档后才返回：仅当该评论属于当前条目才动列表/计数（Bugbot Medium）
       if (comment.entryId === trackedEntryForComments?.id) {
+        // 先 bump fetchId：作废所有在途的 refreshComments（抽屉关闭/创建后刷新）响应，
+        // 否则它们带着删除前的服务器快照晚到，会把已删评论“复活”回列表/计数（Bugbot Medium）
+        commentCountFetchIdRef.current += 1;
         setInlineCommentItems((prev) => prev.filter((c) => c.id !== comment.id));
         setCommentCount((c) => Math.max(0, c - 1));
       }

--- a/prd-admin/src/components/doc-browser/DocBrowser.tsx
+++ b/prd-admin/src/components/doc-browser/DocBrowser.tsx
@@ -1751,13 +1751,18 @@ export function DocBrowser({
     }
   }, [trackedEntryForComments]);
 
-  // 激活某条批注（点正文气泡或点批注卡）：仅 toggle 状态。滚动定位由下面的 effect 按真实锚点处理。
+  // 激活某条批注（点正文气泡或点批注卡）：默认 toggle。滚动定位由下面的 effect 按真实锚点处理。
   const handleActivateComment = useCallback((key: string) => {
+    // margin 收起态下点气泡：重开批注栏并「强制激活」该条（不 toggle off）。
+    // 否则同一条仍 active 时点它会被 toggle 关掉，>3 条时目标卡片仍折叠、点了看不到内容（Codex P2）。
+    if (inlineCommentLayout === 'margin' && marginCollapsed) {
+      setMarginCollapsed(false);
+      setActiveCommentKey(key);
+      return;
+    }
     setActiveCommentKey((prev) => (prev === key ? null : key));
-    // margin 布局下若批注栏被收起（marginCollapsed），点气泡只 toggle 看不到内容；
-    // 重新展开批注栏，让激活的卡片可见（Codex P2：collapsed 时气泡要能露出可读评论面）
     if (inlineCommentLayout === 'margin') setMarginCollapsed(false);
-  }, [inlineCommentLayout]);
+  }, [inlineCommentLayout, marginCollapsed]);
 
   // 激活后把正文锚点滚到眼前：用 overlay 已按 findTextRange（去空白 + contextBefore 消歧）放置的
   // data-active-hl 元素，而非 raw indexOf（会被空白归一化/重复短语坑，Bugbot Medium）。

--- a/prd-admin/src/components/doc-browser/DocBrowser.tsx
+++ b/prd-admin/src/components/doc-browser/DocBrowser.tsx
@@ -3005,8 +3005,7 @@ export function DocBrowser({
               {/* 激活批注的牵引连线（active-only，业界 Word/Figma 做法）：仅 margin 布局且有激活项时出现 */}
               {inlineCommentLayout === 'margin' && !marginCollapsed && !editMode && !contentLoading
                 && tocContent && inlineCommentItems.length > 0 && activeCommentKey && (
-                <InlineCommentConnector activeKey={activeCommentKey} color={threadColor(activeCommentKey)} />
-              )}
+                <InlineCommentConnector activeKey={activeCommentKey} color={threadColor(activeCommentKey)} boundsRef={contentAreaRef} />)}
             </div>
           </>
         ) : (

--- a/prd-admin/src/components/doc-browser/DocBrowser.tsx
+++ b/prd-admin/src/components/doc-browser/DocBrowser.tsx
@@ -1631,15 +1631,19 @@ export function DocBrowser({
     const e = selectedEntryData;
     return e && !e.isFolder ? e : null;
   }, [selectedEntryData]);
+  // 仅用稳定的 entryId 作为「切条目」信号：trackedEntryForComments 对象会因 entries/searchResults
+  // 后台刷新拿到新数组引用而重算（同一 entryId 也变），不能用对象做 effect 依赖，否则后台刷新会
+  // 误触发下面的复位、把正在写的就地浮层/草稿清掉（Bugbot Medium）
+  const entryIdForComments = trackedEntryForComments?.id ?? null;
 
-  // 进入条目时预拉评论计数，让正文上方常驻入口（共享视图也能看到他人评论的存在）
+  // 进入条目时预拉评论 + 复位上一条目的临时 UI 态。只在 entryId / shareToken 真正变化时跑。
   useEffect(() => {
     // 切文档复位：收起批注栏的临时态、未发完的就地输入浮层、激活/hover 态
     setMarginCollapsed(false);
     setComposer(null);
     setActiveCommentKey(null);
     setHoveredCommentKey(null);
-    if (!trackedEntryForComments) {
+    if (!entryIdForComments) {
       setCommentCount(0);
       setInlineCommentItems([]);
       setCommentsCanCreate(false);
@@ -1657,7 +1661,7 @@ export function DocBrowser({
     setCommentsViewerId(null);
     (async () => {
       try {
-        const res = await listInlineComments(trackedEntryForComments.id, inlineCommentShareToken);
+        const res = await listInlineComments(entryIdForComments, inlineCommentShareToken);
         if (myId === commentCountFetchIdRef.current && res.success) {
           setCommentCount(res.data.items.length);
           setInlineCommentItems(res.data.items);
@@ -1667,7 +1671,7 @@ export function DocBrowser({
         }
       } catch { /* 私有库 + 无分享 + 非 owner 会 404，正常 */ }
     })();
-  }, [trackedEntryForComments, inlineCommentShareToken]);
+  }, [entryIdForComments, inlineCommentShareToken]);
 
   // 评论的增/删后重拉（margin/inline/composer 共用一条刷新路径），带 fetchIdRef 守卫防串档
   const refreshComments = useCallback(async () => {

--- a/prd-admin/src/components/doc-browser/DocBrowser.tsx
+++ b/prd-admin/src/components/doc-browser/DocBrowser.tsx
@@ -1600,6 +1600,8 @@ export function DocBrowser({
   // 删除权限逐条判定用（公开库 canCreate 对任意登录者为 true，但删除仅作者/库主，Codex P2）
   const [commentsIsOwner, setCommentsIsOwner] = useState(false);
   const [commentsViewerId, setCommentsViewerId] = useState<string | null>(null);
+  // 其它面板（批注栏/内联/composer）增删评论后自增，驱动已打开的抽屉重拉，避免抽屉与正文数据脱节（Bugbot Medium）
+  const [commentsSyncTick, setCommentsSyncTick] = useState(0);
   // 批注栏 ↔ 正文高亮联动：hover 某条批注卡 → 命中分组 key → 对应高亮微亮
   const [hoveredCommentKey, setHoveredCommentKey] = useState<string | null>(null);
   // 激活态（点正文气泡或点批注卡）：高亮加亮 + 批注卡升起 + 画连线，一次只激活一条
@@ -1684,6 +1686,7 @@ export function DocBrowser({
       setCommentsCanCreate(res.data.canCreate);
       setCommentsIsOwner(!!res.data.isOwner);
       setCommentsViewerId(res.data.viewerUserId ?? null);
+      setCommentsSyncTick((t) => t + 1);
     }
   }, [trackedEntryForComments, inlineCommentShareToken]);
 
@@ -1741,6 +1744,7 @@ export function DocBrowser({
         commentCountFetchIdRef.current += 1;
         setInlineCommentItems((prev) => prev.filter((c) => c.id !== comment.id));
         setCommentCount((c) => Math.max(0, c - 1));
+        setCommentsSyncTick((t) => t + 1);
       }
     } else {
       toast.error('删除失败', res.error?.message);
@@ -3192,6 +3196,7 @@ export function DocBrowser({
           entryId={trackedEntryForComments.id}
           entryTitle={trackedEntryForComments.title}
           shareToken={inlineCommentShareToken}
+          syncTick={commentsSyncTick}
           pendingSelection={pendingSelection}
           onClearPending={() => setPendingSelection(null)}
           onLocate={(text) => {

--- a/prd-admin/src/components/doc-browser/DocBrowser.tsx
+++ b/prd-admin/src/components/doc-browser/DocBrowser.tsx
@@ -306,15 +306,19 @@ import ShinyText from '@/components/reactbits/ShinyText';
 import { systemDialog } from '@/lib/systemDialog';
 import { useViewTracking } from '@/lib/useViewTracking';
 import { useContentSelection, type ContentSelectionInfo } from '@/lib/useContentSelection';
-import { MessageSquareText, MessageSquarePlus, Check, ChevronLeft } from 'lucide-react';
+import { MessageSquareText, MessageSquarePlus, Check, ChevronLeft, PanelRight, MessageSquare } from 'lucide-react';
 import { InlineCommentDrawer, type PendingSelection } from '@/pages/document-store/InlineCommentDrawer';
 import type { DocumentInlineComment } from '@/services/contracts/documentStore';
 import { AcceptanceEvidenceGraph } from './AcceptanceEvidenceGraph';
 import { Workflow } from 'lucide-react';
-import { listInlineComments } from '@/services';
+import { listInlineComments, createInlineComment, deleteInlineComment } from '@/services';
+import { toast } from '@/lib/toast';
 import { DocToc } from './DocToc';
 import { DocEmptyState } from './DocEmptyState';
 import { InlineCommentOverlay } from './InlineCommentOverlay';
+import { InlineCommentMargin } from './InlineCommentMargin';
+import { InlineCommentComposer } from './InlineCommentComposer';
+import { useDocReaderPrefs } from '@/stores/docReaderPrefsStore';
 import { BulkActionBar } from './BulkActionBar';
 
 // ── 类型 ──
@@ -1587,6 +1591,16 @@ export function DocBrowser({
   // 评论计数 fetchIdRef 守卫（PR #685 Bugbot Low）：切换条目 / onClose 重拉时，
   // 旧 entry 的慢响应不覆盖新 entry 已设的计数。
   const commentCountFetchIdRef = useRef(0);
+  // 划词评论布局（margin=右侧批注栏 / inline=正文内联气泡），个人偏好走 localStorage 持久化
+  const inlineCommentLayout = useDocReaderPrefs((s) => s.inlineCommentLayout);
+  const setInlineCommentLayout = useDocReaderPrefs((s) => s.setInlineCommentLayout);
+  const [commentsCanCreate, setCommentsCanCreate] = useState(false);
+  // 批注栏 ↔ 正文高亮联动：hover 某条批注卡 → 命中分组 key → 对应高亮加亮
+  const [hoveredCommentKey, setHoveredCommentKey] = useState<string | null>(null);
+  // 用户点「收起批注栏」后本条目临时切回 TOC（切文档复位）
+  const [marginCollapsed, setMarginCollapsed] = useState(false);
+  // 划词后就地输入浮层（取代甩到右侧抽屉）
+  const [composer, setComposer] = useState<{ sel: PendingSelection; rect: { top: number; left: number; width: number; height: number } } | null>(null);
   // 选区 offset 必须基于"实际渲染的正文"解析：文本类预览渲染的是
   // parseFrontmatter(text).body（已剥 frontmatter），若把含 frontmatter 的
   // 原文喂给 useContentSelection，选中同时出现在 frontmatter 的文字（如标题）
@@ -1613,9 +1627,13 @@ export function DocBrowser({
 
   // 进入条目时预拉评论计数，让正文上方常驻入口（共享视图也能看到他人评论的存在）
   useEffect(() => {
+    // 切文档复位：收起批注栏的临时态、未发完的就地输入浮层
+    setMarginCollapsed(false);
+    setComposer(null);
     if (!trackedEntryForComments) {
       setCommentCount(0);
       setInlineCommentItems([]);
+      setCommentsCanCreate(false);
       return;
     }
     const myId = ++commentCountFetchIdRef.current;
@@ -1623,16 +1641,55 @@ export function DocBrowser({
     // 旧评论残留，甚至因正文文本碰巧匹配把旧高亮/气泡画到新文档上（Codex P2）
     setCommentCount(0);
     setInlineCommentItems([]);
+    setCommentsCanCreate(false);
     (async () => {
       try {
         const res = await listInlineComments(trackedEntryForComments.id, inlineCommentShareToken);
         if (myId === commentCountFetchIdRef.current && res.success) {
           setCommentCount(res.data.items.length);
           setInlineCommentItems(res.data.items);
+          setCommentsCanCreate(res.data.canCreate);
         }
       } catch { /* 私有库 + 无分享 + 非 owner 会 404，正常 */ }
     })();
   }, [trackedEntryForComments, inlineCommentShareToken]);
+
+  // 评论的增/删后重拉（margin/inline/composer 共用一条刷新路径），带 fetchIdRef 守卫防串档
+  const refreshComments = useCallback(async () => {
+    if (!trackedEntryForComments) return;
+    const myId = ++commentCountFetchIdRef.current;
+    const res = await listInlineComments(trackedEntryForComments.id, inlineCommentShareToken);
+    if (myId === commentCountFetchIdRef.current && res.success) {
+      setCommentCount(res.data.items.length);
+      setInlineCommentItems(res.data.items);
+      setCommentsCanCreate(res.data.canCreate);
+    }
+  }, [trackedEntryForComments, inlineCommentShareToken]);
+
+  const handleCreateComment = useCallback(async (input: {
+    selectedText: string;
+    contextBefore?: string;
+    contextAfter?: string;
+    startOffset: number;
+    endOffset: number;
+    content: string;
+  }): Promise<boolean> => {
+    if (!trackedEntryForComments) return false;
+    const res = await createInlineComment(trackedEntryForComments.id, input);
+    if (res.success) { await refreshComments(); return true; }
+    toast.error('添加失败', res.error?.message);
+    return false;
+  }, [trackedEntryForComments, refreshComments]);
+
+  const handleDeleteComment = useCallback(async (comment: DocumentInlineComment) => {
+    const res = await deleteInlineComment(comment.id);
+    if (res.success) {
+      setInlineCommentItems((prev) => prev.filter((c) => c.id !== comment.id));
+      setCommentCount((c) => Math.max(0, c - 1));
+    } else {
+      toast.error('删除失败', res.error?.message);
+    }
+  }, []);
 
   // F1：仅当当前预览是文本类（Markdown/提取文本）时，给右侧 TOC 提供正文
   const tocContent = useMemo(() => {
@@ -2726,6 +2783,29 @@ export function DocBrowser({
                   </button>
                 );
               })()}
+              {/* 划词评论布局切换：批注栏（右侧常驻）/ 内联（正文气泡展开）。仅文本预览态显示 */}
+              {trackedEntryForComments && tocContent && !editMode && (
+                <div className="flex items-center rounded-[8px] overflow-hidden flex-shrink-0"
+                  style={{ border: '1px solid rgba(168,85,247,0.18)' }}
+                  title="切换批注展示方式（保存为个人偏好）">
+                  {([
+                    { m: 'margin' as const, label: '批注栏', Icon: PanelRight },
+                    { m: 'inline' as const, label: '内联', Icon: MessageSquare },
+                  ]).map(({ m, label, Icon }) => (
+                    <button
+                      key={m}
+                      onClick={() => { setInlineCommentLayout(m); if (m === 'margin') setMarginCollapsed(false); }}
+                      className="h-6 px-2 text-[10px] font-semibold flex items-center gap-1 cursor-pointer transition-colors"
+                      style={{
+                        background: inlineCommentLayout === m ? 'rgba(168,85,247,0.18)' : 'transparent',
+                        color: inlineCommentLayout === m ? 'rgba(216,180,254,0.97)' : 'var(--text-muted)',
+                      }}
+                    >
+                      <Icon size={11} /> {label}
+                    </button>
+                  ))}
+                </div>
+              )}
               {/* 批次 D：划词评论开关按钮 */}
               {trackedEntryForComments && (
                 <button
@@ -2837,34 +2917,76 @@ export function DocBrowser({
                   <SelectionActionPopover
                     selection={liveSelection}
                     onAddComment={() => {
-                      setPendingSelection({
-                        selectedText: liveSelection.selectedText,
-                        contextBefore: liveSelection.contextBefore,
-                        contextAfter: liveSelection.contextAfter,
-                        startOffset: liveSelection.startOffset,
-                        endOffset: liveSelection.endOffset,
+                      // 就地输入：在选区旁展开 composer，不再甩到右侧抽屉
+                      const r = liveSelection.rect;
+                      setComposer({
+                        sel: {
+                          selectedText: liveSelection.selectedText,
+                          contextBefore: liveSelection.contextBefore,
+                          contextAfter: liveSelection.contextAfter,
+                          startOffset: liveSelection.startOffset,
+                          endOffset: liveSelection.endOffset,
+                        },
+                        rect: { top: r.top, left: r.left, width: r.width, height: r.height },
                       });
-                      setInlineCommentsOpen(true);
                       clearLiveSelection();
                       window.getSelection()?.removeAllRanges();
                     }}
                   />
                 )}
-                {/* 行内评论高亮 + 气泡：把他人评论锚回正文，气泡点击打开评论抽屉 */}
+                {/* 行内评论高亮 + 气泡/内联展开：把他人评论锚回正文，边读边可见 */}
                 {!editMode && !contentLoading && tocContent && inlineCommentItems.length > 0 && (
                   <InlineCommentOverlay
                     containerRef={contentAreaRef}
                     comments={inlineCommentItems}
                     reflowKey={`${selectedEntryId ?? ''}:${preview?.text?.length ?? 0}`}
-                    onOpenComment={() => setInlineCommentsOpen(true)}
+                    mode={inlineCommentLayout}
+                    hoveredKey={hoveredCommentKey}
+                    canCreate={commentsCanCreate}
+                    onCreate={handleCreateComment}
+                    onDelete={handleDeleteComment}
+                  />
+                )}
+                {/* 划词后就地输入浮层（createPortal 到 body） */}
+                {composer && (
+                  <InlineCommentComposer
+                    selectedText={composer.sel.selectedText}
+                    anchorRect={composer.rect}
+                    onSubmit={(content) => handleCreateComment({
+                      selectedText: composer.sel.selectedText,
+                      contextBefore: composer.sel.contextBefore,
+                      contextAfter: composer.sel.contextAfter,
+                      startOffset: composer.sel.startOffset,
+                      endOffset: composer.sel.endOffset,
+                      content,
+                    })}
+                    onClose={() => setComposer(null)}
                   />
                 )}
               </div>
               </div>
-              {/* F1：本页章节导航——仅文本类预览且非编辑态显示，无标题时组件自身返回 null */}
-              {!contentLoading && !editMode && tocContent && (
-                <DocToc content={tocContent} scrollContainerRef={contentAreaRef} />
-              )}
+              {/* 右侧栏：margin 布局且有评论 → 批注栏常驻（取代 TOC）；否则 → 本页章节导航 */}
+              {(() => {
+                const showMargin = inlineCommentLayout === 'margin' && !contentLoading && !editMode
+                  && !!tocContent && inlineCommentItems.length > 0 && !marginCollapsed;
+                if (showMargin) {
+                  return (
+                    <InlineCommentMargin
+                      comments={inlineCommentItems}
+                      canCreate={commentsCanCreate}
+                      hoveredKey={hoveredCommentKey}
+                      onHoverKey={setHoveredCommentKey}
+                      onLocate={(text) => scrollToTextInContainer(contentAreaRef.current, text)}
+                      onCreate={handleCreateComment}
+                      onDelete={handleDeleteComment}
+                      onClose={() => setMarginCollapsed(true)}
+                    />
+                  );
+                }
+                return (!contentLoading && !editMode && tocContent) ? (
+                  <DocToc content={tocContent} scrollContainerRef={contentAreaRef} />
+                ) : null;
+              })()}
             </div>
           </>
         ) : (

--- a/prd-admin/src/components/doc-browser/DocBrowser.tsx
+++ b/prd-admin/src/components/doc-browser/DocBrowser.tsx
@@ -3043,6 +3043,7 @@ export function DocBrowser({
                   <InlineCommentComposer
                     selectedText={composer.sel.selectedText}
                     anchorRect={composer.rect}
+                    scrollRef={contentAreaRef}
                     onSubmit={(content) => handleCreateComment({
                       selectedText: composer.sel.selectedText,
                       contextBefore: composer.sel.contextBefore,

--- a/prd-admin/src/components/doc-browser/DocBrowser.tsx
+++ b/prd-admin/src/components/doc-browser/DocBrowser.tsx
@@ -1597,6 +1597,9 @@ export function DocBrowser({
   const inlineCommentLayout = useDocReaderPrefs((s) => s.inlineCommentLayout);
   const setInlineCommentLayout = useDocReaderPrefs((s) => s.setInlineCommentLayout);
   const [commentsCanCreate, setCommentsCanCreate] = useState(false);
+  // 删除权限逐条判定用（公开库 canCreate 对任意登录者为 true，但删除仅作者/库主，Codex P2）
+  const [commentsIsOwner, setCommentsIsOwner] = useState(false);
+  const [commentsViewerId, setCommentsViewerId] = useState<string | null>(null);
   // 批注栏 ↔ 正文高亮联动：hover 某条批注卡 → 命中分组 key → 对应高亮微亮
   const [hoveredCommentKey, setHoveredCommentKey] = useState<string | null>(null);
   // 激活态（点正文气泡或点批注卡）：高亮加亮 + 批注卡升起 + 画连线，一次只激活一条
@@ -1640,6 +1643,8 @@ export function DocBrowser({
       setCommentCount(0);
       setInlineCommentItems([]);
       setCommentsCanCreate(false);
+      setCommentsIsOwner(false);
+      setCommentsViewerId(null);
       return;
     }
     const myId = ++commentCountFetchIdRef.current;
@@ -1648,6 +1653,8 @@ export function DocBrowser({
     setCommentCount(0);
     setInlineCommentItems([]);
     setCommentsCanCreate(false);
+    setCommentsIsOwner(false);
+    setCommentsViewerId(null);
     (async () => {
       try {
         const res = await listInlineComments(trackedEntryForComments.id, inlineCommentShareToken);
@@ -1655,6 +1662,8 @@ export function DocBrowser({
           setCommentCount(res.data.items.length);
           setInlineCommentItems(res.data.items);
           setCommentsCanCreate(res.data.canCreate);
+          setCommentsIsOwner(!!res.data.isOwner);
+          setCommentsViewerId(res.data.viewerUserId ?? null);
         }
       } catch { /* 私有库 + 无分享 + 非 owner 会 404，正常 */ }
     })();
@@ -1669,8 +1678,16 @@ export function DocBrowser({
       setCommentCount(res.data.items.length);
       setInlineCommentItems(res.data.items);
       setCommentsCanCreate(res.data.canCreate);
+      setCommentsIsOwner(!!res.data.isOwner);
+      setCommentsViewerId(res.data.viewerUserId ?? null);
     }
   }, [trackedEntryForComments, inlineCommentShareToken]);
+
+  // 逐条删除权限：库主可删任意；作者可删自己。公开库 canCreate 对任意登录者为 true，不能当 canDelete（Codex P2）
+  const canDeleteComment = useCallback(
+    (c: DocumentInlineComment) => commentsIsOwner || (!!commentsViewerId && c.authorUserId === commentsViewerId),
+    [commentsIsOwner, commentsViewerId],
+  );
 
   const handleCreateComment = useCallback(async (input: {
     selectedText: string;
@@ -3016,6 +3033,7 @@ export function DocBrowser({
                     activeKey={activeCommentKey}
                     onActivate={handleActivateComment}
                     canCreate={commentsCanCreate}
+                    canDelete={canDeleteComment}
                     onCreate={handleCreateComment}
                     onDelete={handleDeleteComment}
                   />
@@ -3047,6 +3065,7 @@ export function DocBrowser({
                     <InlineCommentMargin
                       comments={inlineCommentItems}
                       canCreate={commentsCanCreate}
+                      canDelete={canDeleteComment}
                       hoveredKey={hoveredCommentKey}
                       activeKey={activeCommentKey}
                       onHoverKey={setHoveredCommentKey}

--- a/prd-admin/src/components/doc-browser/DocBrowser.tsx
+++ b/prd-admin/src/components/doc-browser/DocBrowser.tsx
@@ -318,6 +318,8 @@ import { DocEmptyState } from './DocEmptyState';
 import { InlineCommentOverlay } from './InlineCommentOverlay';
 import { InlineCommentMargin } from './InlineCommentMargin';
 import { InlineCommentComposer } from './InlineCommentComposer';
+import { InlineCommentConnector } from './InlineCommentConnector';
+import { threadColor } from './inlineCommentShared';
 import { useDocReaderPrefs } from '@/stores/docReaderPrefsStore';
 import { BulkActionBar } from './BulkActionBar';
 
@@ -1595,8 +1597,10 @@ export function DocBrowser({
   const inlineCommentLayout = useDocReaderPrefs((s) => s.inlineCommentLayout);
   const setInlineCommentLayout = useDocReaderPrefs((s) => s.setInlineCommentLayout);
   const [commentsCanCreate, setCommentsCanCreate] = useState(false);
-  // 批注栏 ↔ 正文高亮联动：hover 某条批注卡 → 命中分组 key → 对应高亮加亮
+  // 批注栏 ↔ 正文高亮联动：hover 某条批注卡 → 命中分组 key → 对应高亮微亮
   const [hoveredCommentKey, setHoveredCommentKey] = useState<string | null>(null);
+  // 激活态（点正文气泡或点批注卡）：高亮加亮 + 批注卡升起 + 画连线，一次只激活一条
+  const [activeCommentKey, setActiveCommentKey] = useState<string | null>(null);
   // 用户点「收起批注栏」后本条目临时切回 TOC（切文档复位）
   const [marginCollapsed, setMarginCollapsed] = useState(false);
   // 划词后就地输入浮层（取代甩到右侧抽屉）
@@ -1627,9 +1631,11 @@ export function DocBrowser({
 
   // 进入条目时预拉评论计数，让正文上方常驻入口（共享视图也能看到他人评论的存在）
   useEffect(() => {
-    // 切文档复位：收起批注栏的临时态、未发完的就地输入浮层
+    // 切文档复位：收起批注栏的临时态、未发完的就地输入浮层、激活/hover 态
     setMarginCollapsed(false);
     setComposer(null);
+    setActiveCommentKey(null);
+    setHoveredCommentKey(null);
     if (!trackedEntryForComments) {
       setCommentCount(0);
       setInlineCommentItems([]);
@@ -1689,6 +1695,12 @@ export function DocBrowser({
     } else {
       toast.error('删除失败', res.error?.message);
     }
+  }, []);
+
+  // 激活某条批注（点正文气泡或点批注卡）：toggle；激活时把正文锚点滚到眼前，连线层据 data 属性画线
+  const handleActivateComment = useCallback((key: string, selectedText: string) => {
+    setActiveCommentKey((prev) => (prev === key ? null : key));
+    if (selectedText) scrollToTextInContainer(contentAreaRef.current, selectedText);
   }, []);
 
   // F1：仅当当前预览是文本类（Markdown/提取文本）时，给右侧 TOC 提供正文
@@ -2794,7 +2806,7 @@ export function DocBrowser({
                   ]).map(({ m, label, Icon }) => (
                     <button
                       key={m}
-                      onClick={() => { setInlineCommentLayout(m); if (m === 'margin') setMarginCollapsed(false); }}
+                      onClick={() => { setInlineCommentLayout(m); setActiveCommentKey(null); if (m === 'margin') setMarginCollapsed(false); }}
                       className="h-6 px-2 text-[10px] font-semibold flex items-center gap-1 cursor-pointer transition-colors"
                       style={{
                         background: inlineCommentLayout === m ? 'rgba(168,85,247,0.18)' : 'transparent',
@@ -2942,6 +2954,8 @@ export function DocBrowser({
                     reflowKey={`${selectedEntryId ?? ''}:${preview?.text?.length ?? 0}`}
                     mode={inlineCommentLayout}
                     hoveredKey={hoveredCommentKey}
+                    activeKey={activeCommentKey}
+                    onActivate={handleActivateComment}
                     canCreate={commentsCanCreate}
                     onCreate={handleCreateComment}
                     onDelete={handleDeleteComment}
@@ -2975,8 +2989,9 @@ export function DocBrowser({
                       comments={inlineCommentItems}
                       canCreate={commentsCanCreate}
                       hoveredKey={hoveredCommentKey}
+                      activeKey={activeCommentKey}
                       onHoverKey={setHoveredCommentKey}
-                      onLocate={(text) => scrollToTextInContainer(contentAreaRef.current, text)}
+                      onActivate={handleActivateComment}
                       onCreate={handleCreateComment}
                       onDelete={handleDeleteComment}
                       onClose={() => setMarginCollapsed(true)}
@@ -2987,6 +3002,11 @@ export function DocBrowser({
                   <DocToc content={tocContent} scrollContainerRef={contentAreaRef} />
                 ) : null;
               })()}
+              {/* 激活批注的牵引连线（active-only，业界 Word/Figma 做法）：仅 margin 布局且有激活项时出现 */}
+              {inlineCommentLayout === 'margin' && !marginCollapsed && !editMode && !contentLoading
+                && tocContent && inlineCommentItems.length > 0 && activeCommentKey && (
+                <InlineCommentConnector activeKey={activeCommentKey} color={threadColor(activeCommentKey)} />
+              )}
             </div>
           </>
         ) : (

--- a/prd-admin/src/components/doc-browser/DocBrowser.tsx
+++ b/prd-admin/src/components/doc-browser/DocBrowser.tsx
@@ -1702,6 +1702,15 @@ export function DocBrowser({
   }, [trackedEntryForComments, refreshComments]);
 
   const handleDeleteComment = useCallback(async (comment: DocumentInlineComment) => {
+    // 删除前确认：margin/inline 的「删除」按钮小、易误点，与抽屉路径保持同样的二次确认（Codex P2）
+    const ok = await systemDialog.confirm({
+      title: '删除评论',
+      message: `确认删除这条评论吗？\n\n"${comment.content.slice(0, 80)}"`,
+      tone: 'danger',
+      confirmText: '删除',
+      cancelText: '取消',
+    });
+    if (!ok) return;
     const res = await deleteInlineComment(comment.id);
     if (res.success) {
       // 慢删除可能在切档后才返回：仅当该评论属于当前条目才动列表/计数（Bugbot Medium）
@@ -3165,18 +3174,10 @@ export function DocBrowser({
           onClose={() => {
             setInlineCommentsOpen(false);
             setPendingSelection(null);
-            // 关闭时刷新评论计数（新建/删除/无变化都通用）；带 fetchIdRef 守卫，
-            // 关闭后立刻切换条目时旧响应不覆盖新计数（PR #685 Bugbot Low）
-            if (trackedEntryForComments) {
-              const entryId = trackedEntryForComments.id;
-              const myId = ++commentCountFetchIdRef.current;
-              listInlineComments(entryId, inlineCommentShareToken).then((res) => {
-                if (myId === commentCountFetchIdRef.current && res.success) {
-                  setCommentCount(res.data.items.length);
-                  setInlineCommentItems(res.data.items);
-                }
-              }).catch(() => {});
-            }
+            // 关闭时刷新评论（新建/删除/无变化都通用）。走 refreshComments 统一路径：
+            // 它同时更新 count / items / commentsCanCreate（之前漏同步 canCreate，导致抽屉里
+            // 能评论、关掉后 margin/composer/overlay 仍按只读禁写，Bugbot Medium），并带 fetchIdRef 守卫。
+            void refreshComments();
           }}
         />
       )}

--- a/prd-admin/src/components/doc-browser/DocBrowser.tsx
+++ b/prd-admin/src/components/doc-browser/DocBrowser.tsx
@@ -3197,6 +3197,7 @@ export function DocBrowser({
           entryTitle={trackedEntryForComments.title}
           shareToken={inlineCommentShareToken}
           syncTick={commentsSyncTick}
+          onChanged={() => { void refreshComments(); }}
           pendingSelection={pendingSelection}
           onClearPending={() => setPendingSelection(null)}
           onLocate={(text) => {

--- a/prd-admin/src/components/doc-browser/DocBrowser.tsx
+++ b/prd-admin/src/components/doc-browser/DocBrowser.tsx
@@ -1604,7 +1604,7 @@ export function DocBrowser({
   // 用户点「收起批注栏」后本条目临时切回 TOC（切文档复位）
   const [marginCollapsed, setMarginCollapsed] = useState(false);
   // 划词后就地输入浮层（取代甩到右侧抽屉）
-  const [composer, setComposer] = useState<{ sel: PendingSelection; rect: { top: number; left: number; width: number; height: number } } | null>(null);
+  const [composer, setComposer] = useState<{ entryId: string; sel: PendingSelection; rect: { top: number; left: number; width: number; height: number } } | null>(null);
   // 选区 offset 必须基于"实际渲染的正文"解析：文本类预览渲染的是
   // parseFrontmatter(text).body（已剥 frontmatter），若把含 frontmatter 的
   // 原文喂给 useContentSelection，选中同时出现在 frontmatter 的文字（如标题）
@@ -1679,10 +1679,17 @@ export function DocBrowser({
     startOffset: number;
     endOffset: number;
     content: string;
-  }): Promise<boolean> => {
-    if (!trackedEntryForComments) return false;
-    const res = await createInlineComment(trackedEntryForComments.id, input);
-    if (res.success) { await refreshComments(); return true; }
+  }, entryIdOverride?: string): Promise<boolean> => {
+    // 评论必须落到“产生这段选区的那个条目”。composer 打开时已捕获 entryId，
+    // 用它而非提交时的当前条目，避免切档后把旧选区/偏移写到新文档（Bugbot High）。
+    const targetId = entryIdOverride ?? trackedEntryForComments?.id;
+    if (!targetId) return false;
+    const res = await createInlineComment(targetId, input);
+    if (res.success) {
+      // 仅当目标条目仍是当前正在看的条目才刷新列表，避免改到别的文档状态
+      if (targetId === trackedEntryForComments?.id) await refreshComments();
+      return true;
+    }
     toast.error('添加失败', res.error?.message);
     return false;
   }, [trackedEntryForComments, refreshComments]);
@@ -1690,18 +1697,32 @@ export function DocBrowser({
   const handleDeleteComment = useCallback(async (comment: DocumentInlineComment) => {
     const res = await deleteInlineComment(comment.id);
     if (res.success) {
-      setInlineCommentItems((prev) => prev.filter((c) => c.id !== comment.id));
-      setCommentCount((c) => Math.max(0, c - 1));
+      // 慢删除可能在切档后才返回：仅当该评论属于当前条目才动列表/计数（Bugbot Medium）
+      if (comment.entryId === trackedEntryForComments?.id) {
+        setInlineCommentItems((prev) => prev.filter((c) => c.id !== comment.id));
+        setCommentCount((c) => Math.max(0, c - 1));
+      }
     } else {
       toast.error('删除失败', res.error?.message);
     }
+  }, [trackedEntryForComments]);
+
+  // 激活某条批注（点正文气泡或点批注卡）：仅 toggle 状态。滚动定位由下面的 effect 按真实锚点处理。
+  const handleActivateComment = useCallback((key: string) => {
+    setActiveCommentKey((prev) => (prev === key ? null : key));
   }, []);
 
-  // 激活某条批注（点正文气泡或点批注卡）：toggle；激活时把正文锚点滚到眼前，连线层据 data 属性画线
-  const handleActivateComment = useCallback((key: string, selectedText: string) => {
-    setActiveCommentKey((prev) => (prev === key ? null : key));
-    if (selectedText) scrollToTextInContainer(contentAreaRef.current, selectedText);
-  }, []);
+  // 激活后把正文锚点滚到眼前：用 overlay 已按 findTextRange（去空白 + contextBefore 消歧）放置的
+  // data-active-hl 元素，而非 raw indexOf（会被空白归一化/重复短语坑，Bugbot Medium）。
+  // 仅在激活（非置空）时滚，取消激活不跳视口（Bugbot Low）。下一帧 data 属性才就绪，故走 rAF。
+  useEffect(() => {
+    if (!activeCommentKey) return;
+    const raf = requestAnimationFrame(() => {
+      (document.querySelector('[data-active-hl="1"]') as HTMLElement | null)
+        ?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [activeCommentKey]);
 
   // F1：仅当当前预览是文本类（Markdown/提取文本）时，给右侧 TOC 提供正文
   const tocContent = useMemo(() => {
@@ -2930,8 +2951,10 @@ export function DocBrowser({
                     selection={liveSelection}
                     onAddComment={() => {
                       // 就地输入：在选区旁展开 composer，不再甩到右侧抽屉
+                      if (!trackedEntryForComments) return;
                       const r = liveSelection.rect;
                       setComposer({
+                        entryId: trackedEntryForComments.id,
                         sel: {
                           selectedText: liveSelection.selectedText,
                           contextBefore: liveSelection.contextBefore,
@@ -2973,7 +2996,7 @@ export function DocBrowser({
                       startOffset: composer.sel.startOffset,
                       endOffset: composer.sel.endOffset,
                       content,
-                    })}
+                    }, composer.entryId)}
                     onClose={() => setComposer(null)}
                   />
                 )}

--- a/prd-admin/src/components/doc-browser/InlineCommentComposer.tsx
+++ b/prd-admin/src/components/doc-browser/InlineCommentComposer.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Send, X, CornerDownLeft } from 'lucide-react';
+import { MapSpinner } from '@/components/ui/VideoLoader';
+
+// 划词后「就地输入」批注的小浮层（取代甩到右侧抽屉）。
+// 锚在选区附近，写完 ⌘/Ctrl+Enter 发送；遵 frontend-modal.md：createPortal 到 body + inline style 定位。
+
+export function InlineCommentComposer({
+  selectedText,
+  anchorRect,
+  onSubmit,
+  onClose,
+}: {
+  selectedText: string;
+  /** 选区的视口坐标（getBoundingClientRect），用于定位浮层 */
+  anchorRect: { top: number; left: number; width: number; height: number };
+  onSubmit: (content: string) => Promise<boolean>;
+  onClose: () => void;
+}) {
+  const [draft, setDraft] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    textareaRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const handleSubmit = async () => {
+    const t = draft.trim();
+    if (!t || submitting) return;
+    setSubmitting(true);
+    const ok = await onSubmit(t);
+    setSubmitting(false);
+    if (ok) { setDraft(''); onClose(); }
+  };
+
+  const width = 320;
+  // 默认放选区下方；贴近底部时翻到上方
+  const belowTop = anchorRect.top + anchorRect.height + 8;
+  const wouldOverflow = belowTop + 190 > window.innerHeight;
+  const top = wouldOverflow ? Math.max(8, anchorRect.top - 198) : belowTop;
+  const left = Math.max(8, Math.min(window.innerWidth - width - 8, anchorRect.left));
+
+  const node = (
+    <div
+      className="fixed z-[120]"
+      style={{
+        top,
+        left,
+        width,
+        borderRadius: 14,
+        padding: 12,
+        background: 'linear-gradient(180deg, rgba(30,28,46,0.97), rgba(20,19,28,0.98))',
+        border: '1px solid rgba(168,85,247,0.4)',
+        boxShadow: '0 18px 44px -10px rgba(0,0,0,0.6)',
+        backdropFilter: 'blur(40px)',
+      }}
+      onMouseDown={(e) => e.stopPropagation()}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-[10px] font-semibold" style={{ color: 'var(--text-muted)' }}>划词批注</span>
+        <button onClick={onClose} className="w-5 h-5 rounded-[6px] flex items-center justify-center cursor-pointer hover:bg-white/6 transition-colors"
+          style={{ color: 'var(--text-muted)' }} title="关闭">
+          <X size={13} />
+        </button>
+      </div>
+      <div className="px-2.5 py-1.5 rounded-[8px] text-[11px] mb-2 max-h-16 overflow-y-auto"
+        style={{ background: 'rgba(168,85,247,0.10)', border: '1px solid rgba(168,85,247,0.22)', color: 'rgba(216,180,254,0.95)' }}>
+        {selectedText.length > 100 ? selectedText.slice(0, 100) + '…' : selectedText}
+      </div>
+      <textarea
+        ref={textareaRef}
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); handleSubmit(); }
+        }}
+        placeholder="写下你的批注…（⌘/Ctrl + Enter 发送）"
+        rows={3}
+        className="w-full px-2.5 py-2 rounded-[8px] text-[12px] outline-none resize-none"
+        style={{ background: 'rgba(255,255,255,0.045)', border: '1px solid rgba(255,255,255,0.09)', color: 'var(--text-primary)' }}
+      />
+      <div className="flex items-center justify-between mt-2">
+        <span className="text-[10px]" style={{ color: 'var(--text-muted)' }}>
+          <CornerDownLeft size={9} className="inline mr-1" />
+          ⌘/Ctrl + Enter
+        </span>
+        <button
+          onClick={handleSubmit}
+          disabled={submitting || !draft.trim()}
+          className="h-7 px-3 rounded-[8px] text-[11px] font-semibold flex items-center gap-1.5 cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+          style={{ background: 'rgba(168,85,247,0.18)', border: '1px solid rgba(168,85,247,0.35)', color: 'rgba(216,180,254,0.97)' }}
+        >
+          {submitting ? <MapSpinner size={11} /> : <Send size={11} />}
+          发送
+        </button>
+      </div>
+    </div>
+  );
+
+  return createPortal(node, document.body);
+}

--- a/prd-admin/src/components/doc-browser/InlineCommentComposer.tsx
+++ b/prd-admin/src/components/doc-browser/InlineCommentComposer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type RefObject } from 'react';
 import { createPortal } from 'react-dom';
 import { Send, X, CornerDownLeft } from 'lucide-react';
 import { MapSpinner } from '@/components/ui/VideoLoader';
@@ -9,22 +9,40 @@ import { MapSpinner } from '@/components/ui/VideoLoader';
 export function InlineCommentComposer({
   selectedText,
   anchorRect,
+  scrollRef,
   onSubmit,
   onClose,
 }: {
   selectedText: string;
   /** 选区的视口坐标（getBoundingClientRect），用于定位浮层 */
   anchorRect: { top: number; left: number; width: number; height: number };
+  /** 正文滚动容器：浮层跟随其滚动平移，避免滚动后浮层留在错误位置（Bugbot Medium） */
+  scrollRef?: RefObject<HTMLElement>;
   onSubmit: (content: string) => Promise<boolean>;
   onClose: () => void;
 }) {
   const [draft, setDraft] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  // 打开时清了选区、坐标是当时快照；滚动后按「累计滚动位移」把浮层平移回锚点处
+  const [scrollDy, setScrollDy] = useState(0);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
     textareaRef.current?.focus();
   }, []);
+
+  useEffect(() => {
+    const read = () => (scrollRef?.current?.scrollTop ?? 0) + window.scrollY;
+    const start = read();
+    const onScroll = () => setScrollDy(read() - start);
+    // capture=true 捕获正文内层滚动容器；resize 兜底
+    window.addEventListener('scroll', onScroll, true);
+    window.addEventListener('resize', onScroll);
+    return () => {
+      window.removeEventListener('scroll', onScroll, true);
+      window.removeEventListener('resize', onScroll);
+    };
+  }, [scrollRef]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
@@ -55,6 +73,8 @@ export function InlineCommentComposer({
         top,
         left,
         width,
+        // 正文滚动 dy 后锚点上移 dy，浮层同步上移，保持贴着选区
+        transform: `translateY(${-scrollDy}px)`,
         borderRadius: 14,
         padding: 12,
         background: 'linear-gradient(180deg, rgba(30,28,46,0.97), rgba(20,19,28,0.98))',

--- a/prd-admin/src/components/doc-browser/InlineCommentConnector.tsx
+++ b/prd-admin/src/components/doc-browser/InlineCommentConnector.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+// 激活批注的「牵引连线」（业界做法：Word 选中批注画虚线 / Figma tether）。
+// 只给当前激活的一条画线（active-only，不同时画所有线，避免花哨）。
+// 从正文里激活高亮的气泡（[data-active-hl]）拉一条同色曲线到右侧批注栏的激活卡片（[data-active-card]）。
+// 锚点用 DOM data 属性解耦：overlay 与 margin 各自打标，本层只负责按两点画线 + 跟随滚动/缩放刷新。
+
+export function InlineCommentConnector({ activeKey, color }: { activeKey: string | null; color: string }) {
+  const [geo, setGeo] = useState<{ d: string; ax: number; ay: number; bx: number; by: number } | null>(null);
+
+  useEffect(() => {
+    if (!activeKey) { setGeo(null); return; }
+    let raf = 0;
+    const compute = () => {
+      const hl = document.querySelector('[data-active-hl="1"]') as HTMLElement | null;
+      const card = document.querySelector('[data-active-card="1"]') as HTMLElement | null;
+      if (!hl || !card) { setGeo(null); return; }
+      const a = hl.getBoundingClientRect();
+      const b = card.getBoundingClientRect();
+      const ax = a.right, ay = a.top + a.height / 2;
+      const bx = b.left, by = b.top + Math.min(26, b.height / 2);
+      const mx = ax + (bx - ax) * 0.55;
+      const d = `M ${ax} ${ay} C ${mx} ${ay}, ${mx} ${by}, ${bx} ${by}`;
+      setGeo({ d, ax, ay, bx, by });
+    };
+    const schedule = () => { cancelAnimationFrame(raf); raf = requestAnimationFrame(compute); };
+    schedule();
+    // capture=true 捕获任意内层滚动容器（正文区 + 批注栏各自独立滚）；resize + 兜底定时覆盖异步布局位移
+    window.addEventListener('scroll', schedule, true);
+    window.addEventListener('resize', schedule);
+    const timer = window.setInterval(schedule, 400);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener('scroll', schedule, true);
+      window.removeEventListener('resize', schedule);
+      window.clearInterval(timer);
+    };
+  }, [activeKey]);
+
+  if (!geo) return null;
+  return createPortal(
+    <svg aria-hidden style={{ position: 'fixed', inset: 0, width: '100vw', height: '100vh', pointerEvents: 'none', zIndex: 30 }}>
+      <path d={geo.d} fill="none" stroke={color} strokeWidth={2} strokeOpacity={0.78} strokeLinecap="round" />
+      <circle cx={geo.ax} cy={geo.ay} r={3.5} fill={color} />
+      <circle cx={geo.bx} cy={geo.by} r={3.5} fill={color} />
+    </svg>,
+    document.body,
+  );
+}

--- a/prd-admin/src/components/doc-browser/InlineCommentConnector.tsx
+++ b/prd-admin/src/components/doc-browser/InlineCommentConnector.tsx
@@ -39,11 +39,10 @@ export function InlineCommentConnector({
         const b = card.getBoundingClientRect();
         const bounds = boundsRef.current?.getBoundingClientRect();
         const ay = a.top + a.height / 2;
-        const bCenter = b.top + b.height / 2;
-        // 两端都要在正文可视区内才画（看得见两头才连线，Docs 同理）
-        const offscreen = bounds
-          ? (ay < bounds.top + 4 || ay > bounds.bottom - 4 || bCenter < bounds.top + 4 || bCenter > bounds.bottom - 4)
-          : false;
+        // 只用「正文可视区」判定高亮锚点是否滚出（高亮在 contentAreaRef 里，会随正文滚动消失）。
+        // 不拿正文 bounds 去判定卡片：卡片在右侧批注栏「兄弟列」里，顶部常高于正文滚动区顶，
+        // 用正文 bounds 判会把「两端其实都看得见」的连线误隐藏（Bugbot Medium）。卡片端点下面再 clamp。
+        const offscreen = bounds ? (ay < bounds.top + 4 || ay > bounds.bottom - 4) : false;
         if (offscreen) {
           hide();
         } else {

--- a/prd-admin/src/components/doc-browser/InlineCommentConnector.tsx
+++ b/prd-admin/src/components/doc-browser/InlineCommentConnector.tsx
@@ -1,49 +1,81 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, type RefObject } from 'react';
 import { createPortal } from 'react-dom';
 
 // 激活批注的「牵引连线」（业界做法：Word 选中批注画虚线 / Figma tether）。
-// 只给当前激活的一条画线（active-only，不同时画所有线，避免花哨）。
-// 从正文里激活高亮的气泡（[data-active-hl]）拉一条同色曲线到右侧批注栏的激活卡片（[data-active-card]）。
-// 锚点用 DOM data 属性解耦：overlay 与 margin 各自打标，本层只负责按两点画线 + 跟随滚动/缩放刷新。
+// 只给当前激活的一条画线（active-only），从正文激活高亮的气泡（[data-active-hl]）拉一条同色曲线
+// 到右侧批注栏的激活卡片（[data-active-card]）。
+//
+// 关键实现（两个边界教训）：
+//   1) 边界：高亮或卡片滚出正文可视区时不画线（否则端点按几何位置飞到窗口角 / 越过顶栏）。
+//      两端都落在 boundsRef（正文滚动容器）的可视纵向范围内才画，端点再钳进该范围。
+//   2) 丝滑：用连续 requestAnimationFrame 逐帧「直接改 DOM 属性」跟手，不走 setState（避免每帧
+//      React 重渲染造成线段延迟/抖动，与画布高频交互同策略）。只在激活期间跑，开销可忽略。
 
-export function InlineCommentConnector({ activeKey, color }: { activeKey: string | null; color: string }) {
-  const [geo, setGeo] = useState<{ d: string; ax: number; ay: number; bx: number; by: number } | null>(null);
+export function InlineCommentConnector({
+  activeKey,
+  color,
+  boundsRef,
+}: {
+  activeKey: string | null;
+  color: string;
+  boundsRef: RefObject<HTMLElement>;
+}) {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const pathRef = useRef<SVGPathElement>(null);
+  const dotARef = useRef<SVGCircleElement>(null);
+  const dotBRef = useRef<SVGCircleElement>(null);
 
   useEffect(() => {
-    if (!activeKey) { setGeo(null); return; }
+    if (!activeKey) return;
     let raf = 0;
-    const compute = () => {
+    let alive = true;
+    const hide = () => { if (svgRef.current) svgRef.current.style.opacity = '0'; };
+    const frame = () => {
+      if (!alive) return;
       const hl = document.querySelector('[data-active-hl="1"]') as HTMLElement | null;
       const card = document.querySelector('[data-active-card="1"]') as HTMLElement | null;
-      if (!hl || !card) { setGeo(null); return; }
-      const a = hl.getBoundingClientRect();
-      const b = card.getBoundingClientRect();
-      const ax = a.right, ay = a.top + a.height / 2;
-      const bx = b.left, by = b.top + Math.min(26, b.height / 2);
-      const mx = ax + (bx - ax) * 0.55;
-      const d = `M ${ax} ${ay} C ${mx} ${ay}, ${mx} ${by}, ${bx} ${by}`;
-      setGeo({ d, ax, ay, bx, by });
+      if (hl && card && svgRef.current) {
+        const a = hl.getBoundingClientRect();
+        const b = card.getBoundingClientRect();
+        const bounds = boundsRef.current?.getBoundingClientRect();
+        const ay = a.top + a.height / 2;
+        const bCenter = b.top + b.height / 2;
+        // 两端都要在正文可视区内才画（看得见两头才连线，Docs 同理）
+        const offscreen = bounds
+          ? (ay < bounds.top + 4 || ay > bounds.bottom - 4 || bCenter < bounds.top + 4 || bCenter > bounds.bottom - 4)
+          : false;
+        if (offscreen) {
+          hide();
+        } else {
+          const ax = a.right;
+          const bx = b.left;
+          let by = b.top + Math.min(26, b.height / 2);
+          if (bounds) by = Math.max(bounds.top + 4, Math.min(bounds.bottom - 4, by));
+          const mx = ax + (bx - ax) * 0.55;
+          pathRef.current?.setAttribute('d', `M ${ax} ${ay} C ${mx} ${ay}, ${mx} ${by}, ${bx} ${by}`);
+          dotARef.current?.setAttribute('cx', `${ax}`); dotARef.current?.setAttribute('cy', `${ay}`);
+          dotBRef.current?.setAttribute('cx', `${bx}`); dotBRef.current?.setAttribute('cy', `${by}`);
+          svgRef.current.style.opacity = '1';
+        }
+      } else {
+        hide();
+      }
+      raf = requestAnimationFrame(frame);
     };
-    const schedule = () => { cancelAnimationFrame(raf); raf = requestAnimationFrame(compute); };
-    schedule();
-    // capture=true 捕获任意内层滚动容器（正文区 + 批注栏各自独立滚）；resize + 兜底定时覆盖异步布局位移
-    window.addEventListener('scroll', schedule, true);
-    window.addEventListener('resize', schedule);
-    const timer = window.setInterval(schedule, 400);
-    return () => {
-      cancelAnimationFrame(raf);
-      window.removeEventListener('scroll', schedule, true);
-      window.removeEventListener('resize', schedule);
-      window.clearInterval(timer);
-    };
-  }, [activeKey]);
+    raf = requestAnimationFrame(frame);
+    return () => { alive = false; cancelAnimationFrame(raf); };
+  }, [activeKey, boundsRef]);
 
-  if (!geo) return null;
+  if (!activeKey) return null;
   return createPortal(
-    <svg aria-hidden style={{ position: 'fixed', inset: 0, width: '100vw', height: '100vh', pointerEvents: 'none', zIndex: 30 }}>
-      <path d={geo.d} fill="none" stroke={color} strokeWidth={2} strokeOpacity={0.78} strokeLinecap="round" />
-      <circle cx={geo.ax} cy={geo.ay} r={3.5} fill={color} />
-      <circle cx={geo.bx} cy={geo.by} r={3.5} fill={color} />
+    <svg
+      ref={svgRef}
+      aria-hidden
+      style={{ position: 'fixed', inset: 0, width: '100vw', height: '100vh', pointerEvents: 'none', zIndex: 30, opacity: 0, transition: 'opacity 0.12s' }}
+    >
+      <path ref={pathRef} d="" fill="none" stroke={color} strokeWidth={2} strokeOpacity={0.8} strokeLinecap="round" />
+      <circle ref={dotARef} r={3.5} fill={color} />
+      <circle ref={dotBRef} r={3.5} fill={color} />
     </svg>,
     document.body,
   );

--- a/prd-admin/src/components/doc-browser/InlineCommentMargin.tsx
+++ b/prd-admin/src/components/doc-browser/InlineCommentMargin.tsx
@@ -15,6 +15,7 @@ type Group = { key: string; comments: DocumentInlineComment[]; orphaned: boolean
 export function InlineCommentMargin({
   comments,
   canCreate,
+  canDelete,
   hoveredKey,
   activeKey,
   onHoverKey,
@@ -26,6 +27,8 @@ export function InlineCommentMargin({
 }: {
   comments: DocumentInlineComment[];
   canCreate: boolean;
+  /** 逐条删除权限（库主 / 作者）；缺省不可删 */
+  canDelete?: (comment: DocumentInlineComment) => boolean;
   hoveredKey: string | null;
   activeKey: string | null;
   onHoverKey: (key: string | null) => void;
@@ -103,7 +106,7 @@ export function InlineCommentMargin({
           {g.comments[0].selectedText.length > 120 ? g.comments[0].selectedText.slice(0, 120) + '…' : g.comments[0].selectedText}
         </div>
         <div className="space-y-2.5">
-          {g.comments.map((c) => <CommentLine key={c.id} comment={c} canDelete={canCreate} onDelete={onDelete} />)}
+          {g.comments.map((c) => <CommentLine key={c.id} comment={c} canDelete={canDelete?.(c)} onDelete={onDelete} />)}
         </div>
         {canCreate && !dim && (
           <div className="mt-2.5" onClick={(e) => e.stopPropagation()}>
@@ -168,7 +171,7 @@ export function InlineCommentMargin({
               <div className="pt-1">
                 <div className="text-[10px] font-semibold mb-2 px-0.5" style={{ color: 'rgba(147,197,253,0.9)' }}>全文评论</div>
                 <div className="p-3 rounded-[11px] space-y-2.5" style={{ background: 'rgba(96,165,250,0.05)', border: '1px solid rgba(96,165,250,0.16)' }}>
-                  {wholeDoc.map((c) => <CommentLine key={c.id} comment={c} canDelete={canCreate} onDelete={onDelete} />)}
+                  {wholeDoc.map((c) => <CommentLine key={c.id} comment={c} canDelete={canDelete?.(c)} onDelete={onDelete} />)}
                   {canCreate && (
                     <ReplyBox placeholder="写对整篇文档的评论…" onSubmit={async (text) => onCreate({ selectedText: '', startOffset: 0, endOffset: 0, content: text }, wholeDoc[0]?.entryId)} />
                   )}

--- a/prd-admin/src/components/doc-browser/InlineCommentMargin.tsx
+++ b/prd-admin/src/components/doc-browser/InlineCommentMargin.tsx
@@ -1,0 +1,193 @@
+import { useMemo } from 'react';
+import { MessageSquareText, AlertTriangle, PanelRightClose } from 'lucide-react';
+import type { DocumentInlineComment } from '@/services/contracts/documentStore';
+import { CommentLine, ReplyBox, groupKey } from './inlineCommentShared';
+
+// 右侧「批注栏」——飞书 / Google Docs 式：评论卡片常驻正文右侧，边读边看，不用点气泡。
+// 与 InlineCommentOverlay（高亮层）双向联动：hover 某条卡片 → 对应正文高亮加亮。
+// 有评论时这条栏取代「本页章节导航」，点右上角收起按钮切回 TOC。
+
+type Group = { key: string; comments: DocumentInlineComment[]; orphaned: boolean };
+
+export function InlineCommentMargin({
+  comments,
+  canCreate,
+  hoveredKey,
+  onHoverKey,
+  onLocate,
+  onCreate,
+  onDelete,
+  onClose,
+  width = 300,
+}: {
+  comments: DocumentInlineComment[];
+  canCreate: boolean;
+  hoveredKey: string | null;
+  onHoverKey: (key: string | null) => void;
+  onLocate: (selectedText: string) => void;
+  onCreate: (input: {
+    selectedText: string;
+    contextBefore?: string;
+    contextAfter?: string;
+    startOffset: number;
+    endOffset: number;
+    content: string;
+  }) => Promise<boolean>;
+  onDelete: (comment: DocumentInlineComment) => void;
+  onClose?: () => void;
+  width?: number;
+}) {
+  const { anchored, orphaned, wholeDoc } = useMemo(() => {
+    const map = new Map<string, DocumentInlineComment[]>();
+    const whole: DocumentInlineComment[] = [];
+    for (const c of comments) {
+      if (c.isWholeDocument || !c.selectedText) { whole.push(c); continue; }
+      const k = groupKey(c.selectedText);
+      if (!k) continue;
+      const g = map.get(k) ?? [];
+      g.push(c);
+      map.set(k, g);
+    }
+    const groups: Group[] = [];
+    map.forEach((list, key) => groups.push({ key, comments: list, orphaned: list.every((c) => c.status === 'orphaned') }));
+    return {
+      anchored: groups.filter((g) => !g.orphaned),
+      orphaned: groups.filter((g) => g.orphaned),
+      wholeDoc: whole,
+    };
+  }, [comments]);
+
+  const total = comments.length;
+
+  const renderGroup = (g: Group, dim?: boolean) => (
+    <div
+      key={g.key}
+      onMouseEnter={() => onHoverKey(g.key)}
+      onMouseLeave={() => onHoverKey(null)}
+      className="p-3 rounded-[11px] transition-colors"
+      style={{
+        background: hoveredKey === g.key ? 'rgba(168,85,247,0.10)' : 'rgba(255,255,255,0.03)',
+        border: `1px solid ${hoveredKey === g.key ? 'rgba(168,85,247,0.32)' : 'rgba(255,255,255,0.06)'}`,
+        opacity: dim ? 0.7 : 1,
+      }}
+    >
+      <div
+        className="mb-2 pl-2 py-0.5 text-[11px] line-clamp-2"
+        style={{
+          borderLeft: dim ? '2px dashed rgba(245,158,11,0.5)' : '2px solid rgba(168,85,247,0.45)',
+          color: 'var(--text-muted)',
+          cursor: dim ? 'default' : 'pointer',
+        }}
+        onClick={() => { if (!dim) onLocate(g.comments[0].selectedText); }}
+        title={dim ? undefined : '点击定位到正文位置'}
+      >
+        {g.comments[0].selectedText.length > 120
+          ? g.comments[0].selectedText.slice(0, 120) + '…'
+          : g.comments[0].selectedText}
+      </div>
+      <div className="space-y-2.5">
+        {g.comments.map((c) => (
+          <CommentLine key={c.id} comment={c} canDelete={canCreate} onDelete={onDelete} />
+        ))}
+      </div>
+      {canCreate && !dim && (
+        <div className="mt-2.5">
+          <ReplyBox
+            onSubmit={async (text) => {
+              const base = g.comments[0];
+              return onCreate({
+                selectedText: base.selectedText,
+                contextBefore: base.contextBefore,
+                contextAfter: base.contextAfter,
+                startOffset: base.startOffset,
+                endOffset: base.endOffset,
+                content: text,
+              });
+            }}
+          />
+        </div>
+      )}
+    </div>
+  );
+
+  return (
+    <div
+      className="flex-none flex flex-col min-h-0"
+      style={{ width, borderLeft: '1px solid rgba(255,255,255,0.05)', background: 'rgba(255,255,255,0.012)' }}
+    >
+      {/* 头部 */}
+      <div className="flex items-center justify-between px-3.5 py-3 flex-none" style={{ borderBottom: '1px solid rgba(255,255,255,0.05)' }}>
+        <div className="flex items-center gap-1.5 text-[11px] font-semibold" style={{ color: 'var(--text-secondary)' }}>
+          <MessageSquareText size={13} style={{ color: 'rgba(216,180,254,0.95)' }} />
+          本页批注 · {total}
+        </div>
+        {onClose && (
+          <button
+            onClick={onClose}
+            className="w-6 h-6 rounded-[7px] flex items-center justify-center cursor-pointer hover:bg-white/6 transition-colors flex-none"
+            style={{ color: 'var(--text-muted)' }}
+            title="收起批注栏，显示章节导航"
+          >
+            <PanelRightClose size={14} />
+          </button>
+        )}
+      </div>
+
+      {/* 列表 */}
+      <div className="flex-1 min-h-0 overflow-y-auto p-3 space-y-3" style={{ overscrollBehavior: 'contain' }}>
+        {total === 0 ? (
+          <div className="px-3 py-10 text-center">
+            <MessageSquareText size={20} className="mx-auto mb-2" style={{ color: 'rgba(255,255,255,0.18)' }} />
+            <p className="text-[11px]" style={{ color: 'var(--text-muted)' }}>还没有批注</p>
+            <p className="text-[10px] mt-1" style={{ color: 'rgba(255,255,255,0.3)' }}>
+              在正文里选中一段文字即可批注
+            </p>
+          </div>
+        ) : (
+          <>
+            {anchored.map((g) => renderGroup(g))}
+
+            {wholeDoc.length > 0 && (
+              <div className="pt-1">
+                <div className="text-[10px] font-semibold mb-2 px-0.5" style={{ color: 'rgba(147,197,253,0.9)' }}>
+                  全文评论
+                </div>
+                <div className="p-3 rounded-[11px] space-y-2.5"
+                  style={{ background: 'rgba(96,165,250,0.05)', border: '1px solid rgba(96,165,250,0.16)' }}>
+                  {wholeDoc.map((c) => (
+                    <CommentLine key={c.id} comment={c} canDelete={canCreate} onDelete={onDelete} />
+                  ))}
+                  {canCreate && (
+                    <ReplyBox
+                      placeholder="写对整篇文档的评论…"
+                      onSubmit={async (text) =>
+                        onCreate({ selectedText: '', startOffset: 0, endOffset: 0, content: text })
+                      }
+                    />
+                  )}
+                </div>
+              </div>
+            )}
+
+            {orphaned.length > 0 && (
+              <div className="pt-2 mt-1" style={{ borderTop: '1px dashed rgba(255,255,255,0.08)' }}>
+                <div className="flex items-center gap-1.5 mb-2 mt-2">
+                  <AlertTriangle size={11} style={{ color: 'rgba(245,158,11,0.9)' }} />
+                  <span className="text-[10px] font-semibold" style={{ color: 'rgba(245,158,11,0.9)' }}>
+                    {orphaned.reduce((n, g) => n + g.comments.length, 0)} 条失锚批注
+                  </span>
+                </div>
+                <p className="text-[10px] mb-2" style={{ color: 'var(--text-muted)' }}>
+                  文档更新后，以下批注的原文已不存在
+                </p>
+                <div className="space-y-3">
+                  {orphaned.map((g) => renderGroup(g, true))}
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/prd-admin/src/components/doc-browser/InlineCommentMargin.tsx
+++ b/prd-admin/src/components/doc-browser/InlineCommentMargin.tsx
@@ -1,11 +1,14 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { MessageSquareText, AlertTriangle, PanelRightClose } from 'lucide-react';
 import type { DocumentInlineComment } from '@/services/contracts/documentStore';
-import { CommentLine, ReplyBox, groupKey } from './inlineCommentShared';
+import { CommentLine, CommentAvatar, ReplyBox, groupKey, threadColor, withAlpha } from './inlineCommentShared';
 
-// 右侧「批注栏」——飞书 / Google Docs 式：评论卡片常驻正文右侧，边读边看，不用点气泡。
-// 与 InlineCommentOverlay（高亮层）双向联动：hover 某条卡片 → 对应正文高亮加亮。
-// 有评论时这条栏取代「本页章节导航」，点右上角收起按钮切回 TOC。
+// 右侧「批注栏」——飞书 / Google Docs 式：评论卡片常驻正文右侧，边读边看。
+// 强关联（业界做法）：
+//   - 同色锚定：每条批注一个色，卡片左色条 = 正文高亮下划线同色（threadColor 一致）。
+//   - 激活态：点正文气泡或点卡片 → activeKey 命中 → 该卡升起高亮环 + data-active-card（供连线层取锚点）+ 滚到眼前；
+//             正文对应高亮加亮；一次只激活一条，其余淡化。双向联动。
+//   - 密集折叠：批注 > 3 组时，非激活的压成一行（头像+首句+条数），点开才展开，密度立降。
 
 type Group = { key: string; comments: DocumentInlineComment[]; orphaned: boolean };
 
@@ -13,8 +16,9 @@ export function InlineCommentMargin({
   comments,
   canCreate,
   hoveredKey,
+  activeKey,
   onHoverKey,
-  onLocate,
+  onActivate,
   onCreate,
   onDelete,
   onClose,
@@ -23,8 +27,10 @@ export function InlineCommentMargin({
   comments: DocumentInlineComment[];
   canCreate: boolean;
   hoveredKey: string | null;
+  activeKey: string | null;
   onHoverKey: (key: string | null) => void;
-  onLocate: (selectedText: string) => void;
+  /** 点卡片 → 激活该分组（联动正文高亮 + 连线） */
+  onActivate: (key: string, selectedText: string) => void;
   onCreate: (input: {
     selectedText: string;
     contextBefore?: string;
@@ -37,6 +43,8 @@ export function InlineCommentMargin({
   onClose?: () => void;
   width?: number;
 }) {
+  const listRef = useRef<HTMLDivElement>(null);
+
   const { anchored, orphaned, wholeDoc } = useMemo(() => {
     const map = new Map<string, DocumentInlineComment[]>();
     const whole: DocumentInlineComment[] = [];
@@ -45,8 +53,7 @@ export function InlineCommentMargin({
       const k = groupKey(c.selectedText);
       if (!k) continue;
       const g = map.get(k) ?? [];
-      g.push(c);
-      map.set(k, g);
+      g.push(c); map.set(k, g);
     }
     const groups: Group[] = [];
     map.forEach((list, key) => groups.push({ key, comments: list, orphaned: list.every((c) => c.status === 'orphaned') }));
@@ -58,112 +65,111 @@ export function InlineCommentMargin({
   }, [comments]);
 
   const total = comments.length;
+  // 密集才折叠：≤3 组时全展开（边读边看不打折），>3 组时非激活折叠成一行
+  const dense = anchored.length > 3;
 
-  const renderGroup = (g: Group, dim?: boolean) => (
-    <div
-      key={g.key}
-      onMouseEnter={() => onHoverKey(g.key)}
-      onMouseLeave={() => onHoverKey(null)}
-      className="p-3 rounded-[11px] transition-colors"
-      style={{
-        background: hoveredKey === g.key ? 'rgba(168,85,247,0.10)' : 'rgba(255,255,255,0.03)',
-        border: `1px solid ${hoveredKey === g.key ? 'rgba(168,85,247,0.32)' : 'rgba(255,255,255,0.06)'}`,
-        opacity: dim ? 0.7 : 1,
-      }}
-    >
+  // 激活时把对应卡片滚到批注栏可视区
+  useEffect(() => {
+    if (!activeKey) return;
+    const el = listRef.current?.querySelector('[data-active-card="1"]') as HTMLElement | null;
+    el?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+  }, [activeKey]);
+
+  const renderFull = (g: Group, dim?: boolean) => {
+    const col = dim ? '#94a3b8' : threadColor(g.key);
+    const isActive = activeKey === g.key;
+    const isHover = hoveredKey === g.key;
+    return (
       <div
-        className="mb-2 pl-2 py-0.5 text-[11px] line-clamp-2"
+        key={g.key}
+        data-active-card={isActive && !dim ? '1' : undefined}
+        onMouseEnter={() => onHoverKey(g.key)}
+        onMouseLeave={() => onHoverKey(null)}
+        onClick={() => { if (!dim) onActivate(g.key, g.comments[0].selectedText); }}
+        className="relative rounded-[11px] p-3 pl-3.5 transition-all cursor-pointer"
         style={{
-          borderLeft: dim ? '2px dashed rgba(245,158,11,0.5)' : '2px solid rgba(168,85,247,0.45)',
-          color: 'var(--text-muted)',
-          cursor: dim ? 'default' : 'pointer',
+          background: isActive ? withAlpha(col, 0.1) : isHover ? 'rgba(255,255,255,0.045)' : 'rgba(255,255,255,0.03)',
+          border: `1px solid ${isActive ? withAlpha(col, 0.5) : 'rgba(255,255,255,0.06)'}`,
+          boxShadow: isActive ? `0 10px 26px -12px ${withAlpha(col, 0.5)}` : 'none',
+          opacity: dim ? 0.7 : 1,
         }}
-        onClick={() => { if (!dim) onLocate(g.comments[0].selectedText); }}
-        title={dim ? undefined : '点击定位到正文位置'}
       >
-        {g.comments[0].selectedText.length > 120
-          ? g.comments[0].selectedText.slice(0, 120) + '…'
-          : g.comments[0].selectedText}
-      </div>
-      <div className="space-y-2.5">
-        {g.comments.map((c) => (
-          <CommentLine key={c.id} comment={c} canDelete={canCreate} onDelete={onDelete} />
-        ))}
-      </div>
-      {canCreate && !dim && (
-        <div className="mt-2.5">
-          <ReplyBox
-            onSubmit={async (text) => {
-              const base = g.comments[0];
-              return onCreate({
-                selectedText: base.selectedText,
-                contextBefore: base.contextBefore,
-                contextAfter: base.contextAfter,
-                startOffset: base.startOffset,
-                endOffset: base.endOffset,
-                content: text,
-              });
-            }}
-          />
+        <div style={{ position: 'absolute', left: 0, top: 10, bottom: 10, width: 3, borderRadius: 3, background: col }} />
+        <div
+          className="mb-2 pl-1.5 py-0.5 text-[11px] line-clamp-2"
+          style={{ color: 'var(--text-muted)' }}
+          title={g.comments[0].selectedText}
+        >
+          {g.comments[0].selectedText.length > 120 ? g.comments[0].selectedText.slice(0, 120) + '…' : g.comments[0].selectedText}
         </div>
-      )}
-    </div>
-  );
+        <div className="space-y-2.5">
+          {g.comments.map((c) => <CommentLine key={c.id} comment={c} canDelete={canCreate} onDelete={onDelete} />)}
+        </div>
+        {canCreate && !dim && (
+          <div className="mt-2.5" onClick={(e) => e.stopPropagation()}>
+            <ReplyBox onSubmit={async (text) => {
+              const base = g.comments[0];
+              return onCreate({ selectedText: base.selectedText, contextBefore: base.contextBefore, contextAfter: base.contextAfter, startOffset: base.startOffset, endOffset: base.endOffset, content: text });
+            }} />
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  const renderCollapsed = (g: Group) => {
+    const col = threadColor(g.key);
+    const first = g.comments[0];
+    return (
+      <div
+        key={g.key}
+        onMouseEnter={() => onHoverKey(g.key)}
+        onMouseLeave={() => onHoverKey(null)}
+        onClick={() => onActivate(g.key, first.selectedText)}
+        className="flex items-center gap-2 rounded-[10px] px-2.5 py-2 cursor-pointer transition-colors"
+        style={{ background: hoveredKey === g.key ? 'rgba(255,255,255,0.05)' : 'rgba(255,255,255,0.025)', border: '1px solid rgba(255,255,255,0.06)' }}
+        title={first.selectedText}
+      >
+        <div style={{ width: 3, alignSelf: 'stretch', borderRadius: 3, background: col, flex: 'none' }} />
+        <CommentAvatar name={first.authorDisplayName} avatar={first.authorAvatar} size={20} />
+        <span className="flex-1 min-w-0 truncate text-[11px]" style={{ color: 'var(--text-secondary, rgba(255,255,255,0.7))' }}>{first.content}</span>
+        {g.comments.length > 1 && <span className="text-[10px] font-bold flex-none" style={{ color: 'var(--text-muted)' }}>{g.comments.length}</span>}
+      </div>
+    );
+  };
 
   return (
-    <div
-      className="flex-none flex flex-col min-h-0"
-      style={{ width, borderLeft: '1px solid rgba(255,255,255,0.05)', background: 'rgba(255,255,255,0.012)' }}
-    >
-      {/* 头部 */}
+    <div className="flex-none flex flex-col min-h-0" style={{ width, borderLeft: '1px solid rgba(255,255,255,0.05)', background: 'rgba(255,255,255,0.012)' }}>
       <div className="flex items-center justify-between px-3.5 py-3 flex-none" style={{ borderBottom: '1px solid rgba(255,255,255,0.05)' }}>
         <div className="flex items-center gap-1.5 text-[11px] font-semibold" style={{ color: 'var(--text-secondary)' }}>
           <MessageSquareText size={13} style={{ color: 'rgba(216,180,254,0.95)' }} />
           本页批注 · {total}
         </div>
         {onClose && (
-          <button
-            onClick={onClose}
-            className="w-6 h-6 rounded-[7px] flex items-center justify-center cursor-pointer hover:bg-white/6 transition-colors flex-none"
-            style={{ color: 'var(--text-muted)' }}
-            title="收起批注栏，显示章节导航"
-          >
+          <button onClick={onClose} className="w-6 h-6 rounded-[7px] flex items-center justify-center cursor-pointer hover:bg-white/6 transition-colors flex-none" style={{ color: 'var(--text-muted)' }} title="收起批注栏，显示章节导航">
             <PanelRightClose size={14} />
           </button>
         )}
       </div>
 
-      {/* 列表 */}
-      <div className="flex-1 min-h-0 overflow-y-auto p-3 space-y-3" style={{ overscrollBehavior: 'contain' }}>
+      <div ref={listRef} className="flex-1 min-h-0 overflow-y-auto p-3 space-y-3" style={{ overscrollBehavior: 'contain' }}>
         {total === 0 ? (
           <div className="px-3 py-10 text-center">
             <MessageSquareText size={20} className="mx-auto mb-2" style={{ color: 'rgba(255,255,255,0.18)' }} />
             <p className="text-[11px]" style={{ color: 'var(--text-muted)' }}>还没有批注</p>
-            <p className="text-[10px] mt-1" style={{ color: 'rgba(255,255,255,0.3)' }}>
-              在正文里选中一段文字即可批注
-            </p>
+            <p className="text-[10px] mt-1" style={{ color: 'rgba(255,255,255,0.3)' }}>在正文里选中一段文字即可批注</p>
           </div>
         ) : (
           <>
-            {anchored.map((g) => renderGroup(g))}
+            {anchored.map((g) => (dense && activeKey !== g.key ? renderCollapsed(g) : renderFull(g)))}
 
             {wholeDoc.length > 0 && (
               <div className="pt-1">
-                <div className="text-[10px] font-semibold mb-2 px-0.5" style={{ color: 'rgba(147,197,253,0.9)' }}>
-                  全文评论
-                </div>
-                <div className="p-3 rounded-[11px] space-y-2.5"
-                  style={{ background: 'rgba(96,165,250,0.05)', border: '1px solid rgba(96,165,250,0.16)' }}>
-                  {wholeDoc.map((c) => (
-                    <CommentLine key={c.id} comment={c} canDelete={canCreate} onDelete={onDelete} />
-                  ))}
+                <div className="text-[10px] font-semibold mb-2 px-0.5" style={{ color: 'rgba(147,197,253,0.9)' }}>全文评论</div>
+                <div className="p-3 rounded-[11px] space-y-2.5" style={{ background: 'rgba(96,165,250,0.05)', border: '1px solid rgba(96,165,250,0.16)' }}>
+                  {wholeDoc.map((c) => <CommentLine key={c.id} comment={c} canDelete={canCreate} onDelete={onDelete} />)}
                   {canCreate && (
-                    <ReplyBox
-                      placeholder="写对整篇文档的评论…"
-                      onSubmit={async (text) =>
-                        onCreate({ selectedText: '', startOffset: 0, endOffset: 0, content: text })
-                      }
-                    />
+                    <ReplyBox placeholder="写对整篇文档的评论…" onSubmit={async (text) => onCreate({ selectedText: '', startOffset: 0, endOffset: 0, content: text })} />
                   )}
                 </div>
               </div>
@@ -177,12 +183,8 @@ export function InlineCommentMargin({
                     {orphaned.reduce((n, g) => n + g.comments.length, 0)} 条失锚批注
                   </span>
                 </div>
-                <p className="text-[10px] mb-2" style={{ color: 'var(--text-muted)' }}>
-                  文档更新后，以下批注的原文已不存在
-                </p>
-                <div className="space-y-3">
-                  {orphaned.map((g) => renderGroup(g, true))}
-                </div>
+                <p className="text-[10px] mb-2" style={{ color: 'var(--text-muted)' }}>文档更新后，以下批注的原文已不存在</p>
+                <div className="space-y-3">{orphaned.map((g) => renderFull(g, true))}</div>
               </div>
             )}
           </>

--- a/prd-admin/src/components/doc-browser/InlineCommentMargin.tsx
+++ b/prd-admin/src/components/doc-browser/InlineCommentMargin.tsx
@@ -38,7 +38,7 @@ export function InlineCommentMargin({
     startOffset: number;
     endOffset: number;
     content: string;
-  }) => Promise<boolean>;
+  }, entryId?: string) => Promise<boolean>;
   onDelete: (comment: DocumentInlineComment) => void;
   onClose?: () => void;
   width?: number;
@@ -109,7 +109,8 @@ export function InlineCommentMargin({
           <div className="mt-2.5" onClick={(e) => e.stopPropagation()}>
             <ReplyBox onSubmit={async (text) => {
               const base = g.comments[0];
-              return onCreate({ selectedText: base.selectedText, contextBefore: base.contextBefore, contextAfter: base.contextAfter, startOffset: base.startOffset, endOffset: base.endOffset, content: text });
+              // 回复落到该线程所属条目（base.entryId），防切档后写到别的文档（Bugbot Medium）
+              return onCreate({ selectedText: base.selectedText, contextBefore: base.contextBefore, contextAfter: base.contextAfter, startOffset: base.startOffset, endOffset: base.endOffset, content: text }, base.entryId);
             }} />
           </div>
         )}
@@ -169,7 +170,7 @@ export function InlineCommentMargin({
                 <div className="p-3 rounded-[11px] space-y-2.5" style={{ background: 'rgba(96,165,250,0.05)', border: '1px solid rgba(96,165,250,0.16)' }}>
                   {wholeDoc.map((c) => <CommentLine key={c.id} comment={c} canDelete={canCreate} onDelete={onDelete} />)}
                   {canCreate && (
-                    <ReplyBox placeholder="写对整篇文档的评论…" onSubmit={async (text) => onCreate({ selectedText: '', startOffset: 0, endOffset: 0, content: text })} />
+                    <ReplyBox placeholder="写对整篇文档的评论…" onSubmit={async (text) => onCreate({ selectedText: '', startOffset: 0, endOffset: 0, content: text }, wholeDoc[0]?.entryId)} />
                   )}
                 </div>
               </div>

--- a/prd-admin/src/components/doc-browser/InlineCommentOverlay.tsx
+++ b/prd-admin/src/components/doc-browser/InlineCommentOverlay.tsx
@@ -212,7 +212,7 @@ export function InlineCommentOverlay({
                 激活的气泡带 data-active-hl，供连线层 InlineCommentConnector 取锚点。 */}
             <button
               type="button"
-              data-active-hl={active && mode === 'margin' ? '1' : undefined}
+              data-active-hl={active ? '1' : undefined}
               onClick={(e) => { e.stopPropagation(); onActivate?.(m.key, m.comments[0].selectedText); }}
               title={m.comments.map((c) => `${c.authorDisplayName}：${c.content}`).join('\n').slice(0, 240)}
               className="inline-flex items-center gap-0.5 cursor-pointer"

--- a/prd-admin/src/components/doc-browser/InlineCommentOverlay.tsx
+++ b/prd-admin/src/components/doc-browser/InlineCommentOverlay.tsx
@@ -120,7 +120,7 @@ export function InlineCommentOverlay({
     startOffset: number;
     endOffset: number;
     content: string;
-  }) => Promise<boolean>;
+  }, entryId?: string) => Promise<boolean>;
   onDelete?: (comment: DocumentInlineComment) => void;
 }) {
   const overlayRef = useRef<HTMLDivElement>(null);
@@ -252,7 +252,8 @@ export function InlineCommentOverlay({
                   <div className="mt-3">
                     <ReplyBox onSubmit={async (text) => {
                       const base = m.comments[0];
-                      return onCreate({ selectedText: base.selectedText, contextBefore: base.contextBefore, contextAfter: base.contextAfter, startOffset: base.startOffset, endOffset: base.endOffset, content: text });
+                      // 回复落到该线程所属条目（base.entryId），防切档后写到别的文档（Bugbot Medium）
+                      return onCreate({ selectedText: base.selectedText, contextBefore: base.contextBefore, contextAfter: base.contextAfter, startOffset: base.startOffset, endOffset: base.endOffset, content: text }, base.entryId);
                     }} />
                   </div>
                 )}

--- a/prd-admin/src/components/doc-browser/InlineCommentOverlay.tsx
+++ b/prd-admin/src/components/doc-browser/InlineCommentOverlay.tsx
@@ -1,35 +1,29 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState, type RefObject } from 'react';
+import { useCallback, useLayoutEffect, useRef, useState, type RefObject } from 'react';
 import { MessageSquare } from 'lucide-react';
 import type { DocumentInlineComment } from '@/services/contracts/documentStore';
-import { CommentLine, ReplyBox, groupKey } from './inlineCommentShared';
+import { CommentLine, ReplyBox, groupKey, threadColor, withAlpha } from './inlineCommentShared';
 
 // 行内评论高亮 + 气泡/内联卡片浮层。
-// 把每条评论的 selectedText 锚回「已渲染的 markdown DOM」，在原文上画高亮条。
+// 把每条评论的 selectedText 锚回「已渲染的 markdown DOM」，在原文上画高亮条（按线程配色）。
 // 两种布局（由 mode 控制）：
-//   - inline：高亮末尾放可点气泡，点击就地展开评论卡片（GitHub 评论代码风），边读边可展开看。
-//   - margin：不画气泡，只留高亮；评论卡片在右侧「批注栏」常驻（InlineCommentMargin），
-//             hover 批注栏某条 → hoveredKey 命中 → 本层把对应高亮加亮（双向联动）。
+//   - inline：高亮末尾放气泡，点击就地展开评论卡片（GitHub 评论代码风）。
+//   - margin：高亮末尾放小气泡，点击「激活」右侧批注栏对应卡片（onActivate）；评论卡常驻在 InlineCommentMargin。
+// 强关联（业界做法 Word/Figma/Docs）：同色锚定（高亮下划线=右侧卡片色条同色）+ 激活态（高亮加亮 + 画连线）。
+// activeKey/hoveredKey 由父组件统一管理，margin 与 overlay 双向联动；激活的气泡带 data-active-hl，供连线层取锚点。
 //
 // 坐标系巧思：本层是 contentAreaRef（滚动容器，position:relative）的 absolute 子元素，
-// top:0/left:0、尺寸 0，作为子元素的包含块原点。子元素位置 = 文本 rect 减去本层 rect，
-// 得到「相对本层原点」的偏移——本层与正文同在滚动内容里一起滚，故滚动时无需重算，天然对齐。
+// top:0/left:0、尺寸 0，作为子元素的包含块原点。子元素位置 = 文本 rect 减去本层 rect。
 
 interface AnchorMark {
   key: string;
   rects: Array<{ top: number; left: number; width: number; height: number }>;
   bubble: { top: number; left: number };
-  /** 内联展开卡片的锚点（高亮末行左下角，相对本层原点） */
   card: { top: number; left: number };
   comments: DocumentInlineComment[];
   orphaned: boolean;
 }
 
-// 纯逻辑核心（无 DOM 依赖，可在 node 环境单测）：
-// 在若干文本片段（= 各文本节点的 data）里做「去空白」匹配，markdown 渲染会改变空白/跨块，
-// 故按去空白后的字符序列查找。返回命中区间的起止 (片段下标, 片段内字符偏移)。
-// 短于 2 个非空白字符不锚定，避免误命中。
-// contextBefore（评论创建时记录的「选区前文」）：同一短语在文中多处出现时，用它挑「紧邻前文最吻合」
-// 的那一处，避免重复短语的评论都锚到首次出现（Bugbot/Codex）。无 context 或仅一处时取首个，行为不变。
+// 纯逻辑核心（无 DOM 依赖，可在 node 环境单测）：去空白匹配，contextBefore 消歧多处出现。
 export function locateInSegments(
   segments: string[],
   query: string,
@@ -57,7 +51,7 @@ export function locateInSegments(
       let best = -1;
       for (const i of idxs) {
         const before = hay.slice(Math.max(0, i - ctx.length), i);
-        let k = 0; // 紧邻前文与 contextBefore 的公共后缀长度
+        let k = 0;
         while (k < before.length && k < ctx.length && before[before.length - 1 - k] === ctx[ctx.length - 1 - k]) k++;
         if (k > best) { best = k; chosen = i; }
       }
@@ -69,9 +63,7 @@ export function locateInSegments(
   return { startSeg: a.seg, startOff: a.off, endSeg: b.seg, endOff: b.off };
 }
 
-// DOM 适配层：收集容器内所有文本节点 → 交给纯核心匹配 → 把结果映射回 Range。
-// 只扫正文：跳过 UI 控件文本——代码块「复制」按钮、本浮层自身（aria-hidden）的气泡等，
-// 否则评论可能锚到按钮而非正文（Bugbot「Anchor scan includes copy buttons」）。
+// DOM 适配层：收集容器内所有文本节点 → 交给纯核心匹配 → 把结果映射回 Range。跳过 UI 控件文本。
 function findTextRange(root: HTMLElement, query: string, contextBefore?: string): Range | null {
   const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
     acceptNode(node) {
@@ -104,17 +96,22 @@ export function InlineCommentOverlay({
   reflowKey,
   mode = 'inline',
   hoveredKey = null,
+  activeKey = null,
+  onActivate,
   canCreate = false,
   onCreate,
   onDelete,
 }: {
   containerRef: RefObject<HTMLDivElement>;
   comments: DocumentInlineComment[];
-  /** 变化即重算（切文档 / 正文内容变化） */
   reflowKey: string | number;
   mode?: 'inline' | 'margin';
-  /** margin 模式下，批注栏 hover 命中的分组 key（高亮加亮） */
+  /** 批注栏 hover 命中的分组 key（高亮微亮） */
   hoveredKey?: string | null;
+  /** 当前激活的分组 key（点高亮/气泡或点卡片）：高亮加亮、inline 展开卡片、margin 出连线锚点 */
+  activeKey?: string | null;
+  /** 点气泡 → 激活该分组（margin 联动右侧卡 / inline 展开） */
+  onActivate?: (key: string, selectedText: string) => void;
   canCreate?: boolean;
   onCreate?: (input: {
     selectedText: string;
@@ -129,30 +126,20 @@ export function InlineCommentOverlay({
   const overlayRef = useRef<HTMLDivElement>(null);
   const rafRef = useRef<number | null>(null);
   const [marks, setMarks] = useState<AnchorMark[]>([]);
-  // inline 模式：当前展开的分组（点气泡就地展开卡片）
-  const [expandedKey, setExpandedKey] = useState<string | null>(null);
 
   const recompute = useCallback(() => {
     const container = containerRef.current;
     const overlay = overlayRef.current;
-    if (!container || !overlay) {
-      setMarks([]);
-      return;
-    }
-    // 同一短语的多条评论合并成一颗气泡/一张卡（显示条数）；全文评论不参与行内锚定。
+    if (!container || !overlay) { setMarks([]); return; }
     const groups = new Map<string, DocumentInlineComment[]>();
     for (const c of comments) {
       if (c.isWholeDocument || !c.selectedText) continue;
       const text = groupKey(c.selectedText);
       if (!text) continue;
-      let g = groups.get(text);
-      if (!g) { g = []; groups.set(text, g); }
-      g.push(c);
+      const g = groups.get(text) ?? [];
+      g.push(c); groups.set(text, g);
     }
-    if (groups.size === 0) {
-      setMarks([]);
-      return;
-    }
+    if (groups.size === 0) { setMarks([]); return; }
     const oRect = overlay.getBoundingClientRect();
     const maxLeft = Math.max(0, container.clientWidth - 348);
     const next: AnchorMark[] = [];
@@ -162,22 +149,14 @@ export function InlineCommentOverlay({
       const rectList = Array.from(range.getClientRects());
       if (rectList.length === 0) return;
       const orphaned = list.every((c) => c.status === 'orphaned');
-      const rects = rectList.map((r) => ({
-        top: r.top - oRect.top,
-        left: r.left - oRect.left,
-        width: r.width,
-        height: r.height,
-      }));
+      const rects = rectList.map((r) => ({ top: r.top - oRect.top, left: r.left - oRect.left, width: r.width, height: r.height }));
       const first = rectList[0];
       const last = rectList[rectList.length - 1];
       next.push({
         key: text,
         rects,
         bubble: { top: last.top - oRect.top, left: last.right - oRect.left },
-        card: {
-          top: last.bottom - oRect.top + 6,
-          left: Math.min(Math.max(0, first.left - oRect.left), maxLeft),
-        },
+        card: { top: last.bottom - oRect.top + 6, left: Math.min(Math.max(0, first.left - oRect.left), maxLeft) },
         comments: list,
         orphaned,
       });
@@ -185,7 +164,6 @@ export function InlineCommentOverlay({
     setMarks(next);
   }, [comments, containerRef]);
 
-  // rAF 合并高频触发（resize / 拖宽侧栏），避免每帧全量重算
   const schedule = useCallback(() => {
     if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
     rafRef.current = requestAnimationFrame(() => { rafRef.current = null; recompute(); });
@@ -193,7 +171,6 @@ export function InlineCommentOverlay({
 
   useLayoutEffect(() => {
     recompute();
-    // 图片/字体/公式渲染后正文高度会变，延迟两次兜底重算
     const t1 = window.setTimeout(recompute, 120);
     const t2 = window.setTimeout(recompute, 500);
     const container = containerRef.current;
@@ -209,120 +186,74 @@ export function InlineCommentOverlay({
     };
   }, [recompute, schedule, reflowKey, containerRef]);
 
-  // 切文档 / 切布局时收起展开的内联卡片
-  useEffect(() => { setExpandedKey(null); }, [reflowKey, mode]);
-
   return (
     <div ref={overlayRef} aria-hidden style={{ position: 'absolute', top: 0, left: 0, width: 0, height: 0 }}>
       {marks.map((m) => {
-        const active = hoveredKey === m.key || expandedKey === m.key;
-        const expanded = mode === 'inline' && expandedKey === m.key;
+        const col = m.orphaned ? '#94a3b8' : threadColor(m.key);
+        const active = activeKey === m.key;
+        const hover = hoveredKey === m.key;
+        const inlineExpanded = mode === 'inline' && active;
+        const bg = active ? withAlpha(col, 0.34) : hover ? withAlpha(col, 0.24) : withAlpha(col, 0.15);
         return (
           <div key={m.key}>
-            {/* 高亮条：不挡正文点击/划词；active 时加亮（批注栏 hover / 内联展开联动） */}
+            {/* 高亮条：按线程配色，激活/hover 加亮；不挡正文点击/划词 */}
             {m.rects.map((r, i) => (
               <div
                 key={i}
                 style={{
-                  position: 'absolute',
-                  top: r.top,
-                  left: r.left,
-                  width: r.width,
-                  height: r.height,
-                  background: m.orphaned
-                    ? (active ? 'rgba(148,163,184,0.30)' : 'rgba(148,163,184,0.16)')
-                    : (active ? 'rgba(250,204,21,0.34)' : 'rgba(250,204,21,0.18)'),
-                  borderBottom: `2px solid ${m.orphaned ? 'rgba(148,163,184,0.5)' : 'rgba(234,179,8,0.7)'}`,
-                  borderRadius: 2,
-                  pointerEvents: 'none',
-                  transition: 'background 0.12s',
+                  position: 'absolute', top: r.top, left: r.left, width: r.width, height: r.height,
+                  background: bg, borderBottom: `2px solid ${withAlpha(col, 0.85)}`, borderRadius: 2,
+                  pointerEvents: 'none', transition: 'background 0.12s',
                 }}
               />
             ))}
 
-            {/* inline 模式：可点气泡，就地展开/收起卡片 */}
-            {mode === 'inline' && (
-              <button
-                type="button"
-                onClick={(e) => { e.stopPropagation(); setExpandedKey((k) => (k === m.key ? null : m.key)); }}
-                title={m.comments.map((c) => `${c.authorDisplayName}：${c.content}`).join('\n').slice(0, 240)}
-                className="inline-flex items-center gap-0.5 cursor-pointer"
-                style={{
-                  position: 'absolute',
-                  top: m.bubble.top - 7,
-                  left: m.bubble.left + 2,
-                  height: 17,
-                  padding: '0 5px',
-                  borderRadius: 9,
-                  pointerEvents: 'auto',
-                  background: m.orphaned ? 'rgba(100,116,139,0.95)' : 'rgba(234,179,8,0.96)',
-                  color: m.orphaned ? '#e2e8f0' : '#3a2d05',
-                  fontSize: 10,
-                  fontWeight: 700,
-                  lineHeight: '17px',
-                  boxShadow: expanded ? '0 0 0 2px rgba(234,179,8,0.4)' : '0 2px 6px rgba(0,0,0,0.28)',
-                  zIndex: 6,
-                }}
-              >
-                <MessageSquare size={10} />
-                {m.comments.length > 1 ? m.comments.length : ''}
-              </button>
-            )}
+            {/* 气泡：两种布局都有。点击 → 激活该分组（margin 联动右侧卡 + 连线 / inline 就地展开）。
+                激活的气泡带 data-active-hl，供连线层 InlineCommentConnector 取锚点。 */}
+            <button
+              type="button"
+              data-active-hl={active && mode === 'margin' ? '1' : undefined}
+              onClick={(e) => { e.stopPropagation(); onActivate?.(m.key, m.comments[0].selectedText); }}
+              title={m.comments.map((c) => `${c.authorDisplayName}：${c.content}`).join('\n').slice(0, 240)}
+              className="inline-flex items-center gap-0.5 cursor-pointer"
+              style={{
+                position: 'absolute', top: m.bubble.top - 7, left: m.bubble.left + 2,
+                height: 17, padding: '0 5px', borderRadius: 9, pointerEvents: 'auto',
+                background: withAlpha(col, 0.96), color: m.orphaned ? '#e2e8f0' : '#1a1205',
+                fontSize: 10, fontWeight: 700, lineHeight: '17px',
+                boxShadow: active ? `0 0 0 2px ${withAlpha(col, 0.45)}` : '0 2px 6px rgba(0,0,0,0.28)',
+                zIndex: 6,
+              }}
+            >
+              <MessageSquare size={10} />
+              {m.comments.length > 1 ? m.comments.length : ''}
+            </button>
 
             {/* inline 展开卡片：就地（GitHub 评论代码风），可读可回复可删 */}
-            {expanded && (
+            {inlineExpanded && (
               <div
                 style={{
-                  position: 'absolute',
-                  top: m.card.top,
-                  left: m.card.left,
-                  width: 338,
-                  maxHeight: 360,
-                  overflowY: 'auto',
-                  overscrollBehavior: 'contain',
-                  pointerEvents: 'auto',
-                  zIndex: 8,
-                  borderRadius: 12,
-                  padding: '12px 13px',
+                  position: 'absolute', top: m.card.top, left: m.card.left, width: 338, maxHeight: 360,
+                  overflowY: 'auto', overscrollBehavior: 'contain', pointerEvents: 'auto', zIndex: 8,
+                  borderRadius: 12, padding: '12px 13px',
                   background: 'linear-gradient(180deg, rgba(30,28,46,0.97), rgba(20,19,28,0.98))',
-                  border: '1px solid rgba(168,85,247,0.3)',
-                  boxShadow: '0 18px 44px -10px rgba(0,0,0,0.6)',
-                  backdropFilter: 'blur(40px)',
+                  border: `1px solid ${withAlpha(col, 0.45)}`, boxShadow: '0 18px 44px -10px rgba(0,0,0,0.6)', backdropFilter: 'blur(40px)',
                 }}
                 onClick={(e) => e.stopPropagation()}
               >
                 <div className="flex items-center justify-between mb-2">
-                  <span className="text-[10px] font-semibold truncate" style={{ color: 'var(--text-muted)' }}>
-                    {m.comments.length} 条批注
-                  </span>
-                  <button
-                    onClick={() => setExpandedKey(null)}
-                    className="text-[10px] cursor-pointer hover:underline flex-none"
-                    style={{ color: 'var(--text-muted)' }}
-                  >
-                    收起
-                  </button>
+                  <span className="text-[10px] font-semibold truncate" style={{ color: 'var(--text-muted)' }}>{m.comments.length} 条批注</span>
+                  <button onClick={() => onActivate?.(m.key, m.comments[0].selectedText)} className="text-[10px] cursor-pointer hover:underline flex-none" style={{ color: 'var(--text-muted)' }}>收起</button>
                 </div>
                 <div className="space-y-2.5">
-                  {m.comments.map((c) => (
-                    <CommentLine key={c.id} comment={c} canDelete={canCreate} onDelete={onDelete} />
-                  ))}
+                  {m.comments.map((c) => <CommentLine key={c.id} comment={c} canDelete={canCreate} onDelete={onDelete} />)}
                 </div>
                 {canCreate && onCreate && (
                   <div className="mt-3">
-                    <ReplyBox
-                      onSubmit={async (text) => {
-                        const base = m.comments[0];
-                        return onCreate({
-                          selectedText: base.selectedText,
-                          contextBefore: base.contextBefore,
-                          contextAfter: base.contextAfter,
-                          startOffset: base.startOffset,
-                          endOffset: base.endOffset,
-                          content: text,
-                        });
-                      }}
-                    />
+                    <ReplyBox onSubmit={async (text) => {
+                      const base = m.comments[0];
+                      return onCreate({ selectedText: base.selectedText, contextBefore: base.contextBefore, contextAfter: base.contextAfter, startOffset: base.startOffset, endOffset: base.endOffset, content: text });
+                    }} />
                   </div>
                 )}
               </div>

--- a/prd-admin/src/components/doc-browser/InlineCommentOverlay.tsx
+++ b/prd-admin/src/components/doc-browser/InlineCommentOverlay.tsx
@@ -99,6 +99,7 @@ export function InlineCommentOverlay({
   activeKey = null,
   onActivate,
   canCreate = false,
+  canDelete,
   onCreate,
   onDelete,
 }: {
@@ -113,6 +114,8 @@ export function InlineCommentOverlay({
   /** 点气泡 → 激活该分组（margin 联动右侧卡 / inline 展开） */
   onActivate?: (key: string, selectedText: string) => void;
   canCreate?: boolean;
+  /** 逐条删除权限（库主 / 作者）；缺省不可删 */
+  canDelete?: (comment: DocumentInlineComment) => boolean;
   onCreate?: (input: {
     selectedText: string;
     contextBefore?: string;
@@ -246,7 +249,7 @@ export function InlineCommentOverlay({
                   <button onClick={() => onActivate?.(m.key, m.comments[0].selectedText)} className="text-[10px] cursor-pointer hover:underline flex-none" style={{ color: 'var(--text-muted)' }}>收起</button>
                 </div>
                 <div className="space-y-2.5">
-                  {m.comments.map((c) => <CommentLine key={c.id} comment={c} canDelete={canCreate} onDelete={onDelete} />)}
+                  {m.comments.map((c) => <CommentLine key={c.id} comment={c} canDelete={canDelete?.(c)} onDelete={onDelete} />)}
                 </div>
                 {canCreate && onCreate && (
                   <div className="mt-3">

--- a/prd-admin/src/components/doc-browser/InlineCommentOverlay.tsx
+++ b/prd-admin/src/components/doc-browser/InlineCommentOverlay.tsx
@@ -1,21 +1,26 @@
-import { useCallback, useLayoutEffect, useRef, useState, type RefObject } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type RefObject } from 'react';
 import { MessageSquare } from 'lucide-react';
 import type { DocumentInlineComment } from '@/services/contracts/documentStore';
+import { CommentLine, ReplyBox, groupKey } from './inlineCommentShared';
 
-// 行内评论高亮 + 气泡浮层。
-// 把每条评论的 selectedText 锚回「已渲染的 markdown DOM」，在原文上画高亮条，
-// 并在锚点末尾放一颗可点的评论气泡（点击 → 打开评论抽屉）。
+// 行内评论高亮 + 气泡/内联卡片浮层。
+// 把每条评论的 selectedText 锚回「已渲染的 markdown DOM」，在原文上画高亮条。
+// 两种布局（由 mode 控制）：
+//   - inline：高亮末尾放可点气泡，点击就地展开评论卡片（GitHub 评论代码风），边读边可展开看。
+//   - margin：不画气泡，只留高亮；评论卡片在右侧「批注栏」常驻（InlineCommentMargin），
+//             hover 批注栏某条 → hoveredKey 命中 → 本层把对应高亮加亮（双向联动）。
 //
 // 坐标系巧思：本层是 contentAreaRef（滚动容器，position:relative）的 absolute 子元素，
-// top:0/left:0、尺寸 0，作为子元素的包含块原点。高亮子元素位置 = 文本 rect 减去本层 rect，
+// top:0/left:0、尺寸 0，作为子元素的包含块原点。子元素位置 = 文本 rect 减去本层 rect，
 // 得到「相对本层原点」的偏移——本层与正文同在滚动内容里一起滚，故滚动时无需重算，天然对齐。
 
 interface AnchorMark {
   key: string;
   rects: Array<{ top: number; left: number; width: number; height: number }>;
   bubble: { top: number; left: number };
-  count: number;
-  preview: string;
+  /** 内联展开卡片的锚点（高亮末行左下角，相对本层原点） */
+  card: { top: number; left: number };
+  comments: DocumentInlineComment[];
   orphaned: boolean;
 }
 
@@ -97,17 +102,35 @@ export function InlineCommentOverlay({
   containerRef,
   comments,
   reflowKey,
-  onOpenComment,
+  mode = 'inline',
+  hoveredKey = null,
+  canCreate = false,
+  onCreate,
+  onDelete,
 }: {
   containerRef: RefObject<HTMLDivElement>;
   comments: DocumentInlineComment[];
   /** 变化即重算（切文档 / 正文内容变化） */
   reflowKey: string | number;
-  onOpenComment: () => void;
+  mode?: 'inline' | 'margin';
+  /** margin 模式下，批注栏 hover 命中的分组 key（高亮加亮） */
+  hoveredKey?: string | null;
+  canCreate?: boolean;
+  onCreate?: (input: {
+    selectedText: string;
+    contextBefore?: string;
+    contextAfter?: string;
+    startOffset: number;
+    endOffset: number;
+    content: string;
+  }) => Promise<boolean>;
+  onDelete?: (comment: DocumentInlineComment) => void;
 }) {
   const overlayRef = useRef<HTMLDivElement>(null);
   const rafRef = useRef<number | null>(null);
   const [marks, setMarks] = useState<AnchorMark[]>([]);
+  // inline 模式：当前展开的分组（点气泡就地展开卡片）
+  const [expandedKey, setExpandedKey] = useState<string | null>(null);
 
   const recompute = useCallback(() => {
     const container = containerRef.current;
@@ -116,14 +139,11 @@ export function InlineCommentOverlay({
       setMarks([]);
       return;
     }
-    // 同一短语的多条评论合并成一颗气泡（显示条数）；全文评论不参与行内锚定。
-    // 低风险版（用户定）：分组仍按 selectedText、不按出现位置拆分（key=text 唯一，无重复 React key）；
-    // 但锚定时用首条评论的 contextBefore 选「哪一次出现」，多处出现不再一律锚到首次（Bugbot/Codex）。
-    // 已知边界：同一短语在不同位置的多条评论仍合并到一颗气泡（留待完整版按出现位置拆分）。
+    // 同一短语的多条评论合并成一颗气泡/一张卡（显示条数）；全文评论不参与行内锚定。
     const groups = new Map<string, DocumentInlineComment[]>();
     for (const c of comments) {
       if (c.isWholeDocument || !c.selectedText) continue;
-      const text = c.selectedText.replace(/\s+/g, ' ').trim();
+      const text = groupKey(c.selectedText);
       if (!text) continue;
       let g = groups.get(text);
       if (!g) { g = []; groups.set(text, g); }
@@ -134,6 +154,7 @@ export function InlineCommentOverlay({
       return;
     }
     const oRect = overlay.getBoundingClientRect();
+    const maxLeft = Math.max(0, container.clientWidth - 348);
     const next: AnchorMark[] = [];
     groups.forEach((list, text) => {
       const range = findTextRange(container, text, list[0].contextBefore ?? undefined);
@@ -147,13 +168,17 @@ export function InlineCommentOverlay({
         width: r.width,
         height: r.height,
       }));
+      const first = rectList[0];
       const last = rectList[rectList.length - 1];
       next.push({
         key: text,
         rects,
         bubble: { top: last.top - oRect.top, left: last.right - oRect.left },
-        count: list.length,
-        preview: list.map((c) => `${c.authorDisplayName}：${c.content}`).join('\n').slice(0, 240),
+        card: {
+          top: last.bottom - oRect.top + 6,
+          left: Math.min(Math.max(0, first.left - oRect.left), maxLeft),
+        },
+        comments: list,
         orphaned,
       });
     });
@@ -184,55 +209,127 @@ export function InlineCommentOverlay({
     };
   }, [recompute, schedule, reflowKey, containerRef]);
 
+  // 切文档 / 切布局时收起展开的内联卡片
+  useEffect(() => { setExpandedKey(null); }, [reflowKey, mode]);
+
   return (
     <div ref={overlayRef} aria-hidden style={{ position: 'absolute', top: 0, left: 0, width: 0, height: 0 }}>
-      {marks.map((m) => (
-        <div key={m.key}>
-          {/* 高亮条：不挡正文点击/划词 */}
-          {m.rects.map((r, i) => (
-            <div
-              key={i}
-              style={{
-                position: 'absolute',
-                top: r.top,
-                left: r.left,
-                width: r.width,
-                height: r.height,
-                background: m.orphaned ? 'rgba(148,163,184,0.16)' : 'rgba(250,204,21,0.18)',
-                borderBottom: `2px solid ${m.orphaned ? 'rgba(148,163,184,0.5)' : 'rgba(234,179,8,0.7)'}`,
-                borderRadius: 2,
-                pointerEvents: 'none',
-              }}
-            />
-          ))}
-          {/* 气泡：可点击，打开评论抽屉；hover 显示作者+内容预览 */}
-          <button
-            type="button"
-            onClick={(e) => { e.stopPropagation(); onOpenComment(); }}
-            title={m.preview}
-            className="inline-flex items-center gap-0.5 cursor-pointer"
-            style={{
-              position: 'absolute',
-              top: m.bubble.top - 7,
-              left: m.bubble.left + 2,
-              height: 17,
-              padding: '0 5px',
-              borderRadius: 9,
-              pointerEvents: 'auto',
-              background: m.orphaned ? 'rgba(100,116,139,0.95)' : 'rgba(234,179,8,0.96)',
-              color: m.orphaned ? '#e2e8f0' : '#3a2d05',
-              fontSize: 10,
-              fontWeight: 700,
-              lineHeight: '17px',
-              boxShadow: '0 2px 6px rgba(0,0,0,0.28)',
-              zIndex: 6,
-            }}
-          >
-            <MessageSquare size={10} />
-            {m.count > 1 ? m.count : ''}
-          </button>
-        </div>
-      ))}
+      {marks.map((m) => {
+        const active = hoveredKey === m.key || expandedKey === m.key;
+        const expanded = mode === 'inline' && expandedKey === m.key;
+        return (
+          <div key={m.key}>
+            {/* 高亮条：不挡正文点击/划词；active 时加亮（批注栏 hover / 内联展开联动） */}
+            {m.rects.map((r, i) => (
+              <div
+                key={i}
+                style={{
+                  position: 'absolute',
+                  top: r.top,
+                  left: r.left,
+                  width: r.width,
+                  height: r.height,
+                  background: m.orphaned
+                    ? (active ? 'rgba(148,163,184,0.30)' : 'rgba(148,163,184,0.16)')
+                    : (active ? 'rgba(250,204,21,0.34)' : 'rgba(250,204,21,0.18)'),
+                  borderBottom: `2px solid ${m.orphaned ? 'rgba(148,163,184,0.5)' : 'rgba(234,179,8,0.7)'}`,
+                  borderRadius: 2,
+                  pointerEvents: 'none',
+                  transition: 'background 0.12s',
+                }}
+              />
+            ))}
+
+            {/* inline 模式：可点气泡，就地展开/收起卡片 */}
+            {mode === 'inline' && (
+              <button
+                type="button"
+                onClick={(e) => { e.stopPropagation(); setExpandedKey((k) => (k === m.key ? null : m.key)); }}
+                title={m.comments.map((c) => `${c.authorDisplayName}：${c.content}`).join('\n').slice(0, 240)}
+                className="inline-flex items-center gap-0.5 cursor-pointer"
+                style={{
+                  position: 'absolute',
+                  top: m.bubble.top - 7,
+                  left: m.bubble.left + 2,
+                  height: 17,
+                  padding: '0 5px',
+                  borderRadius: 9,
+                  pointerEvents: 'auto',
+                  background: m.orphaned ? 'rgba(100,116,139,0.95)' : 'rgba(234,179,8,0.96)',
+                  color: m.orphaned ? '#e2e8f0' : '#3a2d05',
+                  fontSize: 10,
+                  fontWeight: 700,
+                  lineHeight: '17px',
+                  boxShadow: expanded ? '0 0 0 2px rgba(234,179,8,0.4)' : '0 2px 6px rgba(0,0,0,0.28)',
+                  zIndex: 6,
+                }}
+              >
+                <MessageSquare size={10} />
+                {m.comments.length > 1 ? m.comments.length : ''}
+              </button>
+            )}
+
+            {/* inline 展开卡片：就地（GitHub 评论代码风），可读可回复可删 */}
+            {expanded && (
+              <div
+                style={{
+                  position: 'absolute',
+                  top: m.card.top,
+                  left: m.card.left,
+                  width: 338,
+                  maxHeight: 360,
+                  overflowY: 'auto',
+                  overscrollBehavior: 'contain',
+                  pointerEvents: 'auto',
+                  zIndex: 8,
+                  borderRadius: 12,
+                  padding: '12px 13px',
+                  background: 'linear-gradient(180deg, rgba(30,28,46,0.97), rgba(20,19,28,0.98))',
+                  border: '1px solid rgba(168,85,247,0.3)',
+                  boxShadow: '0 18px 44px -10px rgba(0,0,0,0.6)',
+                  backdropFilter: 'blur(40px)',
+                }}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <div className="flex items-center justify-between mb-2">
+                  <span className="text-[10px] font-semibold truncate" style={{ color: 'var(--text-muted)' }}>
+                    {m.comments.length} 条批注
+                  </span>
+                  <button
+                    onClick={() => setExpandedKey(null)}
+                    className="text-[10px] cursor-pointer hover:underline flex-none"
+                    style={{ color: 'var(--text-muted)' }}
+                  >
+                    收起
+                  </button>
+                </div>
+                <div className="space-y-2.5">
+                  {m.comments.map((c) => (
+                    <CommentLine key={c.id} comment={c} canDelete={canCreate} onDelete={onDelete} />
+                  ))}
+                </div>
+                {canCreate && onCreate && (
+                  <div className="mt-3">
+                    <ReplyBox
+                      onSubmit={async (text) => {
+                        const base = m.comments[0];
+                        return onCreate({
+                          selectedText: base.selectedText,
+                          contextBefore: base.contextBefore,
+                          contextAfter: base.contextAfter,
+                          startOffset: base.startOffset,
+                          endOffset: base.endOffset,
+                          content: text,
+                        });
+                      }}
+                    />
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/prd-admin/src/components/doc-browser/inlineCommentShared.tsx
+++ b/prd-admin/src/components/doc-browser/inlineCommentShared.tsx
@@ -1,0 +1,135 @@
+import { useState } from 'react';
+import { Send } from 'lucide-react';
+import { resolveAvatarUrl, DEFAULT_AVATAR_FALLBACK } from '@/lib/avatar';
+import type { DocumentInlineComment } from '@/services/contracts/documentStore';
+import { MapSpinner } from '@/components/ui/VideoLoader';
+
+// 划词评论各布局（右侧批注栏 / 内联展开 / 抽屉）共用的小部件：
+// 时间格式化、头像、单条评论行、就地回复输入框。避免三处各写一份。
+
+export function formatRelative(iso?: string | null): string {
+  if (!iso) return '—';
+  const date = new Date(iso).getTime();
+  const diff = Date.now() - date;
+  if (diff < 60_000) return '刚刚';
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)} 分钟前`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)} 小时前`;
+  if (diff < 30 * 86_400_000) return `${Math.floor(diff / 86_400_000)} 天前`;
+  return new Date(iso).toLocaleDateString('zh-CN');
+}
+
+/** 把同一段被批注文字归一化为分组 key（去多余空白）。overlay 与批注栏必须用同一函数，hover 联动才对得上。 */
+export function groupKey(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+/** 用户头像：走可配置 CDN 前缀，加载失败回退内联 SVG，永不裂图。 */
+export function CommentAvatar({
+  name,
+  avatar,
+  size = 26,
+}: {
+  name?: string;
+  avatar?: string | null;
+  size?: number;
+}) {
+  return (
+    <img
+      className="rounded-full object-cover flex-none"
+      width={size}
+      height={size}
+      src={resolveAvatarUrl({ avatarFileName: avatar })}
+      alt={name ?? ''}
+      onError={(e) => {
+        const t = e.currentTarget;
+        if (t.src !== DEFAULT_AVATAR_FALLBACK) t.src = DEFAULT_AVATAR_FALLBACK;
+      }}
+    />
+  );
+}
+
+/** 单条评论行：头像 + 名字 + 相对时间 + 内容（+ 可选删除）。 */
+export function CommentLine({
+  comment,
+  canDelete,
+  onDelete,
+}: {
+  comment: DocumentInlineComment;
+  canDelete?: boolean;
+  onDelete?: (c: DocumentInlineComment) => void;
+}) {
+  return (
+    <div className="flex items-start gap-2">
+      <CommentAvatar name={comment.authorDisplayName} avatar={comment.authorAvatar} size={26} />
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="text-[11.5px] font-semibold truncate" style={{ color: 'var(--text-primary)' }}>
+            {comment.authorDisplayName}
+          </span>
+          <span className="text-[9.5px] flex-none" style={{ color: 'var(--text-muted)' }}>
+            {formatRelative(comment.createdAt)}
+          </span>
+          {canDelete && onDelete && (
+            <button
+              onClick={() => onDelete(comment)}
+              className="ml-auto text-[9.5px] cursor-pointer opacity-50 hover:opacity-100 transition-opacity flex-none"
+              style={{ color: 'rgba(239,68,68,0.85)' }}
+              title="删除评论"
+            >
+              删除
+            </button>
+          )}
+        </div>
+        <p className="text-[12px] whitespace-pre-wrap break-words mt-0.5" style={{ color: 'var(--text-secondary, rgba(255,255,255,0.78))' }}>
+          {comment.content}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+/** 就地回复输入框：写完回车或点发送，调 onSubmit；成功后自清空。 */
+export function ReplyBox({
+  placeholder = '回复…',
+  onSubmit,
+}: {
+  placeholder?: string;
+  onSubmit: (text: string) => Promise<boolean>;
+}) {
+  const [text, setText] = useState('');
+  const [sending, setSending] = useState(false);
+  const submit = async () => {
+    const t = text.trim();
+    if (!t || sending) return;
+    setSending(true);
+    const ok = await onSubmit(t);
+    setSending(false);
+    if (ok) setText('');
+  };
+  return (
+    <div className="flex items-center gap-1.5">
+      <input
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+            e.preventDefault();
+            submit();
+          }
+        }}
+        placeholder={placeholder}
+        className="flex-1 h-7 rounded-[8px] px-2.5 text-[11.5px] outline-none"
+        style={{ background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.09)', color: 'var(--text-primary)' }}
+      />
+      <button
+        onClick={submit}
+        disabled={sending || !text.trim()}
+        className="h-7 w-7 rounded-[8px] flex items-center justify-center cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed flex-none"
+        style={{ background: 'rgba(168,85,247,0.18)', border: '1px solid rgba(168,85,247,0.32)', color: 'rgba(216,180,254,0.97)' }}
+        title="发送回复"
+      >
+        {sending ? <MapSpinner size={12} /> : <Send size={12} />}
+      </button>
+    </div>
+  );
+}

--- a/prd-admin/src/components/doc-browser/inlineCommentShared.tsx
+++ b/prd-admin/src/components/doc-browser/inlineCommentShared.tsx
@@ -23,6 +23,24 @@ export function groupKey(text: string): string {
   return text.replace(/\s+/g, ' ').trim();
 }
 
+// 每条批注线程的稳定配色：正文高亮下划线与右侧卡片色条用同一色，眼睛自动把"这段文字"和"这条评论"连起来
+// （同色锚定，业界做法：Figma/Linear 同色 tether）。按 groupKey 哈希取色，保证同一线程跨重渲染颜色不变。
+const THREAD_COLORS = ['#f5b301', '#a855f7', '#22d3ee', '#34d399', '#f472b6', '#60a5fa', '#fb923c', '#a3e635'];
+
+export function threadColor(key: string): string {
+  let h = 0;
+  for (let i = 0; i < key.length; i++) h = (h * 31 + key.charCodeAt(i)) >>> 0;
+  return THREAD_COLORS[h % THREAD_COLORS.length];
+}
+
+/** 把 #rrggbb + alpha 转成 rgba()，用于按线程色生成不同透明度的底色/描边 */
+export function withAlpha(hex: string, alpha: number): string {
+  const m = /^#?([0-9a-f]{6})$/i.exec(hex);
+  if (!m) return hex;
+  const n = parseInt(m[1], 16);
+  return `rgba(${(n >> 16) & 255}, ${(n >> 8) & 255}, ${n & 255}, ${alpha})`;
+}
+
 /** 用户头像：走可配置 CDN 前缀，加载失败回退内联 SVG，永不裂图。 */
 export function CommentAvatar({
   name,

--- a/prd-admin/src/components/doc-browser/inlineCommentShared.tsx
+++ b/prd-admin/src/components/doc-browser/inlineCommentShared.tsx
@@ -89,7 +89,7 @@ export function CommentLine({
           </span>
           {canDelete && onDelete && (
             <button
-              onClick={() => onDelete(comment)}
+              onClick={(e) => { e.stopPropagation(); onDelete(comment); }}
               className="ml-auto text-[9.5px] cursor-pointer opacity-50 hover:opacity-100 transition-opacity flex-none"
               style={{ color: 'rgba(239,68,68,0.85)' }}
               title="删除评论"

--- a/prd-admin/src/pages/document-store/InlineCommentDrawer.tsx
+++ b/prd-admin/src/pages/document-store/InlineCommentDrawer.tsx
@@ -67,6 +67,9 @@ export function InlineCommentDrawer({
   const [loading, setLoading] = useState(true);
   const [comments, setComments] = useState<DocumentInlineComment[]>([]);
   const [canCreate, setCanCreate] = useState(false);
+  // 删除按库主/作者逐条判定：公开库 canCreate 对任意登录者为 true，但删除仅作者/库主（Bugbot Medium）
+  const [isOwner, setIsOwner] = useState(false);
+  const [viewerId, setViewerId] = useState<string | null>(null);
   const [draft, setDraft] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -81,6 +84,8 @@ export function InlineCommentDrawer({
     if (res.success) {
       setComments(res.data.items);
       setCanCreate(res.data.canCreate);
+      setIsOwner(!!res.data.isOwner);
+      setViewerId(res.data.viewerUserId ?? null);
     } else {
       toast.error('加载评论失败', res.error?.message);
     }
@@ -285,7 +290,7 @@ export function InlineCommentDrawer({
                   <CommentCard
                     key={c.id}
                     comment={c}
-                    canDelete={canCreate}
+                    canDelete={isOwner || c.authorUserId === viewerId}
                     onDelete={() => handleDelete(c)}
                     onLocate={onLocate}
                   />
@@ -306,7 +311,7 @@ export function InlineCommentDrawer({
                       <CommentCard
                         key={c.id}
                         comment={c}
-                        canDelete={canCreate}
+                        canDelete={isOwner || c.authorUserId === viewerId}
                         onDelete={() => handleDelete(c)}
                         orphaned
                       />

--- a/prd-admin/src/pages/document-store/InlineCommentDrawer.tsx
+++ b/prd-admin/src/pages/document-store/InlineCommentDrawer.tsx
@@ -44,6 +44,8 @@ export type InlineCommentDrawerProps = {
   shareToken?: string;
   /** 父级（批注栏/内联/composer）增删评论后自增，抽屉据此重拉，避免与正文数据脱节（Bugbot Medium） */
   syncTick?: number;
+  /** 抽屉内增删后回调父级刷新，让 margin/overlay/计数同步（Bugbot Medium：反向同步） */
+  onChanged?: () => void;
   pendingSelection: PendingSelection | null;
   onClearPending: () => void;
   /** 点击某条评论时：尝试 scroll 到其 selectedText 在 DOM 中的位置 */
@@ -56,6 +58,7 @@ export function InlineCommentDrawer({
   entryTitle,
   shareToken,
   syncTick,
+  onChanged,
   pendingSelection,
   onClearPending,
   onLocate,
@@ -67,10 +70,14 @@ export function InlineCommentDrawer({
   const [draft, setDraft] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  // load 的 stale-response 守卫：entryId/syncTick 变化会触发重叠 fetch，慢的旧响应不得覆盖新结果（Bugbot Medium）
+  const loadIdRef = useRef(0);
 
   const load = useCallback(async () => {
+    const myId = ++loadIdRef.current;
     setLoading(true);
     const res = await listInlineComments(entryId, shareToken);
+    if (myId !== loadIdRef.current) return; // 有更新的 load 已发起，丢弃本次旧响应
     if (res.success) {
       setComments(res.data.items);
       setCanCreate(res.data.canCreate);
@@ -114,10 +121,11 @@ export function InlineCommentDrawer({
       setDraft('');
       onClearPending();
       await load();
+      onChanged?.(); // 通知父级刷新 margin/overlay/计数（反向同步）
     } else {
       toast.error('添加失败', res.error?.message);
     }
-  }, [pendingSelection, draft, entryId, onClearPending, load]);
+  }, [pendingSelection, draft, entryId, onClearPending, load, onChanged]);
 
   const handleDelete = useCallback(async (comment: DocumentInlineComment) => {
     const ok = await systemDialog.confirm({
@@ -132,10 +140,11 @@ export function InlineCommentDrawer({
     if (res.success) {
       toast.success('已删除');
       setComments(prev => prev.filter(c => c.id !== comment.id));
+      onChanged?.(); // 通知父级刷新 margin/overlay/计数（反向同步）
     } else {
       toast.error('删除失败', res.error?.message);
     }
-  }, []);
+  }, [onChanged]);
 
   const activeComments = comments.filter(c => c.status === 'active');
   const orphanedComments = comments.filter(c => c.status === 'orphaned');

--- a/prd-admin/src/pages/document-store/InlineCommentDrawer.tsx
+++ b/prd-admin/src/pages/document-store/InlineCommentDrawer.tsx
@@ -42,6 +42,8 @@ export type InlineCommentDrawerProps = {
   entryTitle: string;
   /** 分享视图传入分享 token，用于私有库读取评论气泡（PR #685 Codex P1） */
   shareToken?: string;
+  /** 父级（批注栏/内联/composer）增删评论后自增，抽屉据此重拉，避免与正文数据脱节（Bugbot Medium） */
+  syncTick?: number;
   pendingSelection: PendingSelection | null;
   onClearPending: () => void;
   /** 点击某条评论时：尝试 scroll 到其 selectedText 在 DOM 中的位置 */
@@ -53,6 +55,7 @@ export function InlineCommentDrawer({
   entryId,
   entryTitle,
   shareToken,
+  syncTick,
   pendingSelection,
   onClearPending,
   onLocate,
@@ -79,7 +82,8 @@ export function InlineCommentDrawer({
 
   useEffect(() => {
     load();
-  }, [load]);
+    // syncTick 变化（其它面板增删）时重拉，保持抽屉与正文数据一致（Bugbot Medium）
+  }, [load, syncTick]);
 
   // 选中新内容时自动聚焦 textarea
   useEffect(() => {

--- a/prd-admin/src/services/real/documentStore.ts
+++ b/prd-admin/src/services/real/documentStore.ts
@@ -637,6 +637,10 @@ export async function listInlineComments(entryId: string, shareToken?: string) {
   return await apiRequest<{
     items: import('@/services/contracts/documentStore').DocumentInlineComment[];
     canCreate: boolean;
+    /** 当前查看者是否为库主（库主可删任意评论） */
+    isOwner?: boolean;
+    /** 当前查看者 userId（用于「作者可删自己评论」逐条判定）；匿名为 null */
+    viewerUserId?: string | null;
   }>(
     url,
     { method: 'GET' },

--- a/prd-admin/src/stores/docReaderPrefsStore.ts
+++ b/prd-admin/src/stores/docReaderPrefsStore.ts
@@ -1,0 +1,27 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+
+// 文档阅读器的个人偏好。
+// 划词评论的展示布局是「纯 UI 偏好 + 设备本地 + 发版后用旧值无害」——
+// 按 no-localstorage.md 的例外清单（同视图模式/排序方式），允许走 localStorage，
+// 这样「关浏览器再打开」也记得用户上次选的布局，不必每次重选。
+export type InlineCommentLayout = 'margin' | 'inline';
+
+interface DocReaderPrefsState {
+  /** 划词评论布局：margin=右侧批注栏（飞书/Docs 式）；inline=正文内联气泡展开（GitHub 式） */
+  inlineCommentLayout: InlineCommentLayout;
+  setInlineCommentLayout: (layout: InlineCommentLayout) => void;
+}
+
+export const useDocReaderPrefs = create<DocReaderPrefsState>()(
+  persist(
+    (set) => ({
+      inlineCommentLayout: 'margin',
+      setInlineCommentLayout: (inlineCommentLayout) => set({ inlineCommentLayout }),
+    }),
+    {
+      name: 'prd-admin-doc-reader',
+      storage: createJSONStorage(() => localStorage),
+    },
+  ),
+);

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/DocumentStoreController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/DocumentStoreController.cs
@@ -4282,7 +4282,9 @@ public class DocumentStoreController : ControllerBase
             .SortBy(c => c.CreatedAt)
             .ToListAsync();
 
-        return Ok(ApiResponse<object>.Ok(new { items = comments, canCreate }));
+        // isOwner + viewerUserId 供前端按「作者或库主」逐条判定删除权限：
+        // 公开库里 canCreate 对任意登录用户为 true，但删除只允许作者/库主，前端不能拿 canCreate 当 canDelete（Codex P2）
+        return Ok(ApiResponse<object>.Ok(new { items = comments, canCreate, isOwner, viewerUserId = currentUser }));
     }
 
     /// <summary>删除划词评论</summary>

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/DocumentStoreController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/DocumentStoreController.cs
@@ -4306,6 +4306,76 @@ public class DocumentStoreController : ControllerBase
         return Ok(ApiResponse<object>.Ok(new { deleted = true }));
     }
 
+    /// <summary>
+    /// 读取知识库最近的划词/全文评论（按时间倒序聚合整库），供验收智能体回读用户在验收文档上的批注。
+    /// 鉴权走类级 [Authorize] + [AdminController(document-store.read)]；AgentApiKey 持
+    /// document-store:read（或 write，write ⊇ read）即可调用。仅返回调用方可读的库
+    /// （owner / 公开 / 团队 / 项目 / 产品成员）的评论，避免越权枚举。
+    /// </summary>
+    /// <param name="storeId">知识库 ID</param>
+    /// <param name="since">仅返回此 ISO-8601 时间之后创建的评论（可选，用于增量轮询）</param>
+    /// <param name="limit">返回上限（1-200，默认 50）</param>
+    [HttpGet("stores/{storeId}/recent-comments")]
+    public async Task<IActionResult> ListRecentStoreComments(string storeId, [FromQuery] string? since = null, [FromQuery] int limit = 50)
+    {
+        var userId = GetUserId();
+        var store = await _db.DocumentStores.Find(s => s.Id == storeId).FirstOrDefaultAsync();
+        if (store == null)
+            return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "知识库不存在"));
+
+        var myTeamIds = await _teams.GetMyTeamIdsAsync(userId);
+        if (!await CanReadStoreAsync(store, userId, myTeamIds))
+            return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "知识库不存在"));
+
+        limit = Math.Clamp(limit, 1, 200);
+
+        var filter = Builders<DocumentInlineComment>.Filter.Eq(c => c.StoreId, storeId);
+        if (!string.IsNullOrWhiteSpace(since)
+            && DateTime.TryParse(since, System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.RoundtripKind, out var sinceUtc))
+        {
+            filter = Builders<DocumentInlineComment>.Filter.And(
+                filter,
+                Builders<DocumentInlineComment>.Filter.Gt(c => c.CreatedAt, sinceUtc.ToUniversalTime()));
+        }
+
+        var comments = await _db.DocumentInlineComments
+            .Find(filter)
+            .SortByDescending(c => c.CreatedAt)
+            .Limit(limit)
+            .ToListAsync();
+
+        // 一次性查出涉及的 entry 标题，避免 N+1
+        var entryIds = comments.Select(c => c.EntryId).Distinct().ToList();
+        var entries = entryIds.Count == 0
+            ? new List<DocumentEntry>()
+            : await _db.DocumentEntries.Find(e => entryIds.Contains(e.Id)).ToListAsync();
+        var titleMap = entries.ToDictionary(e => e.Id, e => e.Title);
+
+        var items = comments.Select(c => new
+        {
+            id = c.Id,
+            entryId = c.EntryId,
+            entryTitle = titleMap.TryGetValue(c.EntryId, out var t) ? t : null,
+            isWholeDocument = c.IsWholeDocument,
+            // 锚点原文（被批注的那段文字）；全文评论为空
+            selectedText = c.SelectedText,
+            content = c.Content,
+            authorUserId = c.AuthorUserId,
+            authorDisplayName = c.AuthorDisplayName,
+            status = c.Status,
+            createdAt = c.CreatedAt,
+        }).ToList();
+
+        return Ok(ApiResponse<object>.Ok(new
+        {
+            storeId,
+            storeName = store.Name,
+            count = items.Count,
+            items,
+        }));
+    }
+
     private static string ComputeSha256(string content)
     {
         var bytes = System.Text.Encoding.UTF8.GetBytes(content);

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/DocumentStoreController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/DocumentStoreController.cs
@@ -4363,6 +4363,9 @@ public class DocumentStoreController : ControllerBase
             content = c.Content,
             authorUserId = c.AuthorUserId,
             authorDisplayName = c.AuthorDisplayName,
+            // 头像文件名快照：与 per-entry inline-comments 返回的完整实体对齐，
+            // 让 read_comments.py 等 store 级轮询也能拿到头像（Bugbot Medium）
+            authorAvatar = c.AuthorAvatar,
             status = c.Status,
             createdAt = c.CreatedAt,
         }).ToList();


### PR DESCRIPTION
## 摘要

实现知识库文档的「边读边看」批注栏布局（飞书/Google Docs 式），支持批注栏与内联气泡两种展示方式切换，并新增划词就地输入浮层、批注头像显示、后端最近批注聚合接口、验收技能回读脚本。

## 改动 diff

### 前端核心（prd-admin/）

- **InlineCommentOverlay.tsx**：重构行内评论高亮层，支持 `mode` 参数（inline/margin），新增激活态联动（activeKey/hoveredKey），高亮按线程配色，气泡支持激活回调
- **InlineCommentMargin.tsx**（新增）：右侧批注栏组件，常驻显示评论卡片，支持密集折叠（>3 组时非激活卡压成一行），卡片左色条与正文高亮同色，hover/激活态联动
- **InlineCommentComposer.tsx**（新增）：划词后就地输入浮层，取代右侧抽屉，支持 Cmd/Ctrl+Enter 发送
- **InlineCommentConnector.tsx**（新增）：激活批注的牵引连线（Word/Figma 式），从正文气泡拉曲线到右侧卡片，逐帧 RAF 跟手
- **inlineCommentShared.tsx**（新增）：共用小部件库（CommentLine/CommentAvatar/ReplyBox/groupKey/threadColor/withAlpha），避免三处重复代码
- **DocBrowser.tsx**：集成新组件，新增布局切换按钮（右上角），管理 hoveredCommentKey/activeCommentKey/marginCollapsed 状态，接入 createInlineComment/deleteInlineComment API
- **docReaderPrefsStore.ts**（新增）：个人偏好 Zustand store，划词评论布局持久化到 localStorage

### 后端（prd-api/）

- **DocumentStoreController.cs**：新增 `GET /api/document-store/stores/{storeId}/recent-comments` 接口，按时间倒序聚合整库评论，支持 `since` 增量轮询、`limit` 分页，返回评论+条目标题+作者头像

### 验收技能（.claude/skills/create-visual-test-to-kb/）

- **read_comments.py**（新增）：回读闭环脚本，拉知识库最近批注供验收智能体复测，支持按库名/ID、按条目、按时间增量过滤
- **SKILL.md**：补充 read_comments.py 使用说明

### 文档

- **debt.kb-inline-comment.md**（新增）：工程债务台账，声明 6 条已知边界（图片批注、inline 卡片定位、margin 卡片排序、批注栏与 TOC 并存、webhook 监听、跨设备同步）
- **guide.list.directory.md** / **index.yml**：同步更新文档索引

## 关键实现细节

1. **同色锚定**：threadColor(groupKey) 哈希函数保证同一线程跨重渲染颜色不变，正文高亮下划线与右侧卡片色条一致（业界做法：Figma/Linear tether）
2. **双向联动**：批注栏 hover 命中分组

https://claude.ai/code/session_01Pjvghy48hTdhqZ3ZJEmYt8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large DocBrowser/state-machine surface (create/delete/sync/race guards) plus new authenticated aggregation API; mostly UI and read paths, but comment anchoring and cross-panel sync are easy to regress.
> 
> **Overview**
> **知识库划词评论**从「抽屉 + 单一高亮气泡」升级为 **批注栏 / 内联** 两种边读边看布局（个人偏好 `localStorage` 持久化），划词改为 **就地 Composer** 写批注，并补齐正文高亮、右侧卡片、激活态 **牵引连线** 与 hover/点击双向联动。
> 
> **DocBrowser** 集中管理评论刷新、创建/删除（含乐观更新、`fetchId` 防串档/复活）、按 **库主/作者** 的删除权限，以及批注栏与 **InlineCommentDrawer** 的 `syncTick` 双向同步；**InlineCommentOverlay** 支持 inline 就地展开卡片与 margin 激活锚点。
> 
> **后端** 新增 `GET .../stores/{storeId}/recent-comments`（`since`/`limit`、条目标题与 `authorAvatar`），条目列表接口补充 **`isOwner` / `viewerUserId`** 供前端逐条判删。
> 
> **验收闭环**：新增 `read_comments.py` 与 SKILL 说明，轮询批注并输出 `COMMENTS_JSON`；同步 **debt 台账**、changelog 与文档索引。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8798b6dd75bb077dc9661710a60cf8b762f8c921. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->