### PR TITLE
feat: 系统级跨节点互传（Peer Sync）框架与知识库接入

### DIFF
--- a/changelogs/2026-06-06_peer-sync.md
+++ b/changelogs/2026-06-06_peer-sync.md
@@ -1,0 +1,4 @@
+| feat | prd-api | 新增系统级跨节点互传（Peer Sync）：管理员配对对端节点（一次性配对码 + HMAC 互信）+ 通用 ISyncableResource 框架 + node-to-node 数据端点 + 用户发起 push/pull/双向 互传 |
+| feat | prd-api | 知识库接入跨节点互传（DocumentStoreSyncResource，支持双向同步，按用户名/邮箱对齐归属，bundle 带 schemaVersion + extras 向下兼容） |
+| feat | prd-admin | 新增「设置 → 系统互联」管理页：配置对端节点、生成配对码、测试连通、解除配对 |
+| feat | prd-admin | 知识库列表右上角新增「发送到」入口（通用 SendToPeerDialog：选节点 + 多选库 + 选方向，知识库支持双向） |

--- a/changelogs/2026-06-07_peer-sync-v2.md
+++ b/changelogs/2026-06-07_peer-sync-v2.md
@@ -1,0 +1,7 @@
+| fix | prd-api | peer-sync: P1 修复 PeerNodeService.GetSelfNodeIdAsync 用 SetOnInsert 在已存在文档场景不落库导致 selfNodeId 每次返回新 GUID 的严重 bug（PR #742 Codex/Bugbot）|
+| fix | prd-api | peer-sync: 配对码原子 claim（FindOneAndUpdate）防止并发握手同码双用拿到不同 secret（PR #742 Bugbot）|
+| fix | prd-api | peer-sync: PeerSync HttpClient 挂 SafeOutbound handler 禁自动重定向，防恶意对端 3xx 跳内网绕过 SSRF（PR #742 Bugbot）|
+| fix | prd-api | peer-sync: transfer 接口 push/pull 任一阶段失败时每条目独立报 ok=false，前端不再误显示"成功"（PR #742 Bugbot）|
+| feat | prd-api | peer-sync: 缺陷管理（Defect）接入 ISyncableResource 单向 push-only（按 DefectProject 粒度互传，附件传引用元数据）|
+| feat | prd-admin | peer-sync: 系统互联页 + 发送到弹窗加进度提示（"正在握手 / 校验配对码 / 交换密钥…"分阶段 + 已用 Xs 秒表），告别空白等待 |
+| refactor | prd-admin | 知识库「跨环境同步」tab 下架 skblink_ 路径：横幅引导改走系统互联，弹窗只保留同环境两库配对，砍 GenerateLinkDialog |

--- a/doc/debt.peer-sync.md
+++ b/doc/debt.peer-sync.md
@@ -1,0 +1,32 @@
+# 工程债务台账：系统级跨节点互传（Peer Sync）
+
+> 类型：debt | 模块：prd-api PeerSync + prd-admin 系统互联 | 关联：doc/design.peer-sync.md
+
+记录 v1 已知边界、后续可补项、未覆盖风险。下一次 session 接手先读这里。
+
+## 已知边界（v1 故意不做）
+
+| # | 边界 | 现状 | 后续方向 |
+|---|------|------|---------|
+| 1 | 二进制附件跨节点 | 只传知识库正文（markdown / 文本）+ 引用元数据；图片等二进制资产不随包传输，对端无对应附件时图片可能断链 | 后续走对象存储签名 URL 或附件流式传输 |
+| 2 | 影子用户 | 归属对齐失败（对端无同名 username / email）时归到「操作者」（push 路径=发起用户；node-to-node apply 路径=配对管理员），不创建影子账号 | 后续加「按邮箱建影子账户」开关 |
+| 3 | 解除配对的对端清理 | DELETE 仅删本端 PeerNode，对端残留记录需对端管理员手动删 | 后续加 revoke 通知对端 |
+| 4 | 双向合并语义 | both = push(targetKey) 然后 pull(targetKey)，共享条目以发起方为准、两侧新增都保留；非「逐条三方合并」 | 复用现有 DocumentStoreSyncController 的签名快照三态判定可做更精细的「仅改动侧驱动」 |
+| 5 | 资源覆盖面 | v1 只实现 document-store 一个 ISyncableResource（双向）；其它应用单向能力尚未接入 | 缺陷/视觉/工作流等各加一个 ISyncableResource 实现 + DI 注册即可 |
+| 6 | 同步引擎重复 | DocumentStoreSyncResource 的 export/apply 算法与 DocumentStoreSyncController 的私有方法是「同算法两份代码」（为零回归风险，未抽公共引擎） | 后续抽 IDocumentStoreSyncEngine，两边共用，消除分叉风险 |
+| 7 | 本节点对外地址来源 | selfBaseUrl 默认从请求 scheme+host 推断，反向代理 / 内网部署可能不可达；可在添加对端时手填 selfBaseUrl 覆盖 | 后续在系统设置固化「本节点对外地址」 |
+| 8 | 进度可视化 | transfer 为同步 HTTP 一次性返回逐条结果，未做 SSE 流式进度（多库大库时等待较久，仅 spinner） | 大批量时改 Run/Worker + SSE 推进度（呼应 CLAUDE.md §6） |
+
+## 安全与一致性要点（已落地）
+
+- 节点配对：一次性配对码（5 分钟 TTL）+ 握手交换 32 字节共享密钥；后续请求 HMAC-SHA256 签名（method+path+ts+sha256(body)），时间戳偏移超 5 分钟拒绝（防重放）。共享密钥永不出现在 URL / 前端 / 日志。
+- SSRF：对端 baseUrl / 发起方回连地址均过 ISafeOutboundUrlValidator。
+- 受信节点导出绕过按用户访问校验（SyncActor.PeerSystem），但仅在 HMAC 验签通过后；这是「系统级互信」的有意设计。
+- 幂等：沿用 metadata.syncLineageId 血缘键，与旧 skblink token 路径数据互通；重复同步按血缘 upsert，内容未变跳过。
+- 向下兼容：bundle / record 带 schemaVersion + Extras 字典，未知字段原样保留。
+
+## 验证状态（截至落地）
+
+- 本地无 .NET SDK，后端编译走 CDS（见交付消息预览链接 / CDS check）。
+- 前端 tsc / lint 见交付消息。
+- 端到端「两个真实节点互传」需两套已部署环境，单分支预览无法自测双节点握手 —— 列为待真人/双环境验收项。

--- a/doc/debt.peer-sync.md
+++ b/doc/debt.peer-sync.md
@@ -25,6 +25,19 @@
 - 幂等：沿用 metadata.syncLineageId 血缘键，与旧 skblink token 路径数据互通；重复同步按血缘 upsert，内容未变跳过。
 - 向下兼容：bundle / record 带 schemaVersion + Extras 字典，未知字段原样保留。
 
+## 防自指（共享 DB / 配置错误兜底）
+
+CDS 灰度环境下两个分支共用同一 MongoDB，导致 `appsettings.global.MapInstanceId` 在两个分支看是同一个值，
+两个分支的 `selfNodeId` 因此相同。已加三层防护：
+
+1. **握手层**：`AddPeerNode` / `Handshake` 收到 `InitiatorNodeId == selfNodeId` 直接拒绝（早期发现）。
+2. **验签层**：`VerifyPeerAsync` 收到 `X-Peer-Node == selfNodeId` 即返回 401「不能与本节点自己同步（同 nodeId）」，
+   即便配对记录被旁路写入也无效。
+3. **用户 transfer 层**：发起 push/pull/双向时若所选节点的 `RemoteNodeId == selfNodeId` → 拒绝。
+
+测试时可用 `PEER_NODE_ID_OVERRIDE` 环境变量强制覆盖 selfNodeId（不写回 DB），让共享 DB 部署的不同分支
+互相看到对方为「不同节点」，从而走通真实握手 + HMAC + bundle 传输路径。运维场景下也可用此 env 重置节点身份。
+
 ## 验证状态（截至落地）
 
 - 本地无 .NET SDK，后端编译走 CDS（见交付消息预览链接 / CDS check）。

--- a/doc/design.peer-sync.md
+++ b/doc/design.peer-sync.md
@@ -1,0 +1,244 @@
+# 系统级跨节点互传（Peer Sync）
+
+> 状态：draft（v1 落地中）
+> 负责模块：prd-api（PeerNode + PeerSync）、prd-admin（系统互联设置 + 发送到对端）
+> 关联：`design.server-authority.md`、`rule.app-identity.md`、知识库现有 `DocumentStoreSyncController`
+
+---
+
+## 1. 管理摘要（30 秒看懂）
+
+MAP 经常需要在「测试环境」与「正式环境」之间互传数据（最典型是知识库）。今天知识库已经能跨环境同步，但**配对方式是让用户手动复制一段 `skblink_` 链接（内含对端地址 + 永久令牌）粘到另一个环境**——用户要在两个站点之间来回倒腾密钥，既麻烦又有泄露风险，而且每个应用各搞各的。
+
+本方案把「**两个 MAP 节点之间的信任关系**」从"用户每次粘贴"上升为"**管理员配一次，全系统复用**"：
+
+1. **管理员在「设置 → 系统互联」里把对端节点配好一次**（输入对端地址 + 一次性配对码，两个节点自动握手交换长期密钥）。从此两个环境互相认识，用户再也不用碰密钥。
+2. **用户在任意应用（首发知识库）右上角点「发送到 →」，选一个已配好的对端节点**，勾选要传的数据（单个 / 多个知识库），点确认即可完成拷贝。
+3. **按用户名对齐归属**：传过去的数据自动归到对端的同名用户名下，找不到同名用户时让用户选择归属，不会串号。
+4. **知识库支持双向同步**（你改我改都能合），其它应用先支持单向发送/拉取。
+5. **向下兼容**：传输包带版本号，对端遇到不认识的新字段会原样保留在 `extras` 里，将来任一方升级加字段，老节点不会丢数据、不会报错。
+
+一句话：**把"用户在两个站点之间手动倒密钥"换成"管理员配一次、用户一键发送"，并抽象成一套所有应用都能接入的通用互传框架。**
+
+---
+
+## 2. 背景与问题
+
+### 2.1 现状（知识库已有的跨环境同步）
+
+知识库现有 `DocumentStoreSyncController` 已经相当完整：
+
+- 配对分 `local`（同环境两库）/ `remote`（跨环境 HTTP）。
+- 支持 `push` / `pull` / `both` 三种方向，`both` 用签名快照判断"哪侧改了"，冲突时本地为准、两侧新增都保留。
+- 幂等 upsert：每条目带稳定「血缘 ID」(`metadata.syncLineageId`)，重复同步按血缘匹配更新而非重建。
+- 远端鉴权：每个库一个永久 `SyncToken`，对端请求头带 `X-Sync-Token`。
+
+**这套同步引擎本身要保留**，它解决的是"内容怎么搬、怎么去重、怎么判方向"——这部分做得好。
+
+### 2.2 痛点（只在"配对/认证"这一层）
+
+| 痛点 | 后果 |
+|------|------|
+| 配对靠用户手动复制 `skblink_` 链接（含 BaseUrl + 永久 Token）粘到对端 | 密钥在用户手里流转，可能泄露；操作繁琐，要在两个站点来回切 |
+| 信任关系是"库级令牌"，每个库一把、每次配对都要重来 | 没有"系统认识系统"的概念，10 个库要倒 10 次 |
+| 每个应用要复用这种能力都得自己实现一套 token + 远端端点 | 无法横向复用，缺陷/视觉等想要也得重造轮子 |
+
+### 2.3 目标
+
+- **系统级配对**：管理员配一次对端节点，建立两节点间的长期互信，用户零接触密钥。
+- **统一框架**：抽象 `ISyncableResource`，任何应用实现接口即可接入互传；知识库做第一个、且支持双向。
+- **数据一致性**：传输保持时间戳、附件引用、文件内容；按用户名对齐归属。
+- **演进安全**：版本协商 + 未知字段保留，向下兼容、未来加字段不破。
+
+### 2.4 非目标（v1 不做）
+
+- 不做实时增量推送（仍是用户触发 / 已有的后台轮询节奏）。
+- 不做附件二进制大文件的跨节点流式传输（v1 同知识库现状：传正文 + 引用元数据，二进制资产走各自对象存储，列入债务）。
+- 不做三个以上节点的网状拓扑编排（只做点对点配对，可配多个对端）。
+
+---
+
+## 3. 核心概念与角色
+
+| 概念 | 说明 |
+|------|------|
+| **节点（Node）** | 一个独立部署的 MAP 实例（如"测试环境"、"正式环境"）。每个节点有一个稳定的 `nodeId`（首启生成，存系统设置）。 |
+| **对端节点（PeerNode）** | 本节点记录的"我认识的另一个节点"：含对端 baseUrl、对端 nodeId、双方共享的 `sharedSecret`。配对成功后两个节点各存一条互指的 PeerNode。 |
+| **配对（Handshake）** | 管理员动作：A 输入 B 的 baseUrl + B 生成的一次性配对码 → A 调 B 的握手端点 → B 校验配对码、生成 sharedSecret、落 PeerNode(A) → 返回 secret → A 落 PeerNode(B)。此后双方互信。 |
+| **可同步资源（SyncableResource）** | 一种能被互传的业务数据类型（如 `document-store`）。由 `ISyncableResource` 实现，声明能力（单向/双向）、导出、导入、签名。 |
+| **互传（Transfer）** | 用户动作：选对端节点 + 选资源条目 + 选方向 → 发起 push / pull / 双向。 |
+
+---
+
+## 4. 用户场景
+
+### 场景 A：管理员首次打通两个环境
+1. 正式环境管理员进入「设置 → 系统互联」，点「生成配对码」，得到一段一次性配对码（5 分钟有效）。
+2. 测试环境管理员进入同一页面，点「添加对端节点」，填正式环境地址 + 把配对码粘进去，点「配对」。
+3. 两节点自动握手，列表里出现彼此，状态「已连接」。**之后所有用户都能用，无需再配。**
+
+### 场景 B：用户把知识库发到正式环境
+1. 用户在知识库列表勾选 1 个或多个库 → 右上角「发送到 →」。
+2. 弹窗列出已配好的对端节点，选「正式环境」。
+3. 选方向：发送（本地→对端）/ 拉取（对端→本地）/ 双向同步。
+4. 点确认 → 进度条逐库推进 → 完成提示「新增 X / 更新 Y / 跳过 Z」。
+
+### 场景 C：知识库双向协作
+- 用户在测试改了 3 篇、正式改了 2 篇，点「双向同步」→ 共享条目以发起方为准、两侧各自新增都保留（沿用现有 both 语义）。
+
+---
+
+## 5. 核心能力
+
+### 5.1 节点配对与互信
+
+握手成功后，双方各存一条 `PeerNode`，含相同的 `sharedSecret`（32 字节随机，仅存本地、永不出现在 URL / 日志 / 前端）。后续所有跨节点数据请求用 **HMAC-SHA256 签名**鉴权，不再传明文令牌：
+
+```
+X-Peer-Node: {发起方 nodeId}
+X-Peer-Ts:   {unix 毫秒}
+X-Peer-Sign: HMAC_SHA256(sharedSecret, "{METHOD}\n{path}\n{ts}\n{sha256(body)}")
+```
+
+对端按 `X-Peer-Node` 找到对应 PeerNode 取出 secret 验签，时间戳偏移超 5 分钟拒绝（防重放）。配对码一次性、短 TTL，握手成功即失效。
+
+### 5.2 通用资源框架（ISyncableResource）
+
+```csharp
+public interface ISyncableResource
+{
+    string ResourceType { get; }              // "document-store"
+    string DisplayName { get; }               // "知识库"
+    bool SupportsBidirectional { get; }       // 知识库 true，其它 false
+
+    // 发起方：列出本节点当前用户可发送的条目
+    Task<IReadOnlyList<SyncItemSummary>> ListItemsAsync(SyncActor actor, CancellationToken ct);
+
+    // 计算/发送两阶段（compute-then-send）：导出一个条目为 bundle
+    Task<SyncResourceBundle> ExportAsync(string itemId, SyncActor actor, CancellationToken ct);
+    Task<string> ComputeSignatureAsync(string itemId, CancellationToken ct);
+
+    // 接收方：把 bundle 落到本节点，按用户名对齐归属
+    Task<SyncApplyOutcome> ApplyAsync(SyncResourceBundle bundle, SyncActor actor, SyncApplyMode mode, CancellationToken ct);
+}
+```
+
+`SyncResourceRegistry` 反射收集所有实现，按 `ResourceType` 索引。新增资源 = 加一个实现类 + DI 注册，端点零改动。
+
+### 5.3 版本协商与向下兼容
+
+每个 bundle 头带 `schemaVersion`（整数）。接收方规则：
+
+- **已知字段**：按本节点 schema 映射落库。
+- **未知字段**：原样收进每条记录的 `Extras`（`Dictionary<string, JsonElement>`）字典保留，落库到 metadata 命名空间 `peer.extras.*`，不丢弃、不报错。
+- **缺字段**：用本节点默认值兜底（向下兼容旧节点发来的老 bundle）。
+- **版本高于本节点能处理**：仍尽力 apply 已知字段 + 保留 extras，并在结果里回 `partial: true` + 提示"对端版本较新，部分字段已保留但未解释"。
+
+这样任一节点升级加字段，老节点既不丢数据也不崩。
+
+### 5.4 用户名对齐归属
+
+bundle 里每个"作者/拥有者"字段带**用户名 + 邮箱**（不带 userId，userId 跨环境无意义）。接收方：
+
+1. 按 `username` 精确匹配本节点用户 → 命中即归到该用户。
+2. 未命中按 `email` 匹配 → 命中即归。
+3. 都未命中 → 归到**发起本次 apply 的操作者**（带标记 `peer.originalAuthor` 留痕），不创建影子用户（v1 保守，避免脏号），并在结果里列出"N 条作者未对齐，已归到你名下"。
+
+---
+
+## 6. 架构
+
+```
+节点 A（测试）                                  节点 B（正式）
+┌──────────────────────────┐                  ┌──────────────────────────┐
+│ 设置→系统互联             │   握手(配对码)    │ /api/peer-sync/handshake  │
+│ AdminPeerNodesController  │ ───────────────► │ 校验码→生成 secret→存PeerNode│
+│ 存 PeerNode(B)+secret     │ ◄─────────────── │ 返回 secret + nodeId       │
+├──────────────────────────┤                  ├──────────────────────────┤
+│ 用户「发送到 B」          │  HMAC 签名请求    │ /api/peer-sync/...        │
+│ PeerSyncController(发起)  │ ───────────────► │ PeerSyncController(接收)   │
+│  ↳ ISyncableResource.Export│  bundle(schemaV) │  ↳ 验签→Registry→Resource │
+│  ↳ push: 调对端 apply     │                  │  ↳ ApplyAsync 按用户名对齐 │
+│  ↳ pull: 调对端 export    │                  │                          │
+└──────────────────────────┘                  └──────────────────────────┘
+         共享同步引擎：DocumentStoreSyncService（BuildBundle/ApplyBundle 抽出复用）
+```
+
+发起方与接收方是**同一份 PeerSyncController 代码**（每个节点既能发又能收）。发起方用 HMAC 调对端的接收端点；接收端点 `[AllowAnonymous]` + 验签中间逻辑鉴权。
+
+### 6.1 与现有知识库同步引擎的关系
+
+现有 `DocumentStoreSyncController` 的 `BuildBundleAsync` / `ApplyBundleAsync` / `ComputeSignatureAsync` 抽到 `DocumentStoreSyncService`（Infrastructure），供：
+- 旧的 `X-Sync-Token` 路径继续用（保留向后兼容，不动现有用户的链接）。
+- 新的 `DocumentStoreSyncResource`（实现 `ISyncableResource`）复用同一引擎。
+
+旧的 `skblink_` 手动配对**保留**（不删），新增系统级配对作为**推荐路径**。
+
+---
+
+## 7. 数据设计
+
+### 7.1 PeerNode（集合 `peer_nodes`）
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| Id | string | 主键 |
+| RemoteNodeId | string | 对端节点稳定 id |
+| DisplayName | string | 对端展示名（"正式环境"） |
+| BaseUrl | string | 对端 baseUrl（含可能的子路径前缀） |
+| SharedSecret | string | 双方共享密钥（base64，仅后端可见） |
+| Status | string | pending / connected / error |
+| LastError | string? | 最近一次通信错误 |
+| LastContactAt | DateTime? | 最近一次成功通信 |
+| CreatedBy | string | 配对发起管理员 userId |
+| CreatedAt / UpdatedAt | DateTime | 时间戳 |
+
+### 7.2 节点自身标识 + 配对码
+
+- 本节点 `nodeId` 存 `appsettings` 集合（key `peer.selfNodeId`，首次访问惰性生成）。
+- 一次性配对码存 `peer_pairing_codes` 集合：`{ Id=code, ExpiresAt, Used }`，TTL 5 分钟。
+
+### 7.3 传输契约（不落库，HTTP body）
+
+`SyncResourceBundle { schemaVersion, resourceType, item: {key,name,...,extras}, records:[{...,extras}] }`，camelCase 序列化。知识库的 records 即现有 `SyncEntryDto` 扩展 `extras` 字段。
+
+---
+
+## 8. 接口设计
+
+### 管理端（[AdminController] + 新权限 `peer-sync.manage`）
+| 方法 | 路由 | 说明 |
+|------|------|------|
+| GET | `/api/admin/peer-nodes` | 列出已配对节点 + 本节点 nodeId |
+| POST | `/api/admin/peer-nodes/pairing-code` | 生成一次性配对码 |
+| POST | `/api/admin/peer-nodes` | 添加对端：填 baseUrl + 配对码，触发握手 |
+| POST | `/api/admin/peer-nodes/{id}/test` | 测试连通性（HMAC ping） |
+| DELETE | `/api/admin/peer-nodes/{id}` | 解除配对（本端删除，建议同时通知对端） |
+
+### 节点间（[AllowAnonymous] + HMAC 验签）
+| 方法 | 路由 | 说明 |
+|------|------|------|
+| POST | `/api/peer-sync/handshake` | 接收握手（校验配对码，建互信） |
+| GET | `/api/peer-sync/ping` | 连通 + 验签自检 |
+| GET | `/api/peer-sync/capabilities` | 本节点支持的资源类型 |
+| POST | `/api/peer-sync/resources/{type}/signature` | 取条目签名 |
+| POST | `/api/peer-sync/resources/{type}/export` | 导出条目 bundle（对端 pull 用） |
+| POST | `/api/peer-sync/resources/{type}/apply` | 应用 bundle（对端 push 用） |
+
+### 用户端（[Authorize]，发起互传）
+| 方法 | 路由 | 说明 |
+|------|------|------|
+| GET | `/api/peer-sync/nodes` | 列出可发送的对端节点（用户可见，不含 secret） |
+| POST | `/api/peer-sync/transfer` | 发起互传：{nodeId, resourceType, itemIds[], direction} |
+
+---
+
+## 9. 关联设计文档
+- `design.server-authority.md`：长任务 / CancellationToken.None
+- 知识库现有同步：`DocumentStoreSyncController`（保留 token 路径）
+
+## 10. 风险与债务
+- **二进制附件跨节点**：v1 只传正文 + 引用元数据，对端无对应附件时图片可能断链 → 列入 `debt.peer-sync.md`。
+- **影子用户**：v1 不创建，未对齐作者归到操作者 → 后续可加"按邮箱建影子账户"开关。
+- **解除配对的对端清理**：v1 仅本端删除，对端残留 PeerNode 需对端管理员手动删 → 后续加 revoke 通知。
+- **SSRF**：对端 baseUrl 必须过 `ISafeOutboundUrlValidator`（沿用知识库同步）。

--- a/doc/guide.mongodb-indexes.md
+++ b/doc/guide.mongodb-indexes.md
@@ -1291,3 +1291,19 @@ db.changelog_snapshots.createIndex(
   { name: "uniq_changelog_snapshots_key", unique: true }
 )
 ```
+
+
+### peer_nodes
+
+系统级跨节点互传的对端节点表 — 每个 `RemoteNodeId` 在本节点只能有一条配对记录。后端
+握手 / 重配对都改为原子 upsert（`UpdateOne` + `IsUpsert`），但彻底杜绝并发握手 / 两个
+admin 同时配同对端各拿新配对码各插一行（导致 `VerifyPeerAsync.FirstOrDefault` 随机选一行
+HMAC 校验失败），需 `RemoteNodeId` 唯一索引兜底（PR #742 review P2）。
+
+```js
+// RemoteNodeId 唯一 — 同一对端在本节点只能一条配对，并发 upsert 被 unique 索引拦截
+db.peer_nodes.createIndex(
+  { "RemoteNodeId": 1 },
+  { name: "uniq_peer_nodes_remote_node_id", unique: true }
+)
+```

--- a/prd-admin/src/components/sync/SendToPeerDialog.tsx
+++ b/prd-admin/src/components/sync/SendToPeerDialog.tsx
@@ -94,7 +94,13 @@ export function SendToPeerDialog({ resourceType, presetItemIds, onClose, onDone 
     } else {
       setError(nodesRes.error?.message || '加载对端节点失败');
     }
-    if (itemsRes.success && itemsRes.data) setItems(itemsRes.data.items || []);
+    if (itemsRes.success && itemsRes.data) {
+      setItems(itemsRes.data.items || []);
+    } else {
+      // PR #742 review Medium fix：之前只看 nodesRes，items 加载失败时静默走空状态，用户以为"没东西可发"。
+      // 用 || 累加错误（nodes 已报错时优先保留）。
+      setError((prev) => prev || itemsRes.error?.message || '加载可发送条目失败');
+    }
     setLoading(false);
   }, [resourceType, direction]);
 
@@ -147,7 +153,9 @@ export function SendToPeerDialog({ resourceType, presetItemIds, onClose, onDone 
   };
 
   const availableDirections = useMemo(
-    () => DIRECTIONS.filter((d) => d.key !== 'both' || capability?.supportsBidirectional),
+    // PR #742 review P2 fix：之前只过滤掉 both，仍允许用户选 pull → 后端拒 → 验证失败提示。
+    // 单向资源（push-only）应该在 UI 就只露出 push。
+    () => DIRECTIONS.filter((d) => d.key === 'push' || capability?.supportsBidirectional),
     [capability],
   );
 

--- a/prd-admin/src/components/sync/SendToPeerDialog.tsx
+++ b/prd-admin/src/components/sync/SendToPeerDialog.tsx
@@ -51,6 +51,13 @@ export function SendToPeerDialog({ resourceType, presetItemIds, onClose, onDone 
   const [submitting, setSubmitting] = useState(false);
   const [results, setResults] = useState<TransferItemResult[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [progress, setProgress] = useState<{ stage: string; startedAt: number } | null>(null);
+  const [, setNow] = useState(0);
+  useEffect(() => {
+    if (!submitting) return;
+    const t = setInterval(() => setNow((n) => n + 1), 1000);
+    return () => clearInterval(t);
+  }, [submitting]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -98,13 +105,22 @@ export function SendToPeerDialog({ resourceType, presetItemIds, onClose, onDone 
     setSubmitting(true);
     setError(null);
     setResults(null);
+    const startedAt = Date.now();
+    const total = selected.size;
+    const dirLabel = direction === 'push' ? '发送' : direction === 'pull' ? '拉取' : '双向同步';
+    setProgress({ stage: `准备 ${dirLabel} ${total} 项条目…`, startedAt });
+    const t1 = setTimeout(() => setProgress({ stage: `正在导出 / 跨节点传输 bundle…`, startedAt }), 1500);
+    const t2 = setTimeout(() => setProgress({ stage: `对端正在 apply（按血缘 upsert）…`, startedAt }), 5000);
+    const t3 = setTimeout(() => setProgress({ stage: `对端响应较慢，知识库较大或网络较差时可能需要更长时间…`, startedAt }), 12000);
     const res = await transferToPeer({
       nodeId,
       resourceType,
       itemIds: Array.from(selected),
       direction,
     });
+    clearTimeout(t1); clearTimeout(t2); clearTimeout(t3);
     setSubmitting(false);
+    setProgress(null);
     if (res.success && res.data) {
       setResults(res.data.results || []);
       if (!res.data.anyFail) onDone?.();
@@ -234,6 +250,25 @@ export function SendToPeerDialog({ resourceType, presetItemIds, onClose, onDone 
                   </div>
                 )}
               </div>
+
+              {/* 进度（等提示信息，避免空白等待 — CLAUDE.md §6） */}
+              {submitting && progress && (
+                <div
+                  className="rounded-lg p-3 flex items-start gap-2"
+                  style={{
+                    background: 'rgba(59,130,246,0.08)',
+                    border: '1px solid rgba(59,130,246,0.20)',
+                  }}
+                >
+                  <MapSpinner size={13} />
+                  <div className="min-w-0 flex-1 text-[12px]" style={{ color: 'var(--text-primary)' }}>
+                    {progress.stage}
+                    <span className="ml-2 text-[11px]" style={{ color: 'var(--text-muted)' }}>
+                      已用 {Math.round((Date.now() - progress.startedAt) / 1000)}s
+                    </span>
+                  </div>
+                </div>
+              )}
 
               {/* 结果 */}
               {results && (

--- a/prd-admin/src/components/sync/SendToPeerDialog.tsx
+++ b/prd-admin/src/components/sync/SendToPeerDialog.tsx
@@ -136,8 +136,11 @@ export function SendToPeerDialog({ resourceType, presetItemIds, onClose, onDone 
     setSubmitting(false);
     setProgress(null);
     if (res.success && res.data) {
-      setResults(res.data.results || []);
-      if (!res.data.anyFail) onDone?.();
+      const items = res.data.results || [];
+      setResults(items);
+      // PR #742 review Medium fix：之前只有 anyFail=false 才回调 onDone，部分成功部分失败时知识库列表不刷新
+      // 用户看到弹窗里某些条目「成功」但列表没变化，以为啥都没发生。只要至少一条 ok=true 就触发刷新。
+      if (items.some((r) => r.ok)) onDone?.();
     } else {
       setError(res.error?.message || '互传失败');
     }

--- a/prd-admin/src/components/sync/SendToPeerDialog.tsx
+++ b/prd-admin/src/components/sync/SendToPeerDialog.tsx
@@ -59,13 +59,20 @@ export function SendToPeerDialog({ resourceType, presetItemIds, onClose, onDone 
     return () => clearInterval(t);
   }, [submitting]);
 
+  // PR #742 review Medium：transfer 进行中拦住所有关闭路径（ESC / 蒙版 / 关闭按钮），
+  // 否则 HTTP 还在跑、结果没回前 modal 被关掉，用户以为"啥都没发生"，
+  // onDone 也不触发，知识库列表不刷新。
+  const safeClose = useCallback(() => {
+    if (submitting) return;
+    onClose();
+  }, [submitting, onClose]);
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
+      if (e.key === 'Escape') safeClose();
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [onClose]);
+  }, [safeClose]);
 
   // PR #742 review fix: 慢响应回填可能在 modal 关闭后 / 新一轮 load 启动后才到，
   // 导致弹窗状态被旧数据短暂覆盖。沿用 prd-admin learned rule: fetchIdRef stale guard。
@@ -144,7 +151,7 @@ export function SendToPeerDialog({ resourceType, presetItemIds, onClose, onDone 
   const modal = (
     <div
       className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 p-4"
-      onClick={onClose}
+      onClick={safeClose}
     >
       <div
         className="w-full max-w-lg rounded-xl border border-white/10 bg-[#16171b] flex flex-col shadow-2xl"
@@ -157,7 +164,7 @@ export function SendToPeerDialog({ resourceType, presetItemIds, onClose, onDone 
             <Send size={16} className="text-white/70" />
             <span className="text-sm font-medium">发送到对端节点</span>
           </div>
-          <button onClick={onClose} className="text-white/40 hover:text-white">
+          <button onClick={safeClose} className="text-white/40 hover:text-white">
             <X size={16} />
           </button>
         </div>
@@ -301,7 +308,7 @@ export function SendToPeerDialog({ resourceType, presetItemIds, onClose, onDone 
 
         {/* footer */}
         <div className="flex items-center justify-end gap-2 px-5 py-3 border-t border-white/10 shrink-0">
-          <Button size="sm" variant="ghost" onClick={onClose}>
+          <Button size="sm" variant="ghost" onClick={safeClose}>
             关闭
           </Button>
           <Button size="sm" onClick={handleSubmit} disabled={!canSubmit}>

--- a/prd-admin/src/components/sync/SendToPeerDialog.tsx
+++ b/prd-admin/src/components/sync/SendToPeerDialog.tsx
@@ -182,6 +182,20 @@ export function SendToPeerDialog({ resourceType, presetItemIds, onClose, onDone 
 
         {/* body */}
         <div className="flex-1 px-5 py-4 space-y-4" style={{ minHeight: 0, overflowY: 'auto', overscrollBehavior: 'contain' }}>
+          {/* PR #742 review Medium fix：error 之前只在 nodes.length>0 分支渲染，
+              listPeerNodes 失败时 nodes=[] 走"还没有可用的对端节点"空状态，真实错误被吞掉。
+              改为顶层渲染 error，让 API 失败时用户能看到真因。 */}
+          {!loading && error && (
+            <div className="flex items-start gap-2 text-[12px] rounded-lg px-3 py-2"
+              style={{
+                background: 'rgba(239,68,68,0.08)',
+                border: '1px solid rgba(239,68,68,0.20)',
+                color: 'rgba(252,165,165,0.95)',
+              }}>
+              <span className="font-medium shrink-0">加载失败：</span>
+              <span className="min-w-0 break-words">{error}</span>
+            </div>
+          )}
           {loading ? (
             <MapSectionLoader text="正在加载…" />
           ) : nodes.length === 0 ? (
@@ -312,7 +326,7 @@ export function SendToPeerDialog({ resourceType, presetItemIds, onClose, onDone 
                 </div>
               )}
 
-              {error && <div className="text-xs text-red-400">{error}</div>}
+              {/* error 顶层渲染，见 body 顶部空状态前的渲染块 */}
             </>
           )}
         </div>

--- a/prd-admin/src/components/sync/SendToPeerDialog.tsx
+++ b/prd-admin/src/components/sync/SendToPeerDialog.tsx
@@ -7,7 +7,7 @@
  * 遵守 .claude/rules/frontend-modal.md：createPortal 到 body、inline 高度、min-h-0 滚动、ESC + 蒙版关闭。
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Globe, X, Check, Send, ArrowRightLeft, ArrowLeft, ArrowRight } from 'lucide-react';
 import { Button } from '@/components/design/Button';
@@ -67,10 +67,17 @@ export function SendToPeerDialog({ resourceType, presetItemIds, onClose, onDone 
     return () => window.removeEventListener('keydown', onKey);
   }, [onClose]);
 
+  // PR #742 review fix: 慢响应回填可能在 modal 关闭后 / 新一轮 load 启动后才到，
+  // 导致弹窗状态被旧数据短暂覆盖。沿用 prd-admin learned rule: fetchIdRef stale guard。
+  const loadSeqRef = useRef(0);
+  const isMountedRef = useRef(true);
+  useEffect(() => () => { isMountedRef.current = false; }, []);
   const load = useCallback(async () => {
+    const mySeq = ++loadSeqRef.current;
     setLoading(true);
     setError(null);
     const [nodesRes, itemsRes] = await Promise.all([listPeerNodes(), listPeerItems(resourceType)]);
+    if (mySeq !== loadSeqRef.current || !isMountedRef.current) return; // 旧响应或 modal 已关闭 → 丢弃
     if (nodesRes.success && nodesRes.data) {
       setNodes(nodesRes.data.items || []);
       const cap = (nodesRes.data.capabilities || []).find((c) => c.resourceType === resourceType) || null;

--- a/prd-admin/src/components/sync/SendToPeerDialog.tsx
+++ b/prd-admin/src/components/sync/SendToPeerDialog.tsx
@@ -1,0 +1,275 @@
+/**
+ * 「发送到对端节点」通用弹窗 —— 系统级跨节点互传的用户入口。
+ *
+ * 任意应用都可复用：传 resourceType 即可。知识库（document-store）支持双向同步，
+ * 其它资源默认单向发送。详见 doc/design.peer-sync.md。
+ *
+ * 遵守 .claude/rules/frontend-modal.md：createPortal 到 body、inline 高度、min-h-0 滚动、ESC + 蒙版关闭。
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Globe, X, Check, Send, ArrowRightLeft, ArrowLeft, ArrowRight } from 'lucide-react';
+import { Button } from '@/components/design/Button';
+import { MapSectionLoader, MapSpinner } from '@/components/ui/VideoLoader';
+import {
+  listPeerNodes,
+  listPeerItems,
+  transferToPeer,
+  type PeerNode,
+  type SyncResourceCapability,
+  type SyncItemSummary,
+  type TransferItemResult,
+  type PeerTransferDirection,
+} from '@/services/real/peerSync';
+
+interface Props {
+  resourceType: string;
+  /** 预选条目（如知识库列表里勾选的库 id）。为空则在弹窗内多选。 */
+  presetItemIds?: string[];
+  onClose: () => void;
+  /** 互传完成回调（可用于刷新列表） */
+  onDone?: () => void;
+}
+
+const DIRECTIONS: { key: PeerTransferDirection; label: string; icon: React.ReactNode; hint: string }[] = [
+  { key: 'push', label: '发送到对端', icon: <ArrowRight size={14} />, hint: '本地内容覆盖对端（对端被更新）' },
+  { key: 'pull', label: '从对端拉取', icon: <ArrowLeft size={14} />, hint: '对端内容覆盖本地（本地被更新）' },
+  { key: 'both', label: '双向同步', icon: <ArrowRightLeft size={14} />, hint: '两侧合并，冲突以本地为准，各自新增都保留' },
+];
+
+export function SendToPeerDialog({ resourceType, presetItemIds, onClose, onDone }: Props) {
+  const [loading, setLoading] = useState(true);
+  const [nodes, setNodes] = useState<PeerNode[]>([]);
+  const [capability, setCapability] = useState<SyncResourceCapability | null>(null);
+  const [items, setItems] = useState<SyncItemSummary[]>([]);
+
+  const [nodeId, setNodeId] = useState<string>('');
+  const [selected, setSelected] = useState<Set<string>>(new Set(presetItemIds ?? []));
+  const [direction, setDirection] = useState<PeerTransferDirection>('push');
+
+  const [submitting, setSubmitting] = useState(false);
+  const [results, setResults] = useState<TransferItemResult[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const [nodesRes, itemsRes] = await Promise.all([listPeerNodes(), listPeerItems(resourceType)]);
+    if (nodesRes.success && nodesRes.data) {
+      setNodes(nodesRes.data.items || []);
+      const cap = (nodesRes.data.capabilities || []).find((c) => c.resourceType === resourceType) || null;
+      setCapability(cap);
+      if (!cap?.supportsBidirectional && direction === 'both') setDirection('push');
+      if ((nodesRes.data.items || []).length === 1) setNodeId(nodesRes.data.items[0].id);
+    } else {
+      setError(nodesRes.error?.message || '加载对端节点失败');
+    }
+    if (itemsRes.success && itemsRes.data) setItems(itemsRes.data.items || []);
+    setLoading(false);
+  }, [resourceType, direction]);
+
+  useEffect(() => {
+    void load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [resourceType]);
+
+  const toggleItem = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const canSubmit = nodeId && selected.size > 0 && !submitting;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setError(null);
+    setResults(null);
+    const res = await transferToPeer({
+      nodeId,
+      resourceType,
+      itemIds: Array.from(selected),
+      direction,
+    });
+    setSubmitting(false);
+    if (res.success && res.data) {
+      setResults(res.data.results || []);
+      if (!res.data.anyFail) onDone?.();
+    } else {
+      setError(res.error?.message || '互传失败');
+    }
+  };
+
+  const availableDirections = useMemo(
+    () => DIRECTIONS.filter((d) => d.key !== 'both' || capability?.supportsBidirectional),
+    [capability],
+  );
+
+  const modal = (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-lg rounded-xl border border-white/10 bg-[#16171b] flex flex-col shadow-2xl"
+        style={{ maxHeight: '88vh' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* header */}
+        <div className="flex items-center justify-between px-5 py-3.5 border-b border-white/10 shrink-0">
+          <div className="flex items-center gap-2">
+            <Send size={16} className="text-white/70" />
+            <span className="text-sm font-medium">发送到对端节点</span>
+          </div>
+          <button onClick={onClose} className="text-white/40 hover:text-white">
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* body */}
+        <div className="flex-1 px-5 py-4 space-y-4" style={{ minHeight: 0, overflowY: 'auto', overscrollBehavior: 'contain' }}>
+          {loading ? (
+            <MapSectionLoader text="正在加载…" />
+          ) : nodes.length === 0 ? (
+            <div className="text-center py-8">
+              <Globe size={26} className="mx-auto text-white/25" />
+              <div className="mt-3 text-sm text-white/60">还没有可用的对端节点</div>
+              <div className="mt-1 text-xs text-white/40">
+                请联系管理员在「设置 → 系统互联」中配置对端节点后再试。
+              </div>
+            </div>
+          ) : (
+            <>
+              {/* 目标节点 */}
+              <div>
+                <div className="text-xs text-white/50 mb-1.5">目标节点</div>
+                <div className="grid gap-1.5">
+                  {nodes.map((n) => (
+                    <button
+                      key={n.id}
+                      onClick={() => setNodeId(n.id)}
+                      className={`flex items-center gap-2.5 rounded-lg border px-3 py-2 text-left transition ${
+                        nodeId === n.id ? 'border-white/40 bg-white/10' : 'border-white/10 bg-white/5 hover:bg-white/[0.07]'
+                      }`}
+                    >
+                      <Globe size={15} className="text-white/50 shrink-0" />
+                      <div className="min-w-0 flex-1">
+                        <div className="text-sm truncate">{n.displayName}</div>
+                        <div className="text-[11px] text-white/40 font-mono truncate">{n.baseUrl}</div>
+                      </div>
+                      {nodeId === n.id && <Check size={15} className="text-white/70 shrink-0" />}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* 方向 */}
+              <div>
+                <div className="text-xs text-white/50 mb-1.5">方向</div>
+                <div className="grid gap-1.5">
+                  {availableDirections.map((d) => (
+                    <button
+                      key={d.key}
+                      onClick={() => setDirection(d.key)}
+                      className={`flex items-center gap-2.5 rounded-lg border px-3 py-2 text-left transition ${
+                        direction === d.key ? 'border-white/40 bg-white/10' : 'border-white/10 bg-white/5 hover:bg-white/[0.07]'
+                      }`}
+                    >
+                      <span className="text-white/60 shrink-0">{d.icon}</span>
+                      <div className="min-w-0 flex-1">
+                        <div className="text-sm">{d.label}</div>
+                        <div className="text-[11px] text-white/40">{d.hint}</div>
+                      </div>
+                      {direction === d.key && <Check size={15} className="text-white/70 shrink-0" />}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* 条目选择 */}
+              <div>
+                <div className="text-xs text-white/50 mb-1.5">
+                  选择条目（{capability?.displayName || resourceType}）· 已选 {selected.size}
+                </div>
+                {items.length === 0 ? (
+                  <div className="text-xs text-white/40 px-3 py-4 text-center rounded-lg border border-white/10 bg-white/5">
+                    没有可发送的条目
+                  </div>
+                ) : (
+                  <div className="grid gap-1 max-h-52 overflow-y-auto" style={{ overscrollBehavior: 'contain' }}>
+                    {items.map((it) => (
+                      <button
+                        key={it.itemId}
+                        onClick={() => toggleItem(it.itemId)}
+                        className={`flex items-center gap-2.5 rounded-lg border px-3 py-2 text-left transition ${
+                          selected.has(it.itemId) ? 'border-white/40 bg-white/10' : 'border-white/10 bg-white/5 hover:bg-white/[0.07]'
+                        }`}
+                      >
+                        <span
+                          className={`w-4 h-4 rounded border flex items-center justify-center shrink-0 ${
+                            selected.has(it.itemId) ? 'bg-white/80 border-white/80' : 'border-white/30'
+                          }`}
+                        >
+                          {selected.has(it.itemId) && <Check size={11} className="text-black" />}
+                        </span>
+                        <div className="min-w-0 flex-1">
+                          <div className="text-sm truncate">{it.name}</div>
+                          <div className="text-[11px] text-white/40">{it.recordCount} 项内容</div>
+                        </div>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              {/* 结果 */}
+              {results && (
+                <div className="rounded-lg border border-white/10 bg-white/5 p-3 space-y-1">
+                  <div className="text-xs text-white/60 mb-1">互传结果</div>
+                  {results.map((r) => {
+                    const name = items.find((i) => i.itemId === r.itemId)?.name || r.itemId;
+                    return (
+                      <div key={r.itemId} className="flex items-start gap-2 text-[12px]">
+                        <span className={r.ok ? 'text-green-400' : 'text-red-400'}>{r.ok ? '成功' : '失败'}</span>
+                        <span className="text-white/70 truncate">{name}</span>
+                        {r.message && <span className="text-white/40">— {r.message}</span>}
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+
+              {error && <div className="text-xs text-red-400">{error}</div>}
+            </>
+          )}
+        </div>
+
+        {/* footer */}
+        <div className="flex items-center justify-end gap-2 px-5 py-3 border-t border-white/10 shrink-0">
+          <Button size="sm" variant="ghost" onClick={onClose}>
+            关闭
+          </Button>
+          <Button size="sm" onClick={handleSubmit} disabled={!canSubmit}>
+            {submitting ? <MapSpinner size={14} /> : <Send size={14} />}
+            {direction === 'pull' ? '拉取' : direction === 'both' ? '双向同步' : '发送'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+
+  return createPortal(modal, document.body);
+}

--- a/prd-admin/src/pages/SettingsPage.tsx
+++ b/prd-admin/src/pages/SettingsPage.tsx
@@ -13,6 +13,7 @@ import { AccountSettings } from '@/pages/settings/AccountSettings';
 import { DailyTipsEditor } from '@/pages/settings/DailyTipsEditor';
 import { NavLayoutEditor } from '@/pages/settings/NavLayoutEditor';
 import { ShortLinksAdminSettings } from '@/pages/settings/ShortLinksAdminSettings';
+import { PeerNodesSettings } from '@/pages/settings/PeerNodesSettings';
 import { InfraServicesPage } from '@/pages/infra-services';
 import { useNavOrderStore } from '@/stores/navOrderStore';
 import { useAuthStore } from '@/stores/authStore';
@@ -33,6 +34,7 @@ import {
   Users,
   Link2,
   Server,
+  Globe,
 } from 'lucide-react';
 
 function SkinSettings() {
@@ -304,6 +306,7 @@ export default function SettingsPage() {
     if (hasPerm('settings.write')) list.push({ key: 'update-accel', label: '更新加速', icon: <Zap size={14} /> });
     if (hasPerm('daily-tips.read')) list.push({ key: 'daily-tips', label: '小技巧', icon: <Sparkles size={14} /> });
     if (hasPerm('short-links.manage')) list.push({ key: 'short-links', label: '分享短链', icon: <Link2 size={14} /> });
+    if (hasPerm('peer-sync.manage')) list.push({ key: 'peer-sync', label: '系统互联', icon: <Globe size={14} /> });
     return list;
   }, [isRoot, perms]);
 
@@ -338,6 +341,7 @@ export default function SettingsPage() {
         {activeTab === 'update-accel' && <UpdateAccelerationSettings />}
         {activeTab === 'daily-tips' && <DailyTipsEditor />}
         {activeTab === 'short-links' && <ShortLinksAdminSettings />}
+        {activeTab === 'peer-sync' && <PeerNodesSettings />}
       </div>
     </div>
   );

--- a/prd-admin/src/pages/document-store/DocumentStorePage.tsx
+++ b/prd-admin/src/pages/document-store/DocumentStorePage.tsx
@@ -31,6 +31,7 @@ import {
   Tag,
   FolderSync,
   BarChart3,
+  Send,
 } from 'lucide-react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { GlassCard } from '@/components/design/GlassCard';
@@ -39,6 +40,7 @@ import { Button } from '@/components/design/Button';
 import { MapSpinner, MapSectionLoader } from '@/components/ui/VideoLoader';
 import { TeamScopeBar, type TeamScope } from '@/components/team/TeamScopeBar';
 import { SyncManagerPanel, StoreSyncBadge } from './SyncManagerPanel';
+import { SendToPeerDialog } from '@/components/sync/SendToPeerDialog';
 import { useTeamStore } from '@/stores/teamStore';
 import { useAuthStore } from '@/stores/authStore';
 import { AnimatePresence } from 'motion/react';
@@ -1453,6 +1455,7 @@ export function DocumentStorePage() {
   // 我的 / 团队 作用域（默认我的；仅 mine 标签生效）
   const [teamScope, setTeamScope] = useState<TeamScope>(() => useTeamStore.getState().getScope('document-store'));
   const [showCreate, setShowCreate] = useState(false);
+  const [showSendToPeer, setShowSendToPeer] = useState(false);
   const [editTarget, setEditTarget] = useState<{ id: string; name: string; tags: string[] } | null>(null);
   const [shareTeamTarget, setShareTeamTarget] = useState<{ id: string; name: string; teamIds: string[] } | null>(null);
   // 使用 storeId 而不是 store 对象，这样刷新后可以从 URL 或 sessionStorage 恢复
@@ -1990,6 +1993,16 @@ export function DocumentStorePage() {
               <BarChart3 size={13} /> 统计
             </Button>
           )}
+          {tab === 'mine' && (
+            <Button
+              variant="secondary"
+              size="xs"
+              onClick={() => setShowSendToPeer(true)}
+              title="把知识库发送到 / 双向同步到另一个 MAP 节点（如正式环境），由管理员预先在「设置 → 系统互联」配好"
+            >
+              <Send size={13} /> 发送到
+            </Button>
+          )}
           <Button
             variant="primary"
             size="xs"
@@ -2323,6 +2336,14 @@ export function DocumentStorePage() {
             setShowCreate(false);
             setSelectedStoreId(s.id);
           }}
+        />
+      )}
+
+      {showSendToPeer && (
+        <SendToPeerDialog
+          resourceType="document-store"
+          onClose={() => setShowSendToPeer(false)}
+          onDone={() => { if (tab === 'mine') loadStores('mine', null); }}
         />
       )}
 

--- a/prd-admin/src/pages/document-store/SyncManagerPanel.tsx
+++ b/prd-admin/src/pages/document-store/SyncManagerPanel.tsx
@@ -1,20 +1,19 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
-  Link as LinkIcon, Copy, CheckCircle2, AlertCircle, RefreshCw,
+  Link as LinkIcon, CheckCircle2, AlertCircle, RefreshCw,
   Trash2, X, ArrowLeftRight, ArrowRight, ArrowLeft, Globe, FolderSync, Clock,
 } from 'lucide-react';
 import { Button } from '@/components/design/Button';
 import { MapSectionLoader, MapSpinner } from '@/components/ui/VideoLoader';
 import { toast } from '@/lib/toast';
 import {
-  listAllSyncLinks, listStoreSyncLinks, createLocalSyncLink, generateSyncLink, connectSyncLink,
-  runSyncLink, updateSyncLinkDirection, deleteSyncLink, revokeSyncToken,
+  listAllSyncLinks, listStoreSyncLinks, createLocalSyncLink,
+  runSyncLink, updateSyncLinkDirection, deleteSyncLink,
   type DocumentSyncLink, type SyncDirection, type SyncLinkStatus,
 } from '@/services/real/documentStoreSync';
 import { listDocumentStoresWithPreview } from '@/services/real/documentStore';
 import type { DocumentStoreWithPreview } from '@/services/contracts/documentStore';
 import { useTeamStore } from '@/stores/teamStore';
-import { useAuthStore } from '@/stores/authStore';
 
 const DIRECTIONS: { key: SyncDirection; label: string; icon: typeof ArrowRight }[] = [
   { key: 'both', label: '双向同步', icon: ArrowLeftRight },
@@ -91,13 +90,12 @@ export function SyncManagerPanel() {
   const [loading, setLoading] = useState(true);
   const [runningId, setRunningId] = useState<string | null>(null);
   const [showStart, setShowStart] = useState(false);
-  const [showGenerate, setShowGenerate] = useState(false);
+  // showGenerate / GenerateLinkDialog 已在 PR #742 v2 下架（skblink_ 跨环境路径），改走系统互联
+  const loadSeq = useRef(0);
 
   // 防 stale 响应：快速点刷新 / 切走再回来时，旧请求回填会覆盖新数据。
   // 单调递增序号锁住"只有最新一次请求才能 setState"（与 DocumentStorePage 的 listFetchSeq 同款，
   // 满足 prd-admin learned rule: tab/filter 触发的 async fetch 必须有 fetchId stale-guard）。
-  const currentUserId = useAuthStore((s) => s.user?.userId ?? null);
-  const loadSeq = useRef(0);
   const load = useCallback(async () => {
     const mySeq = ++loadSeq.current;
     setLoading(true);
@@ -168,13 +166,30 @@ export function SyncManagerPanel() {
 
   return (
     <div className="flex flex-col">
-      {/* 工具栏 */}
+      {/* 跨环境路径弃用横幅（保留本环境库↔库配对，跨环境改走系统互联）*/}
+      <div
+        className="mb-4 rounded-lg px-3.5 py-2.5 flex items-start gap-2.5"
+        style={{
+          background: 'rgba(245,158,11,0.08)',
+          border: '1px solid rgba(245,158,11,0.22)',
+        }}
+      >
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="shrink-0 mt-0.5" style={{ color: 'rgba(251,191,36,0.95)' }}>
+          <path d="M12 9v4M12 17h.01" strokeLinecap="round"/>
+          <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
+        </svg>
+        <div className="text-[12px] leading-relaxed min-w-0" style={{ color: 'var(--text-secondary)' }}>
+          <span className="font-medium" style={{ color: 'var(--text-primary)' }}>跨环境同步建议改走「系统互联」</span> ——
+          手粘 <code className="text-[11px] mx-0.5">skblink_</code> 链接的方式需用户手动倒密钥、永久令牌进 URL，已不推荐。
+          请管理员到「设置 → 系统互联」一次性配对两个 MAP 节点，之后回到知识库列表点右上角「发送到」即可一键互传。
+          本页保留同环境两个库之间的「本地配对」用法。
+        </div>
+      </div>
+
+      {/* 工具栏（只保留本地库↔库配对入口，跨环境 skblink_ 路径已下架）*/}
       <div data-tour-id="sync-toolbar" className="flex items-center gap-2 mb-4 flex-wrap">
         <Button data-tour-id="sync-start-link" variant="primary" size="sm" onClick={() => setShowStart(true)}>
-          <LinkIcon size={14} />启动链接
-        </Button>
-        <Button data-tour-id="sync-generate-link" variant="secondary" size="sm" onClick={() => setShowGenerate(true)}>
-          <Copy size={14} />生成连接链接
+          <LinkIcon size={14} />配对本环境另一个库
         </Button>
         <Button variant="ghost" size="sm" onClick={load} disabled={loading}>
           <RefreshCw size={14} />刷新
@@ -194,14 +209,12 @@ export function SyncManagerPanel() {
             </div>
             <p className="text-[15px] font-semibold text-token-primary mb-1.5">还没有同步配对</p>
             <p className="text-[13px] text-token-muted mb-5 max-w-[420px]">
-              把另一处知识库的「连接链接」粘贴进来，即可让两个知识库互相同步内容（支持跨环境，也支持本环境两个库）。
+              本页用于在同一环境的两个知识库之间互相同步。
+              跨环境（如测试↔正式）请走「设置 → 系统互联」配对节点后用右上角「发送到」。
             </p>
             <div className="flex gap-2">
               <Button variant="primary" size="sm" onClick={() => setShowStart(true)}>
-                <LinkIcon size={14} />启动链接
-              </Button>
-              <Button variant="secondary" size="sm" onClick={() => setShowGenerate(true)}>
-                <Copy size={14} />生成连接链接
+                <LinkIcon size={14} />配对本环境另一个库
               </Button>
             </div>
           </div>
@@ -288,13 +301,6 @@ export function SyncManagerPanel() {
           onDone={() => { setShowStart(false); load(); }}
         />
       )}
-      {showGenerate && (
-        <GenerateLinkDialog
-          // 生成连接链接只能用自己拥有的库（后端 GenerateLink 仅放行 owner，团队共享库会 403）
-          stores={myStores.filter(s => s.ownerId === currentUserId)}
-          onClose={() => setShowGenerate(false)}
-        />
-      )}
     </div>
   );
 }
@@ -306,10 +312,9 @@ function StartLinkDialog({ stores, onClose, onDone }: {
   onClose: () => void;
   onDone: () => void;
 }) {
-  const [mode, setMode] = useState<'remote' | 'local'>('remote');
+  // 跨环境 skblink_ 路径已下架（PR #742 v2），本对话框只保留同环境两库配对。
   const [localStoreId, setLocalStoreId] = useState(stores[0]?.id ?? '');
   const [targetStoreId, setTargetStoreId] = useState('');
-  const [link, setLink] = useState('');
   const [direction, setDirection] = useState<SyncDirection>('both');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState('');
@@ -320,19 +325,12 @@ function StartLinkDialog({ stores, onClose, onDone }: {
   const submit = async () => {
     if (busy) return;
     if (!localStoreId) { setError('请选择本地知识库'); return; }
+    if (!targetStoreId) { setError('请选择对端知识库'); return; }
     setBusy(true);
     setError('');
-    if (mode === 'remote') {
-      if (!link.trim()) { setError('请粘贴对方的连接链接'); setBusy(false); return; }
-      const res = await connectSyncLink(localStoreId, link.trim(), direction);
-      if (res.success) { toast.success('已连接，可在列表点「立即同步」'); onDone(); }
-      else { setError(res.error?.message ?? '连接失败'); }
-    } else {
-      if (!targetStoreId) { setError('请选择对端知识库'); setBusy(false); return; }
-      const res = await createLocalSyncLink(localStoreId, targetStoreId, direction);
-      if (res.success) { toast.success('已配对，可在列表点「立即同步」'); onDone(); }
-      else { setError(res.error?.message ?? '配对失败'); }
-    }
+    const res = await createLocalSyncLink(localStoreId, targetStoreId, direction);
+    if (res.success) { toast.success('已配对，可在列表点「立即同步」'); onDone(); }
+    else { setError(res.error?.message ?? '配对失败'); }
     setBusy(false);
   };
 
@@ -345,25 +343,11 @@ function StartLinkDialog({ stores, onClose, onDone }: {
             <div className="surface-action-accent flex h-8 w-8 items-center justify-center rounded-[10px]">
               <LinkIcon size={15} />
             </div>
-            <span className="text-[15px] font-semibold text-token-primary">启动同步链接</span>
+            <span className="text-[15px] font-semibold text-token-primary">配对同环境两个库</span>
           </div>
           <button onClick={() => !busy && onClose()} disabled={busy}
             className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-[8px] text-token-muted hover:bg-white/6 disabled:opacity-40">
             <X size={15} />
-          </button>
-        </div>
-
-        {/* 模式切换 */}
-        <div className="flex gap-2 mb-4">
-          <button onClick={() => setMode('remote')}
-            className={`flex-1 inline-flex items-center justify-center gap-1.5 h-9 rounded-[10px] text-[13px] transition-colors ${
-              mode === 'remote' ? 'surface-action-accent text-token-primary' : 'text-token-muted hover:bg-white/6'}`}>
-            <Globe size={14} />跨环境（粘贴链接）
-          </button>
-          <button onClick={() => setMode('local')}
-            className={`flex-1 inline-flex items-center justify-center gap-1.5 h-9 rounded-[10px] text-[13px] transition-colors ${
-              mode === 'local' ? 'surface-action-accent text-token-primary' : 'text-token-muted hover:bg-white/6'}`}>
-            <FolderSync size={14} />本环境两个库
           </button>
         </div>
 
@@ -376,25 +360,14 @@ function StartLinkDialog({ stores, onClose, onDone }: {
           </select>
         </div>
 
-        {mode === 'remote' ? (
-          <div className="mb-4">
-            <label className="mb-1.5 block text-[12px] text-token-muted">对方的连接链接</label>
-            <textarea value={link} onChange={e => setLink(e.target.value)} disabled={busy}
-              placeholder="粘贴对方在「生成连接链接」里复制的 skblink_… 链接"
-              className="prd-field w-full rounded-[10px] px-3 py-2 text-[13px] outline-none disabled:opacity-60 resize-none"
-              rows={3}
-            />
-          </div>
-        ) : (
-          <div className="mb-4">
-            <label className="mb-1.5 block text-[12px] text-token-muted">对端知识库（同环境）</label>
-            <select value={targetStoreId} onChange={e => setTargetStoreId(e.target.value)} disabled={busy}
-              className="prd-field h-9 w-full rounded-[10px] px-3 text-[13px] outline-none disabled:opacity-60">
-              <option value="">请选择…</option>
-              {targetOptions.map(s => <option key={s.id} value={s.id}>{s.name}</option>)}
-            </select>
-          </div>
-        )}
+        <div className="mb-4">
+          <label className="mb-1.5 block text-[12px] text-token-muted">对端知识库（同环境）</label>
+          <select value={targetStoreId} onChange={e => setTargetStoreId(e.target.value)} disabled={busy}
+            className="prd-field h-9 w-full rounded-[10px] px-3 text-[13px] outline-none disabled:opacity-60">
+            <option value="">请选择…</option>
+            {targetOptions.map(s => <option key={s.id} value={s.id}>{s.name}</option>)}
+          </select>
+        </div>
 
         <div className="mb-4">
           <label className="mb-1.5 block text-[12px] text-token-muted">同步方向</label>
@@ -425,110 +398,3 @@ function StartLinkDialog({ stores, onClose, onDone }: {
   );
 }
 
-// ── 生成连接链接（把本库交给对端来连）──
-
-function GenerateLinkDialog({ stores, onClose }: {
-  stores: DocumentStoreWithPreview[];
-  onClose: () => void;
-}) {
-  const [storeId, setStoreId] = useState(stores[0]?.id ?? '');
-  // 默认带上部署路径前缀（如 /prod）：后端 CallRemoteAsync 会保留 base 的 path，
-  // 只给 origin 会丢前缀导致对端探测打到错误路径（Codex P2）。仍可编辑覆盖。
-  const [baseUrl, setBaseUrl] = useState(() =>
-    (window.location.origin + (import.meta.env.BASE_URL || '/')).replace(/\/+$/, ''));
-  const [link, setLink] = useState('');
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState('');
-
-  const generate = async () => {
-    if (busy || !storeId) { if (!storeId) setError('请选择知识库'); return; }
-    setBusy(true);
-    setError('');
-    const res = await generateSyncLink(storeId, baseUrl.trim() || undefined);
-    if (res.success) setLink(res.data.link);
-    else setError(res.error?.message ?? '生成失败');
-    setBusy(false);
-  };
-
-  const copy = async () => {
-    try { await navigator.clipboard.writeText(link); toast.success('已复制连接链接'); }
-    catch { toast.error('复制失败，请手动选择复制'); }
-  };
-
-  const revoke = async () => {
-    if (busy || !storeId) return;
-    if (!window.confirm('撤销后，所有用本库连接链接连入的对端将立即失效（已建立的配对无法再同步）。确定撤销？')) return;
-    setBusy(true);
-    setError('');
-    const res = await revokeSyncToken(storeId);
-    if (res.success) { setLink(''); toast.success('已撤销本库连接令牌，旧链接立即失效'); }
-    else setError(res.error?.message ?? '撤销失败');
-    setBusy(false);
-  };
-
-  return (
-    <div className="surface-backdrop fixed inset-0 z-50 flex items-center justify-center"
-      onClick={(e) => { if (e.target === e.currentTarget && !busy) onClose(); }}>
-      <div className="surface-popover w-[480px] max-w-[92vw] rounded-[16px] p-6">
-        <div className="flex items-center justify-between mb-5">
-          <div className="flex items-center gap-2.5">
-            <div className="surface-action-accent flex h-8 w-8 items-center justify-center rounded-[10px]">
-              <Copy size={15} />
-            </div>
-            <span className="text-[15px] font-semibold text-token-primary">生成连接链接</span>
-          </div>
-          <button onClick={onClose}
-            className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-[8px] text-token-muted hover:bg-white/6">
-            <X size={15} />
-          </button>
-        </div>
-
-        <p className="mb-4 text-[12px] text-token-muted leading-relaxed">
-          把生成的链接发给对端环境，对端在「启动链接」里粘贴即可双向同步。令牌永久有效；不想再被连入时，点下方「撤销连接令牌」即刻失效所有旧链接。
-        </p>
-
-        <div className="mb-4">
-          <label className="mb-1.5 block text-[12px] text-token-muted">知识库</label>
-          <select value={storeId} onChange={e => { setStoreId(e.target.value); setLink(''); }} disabled={busy}
-            className="prd-field h-9 w-full rounded-[10px] px-3 text-[13px] outline-none disabled:opacity-60">
-            {stores.length === 0 && <option value="">（暂无知识库）</option>}
-            {stores.map(s => <option key={s.id} value={s.id}>{s.name}</option>)}
-          </select>
-        </div>
-
-        <div className="mb-4">
-          <label className="mb-1.5 block text-[12px] text-token-muted">本环境对外地址（对端需能访问）</label>
-          <input value={baseUrl} onChange={e => { setBaseUrl(e.target.value); setLink(''); }} disabled={busy}
-            placeholder="https://your-env.example.com"
-            className="prd-field h-9 w-full rounded-[10px] px-3 text-[13px] outline-none disabled:opacity-60" />
-          <p className="mt-1 text-[11px] text-token-muted">默认填当前访问地址，跨环境时请改成对端能访问到的地址。本环境两个库互同步不需要它。</p>
-        </div>
-
-        {link && (
-          <div className="mb-4">
-            <label className="mb-1.5 block text-[12px] text-token-muted">连接链接（发给对端）</label>
-            <div className="flex gap-2">
-              <textarea value={link} readOnly rows={2}
-                className="prd-field flex-1 rounded-[10px] px-3 py-2 text-[12px] outline-none resize-none break-all" />
-              <Button variant="secondary" size="xs" onClick={copy}><Copy size={13} />复制</Button>
-            </div>
-          </div>
-        )}
-
-        {error && <p className="mb-3 text-[12px] text-token-error">{error}</p>}
-
-        <div className="flex items-center justify-between gap-2">
-          <Button variant="danger" size="xs" onClick={revoke} disabled={busy || !storeId}>
-            <Trash2 size={13} />撤销连接令牌
-          </Button>
-          <div className="flex gap-2">
-            <Button variant="ghost" size="xs" onClick={onClose}>关闭</Button>
-            <Button variant="primary" size="xs" onClick={generate} disabled={busy}>
-              {busy ? '生成中…' : link ? '重新生成' : '生成链接'}
-            </Button>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}

--- a/prd-admin/src/pages/document-store/SyncManagerPanel.tsx
+++ b/prd-admin/src/pages/document-store/SyncManagerPanel.tsx
@@ -110,13 +110,18 @@ export function SyncManagerPanel() {
     const teamResults = await Promise.all(
       teams.map(t => listDocumentStoresWithPreview(1, 500, { scope: 'team', teamId: t.team.id })),
     );
-    if (mySeq !== loadSeq.current) return; // 已有更新的请求发出，丢弃本次回填
-    if (linkRes.success) setLinks(linkRes.data.items ?? []);
-    // 合并去重（按 store id）：mine 优先，团队共享库补充
-    const merged = new Map<string, DocumentStoreWithPreview>();
-    if (mineRes.success) for (const s of mineRes.data.items ?? []) merged.set(s.id, s);
-    for (const tr of teamResults) if (tr.success) for (const s of tr.data.items ?? []) if (!merged.has(s.id)) merged.set(s.id, s);
-    setMyStores([...merged.values()]);
+    // PR #742 review Medium fix：mySeq 失效时之前直接 return 不清 loading，导致
+    // handleRun/handleDirection/handleDelete 在 in-flight 时 bump loadSeq → 旧请求早退 → spinner 永久卡死。
+    // 改为：失效时只跳过数据写入 + 仍清 loading（更新的请求会自己再 setLoading(true)）。
+    const stale = mySeq !== loadSeq.current;
+    if (!stale) {
+      if (linkRes.success) setLinks(linkRes.data.items ?? []);
+      // 合并去重（按 store id）：mine 优先，团队共享库补充
+      const merged = new Map<string, DocumentStoreWithPreview>();
+      if (mineRes.success) for (const s of mineRes.data.items ?? []) merged.set(s.id, s);
+      for (const tr of teamResults) if (tr.success) for (const s of tr.data.items ?? []) if (!merged.has(s.id)) merged.set(s.id, s);
+      setMyStores([...merged.values()]);
+    }
     setLoading(false);
   }, []);
 

--- a/prd-admin/src/pages/document-store/SyncManagerPanel.tsx
+++ b/prd-admin/src/pages/document-store/SyncManagerPanel.tsx
@@ -96,33 +96,42 @@ export function SyncManagerPanel() {
   // 防 stale 响应：快速点刷新 / 切走再回来时，旧请求回填会覆盖新数据。
   // 单调递增序号锁住"只有最新一次请求才能 setState"（与 DocumentStorePage 的 listFetchSeq 同款，
   // 满足 prd-admin learned rule: tab/filter 触发的 async fetch 必须有 fetchId stale-guard）。
+  // PR #742 review Medium 续修：用 in-flight 计数器决定何时清 loading。
+  // 之前两版方案都有问题：(a) 旧版 stale 时直接 return 不清 loading → handleRun 等 bump seq
+  // 让 in-flight load 早退 → spinner 卡死；(b) 上版 stale 也 setLoading(false) → 并发两次
+  // load() 旧的先回会把 loading 提前清掉露出过期数据。正解：每个 load 进来 ++inFlight，结束
+  // --inFlight；仅当 inFlight == 0 时才 setLoading(false)，handleRun 等不再依赖 load 自然清。
+  const inFlightRef = useRef(0);
   const load = useCallback(async () => {
     const mySeq = ++loadSeq.current;
+    inFlightRef.current++;
     setLoading(true);
-    // 选择器要列出"我能写的所有库"：自己拥有的(mine) + 各团队共享给我的(team)。
-    // 后端 LoadWritableStoreAsync 接受团队写者，UI 不补这些库的话团队共享库就配不了对（Codex P2）。
-    await useTeamStore.getState().loadTeams().catch(() => {});
-    const teams = useTeamStore.getState().teams;
-    const [linkRes, mineRes] = await Promise.all([
-      listAllSyncLinks(),
-      listDocumentStoresWithPreview(1, 500, { scope: 'mine' }),
-    ]);
-    const teamResults = await Promise.all(
-      teams.map(t => listDocumentStoresWithPreview(1, 500, { scope: 'team', teamId: t.team.id })),
-    );
-    // PR #742 review Medium fix：mySeq 失效时之前直接 return 不清 loading，导致
-    // handleRun/handleDirection/handleDelete 在 in-flight 时 bump loadSeq → 旧请求早退 → spinner 永久卡死。
-    // 改为：失效时只跳过数据写入 + 仍清 loading（更新的请求会自己再 setLoading(true)）。
-    const stale = mySeq !== loadSeq.current;
-    if (!stale) {
-      if (linkRes.success) setLinks(linkRes.data.items ?? []);
-      // 合并去重（按 store id）：mine 优先，团队共享库补充
-      const merged = new Map<string, DocumentStoreWithPreview>();
-      if (mineRes.success) for (const s of mineRes.data.items ?? []) merged.set(s.id, s);
-      for (const tr of teamResults) if (tr.success) for (const s of tr.data.items ?? []) if (!merged.has(s.id)) merged.set(s.id, s);
-      setMyStores([...merged.values()]);
+    try {
+      // 选择器要列出"我能写的所有库"：自己拥有的(mine) + 各团队共享给我的(team)。
+      // 后端 LoadWritableStoreAsync 接受团队写者，UI 不补这些库的话团队共享库就配不了对（Codex P2）。
+      await useTeamStore.getState().loadTeams().catch(() => {});
+      const teams = useTeamStore.getState().teams;
+      const [linkRes, mineRes] = await Promise.all([
+        listAllSyncLinks(),
+        listDocumentStoresWithPreview(1, 500, { scope: 'mine' }),
+      ]);
+      const teamResults = await Promise.all(
+        teams.map(t => listDocumentStoresWithPreview(1, 500, { scope: 'team', teamId: t.team.id })),
+      );
+      if (mySeq === loadSeq.current) {
+        if (linkRes.success) setLinks(linkRes.data.items ?? []);
+        // 合并去重（按 store id）：mine 优先，团队共享库补充
+        const merged = new Map<string, DocumentStoreWithPreview>();
+        if (mineRes.success) for (const s of mineRes.data.items ?? []) merged.set(s.id, s);
+        for (const tr of teamResults) if (tr.success) for (const s of tr.data.items ?? []) if (!merged.has(s.id)) merged.set(s.id, s);
+        setMyStores([...merged.values()]);
+      }
+    } finally {
+      // 计数到 0 才清 loading：避免并发两次 load() 时旧请求先回提前清 loading 露出过期数据；
+      // 也避免 handleRun/Delete bump seq 让本 load 早退后 spinner 卡死（计数器降到 0 触发清理）。
+      inFlightRef.current = Math.max(0, inFlightRef.current - 1);
+      if (inFlightRef.current === 0) setLoading(false);
     }
-    setLoading(false);
   }, []);
 
   useEffect(() => { load(); }, [load]);

--- a/prd-admin/src/pages/settings/PeerNodesSettings.tsx
+++ b/prd-admin/src/pages/settings/PeerNodesSettings.tsx
@@ -234,7 +234,11 @@ export function PeerNodesSettings() {
       setAddSelfName('');
       void load();
     } else {
-      setAddError(res.error?.message || '配对失败');
+      // PR #742 review Medium fix：若用户在 in-flight 时点过"收起表单"（被本提交的 disabled 兜底拦下时尤其要兜底），
+      // addError 渲染在 showAdd 块里看不到，再 flash 一条 toast 确保失败原因可见。
+      const msg = res.error?.message || '配对失败';
+      setAddError(msg);
+      flash(msg, 'err');
     }
   };
 
@@ -398,8 +402,9 @@ export function PeerNodesSettings() {
               </div>
             </div>
           </div>
-          <Button size="sm" onClick={() => setShowAdd((v) => !v)} className="mt-2 w-full">
-            <Plus size={13} /> {showAdd ? '收起表单' : '添加对端节点'}
+          {/* PR #742 review Medium fix：握手 in-flight 时禁掉收起，否则收起会把进度 + addError 全藏起来 */}
+          <Button size="sm" onClick={() => { if (!addBusy) setShowAdd((v) => !v); }} disabled={addBusy} className="mt-2 w-full">
+            <Plus size={13} /> {showAdd ? (addBusy ? '握手中…（请勿关闭）' : '收起表单') : '添加对端节点'}
           </Button>
         </div>
       </section>

--- a/prd-admin/src/pages/settings/PeerNodesSettings.tsx
+++ b/prd-admin/src/pages/settings/PeerNodesSettings.tsx
@@ -142,12 +142,13 @@ export function PeerNodesSettings() {
   const [addProgress, setAddProgress] = useState<{ stage: string; startedAt: number } | null>(null);
   const [testProgress, setTestProgress] = useState<{ id: string; startedAt: number } | null>(null);
   const [, setNow] = useState(0);
-  // 1s 节拍器：handshake/test 进行中时驱动「已用 Xs」自增显示，避免空白等待（CLAUDE.md §6）
+  // 1s 节拍器：handshake/test 进行中 或 配对码倒计时显示时驱动「已用 Xs / 剩余 Xs」自增显示
+  // （CLAUDE.md §6 + PR #742 review fix：之前配对码倒计时只在首渲染那一刻定格，永不更新）
   useEffect(() => {
-    if (!addBusy && !testProgress) return;
+    if (!addBusy && !testProgress && !code) return;
     const t = setInterval(() => setNow((n) => n + 1), 1000);
     return () => clearInterval(t);
-  }, [addBusy, testProgress]);
+  }, [addBusy, testProgress, code]);
 
   const flash = (msg: string, kind: 'ok' | 'err' = 'ok') => {
     setToast({ msg, kind });

--- a/prd-admin/src/pages/settings/PeerNodesSettings.tsx
+++ b/prd-admin/src/pages/settings/PeerNodesSettings.tsx
@@ -158,12 +158,15 @@ export function PeerNodesSettings() {
   // PR #742 review fix: 工具栏刷新 / test/delete/add 后续 load 可能并发，旧响应若回填会
   // 覆盖较新的节点状态或错误。用单调序号守卫：只有"最新一次"调用允许 setState。
   // 沿用 prd-admin learned rule: 由用户动作触发的 async fetch 必须有 fetchIdRef stale 保护。
+  // PR #742 review Low fix：补 isMountedRef 卸载守卫（用户切到别的 settings tab）。
   const loadSeqRef = useRef(0);
+  const isMountedRef = useRef(true);
+  useEffect(() => () => { isMountedRef.current = false; }, []);
   const load = useCallback(async () => {
     const mySeq = ++loadSeqRef.current;
     setLoading(true);
     const res = await listAdminPeerNodes();
-    if (mySeq !== loadSeqRef.current) return; // 已有更新的 load 发出，丢弃本次回填
+    if (mySeq !== loadSeqRef.current || !isMountedRef.current) return;
     if (res.success && res.data) {
       setNodes(res.data.items || []);
       setSelfNodeId(res.data.selfNodeId);
@@ -222,6 +225,7 @@ export function PeerNodesSettings() {
       selfDisplayName: addSelfName.trim() || undefined,
     });
     clearTimeout(t1); clearTimeout(t2); clearTimeout(t3);
+    if (!isMountedRef.current) return; // PR #742 review Low fix
     setAddBusy(false);
     setAddProgress(null);
     if (res.success) {
@@ -247,6 +251,7 @@ export function PeerNodesSettings() {
     const startedAt = Date.now();
     setTestProgress({ id, startedAt });
     const res = await testPeerNode(id);
+    if (!isMountedRef.current) return; // PR #742 review Low fix
     setBusyId(null);
     setTestProgress(null);
     const elapsed = Math.round((Date.now() - startedAt) / 100) / 10;

--- a/prd-admin/src/pages/settings/PeerNodesSettings.tsx
+++ b/prd-admin/src/pages/settings/PeerNodesSettings.tsx
@@ -1,0 +1,323 @@
+/**
+ * 「系统互联」Tab — 系统设置内的管理员视图。
+ *
+ * 管理员配一次对端节点（测试↔正式环境），两节点自动握手交换长期密钥，
+ * 此后用户在知识库等应用「发送到 →」即可一键互传，无需再手动倒密钥。
+ * 详见 doc/design.peer-sync.md。
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Globe, Plus, Copy, Check, Trash2, RefreshCw, Wifi, KeyRound, X } from 'lucide-react';
+import { GlassCard } from '@/components/design/GlassCard';
+import { Button } from '@/components/design/Button';
+import { Badge } from '@/components/design/Badge';
+import { MapSectionLoader, MapSpinner } from '@/components/ui/VideoLoader';
+import {
+  listAdminPeerNodes,
+  generatePairingCode,
+  addPeerNode,
+  testPeerNode,
+  deletePeerNode,
+  type PeerNode,
+} from '@/services/real/peerSync';
+
+function fmtDate(s?: string | null) {
+  if (!s) return '-';
+  try {
+    return new Date(s).toLocaleString('zh-CN', { hour12: false });
+  } catch {
+    return s;
+  }
+}
+
+function statusBadge(status: PeerNode['status']) {
+  if (status === 'connected') return <Badge variant="success">已连接</Badge>;
+  if (status === 'error') return <Badge variant="danger">通信异常</Badge>;
+  return <Badge variant="subtle">待握手</Badge>;
+}
+
+export function PeerNodesSettings() {
+  const [nodes, setNodes] = useState<PeerNode[]>([]);
+  const [selfNodeId, setSelfNodeId] = useState('');
+  const [selfBaseUrl, setSelfBaseUrl] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+
+  // 配对码
+  const [code, setCode] = useState<string | null>(null);
+  const [genBusy, setGenBusy] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  // 添加对端表单
+  const [showAdd, setShowAdd] = useState(false);
+  const [addBaseUrl, setAddBaseUrl] = useState('');
+  const [addCode, setAddCode] = useState('');
+  const [addName, setAddName] = useState('');
+  const [addSelfName, setAddSelfName] = useState('');
+  const [addBusy, setAddBusy] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
+
+  const flash = (m: string) => {
+    setToast(m);
+    setTimeout(() => setToast(null), 2600);
+  };
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    const res = await listAdminPeerNodes();
+    if (res.success && res.data) {
+      setNodes(res.data.items || []);
+      setSelfNodeId(res.data.selfNodeId);
+      setSelfBaseUrl(res.data.selfBaseUrl);
+    } else {
+      flash(res.error?.message || '加载失败');
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleGenCode = async () => {
+    setGenBusy(true);
+    const res = await generatePairingCode();
+    setGenBusy(false);
+    if (res.success && res.data) {
+      setCode(res.data.pairingCode);
+      setCopied(false);
+    } else {
+      flash(res.error?.message || '生成失败');
+    }
+  };
+
+  const handleCopyCode = async () => {
+    if (!code) return;
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      flash('复制失败，请手动选择复制');
+    }
+  };
+
+  const handleAdd = async () => {
+    if (!addBaseUrl.trim() || !addCode.trim()) {
+      setAddError('请填写对端地址和配对码');
+      return;
+    }
+    setAddBusy(true);
+    setAddError(null);
+    const res = await addPeerNode({
+      baseUrl: addBaseUrl.trim(),
+      pairingCode: addCode.trim(),
+      displayName: addName.trim() || undefined,
+      selfDisplayName: addSelfName.trim() || undefined,
+    });
+    setAddBusy(false);
+    if (res.success) {
+      flash('配对成功');
+      setShowAdd(false);
+      setAddBaseUrl('');
+      setAddCode('');
+      setAddName('');
+      setAddSelfName('');
+      void load();
+    } else {
+      setAddError(res.error?.message || '配对失败');
+    }
+  };
+
+  const handleTest = async (id: string) => {
+    setBusyId(id);
+    const res = await testPeerNode(id);
+    setBusyId(null);
+    if (res.success && res.data?.ok) flash('连通正常');
+    else flash(res.data?.error || '连通失败，请检查对端地址与配对状态');
+    void load();
+  };
+
+  const handleDelete = async (id: string, name: string) => {
+    if (!window.confirm(`确定解除与「${name}」的配对？仅删除本端记录，对端需自行删除。`)) return;
+    setBusyId(id);
+    const res = await deletePeerNode(id);
+    setBusyId(null);
+    if (res.success) {
+      flash('已解除配对');
+      void load();
+    } else {
+      flash(res.error?.message || '删除失败');
+    }
+  };
+
+  return (
+    <div className="h-full min-h-0 flex flex-col gap-4 overflow-y-auto" style={{ overscrollBehavior: 'contain' }}>
+      {/* 说明 + 本节点身份 */}
+      <GlassCard className="p-4">
+        <div className="flex items-start gap-3">
+          <Globe size={18} className="text-white/60 mt-0.5 shrink-0" />
+          <div className="flex-1 min-w-0">
+            <div className="text-sm font-medium">系统互联（跨节点互传）</div>
+            <div className="text-xs text-white/50 mt-1 leading-relaxed">
+              配置对端 MAP 节点（如测试环境 ↔ 正式环境）。配对一次后，用户在知识库等应用右上角「发送到」即可一键互传，
+              无需在两个环境之间手动复制密钥。配对走一次性配对码 + HMAC 签名，密钥永不在前端 / 链接中暴露。
+            </div>
+            <div className="mt-2 text-[11px] text-white/40 font-mono break-all">
+              本节点标识：{selfNodeId || '...'} | 对外地址：{selfBaseUrl || '...'}
+            </div>
+          </div>
+        </div>
+      </GlassCard>
+
+      {/* 配对码生成 */}
+      <GlassCard className="p-4">
+        <div className="flex items-center justify-between gap-3 flex-wrap">
+          <div className="flex items-center gap-2">
+            <KeyRound size={15} className="text-white/60" />
+            <span className="text-sm">让对端连接本节点</span>
+          </div>
+          <Button size="sm" variant="secondary" onClick={handleGenCode} disabled={genBusy}>
+            {genBusy ? <MapSpinner size={14} /> : <KeyRound size={14} />}
+            生成配对码
+          </Button>
+        </div>
+        {code && (
+          <div className="mt-3 rounded-lg border border-white/10 bg-white/5 p-3">
+            <div className="text-[11px] text-white/45 mb-1.5">
+              把下面这串配对码 + 本节点对外地址发给对端管理员，让对端在「系统互联 → 添加对端节点」里粘贴（5 分钟内有效，仅用一次）：
+            </div>
+            <div className="flex items-center gap-2">
+              <code className="flex-1 text-xs font-mono break-all bg-black/20 rounded px-2 py-1.5">{code}</code>
+              <Button size="sm" variant="ghost" onClick={handleCopyCode}>
+                {copied ? <Check size={14} /> : <Copy size={14} />}
+              </Button>
+            </div>
+            <div className="mt-1.5 text-[11px] text-white/40 font-mono break-all">对外地址：{selfBaseUrl}</div>
+          </div>
+        )}
+      </GlassCard>
+
+      {/* 对端节点列表 */}
+      <div className="flex items-center justify-between">
+        <div className="text-sm text-white/70">已配对节点</div>
+        <div className="flex items-center gap-2">
+          <Button size="sm" variant="ghost" onClick={() => void load()} disabled={loading}>
+            <RefreshCw size={14} />
+          </Button>
+          <Button size="sm" onClick={() => setShowAdd((v) => !v)}>
+            <Plus size={14} /> 添加对端节点
+          </Button>
+        </div>
+      </div>
+
+      {showAdd && (
+        <GlassCard className="p-4">
+          <div className="text-sm font-medium mb-3">添加对端节点</div>
+          <div className="grid gap-3">
+            <label className="grid gap-1">
+              <span className="text-xs text-white/50">对端地址（baseUrl）</span>
+              <input
+                className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm outline-none focus:border-white/30"
+                placeholder="https://prod-xxx.miduo.org"
+                value={addBaseUrl}
+                onChange={(e) => setAddBaseUrl(e.target.value)}
+              />
+            </label>
+            <label className="grid gap-1">
+              <span className="text-xs text-white/50">对端生成的配对码</span>
+              <input
+                className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm outline-none focus:border-white/30 font-mono"
+                placeholder="粘贴对端管理员发来的配对码"
+                value={addCode}
+                onChange={(e) => setAddCode(e.target.value)}
+              />
+            </label>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <label className="grid gap-1">
+                <span className="text-xs text-white/50">我方称呼对端（可选）</span>
+                <input
+                  className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm outline-none focus:border-white/30"
+                  placeholder="如：正式环境"
+                  value={addName}
+                  onChange={(e) => setAddName(e.target.value)}
+                />
+              </label>
+              <label className="grid gap-1">
+                <span className="text-xs text-white/50">对端称呼本节点（可选）</span>
+                <input
+                  className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm outline-none focus:border-white/30"
+                  placeholder="如：测试环境"
+                  value={addSelfName}
+                  onChange={(e) => setAddSelfName(e.target.value)}
+                />
+              </label>
+            </div>
+            {addError && <div className="text-xs text-red-400">{addError}</div>}
+            <div className="flex items-center gap-2 justify-end">
+              <Button size="sm" variant="ghost" onClick={() => setShowAdd(false)}>
+                取消
+              </Button>
+              <Button size="sm" onClick={handleAdd} disabled={addBusy}>
+                {addBusy ? <MapSpinner size={14} /> : <Wifi size={14} />}
+                配对
+              </Button>
+            </div>
+          </div>
+        </GlassCard>
+      )}
+
+      {loading ? (
+        <MapSectionLoader text="正在加载对端节点…" />
+      ) : nodes.length === 0 ? (
+        <GlassCard className="p-8 text-center">
+          <Globe size={28} className="mx-auto text-white/25" />
+          <div className="mt-3 text-sm text-white/60">还没有配对任何对端节点</div>
+          <div className="mt-1 text-xs text-white/40">
+            点「生成配对码」发给对端，或拿到对端配对码后点「添加对端节点」即可打通两个环境。
+          </div>
+        </GlassCard>
+      ) : (
+        <div className="grid gap-2">
+          {nodes.map((n) => (
+            <GlassCard key={n.id} className="p-3.5">
+              <div className="flex items-center justify-between gap-3 flex-wrap">
+                <div className="flex items-center gap-3 min-w-0">
+                  <Globe size={16} className="text-white/50 shrink-0" />
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium truncate">{n.displayName}</span>
+                      {statusBadge(n.status)}
+                    </div>
+                    <div className="text-[11px] text-white/40 font-mono truncate">{n.baseUrl}</div>
+                    {n.lastError && <div className="text-[11px] text-red-400/80 mt-0.5 truncate">{n.lastError}</div>}
+                  </div>
+                </div>
+                <div className="flex items-center gap-1.5">
+                  <span className="text-[11px] text-white/35 mr-1">最近通信 {fmtDate(n.lastContactAt)}</span>
+                  <Button size="sm" variant="ghost" onClick={() => handleTest(n.id)} disabled={busyId === n.id}>
+                    {busyId === n.id ? <MapSpinner size={14} /> : <Wifi size={14} />}
+                    测试
+                  </Button>
+                  <Button size="sm" variant="ghost" onClick={() => handleDelete(n.id, n.displayName)} disabled={busyId === n.id}>
+                    <Trash2 size={14} />
+                  </Button>
+                </div>
+              </div>
+            </GlassCard>
+          ))}
+        </div>
+      )}
+
+      {toast && (
+        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-[100] rounded-lg bg-black/80 px-4 py-2 text-sm text-white shadow-lg flex items-center gap-2">
+          <span>{toast}</span>
+          <button onClick={() => setToast(null)} className="text-white/50 hover:text-white">
+            <X size={13} />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/prd-admin/src/pages/settings/PeerNodesSettings.tsx
+++ b/prd-admin/src/pages/settings/PeerNodesSettings.tsx
@@ -12,7 +12,7 @@
  * 4. 严格遵守 cds-theme-tokens.md：颜色全部走 var(--*) token
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Globe,
   Plus,
@@ -154,9 +154,15 @@ export function PeerNodesSettings() {
     setTimeout(() => setToast(null), 2800);
   };
 
+  // PR #742 review fix: 工具栏刷新 / test/delete/add 后续 load 可能并发，旧响应若回填会
+  // 覆盖较新的节点状态或错误。用单调序号守卫：只有"最新一次"调用允许 setState。
+  // 沿用 prd-admin learned rule: 由用户动作触发的 async fetch 必须有 fetchIdRef stale 保护。
+  const loadSeqRef = useRef(0);
   const load = useCallback(async () => {
+    const mySeq = ++loadSeqRef.current;
     setLoading(true);
     const res = await listAdminPeerNodes();
+    if (mySeq !== loadSeqRef.current) return; // 已有更新的 load 发出，丢弃本次回填
     if (res.success && res.data) {
       setNodes(res.data.items || []);
       setSelfNodeId(res.data.selfNodeId);

--- a/prd-admin/src/pages/settings/PeerNodesSettings.tsx
+++ b/prd-admin/src/pages/settings/PeerNodesSettings.tsx
@@ -4,13 +4,33 @@
  * 管理员配一次对端节点（测试↔正式环境），两节点自动握手交换长期密钥，
  * 此后用户在知识库等应用「发送到 →」即可一键互传，无需再手动倒密钥。
  * 详见 doc/design.peer-sync.md。
+ *
+ * 设计要点（基于 2026-06-07 真人验收反馈打磨）：
+ * 1. 本节点身份明显可见且可复制（旧版用 11px mono 灰字塞在角落）
+ * 2. 动作分两栏 — 邀请对端接入我 / 接入已知对端 — 角色一眼可辨
+ * 3. 已配对节点卡片改用图标 + 状态点 + 时间 + 内联动作，错误自动展开真因
+ * 4. 严格遵守 cds-theme-tokens.md：颜色全部走 var(--*) token
  */
 
 import { useCallback, useEffect, useState } from 'react';
-import { Globe, Plus, Copy, Check, Trash2, RefreshCw, Wifi, KeyRound, X } from 'lucide-react';
-import { GlassCard } from '@/components/design/GlassCard';
+import {
+  Globe,
+  Plus,
+  Copy,
+  Check,
+  Trash2,
+  RefreshCw,
+  Wifi,
+  KeyRound,
+  X,
+  Send,
+  ArrowRight,
+  Inbox,
+  AlertCircle,
+  CheckCircle2,
+  Server,
+} from 'lucide-react';
 import { Button } from '@/components/design/Button';
-import { Badge } from '@/components/design/Badge';
 import { MapSectionLoader, MapSpinner } from '@/components/ui/VideoLoader';
 import {
   listAdminPeerNodes,
@@ -21,19 +41,80 @@ import {
   type PeerNode,
 } from '@/services/real/peerSync';
 
-function fmtDate(s?: string | null) {
-  if (!s) return '-';
+function fmtRelative(s?: string | null) {
+  if (!s) return '从未';
   try {
+    const ms = Date.now() - new Date(s).getTime();
+    if (ms < 60_000) return '刚刚';
+    if (ms < 3_600_000) return `${Math.floor(ms / 60_000)} 分钟前`;
+    if (ms < 86_400_000) return `${Math.floor(ms / 3_600_000)} 小时前`;
     return new Date(s).toLocaleString('zh-CN', { hour12: false });
   } catch {
     return s;
   }
 }
 
-function statusBadge(status: PeerNode['status']) {
-  if (status === 'connected') return <Badge variant="success">已连接</Badge>;
-  if (status === 'error') return <Badge variant="danger">通信异常</Badge>;
-  return <Badge variant="subtle">待握手</Badge>;
+function StatusDot({ status }: { status: PeerNode['status'] }) {
+  const colorVar =
+    status === 'connected'
+      ? 'rgba(34,197,94,0.95)'
+      : status === 'error'
+        ? 'rgba(239,68,68,0.95)'
+        : 'rgba(245,158,11,0.95)';
+  const label = status === 'connected' ? '已连接' : status === 'error' ? '通信异常' : '待握手';
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 text-[11px] px-2 py-0.5 rounded-full"
+      style={{
+        background:
+          status === 'connected'
+            ? 'rgba(34,197,94,0.10)'
+            : status === 'error'
+              ? 'rgba(239,68,68,0.10)'
+              : 'rgba(245,158,11,0.10)',
+        color: colorVar,
+      }}
+    >
+      <span className="w-1.5 h-1.5 rounded-full" style={{ background: colorVar, boxShadow: `0 0 6px ${colorVar}` }} />
+      {label}
+    </span>
+  );
+}
+
+function CopyChip({ value, label }: { value: string; label: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      onClick={async () => {
+        try {
+          await navigator.clipboard.writeText(value);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1600);
+        } catch {
+          /* ignore */
+        }
+      }}
+      className="group inline-flex items-center gap-1.5 max-w-full text-left rounded-md px-2 py-1 transition-colors"
+      style={{
+        background: 'rgba(255,255,255,0.04)',
+        border: '1px solid rgba(255,255,255,0.08)',
+        color: 'var(--text-primary)',
+      }}
+      title={`点击复制 ${label}`}
+    >
+      <span className="text-[10px] font-medium shrink-0" style={{ color: 'var(--text-muted)' }}>
+        {label}
+      </span>
+      <code className="text-[11px] font-mono truncate min-w-0" style={{ color: 'var(--text-primary)' }}>
+        {value || '—'}
+      </code>
+      {copied ? (
+        <Check size={11} style={{ color: 'rgba(34,197,94,0.95)' }} className="shrink-0" />
+      ) : (
+        <Copy size={11} className="shrink-0 opacity-40 group-hover:opacity-90 transition-opacity" style={{ color: 'var(--text-muted)' }} />
+      )}
+    </button>
+  );
 }
 
 export function PeerNodesSettings() {
@@ -42,14 +123,15 @@ export function PeerNodesSettings() {
   const [selfBaseUrl, setSelfBaseUrl] = useState('');
   const [loading, setLoading] = useState(true);
   const [busyId, setBusyId] = useState<string | null>(null);
-  const [toast, setToast] = useState<string | null>(null);
+  const [toast, setToast] = useState<{ msg: string; kind: 'ok' | 'err' } | null>(null);
 
   // 配对码
   const [code, setCode] = useState<string | null>(null);
+  const [codeExpiresAt, setCodeExpiresAt] = useState<number | null>(null);
   const [genBusy, setGenBusy] = useState(false);
-  const [copied, setCopied] = useState(false);
+  const [copiedCode, setCopiedCode] = useState(false);
 
-  // 添加对端表单
+  // 添加对端
   const [showAdd, setShowAdd] = useState(false);
   const [addBaseUrl, setAddBaseUrl] = useState('');
   const [addCode, setAddCode] = useState('');
@@ -58,9 +140,9 @@ export function PeerNodesSettings() {
   const [addBusy, setAddBusy] = useState(false);
   const [addError, setAddError] = useState<string | null>(null);
 
-  const flash = (m: string) => {
-    setToast(m);
-    setTimeout(() => setToast(null), 2600);
+  const flash = (msg: string, kind: 'ok' | 'err' = 'ok') => {
+    setToast({ msg, kind });
+    setTimeout(() => setToast(null), 2800);
   };
 
   const load = useCallback(async () => {
@@ -71,7 +153,7 @@ export function PeerNodesSettings() {
       setSelfNodeId(res.data.selfNodeId);
       setSelfBaseUrl(res.data.selfBaseUrl);
     } else {
-      flash(res.error?.message || '加载失败');
+      flash(res.error?.message || '加载失败', 'err');
     }
     setLoading(false);
   }, []);
@@ -86,9 +168,10 @@ export function PeerNodesSettings() {
     setGenBusy(false);
     if (res.success && res.data) {
       setCode(res.data.pairingCode);
-      setCopied(false);
+      setCodeExpiresAt(Date.now() + (res.data.expiresInSeconds || 300) * 1000);
+      setCopiedCode(false);
     } else {
-      flash(res.error?.message || '生成失败');
+      flash(res.error?.message || '生成失败', 'err');
     }
   };
 
@@ -96,10 +179,10 @@ export function PeerNodesSettings() {
     if (!code) return;
     try {
       await navigator.clipboard.writeText(code);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      setCopiedCode(true);
+      setTimeout(() => setCopiedCode(false), 2000);
     } catch {
-      flash('复制失败，请手动选择复制');
+      flash('复制失败，请手动选择复制', 'err');
     }
   };
 
@@ -135,7 +218,7 @@ export function PeerNodesSettings() {
     const res = await testPeerNode(id);
     setBusyId(null);
     if (res.success && res.data?.ok) flash('连通正常');
-    else flash(res.data?.error || '连通失败，请检查对端地址与配对状态');
+    else flash(res.data?.error || '连通失败，请稍后重试或检查对端配对状态', 'err');
     void load();
   };
 
@@ -148,173 +231,404 @@ export function PeerNodesSettings() {
       flash('已解除配对');
       void load();
     } else {
-      flash(res.error?.message || '删除失败');
+      flash(res.error?.message || '删除失败', 'err');
     }
   };
 
+  const codeSecondsLeft = codeExpiresAt ? Math.max(0, Math.ceil((codeExpiresAt - Date.now()) / 1000)) : 0;
+
   return (
-    <div className="h-full min-h-0 flex flex-col gap-4 overflow-y-auto" style={{ overscrollBehavior: 'contain' }}>
-      {/* 说明 + 本节点身份 */}
-      <GlassCard className="p-4">
-        <div className="flex items-start gap-3">
-          <Globe size={18} className="text-white/60 mt-0.5 shrink-0" />
-          <div className="flex-1 min-w-0">
-            <div className="text-sm font-medium">系统互联（跨节点互传）</div>
-            <div className="text-xs text-white/50 mt-1 leading-relaxed">
-              配置对端 MAP 节点（如测试环境 ↔ 正式环境）。配对一次后，用户在知识库等应用右上角「发送到」即可一键互传，
-              无需在两个环境之间手动复制密钥。配对走一次性配对码 + HMAC 签名，密钥永不在前端 / 链接中暴露。
+    <div
+      className="h-full min-h-0 flex flex-col gap-5 overflow-y-auto pb-6"
+      style={{ overscrollBehavior: 'contain' }}
+    >
+      {/* ── 本节点身份卡（hero） ── */}
+      <section
+        className="relative rounded-2xl overflow-hidden p-5"
+        style={{
+          background:
+            'linear-gradient(135deg, rgba(99,102,241,0.10) 0%, rgba(59,130,246,0.06) 50%, rgba(236,72,153,0.06) 100%)',
+          border: '1px solid rgba(255,255,255,0.08)',
+        }}
+      >
+        <div className="flex items-start gap-4 flex-wrap">
+          <div
+            className="shrink-0 w-11 h-11 rounded-xl flex items-center justify-center"
+            style={{ background: 'rgba(99,102,241,0.18)', border: '1px solid rgba(99,102,241,0.30)' }}
+          >
+            <Server size={20} style={{ color: 'rgba(165,180,252,0.95)' }} />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2 mb-1">
+              <span className="text-[13px] font-semibold" style={{ color: 'var(--text-primary)' }}>
+                本节点
+              </span>
+              <span
+                className="text-[10px] px-1.5 py-0.5 rounded"
+                style={{ background: 'rgba(255,255,255,0.06)', color: 'var(--text-muted)' }}
+              >
+                {nodes.length} 个对端已配对
+              </span>
             </div>
-            <div className="mt-2 text-[11px] text-white/40 font-mono break-all">
-              本节点标识：{selfNodeId || '...'} | 对外地址：{selfBaseUrl || '...'}
+            <p className="text-[12px] mb-3 leading-relaxed" style={{ color: 'var(--text-secondary)' }}>
+              管理员一次配置对端节点（测试 ↔ 正式环境），用户即可在知识库等应用右上角「发送到」一键互传。
+              配对走一次性码 + HMAC 签名，共享密钥永不在前端 / 链接中暴露。
+            </p>
+            <div className="flex items-center gap-2 flex-wrap">
+              <CopyChip value={selfNodeId} label="节点标识" />
+              <CopyChip value={selfBaseUrl} label="对外地址" />
             </div>
           </div>
         </div>
-      </GlassCard>
+      </section>
 
-      {/* 配对码生成 */}
-      <GlassCard className="p-4">
-        <div className="flex items-center justify-between gap-3 flex-wrap">
-          <div className="flex items-center gap-2">
-            <KeyRound size={15} className="text-white/60" />
-            <span className="text-sm">让对端连接本节点</span>
+      {/* ── 双动作：邀请对端 vs 接入对端 ── */}
+      <section className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        {/* 邀请对端接入我 */}
+        <div
+          className="rounded-xl p-4"
+          style={{
+            background: 'var(--bg-card, rgba(255,255,255,0.03))',
+            border: '1px solid rgba(255,255,255,0.08)',
+          }}
+        >
+          <div className="flex items-start gap-3 mb-2">
+            <div
+              className="shrink-0 w-9 h-9 rounded-lg flex items-center justify-center"
+              style={{ background: 'rgba(59,130,246,0.12)', border: '1px solid rgba(59,130,246,0.20)' }}
+            >
+              <Send size={15} style={{ color: 'rgba(96,165,250,0.95)' }} />
+            </div>
+            <div className="min-w-0">
+              <div className="text-[13px] font-medium" style={{ color: 'var(--text-primary)' }}>
+                邀请对端接入我
+              </div>
+              <div className="text-[11px] mt-0.5 leading-relaxed" style={{ color: 'var(--text-muted)' }}>
+                生成一次性配对码，配上本节点对外地址发给对端管理员
+              </div>
+            </div>
           </div>
-          <Button size="sm" variant="secondary" onClick={handleGenCode} disabled={genBusy}>
-            {genBusy ? <MapSpinner size={14} /> : <KeyRound size={14} />}
-            生成配对码
+          {code ? (
+            <div
+              className="mt-3 rounded-lg p-3 space-y-2"
+              style={{ background: 'rgba(59,130,246,0.06)', border: '1px solid rgba(59,130,246,0.16)' }}
+            >
+              <div className="flex items-center gap-2">
+                <code
+                  className="flex-1 text-[12px] font-mono break-all px-2 py-1.5 rounded"
+                  style={{ background: 'rgba(0,0,0,0.20)', color: 'var(--text-primary)' }}
+                >
+                  {code}
+                </code>
+                <Button size="xs" variant="secondary" onClick={handleCopyCode}>
+                  {copiedCode ? <Check size={12} /> : <Copy size={12} />}
+                  {copiedCode ? '已复制' : '复制'}
+                </Button>
+              </div>
+              <div className="flex items-center justify-between text-[11px]" style={{ color: 'var(--text-muted)' }}>
+                <span>剩余有效时间 {codeSecondsLeft}s · 仅可用一次</span>
+                <button
+                  onClick={handleGenCode}
+                  className="hover:underline"
+                  style={{ color: 'rgba(96,165,250,0.95)' }}
+                  disabled={genBusy}
+                >
+                  重新生成
+                </button>
+              </div>
+            </div>
+          ) : (
+            <Button size="sm" variant="secondary" onClick={handleGenCode} disabled={genBusy} className="mt-2 w-full">
+              {genBusy ? <MapSpinner size={13} /> : <KeyRound size={13} />}
+              生成配对码
+            </Button>
+          )}
+        </div>
+
+        {/* 接入已知对端 */}
+        <div
+          className="rounded-xl p-4"
+          style={{
+            background: 'var(--bg-card, rgba(255,255,255,0.03))',
+            border: '1px solid rgba(255,255,255,0.08)',
+          }}
+        >
+          <div className="flex items-start gap-3 mb-2">
+            <div
+              className="shrink-0 w-9 h-9 rounded-lg flex items-center justify-center"
+              style={{ background: 'rgba(168,85,247,0.12)', border: '1px solid rgba(168,85,247,0.20)' }}
+            >
+              <Inbox size={15} style={{ color: 'rgba(192,132,252,0.95)' }} />
+            </div>
+            <div className="min-w-0">
+              <div className="text-[13px] font-medium" style={{ color: 'var(--text-primary)' }}>
+                接入已知对端
+              </div>
+              <div className="text-[11px] mt-0.5 leading-relaxed" style={{ color: 'var(--text-muted)' }}>
+                拿到对端管理员发来的配对码后，在这里录入对端地址
+              </div>
+            </div>
+          </div>
+          <Button size="sm" onClick={() => setShowAdd((v) => !v)} className="mt-2 w-full">
+            <Plus size={13} /> {showAdd ? '收起表单' : '添加对端节点'}
           </Button>
         </div>
-        {code && (
-          <div className="mt-3 rounded-lg border border-white/10 bg-white/5 p-3">
-            <div className="text-[11px] text-white/45 mb-1.5">
-              把下面这串配对码 + 本节点对外地址发给对端管理员，让对端在「系统互联 → 添加对端节点」里粘贴（5 分钟内有效，仅用一次）：
-            </div>
-            <div className="flex items-center gap-2">
-              <code className="flex-1 text-xs font-mono break-all bg-black/20 rounded px-2 py-1.5">{code}</code>
-              <Button size="sm" variant="ghost" onClick={handleCopyCode}>
-                {copied ? <Check size={14} /> : <Copy size={14} />}
-              </Button>
-            </div>
-            <div className="mt-1.5 text-[11px] text-white/40 font-mono break-all">对外地址：{selfBaseUrl}</div>
-          </div>
-        )}
-      </GlassCard>
+      </section>
 
-      {/* 对端节点列表 */}
-      <div className="flex items-center justify-between">
-        <div className="text-sm text-white/70">已配对节点</div>
-        <div className="flex items-center gap-2">
-          <Button size="sm" variant="ghost" onClick={() => void load()} disabled={loading}>
-            <RefreshCw size={14} />
-          </Button>
-          <Button size="sm" onClick={() => setShowAdd((v) => !v)}>
-            <Plus size={14} /> 添加对端节点
-          </Button>
-        </div>
-      </div>
-
+      {/* ── 添加对端表单（展开式） ── */}
       {showAdd && (
-        <GlassCard className="p-4">
-          <div className="text-sm font-medium mb-3">添加对端节点</div>
-          <div className="grid gap-3">
-            <label className="grid gap-1">
-              <span className="text-xs text-white/50">对端地址（baseUrl）</span>
-              <input
-                className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm outline-none focus:border-white/30"
-                placeholder="https://prod-xxx.miduo.org"
-                value={addBaseUrl}
-                onChange={(e) => setAddBaseUrl(e.target.value)}
-              />
-            </label>
-            <label className="grid gap-1">
-              <span className="text-xs text-white/50">对端生成的配对码</span>
-              <input
-                className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm outline-none focus:border-white/30 font-mono"
-                placeholder="粘贴对端管理员发来的配对码"
-                value={addCode}
-                onChange={(e) => setAddCode(e.target.value)}
-              />
-            </label>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-              <label className="grid gap-1">
-                <span className="text-xs text-white/50">我方称呼对端（可选）</span>
-                <input
-                  className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm outline-none focus:border-white/30"
-                  placeholder="如：正式环境"
-                  value={addName}
-                  onChange={(e) => setAddName(e.target.value)}
-                />
-              </label>
-              <label className="grid gap-1">
-                <span className="text-xs text-white/50">对端称呼本节点（可选）</span>
-                <input
-                  className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm outline-none focus:border-white/30"
-                  placeholder="如：测试环境"
-                  value={addSelfName}
-                  onChange={(e) => setAddSelfName(e.target.value)}
-                />
-              </label>
-            </div>
-            {addError && <div className="text-xs text-red-400">{addError}</div>}
-            <div className="flex items-center gap-2 justify-end">
-              <Button size="sm" variant="ghost" onClick={() => setShowAdd(false)}>
-                取消
-              </Button>
-              <Button size="sm" onClick={handleAdd} disabled={addBusy}>
-                {addBusy ? <MapSpinner size={14} /> : <Wifi size={14} />}
-                配对
-              </Button>
-            </div>
+        <section
+          className="rounded-xl p-4 space-y-3"
+          style={{
+            background: 'var(--bg-card, rgba(255,255,255,0.03))',
+            border: '1px solid rgba(168,85,247,0.20)',
+          }}
+        >
+          <div className="text-[13px] font-medium" style={{ color: 'var(--text-primary)' }}>
+            添加对端节点
           </div>
-        </GlassCard>
+          <label className="grid gap-1.5">
+            <span className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
+              对端地址 baseUrl
+            </span>
+            <input
+              className="w-full rounded-lg px-3 py-2 text-[13px] outline-none"
+              style={{
+                background: 'var(--bg-input, rgba(255,255,255,0.04))',
+                border: '1px solid rgba(255,255,255,0.10)',
+                color: 'var(--text-primary)',
+              }}
+              placeholder="https://prod-xxx.miduo.org"
+              value={addBaseUrl}
+              onChange={(e) => setAddBaseUrl(e.target.value)}
+            />
+          </label>
+          <label className="grid gap-1.5">
+            <span className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
+              对端生成的配对码
+            </span>
+            <input
+              className="w-full rounded-lg px-3 py-2 text-[13px] outline-none font-mono"
+              style={{
+                background: 'var(--bg-input, rgba(255,255,255,0.04))',
+                border: '1px solid rgba(255,255,255,0.10)',
+                color: 'var(--text-primary)',
+              }}
+              placeholder="粘贴对端管理员发来的配对码"
+              value={addCode}
+              onChange={(e) => setAddCode(e.target.value)}
+            />
+          </label>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <label className="grid gap-1.5">
+              <span className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
+                我方称呼对端（可选）
+              </span>
+              <input
+                className="w-full rounded-lg px-3 py-2 text-[13px] outline-none"
+                style={{
+                  background: 'var(--bg-input, rgba(255,255,255,0.04))',
+                  border: '1px solid rgba(255,255,255,0.10)',
+                  color: 'var(--text-primary)',
+                }}
+                placeholder="如：正式环境"
+                value={addName}
+                onChange={(e) => setAddName(e.target.value)}
+              />
+            </label>
+            <label className="grid gap-1.5">
+              <span className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
+                对端称呼本节点（可选）
+              </span>
+              <input
+                className="w-full rounded-lg px-3 py-2 text-[13px] outline-none"
+                style={{
+                  background: 'var(--bg-input, rgba(255,255,255,0.04))',
+                  border: '1px solid rgba(255,255,255,0.10)',
+                  color: 'var(--text-primary)',
+                }}
+                placeholder="如：测试环境"
+                value={addSelfName}
+                onChange={(e) => setAddSelfName(e.target.value)}
+              />
+            </label>
+          </div>
+          {addError && (
+            <div
+              className="flex items-start gap-2 text-[12px] rounded-lg px-3 py-2"
+              style={{
+                background: 'rgba(239,68,68,0.08)',
+                border: '1px solid rgba(239,68,68,0.20)',
+                color: 'rgba(252,165,165,0.95)',
+              }}
+            >
+              <AlertCircle size={14} className="shrink-0 mt-0.5" />
+              <span className="min-w-0 break-words">{addError}</span>
+            </div>
+          )}
+          <div className="flex items-center gap-2 justify-end pt-1">
+            <Button size="sm" variant="ghost" onClick={() => setShowAdd(false)}>
+              取消
+            </Button>
+            <Button size="sm" onClick={handleAdd} disabled={addBusy}>
+              {addBusy ? <MapSpinner size={13} /> : <Wifi size={13} />}
+              配对
+            </Button>
+          </div>
+        </section>
       )}
 
-      {loading ? (
-        <MapSectionLoader text="正在加载对端节点…" />
-      ) : nodes.length === 0 ? (
-        <GlassCard className="p-8 text-center">
-          <Globe size={28} className="mx-auto text-white/25" />
-          <div className="mt-3 text-sm text-white/60">还没有配对任何对端节点</div>
-          <div className="mt-1 text-xs text-white/40">
-            点「生成配对码」发给对端，或拿到对端配对码后点「添加对端节点」即可打通两个环境。
+      {/* ── 已配对节点 ── */}
+      <section className="space-y-2.5">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <span className="text-[13px] font-medium" style={{ color: 'var(--text-primary)' }}>
+              已配对节点
+            </span>
+            {!loading && (
+              <span className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
+                {nodes.length} 个
+              </span>
+            )}
           </div>
-        </GlassCard>
-      ) : (
-        <div className="grid gap-2">
-          {nodes.map((n) => (
-            <GlassCard key={n.id} className="p-3.5">
-              <div className="flex items-center justify-between gap-3 flex-wrap">
-                <div className="flex items-center gap-3 min-w-0">
-                  <Globe size={16} className="text-white/50 shrink-0" />
-                  <div className="min-w-0">
-                    <div className="flex items-center gap-2">
-                      <span className="text-sm font-medium truncate">{n.displayName}</span>
-                      {statusBadge(n.status)}
+          <Button size="xs" variant="ghost" onClick={() => void load()} disabled={loading}>
+            <RefreshCw size={12} className={loading ? 'animate-spin' : ''} />
+          </Button>
+        </div>
+
+        {loading ? (
+          <MapSectionLoader text="正在加载对端节点…" />
+        ) : nodes.length === 0 ? (
+          <div
+            className="rounded-xl p-10 text-center"
+            style={{
+              background: 'var(--bg-card, rgba(255,255,255,0.02))',
+              border: '1px dashed rgba(255,255,255,0.10)',
+            }}
+          >
+            <div
+              className="mx-auto w-12 h-12 rounded-2xl flex items-center justify-center mb-3"
+              style={{ background: 'rgba(255,255,255,0.04)' }}
+            >
+              <Globe size={22} style={{ color: 'var(--text-muted)' }} />
+            </div>
+            <div className="text-[13px] mb-1" style={{ color: 'var(--text-primary)' }}>
+              还没有配对任何对端节点
+            </div>
+            <div className="text-[12px] max-w-md mx-auto leading-relaxed" style={{ color: 'var(--text-muted)' }}>
+              从上面「邀请对端接入我」生成配对码发给对端，
+              <br />
+              或拿到对端配对码后点「添加对端节点」打通两个环境。
+            </div>
+          </div>
+        ) : (
+          <div className="grid gap-2">
+            {nodes.map((n) => (
+              <article
+                key={n.id}
+                className="rounded-xl p-3.5 transition-colors"
+                style={{
+                  background: 'var(--bg-card, rgba(255,255,255,0.03))',
+                  border: '1px solid rgba(255,255,255,0.08)',
+                }}
+              >
+                <div className="flex items-start justify-between gap-3 flex-wrap">
+                  <div className="flex items-start gap-3 min-w-0 flex-1">
+                    <div
+                      className="shrink-0 w-9 h-9 rounded-lg flex items-center justify-center mt-0.5"
+                      style={{
+                        background:
+                          n.status === 'connected'
+                            ? 'rgba(34,197,94,0.10)'
+                            : n.status === 'error'
+                              ? 'rgba(239,68,68,0.10)'
+                              : 'rgba(255,255,255,0.04)',
+                        border: `1px solid ${
+                          n.status === 'connected'
+                            ? 'rgba(34,197,94,0.20)'
+                            : n.status === 'error'
+                              ? 'rgba(239,68,68,0.20)'
+                              : 'rgba(255,255,255,0.08)'
+                        }`,
+                      }}
+                    >
+                      {n.status === 'connected' ? (
+                        <CheckCircle2 size={16} style={{ color: 'rgba(34,197,94,0.95)' }} />
+                      ) : n.status === 'error' ? (
+                        <AlertCircle size={16} style={{ color: 'rgba(239,68,68,0.95)' }} />
+                      ) : (
+                        <Globe size={16} style={{ color: 'var(--text-muted)' }} />
+                      )}
                     </div>
-                    <div className="text-[11px] text-white/40 font-mono truncate">{n.baseUrl}</div>
-                    {n.lastError && <div className="text-[11px] text-red-400/80 mt-0.5 truncate">{n.lastError}</div>}
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="text-[13px] font-medium truncate" style={{ color: 'var(--text-primary)' }}>
+                          {n.displayName}
+                        </span>
+                        <StatusDot status={n.status} />
+                      </div>
+                      <div
+                        className="text-[11px] font-mono truncate mt-0.5"
+                        style={{ color: 'var(--text-muted)' }}
+                        title={n.baseUrl}
+                      >
+                        <ArrowRight size={9} className="inline mr-1" />
+                        {n.baseUrl}
+                      </div>
+                      <div className="flex items-center gap-2 mt-1.5 text-[11px]" style={{ color: 'var(--text-muted)' }}>
+                        <span>最近通信 {fmtRelative(n.lastContactAt)}</span>
+                      </div>
+                      {n.lastError && (
+                        <div
+                          className="mt-2 flex items-start gap-1.5 text-[11px] rounded-md px-2 py-1.5"
+                          style={{
+                            background: 'rgba(239,68,68,0.06)',
+                            border: '1px solid rgba(239,68,68,0.16)',
+                            color: 'rgba(252,165,165,0.95)',
+                          }}
+                        >
+                          <AlertCircle size={11} className="shrink-0 mt-0.5" />
+                          <span className="min-w-0 break-words">{n.lastError}</span>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-1.5 shrink-0">
+                    <Button size="xs" variant="ghost" onClick={() => handleTest(n.id)} disabled={busyId === n.id}>
+                      {busyId === n.id ? <MapSpinner size={12} /> : <Wifi size={12} />}
+                      测试
+                    </Button>
+                    <Button
+                      size="xs"
+                      variant="ghost"
+                      onClick={() => handleDelete(n.id, n.displayName)}
+                      disabled={busyId === n.id}
+                      title="解除配对"
+                    >
+                      <Trash2 size={12} />
+                    </Button>
                   </div>
                 </div>
-                <div className="flex items-center gap-1.5">
-                  <span className="text-[11px] text-white/35 mr-1">最近通信 {fmtDate(n.lastContactAt)}</span>
-                  <Button size="sm" variant="ghost" onClick={() => handleTest(n.id)} disabled={busyId === n.id}>
-                    {busyId === n.id ? <MapSpinner size={14} /> : <Wifi size={14} />}
-                    测试
-                  </Button>
-                  <Button size="sm" variant="ghost" onClick={() => handleDelete(n.id, n.displayName)} disabled={busyId === n.id}>
-                    <Trash2 size={14} />
-                  </Button>
-                </div>
-              </div>
-            </GlassCard>
-          ))}
-        </div>
-      )}
+              </article>
+            ))}
+          </div>
+        )}
+      </section>
 
+      {/* ── Toast ── */}
       {toast && (
-        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-[100] rounded-lg bg-black/80 px-4 py-2 text-sm text-white shadow-lg flex items-center gap-2">
-          <span>{toast}</span>
-          <button onClick={() => setToast(null)} className="text-white/50 hover:text-white">
-            <X size={13} />
+        <div
+          className="fixed bottom-6 left-1/2 -translate-x-1/2 z-[100] rounded-lg px-4 py-2 text-[13px] shadow-lg flex items-center gap-2"
+          style={{
+            background: toast.kind === 'err' ? 'rgba(127,29,29,0.92)' : 'rgba(20,83,45,0.92)',
+            color: '#fff',
+            border: `1px solid ${toast.kind === 'err' ? 'rgba(239,68,68,0.40)' : 'rgba(34,197,94,0.40)'}`,
+          }}
+        >
+          {toast.kind === 'err' ? <AlertCircle size={14} /> : <CheckCircle2 size={14} />}
+          <span>{toast.msg}</span>
+          <button onClick={() => setToast(null)} className="opacity-60 hover:opacity-100 ml-1">
+            <X size={12} />
           </button>
         </div>
       )}

--- a/prd-admin/src/pages/settings/PeerNodesSettings.tsx
+++ b/prd-admin/src/pages/settings/PeerNodesSettings.tsx
@@ -139,6 +139,15 @@ export function PeerNodesSettings() {
   const [addSelfName, setAddSelfName] = useState('');
   const [addBusy, setAddBusy] = useState(false);
   const [addError, setAddError] = useState<string | null>(null);
+  const [addProgress, setAddProgress] = useState<{ stage: string; startedAt: number } | null>(null);
+  const [testProgress, setTestProgress] = useState<{ id: string; startedAt: number } | null>(null);
+  const [, setNow] = useState(0);
+  // 1s 节拍器：handshake/test 进行中时驱动「已用 Xs」自增显示，避免空白等待（CLAUDE.md §6）
+  useEffect(() => {
+    if (!addBusy && !testProgress) return;
+    const t = setInterval(() => setNow((n) => n + 1), 1000);
+    return () => clearInterval(t);
+  }, [addBusy, testProgress]);
 
   const flash = (msg: string, kind: 'ok' | 'err' = 'ok') => {
     setToast({ msg, kind });
@@ -193,15 +202,24 @@ export function PeerNodesSettings() {
     }
     setAddBusy(true);
     setAddError(null);
+    const startedAt = Date.now();
+    setAddProgress({ stage: '正在与对端发起握手…', startedAt });
+    // 阶段提示节奏：避免单一 spinner，让用户知道系统在做什么
+    const t1 = setTimeout(() => setAddProgress({ stage: '对端正在校验配对码 + 生成共享密钥…', startedAt }), 1500);
+    const t2 = setTimeout(() => setAddProgress({ stage: '交换 HMAC 密钥并落地配对记录…', startedAt }), 4000);
+    const t3 = setTimeout(() => setAddProgress({ stage: '对端响应较慢，仍在等待…', startedAt }), 8000);
     const res = await addPeerNode({
       baseUrl: addBaseUrl.trim(),
       pairingCode: addCode.trim(),
       displayName: addName.trim() || undefined,
       selfDisplayName: addSelfName.trim() || undefined,
     });
+    clearTimeout(t1); clearTimeout(t2); clearTimeout(t3);
     setAddBusy(false);
+    setAddProgress(null);
     if (res.success) {
-      flash('配对成功');
+      const elapsed = Math.round((Date.now() - startedAt) / 100) / 10;
+      flash(`配对成功（耗时 ${elapsed}s）`);
       setShowAdd(false);
       setAddBaseUrl('');
       setAddCode('');
@@ -215,10 +233,14 @@ export function PeerNodesSettings() {
 
   const handleTest = async (id: string) => {
     setBusyId(id);
+    const startedAt = Date.now();
+    setTestProgress({ id, startedAt });
     const res = await testPeerNode(id);
     setBusyId(null);
-    if (res.success && res.data?.ok) flash('连通正常');
-    else flash(res.data?.error || '连通失败，请稍后重试或检查对端配对状态', 'err');
+    setTestProgress(null);
+    const elapsed = Math.round((Date.now() - startedAt) / 100) / 10;
+    if (res.success && res.data?.ok) flash(`连通正常（${elapsed}s）`);
+    else flash(`${res.data?.error || '连通失败，请稍后重试或检查对端配对状态'}（${elapsed}s）`, 'err');
     void load();
   };
 
@@ -466,13 +488,31 @@ export function PeerNodesSettings() {
               <span className="min-w-0 break-words">{addError}</span>
             </div>
           )}
+          {addBusy && addProgress && (
+            <div
+              className="flex items-start gap-2 text-[12px] rounded-lg px-3 py-2"
+              style={{
+                background: 'rgba(59,130,246,0.06)',
+                border: '1px solid rgba(59,130,246,0.18)',
+                color: 'rgba(147,197,253,0.95)',
+              }}
+            >
+              <MapSpinner size={12} />
+              <span className="min-w-0 flex-1">
+                {addProgress.stage}{' '}
+                <span style={{ color: 'rgba(147,197,253,0.6)' }}>
+                  · 已用 {Math.round((Date.now() - addProgress.startedAt) / 1000)}s
+                </span>
+              </span>
+            </div>
+          )}
           <div className="flex items-center gap-2 justify-end pt-1">
-            <Button size="sm" variant="ghost" onClick={() => setShowAdd(false)}>
+            <Button size="sm" variant="ghost" onClick={() => setShowAdd(false)} disabled={addBusy}>
               取消
             </Button>
             <Button size="sm" onClick={handleAdd} disabled={addBusy}>
               {addBusy ? <MapSpinner size={13} /> : <Wifi size={13} />}
-              配对
+              {addBusy ? '握手中…' : '配对'}
             </Button>
           </div>
         </section>
@@ -577,6 +617,11 @@ export function PeerNodesSettings() {
                       </div>
                       <div className="flex items-center gap-2 mt-1.5 text-[11px]" style={{ color: 'var(--text-muted)' }}>
                         <span>最近通信 {fmtRelative(n.lastContactAt)}</span>
+                        {testProgress?.id === n.id && (
+                          <span style={{ color: 'rgba(147,197,253,0.95)' }}>
+                            · 测试中 {Math.round((Date.now() - testProgress.startedAt) / 1000)}s…
+                          </span>
+                        )}
                       </div>
                       {n.lastError && (
                         <div

--- a/prd-admin/src/services/api.ts
+++ b/prd-admin/src/services/api.ts
@@ -1233,6 +1233,19 @@ export const api = {
       delete: (linkId: string) => `/api/document-store/sync/${linkId}`,
     },
   },
+  // ============ 系统级跨节点互传（Peer Sync） ============
+  peerSync: {
+    // 用户侧
+    nodes: () => '/api/peer-sync/nodes',
+    items: (type: string) => `/api/peer-sync/resources/${type}/items`,
+    transfer: () => '/api/peer-sync/transfer',
+    // 管理侧（设置 → 系统互联）
+    adminList: () => '/api/admin/peer-nodes',
+    adminPairingCode: () => '/api/admin/peer-nodes/pairing-code',
+    adminAdd: () => '/api/admin/peer-nodes',
+    adminTest: (id: string) => `/api/admin/peer-nodes/${id}/test`,
+    adminDelete: (id: string) => `/api/admin/peer-nodes/${id}`,
+  },
   // ============ 波2 高级权限：全部网页审计视图 ============
   adminWebPages: {
     list: () => '/api/admin-web-pages',

--- a/prd-admin/src/services/real/peerSync.ts
+++ b/prd-admin/src/services/real/peerSync.ts
@@ -1,0 +1,110 @@
+import { apiRequest } from '@/services/real/apiClient';
+import { api } from '@/services/api';
+
+/** 互传方向：push（本地→对端）/ pull（对端→本地）/ both（双向，仅双向资源） */
+export type PeerTransferDirection = 'push' | 'pull' | 'both';
+export type PeerApplyMode = 'overwrite' | 'add-only';
+export type PeerNodeStatus = 'pending' | 'connected' | 'error';
+
+export interface PeerNode {
+  id: string;
+  remoteNodeId: string;
+  displayName: string;
+  baseUrl: string;
+  status: PeerNodeStatus;
+  lastError?: string | null;
+  lastContactAt?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface SyncResourceCapability {
+  resourceType: string;
+  displayName: string;
+  supportsBidirectional: boolean;
+  schemaVersion: number;
+}
+
+export interface SyncItemSummary {
+  itemId: string;
+  name: string;
+  description?: string | null;
+  recordCount: number;
+  updatedAt?: string | null;
+}
+
+export interface TransferItemResult {
+  itemId: string;
+  ok: boolean;
+  message?: string;
+}
+
+// ─────────────────────────────────────────────
+// 用户侧：发起互传
+// ─────────────────────────────────────────────
+
+/** 列出可发送的对端节点 + 本节点支持的资源能力 */
+export async function listPeerNodes() {
+  return await apiRequest<{ items: PeerNode[]; capabilities: SyncResourceCapability[] }>(
+    api.peerSync.nodes(),
+    { method: 'GET' },
+  );
+}
+
+/** 列出本节点当前用户可发送的某类资源条目 */
+export async function listPeerItems(resourceType: string) {
+  return await apiRequest<{ items: SyncItemSummary[] }>(api.peerSync.items(resourceType), { method: 'GET' });
+}
+
+/** 发起互传 */
+export async function transferToPeer(params: {
+  nodeId: string;
+  resourceType: string;
+  itemIds: string[];
+  direction: PeerTransferDirection;
+  mode?: PeerApplyMode;
+}) {
+  return await apiRequest<{ direction: string; results: TransferItemResult[]; anyFail: boolean }>(
+    api.peerSync.transfer(),
+    { method: 'POST', body: params },
+  );
+}
+
+// ─────────────────────────────────────────────
+// 管理侧：系统互联配置
+// ─────────────────────────────────────────────
+
+export async function listAdminPeerNodes() {
+  return await apiRequest<{ selfNodeId: string; selfBaseUrl: string; items: PeerNode[] }>(
+    api.peerSync.adminList(),
+    { method: 'GET' },
+  );
+}
+
+export async function generatePairingCode() {
+  return await apiRequest<{ pairingCode: string; expiresInSeconds: number; selfNodeId: string; selfBaseUrl: string }>(
+    api.peerSync.adminPairingCode(),
+    { method: 'POST' },
+  );
+}
+
+export async function addPeerNode(params: {
+  baseUrl: string;
+  pairingCode: string;
+  displayName?: string;
+  selfBaseUrl?: string;
+  selfDisplayName?: string;
+}) {
+  return await apiRequest<PeerNode>(api.peerSync.adminAdd(), { method: 'POST', body: params });
+}
+
+export async function testPeerNode(id: string) {
+  return await apiRequest<{ ok: boolean; status?: number; error?: string }>(
+    api.peerSync.adminTest(id),
+    { method: 'POST' },
+  );
+}
+
+export async function deletePeerNode(id: string) {
+  return await apiRequest<{ deleted: boolean }>(api.peerSync.adminDelete(id), { method: 'DELETE' });
+}

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/AdminPeerNodesController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/AdminPeerNodesController.cs
@@ -143,8 +143,8 @@ public class AdminPeerNodesController : ControllerBase
                 string? innerMsg = null;
                 try
                 {
-                    using var doc = JsonDocument.Parse(json);
-                    if (doc.RootElement.TryGetProperty("error", out var err)
+                    using var errDoc = JsonDocument.Parse(json);
+                    if (errDoc.RootElement.TryGetProperty("error", out var err)
                         && err.ValueKind == JsonValueKind.Object
                         && err.TryGetProperty("message", out var msg))
                         innerMsg = msg.GetString();

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/AdminPeerNodesController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/AdminPeerNodesController.cs
@@ -1,0 +1,273 @@
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using MongoDB.Driver;
+using PrdAgent.Api.Extensions;
+using PrdAgent.Core.Interfaces;
+using PrdAgent.Core.Models;
+using PrdAgent.Core.Security;
+using PrdAgent.Infrastructure.Database;
+using PrdAgent.Infrastructure.Services;
+
+namespace PrdAgent.Api.Controllers.Api;
+
+/// <summary>
+/// 系统互联（跨节点互传）管理端 —— 管理员配置对端节点、生成配对码、握手、解除配对。
+/// 「设置 → 系统互联」页面的后端入口。详见 doc/design.peer-sync.md §8。
+/// </summary>
+[ApiController]
+[Route("api/admin/peer-nodes")]
+[Authorize]
+[AdminController("peer-sync", AdminPermissionCatalog.PeerSyncManage,
+    WritePermission = AdminPermissionCatalog.PeerSyncManage)]
+public class AdminPeerNodesController : ControllerBase
+{
+    private readonly MongoDbContext _db;
+    private readonly IPeerNodeService _peer;
+    private readonly ISafeOutboundUrlValidator _urlValidator;
+    private readonly IHttpClientFactory _httpFactory;
+    private readonly ILogger<AdminPeerNodesController> _logger;
+
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    public AdminPeerNodesController(
+        MongoDbContext db,
+        IPeerNodeService peer,
+        ISafeOutboundUrlValidator urlValidator,
+        IHttpClientFactory httpFactory,
+        ILogger<AdminPeerNodesController> logger)
+    {
+        _db = db;
+        _peer = peer;
+        _urlValidator = urlValidator;
+        _httpFactory = httpFactory;
+        _logger = logger;
+    }
+
+    private string GetUserId() => this.GetRequiredUserId();
+
+    private string SelfBaseUrl(string? overrideUrl)
+        => !string.IsNullOrWhiteSpace(overrideUrl)
+            ? overrideUrl!.TrimEnd('/')
+            : $"{Request.Scheme}://{Request.Host}{Request.PathBase}".TrimEnd('/');
+
+    /// <summary>列出已配对节点 + 本节点标识（不返回 SharedSecret）。</summary>
+    [HttpGet]
+    public async Task<IActionResult> List(CancellationToken ct)
+    {
+        var selfNodeId = await _peer.GetSelfNodeIdAsync(ct);
+        var nodes = await _db.PeerNodes.Find(_ => true).SortByDescending(n => n.UpdatedAt).ToListAsync(ct);
+        return Ok(ApiResponse<object>.Ok(new
+        {
+            selfNodeId,
+            selfBaseUrl = SelfBaseUrl(null),
+            items = nodes.Select(ToDto).ToList(),
+        }));
+    }
+
+    /// <summary>生成一次性配对码（5 分钟有效，供对端管理员粘贴）。</summary>
+    [HttpPost("pairing-code")]
+    public async Task<IActionResult> GeneratePairingCode(CancellationToken ct)
+    {
+        var code = PeerNodeService.GeneratePairingCode();
+        await _db.PeerPairingCodes.InsertOneAsync(new PeerPairingCode
+        {
+            Id = code,
+            CreatedBy = GetUserId(),
+            ExpiresAt = DateTime.UtcNow.AddMinutes(5),
+        }, cancellationToken: ct);
+        var selfNodeId = await _peer.GetSelfNodeIdAsync(ct);
+        return Ok(ApiResponse<object>.Ok(new
+        {
+            pairingCode = code,
+            expiresInSeconds = 300,
+            selfNodeId,
+            selfBaseUrl = SelfBaseUrl(null),
+        }));
+    }
+
+    /// <summary>添加对端节点：填对端 baseUrl + 对端生成的配对码，触发握手建立互信。</summary>
+    [HttpPost]
+    public async Task<IActionResult> Add([FromBody] AddPeerRequest request, CancellationToken ct)
+    {
+        if (request == null || string.IsNullOrWhiteSpace(request.BaseUrl) || string.IsNullOrWhiteSpace(request.PairingCode))
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "请填写对端地址和配对码"));
+
+        var baseUrl = request.BaseUrl.Trim().TrimEnd('/');
+        Uri baseUri;
+        try { baseUri = await _urlValidator.EnsureSafeHttpUrlAsync(baseUrl, "peer-sync", ct); }
+        catch (Exception ex) { return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, $"对端地址不合法：{ex.Message}")); }
+
+        var selfNodeId = await _peer.GetSelfNodeIdAsync(ct);
+        var selfBaseUrl = SelfBaseUrl(request.SelfBaseUrl);
+
+        // 向对端发起握手（配对码鉴权，未握手前无共享密钥，故 handshake 端点本身 AllowAnonymous）
+        var handshakeBody = new HandshakePayload
+        {
+            PairingCode = request.PairingCode.Trim(),
+            InitiatorNodeId = selfNodeId,
+            InitiatorBaseUrl = selfBaseUrl,
+            InitiatorDisplayName = string.IsNullOrWhiteSpace(request.SelfDisplayName) ? "对端 MAP 节点" : request.SelfDisplayName!.Trim(),
+        };
+        var baseLeft = baseUri.GetLeftPart(UriPartial.Path).TrimEnd('/');
+        var url = $"{baseLeft}/api/peer-sync/handshake";
+
+        HandshakeResult? result;
+        try
+        {
+            var client = _httpFactory.CreateClient("PeerSync");
+            client.Timeout = TimeSpan.FromSeconds(30);
+            var content = new StringContent(JsonSerializer.Serialize(handshakeBody, JsonOpts), Encoding.UTF8, "application/json");
+            using var resp = await client.PostAsync(url, content, ct);
+            var json = await resp.Content.ReadAsStringAsync(ct);
+            if (!resp.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("[peer-sync] handshake failed {Status}: {Body}", resp.StatusCode, json);
+                return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT,
+                    $"对端握手失败（HTTP {(int)resp.StatusCode}）：配对码可能已过期或对端不可达"));
+            }
+            using var doc = JsonDocument.Parse(json);
+            if (!doc.RootElement.TryGetProperty("data", out var data))
+                return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "对端握手响应格式不正确"));
+            result = JsonSerializer.Deserialize<HandshakeResult>(data.GetRawText(), JsonOpts);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "[peer-sync] handshake request error to {Url}", url);
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, $"无法连接对端：{ex.Message}"));
+        }
+
+        if (result == null || string.IsNullOrWhiteSpace(result.NodeId) || string.IsNullOrWhiteSpace(result.SharedSecret))
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "对端握手未返回有效凭据"));
+
+        if (result.NodeId == selfNodeId)
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "不能与本节点自己配对"));
+
+        // 落本端 PeerNode（指向对端 B）
+        var existing = await _db.PeerNodes.Find(n => n.RemoteNodeId == result.NodeId).FirstOrDefaultAsync(ct);
+        var displayName = string.IsNullOrWhiteSpace(request.DisplayName)
+            ? (string.IsNullOrWhiteSpace(result.DisplayName) ? "对端节点" : result.DisplayName!)
+            : request.DisplayName!.Trim();
+        if (existing != null)
+        {
+            await _db.PeerNodes.UpdateOneAsync(n => n.Id == existing.Id,
+                Builders<PeerNode>.Update
+                    .Set(n => n.DisplayName, displayName)
+                    .Set(n => n.BaseUrl, baseUrl)
+                    .Set(n => n.SharedSecret, result.SharedSecret)
+                    .Set(n => n.Status, PeerNodeStatus.Connected)
+                    .Set(n => n.LastError, (string?)null)
+                    .Set(n => n.LastContactAt, DateTime.UtcNow)
+                    .Set(n => n.UpdatedAt, DateTime.UtcNow), cancellationToken: ct);
+            var reloaded = await _db.PeerNodes.Find(n => n.Id == existing.Id).FirstOrDefaultAsync(ct);
+            return Ok(ApiResponse<object>.Ok(ToDto(reloaded!)));
+        }
+
+        var node = new PeerNode
+        {
+            RemoteNodeId = result.NodeId,
+            DisplayName = displayName,
+            BaseUrl = baseUrl,
+            SharedSecret = result.SharedSecret,
+            Status = PeerNodeStatus.Connected,
+            LastContactAt = DateTime.UtcNow,
+            CreatedBy = GetUserId(),
+        };
+        await _db.PeerNodes.InsertOneAsync(node, cancellationToken: ct);
+        return Ok(ApiResponse<object>.Ok(ToDto(node)));
+    }
+
+    /// <summary>测试连通性（HMAC 签名 ping 对端）。</summary>
+    [HttpPost("{id}/test")]
+    public async Task<IActionResult> Test(string id, CancellationToken ct)
+    {
+        var node = await _db.PeerNodes.Find(n => n.Id == id).FirstOrDefaultAsync(ct);
+        if (node == null) return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "对端节点不存在"));
+
+        try
+        {
+            var baseUri = await _urlValidator.EnsureSafeHttpUrlAsync(node.BaseUrl, "peer-sync", ct);
+            var baseLeft = baseUri.GetLeftPart(UriPartial.Path).TrimEnd('/');
+            const string path = "/api/peer-sync/ping";
+            var selfNodeId = await _peer.GetSelfNodeIdAsync(ct);
+            var (ts, sign) = _peer.Sign(node.SharedSecret, "GET", path, string.Empty);
+            var client = _httpFactory.CreateClient("PeerSync");
+            client.Timeout = TimeSpan.FromSeconds(20);
+            var req = new HttpRequestMessage(HttpMethod.Get, baseLeft + path);
+            req.Headers.TryAddWithoutValidation("X-Peer-Node", selfNodeId);
+            req.Headers.TryAddWithoutValidation("X-Peer-Ts", ts);
+            req.Headers.TryAddWithoutValidation("X-Peer-Sign", sign);
+            using var resp = await client.SendAsync(req, ct);
+            var ok = resp.IsSuccessStatusCode;
+            await _db.PeerNodes.UpdateOneAsync(n => n.Id == id,
+                Builders<PeerNode>.Update
+                    .Set(n => n.Status, ok ? PeerNodeStatus.Connected : PeerNodeStatus.Error)
+                    .Set(n => n.LastError, ok ? null : $"ping 返回 HTTP {(int)resp.StatusCode}")
+                    .Set(n => n.LastContactAt, ok ? DateTime.UtcNow : node.LastContactAt)
+                    .Set(n => n.UpdatedAt, DateTime.UtcNow), cancellationToken: ct);
+            return Ok(ApiResponse<object>.Ok(new { ok, status = (int)resp.StatusCode }));
+        }
+        catch (Exception ex)
+        {
+            await _db.PeerNodes.UpdateOneAsync(n => n.Id == id,
+                Builders<PeerNode>.Update.Set(n => n.Status, PeerNodeStatus.Error)
+                    .Set(n => n.LastError, ex.Message).Set(n => n.UpdatedAt, DateTime.UtcNow), cancellationToken: ct);
+            return Ok(ApiResponse<object>.Ok(new { ok = false, error = ex.Message }));
+        }
+    }
+
+    /// <summary>解除配对（删除本端记录；对端残留需对端管理员手动删，见 debt.peer-sync.md）。</summary>
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> Delete(string id, CancellationToken ct)
+    {
+        var node = await _db.PeerNodes.Find(n => n.Id == id).FirstOrDefaultAsync(ct);
+        if (node == null) return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "对端节点不存在"));
+        await _db.PeerNodes.DeleteOneAsync(n => n.Id == id, ct);
+        return Ok(ApiResponse<object>.Ok(new { deleted = true }));
+    }
+
+    private static object ToDto(PeerNode n) => new
+    {
+        n.Id,
+        n.RemoteNodeId,
+        n.DisplayName,
+        n.BaseUrl,
+        n.Status,
+        n.LastError,
+        n.LastContactAt,
+        n.CreatedAt,
+        n.UpdatedAt,
+    };
+
+    // ── DTO ──
+    public class AddPeerRequest
+    {
+        public string? BaseUrl { get; set; }
+        public string? PairingCode { get; set; }
+        public string? DisplayName { get; set; }      // 我方给对端起的名字（如「正式环境」）
+        public string? SelfBaseUrl { get; set; }       // 本节点对外地址（默认从请求推断）
+        public string? SelfDisplayName { get; set; }   // 对端将用此名字称呼本节点
+    }
+
+    // 与 PeerSyncController.HandshakePayload / HandshakeResult 对应（同进程内复用同结构）
+    public class HandshakePayload
+    {
+        public string PairingCode { get; set; } = string.Empty;
+        public string InitiatorNodeId { get; set; } = string.Empty;
+        public string InitiatorBaseUrl { get; set; } = string.Empty;
+        public string InitiatorDisplayName { get; set; } = string.Empty;
+    }
+
+    public class HandshakeResult
+    {
+        public string NodeId { get; set; } = string.Empty;
+        public string? DisplayName { get; set; }
+        public string SharedSecret { get; set; } = string.Empty;
+    }
+}

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/AdminPeerNodesController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/AdminPeerNodesController.cs
@@ -199,8 +199,21 @@ public class AdminPeerNodesController : ControllerBase
                 .Set(n => n.CreatedBy, GetUserId())
                 .Set(n => n.UpdatedAt, DateTime.UtcNow),
             new UpdateOptions { IsUpsert = true }, ct);
+        // PR #742 review Medium fix：upsert 后回读可能因极端时序 / 副本集读不到，不可直接 ! 解引用。
+        // 命中 null 时 500 已配对成功用户却看 NRE，体验糟；显式回报"已配对但读取失败"，配对码已用过、
+        // SharedSecret 已落库，让用户刷新即能看到。
         var reloaded = await _db.PeerNodes.Find(n => n.RemoteNodeId == result.NodeId).FirstOrDefaultAsync(ct);
-        return Ok(ApiResponse<object>.Ok(ToDto(reloaded!)));
+        if (reloaded == null)
+        {
+            _logger.LogWarning("[peer-sync] upsert 后回读 PeerNode 为空 remoteNodeId={RemoteNodeId}", result.NodeId);
+            return Ok(ApiResponse<object>.Ok(new
+            {
+                pending = true,
+                remoteNodeId = result.NodeId,
+                message = "配对成功，但本端回读延迟。请稍后刷新列表查看。",
+            }));
+        }
+        return Ok(ApiResponse<object>.Ok(ToDto(reloaded)));
     }
 
     /// <summary>测试连通性（HMAC 签名 ping 对端）。</summary>

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/AdminPeerNodesController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/AdminPeerNodesController.cs
@@ -66,12 +66,16 @@ public class AdminPeerNodesController : ControllerBase
         return $"{scheme}://{host}{Request.PathBase}".TrimEnd('/');
     }
 
-    /// <summary>列出已配对节点 + 本节点标识（不返回 SharedSecret）。</summary>
+    /// <summary>列出已配对节点 + 本节点标识（不返回 SharedSecret）。
+    /// 过滤掉 RemoteNodeId == selfNodeId 的记录：这些是「对端创建过来指向我自己」的影子记录，
+    /// 生产环境分库部署根本不会有；CDS 共享 DB 部署下会同时看到两条，导致本端点击「测试」走自指
+    /// 防护被拦 401，UX 极差。过滤后视图一致。</summary>
     [HttpGet]
     public async Task<IActionResult> List(CancellationToken ct)
     {
         var selfNodeId = await _peer.GetSelfNodeIdAsync(ct);
-        var nodes = await _db.PeerNodes.Find(_ => true).SortByDescending(n => n.UpdatedAt).ToListAsync(ct);
+        var nodes = await _db.PeerNodes.Find(n => n.RemoteNodeId != selfNodeId)
+            .SortByDescending(n => n.UpdatedAt).ToListAsync(ct);
         return Ok(ApiResponse<object>.Ok(new
         {
             selfNodeId,

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/AdminPeerNodesController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/AdminPeerNodesController.cs
@@ -53,9 +53,18 @@ public class AdminPeerNodesController : ControllerBase
     private string GetUserId() => this.GetRequiredUserId();
 
     private string SelfBaseUrl(string? overrideUrl)
-        => !string.IsNullOrWhiteSpace(overrideUrl)
-            ? overrideUrl!.TrimEnd('/')
-            : $"{Request.Scheme}://{Request.Host}{Request.PathBase}".TrimEnd('/');
+    {
+        if (!string.IsNullOrWhiteSpace(overrideUrl)) return overrideUrl!.TrimEnd('/');
+        // CDS 等反向代理后 Request.Host 是容器内部地址（127.0.0.1:30707），SSRF 校验会拒。
+        // 优先环境变量 PEER_SELF_BASE_URL（运维显式指定）→ X-Forwarded-* 头 → Request.Host 兜底。
+        var envBase = Environment.GetEnvironmentVariable("PEER_SELF_BASE_URL");
+        if (!string.IsNullOrWhiteSpace(envBase)) return envBase.Trim().TrimEnd('/');
+        var fwdProto = Request.Headers["X-Forwarded-Proto"].ToString();
+        var fwdHost = Request.Headers["X-Forwarded-Host"].ToString();
+        var scheme = !string.IsNullOrWhiteSpace(fwdProto) ? fwdProto.Split(',')[0].Trim() : Request.Scheme;
+        var host = !string.IsNullOrWhiteSpace(fwdHost) ? fwdHost.Split(',')[0].Trim() : Request.Host.Value;
+        return $"{scheme}://{host}{Request.PathBase}".TrimEnd('/');
+    }
 
     /// <summary>列出已配对节点 + 本节点标识（不返回 SharedSecret）。</summary>
     [HttpGet]
@@ -129,8 +138,23 @@ public class AdminPeerNodesController : ControllerBase
             if (!resp.IsSuccessStatusCode)
             {
                 _logger.LogWarning("[peer-sync] handshake failed {Status}: {Body}", resp.StatusCode, json);
+                // 解析对端的 ApiResponse.error.message 让用户看到真正失败原因（如「不能与本节点自己配对」、
+                // 「发起方地址不合法」），而不是"配对码可能已过期"这种万能搪塞。
+                string? innerMsg = null;
+                try
+                {
+                    using var doc = JsonDocument.Parse(json);
+                    if (doc.RootElement.TryGetProperty("error", out var err)
+                        && err.ValueKind == JsonValueKind.Object
+                        && err.TryGetProperty("message", out var msg))
+                        innerMsg = msg.GetString();
+                }
+                catch { /* 对端可能不是标准 ApiResponse 包装 */ }
+                var detail = !string.IsNullOrWhiteSpace(innerMsg)
+                    ? innerMsg!
+                    : "配对码可能已过期或对端不可达";
                 return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT,
-                    $"对端握手失败（HTTP {(int)resp.StatusCode}）：配对码可能已过期或对端不可达"));
+                    $"对端握手失败（HTTP {(int)resp.StatusCode}）：{detail}"));
             }
             using var doc = JsonDocument.Parse(json);
             if (!doc.RootElement.TryGetProperty("data", out var data))

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/AdminPeerNodesController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/AdminPeerNodesController.cs
@@ -178,41 +178,29 @@ public class AdminPeerNodesController : ControllerBase
             return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "不能与本节点自己配对"));
 
         // 落本端 PeerNode（指向对端 B）
-        var existing = await _db.PeerNodes.Find(n => n.RemoteNodeId == result.NodeId).FirstOrDefaultAsync(ct);
+        // PR #742 review P2 fix：原子 upsert by RemoteNodeId，避免并发 Add（两个 admin 同时配同对端）
+        // 产生两行同 RemoteNodeId 但不同 SharedSecret 的脏数据。Last-writer-wins，可接受。
+        // 需配套 peer_nodes.RemoteNodeId 唯一索引（DBA 手建，见 doc/guide.mongodb-indexes.md）。
         var displayName = string.IsNullOrWhiteSpace(request.DisplayName)
             ? (string.IsNullOrWhiteSpace(result.DisplayName) ? "对端节点" : result.DisplayName!)
             : request.DisplayName!.Trim();
-        if (existing != null)
-        {
-            // PR #742 review P2 fix：重新配对必须刷新 CreatedBy 为本次操作管理员。
-            // 否则 PeerSyncController.RemoteApply 用 node.CreatedBy 兜底归属时会落到上次配对的
-            // 老管理员（可能已离职 / 删账号），新接手的 admin 看不到自己授信导入的数据。
-            await _db.PeerNodes.UpdateOneAsync(n => n.Id == existing.Id,
-                Builders<PeerNode>.Update
-                    .Set(n => n.DisplayName, displayName)
-                    .Set(n => n.BaseUrl, baseUrl)
-                    .Set(n => n.SharedSecret, result.SharedSecret)
-                    .Set(n => n.Status, PeerNodeStatus.Connected)
-                    .Set(n => n.LastError, (string?)null)
-                    .Set(n => n.LastContactAt, DateTime.UtcNow)
-                    .Set(n => n.CreatedBy, GetUserId())
-                    .Set(n => n.UpdatedAt, DateTime.UtcNow), cancellationToken: ct);
-            var reloaded = await _db.PeerNodes.Find(n => n.Id == existing.Id).FirstOrDefaultAsync(ct);
-            return Ok(ApiResponse<object>.Ok(ToDto(reloaded!)));
-        }
-
-        var node = new PeerNode
-        {
-            RemoteNodeId = result.NodeId,
-            DisplayName = displayName,
-            BaseUrl = baseUrl,
-            SharedSecret = result.SharedSecret,
-            Status = PeerNodeStatus.Connected,
-            LastContactAt = DateTime.UtcNow,
-            CreatedBy = GetUserId(),
-        };
-        await _db.PeerNodes.InsertOneAsync(node, cancellationToken: ct);
-        return Ok(ApiResponse<object>.Ok(ToDto(node)));
+        await _db.PeerNodes.UpdateOneAsync(
+            n => n.RemoteNodeId == result.NodeId,
+            Builders<PeerNode>.Update
+                .SetOnInsert(n => n.Id, Guid.NewGuid().ToString("N"))
+                .SetOnInsert(n => n.RemoteNodeId, result.NodeId)
+                .SetOnInsert(n => n.CreatedAt, DateTime.UtcNow)
+                .Set(n => n.DisplayName, displayName)
+                .Set(n => n.BaseUrl, baseUrl)
+                .Set(n => n.SharedSecret, result.SharedSecret)
+                .Set(n => n.Status, PeerNodeStatus.Connected)
+                .Set(n => n.LastError, (string?)null)
+                .Set(n => n.LastContactAt, DateTime.UtcNow)
+                .Set(n => n.CreatedBy, GetUserId())
+                .Set(n => n.UpdatedAt, DateTime.UtcNow),
+            new UpdateOptions { IsUpsert = true }, ct);
+        var reloaded = await _db.PeerNodes.Find(n => n.RemoteNodeId == result.NodeId).FirstOrDefaultAsync(ct);
+        return Ok(ApiResponse<object>.Ok(ToDto(reloaded!)));
     }
 
     /// <summary>测试连通性（HMAC 签名 ping 对端）。</summary>

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/AdminPeerNodesController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/AdminPeerNodesController.cs
@@ -184,6 +184,9 @@ public class AdminPeerNodesController : ControllerBase
             : request.DisplayName!.Trim();
         if (existing != null)
         {
+            // PR #742 review P2 fix：重新配对必须刷新 CreatedBy 为本次操作管理员。
+            // 否则 PeerSyncController.RemoteApply 用 node.CreatedBy 兜底归属时会落到上次配对的
+            // 老管理员（可能已离职 / 删账号），新接手的 admin 看不到自己授信导入的数据。
             await _db.PeerNodes.UpdateOneAsync(n => n.Id == existing.Id,
                 Builders<PeerNode>.Update
                     .Set(n => n.DisplayName, displayName)
@@ -192,6 +195,7 @@ public class AdminPeerNodesController : ControllerBase
                     .Set(n => n.Status, PeerNodeStatus.Connected)
                     .Set(n => n.LastError, (string?)null)
                     .Set(n => n.LastContactAt, DateTime.UtcNow)
+                    .Set(n => n.CreatedBy, GetUserId())
                     .Set(n => n.UpdatedAt, DateTime.UtcNow), cancellationToken: ct);
             var reloaded = await _db.PeerNodes.Find(n => n.Id == existing.Id).FirstOrDefaultAsync(ct);
             return Ok(ApiResponse<object>.Ok(ToDto(reloaded!)));

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/PeerSyncController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/PeerSyncController.cs
@@ -106,6 +106,8 @@ public class PeerSyncController : ControllerBase
         var fallbackUser = code.CreatedBy;
         if (existing != null)
         {
+            // PR #742 review P2 fix：重新握手同样刷新 CreatedBy 为本次配对码的管理员。
+            // RemoteApply 用 node.CreatedBy 兜底归属，不刷新会落到上次握手的老管理员（可能已离职）。
             await _db.PeerNodes.UpdateOneAsync(n => n.Id == existing.Id,
                 Builders<PeerNode>.Update
                     .Set(n => n.DisplayName, string.IsNullOrWhiteSpace(payload.InitiatorDisplayName) ? existing.DisplayName : payload.InitiatorDisplayName)
@@ -114,6 +116,7 @@ public class PeerSyncController : ControllerBase
                     .Set(n => n.Status, PeerNodeStatus.Connected)
                     .Set(n => n.LastError, (string?)null)
                     .Set(n => n.LastContactAt, DateTime.UtcNow)
+                    .Set(n => n.CreatedBy, fallbackUser)
                     .Set(n => n.UpdatedAt, DateTime.UtcNow), cancellationToken: ct);
         }
         else
@@ -160,7 +163,8 @@ public class PeerSyncController : ControllerBase
         return Ok(ApiResponse<object>.Ok(new { items = _registry.Capabilities }));
     }
 
-    /// <summary>取条目签名（对端变更检测）。</summary>
+    /// <summary>取条目签名（对端变更检测）。
+    /// 单向资源同样拒绝，避免对端旁路本接口拿到漂移信号反推数据存在性。</summary>
     [AllowAnonymous]
     [HttpPost("resources/{type}/signature")]
     public async Task<IActionResult> RemoteSignature(string type, CancellationToken ct)
@@ -169,6 +173,9 @@ public class PeerSyncController : ControllerBase
         if (error != null) return error;
         var resource = _registry.Resolve(type);
         if (resource == null) return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "资源类型未注册"));
+        if (!resource.SupportsBidirectional)
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT,
+                $"{resource.DisplayName}是单向（push-only）资源，对端不能查询本端签名"));
         var req = Deserialize<ItemRequest>(body);
         if (req == null || string.IsNullOrWhiteSpace(req.ItemId))
             return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "缺少 itemId"));
@@ -176,7 +183,9 @@ public class PeerSyncController : ControllerBase
         return Ok(ApiResponse<object>.Ok(new { signature = sig }));
     }
 
-    /// <summary>导出条目 bundle（对端 pull 用，受信节点绕过按用户访问校验）。</summary>
+    /// <summary>导出条目 bundle（对端 pull 用，受信节点绕过按用户访问校验）。
+    /// PR #742 review P2 fix：单向资源（SupportsBidirectional=false）禁止 export ——
+    /// 用户层 transfer 已拒 pull/both，但若对端旁路直接调本端点仍可强行拉取数据。</summary>
     [AllowAnonymous]
     [HttpPost("resources/{type}/export")]
     public async Task<IActionResult> RemoteExport(string type, CancellationToken ct)
@@ -185,6 +194,9 @@ public class PeerSyncController : ControllerBase
         if (error != null) return error;
         var resource = _registry.Resolve(type);
         if (resource == null) return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "资源类型未注册"));
+        if (!resource.SupportsBidirectional)
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT,
+                $"{resource.DisplayName}是单向（push-only）资源，对端不能从本节点拉取"));
         var req = Deserialize<ItemRequest>(body);
         if (req == null || string.IsNullOrWhiteSpace(req.ItemId))
             return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "缺少 itemId"));

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/PeerSyncController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/PeerSyncController.cs
@@ -101,37 +101,31 @@ public class PeerSyncController : ControllerBase
             return StatusCode(401, ApiResponse<object>.Fail(ErrorCodes.UNAUTHORIZED, "配对码无效、已使用或已过期"));
 
         var secret = PrdAgent.Infrastructure.Services.PeerNodeService.GenerateSharedSecret();
+        // PR #742 review P2 fix：原子 upsert by RemoteNodeId，避免并发握手（两个 admin 同时配同一对端
+        // 各拿新配对码）产生两行同 RemoteNodeId 但不同 SharedSecret 的脏数据 — VerifyPeerAsync 的
+        // FirstOrDefault 会随机选一行 HMAC 校验失败。需配套在 peer_nodes 集合的 RemoteNodeId 上加唯一
+        // 索引（CLAUDE 项目禁自动建索引，DBA 手动创建：见 doc/guide.mongodb-indexes.md）。
         var existing = await _db.PeerNodes.Find(n => n.RemoteNodeId == payload.InitiatorNodeId).FirstOrDefaultAsync(ct);
         // 握手发起方/接受方都用配对管理员；接受方无登录上下文，用配对码创建者作为兜底归属操作者。
         var fallbackUser = code.CreatedBy;
-        if (existing != null)
-        {
-            // PR #742 review P2 fix：重新握手同样刷新 CreatedBy 为本次配对码的管理员。
-            // RemoteApply 用 node.CreatedBy 兜底归属，不刷新会落到上次握手的老管理员（可能已离职）。
-            await _db.PeerNodes.UpdateOneAsync(n => n.Id == existing.Id,
-                Builders<PeerNode>.Update
-                    .Set(n => n.DisplayName, string.IsNullOrWhiteSpace(payload.InitiatorDisplayName) ? existing.DisplayName : payload.InitiatorDisplayName)
-                    .Set(n => n.BaseUrl, initiatorBaseUrl)
-                    .Set(n => n.SharedSecret, secret)
-                    .Set(n => n.Status, PeerNodeStatus.Connected)
-                    .Set(n => n.LastError, (string?)null)
-                    .Set(n => n.LastContactAt, DateTime.UtcNow)
-                    .Set(n => n.CreatedBy, fallbackUser)
-                    .Set(n => n.UpdatedAt, DateTime.UtcNow), cancellationToken: ct);
-        }
-        else
-        {
-            await _db.PeerNodes.InsertOneAsync(new PeerNode
-            {
-                RemoteNodeId = payload.InitiatorNodeId,
-                DisplayName = string.IsNullOrWhiteSpace(payload.InitiatorDisplayName) ? "对端节点" : payload.InitiatorDisplayName,
-                BaseUrl = initiatorBaseUrl,
-                SharedSecret = secret,
-                Status = PeerNodeStatus.Connected,
-                LastContactAt = DateTime.UtcNow,
-                CreatedBy = fallbackUser,
-            }, cancellationToken: ct);
-        }
+        var displayNameToSet = string.IsNullOrWhiteSpace(payload.InitiatorDisplayName)
+            ? (existing?.DisplayName ?? "对端节点")
+            : payload.InitiatorDisplayName;
+        await _db.PeerNodes.UpdateOneAsync(
+            n => n.RemoteNodeId == payload.InitiatorNodeId,
+            Builders<PeerNode>.Update
+                .SetOnInsert(n => n.Id, Guid.NewGuid().ToString("N"))
+                .SetOnInsert(n => n.RemoteNodeId, payload.InitiatorNodeId)
+                .SetOnInsert(n => n.CreatedAt, DateTime.UtcNow)
+                .Set(n => n.DisplayName, displayNameToSet)
+                .Set(n => n.BaseUrl, initiatorBaseUrl)
+                .Set(n => n.SharedSecret, secret)
+                .Set(n => n.Status, PeerNodeStatus.Connected)
+                .Set(n => n.LastError, (string?)null)
+                .Set(n => n.LastContactAt, DateTime.UtcNow)
+                .Set(n => n.CreatedBy, fallbackUser)
+                .Set(n => n.UpdatedAt, DateTime.UtcNow),
+            new UpdateOptions { IsUpsert = true }, ct);
 
         // 配对码已在上面 FindOneAndUpdate 时原子 claim，不需要再 set Used。
         var settings = await _db.AppSettings.Find(s => s.Id == "global").FirstOrDefaultAsync(ct);

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/PeerSyncController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/PeerSyncController.cs
@@ -8,6 +8,7 @@ using MongoDB.Driver;
 using PrdAgent.Api.Extensions;
 using PrdAgent.Core.Interfaces;
 using PrdAgent.Core.Models;
+using PrdAgent.Core.Security;
 using PrdAgent.Core.Sync;
 using PrdAgent.Infrastructure.Database;
 
@@ -269,10 +270,22 @@ public class PeerSyncController : ControllerBase
         var mode = request.Mode == "add-only" ? SyncApplyMode.AddOnly : SyncApplyMode.Overwrite;
         var actor = await BuildActorAsync(this.GetRequiredUserId(), ct);
 
+        // PR #742 Review High：授权门——每个 itemId 必须出现在 actor 自己的 ListItemsAsync 结果里。
+        // 这一道门同时拦：(a) 越权 push 自己看不到的条目；(b) pull 到不存在/不可写的目标 store/project。
+        // ListItemsAsync 已经按 actor 视角做了访问过滤，此处用集合判定，资源层不必再各自重复鉴权。
+        var allowedItems = await resource.ListItemsAsync(actor, ct);
+        var allowedSet = allowedItems.Select(i => i.ItemId).ToHashSet(StringComparer.Ordinal);
+
         var results = new List<object>();
         var anyFail = false;
         foreach (var itemId in request.ItemIds.Distinct())
         {
+            if (!allowedSet.Contains(itemId))
+            {
+                results.Add(new { itemId, ok = false, message = "无权访问该条目（不在你的可访问范围内）" });
+                anyFail = true;
+                continue;
+            }
             try
             {
                 // PR #742 review fix：每条目独立 ok 标记。Push 或 Pull 任一阶段 outcome.Failed>0、
@@ -419,7 +432,11 @@ public class PeerSyncController : ControllerBase
         var user = await _db.Users.Find(u => u.UserId == userId).FirstOrDefaultAsync(ct);
         var name = user != null && !string.IsNullOrWhiteSpace(user.DisplayName) ? user.DisplayName
             : (user?.Username ?? "同步");
-        return new SyncActor(userId, name, user?.Email);
+        // 从 HttpContext 取出权限位（与 AdminPermissionMiddleware / 各 controller 的判定保持一致）。
+        // SuperUser / isAiSuperAccess 视为管理员；具体资源可以再用更细的权限位收敛（如 defect-agent.manage）。
+        var isSuper = User.FindAll("permissions").Any(c => c.Value == AdminPermissionCatalog.Super)
+            || string.Equals(User.FindFirst("isAiSuperAccess")?.Value, "1", StringComparison.Ordinal);
+        return new SyncActor(userId, name, user?.Email, IsAdmin: isSuper);
     }
 
     private static T? Deserialize<T>(string body) where T : class

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/PeerSyncController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/PeerSyncController.cs
@@ -67,9 +67,23 @@ public class PeerSyncController : ControllerBase
             || string.IsNullOrWhiteSpace(payload.InitiatorNodeId) || string.IsNullOrWhiteSpace(payload.InitiatorBaseUrl))
             return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "握手请求缺少必要信息"));
 
-        var code = await _db.PeerPairingCodes.Find(c => c.Id == payload.PairingCode).FirstOrDefaultAsync(ct);
-        if (code == null || code.Used || code.ExpiresAt < DateTime.UtcNow)
-            return StatusCode(401, ApiResponse<object>.Fail(ErrorCodes.UNAUTHORIZED, "配对码无效或已过期"));
+        // 原子 claim 配对码（PR #742 review fix）：FindOneAndUpdate 以「未使用 + 未过期」为条件，
+        // 命中即刻把 Used 设为 true 并落 UsedByNodeId。并发 handshake 同一码只有一方拿得到，
+        // 失败方拿到 null，直接 401。避免「先读后写」窗口里两个发起方各拿到不同 secret 的紫绳。
+        var nowUtc = DateTime.UtcNow;
+        var claimFilter = Builders<PeerPairingCode>.Filter.And(
+            Builders<PeerPairingCode>.Filter.Eq(c => c.Id, payload.PairingCode),
+            Builders<PeerPairingCode>.Filter.Eq(c => c.Used, false),
+            Builders<PeerPairingCode>.Filter.Gte(c => c.ExpiresAt, nowUtc));
+        var claimUpdate = Builders<PeerPairingCode>.Update
+            .Set(c => c.Used, true)
+            .Set(c => c.UsedByNodeId, payload.InitiatorNodeId);
+        var code = await _db.PeerPairingCodes.FindOneAndUpdateAsync(
+            claimFilter, claimUpdate,
+            new FindOneAndUpdateOptions<PeerPairingCode> { ReturnDocument = ReturnDocument.Before },
+            ct);
+        if (code == null)
+            return StatusCode(401, ApiResponse<object>.Fail(ErrorCodes.UNAUTHORIZED, "配对码无效、已使用或已过期"));
 
         var selfNodeId = await _peer.GetSelfNodeIdAsync(ct);
         if (payload.InitiatorNodeId == selfNodeId)
@@ -110,10 +124,7 @@ public class PeerSyncController : ControllerBase
             }, cancellationToken: ct);
         }
 
-        await _db.PeerPairingCodes.UpdateOneAsync(c => c.Id == code.Id,
-            Builders<PeerPairingCode>.Update.Set(c => c.Used, true).Set(c => c.UsedByNodeId, payload.InitiatorNodeId),
-            cancellationToken: ct);
-
+        // 配对码已在上面 FindOneAndUpdate 时原子 claim，不需要再 set Used。
         var settings = await _db.AppSettings.Find(s => s.Id == "global").FirstOrDefaultAsync(ct);
         return Ok(ApiResponse<object>.Ok(new HandshakeResult
         {
@@ -264,24 +275,46 @@ public class PeerSyncController : ControllerBase
         {
             try
             {
+                // PR #742 review fix：每条目独立 ok 标记。Push 或 Pull 任一阶段 outcome.Failed>0、
+                // outcome 为 null（对端返回无效）、bundle 为 null 都判失败，前端可正确标红、不再误显示"成功"。
                 var perItem = new List<string>();
+                var itemOk = true;
                 if (direction is "push" or "both")
                 {
                     var bundle = await resource.ExportAsync(itemId, actor, ct);
-                    if (bundle == null) { results.Add(new { itemId, ok = false, message = "本地条目不存在或无权访问" }); anyFail = true; continue; }
+                    if (bundle == null)
+                    {
+                        results.Add(new { itemId, ok = false, message = "本地条目不存在或无权访问" });
+                        anyFail = true;
+                        continue;
+                    }
                     var outcome = await PushToPeerAsync(node, resource.ResourceType, bundle, itemId, mode, ct);
-                    perItem.Add("发送 " + (outcome?.Message ?? "完成"));
-                    if (outcome == null || outcome.Failed > 0) anyFail = true;
+                    if (outcome == null)
+                    {
+                        perItem.Add("发送 失败（对端返回无效）");
+                        itemOk = false;
+                        anyFail = true;
+                    }
+                    else
+                    {
+                        perItem.Add("发送 " + (outcome.Message ?? "完成"));
+                        if (outcome.Failed > 0) { itemOk = false; anyFail = true; }
+                    }
                 }
                 if (direction is "pull" or "both")
                 {
                     var bundle = await PullFromPeerAsync(node, resource.ResourceType, itemId, ct);
-                    if (bundle == null) { results.Add(new { itemId, ok = false, message = "对端条目不存在或不可达" }); anyFail = true; continue; }
+                    if (bundle == null)
+                    {
+                        results.Add(new { itemId, ok = false, message = string.Join("；", perItem.Append("拉取 失败（对端条目不存在或不可达）")) });
+                        anyFail = true;
+                        continue;
+                    }
                     var outcome = await resource.ApplyAsync(bundle, actor, mode, itemId, ct);
                     perItem.Add("拉取 " + (outcome.Message ?? "完成"));
-                    if (outcome.Failed > 0) anyFail = true;
+                    if (outcome.Failed > 0) { itemOk = false; anyFail = true; }
                 }
-                results.Add(new { itemId, ok = true, message = string.Join("；", perItem) });
+                results.Add(new { itemId, ok = itemOk, message = string.Join("；", perItem) });
             }
             catch (Exception ex)
             {

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/PeerSyncController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/PeerSyncController.cs
@@ -353,6 +353,14 @@ public class PeerSyncController : ControllerBase
                         anyFail = true;
                         continue;
                     }
+                    // PR #742 review P2 fix：对称 RemoteApply 的类型校验 — 旧版/定制的对端或路由错配
+                    // 可能回 bundle.ResourceType 与本地请求的不一致，直接 ApplyAsync 会用错 handler 污染数据。
+                    if (!string.Equals(bundle.ResourceType, resource.ResourceType, StringComparison.Ordinal))
+                    {
+                        results.Add(new { itemId, ok = false, message = string.Join("；", perItem.Append($"拉取 失败（对端 bundle.resourceType={bundle.ResourceType} 与请求 {resource.ResourceType} 不匹配）")) });
+                        anyFail = true;
+                        continue;
+                    }
                     anyPeerContact = true; // bundle != null = 对端 HTTP 200 应答 = 通信成功
                     var outcome = await resource.ApplyAsync(bundle, actor, mode, itemId, ct);
                     perItem.Add("拉取 " + (outcome.Message ?? "完成"));

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/PeerSyncController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/PeerSyncController.cs
@@ -1,0 +1,429 @@
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using MongoDB.Driver;
+using PrdAgent.Api.Extensions;
+using PrdAgent.Core.Interfaces;
+using PrdAgent.Core.Models;
+using PrdAgent.Core.Sync;
+using PrdAgent.Infrastructure.Database;
+
+namespace PrdAgent.Api.Controllers.Api;
+
+/// <summary>
+/// 系统级跨节点互传：node-to-node 数据端点（HMAC 验签）+ 用户发起互传。
+/// 同一份代码每个节点既能发又能收。详见 doc/design.peer-sync.md §8。
+/// </summary>
+[ApiController]
+[Route("api/peer-sync")]
+public class PeerSyncController : ControllerBase
+{
+    private readonly MongoDbContext _db;
+    private readonly IPeerNodeService _peer;
+    private readonly ISyncResourceRegistry _registry;
+    private readonly ISafeOutboundUrlValidator _urlValidator;
+    private readonly IHttpClientFactory _httpFactory;
+    private readonly ILogger<PeerSyncController> _logger;
+
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    public PeerSyncController(
+        MongoDbContext db,
+        IPeerNodeService peer,
+        ISyncResourceRegistry registry,
+        ISafeOutboundUrlValidator urlValidator,
+        IHttpClientFactory httpFactory,
+        ILogger<PeerSyncController> logger)
+    {
+        _db = db;
+        _peer = peer;
+        _registry = registry;
+        _urlValidator = urlValidator;
+        _httpFactory = httpFactory;
+        _logger = logger;
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // node-to-node（被对端调用，HMAC 验签 / 配对码验证）
+    // ═══════════════════════════════════════════════════════════════
+
+    /// <summary>接收握手：校验配对码 → 生成共享密钥 → 落 PeerNode(发起方) → 返回密钥。</summary>
+    [AllowAnonymous]
+    [HttpPost("handshake")]
+    public async Task<IActionResult> Handshake(CancellationToken ct)
+    {
+        var body = await ReadBodyAsync();
+        HandshakePayload? payload;
+        try { payload = JsonSerializer.Deserialize<HandshakePayload>(body, JsonOpts); }
+        catch { return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "握手请求格式不正确")); }
+        if (payload == null || string.IsNullOrWhiteSpace(payload.PairingCode)
+            || string.IsNullOrWhiteSpace(payload.InitiatorNodeId) || string.IsNullOrWhiteSpace(payload.InitiatorBaseUrl))
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "握手请求缺少必要信息"));
+
+        var code = await _db.PeerPairingCodes.Find(c => c.Id == payload.PairingCode).FirstOrDefaultAsync(ct);
+        if (code == null || code.Used || code.ExpiresAt < DateTime.UtcNow)
+            return StatusCode(401, ApiResponse<object>.Fail(ErrorCodes.UNAUTHORIZED, "配对码无效或已过期"));
+
+        var selfNodeId = await _peer.GetSelfNodeIdAsync(ct);
+        if (payload.InitiatorNodeId == selfNodeId)
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "不能与本节点自己配对"));
+
+        // SSRF 校验发起方回连地址
+        var initiatorBaseUrl = payload.InitiatorBaseUrl.Trim().TrimEnd('/');
+        try { await _urlValidator.EnsureSafeHttpUrlAsync(initiatorBaseUrl, "peer-sync", ct); }
+        catch (Exception ex) { return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, $"发起方地址不合法：{ex.Message}")); }
+
+        var secret = PrdAgent.Infrastructure.Services.PeerNodeService.GenerateSharedSecret();
+        var existing = await _db.PeerNodes.Find(n => n.RemoteNodeId == payload.InitiatorNodeId).FirstOrDefaultAsync(ct);
+        // 握手发起方/接受方都用配对管理员；接受方无登录上下文，用配对码创建者作为兜底归属操作者。
+        var fallbackUser = code.CreatedBy;
+        if (existing != null)
+        {
+            await _db.PeerNodes.UpdateOneAsync(n => n.Id == existing.Id,
+                Builders<PeerNode>.Update
+                    .Set(n => n.DisplayName, string.IsNullOrWhiteSpace(payload.InitiatorDisplayName) ? existing.DisplayName : payload.InitiatorDisplayName)
+                    .Set(n => n.BaseUrl, initiatorBaseUrl)
+                    .Set(n => n.SharedSecret, secret)
+                    .Set(n => n.Status, PeerNodeStatus.Connected)
+                    .Set(n => n.LastError, (string?)null)
+                    .Set(n => n.LastContactAt, DateTime.UtcNow)
+                    .Set(n => n.UpdatedAt, DateTime.UtcNow), cancellationToken: ct);
+        }
+        else
+        {
+            await _db.PeerNodes.InsertOneAsync(new PeerNode
+            {
+                RemoteNodeId = payload.InitiatorNodeId,
+                DisplayName = string.IsNullOrWhiteSpace(payload.InitiatorDisplayName) ? "对端节点" : payload.InitiatorDisplayName,
+                BaseUrl = initiatorBaseUrl,
+                SharedSecret = secret,
+                Status = PeerNodeStatus.Connected,
+                LastContactAt = DateTime.UtcNow,
+                CreatedBy = fallbackUser,
+            }, cancellationToken: ct);
+        }
+
+        await _db.PeerPairingCodes.UpdateOneAsync(c => c.Id == code.Id,
+            Builders<PeerPairingCode>.Update.Set(c => c.Used, true).Set(c => c.UsedByNodeId, payload.InitiatorNodeId),
+            cancellationToken: ct);
+
+        var settings = await _db.AppSettings.Find(s => s.Id == "global").FirstOrDefaultAsync(ct);
+        return Ok(ApiResponse<object>.Ok(new HandshakeResult
+        {
+            NodeId = selfNodeId,
+            DisplayName = settings?.DesktopName ?? "MAP 节点",
+            SharedSecret = secret,
+        }));
+    }
+
+    /// <summary>连通 + 验签自检。</summary>
+    [AllowAnonymous]
+    [HttpGet("ping")]
+    public async Task<IActionResult> Ping(CancellationToken ct)
+    {
+        var (node, _, error) = await VerifyPeerAsync(string.Empty, ct);
+        if (error != null) return error;
+        return Ok(ApiResponse<object>.Ok(new { ok = true, node = node!.RemoteNodeId }));
+    }
+
+    /// <summary>本节点支持的资源类型。</summary>
+    [AllowAnonymous]
+    [HttpGet("capabilities")]
+    public async Task<IActionResult> Capabilities(CancellationToken ct)
+    {
+        var (_, _, error) = await VerifyPeerAsync(string.Empty, ct);
+        if (error != null) return error;
+        return Ok(ApiResponse<object>.Ok(new { items = _registry.Capabilities }));
+    }
+
+    /// <summary>取条目签名（对端变更检测）。</summary>
+    [AllowAnonymous]
+    [HttpPost("resources/{type}/signature")]
+    public async Task<IActionResult> RemoteSignature(string type, CancellationToken ct)
+    {
+        var (node, body, error) = await VerifyPeerAsync(null, ct);
+        if (error != null) return error;
+        var resource = _registry.Resolve(type);
+        if (resource == null) return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "资源类型未注册"));
+        var req = Deserialize<ItemRequest>(body);
+        if (req == null || string.IsNullOrWhiteSpace(req.ItemId))
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "缺少 itemId"));
+        var sig = await resource.ComputeSignatureAsync(req.ItemId, ct);
+        return Ok(ApiResponse<object>.Ok(new { signature = sig }));
+    }
+
+    /// <summary>导出条目 bundle（对端 pull 用，受信节点绕过按用户访问校验）。</summary>
+    [AllowAnonymous]
+    [HttpPost("resources/{type}/export")]
+    public async Task<IActionResult> RemoteExport(string type, CancellationToken ct)
+    {
+        var (node, body, error) = await VerifyPeerAsync(null, ct);
+        if (error != null) return error;
+        var resource = _registry.Resolve(type);
+        if (resource == null) return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "资源类型未注册"));
+        var req = Deserialize<ItemRequest>(body);
+        if (req == null || string.IsNullOrWhiteSpace(req.ItemId))
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "缺少 itemId"));
+        var bundle = await resource.ExportAsync(req.ItemId, SyncActor.PeerSystem, ct);
+        if (bundle == null) return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "条目不存在"));
+        return Ok(ApiResponse<object>.Ok(bundle));
+    }
+
+    /// <summary>应用 bundle（对端 push 用）。归属兜底用配对管理员。</summary>
+    [AllowAnonymous]
+    [HttpPost("resources/{type}/apply")]
+    public async Task<IActionResult> RemoteApply(string type, CancellationToken ct)
+    {
+        var (node, body, error) = await VerifyPeerAsync(null, ct);
+        if (error != null) return error;
+        var resource = _registry.Resolve(type);
+        if (resource == null) return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "资源类型未注册"));
+        var req = Deserialize<ApplyRequest>(body);
+        if (req == null || req.Bundle == null)
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "缺少 bundle"));
+
+        var actor = await BuildActorAsync(node!.CreatedBy, ct);
+        var mode = req.Mode == "add-only" ? SyncApplyMode.AddOnly : SyncApplyMode.Overwrite;
+        var outcome = await resource.ApplyAsync(req.Bundle, actor, mode, req.TargetKey, ct);
+        return Ok(ApiResponse<object>.Ok(outcome));
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 用户发起（需登录）
+    // ═══════════════════════════════════════════════════════════════
+
+    /// <summary>列出可发送的对端节点（已连接，不含 secret）+ 本节点支持的资源能力。</summary>
+    [Authorize]
+    [HttpGet("nodes")]
+    public async Task<IActionResult> ListNodes(CancellationToken ct)
+    {
+        var nodes = await _db.PeerNodes.Find(n => n.Status == PeerNodeStatus.Connected)
+            .SortBy(n => n.DisplayName).ToListAsync(ct);
+        return Ok(ApiResponse<object>.Ok(new
+        {
+            items = nodes.Select(n => new { n.Id, n.RemoteNodeId, n.DisplayName, n.BaseUrl, n.Status }).ToList(),
+            capabilities = _registry.Capabilities,
+        }));
+    }
+
+    /// <summary>列出本节点当前用户可发送的某类资源条目。</summary>
+    [Authorize]
+    [HttpGet("resources/{type}/items")]
+    public async Task<IActionResult> ListItems(string type, CancellationToken ct)
+    {
+        var resource = _registry.Resolve(type);
+        if (resource == null) return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "资源类型未注册"));
+        var actor = await BuildActorAsync(this.GetRequiredUserId(), ct);
+        var items = await resource.ListItemsAsync(actor, ct);
+        return Ok(ApiResponse<object>.Ok(new { items }));
+    }
+
+    /// <summary>发起互传：push（本地→对端）/ pull（对端→本地）/ both（双向，仅双向资源）。</summary>
+    [Authorize]
+    [HttpPost("transfer")]
+    public async Task<IActionResult> Transfer([FromBody] TransferRequest request, CancellationToken ct)
+    {
+        if (request == null || string.IsNullOrWhiteSpace(request.NodeId)
+            || string.IsNullOrWhiteSpace(request.ResourceType) || request.ItemIds == null || request.ItemIds.Count == 0)
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "请选择对端节点、资源类型和至少一个条目"));
+
+        var node = await _db.PeerNodes.Find(n => n.Id == request.NodeId && n.Status == PeerNodeStatus.Connected)
+            .FirstOrDefaultAsync(ct);
+        if (node == null) return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "对端节点不存在或未连接"));
+
+        var resource = _registry.Resolve(request.ResourceType);
+        if (resource == null) return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "资源类型未注册"));
+
+        var direction = (request.Direction ?? "push").Trim().ToLowerInvariant();
+        if (direction is not ("push" or "pull" or "both"))
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "方向无效（push/pull/both）"));
+        if (direction == "both" && !resource.SupportsBidirectional)
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, $"{resource.DisplayName}不支持双向同步"));
+
+        var mode = request.Mode == "add-only" ? SyncApplyMode.AddOnly : SyncApplyMode.Overwrite;
+        var actor = await BuildActorAsync(this.GetRequiredUserId(), ct);
+
+        var results = new List<object>();
+        var anyFail = false;
+        foreach (var itemId in request.ItemIds.Distinct())
+        {
+            try
+            {
+                var perItem = new List<string>();
+                if (direction is "push" or "both")
+                {
+                    var bundle = await resource.ExportAsync(itemId, actor, ct);
+                    if (bundle == null) { results.Add(new { itemId, ok = false, message = "本地条目不存在或无权访问" }); anyFail = true; continue; }
+                    var outcome = await PushToPeerAsync(node, resource.ResourceType, bundle, itemId, mode, ct);
+                    perItem.Add("发送 " + (outcome?.Message ?? "完成"));
+                    if (outcome == null || outcome.Failed > 0) anyFail = true;
+                }
+                if (direction is "pull" or "both")
+                {
+                    var bundle = await PullFromPeerAsync(node, resource.ResourceType, itemId, ct);
+                    if (bundle == null) { results.Add(new { itemId, ok = false, message = "对端条目不存在或不可达" }); anyFail = true; continue; }
+                    var outcome = await resource.ApplyAsync(bundle, actor, mode, itemId, ct);
+                    perItem.Add("拉取 " + (outcome.Message ?? "完成"));
+                    if (outcome.Failed > 0) anyFail = true;
+                }
+                results.Add(new { itemId, ok = true, message = string.Join("；", perItem) });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "[peer-sync] transfer item {ItemId} failed", itemId);
+                results.Add(new { itemId, ok = false, message = ex.Message });
+                anyFail = true;
+            }
+        }
+
+        await _db.PeerNodes.UpdateOneAsync(n => n.Id == node.Id,
+            Builders<PeerNode>.Update.Set(n => n.LastContactAt, DateTime.UtcNow).Set(n => n.UpdatedAt, DateTime.UtcNow),
+            cancellationToken: ct);
+
+        return Ok(ApiResponse<object>.Ok(new { direction, results, anyFail }));
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 内部辅助
+    // ═══════════════════════════════════════════════════════════════
+
+    private async Task<SyncApplyOutcome?> PushToPeerAsync(PeerNode node, string type, SyncResourceBundle bundle, string targetKey, SyncApplyMode mode, CancellationToken ct)
+    {
+        var payload = new ApplyRequest { Bundle = bundle, TargetKey = targetKey, Mode = mode == SyncApplyMode.AddOnly ? "add-only" : "overwrite" };
+        var (ok, json, status) = await CallPeerAsync(node, HttpMethod.Post, $"/api/peer-sync/resources/{type}/apply", payload, ct);
+        if (!ok) throw new InvalidOperationException($"对端 apply 失败（HTTP {status}）");
+        return ExtractData<SyncApplyOutcome>(json);
+    }
+
+    private async Task<SyncResourceBundle?> PullFromPeerAsync(PeerNode node, string type, string itemId, CancellationToken ct)
+    {
+        var payload = new ItemRequest { ItemId = itemId };
+        var (ok, json, status) = await CallPeerAsync(node, HttpMethod.Post, $"/api/peer-sync/resources/{type}/export", payload, ct);
+        if (!ok) return null;
+        return ExtractData<SyncResourceBundle>(json);
+    }
+
+    /// <summary>带 HMAC 签名调用对端（SSRF 校验 + 保留 base 子路径）。</summary>
+    private async Task<(bool ok, string json, int status)> CallPeerAsync(PeerNode node, HttpMethod method, string path, object? body, CancellationToken ct)
+    {
+        var baseUri = await _urlValidator.EnsureSafeHttpUrlAsync(node.BaseUrl, "peer-sync", ct);
+        var baseLeft = baseUri.GetLeftPart(UriPartial.Path).TrimEnd('/');
+        var bodyStr = body != null ? JsonSerializer.Serialize(body, JsonOpts) : string.Empty;
+        var selfNodeId = await _peer.GetSelfNodeIdAsync(ct);
+        var (ts, sign) = _peer.Sign(node.SharedSecret, method.Method, path, bodyStr);
+
+        var req = new HttpRequestMessage(method, baseLeft + path);
+        req.Headers.TryAddWithoutValidation("X-Peer-Node", selfNodeId);
+        req.Headers.TryAddWithoutValidation("X-Peer-Ts", ts);
+        req.Headers.TryAddWithoutValidation("X-Peer-Sign", sign);
+        if (body != null)
+            req.Content = new StringContent(bodyStr, Encoding.UTF8, "application/json");
+
+        var client = _httpFactory.CreateClient("PeerSync");
+        client.Timeout = TimeSpan.FromSeconds(120);
+        using var resp = await client.SendAsync(req, ct);
+        var json = await resp.Content.ReadAsStringAsync(ct);
+        return (resp.IsSuccessStatusCode, json, (int)resp.StatusCode);
+    }
+
+    /// <summary>
+    /// 校验对端请求签名。expectedBody 传 null 时读取并返回原始 body 参与验签（POST 用）；
+    /// 传 string.Empty 表示无 body（GET 用）。失败返回 error IActionResult。
+    /// </summary>
+    private async Task<(PeerNode? node, string body, IActionResult? error)> VerifyPeerAsync(string? expectedBody, CancellationToken ct)
+    {
+        var body = expectedBody ?? await ReadBodyAsync();
+        if (!Request.Headers.TryGetValue("X-Peer-Node", out var nodeIdVals)
+            || !Request.Headers.TryGetValue("X-Peer-Ts", out var tsVals)
+            || !Request.Headers.TryGetValue("X-Peer-Sign", out var signVals))
+            return (null, body, Unauthorized(ApiResponse<object>.Fail(ErrorCodes.UNAUTHORIZED, "缺少节点签名头")));
+
+        var remoteNodeId = nodeIdVals.ToString();
+        var node = await _db.PeerNodes.Find(n => n.RemoteNodeId == remoteNodeId).FirstOrDefaultAsync(ct);
+        if (node == null || string.IsNullOrEmpty(node.SharedSecret))
+            return (null, body, Unauthorized(ApiResponse<object>.Fail(ErrorCodes.UNAUTHORIZED, "未知或未配对的节点")));
+
+        var path = Request.Path.Value ?? string.Empty;
+        if (!_peer.Verify(node.SharedSecret, Request.Method, path, body, tsVals.ToString(), signVals.ToString()))
+            return (null, body, Unauthorized(ApiResponse<object>.Fail(ErrorCodes.UNAUTHORIZED, "签名校验失败")));
+
+        return (node, body, null);
+    }
+
+    private async Task<string> ReadBodyAsync()
+    {
+        Request.EnableBuffering();
+        Request.Body.Position = 0;
+        using var reader = new StreamReader(Request.Body, Encoding.UTF8, detectEncodingFromByteOrderMarks: false, leaveOpen: true);
+        var body = await reader.ReadToEndAsync();
+        Request.Body.Position = 0;
+        return body;
+    }
+
+    private async Task<SyncActor> BuildActorAsync(string userId, CancellationToken ct)
+    {
+        var user = await _db.Users.Find(u => u.UserId == userId).FirstOrDefaultAsync(ct);
+        var name = user != null && !string.IsNullOrWhiteSpace(user.DisplayName) ? user.DisplayName
+            : (user?.Username ?? "同步");
+        return new SyncActor(userId, name, user?.Email);
+    }
+
+    private static T? Deserialize<T>(string body) where T : class
+    {
+        if (string.IsNullOrWhiteSpace(body)) return null;
+        try { return JsonSerializer.Deserialize<T>(body, JsonOpts); } catch { return null; }
+    }
+
+    private static T? ExtractData<T>(string json) where T : class
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.TryGetProperty("data", out var data))
+                return JsonSerializer.Deserialize<T>(data.GetRawText(), JsonOpts);
+        }
+        catch { /* ignore */ }
+        return null;
+    }
+
+    // ── DTO ──
+    public class HandshakePayload
+    {
+        public string PairingCode { get; set; } = string.Empty;
+        public string InitiatorNodeId { get; set; } = string.Empty;
+        public string InitiatorBaseUrl { get; set; } = string.Empty;
+        public string InitiatorDisplayName { get; set; } = string.Empty;
+    }
+
+    public class HandshakeResult
+    {
+        public string NodeId { get; set; } = string.Empty;
+        public string? DisplayName { get; set; }
+        public string SharedSecret { get; set; } = string.Empty;
+    }
+
+    public class ItemRequest { public string ItemId { get; set; } = string.Empty; }
+
+    public class ApplyRequest
+    {
+        public SyncResourceBundle? Bundle { get; set; }
+        public string? TargetKey { get; set; }
+        public string? Mode { get; set; }
+    }
+
+    public class TransferRequest
+    {
+        public string? NodeId { get; set; }
+        public string? ResourceType { get; set; }
+        public List<string>? ItemIds { get; set; }
+        public string? Direction { get; set; }
+        public string? Mode { get; set; }
+    }
+}

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/PeerSyncController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/PeerSyncController.cs
@@ -282,6 +282,10 @@ public class PeerSyncController : ControllerBase
 
         var results = new List<object>();
         var anyFail = false;
+        // PR #742 review Medium fix：跟踪是否真的与对端发生过成功的 HTTP 通信。
+        // 之前总是 bump LastContactAt，即便全部 itemId 在本地（无权访问 / Export 返回 null）就失败、
+        // 一次都没真正联系对端。LastContactAt 语义是"最近成功通信"（与 admin ping test 对齐），不该被误更新。
+        var anyPeerContact = false;
         foreach (var itemId in request.ItemIds.Distinct())
         {
             if (!allowedSet.Contains(itemId))
@@ -307,6 +311,7 @@ public class PeerSyncController : ControllerBase
                         continue;
                     }
                     var outcome = await PushToPeerAsync(node, resource.ResourceType, bundle, itemId, mode, ct);
+                    // outcome != null = 已收到对端 HTTP 响应 = 通信成功（即便 Failed>0 也算"通"了）
                     if (outcome == null)
                     {
                         perItem.Add("发送 失败（对端返回无效）");
@@ -316,6 +321,7 @@ public class PeerSyncController : ControllerBase
                     }
                     else
                     {
+                        anyPeerContact = true;
                         perItem.Add("发送 " + (outcome.Message ?? "完成"));
                         if (outcome.Failed > 0) { itemOk = false; pushOk = false; anyFail = true; }
                     }
@@ -331,6 +337,7 @@ public class PeerSyncController : ControllerBase
                         anyFail = true;
                         continue;
                     }
+                    anyPeerContact = true; // bundle != null = 对端 HTTP 200 应答 = 通信成功
                     var outcome = await resource.ApplyAsync(bundle, actor, mode, itemId, ct);
                     perItem.Add("拉取 " + (outcome.Message ?? "完成"));
                     if (outcome.Failed > 0) { itemOk = false; anyFail = true; }
@@ -349,9 +356,12 @@ public class PeerSyncController : ControllerBase
             }
         }
 
-        await _db.PeerNodes.UpdateOneAsync(n => n.Id == node.Id,
-            Builders<PeerNode>.Update.Set(n => n.LastContactAt, DateTime.UtcNow).Set(n => n.UpdatedAt, DateTime.UtcNow),
-            cancellationToken: ct);
+        // 仅在至少有一次真正与对端 HTTP 通信成功时才 bump LastContactAt（与 admin ping test 同口径），
+        // 否则字段会变成"最近 transfer 尝试时间"——偏离原文档的"最近成功通信"语义。
+        var nodeUpdate = anyPeerContact
+            ? Builders<PeerNode>.Update.Set(n => n.LastContactAt, DateTime.UtcNow).Set(n => n.UpdatedAt, DateTime.UtcNow)
+            : Builders<PeerNode>.Update.Set(n => n.UpdatedAt, DateTime.UtcNow);
+        await _db.PeerNodes.UpdateOneAsync(n => n.Id == node.Id, nodeUpdate, cancellationToken: ct);
 
         return Ok(ApiResponse<object>.Ok(new { direction, results, anyFail }));
     }

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/PeerSyncController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/PeerSyncController.cs
@@ -27,6 +27,7 @@ public class PeerSyncController : ControllerBase
     private readonly ISyncResourceRegistry _registry;
     private readonly ISafeOutboundUrlValidator _urlValidator;
     private readonly IHttpClientFactory _httpFactory;
+    private readonly IAdminPermissionService _permissionService;
     private readonly ILogger<PeerSyncController> _logger;
 
     private static readonly JsonSerializerOptions JsonOpts = new()
@@ -41,6 +42,7 @@ public class PeerSyncController : ControllerBase
         ISyncResourceRegistry registry,
         ISafeOutboundUrlValidator urlValidator,
         IHttpClientFactory httpFactory,
+        IAdminPermissionService permissionService,
         ILogger<PeerSyncController> logger)
     {
         _db = db;
@@ -48,6 +50,7 @@ public class PeerSyncController : ControllerBase
         _registry = registry;
         _urlValidator = urlValidator;
         _httpFactory = httpFactory;
+        _permissionService = permissionService;
         _logger = logger;
     }
 
@@ -454,13 +457,26 @@ public class PeerSyncController : ControllerBase
         var user = await _db.Users.Find(u => u.UserId == userId).FirstOrDefaultAsync(ct);
         var name = user != null && !string.IsNullOrWhiteSpace(user.DisplayName) ? user.DisplayName
             : (user?.Username ?? "同步");
-        // 从 HttpContext 取出权限位（与 AdminPermissionMiddleware / 各 controller 的判定保持一致）。
-        // - IsAdmin = super / AI 超级访问 → 跨资源放行全域
-        // - Permissions = 完整权限位列表 → 资源按模块权限自决（如 defect-agent.manage / document-store.write）
-        // PR #742 review fix：之前 IsAdmin 仅看 super，defect-agent.manage 持有者看不到/推不动他们管理的项目。
-        var perms = User.FindAll("permissions").Select(c => c.Value).ToHashSet(StringComparer.Ordinal);
-        var isSuper = perms.Contains(AdminPermissionCatalog.Super)
+
+        // PR #742 review P2 fix：AdminPermissionMiddleware 只对 [AdminController] 路由注入 permissions claim。
+        // PeerSyncController 不是 admin controller，于是用户端点的 HttpContext.User 里 permissions 多半为空 —
+        // 之前的实现把 root/super/defect-agent.manage 用户全当作普通用户。
+        // 改成在这里主动调 IAdminPermissionService.GetEffectivePermissionsAsync（中间件同款数据源），
+        // 取得 system role + allow - deny 的有效权限集，保证资源层得到的 actor 视角准确。
+        var isRoot = string.Equals(User.FindFirst("isRoot")?.Value, "1", StringComparison.Ordinal)
             || string.Equals(User.FindFirst("isAiSuperAccess")?.Value, "1", StringComparison.Ordinal);
+        IReadOnlyCollection<string> perms;
+        try
+        {
+            var list = await _permissionService.GetEffectivePermissionsAsync(userId, isRoot, ct);
+            perms = list.ToHashSet(StringComparer.Ordinal);
+        }
+        catch
+        {
+            // 兜底：极端故障下退回 claims（不至于直接拒绝服务）
+            perms = User.FindAll("permissions").Select(c => c.Value).ToHashSet(StringComparer.Ordinal);
+        }
+        var isSuper = isRoot || perms.Contains(AdminPermissionCatalog.Super);
         return new SyncActor(userId, name, user?.Email, IsAdmin: isSuper, Permissions: perms);
     }
 

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/PeerSyncController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/PeerSyncController.cs
@@ -266,8 +266,10 @@ public class PeerSyncController : ControllerBase
         var direction = (request.Direction ?? "push").Trim().ToLowerInvariant();
         if (direction is not ("push" or "pull" or "both"))
             return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "方向无效（push/pull/both）"));
-        if (direction == "both" && !resource.SupportsBidirectional)
-            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, $"{resource.DisplayName}不支持双向同步"));
+        // PR #742 review P2：非双向资源拒绝 pull/both，否则 push-only 的 DefectSyncResource 等会被绕过状态机
+        // 反向 import 对端数据（例如把对端的 resolved 缺陷拉回本地覆盖本地未结的状态）。
+        if (!resource.SupportsBidirectional && direction != "push")
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, $"{resource.DisplayName}是单向（push-only）资源，不支持 {direction}"));
 
         var mode = request.Mode == "add-only" ? SyncApplyMode.AddOnly : SyncApplyMode.Overwrite;
         var actor = await BuildActorAsync(this.GetRequiredUserId(), ct);

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/PeerSyncController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/PeerSyncController.cs
@@ -68,9 +68,20 @@ public class PeerSyncController : ControllerBase
             || string.IsNullOrWhiteSpace(payload.InitiatorNodeId) || string.IsNullOrWhiteSpace(payload.InitiatorBaseUrl))
             return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "握手请求缺少必要信息"));
 
+        // PR #742 review fix：软校验前置 — 自指 / SSRF 这类配置错误不消费一次性配对码，
+        // 否则管理员每次填错都要重发码。先做不需要 DB 状态的校验，再原子 claim。
+        var selfNodeId = await _peer.GetSelfNodeIdAsync(ct);
+        if (payload.InitiatorNodeId == selfNodeId)
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "不能与本节点自己配对"));
+
+        // SSRF 校验发起方回连地址
+        var initiatorBaseUrl = payload.InitiatorBaseUrl.Trim().TrimEnd('/');
+        try { await _urlValidator.EnsureSafeHttpUrlAsync(initiatorBaseUrl, "peer-sync", ct); }
+        catch (Exception ex) { return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, $"发起方地址不合法：{ex.Message}")); }
+
         // 原子 claim 配对码（PR #742 review fix）：FindOneAndUpdate 以「未使用 + 未过期」为条件，
         // 命中即刻把 Used 设为 true 并落 UsedByNodeId。并发 handshake 同一码只有一方拿得到，
-        // 失败方拿到 null，直接 401。避免「先读后写」窗口里两个发起方各拿到不同 secret 的紫绳。
+        // 失败方拿到 null，直接 401。避免「先读后写」窗口里两个发起方各拿到不同 secret。
         var nowUtc = DateTime.UtcNow;
         var claimFilter = Builders<PeerPairingCode>.Filter.And(
             Builders<PeerPairingCode>.Filter.Eq(c => c.Id, payload.PairingCode),
@@ -85,15 +96,6 @@ public class PeerSyncController : ControllerBase
             ct);
         if (code == null)
             return StatusCode(401, ApiResponse<object>.Fail(ErrorCodes.UNAUTHORIZED, "配对码无效、已使用或已过期"));
-
-        var selfNodeId = await _peer.GetSelfNodeIdAsync(ct);
-        if (payload.InitiatorNodeId == selfNodeId)
-            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "不能与本节点自己配对"));
-
-        // SSRF 校验发起方回连地址
-        var initiatorBaseUrl = payload.InitiatorBaseUrl.Trim().TrimEnd('/');
-        try { await _urlValidator.EnsureSafeHttpUrlAsync(initiatorBaseUrl, "peer-sync", ct); }
-        catch (Exception ex) { return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, $"发起方地址不合法：{ex.Message}")); }
 
         var secret = PrdAgent.Infrastructure.Services.PeerNodeService.GenerateSharedSecret();
         var existing = await _db.PeerNodes.Find(n => n.RemoteNodeId == payload.InitiatorNodeId).FirstOrDefaultAsync(ct);
@@ -292,6 +294,7 @@ public class PeerSyncController : ControllerBase
                 // outcome 为 null（对端返回无效）、bundle 为 null 都判失败，前端可正确标红、不再误显示"成功"。
                 var perItem = new List<string>();
                 var itemOk = true;
+                var pushOk = true;
                 if (direction is "push" or "both")
                 {
                     var bundle = await resource.ExportAsync(itemId, actor, ct);
@@ -306,15 +309,18 @@ public class PeerSyncController : ControllerBase
                     {
                         perItem.Add("发送 失败（对端返回无效）");
                         itemOk = false;
+                        pushOk = false;
                         anyFail = true;
                     }
                     else
                     {
                         perItem.Add("发送 " + (outcome.Message ?? "完成"));
-                        if (outcome.Failed > 0) { itemOk = false; anyFail = true; }
+                        if (outcome.Failed > 0) { itemOk = false; pushOk = false; anyFail = true; }
                     }
                 }
-                if (direction is "pull" or "both")
+                // PR #742 review High：both 模式下若 push 失败仍跑 pull 会用对端覆盖本地未推上去的改动 ——
+                // 用户的本地编辑可能被丢。语义应为「先推后拉，推不通就不拉」，避免静默数据丢失。
+                if (direction == "pull" || (direction == "both" && pushOk))
                 {
                     var bundle = await PullFromPeerAsync(node, resource.ResourceType, itemId, ct);
                     if (bundle == null)
@@ -326,6 +332,10 @@ public class PeerSyncController : ControllerBase
                     var outcome = await resource.ApplyAsync(bundle, actor, mode, itemId, ct);
                     perItem.Add("拉取 " + (outcome.Message ?? "完成"));
                     if (outcome.Failed > 0) { itemOk = false; anyFail = true; }
+                }
+                else if (direction == "both" && !pushOk)
+                {
+                    perItem.Add("拉取 已跳过（push 未成功，避免对端覆盖本地未推上去的改动）");
                 }
                 results.Add(new { itemId, ok = itemOk, message = string.Join("；", perItem) });
             }

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/PeerSyncController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/PeerSyncController.cs
@@ -238,6 +238,11 @@ public class PeerSyncController : ControllerBase
             .FirstOrDefaultAsync(ct);
         if (node == null) return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "对端节点不存在或未连接"));
 
+        // 防自指：对端 RemoteNodeId 等于本节点 selfNodeId（共享 DB 误配等）→ 拒绝，避免同 DB 自互传。
+        var selfNodeId = await _peer.GetSelfNodeIdAsync(ct);
+        if (node.RemoteNodeId == selfNodeId)
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "该对端实际指向本节点自己（同 nodeId / 共享数据库），不能互传"));
+
         var resource = _registry.Resolve(request.ResourceType);
         if (resource == null) return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, "资源类型未注册"));
 
@@ -346,6 +351,12 @@ public class PeerSyncController : ControllerBase
             return (null, body, Unauthorized(ApiResponse<object>.Fail(ErrorCodes.UNAUTHORIZED, "缺少节点签名头")));
 
         var remoteNodeId = nodeIdVals.ToString();
+        // 防自指（shared-DB / 配置错误兜底）：发起方 nodeId 等于本节点 selfNodeId 时直接拒绝，
+        // 避免在共享数据库部署下发生「自己签自己」的伪互传。
+        var selfNodeId = await _peer.GetSelfNodeIdAsync(ct);
+        if (remoteNodeId == selfNodeId)
+            return (null, body, Unauthorized(ApiResponse<object>.Fail(ErrorCodes.UNAUTHORIZED, "不能与本节点自己同步（同 nodeId）")));
+
         var node = await _db.PeerNodes.Find(n => n.RemoteNodeId == remoteNodeId).FirstOrDefaultAsync(ct);
         if (node == null || string.IsNullOrEmpty(node.SharedSecret))
             return (null, body, Unauthorized(ApiResponse<object>.Fail(ErrorCodes.UNAUTHORIZED, "未知或未配对的节点")));

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/PeerSyncController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/PeerSyncController.cs
@@ -445,10 +445,13 @@ public class PeerSyncController : ControllerBase
         var name = user != null && !string.IsNullOrWhiteSpace(user.DisplayName) ? user.DisplayName
             : (user?.Username ?? "同步");
         // 从 HttpContext 取出权限位（与 AdminPermissionMiddleware / 各 controller 的判定保持一致）。
-        // SuperUser / isAiSuperAccess 视为管理员；具体资源可以再用更细的权限位收敛（如 defect-agent.manage）。
-        var isSuper = User.FindAll("permissions").Any(c => c.Value == AdminPermissionCatalog.Super)
+        // - IsAdmin = super / AI 超级访问 → 跨资源放行全域
+        // - Permissions = 完整权限位列表 → 资源按模块权限自决（如 defect-agent.manage / document-store.write）
+        // PR #742 review fix：之前 IsAdmin 仅看 super，defect-agent.manage 持有者看不到/推不动他们管理的项目。
+        var perms = User.FindAll("permissions").Select(c => c.Value).ToHashSet(StringComparer.Ordinal);
+        var isSuper = perms.Contains(AdminPermissionCatalog.Super)
             || string.Equals(User.FindFirst("isAiSuperAccess")?.Value, "1", StringComparison.Ordinal);
-        return new SyncActor(userId, name, user?.Email, IsAdmin: isSuper);
+        return new SyncActor(userId, name, user?.Email, IsAdmin: isSuper, Permissions: perms);
     }
 
     private static T? Deserialize<T>(string body) where T : class

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/PeerSyncController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/PeerSyncController.cs
@@ -199,12 +199,15 @@ public class PeerSyncController : ControllerBase
     // 用户发起（需登录）
     // ═══════════════════════════════════════════════════════════════
 
-    /// <summary>列出可发送的对端节点（已连接，不含 secret）+ 本节点支持的资源能力。</summary>
+    /// <summary>列出可发送的对端节点（已连接，不含 secret）+ 本节点支持的资源能力。
+    /// 过滤掉 RemoteNodeId == selfNodeId 的影子记录（CDS 共享 DB 部署的产物，生产环境不会有）。</summary>
     [Authorize]
     [HttpGet("nodes")]
     public async Task<IActionResult> ListNodes(CancellationToken ct)
     {
-        var nodes = await _db.PeerNodes.Find(n => n.Status == PeerNodeStatus.Connected)
+        var selfNodeId = await _peer.GetSelfNodeIdAsync(ct);
+        var nodes = await _db.PeerNodes
+            .Find(n => n.Status == PeerNodeStatus.Connected && n.RemoteNodeId != selfNodeId)
             .SortBy(n => n.DisplayName).ToListAsync(ct);
         return Ok(ApiResponse<object>.Ok(new
         {

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/PeerSyncController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/PeerSyncController.cs
@@ -212,6 +212,13 @@ public class PeerSyncController : ControllerBase
         if (req == null || req.Bundle == null)
             return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "缺少 bundle"));
 
+        // PR #742 review Medium fix：URL 段 {type} 决定走哪个 handler，但 bundle 自带 ResourceType。
+        // 不校验匹配，配对节点可以把知识库 bundle POST 到 /defect-agent/apply，导致 defect resource
+        // 拿着文档记录硬塞 DefectReport，数据形状错位污染。要求两者一致才放行。
+        if (!string.Equals(req.Bundle.ResourceType, resource.ResourceType, StringComparison.Ordinal))
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT,
+                $"bundle.resourceType={req.Bundle.ResourceType} 与端点 {resource.ResourceType} 不匹配"));
+
         var actor = await BuildActorAsync(node!.CreatedBy, ct);
         var mode = req.Mode == "add-only" ? SyncApplyMode.AddOnly : SyncApplyMode.Overwrite;
         var outcome = await resource.ApplyAsync(req.Bundle, actor, mode, req.TargetKey, ct);

--- a/prd-api/src/PrdAgent.Api/Program.cs
+++ b/prd-api/src/PrdAgent.Api/Program.cs
@@ -136,6 +136,8 @@ builder.Services.AddSingleton<PrdAgent.Core.Interfaces.IPeerNodeService,
     PrdAgent.Infrastructure.Services.PeerNodeService>();
 builder.Services.AddScoped<PrdAgent.Core.Sync.ISyncableResource,
     PrdAgent.Infrastructure.Sync.Resources.DocumentStoreSyncResource>();
+builder.Services.AddScoped<PrdAgent.Core.Sync.ISyncableResource,
+    PrdAgent.Infrastructure.Sync.Resources.DefectSyncResource>();
 builder.Services.AddScoped<PrdAgent.Core.Sync.ISyncResourceRegistry,
     PrdAgent.Infrastructure.Sync.SyncResourceRegistry>();
 
@@ -280,6 +282,13 @@ builder.Services.AddSingleton<PrdAgent.Core.Interfaces.ISkillAgentSessionStore, 
 
 // 文档订阅同步引擎。用户可控 URL 禁止自动重定向，避免首跳校验后跳入内网。
 builder.Services.AddHttpClient("DocumentSync")
+    .ConfigurePrimaryHttpMessageHandler(sp =>
+        sp.GetRequiredService<PrdAgent.Infrastructure.Services.ISafeOutboundHttpHandlerFactory>().CreateHandler());
+
+// 系统级跨节点互传 HttpClient（PR #742 review fix）。
+// 对端 baseUrl 是管理员配置 + ISafeOutboundUrlValidator 把过的，但默认 HttpClientHandler 会自动跟随
+// 重定向 —— 恶意对端响应 3xx 跳内网即可绕过首跳校验。挂 SafeOutbound handler 禁自动跟随。
+builder.Services.AddHttpClient("PeerSync")
     .ConfigurePrimaryHttpMessageHandler(sp =>
         sp.GetRequiredService<PrdAgent.Infrastructure.Services.ISafeOutboundHttpHandlerFactory>().CreateHandler());
 builder.Services.AddHostedService<PrdAgent.Api.Services.DocumentSyncWorker>();

--- a/prd-api/src/PrdAgent.Api/Program.cs
+++ b/prd-api/src/PrdAgent.Api/Program.cs
@@ -131,6 +131,14 @@ builder.Services.AddSingleton<ISafeOutboundUrlValidator, PrdAgent.Infrastructure
 builder.Services.AddSingleton<PrdAgent.Infrastructure.Services.ISafeOutboundHttpHandlerFactory,
     PrdAgent.Infrastructure.Services.SafeOutboundHttpHandlerFactory>();
 
+// 系统级跨节点互传（Peer Sync）—— 详见 doc/design.peer-sync.md
+builder.Services.AddSingleton<PrdAgent.Core.Interfaces.IPeerNodeService,
+    PrdAgent.Infrastructure.Services.PeerNodeService>();
+builder.Services.AddScoped<PrdAgent.Core.Sync.ISyncableResource,
+    PrdAgent.Infrastructure.Sync.Resources.DocumentStoreSyncResource>();
+builder.Services.AddScoped<PrdAgent.Core.Sync.ISyncResourceRegistry,
+    PrdAgent.Infrastructure.Sync.SyncResourceRegistry>();
+
 // LLM 请求上下文与日志（旁路写入，便于后台调试）
 builder.Services.AddSingleton<ILLMRequestContextAccessor, LLMRequestContextAccessor>();
 builder.Services.AddSingleton<LlmRequestLogBackground>();

--- a/prd-api/src/PrdAgent.Core/Interfaces/IPeerNodeService.cs
+++ b/prd-api/src/PrdAgent.Core/Interfaces/IPeerNodeService.cs
@@ -1,0 +1,18 @@
+using PrdAgent.Core.Models;
+
+namespace PrdAgent.Core.Interfaces;
+
+/// <summary>
+/// 系统级跨节点互传的节点身份与 HMAC 鉴权服务。详见 doc/design.peer-sync.md §5.1。
+/// </summary>
+public interface IPeerNodeService
+{
+    /// <summary>取本节点稳定标识（复用 AppSettings.MapInstanceId，首次惰性生成）。</summary>
+    Task<string> GetSelfNodeIdAsync(CancellationToken ct = default);
+
+    /// <summary>生成 HMAC 签名头：返回 (ts, sign)。body 为已序列化的请求体（无则空串）。</summary>
+    (string ts, string sign) Sign(string sharedSecret, string method, string path, string body);
+
+    /// <summary>校验对端请求签名（时间戳偏移超 maxSkew 拒绝，防重放）。</summary>
+    bool Verify(string sharedSecret, string method, string path, string body, string ts, string sign);
+}

--- a/prd-api/src/PrdAgent.Core/Models/PeerNode.cs
+++ b/prd-api/src/PrdAgent.Core/Models/PeerNode.cs
@@ -1,0 +1,74 @@
+namespace PrdAgent.Core.Models;
+
+/// <summary>
+/// 对端节点（系统级跨节点互传）。
+/// 一条记录 = 本节点记录的「我认识的另一个 MAP 实例」（如测试环境记录正式环境）。
+/// 配对成功后，两个节点各存一条互指的 PeerNode，持有相同的 SharedSecret，
+/// 后续所有跨节点数据请求用 HMAC-SHA256 签名鉴权，不再传明文令牌。
+/// 详见 doc/design.peer-sync.md。
+/// </summary>
+public class PeerNode
+{
+    /// <summary>主键（Guid）</summary>
+    public string Id { get; set; } = Guid.NewGuid().ToString("N");
+
+    /// <summary>对端节点稳定标识（对端的 selfNodeId）</summary>
+    public string RemoteNodeId { get; set; } = string.Empty;
+
+    /// <summary>对端展示名（如「正式环境」），配对时由对端 handshake 返回 / 本端可改</summary>
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>对端 baseUrl（含可能的子路径前缀，如 https://xxx.miduo.org/prod）</summary>
+    public string BaseUrl { get; set; } = string.Empty;
+
+    /// <summary>双方共享密钥（base64，仅后端可见，永不出现在 URL / 日志 / 前端）。HMAC 签名用。</summary>
+    public string SharedSecret { get; set; } = string.Empty;
+
+    /// <summary>状态：pending（待握手）/ connected（已连接）/ error（通信异常）</summary>
+    public string Status { get; set; } = PeerNodeStatus.Pending;
+
+    /// <summary>最近一次通信错误信息</summary>
+    public string? LastError { get; set; }
+
+    /// <summary>最近一次成功通信时间</summary>
+    public DateTime? LastContactAt { get; set; }
+
+    /// <summary>配对发起的管理员 userId</summary>
+    public string CreatedBy { get; set; } = string.Empty;
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}
+
+/// <summary>对端节点状态常量</summary>
+public static class PeerNodeStatus
+{
+    public const string Pending = "pending";
+    public const string Connected = "connected";
+    public const string Error = "error";
+}
+
+/// <summary>
+/// 一次性配对码（管理员握手用，短 TTL，握手成功即失效）。
+/// 集合 peer_pairing_codes，Id 即配对码本身。
+/// </summary>
+public class PeerPairingCode
+{
+    /// <summary>配对码（即主键，高熵随机串）</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>生成该配对码的管理员 userId</summary>
+    public string CreatedBy { get; set; } = string.Empty;
+
+    /// <summary>过期时间（默认 5 分钟）</summary>
+    public DateTime ExpiresAt { get; set; } = DateTime.UtcNow.AddMinutes(5);
+
+    /// <summary>是否已被使用（一次性）</summary>
+    public bool Used { get; set; }
+
+    /// <summary>使用方（握手成功后记录对端 nodeId，审计用）</summary>
+    public string? UsedByNodeId { get; set; }
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/prd-api/src/PrdAgent.Core/Security/AdminPermissionCatalog.cs
+++ b/prd-api/src/PrdAgent.Core/Security/AdminPermissionCatalog.cs
@@ -307,6 +307,11 @@ public static class AdminPermissionCatalog
     public const string PaAgentUse = "pa-agent.use";
 
     /// <summary>
+    /// 系统互联管理权限：配置跨节点互传的对端节点（测试↔正式环境配对），管理员级。
+    /// </summary>
+    public const string PeerSyncManage = "peer-sync.manage";
+
+    /// <summary>
     /// 超级权限（当路由未配置映射时，用于兜底放行；同时也可用于 root 破窗全权限）。
     /// </summary>
     public const string Super = "super";
@@ -415,6 +420,8 @@ public static class AdminPermissionCatalog
 
         new(CcasAgentUse, "赋码采集关联系统智能体", "产线赋码业务的 PRD 生成 + 设备素材库 + 流程示意图绘制"),
         new(PaAgentUse, "私人助理 Agent", "任务拆解、四象限排序、任务清单管理"),
+
+        new(PeerSyncManage, "系统互联-管理", "配置跨节点互传的对端节点（测试↔正式环境配对）"),
 
         new(DailyTipsRead, "小技巧-读", "查看小技巧列表（管理视图）"),
         new(DailyTipsWrite, "小技巧-写", "新建/编辑/删除首页小技巧与引导卡片"),

--- a/prd-api/src/PrdAgent.Core/Sync/ISyncResourceRegistry.cs
+++ b/prd-api/src/PrdAgent.Core/Sync/ISyncResourceRegistry.cs
@@ -1,0 +1,14 @@
+namespace PrdAgent.Core.Sync;
+
+/// <summary>
+/// 可同步资源注册表：按 ResourceType 索引所有 ISyncableResource 实现。
+/// 新增资源 = 加实现类 + DI 注册，端点零改动。
+/// </summary>
+public interface ISyncResourceRegistry
+{
+    /// <summary>列出所有已注册资源的能力声明。</summary>
+    IReadOnlyList<SyncResourceCapability> Capabilities { get; }
+
+    /// <summary>按类型取资源实现，未注册返回 null。</summary>
+    ISyncableResource? Resolve(string resourceType);
+}

--- a/prd-api/src/PrdAgent.Core/Sync/ISyncableResource.cs
+++ b/prd-api/src/PrdAgent.Core/Sync/ISyncableResource.cs
@@ -1,0 +1,38 @@
+namespace PrdAgent.Core.Sync;
+
+/// <summary>
+/// 可跨节点互传的业务资源。任何应用实现本接口 + DI 注册即可接入系统级互传，
+/// PeerSyncController 端点零改动。详见 doc/design.peer-sync.md §5.2。
+///
+/// 计算/发送分离：ExportAsync 是纯计算（导出 bundle），发送由 PeerSyncController 统一负责；
+/// ApplyAsync 是接收侧落库（按用户名对齐归属）。
+/// </summary>
+public interface ISyncableResource
+{
+    /// <summary>资源类型标识（kebab-case，如 "document-store"），全局唯一。</summary>
+    string ResourceType { get; }
+
+    /// <summary>展示名（如「知识库」）。</summary>
+    string DisplayName { get; }
+
+    /// <summary>是否支持双向同步（知识库 true，其它资源先 false）。</summary>
+    bool SupportsBidirectional { get; }
+
+    /// <summary>本节点当前 schema 版本。</summary>
+    int SchemaVersion { get; }
+
+    /// <summary>列出本节点当前用户【可发送】的条目（供「发送到」弹窗展示）。</summary>
+    Task<IReadOnlyList<SyncItemSummary>> ListItemsAsync(SyncActor actor, CancellationToken ct);
+
+    /// <summary>导出一个条目为 bundle（计算阶段）。条目不存在 / 无权访问返回 null。</summary>
+    Task<SyncResourceBundle?> ExportAsync(string itemId, SyncActor actor, CancellationToken ct);
+
+    /// <summary>计算条目内容签名（变更检测用，不加载正文，廉价）。条目不存在返回 null。</summary>
+    Task<string?> ComputeSignatureAsync(string itemId, CancellationToken ct);
+
+    /// <summary>
+    /// 把 bundle 落到本节点（接收阶段），按用户名/邮箱对齐归属。
+    /// targetKey 为对端指定的目标条目键（双向 / 指定目标时用；为空则按 bundle.Item.Key 解析或新建）。
+    /// </summary>
+    Task<SyncApplyOutcome> ApplyAsync(SyncResourceBundle bundle, SyncActor actor, SyncApplyMode mode, string? targetKey, CancellationToken ct);
+}

--- a/prd-api/src/PrdAgent.Core/Sync/SyncContracts.cs
+++ b/prd-api/src/PrdAgent.Core/Sync/SyncContracts.cs
@@ -17,7 +17,8 @@ namespace PrdAgent.Core.Sync;
 public sealed record SyncActor(
     string UserId,        // 本节点操作者 userId（接收侧用于兜底归属）
     string UserName,      // 本节点操作者用户名
-    string? Email)        // 本节点操作者邮箱（可空）
+    string? Email,        // 本节点操作者邮箱（可空）
+    bool IsAdmin = false) // 是否持有超级 / 管理权限（资源 ListItemsAsync 据此放行全域 vs. 仅自己）
 {
     /// <summary>
     /// 受信对端节点身份（node-to-node 导出时使用）。该路径已被 HMAC 验签门禁，
@@ -26,7 +27,7 @@ public sealed record SyncActor(
     /// </summary>
     public const string PeerSystemUserId = "__peer_node__";
 
-    public static SyncActor PeerSystem => new(PeerSystemUserId, "对端节点", null);
+    public static SyncActor PeerSystem => new(PeerSystemUserId, "对端节点", null, IsAdmin: true);
 
     public bool IsPeerSystem => UserId == PeerSystemUserId;
 }

--- a/prd-api/src/PrdAgent.Core/Sync/SyncContracts.cs
+++ b/prd-api/src/PrdAgent.Core/Sync/SyncContracts.cs
@@ -1,0 +1,141 @@
+using System.Text.Json;
+
+namespace PrdAgent.Core.Sync;
+
+/// <summary>
+/// 跨节点互传通用契约。详见 doc/design.peer-sync.md §5.2 / §7.3。
+///
+/// 设计原则（compute-then-send + 向下兼容）：
+/// - 发起方调用 ISyncableResource.ExportAsync 得到 SyncResourceBundle（计算阶段），
+///   再通过 HMAC 调对端的 apply 端点（发送阶段），发送阶段不再 resolve 业务状态。
+/// - 每个 bundle / record 带 schemaVersion + Extras 字典：接收方遇到不认识的字段原样保留在
+///   Extras，不丢弃、不报错；缺字段用本节点默认值兜底。任一节点升级加字段都不破旧节点。
+/// - 归属按用户名/邮箱对齐（不带 userId，userId 跨节点无意义）。
+/// </summary>
+
+/// <summary>发起 / 接收互传的操作者上下文（当前登录用户 / 对端归属信息）。</summary>
+public sealed record SyncActor(
+    string UserId,        // 本节点操作者 userId（接收侧用于兜底归属）
+    string UserName,      // 本节点操作者用户名
+    string? Email)        // 本节点操作者邮箱（可空）
+{
+    /// <summary>
+    /// 受信对端节点身份（node-to-node 导出时使用）。该路径已被 HMAC 验签门禁，
+    /// 只有已配对的可信节点能到达，故导出绕过「按登录用户」的访问校验。
+    /// 不可用于接收侧归属兜底（那里要用真实管理员 userId）。
+    /// </summary>
+    public const string PeerSystemUserId = "__peer_node__";
+
+    public static SyncActor PeerSystem => new(PeerSystemUserId, "对端节点", null);
+
+    public bool IsPeerSystem => UserId == PeerSystemUserId;
+}
+
+/// <summary>同步应用模式。</summary>
+public enum SyncApplyMode
+{
+    /// <summary>覆盖式：以发起方为准（共享条目对端被覆盖，两侧新增都保留）。</summary>
+    Overwrite = 0,
+
+    /// <summary>仅新增：对端已存在的条目跳过，不覆盖。</summary>
+    AddOnly = 1,
+}
+
+/// <summary>资源条目摘要（列出本节点当前用户可发送的条目，供「发送到」弹窗展示）。</summary>
+public sealed class SyncItemSummary
+{
+    public string ItemId { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    /// <summary>条目内含的记录数（如知识库的文档数），UI 展示用。</summary>
+    public int RecordCount { get; set; }
+    public DateTime? UpdatedAt { get; set; }
+}
+
+/// <summary>资源的可同步能力声明。</summary>
+public sealed class SyncResourceCapability
+{
+    public string ResourceType { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
+    /// <summary>是否支持双向同步（知识库 true，其它资源先 false）。</summary>
+    public bool SupportsBidirectional { get; set; }
+    /// <summary>本节点当前 schema 版本。</summary>
+    public int SchemaVersion { get; set; } = 1;
+}
+
+/// <summary>跨节点传输的一个资源条目（HTTP body，不落库）。</summary>
+public sealed class SyncResourceBundle
+{
+    /// <summary>本 bundle 的 schema 版本（发起方节点的版本）。</summary>
+    public int SchemaVersion { get; set; } = 1;
+
+    /// <summary>资源类型，如 "document-store"。</summary>
+    public string ResourceType { get; set; } = string.Empty;
+
+    /// <summary>条目级元信息（名称、标签、归属作者用户名/邮箱等）。</summary>
+    public SyncBundleItem Item { get; set; } = new();
+
+    /// <summary>条目内的记录（如知识库的每篇文档 / 文件夹）。</summary>
+    public List<SyncRecord> Records { get; set; } = new();
+}
+
+/// <summary>条目级元信息。</summary>
+public sealed class SyncBundleItem
+{
+    /// <summary>稳定条目键（跨节点对齐用，知识库即 storeId；保留同一 id 便于 test↔prod 同库）。</summary>
+    public string Key { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public List<string>? Tags { get; set; }
+
+    /// <summary>归属作者用户名（接收方按此对齐本节点用户）。</summary>
+    public string? OwnerUserName { get; set; }
+    /// <summary>归属作者邮箱（用户名未命中时按邮箱对齐）。</summary>
+    public string? OwnerEmail { get; set; }
+
+    /// <summary>未知 / 扩展字段（向下兼容：接收方不认识就原样保留）。</summary>
+    public Dictionary<string, JsonElement> Extras { get; set; } = new();
+}
+
+/// <summary>条目内的一条记录（资源无关；知识库映射为一个 DocumentEntry + 正文）。</summary>
+public sealed class SyncRecord
+{
+    /// <summary>稳定血缘 ID（跨节点幂等 upsert 的对齐键）。</summary>
+    public string LineageId { get; set; } = string.Empty;
+    /// <summary>父记录血缘 ID（树形结构用，无则 null）。</summary>
+    public string? ParentLineageId { get; set; }
+
+    public bool IsFolder { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public string? Summary { get; set; }
+    public string? ContentType { get; set; }
+    public long FileSize { get; set; }
+    public List<string>? Tags { get; set; }
+
+    /// <summary>正文内容（文件夹 / 二进制为 null；空字符串是合法的空文本）。</summary>
+    public string? Content { get; set; }
+
+    /// <summary>结构化元信息（如知识库 metadata）。</summary>
+    public Dictionary<string, string>? Metadata { get; set; }
+
+    /// <summary>未知 / 扩展字段（向下兼容）。</summary>
+    public Dictionary<string, JsonElement> Extras { get; set; } = new();
+}
+
+/// <summary>apply 结果。</summary>
+public sealed class SyncApplyOutcome
+{
+    public int Created { get; set; }
+    public int Updated { get; set; }
+    public int Skipped { get; set; }
+    public int Failed { get; set; }
+
+    /// <summary>对端 schema 版本高于本节点、部分字段仅保留未解释时为 true。</summary>
+    public bool Partial { get; set; }
+
+    /// <summary>未对齐归属的记录数（已归到操作者名下）。</summary>
+    public int UnmatchedAuthors { get; set; }
+
+    /// <summary>人类可读摘要。</summary>
+    public string? Message { get; set; }
+}

--- a/prd-api/src/PrdAgent.Core/Sync/SyncContracts.cs
+++ b/prd-api/src/PrdAgent.Core/Sync/SyncContracts.cs
@@ -18,8 +18,12 @@ public sealed record SyncActor(
     string UserId,        // 本节点操作者 userId（接收侧用于兜底归属）
     string UserName,      // 本节点操作者用户名
     string? Email,        // 本节点操作者邮箱（可空）
-    bool IsAdmin = false) // 是否持有超级 / 管理权限（资源 ListItemsAsync 据此放行全域 vs. 仅自己）
+    bool IsAdmin = false, // 是否持有 super / AI 超级访问（资源据此放行全域）
+    IReadOnlyCollection<string>? Permissions = null) // 完整权限位（资源可按需检查 defect-agent.manage 等模块权限）
 {
+    /// <summary>检查是否持有某个具体权限位（如 "defect-agent.manage"），IsAdmin 自动放行。</summary>
+    public bool HasPermission(string permission)
+        => IsAdmin || (Permissions != null && Permissions.Contains(permission));
     /// <summary>
     /// 受信对端节点身份（node-to-node 导出时使用）。该路径已被 HMAC 验签门禁，
     /// 只有已配对的可信节点能到达，故导出绕过「按登录用户」的访问校验。

--- a/prd-api/src/PrdAgent.Infrastructure/Database/MongoDbContext.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Database/MongoDbContext.cs
@@ -297,6 +297,10 @@ public class MongoDbContext
     public IMongoCollection<KnowledgeBaseDraft> KnowledgeBaseDrafts => _database.GetCollection<KnowledgeBaseDraft>("knowledge_base_drafts");
     public IMongoCollection<DocumentStoreSyncLink> DocumentStoreSyncLinks => _database.GetCollection<DocumentStoreSyncLink>("document_store_sync_links");
 
+    // 系统级跨节点互传（Peer Sync）
+    public IMongoCollection<PeerNode> PeerNodes => _database.GetCollection<PeerNode>("peer_nodes");
+    public IMongoCollection<PeerPairingCode> PeerPairingCodes => _database.GetCollection<PeerPairingCode>("peer_pairing_codes");
+
     // Team 团队（跨应用协作单位：网页托管 + 知识库共用）
     public IMongoCollection<Team> Teams => _database.GetCollection<Team>("teams");
     public IMongoCollection<TeamMember> TeamMembers => _database.GetCollection<TeamMember>("team_members");

--- a/prd-api/src/PrdAgent.Infrastructure/Database/MongoDbContext.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Database/MongoDbContext.cs
@@ -1674,5 +1674,19 @@ public class MongoDbContext
         {
             // ignore
         }
+
+        // PeerNodes：按 RemoteNodeId 唯一 — 防并发握手/重配对产生两行同 RemoteNodeId 但不同 SharedSecret
+        // 的脏数据（VerifyPeerAsync 的 FirstOrDefault 会随机选一行致 HMAC 校验失败）。
+        // PR #742 review P2 配套：上游用 IsUpsert 原子 upsert，索引在 DB 层兜底。
+        try
+        {
+            PeerNodes.Indexes.CreateOne(new CreateIndexModel<PeerNode>(
+                Builders<PeerNode>.IndexKeys.Ascending(x => x.RemoteNodeId),
+                new CreateIndexOptions { Name = "uniq_peer_nodes_remote_node_id", Unique = true }));
+        }
+        catch (MongoCommandException ex) when (IsIndexConflict(ex))
+        {
+            // ignore
+        }
     }
 }

--- a/prd-api/src/PrdAgent.Infrastructure/Services/PeerNodeService.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/PeerNodeService.cs
@@ -90,9 +90,13 @@ public class PeerNodeService : IPeerNodeService
         if (Math.Abs(now - tsMs) > MaxSkewMs) return false;
 
         var expected = Compute(sharedSecret, method, path, ts, body);
+        var expectedBytes = Encoding.UTF8.GetBytes(expected);
+        var signBytes = Encoding.UTF8.GetBytes(sign);
+        // PR #742 review Medium fix：FixedTimeEquals 在两数组长度不同时会抛 ArgumentException，
+        // 让恶意/畸形 X-Peer-Sign 头把 [AllowAnonymous] 端点打成 500 而不是 401。先比长度。
+        if (expectedBytes.Length != signBytes.Length) return false;
         // 常量时间比较，防时序侧信道
-        return CryptographicOperations.FixedTimeEquals(
-            Encoding.UTF8.GetBytes(expected), Encoding.UTF8.GetBytes(sign));
+        return CryptographicOperations.FixedTimeEquals(expectedBytes, signBytes);
     }
 
     private static string Compute(string sharedSecret, string method, string path, string ts, string body)

--- a/prd-api/src/PrdAgent.Infrastructure/Services/PeerNodeService.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/PeerNodeService.cs
@@ -26,6 +26,12 @@ public class PeerNodeService : IPeerNodeService
 
     public async Task<string> GetSelfNodeIdAsync(CancellationToken ct = default)
     {
+        // 优先环境变量覆盖：允许同 DB 部署的不同分支（如 CDS 灰度环境共享 MongoDB）用 env
+        // 强制不同 nodeId 以测试互传；也用于运维需要重置节点身份的场景。
+        var envOverride = Environment.GetEnvironmentVariable("PEER_NODE_ID_OVERRIDE");
+        if (!string.IsNullOrWhiteSpace(envOverride))
+            return envOverride.Trim();
+
         var existing = await _db.AppSettings.Find(s => s.Id == "global").FirstOrDefaultAsync(ct);
         if (existing != null && !string.IsNullOrWhiteSpace(existing.MapInstanceId))
             return existing.MapInstanceId!;

--- a/prd-api/src/PrdAgent.Infrastructure/Services/PeerNodeService.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/PeerNodeService.cs
@@ -1,0 +1,95 @@
+using System.Security.Cryptography;
+using System.Text;
+using MongoDB.Driver;
+using PrdAgent.Core.Interfaces;
+using PrdAgent.Core.Models;
+using PrdAgent.Infrastructure.Database;
+
+namespace PrdAgent.Infrastructure.Services;
+
+/// <summary>
+/// 节点身份 + HMAC 鉴权（系统级跨节点互传）。详见 doc/design.peer-sync.md §5.1。
+///
+/// 签名串：HMAC_SHA256(sharedSecret, "{METHOD}\n{path}\n{ts}\n{sha256(body)}")。
+/// 共享密钥永不出现在 URL / 日志 / 前端；时间戳偏移超 5 分钟拒绝（防重放）。
+/// </summary>
+public class PeerNodeService : IPeerNodeService
+{
+    private const int MaxSkewMs = 5 * 60 * 1000;
+
+    private readonly MongoDbContext _db;
+
+    public PeerNodeService(MongoDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task<string> GetSelfNodeIdAsync(CancellationToken ct = default)
+    {
+        var existing = await _db.AppSettings.Find(s => s.Id == "global").FirstOrDefaultAsync(ct);
+        if (existing != null && !string.IsNullOrWhiteSpace(existing.MapInstanceId))
+            return existing.MapInstanceId!;
+
+        var newId = Guid.NewGuid().ToString("N");
+        var update = Builders<AppSettings>.Update
+            .SetOnInsert(s => s.MapInstanceId, newId)
+            .SetOnInsert(s => s.UpdatedAt, DateTime.UtcNow);
+        await _db.AppSettings.UpdateOneAsync(
+            s => s.Id == "global", update, new UpdateOptions { IsUpsert = true }, ct);
+        var reloaded = await _db.AppSettings.Find(s => s.Id == "global").FirstOrDefaultAsync(ct);
+        return reloaded?.MapInstanceId ?? newId;
+    }
+
+    public (string ts, string sign) Sign(string sharedSecret, string method, string path, string body)
+    {
+        var ts = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString();
+        var sign = Compute(sharedSecret, method, path, ts, body);
+        return (ts, sign);
+    }
+
+    public bool Verify(string sharedSecret, string method, string path, string body, string ts, string sign)
+    {
+        if (string.IsNullOrEmpty(sharedSecret) || string.IsNullOrEmpty(ts) || string.IsNullOrEmpty(sign))
+            return false;
+        if (!long.TryParse(ts, out var tsMs)) return false;
+        var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        if (Math.Abs(now - tsMs) > MaxSkewMs) return false;
+
+        var expected = Compute(sharedSecret, method, path, ts, body);
+        // 常量时间比较，防时序侧信道
+        return CryptographicOperations.FixedTimeEquals(
+            Encoding.UTF8.GetBytes(expected), Encoding.UTF8.GetBytes(sign));
+    }
+
+    private static string Compute(string sharedSecret, string method, string path, string ts, string body)
+    {
+        var bodyHash = Sha256Hex(body ?? string.Empty);
+        var payload = $"{method.ToUpperInvariant()}\n{path}\n{ts}\n{bodyHash}";
+        var key = Convert.FromBase64String(NormalizeSecret(sharedSecret));
+        using var hmac = new HMACSHA256(key);
+        var hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(payload));
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    private static string NormalizeSecret(string s)
+    {
+        // SharedSecret 存的是 base64。容错：非法 base64 时按 UTF8 兜底（不应发生，但避免抛异常）。
+        try { _ = Convert.FromBase64String(s); return s; }
+        catch { return Convert.ToBase64String(Encoding.UTF8.GetBytes(s)); }
+    }
+
+    private static string Sha256Hex(string s)
+    {
+        using var sha = SHA256.Create();
+        return Convert.ToHexString(sha.ComputeHash(Encoding.UTF8.GetBytes(s ?? string.Empty))).ToLowerInvariant();
+    }
+
+    /// <summary>生成一个新的 32 字节共享密钥（base64）。</summary>
+    public static string GenerateSharedSecret()
+        => Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+
+    /// <summary>生成一个高熵一次性配对码（URL-safe）。</summary>
+    public static string GeneratePairingCode()
+        => Convert.ToBase64String(RandomNumberGenerator.GetBytes(18))
+            .Replace("+", "-").Replace("/", "_").TrimEnd('=');
+}

--- a/prd-api/src/PrdAgent.Infrastructure/Services/PeerNodeService.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/PeerNodeService.cs
@@ -36,14 +36,42 @@ public class PeerNodeService : IPeerNodeService
         if (existing != null && !string.IsNullOrWhiteSpace(existing.MapInstanceId))
             return existing.MapInstanceId!;
 
+        // 关键修复（PR #742 review P1）：旧版 SetOnInsert 在「AppSettings.global 已存在但 MapInstanceId 为空」
+        // 的升级场景下是 no-op —— 每次调用都返回新 GUID 但永不落库，导致 HMAC 身份在请求间漂移、配对失效。
+        // 改为：缺失文档时 InsertOne（带唯一约束兜底）；存在但 MapInstanceId 空时显式 $set 持久化。
         var newId = Guid.NewGuid().ToString("N");
-        var update = Builders<AppSettings>.Update
-            .SetOnInsert(s => s.MapInstanceId, newId)
-            .SetOnInsert(s => s.UpdatedAt, DateTime.UtcNow);
-        await _db.AppSettings.UpdateOneAsync(
-            s => s.Id == "global", update, new UpdateOptions { IsUpsert = true }, ct);
+        if (existing == null)
+        {
+            try
+            {
+                await _db.AppSettings.InsertOneAsync(
+                    new AppSettings { Id = "global", MapInstanceId = newId, UpdatedAt = DateTime.UtcNow },
+                    cancellationToken: ct);
+                return newId;
+            }
+            catch (MongoWriteException)
+            {
+                // 并发：另一进程刚插入。重读取它的 MapInstanceId。
+            }
+        }
+        else
+        {
+            // 文档存在但 MapInstanceId 为空：用条件 $set 落入，仅当当前仍为空时写（避免并发覆盖）。
+            var filter = Builders<AppSettings>.Filter.And(
+                Builders<AppSettings>.Filter.Eq(s => s.Id, "global"),
+                Builders<AppSettings>.Filter.Or(
+                    Builders<AppSettings>.Filter.Eq(s => s.MapInstanceId, (string?)null),
+                    Builders<AppSettings>.Filter.Eq(s => s.MapInstanceId, string.Empty)));
+            var update = Builders<AppSettings>.Update
+                .Set(s => s.MapInstanceId, newId)
+                .Set(s => s.UpdatedAt, DateTime.UtcNow);
+            await _db.AppSettings.UpdateOneAsync(filter, update, cancellationToken: ct);
+        }
         var reloaded = await _db.AppSettings.Find(s => s.Id == "global").FirstOrDefaultAsync(ct);
-        return reloaded?.MapInstanceId ?? newId;
+        if (reloaded != null && !string.IsNullOrWhiteSpace(reloaded.MapInstanceId))
+            return reloaded.MapInstanceId!;
+        // 极端兜底：不返回未持久化的 GUID 给上层（保证调用方拿到的 nodeId 永远是 DB 里那个）
+        throw new InvalidOperationException("PeerNodeService.GetSelfNodeIdAsync: 无法持久化 MapInstanceId");
     }
 
     public (string ts, string sign) Sign(string sharedSecret, string method, string path, string body)

--- a/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DefectSyncResource.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DefectSyncResource.cs
@@ -211,8 +211,13 @@ public class DefectSyncResource : ISyncableResource
             try
             {
                 // 血缘 = DefectReport.Id（跨节点保留同 id 便于 test↔prod 同库识别）
+                // PR #742 review P2：必须同时 match ProjectId，否则若同 id 已存在于其它项目，
+                // 会误把对端的更新写到无关项目里。我们只在「同 id 且同项目」时认作同一条；
+                // 同 id 但不同项目 → 当成新建（避免跨项目串号）。
                 var lineageId = r.LineageId;
-                var existing = await _db.DefectReports.Find(d => d.Id == lineageId).FirstOrDefaultAsync(ct);
+                var existing = await _db.DefectReports
+                    .Find(d => d.Id == lineageId && d.ProjectId == project.Id)
+                    .FirstOrDefaultAsync(ct);
 
                 var meta = r.Metadata ?? new Dictionary<string, string>();
                 string? Get(string k) => meta.TryGetValue(k, out var v) && !string.IsNullOrEmpty(v) ? v : null;
@@ -255,11 +260,25 @@ public class DefectSyncResource : ISyncableResource
                 if (existing != null)
                 {
                     if (addOnly) { skipped++; continue; }
-                    // 内容 + status 无变化 → 跳过避免无意义 bump
+                    // PR #742 review P2：no-op 比对必须覆盖所有可更新字段，否则只改 priority / resolution /
+                    // assigneeName / attachments / structuredData 的工作流更新会被错误地判为「无变化」而静默跳过。
+                    var existingAttSig = JsonSerializer.Serialize((existing.Attachments ?? new List<DefectAttachment>())
+                        .Select(a => new { a.FileName, a.Url, a.FileSize }).OrderBy(a => a.FileName + a.Url));
+                    var newAttSig = JsonSerializer.Serialize((attachments ?? new List<DefectAttachment>())
+                        .Select(a => new { a.FileName, a.Url, a.FileSize }).OrderBy(a => a.FileName + a.Url));
+                    var existingStructSig = JsonSerializer.Serialize((existing.StructuredData ?? new Dictionary<string, string>())
+                        .OrderBy(kv => kv.Key, StringComparer.Ordinal));
+                    var newStructSig = JsonSerializer.Serialize((structured ?? new Dictionary<string, string>())
+                        .OrderBy(kv => kv.Key, StringComparer.Ordinal));
                     if (existing.RawContent == r.Content
                         && existing.Title == r.Title
-                        && existing.Status == Get("status")
-                        && existing.Severity == Get("severity"))
+                        && existing.Status == (Get("status") ?? existing.Status)
+                        && existing.Severity == (Get("severity") ?? existing.Severity)
+                        && existing.Priority == (Get("priority") ?? existing.Priority)
+                        && existing.Resolution == (Get("resolution") ?? existing.Resolution)
+                        && existing.AssigneeName == (Get("assigneeName") ?? existing.AssigneeName)
+                        && existingAttSig == newAttSig
+                        && existingStructSig == newStructSig)
                     {
                         skipped++;
                         continue;
@@ -271,6 +290,9 @@ public class DefectSyncResource : ISyncableResource
                         .Set(x => x.Severity, Get("severity") ?? existing.Severity)
                         .Set(x => x.Priority, Get("priority") ?? existing.Priority)
                         .Set(x => x.Resolution, Get("resolution") ?? existing.Resolution)
+                        .Set(x => x.AssigneeName, Get("assigneeName") ?? existing.AssigneeName)
+                        .Set(x => x.ProjectId, project.Id)
+                        .Set(x => x.ProjectName, project.Name)
                         .Set(x => x.UpdatedAt, DateTime.UtcNow);
                     if (attachments != null) u = u.Set(x => x.Attachments, attachments);
                     if (structured != null) u = u.Set(x => x.StructuredData, structured);
@@ -279,6 +301,17 @@ public class DefectSyncResource : ISyncableResource
                 }
                 else
                 {
+                    // 跨项目串号兜底：若同 id 存在于其它项目，不插入以免 DuplicateKey；当成 skipped 并记日志。
+                    var crossProject = await _db.DefectReports
+                        .Find(d => d.Id == lineageId && d.ProjectId != project.Id)
+                        .FirstOrDefaultAsync(ct);
+                    if (crossProject != null)
+                    {
+                        _logger.LogWarning("[peer-sync] defect lineage {LineageId} already exists in different project {Other}, skipping insert to target {Target}",
+                            lineageId, crossProject.ProjectId, project.Id);
+                        skipped++;
+                        continue;
+                    }
                     DateTime parsedCreated = DateTime.UtcNow;
                     if (Get("createdAt") is string c && DateTime.TryParse(c, out var dt)) parsedCreated = dt.ToUniversalTime();
 

--- a/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DefectSyncResource.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DefectSyncResource.cs
@@ -217,6 +217,41 @@ public class DefectSyncResource : ISyncableResource
                 var meta = r.Metadata ?? new Dictionary<string, string>();
                 string? Get(string k) => meta.TryGetValue(k, out var v) && !string.IsNullOrEmpty(v) ? v : null;
 
+                // PR #742 review fix：消化 export 写入 Extras 的 attachments / structuredData，
+                // 否则附件元数据和结构化字段在对端被静默丢弃。
+                List<DefectAttachment>? attachments = null;
+                if (r.Extras.TryGetValue("attachments", out var attEl) && attEl.ValueKind == JsonValueKind.Array)
+                {
+                    try
+                    {
+                        attachments = new List<DefectAttachment>();
+                        foreach (var item in attEl.EnumerateArray())
+                        {
+                            attachments.Add(new DefectAttachment
+                            {
+                                FileName = item.TryGetProperty("fileName", out var fn) ? fn.GetString() ?? string.Empty : string.Empty,
+                                MimeType = item.TryGetProperty("mimeType", out var mt) ? mt.GetString() ?? string.Empty : string.Empty,
+                                FileSize = item.TryGetProperty("size", out var sz) && sz.TryGetInt64(out var lz) ? lz : 0,
+                                Url = item.TryGetProperty("url", out var u) ? u.GetString() ?? string.Empty : string.Empty,
+                                Type = item.TryGetProperty("type", out var tt) ? tt.GetString() ?? "file" : "file",
+                                Description = "（由对端互传带入，URL 在本节点环境可能不可达，需手动重传）",
+                            });
+                        }
+                    }
+                    catch { attachments = null; }
+                }
+                Dictionary<string, string>? structured = null;
+                if (r.Extras.TryGetValue("structuredData", out var sdEl) && sdEl.ValueKind == JsonValueKind.Object)
+                {
+                    try
+                    {
+                        structured = new Dictionary<string, string>();
+                        foreach (var prop in sdEl.EnumerateObject())
+                            structured[prop.Name] = prop.Value.ValueKind == JsonValueKind.String ? prop.Value.GetString() ?? string.Empty : prop.Value.ToString();
+                    }
+                    catch { structured = null; }
+                }
+
                 if (existing != null)
                 {
                     if (addOnly) { skipped++; continue; }
@@ -237,6 +272,8 @@ public class DefectSyncResource : ISyncableResource
                         .Set(x => x.Priority, Get("priority") ?? existing.Priority)
                         .Set(x => x.Resolution, Get("resolution") ?? existing.Resolution)
                         .Set(x => x.UpdatedAt, DateTime.UtcNow);
+                    if (attachments != null) u = u.Set(x => x.Attachments, attachments);
+                    if (structured != null) u = u.Set(x => x.StructuredData, structured);
                     await _db.DefectReports.UpdateOneAsync(d => d.Id == lineageId, u, cancellationToken: ct);
                     updated++;
                 }
@@ -262,6 +299,8 @@ public class DefectSyncResource : ISyncableResource
                         ProjectName = project.Name,
                         CreatedAt = parsedCreated,
                         UpdatedAt = DateTime.UtcNow,
+                        Attachments = attachments ?? new List<DefectAttachment>(),
+                        StructuredData = structured ?? new Dictionary<string, string>(),
                     };
                     await _db.DefectReports.InsertOneAsync(defect, cancellationToken: ct);
                     created++;

--- a/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DefectSyncResource.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DefectSyncResource.cs
@@ -316,14 +316,21 @@ public class DefectSyncResource : ISyncableResource
                     if (addOnly) { skipped++; continue; }
                     // PR #742 review P2：no-op 比对必须覆盖所有可更新字段，否则只改 priority / resolution /
                     // assigneeName / attachments / structuredData 的工作流更新会被错误地判为「无变化」而静默跳过。
+                    // PR #742 review P2 fix：旧版 bundle 不带 attachments/structuredData key 时
+                    // (hasAttachmentsKey/hasStructuredKey 为 false)，update 路径会保留旧值；no-op 比对
+                    // 也必须按"保留"对待，否则把本地非空字段当成"对端清空"，每次同步都 false drift。
                     var existingAttSig = JsonSerializer.Serialize((existing.Attachments ?? new List<DefectAttachment>())
                         .Select(a => new { a.FileName, a.Url, a.FileSize }).OrderBy(a => a.FileName + a.Url));
-                    var newAttSig = JsonSerializer.Serialize((attachments ?? new List<DefectAttachment>())
-                        .Select(a => new { a.FileName, a.Url, a.FileSize }).OrderBy(a => a.FileName + a.Url));
+                    var newAttSig = hasAttachmentsKey
+                        ? JsonSerializer.Serialize((attachments ?? new List<DefectAttachment>())
+                            .Select(a => new { a.FileName, a.Url, a.FileSize }).OrderBy(a => a.FileName + a.Url))
+                        : existingAttSig;
                     var existingStructSig = JsonSerializer.Serialize((existing.StructuredData ?? new Dictionary<string, string>())
                         .OrderBy(kv => kv.Key, StringComparer.Ordinal));
-                    var newStructSig = JsonSerializer.Serialize((structured ?? new Dictionary<string, string>())
-                        .OrderBy(kv => kv.Key, StringComparer.Ordinal));
+                    var newStructSig = hasStructuredKey
+                        ? JsonSerializer.Serialize((structured ?? new Dictionary<string, string>())
+                            .OrderBy(kv => kv.Key, StringComparer.Ordinal))
+                        : existingStructSig;
                     // 用 Resolved 让 no-op 比对正确处理"源端显式清空"（用空字符串 vs 缺失 key 区分）。
                     var newStatus = Resolved("status", existing.Status);
                     var newSeverity = Resolved("severity", existing.Severity);

--- a/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DefectSyncResource.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DefectSyncResource.cs
@@ -42,14 +42,16 @@ public class DefectSyncResource : ISyncableResource
     // ─── 列出可发送的缺陷项目 ───
     public async Task<IReadOnlyList<SyncItemSummary>> ListItemsAsync(SyncActor actor, CancellationToken ct)
     {
-        // PR #742 review P1 fix：必须按 actor 视角过滤，否则任意登录用户可越权拉所有缺陷项目。
+        // PR #742 review P1 fix + Medium 续修：必须按 actor 视角过滤。
         // - 受信对端节点（IsPeerSystem，来自 HMAC 验签通过的 export 请求）：全域
-        // - 本节点管理员（IsAdmin = Super / AI 超级访问）：全域
+        // - 本节点 super / AI 超级访问 → 全域
+        // - 本节点 defect-agent.manage 持有者 → 全域（与 DefectAgentController.HasManagePermission 对齐）
         // - 普通用户：仅放行自己作为 OwnerUserId 的项目（不暴露其他人项目里的缺陷）
-        //
         // 个人散列缺陷（无 ProjectId）不可通过本接口互传，避免一次拷一整个用户名下零散缺陷。
+        var canSeeAll = actor.IsPeerSystem
+            || actor.HasPermission("defect-agent.manage");
         var baseFilter = Builders<DefectProject>.Filter.Eq(p => p.IsArchived, false);
-        var visibleFilter = (actor.IsPeerSystem || actor.IsAdmin)
+        var visibleFilter = canSeeAll
             ? baseFilter
             : Builders<DefectProject>.Filter.And(
                 baseFilter,
@@ -82,7 +84,11 @@ public class DefectSyncResource : ISyncableResource
         if (project == null) return null;
         // 双闸门：即便上层 transfer 已用 ListItemsAsync 做了集合判定，本方法仍独立校验 actor 是否可读，
         // 避免对端 export 端点或未来旁路调用绕过授权。
-        if (!actor.IsPeerSystem && !actor.IsAdmin && project.OwnerUserId != actor.UserId) return null;
+        // 与 ListItemsAsync 的可见集合保持一致：PeerSystem / defect-agent.manage / 项目 OwnerUserId。
+        var canRead = actor.IsPeerSystem
+            || actor.HasPermission("defect-agent.manage")
+            || project.OwnerUserId == actor.UserId;
+        if (!canRead) return null;
 
         var defects = await _db.DefectReports
             .Find(d => d.ProjectId == project.Id && !d.IsDeleted)

--- a/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DefectSyncResource.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DefectSyncResource.cs
@@ -42,20 +42,19 @@ public class DefectSyncResource : ISyncableResource
     // ─── 列出可发送的缺陷项目 ───
     public async Task<IReadOnlyList<SyncItemSummary>> ListItemsAsync(SyncActor actor, CancellationToken ct)
     {
-        // PR #742 review P1 fix + Medium 续修：必须按 actor 视角过滤。
-        // - 受信对端节点（IsPeerSystem，来自 HMAC 验签通过的 export 请求）：全域
-        // - 本节点 super / AI 超级访问 → 全域
-        // - 本节点 defect-agent.manage 持有者 → 全域（与 DefectAgentController.HasManagePermission 对齐）
-        // - 普通用户：仅放行自己作为 OwnerUserId 的项目（不暴露其他人项目里的缺陷）
-        // 个人散列缺陷（无 ProjectId）不可通过本接口互传，避免一次拷一整个用户名下零散缺陷。
+        // PR #742 review fix（多轮闭环）：缺陷 bundle 是项目级整体导出（含他人提交/指派的报告）。
+        // DefectAgentController.ListDefects 对非管理员只放行 ReporterId/AssigneeId == userId，
+        // 这里若按"项目 OwnerUserId"放行就让非管理员的项目 owner 能通过 peer-sync 越权拉走全项目所有
+        // 报告——绕过了正常 API 的可见性。
+        // 收敛为：仅以下两类可在 peer-sync 列/导出缺陷项目：
+        //   - PeerSystem（HMAC 验签通过的对端 export 请求）
+        //   - 本节点 defect-agent.manage 持有者（含 super，被 HasPermission 自动放行）
+        // 个人散列缺陷（无 ProjectId）始终不互传。
         var canSeeAll = actor.IsPeerSystem
             || actor.HasPermission("defect-agent.manage");
-        var baseFilter = Builders<DefectProject>.Filter.Eq(p => p.IsArchived, false);
-        var visibleFilter = canSeeAll
-            ? baseFilter
-            : Builders<DefectProject>.Filter.And(
-                baseFilter,
-                Builders<DefectProject>.Filter.Eq(p => p.OwnerUserId, actor.UserId));
+        if (!canSeeAll)
+            return Array.Empty<SyncItemSummary>();
+        var visibleFilter = Builders<DefectProject>.Filter.Eq(p => p.IsArchived, false);
         var projects = await _db.DefectProjects
             .Find(visibleFilter)
             .SortBy(p => p.Name)
@@ -82,12 +81,10 @@ public class DefectSyncResource : ISyncableResource
     {
         var project = await _db.DefectProjects.Find(p => p.Id == itemId).FirstOrDefaultAsync(ct);
         if (project == null) return null;
-        // 双闸门：即便上层 transfer 已用 ListItemsAsync 做了集合判定，本方法仍独立校验 actor 是否可读，
-        // 避免对端 export 端点或未来旁路调用绕过授权。
-        // 与 ListItemsAsync 的可见集合保持一致：PeerSystem / defect-agent.manage / 项目 OwnerUserId。
-        var canRead = actor.IsPeerSystem
-            || actor.HasPermission("defect-agent.manage")
-            || project.OwnerUserId == actor.UserId;
+        // 双闸门：与 ListItemsAsync 同口径 — 只放行 PeerSystem / defect-agent.manage。
+        // 项目 OwnerUserId 路径已撤销（PR #742 review fix），避免非管理员的项目 owner 越权
+        // 拉走他人提交/指派的全项目报告，与 DefectAgentController.ListDefects 的可见性对齐。
+        var canRead = actor.IsPeerSystem || actor.HasPermission("defect-agent.manage");
         if (!canRead) return null;
 
         var defects = await _db.DefectReports

--- a/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DefectSyncResource.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DefectSyncResource.cs
@@ -190,36 +190,37 @@ public class DefectSyncResource : ISyncableResource
             : await _db.DefectProjects.Find(p => p.Id == key).FirstOrDefaultAsync(ct);
         if (project == null)
         {
-            // PR #742 review P2 fix：defect_projects.Key 有唯一索引（uniq_defect_projects_key），
-            // 若同 Key 已被其它项目占用 -> InsertOne 会 DuplicateKey 整个 apply 报错。
-            // 三段策略：(a) 若同 Key 存在 -> 直接复用既有项目（更符合用户语义：同名项目就是同一个）；
-            // (b) Key 为空时给 base+随机后缀；(c) 兜底用 -timestamp 后缀防漏网。
+            // PR #742 review P2/High 二次修订：之前为了规避 defect_projects.Key 唯一索引冲突而"同 Key 直接复用既有项目"
+            // 引入了新 High：跨环境 push 时 targetKey 是对端项目 Id，若本地不存在对应 Id，会落到一个仅 slug 同名的
+            // 无关项目里造成数据串号。正确语义是"用指定的 Id 创建新项目，Key 用后缀保证唯一不抢占他人的 slug"。
             var baseKey = (bundle.Item.Name ?? "imported").ToLowerInvariant().Trim().Replace(' ', '-');
             if (string.IsNullOrWhiteSpace(baseKey)) baseKey = "imported-" + DateTime.UtcNow.Ticks.ToString("x");
-            var existingByKey = await _db.DefectProjects
-                .Find(p => p.Key == baseKey)
-                .FirstOrDefaultAsync(ct);
-            if (existingByKey != null)
+
+            string newId = !string.IsNullOrWhiteSpace(key) ? key : Guid.NewGuid().ToString("N");
+            // 若 Key 已被占用 → 加 -peer-{shortid} 后缀使新项目独立存在，**不复用别人的项目**
+            var keyTaken = await _db.DefectProjects.Find(p => p.Key == baseKey).AnyAsync(ct);
+            string finalKey = keyTaken ? $"{baseKey}-peer-{newId[..Math.Min(8, newId.Length)]}" : baseKey;
+
+            project = new DefectProject
             {
-                project = existingByKey;
-            }
-            else
+                Id = newId,
+                Name = string.IsNullOrWhiteSpace(bundle.Item.Name) ? "（来自对端的缺陷项目）" : bundle.Item.Name,
+                Key = finalKey,
+                Description = bundle.Item.Description,
+                OwnerUserId = ownerUserId,
+                OwnerName = ownerName,
+            };
+            try { await _db.DefectProjects.InsertOneAsync(project, cancellationToken: ct); }
+            catch (MongoWriteException ex) when (ex.WriteError?.Category == ServerErrorCategory.DuplicateKey)
             {
-                project = new DefectProject
-                {
-                    Id = !string.IsNullOrWhiteSpace(key) ? key : Guid.NewGuid().ToString("N"),
-                    Name = string.IsNullOrWhiteSpace(bundle.Item.Name) ? "（来自对端的缺陷项目）" : bundle.Item.Name,
-                    Key = baseKey,
-                    Description = bundle.Item.Description,
-                    OwnerUserId = ownerUserId,
-                    OwnerName = ownerName,
-                };
+                // 竞态 - 在 lookup 后他人插入了同 Key。改 Key 再试一次，使用 GUID 后缀，几乎不可能再冲突。
+                project.Key = $"{baseKey}-peer-{Guid.NewGuid().ToString("N")[..12]}";
                 try { await _db.DefectProjects.InsertOneAsync(project, cancellationToken: ct); }
-                catch (MongoWriteException ex) when (ex.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+                catch (MongoWriteException ex2)
                 {
-                    // 极端竞态：刚 lookup 完别人就插了同 Key。重新读一次复用。
-                    project = await _db.DefectProjects.Find(p => p.Key == baseKey).FirstOrDefaultAsync(ct)
-                        ?? throw new InvalidOperationException("无法创建或复用缺陷项目（同 Key 冲突解决失败）");
+                    // 如果 Id 维度也撞了（极罕见，需要 newId 已经被占），抛出明确错误而非串号落库。
+                    throw new InvalidOperationException(
+                        $"无法创建缺陷项目（Id={newId}，Key={project.Key}）：{ex2.Message}");
                 }
             }
         }
@@ -241,6 +242,23 @@ public class DefectSyncResource : ISyncableResource
                     .FirstOrDefaultAsync(ct);
 
                 var meta = r.Metadata ?? new Dictionary<string, string>();
+                // PR #742 review P2 fix：必须区分 key 缺失 vs key 存在且空值 ——
+                //   - key 缺失 = 源端未携带该字段的信息（保留现状）
+                //   - key 存在但 v=空 = 源端【显式清空】（同步到 null/null-ts）
+                // 旧版 Get 把两者混为 null 导致清除操作无法跨节点传递。
+                string? Resolved(string k, string? current)
+                {
+                    if (!meta.TryGetValue(k, out var v)) return current; // 缺失 = 保留
+                    return string.IsNullOrEmpty(v) ? null : v;            // 存在但空 = 显式清
+                }
+                DateTime? ResolvedTs(string k, DateTime? current)
+                {
+                    if (!meta.TryGetValue(k, out var v)) return current;
+                    if (string.IsNullOrEmpty(v)) return null;
+                    return DateTime.TryParse(v, out var dt) ? dt.ToUniversalTime() : current;
+                }
+                // 保留 Get 给只读 metadata（如 defectNo / createdAt / reporterName / assigneeName）用——
+                // 这些字段空值就当不存在合理。下方业务字段都改走 Resolved 走"显式清"语义。
                 string? Get(string k) => meta.TryGetValue(k, out var v) && !string.IsNullOrEmpty(v) ? v : null;
 
                 // PR #742 review fix：消化 export 写入 Extras 的 attachments / structuredData，
@@ -281,10 +299,8 @@ public class DefectSyncResource : ISyncableResource
                     }
                     catch { structured = new Dictionary<string, string>(); }
                 }
-                // 解析 resolvedAt：源端解决/重新打开时 timestamp 必须搬过来，否则分析的"解决耗时"会断
-                DateTime? resolvedAt = null;
-                if (Get("resolvedAt") is string ra && DateTime.TryParse(ra, out var raDt))
-                    resolvedAt = raDt.ToUniversalTime();
+                // 解析 resolvedAt：源端解决/重新打开时 timestamp 必须搬过来，否则分析的"解决耗时"会断。
+                // 走 ResolvedTs 支持源端把"重开"传过来（resolvedAt = "" → 清回 null）。
 
                 if (existing != null)
                 {
@@ -299,14 +315,21 @@ public class DefectSyncResource : ISyncableResource
                         .OrderBy(kv => kv.Key, StringComparer.Ordinal));
                     var newStructSig = JsonSerializer.Serialize((structured ?? new Dictionary<string, string>())
                         .OrderBy(kv => kv.Key, StringComparer.Ordinal));
+                    // 用 Resolved 让 no-op 比对正确处理"源端显式清空"（用空字符串 vs 缺失 key 区分）。
+                    var newStatus = Resolved("status", existing.Status);
+                    var newSeverity = Resolved("severity", existing.Severity);
+                    var newPriority = Resolved("priority", existing.Priority);
+                    var newResolution = Resolved("resolution", existing.Resolution);
+                    var newAssignee = Resolved("assigneeName", existing.AssigneeName);
+                    var newResolvedAt = ResolvedTs("resolvedAt", existing.ResolvedAt);
                     if (existing.RawContent == r.Content
                         && existing.Title == r.Title
-                        && existing.Status == (Get("status") ?? existing.Status)
-                        && existing.Severity == (Get("severity") ?? existing.Severity)
-                        && existing.Priority == (Get("priority") ?? existing.Priority)
-                        && existing.Resolution == (Get("resolution") ?? existing.Resolution)
-                        && existing.AssigneeName == (Get("assigneeName") ?? existing.AssigneeName)
-                        && existing.ResolvedAt == (resolvedAt ?? existing.ResolvedAt)
+                        && existing.Status == newStatus
+                        && existing.Severity == newSeverity
+                        && existing.Priority == newPriority
+                        && existing.Resolution == newResolution
+                        && existing.AssigneeName == newAssignee
+                        && existing.ResolvedAt == newResolvedAt
                         && existingAttSig == newAttSig
                         && existingStructSig == newStructSig)
                     {
@@ -316,12 +339,12 @@ public class DefectSyncResource : ISyncableResource
                     var u = Builders<DefectReport>.Update
                         .Set(x => x.Title, r.Title)
                         .Set(x => x.RawContent, r.Content ?? string.Empty)
-                        .Set(x => x.Status, Get("status") ?? existing.Status)
-                        .Set(x => x.Severity, Get("severity") ?? existing.Severity)
-                        .Set(x => x.Priority, Get("priority") ?? existing.Priority)
-                        .Set(x => x.Resolution, Get("resolution") ?? existing.Resolution)
-                        .Set(x => x.AssigneeName, Get("assigneeName") ?? existing.AssigneeName)
-                        .Set(x => x.ResolvedAt, resolvedAt ?? existing.ResolvedAt)
+                        .Set(x => x.Status, newStatus ?? string.Empty)
+                        .Set(x => x.Severity, newSeverity)
+                        .Set(x => x.Priority, newPriority)
+                        .Set(x => x.Resolution, newResolution)
+                        .Set(x => x.AssigneeName, newAssignee)
+                        .Set(x => x.ResolvedAt, newResolvedAt)
                         .Set(x => x.ProjectId, project.Id)
                         .Set(x => x.ProjectName, project.Name)
                         .Set(x => x.UpdatedAt, DateTime.UtcNow);
@@ -354,18 +377,18 @@ public class DefectSyncResource : ISyncableResource
                         DefectNo = Get("defectNo") ?? string.Empty,
                         Title = r.Title,
                         RawContent = r.Content ?? string.Empty,
-                        Status = Get("status") ?? "submitted",
-                        Severity = Get("severity"),
-                        Priority = Get("priority"),
-                        Resolution = Get("resolution"),
+                        Status = Resolved("status", "submitted") ?? "submitted",
+                        Severity = Resolved("severity", null),
+                        Priority = Resolved("priority", null),
+                        Resolution = Resolved("resolution", null),
                         ReporterId = ownerUserId,
                         ReporterName = Get("reporterName") ?? ownerName,
-                        AssigneeName = Get("assigneeName"),
+                        AssigneeName = Resolved("assigneeName", null),
                         ProjectId = project.Id,
                         ProjectName = project.Name,
                         CreatedAt = parsedCreated,
                         UpdatedAt = DateTime.UtcNow,
-                        ResolvedAt = resolvedAt,
+                        ResolvedAt = ResolvedTs("resolvedAt", null),
                         Attachments = attachments ?? new List<DefectAttachment>(),
                         StructuredData = structured ?? new Dictionary<string, string>(),
                     };

--- a/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DefectSyncResource.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DefectSyncResource.cs
@@ -97,6 +97,8 @@ public class DefectSyncResource : ISyncableResource
         {
             // 业务字段塞进 metadata（避免 v2 加字段时破坏 schema）。已知字段值用 String 表达，
             // 未知字段或对端不识别由 Extras 兜底向下兼容。
+            // PR #742 review fix：attachments / structuredData 即使为空也必须在 extras 里显式 emit
+            // 空数组 / 空对象 —— 否则源端清空后接收方收到的是缺 key，永远当成「没变」无法清。
             var meta = new Dictionary<string, string>
             {
                 [LineageKey] = d.Id,
@@ -111,26 +113,23 @@ public class DefectSyncResource : ISyncableResource
                 ["resolution"] = d.Resolution ?? string.Empty,
             };
 
-            // 附件只传引用元数据（URL），不内联二进制。
+            // 附件只传引用元数据（URL），不内联二进制；空数组也要 emit 让对端能识别"源端已清空"。
             var extras = new Dictionary<string, JsonElement>();
-            if (d.Attachments != null && d.Attachments.Count > 0)
+            var attRefs = (d.Attachments ?? new List<DefectAttachment>()).Select(a => new
             {
-                var attRefs = d.Attachments.Select(a => new
-                {
-                    fileName = a.FileName,
-                    mimeType = a.MimeType,
-                    size = a.FileSize,
-                    url = a.Url,
-                    type = a.Type,
-                }).ToList();
-                extras["attachments"] = JsonSerializer.SerializeToElement(attRefs);
+                fileName = a.FileName,
+                mimeType = a.MimeType,
+                size = a.FileSize,
+                url = a.Url,
+                type = a.Type,
+            }).ToList();
+            extras["attachments"] = JsonSerializer.SerializeToElement(attRefs);
+            if (attRefs.Count > 0)
                 extras["attachmentsNote"] = JsonSerializer.SerializeToElement(
                     "附件保留为引用 URL；对端环境网络不可达时需手动重新上传");
-            }
 
-            // structuredData 也传过去（保留原始结构）
-            if (d.StructuredData != null && d.StructuredData.Count > 0)
-                extras["structuredData"] = JsonSerializer.SerializeToElement(d.StructuredData);
+            // structuredData 也传过去（保留原始结构），空对象也要 emit
+            extras["structuredData"] = JsonSerializer.SerializeToElement(d.StructuredData ?? new Dictionary<string, string>());
 
             records.Add(new SyncRecord
             {
@@ -246,12 +245,15 @@ public class DefectSyncResource : ISyncableResource
 
                 // PR #742 review fix：消化 export 写入 Extras 的 attachments / structuredData，
                 // 否则附件元数据和结构化字段在对端被静默丢弃。
+                // 现在 export 必 emit 这两 key（即便空），此处只要 key 存在就 set（含空清空语义）；
+                // key 不存在则不动（向下兼容旧 bundle）。
                 List<DefectAttachment>? attachments = null;
-                if (r.Extras.TryGetValue("attachments", out var attEl) && attEl.ValueKind == JsonValueKind.Array)
+                bool hasAttachmentsKey = r.Extras.TryGetValue("attachments", out var attEl) && attEl.ValueKind == JsonValueKind.Array;
+                if (hasAttachmentsKey)
                 {
+                    attachments = new List<DefectAttachment>();
                     try
                     {
-                        attachments = new List<DefectAttachment>();
                         foreach (var item in attEl.EnumerateArray())
                         {
                             attachments.Add(new DefectAttachment
@@ -265,19 +267,24 @@ public class DefectSyncResource : ISyncableResource
                             });
                         }
                     }
-                    catch { attachments = null; }
+                    catch { attachments = new List<DefectAttachment>(); }
                 }
                 Dictionary<string, string>? structured = null;
-                if (r.Extras.TryGetValue("structuredData", out var sdEl) && sdEl.ValueKind == JsonValueKind.Object)
+                bool hasStructuredKey = r.Extras.TryGetValue("structuredData", out var sdEl) && sdEl.ValueKind == JsonValueKind.Object;
+                if (hasStructuredKey)
                 {
+                    structured = new Dictionary<string, string>();
                     try
                     {
-                        structured = new Dictionary<string, string>();
                         foreach (var prop in sdEl.EnumerateObject())
                             structured[prop.Name] = prop.Value.ValueKind == JsonValueKind.String ? prop.Value.GetString() ?? string.Empty : prop.Value.ToString();
                     }
-                    catch { structured = null; }
+                    catch { structured = new Dictionary<string, string>(); }
                 }
+                // 解析 resolvedAt：源端解决/重新打开时 timestamp 必须搬过来，否则分析的"解决耗时"会断
+                DateTime? resolvedAt = null;
+                if (Get("resolvedAt") is string ra && DateTime.TryParse(ra, out var raDt))
+                    resolvedAt = raDt.ToUniversalTime();
 
                 if (existing != null)
                 {
@@ -299,6 +306,7 @@ public class DefectSyncResource : ISyncableResource
                         && existing.Priority == (Get("priority") ?? existing.Priority)
                         && existing.Resolution == (Get("resolution") ?? existing.Resolution)
                         && existing.AssigneeName == (Get("assigneeName") ?? existing.AssigneeName)
+                        && existing.ResolvedAt == (resolvedAt ?? existing.ResolvedAt)
                         && existingAttSig == newAttSig
                         && existingStructSig == newStructSig)
                     {
@@ -313,11 +321,14 @@ public class DefectSyncResource : ISyncableResource
                         .Set(x => x.Priority, Get("priority") ?? existing.Priority)
                         .Set(x => x.Resolution, Get("resolution") ?? existing.Resolution)
                         .Set(x => x.AssigneeName, Get("assigneeName") ?? existing.AssigneeName)
+                        .Set(x => x.ResolvedAt, resolvedAt ?? existing.ResolvedAt)
                         .Set(x => x.ProjectId, project.Id)
                         .Set(x => x.ProjectName, project.Name)
                         .Set(x => x.UpdatedAt, DateTime.UtcNow);
-                    if (attachments != null) u = u.Set(x => x.Attachments, attachments);
-                    if (structured != null) u = u.Set(x => x.StructuredData, structured);
+                    // hasAttachmentsKey/hasStructuredKey 表示 export 端 emit 了该 key（含清空语义）→
+                    // 即便集合为空也要 .Set 让对端清掉；key 缺失（旧 bundle）才保留旧值。
+                    if (hasAttachmentsKey) u = u.Set(x => x.Attachments, attachments ?? new List<DefectAttachment>());
+                    if (hasStructuredKey) u = u.Set(x => x.StructuredData, structured ?? new Dictionary<string, string>());
                     await _db.DefectReports.UpdateOneAsync(d => d.Id == lineageId, u, cancellationToken: ct);
                     updated++;
                 }
@@ -354,6 +365,7 @@ public class DefectSyncResource : ISyncableResource
                         ProjectName = project.Name,
                         CreatedAt = parsedCreated,
                         UpdatedAt = DateTime.UtcNow,
+                        ResolvedAt = resolvedAt,
                         Attachments = attachments ?? new List<DefectAttachment>(),
                         StructuredData = structured ?? new Dictionary<string, string>(),
                     };

--- a/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DefectSyncResource.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DefectSyncResource.cs
@@ -322,7 +322,10 @@ public class DefectSyncResource : ISyncableResource
                     var newResolution = Resolved("resolution", existing.Resolution);
                     var newAssignee = Resolved("assigneeName", existing.AssigneeName);
                     var newResolvedAt = ResolvedTs("resolvedAt", existing.ResolvedAt);
-                    if (existing.RawContent == r.Content
+                    // no-op 比对同时纳入 IsDeleted —— 本地软删的条目即便其他字段未变也要走 update 路径
+                    // 恢复 IsDeleted=false（PR #742 review fix 同条）。
+                    if (!existing.IsDeleted
+                        && existing.RawContent == r.Content
                         && existing.Title == r.Title
                         && existing.Status == newStatus
                         && existing.Severity == newSeverity
@@ -345,6 +348,12 @@ public class DefectSyncResource : ISyncableResource
                         .Set(x => x.Resolution, newResolution)
                         .Set(x => x.AssigneeName, newAssignee)
                         .Set(x => x.ResolvedAt, newResolvedAt)
+                        // PR #742 review Medium fix：清掉本地软删标记。Export 只会发非删除的条目，
+                        // 源端再次推送此条目 = 它在源端是活的；若本地此前被软删，应"复活"，否则
+                        // 同步看似成功但 UI 仍隐藏该缺陷。
+                        .Set(x => x.IsDeleted, false)
+                        .Set(x => x.DeletedAt, (DateTime?)null)
+                        .Set(x => x.DeletedBy, (string?)null)
                         .Set(x => x.ProjectId, project.Id)
                         .Set(x => x.ProjectName, project.Name)
                         .Set(x => x.UpdatedAt, DateTime.UtcNow);

--- a/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DefectSyncResource.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DefectSyncResource.cs
@@ -445,6 +445,19 @@ public class DefectSyncResource : ISyncableResource
                     DateTime parsedCreated = DateTime.UtcNow;
                     if (Get("createdAt") is string c && DateTime.TryParse(c, out var dt)) parsedCreated = dt.ToUniversalTime();
 
+                    // PR #742 review P2 fix：DefectNo 有唯一索引 uniq_defect_reports_no。
+                    // test/prod 各自独立生成的同 DefectNo（如 DEF-2026-0001）冲突时直接 InsertOne 会
+                    // DuplicateKey 报错，整条 import 算 failed。改为：保留源端编号优先；同号被占即加
+                    // -peer-{shortLineage} 后缀；竞态时再用 GUID 后缀兜底。
+                    var srcDefectNo = Get("defectNo") ?? string.Empty;
+                    string finalDefectNo = srcDefectNo;
+                    if (!string.IsNullOrWhiteSpace(srcDefectNo))
+                    {
+                        var noTaken = await _db.DefectReports.Find(d => d.DefectNo == srcDefectNo).AnyAsync(ct);
+                        if (noTaken)
+                            finalDefectNo = $"{srcDefectNo}-peer-{lineageId[..Math.Min(8, lineageId.Length)]}";
+                    }
+
                     // PR #742 review Medium fix：按 reporterUserName / reporterEmail 对齐到本地用户；
                     // 未命中才退回项目 owner（同 doc-store 的兜底逻辑），避免所有 import 全部归项目 owner。
                     var (reporterId, reporterName) = await ResolveUserAsync(
@@ -462,7 +475,7 @@ public class DefectSyncResource : ISyncableResource
                     var defect = new DefectReport
                     {
                         Id = lineageId,
-                        DefectNo = Get("defectNo") ?? string.Empty,
+                        DefectNo = finalDefectNo,
                         Title = r.Title,
                         RawContent = r.Content ?? string.Empty,
                         Status = Resolved("status", "submitted") ?? "submitted",
@@ -481,7 +494,22 @@ public class DefectSyncResource : ISyncableResource
                         Attachments = attachments ?? new List<DefectAttachment>(),
                         StructuredData = structured ?? new Dictionary<string, string>(),
                     };
-                    await _db.DefectReports.InsertOneAsync(defect, cancellationToken: ct);
+                    try
+                    {
+                        await _db.DefectReports.InsertOneAsync(defect, cancellationToken: ct);
+                    }
+                    catch (MongoWriteException dupEx) when (dupEx.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+                    {
+                        // 竞态：DefectNo / lineage 同号正好被另一并发 import 抢插。retry 一次：DefectNo 加 GUID 后缀。
+                        defect.DefectNo = $"{srcDefectNo}-peer-{Guid.NewGuid().ToString("N")[..12]}";
+                        try { await _db.DefectReports.InsertOneAsync(defect, cancellationToken: ct); }
+                        catch (Exception ex)
+                        {
+                            _logger.LogWarning(ex, "[peer-sync] insert defect 二次竞态失败 lineage={LineageId} no={No}", lineageId, defect.DefectNo);
+                            failed++;
+                            continue;
+                        }
+                    }
                     created++;
                 }
             }

--- a/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DefectSyncResource.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DefectSyncResource.cs
@@ -40,10 +40,20 @@ public class DefectSyncResource : ISyncableResource
     // ─── 列出可发送的缺陷项目 ───
     public async Task<IReadOnlyList<SyncItemSummary>> ListItemsAsync(SyncActor actor, CancellationToken ct)
     {
-        // 列出所有非归档项目（用户能看到 / 管理员能看到由调用方的鉴权层决定，此处不限）。
+        // PR #742 review P1 fix：必须按 actor 视角过滤，否则任意登录用户可越权拉所有缺陷项目。
+        // - 受信对端节点（IsPeerSystem，来自 HMAC 验签通过的 export 请求）：全域
+        // - 本节点管理员（IsAdmin = Super / AI 超级访问）：全域
+        // - 普通用户：仅放行自己作为 OwnerUserId 的项目（不暴露其他人项目里的缺陷）
+        //
         // 个人散列缺陷（无 ProjectId）不可通过本接口互传，避免一次拷一整个用户名下零散缺陷。
+        var baseFilter = Builders<DefectProject>.Filter.Eq(p => p.IsArchived, false);
+        var visibleFilter = (actor.IsPeerSystem || actor.IsAdmin)
+            ? baseFilter
+            : Builders<DefectProject>.Filter.And(
+                baseFilter,
+                Builders<DefectProject>.Filter.Eq(p => p.OwnerUserId, actor.UserId));
         var projects = await _db.DefectProjects
-            .Find(p => !p.IsArchived)
+            .Find(visibleFilter)
             .SortBy(p => p.Name)
             .ToListAsync(ct);
         var ids = projects.Select(p => p.Id).ToList();
@@ -68,6 +78,9 @@ public class DefectSyncResource : ISyncableResource
     {
         var project = await _db.DefectProjects.Find(p => p.Id == itemId).FirstOrDefaultAsync(ct);
         if (project == null) return null;
+        // 双闸门：即便上层 transfer 已用 ListItemsAsync 做了集合判定，本方法仍独立校验 actor 是否可读，
+        // 避免对端 export 端点或未来旁路调用绕过授权。
+        if (!actor.IsPeerSystem && !actor.IsAdmin && project.OwnerUserId != actor.UserId) return null;
 
         var defects = await _db.DefectReports
             .Find(d => d.ProjectId == project.Id && !d.IsDeleted)

--- a/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DefectSyncResource.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DefectSyncResource.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
@@ -173,7 +175,11 @@ public class DefectSyncResource : ISyncableResource
         var parts = defects
             .Select(d => $"{d.Id}|{d.UpdatedAt.Ticks}|{d.Status}")
             .OrderBy(x => x, StringComparer.Ordinal);
-        return string.Join("\n", parts).GetHashCode().ToString("x");
+        // PR #742 review P2 fix：string.GetHashCode() 每个 .NET 进程随机化，跨节点 / 重启永不一致
+        // → 漂移检测永远报"不同步"。改用 SHA-256，与 DocumentStoreSyncResource 同款稳定算法。
+        using var sha = SHA256.Create();
+        var hash = sha.ComputeHash(Encoding.UTF8.GetBytes(string.Join("\n", parts)));
+        return Convert.ToHexString(hash).ToLowerInvariant();
     }
 
     // ─── 应用（接收阶段：单向 push 接收方） ───

--- a/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DefectSyncResource.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DefectSyncResource.cs
@@ -354,6 +354,33 @@ public class DefectSyncResource : ISyncableResource
                     var newResolution = Resolved("resolution", existing.Resolution);
                     var newAssignee = Resolved("assigneeName", existing.AssigneeName);
                     var newResolvedAt = ResolvedTs("resolvedAt", existing.ResolvedAt);
+                    // PR #742 review Medium fix：update 路径也要按 username/email 重新对齐 reporter
+                    // 和 assignee，否则显示名变了但 ReporterId/AssigneeId 永远保留首次 insert 时的兜底
+                    // 旧值（项目 owner），破坏 reporter/assignee 过滤与工作流。
+                    string? newReporterId = existing.ReporterId;
+                    string? newReporterName = existing.ReporterName;
+                    if (!string.IsNullOrWhiteSpace(Get("reporterUserName")) || !string.IsNullOrWhiteSpace(Get("reporterEmail")))
+                    {
+                        var (rId, rName) = await ResolveUserAsync(
+                            Get("reporterUserName"), Get("reporterEmail"), Get("reporterName"),
+                            existing.ReporterId, existing.ReporterName, ct);
+                        newReporterId = rId;
+                        newReporterName = rName;
+                    }
+                    else if (!string.IsNullOrWhiteSpace(Get("reporterName")))
+                    {
+                        newReporterName = Get("reporterName");
+                    }
+                    string? newAssigneeId = existing.AssigneeId;
+                    string? newAssigneeName = newAssignee; // 同 Resolved("assigneeName") 行为
+                    if (!string.IsNullOrWhiteSpace(Get("assigneeUserName")) || !string.IsNullOrWhiteSpace(Get("assigneeEmail")))
+                    {
+                        var (aId, aName) = await ResolveUserAsync(
+                            Get("assigneeUserName"), Get("assigneeEmail"), Get("assigneeName"),
+                            existing.AssigneeId, existing.AssigneeName, ct);
+                        newAssigneeId = aId;
+                        if (!string.IsNullOrWhiteSpace(aName)) newAssigneeName = aName;
+                    }
                     // no-op 比对同时纳入 IsDeleted —— 本地软删的条目即便其他字段未变也要走 update 路径
                     // 恢复 IsDeleted=false（PR #742 review fix 同条）。
                     if (!existing.IsDeleted
@@ -363,7 +390,10 @@ public class DefectSyncResource : ISyncableResource
                         && existing.Severity == newSeverity
                         && existing.Priority == newPriority
                         && existing.Resolution == newResolution
-                        && existing.AssigneeName == newAssignee
+                        && existing.AssigneeName == newAssigneeName
+                        && existing.AssigneeId == newAssigneeId
+                        && existing.ReporterId == newReporterId
+                        && existing.ReporterName == newReporterName
                         && existing.ResolvedAt == newResolvedAt
                         && existingAttSig == newAttSig
                         && existingStructSig == newStructSig)
@@ -378,7 +408,10 @@ public class DefectSyncResource : ISyncableResource
                         .Set(x => x.Severity, newSeverity)
                         .Set(x => x.Priority, newPriority)
                         .Set(x => x.Resolution, newResolution)
-                        .Set(x => x.AssigneeName, newAssignee)
+                        .Set(x => x.AssigneeId, newAssigneeId)
+                        .Set(x => x.AssigneeName, newAssigneeName)
+                        .Set(x => x.ReporterId, newReporterId ?? existing.ReporterId)
+                        .Set(x => x.ReporterName, newReporterName)
                         .Set(x => x.ResolvedAt, newResolvedAt)
                         // PR #742 review Medium fix：清掉本地软删标记。Export 只会发非删除的条目，
                         // 源端再次推送此条目 = 它在源端是活的；若本地此前被软删，应"复活"，否则

--- a/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DefectSyncResource.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DefectSyncResource.cs
@@ -97,6 +97,15 @@ public class DefectSyncResource : ISyncableResource
         if (!string.IsNullOrWhiteSpace(project.OwnerUserId))
             owner = await _db.Users.Find(u => u.UserId == project.OwnerUserId).FirstOrDefaultAsync(ct);
 
+        // PR #742 review Medium fix：预取所有 reporter/assignee 的 username/email，让接收侧能按
+        // 用户名/邮箱对齐到自己节点的真实用户，而不是统一归到项目 owner。
+        var userIds = defects.SelectMany(d => new[] { d.ReporterId, d.AssigneeId })
+            .Where(s => !string.IsNullOrWhiteSpace(s)).Select(s => s!).Distinct().ToList();
+        var usersById = userIds.Count == 0
+            ? new Dictionary<string, User>()
+            : (await _db.Users.Find(Builders<User>.Filter.In(u => u.UserId, userIds)).ToListAsync(ct))
+                .ToDictionary(u => u.UserId, u => u);
+
         var records = new List<SyncRecord>();
         foreach (var d in defects)
         {
@@ -104,6 +113,9 @@ public class DefectSyncResource : ISyncableResource
             // 未知字段或对端不识别由 Extras 兜底向下兼容。
             // PR #742 review fix：attachments / structuredData 即使为空也必须在 extras 里显式 emit
             // 空数组 / 空对象 —— 否则源端清空后接收方收到的是缺 key，永远当成「没变」无法清。
+            // PR #742 review Medium fix：除显示名外还带 username/email，接收侧据此对齐到本地真实用户
+            User? reporterUser = !string.IsNullOrWhiteSpace(d.ReporterId) && usersById.TryGetValue(d.ReporterId!, out var rep) ? rep : null;
+            User? assigneeUser = !string.IsNullOrWhiteSpace(d.AssigneeId) && usersById.TryGetValue(d.AssigneeId!, out var asg) ? asg : null;
             var meta = new Dictionary<string, string>
             {
                 [LineageKey] = d.Id,
@@ -112,7 +124,11 @@ public class DefectSyncResource : ISyncableResource
                 ["severity"] = d.Severity ?? string.Empty,
                 ["priority"] = d.Priority ?? string.Empty,
                 ["reporterName"] = d.ReporterName ?? string.Empty,
+                ["reporterUserName"] = reporterUser?.Username ?? string.Empty,
+                ["reporterEmail"] = reporterUser?.Email ?? string.Empty,
                 ["assigneeName"] = d.AssigneeName ?? string.Empty,
+                ["assigneeUserName"] = assigneeUser?.Username ?? string.Empty,
+                ["assigneeEmail"] = assigneeUser?.Email ?? string.Empty,
                 ["createdAt"] = d.CreatedAt.ToString("O"),
                 ["resolvedAt"] = d.ResolvedAt?.ToString("O") ?? string.Empty,
                 ["resolution"] = d.Resolution ?? string.Empty,
@@ -396,6 +412,20 @@ public class DefectSyncResource : ISyncableResource
                     DateTime parsedCreated = DateTime.UtcNow;
                     if (Get("createdAt") is string c && DateTime.TryParse(c, out var dt)) parsedCreated = dt.ToUniversalTime();
 
+                    // PR #742 review Medium fix：按 reporterUserName / reporterEmail 对齐到本地用户；
+                    // 未命中才退回项目 owner（同 doc-store 的兜底逻辑），避免所有 import 全部归项目 owner。
+                    var (reporterId, reporterName) = await ResolveUserAsync(
+                        Get("reporterUserName"), Get("reporterEmail"), Get("reporterName"), ownerUserId, ownerName, ct);
+                    // assignee 可以为空 - 只在 bundle 带了对齐字段时才尝试
+                    string? assigneeId = null;
+                    var assigneeDisplayName = Resolved("assigneeName", null);
+                    if (!string.IsNullOrWhiteSpace(Get("assigneeUserName")) || !string.IsNullOrWhiteSpace(Get("assigneeEmail")))
+                    {
+                        var (aId, aName) = await ResolveUserAsync(
+                            Get("assigneeUserName"), Get("assigneeEmail"), Get("assigneeName"), null, null, ct);
+                        assigneeId = aId;
+                        if (!string.IsNullOrWhiteSpace(aName)) assigneeDisplayName = aName;
+                    }
                     var defect = new DefectReport
                     {
                         Id = lineageId,
@@ -406,9 +436,10 @@ public class DefectSyncResource : ISyncableResource
                         Severity = Resolved("severity", null),
                         Priority = Resolved("priority", null),
                         Resolution = Resolved("resolution", null),
-                        ReporterId = ownerUserId,
-                        ReporterName = Get("reporterName") ?? ownerName,
-                        AssigneeName = Resolved("assigneeName", null),
+                        ReporterId = reporterId ?? ownerUserId,
+                        ReporterName = reporterName,
+                        AssigneeId = assigneeId,
+                        AssigneeName = assigneeDisplayName,
                         ProjectId = project.Id,
                         ProjectName = project.Name,
                         CreatedAt = parsedCreated,
@@ -437,6 +468,25 @@ public class DefectSyncResource : ISyncableResource
             UnmatchedAuthors = authorMatched ? 0 : 1,
             Message = $"新增{created}/更新{updated}/跳过{skipped}" + (failed > 0 ? $"/失败{failed}" : ""),
         };
+    }
+
+    /// <summary>按 username → email 对齐到本地用户；未命中退回 fallbackUserId/Name（可为 null）。
+    /// PR #742 review Medium fix：导入缺陷的 reporter/assignee 不能统一归到项目 owner。</summary>
+    private async Task<(string? userId, string? displayName)> ResolveUserAsync(
+        string? username, string? email, string? displayNameFromMeta,
+        string? fallbackUserId, string? fallbackName, CancellationToken ct)
+    {
+        User? user = null;
+        if (!string.IsNullOrWhiteSpace(username))
+            user = await _db.Users.Find(u => u.Username == username).FirstOrDefaultAsync(ct);
+        if (user == null && !string.IsNullOrWhiteSpace(email))
+            user = await _db.Users.Find(u => u.Email == email).FirstOrDefaultAsync(ct);
+        if (user != null)
+        {
+            var n = !string.IsNullOrWhiteSpace(user.DisplayName) ? user.DisplayName : user.Username;
+            return (user.UserId, n);
+        }
+        return (fallbackUserId, !string.IsNullOrWhiteSpace(displayNameFromMeta) ? displayNameFromMeta : fallbackName);
     }
 
     private async Task<(string userId, string name, bool matched)> ResolveOwnerAsync(

--- a/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DefectSyncResource.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DefectSyncResource.cs
@@ -191,16 +191,38 @@ public class DefectSyncResource : ISyncableResource
             : await _db.DefectProjects.Find(p => p.Id == key).FirstOrDefaultAsync(ct);
         if (project == null)
         {
-            project = new DefectProject
+            // PR #742 review P2 fix：defect_projects.Key 有唯一索引（uniq_defect_projects_key），
+            // 若同 Key 已被其它项目占用 -> InsertOne 会 DuplicateKey 整个 apply 报错。
+            // 三段策略：(a) 若同 Key 存在 -> 直接复用既有项目（更符合用户语义：同名项目就是同一个）；
+            // (b) Key 为空时给 base+随机后缀；(c) 兜底用 -timestamp 后缀防漏网。
+            var baseKey = (bundle.Item.Name ?? "imported").ToLowerInvariant().Trim().Replace(' ', '-');
+            if (string.IsNullOrWhiteSpace(baseKey)) baseKey = "imported-" + DateTime.UtcNow.Ticks.ToString("x");
+            var existingByKey = await _db.DefectProjects
+                .Find(p => p.Key == baseKey)
+                .FirstOrDefaultAsync(ct);
+            if (existingByKey != null)
             {
-                Id = !string.IsNullOrWhiteSpace(key) ? key : Guid.NewGuid().ToString("N"),
-                Name = string.IsNullOrWhiteSpace(bundle.Item.Name) ? "（来自对端的缺陷项目）" : bundle.Item.Name,
-                Key = (bundle.Item.Name ?? "imported").ToLowerInvariant().Replace(' ', '-'),
-                Description = bundle.Item.Description,
-                OwnerUserId = ownerUserId,
-                OwnerName = ownerName,
-            };
-            await _db.DefectProjects.InsertOneAsync(project, cancellationToken: ct);
+                project = existingByKey;
+            }
+            else
+            {
+                project = new DefectProject
+                {
+                    Id = !string.IsNullOrWhiteSpace(key) ? key : Guid.NewGuid().ToString("N"),
+                    Name = string.IsNullOrWhiteSpace(bundle.Item.Name) ? "（来自对端的缺陷项目）" : bundle.Item.Name,
+                    Key = baseKey,
+                    Description = bundle.Item.Description,
+                    OwnerUserId = ownerUserId,
+                    OwnerName = ownerName,
+                };
+                try { await _db.DefectProjects.InsertOneAsync(project, cancellationToken: ct); }
+                catch (MongoWriteException ex) when (ex.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+                {
+                    // 极端竞态：刚 lookup 完别人就插了同 Key。重新读一次复用。
+                    project = await _db.DefectProjects.Find(p => p.Key == baseKey).FirstOrDefaultAsync(ct)
+                        ?? throw new InvalidOperationException("无法创建或复用缺陷项目（同 Key 冲突解决失败）");
+                }
+            }
         }
 
         int created = 0, updated = 0, skipped = 0, failed = 0;

--- a/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DefectSyncResource.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DefectSyncResource.cs
@@ -1,0 +1,290 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using MongoDB.Driver;
+using PrdAgent.Core.Models;
+using PrdAgent.Core.Sync;
+using PrdAgent.Infrastructure.Database;
+
+namespace PrdAgent.Infrastructure.Sync.Resources;
+
+/// <summary>
+/// 缺陷管理（DefectReport）跨节点互传 — **单向 push-only**。
+///
+/// 设计抉择：
+/// - SupportsBidirectional = false：缺陷天然单向流动（测试环境提交 → 正式环境归档 / 处理人通知），
+///   双向合并语义会污染状态机（resolved 被对端的 draft 覆盖等）。
+/// - 列出条目以「DefectProject」为粒度：每个项目下的缺陷打包成一个 bundle（与知识库的 storeId 同思路）。
+/// - 个人粒度的散列缺陷（未关联项目）不在本互传范围。
+/// - 附件只传引用 URL（同名 URL 在跨环境通常不可达），接收侧标注「附件待手动下载」。
+/// - 流转状态字段（assignee / status / version 等）原样传输，对端按本节点 schema 落库；
+///   不在本节点 schema 的字段进 record.Extras，向下兼容。
+/// </summary>
+public class DefectSyncResource : ISyncableResource
+{
+    private const string LineageKey = "syncLineageId";
+
+    private readonly MongoDbContext _db;
+    private readonly ILogger<DefectSyncResource> _logger;
+
+    public DefectSyncResource(MongoDbContext db, ILogger<DefectSyncResource> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    public string ResourceType => "defect-agent";
+    public string DisplayName => "缺陷管理";
+    public bool SupportsBidirectional => false;  // 单向 push-only
+    public int SchemaVersion => 1;
+
+    // ─── 列出可发送的缺陷项目 ───
+    public async Task<IReadOnlyList<SyncItemSummary>> ListItemsAsync(SyncActor actor, CancellationToken ct)
+    {
+        // 列出所有非归档项目（用户能看到 / 管理员能看到由调用方的鉴权层决定，此处不限）。
+        // 个人散列缺陷（无 ProjectId）不可通过本接口互传，避免一次拷一整个用户名下零散缺陷。
+        var projects = await _db.DefectProjects
+            .Find(p => !p.IsArchived)
+            .SortBy(p => p.Name)
+            .ToListAsync(ct);
+        var ids = projects.Select(p => p.Id).ToList();
+        var counts = await _db.DefectReports
+            .Aggregate()
+            .Match(d => ids.Contains(d.ProjectId!) && !d.IsDeleted)
+            .Group(d => d.ProjectId, g => new { ProjectId = g.Key, Count = g.Count() })
+            .ToListAsync(ct);
+        var byProj = counts.ToDictionary(c => c.ProjectId!, c => c.Count);
+        return projects.Select(p => new SyncItemSummary
+        {
+            ItemId = p.Id,
+            Name = p.Name,
+            Description = p.Description,
+            RecordCount = byProj.TryGetValue(p.Id, out var n) ? n : 0,
+            UpdatedAt = p.UpdatedAt,
+        }).ToList();
+    }
+
+    // ─── 导出（计算阶段） ───
+    public async Task<SyncResourceBundle?> ExportAsync(string itemId, SyncActor actor, CancellationToken ct)
+    {
+        var project = await _db.DefectProjects.Find(p => p.Id == itemId).FirstOrDefaultAsync(ct);
+        if (project == null) return null;
+
+        var defects = await _db.DefectReports
+            .Find(d => d.ProjectId == project.Id && !d.IsDeleted)
+            .SortByDescending(d => d.CreatedAt)
+            .ToListAsync(ct);
+
+        // 找项目负责人的用户名/邮箱，用于接收侧归属对齐
+        User? owner = null;
+        if (!string.IsNullOrWhiteSpace(project.OwnerUserId))
+            owner = await _db.Users.Find(u => u.UserId == project.OwnerUserId).FirstOrDefaultAsync(ct);
+
+        var records = new List<SyncRecord>();
+        foreach (var d in defects)
+        {
+            // 业务字段塞进 metadata（避免 v2 加字段时破坏 schema）。已知字段值用 String 表达，
+            // 未知字段或对端不识别由 Extras 兜底向下兼容。
+            var meta = new Dictionary<string, string>
+            {
+                [LineageKey] = d.Id,
+                ["defectNo"] = d.DefectNo ?? string.Empty,
+                ["status"] = d.Status ?? string.Empty,
+                ["severity"] = d.Severity ?? string.Empty,
+                ["priority"] = d.Priority ?? string.Empty,
+                ["reporterName"] = d.ReporterName ?? string.Empty,
+                ["assigneeName"] = d.AssigneeName ?? string.Empty,
+                ["createdAt"] = d.CreatedAt.ToString("O"),
+                ["resolvedAt"] = d.ResolvedAt?.ToString("O") ?? string.Empty,
+                ["resolution"] = d.Resolution ?? string.Empty,
+            };
+
+            // 附件只传引用元数据（URL），不内联二进制。
+            var extras = new Dictionary<string, JsonElement>();
+            if (d.Attachments != null && d.Attachments.Count > 0)
+            {
+                var attRefs = d.Attachments.Select(a => new
+                {
+                    fileName = a.FileName,
+                    mimeType = a.MimeType,
+                    size = a.FileSize,
+                    url = a.Url,
+                    type = a.Type,
+                }).ToList();
+                extras["attachments"] = JsonSerializer.SerializeToElement(attRefs);
+                extras["attachmentsNote"] = JsonSerializer.SerializeToElement(
+                    "附件保留为引用 URL；对端环境网络不可达时需手动重新上传");
+            }
+
+            // structuredData 也传过去（保留原始结构）
+            if (d.StructuredData != null && d.StructuredData.Count > 0)
+                extras["structuredData"] = JsonSerializer.SerializeToElement(d.StructuredData);
+
+            records.Add(new SyncRecord
+            {
+                LineageId = d.Id,
+                IsFolder = false,
+                Title = string.IsNullOrWhiteSpace(d.Title) ? (d.DefectNo ?? d.Id) : d.Title!,
+                Summary = d.RawContent != null && d.RawContent.Length > 200 ? d.RawContent[..200] : d.RawContent,
+                ContentType = "text/plain",
+                FileSize = d.RawContent?.Length ?? 0,
+                Tags = string.IsNullOrEmpty(d.Severity) ? null : new List<string> { d.Severity! },
+                Content = d.RawContent,
+                Metadata = meta,
+                Extras = extras,
+            });
+        }
+
+        return new SyncResourceBundle
+        {
+            SchemaVersion = SchemaVersion,
+            ResourceType = ResourceType,
+            Item = new SyncBundleItem
+            {
+                Key = project.Id,
+                Name = project.Name,
+                Description = project.Description,
+                OwnerUserName = owner?.Username,
+                OwnerEmail = owner?.Email,
+            },
+            Records = records,
+        };
+    }
+
+    public async Task<string?> ComputeSignatureAsync(string itemId, CancellationToken ct)
+    {
+        var project = await _db.DefectProjects.Find(p => p.Id == itemId).FirstOrDefaultAsync(ct);
+        if (project == null) return null;
+        var defects = await _db.DefectReports
+            .Find(d => d.ProjectId == project.Id && !d.IsDeleted)
+            .Project(d => new { d.Id, d.UpdatedAt, d.Status })
+            .ToListAsync(ct);
+        var parts = defects
+            .Select(d => $"{d.Id}|{d.UpdatedAt.Ticks}|{d.Status}")
+            .OrderBy(x => x, StringComparer.Ordinal);
+        return string.Join("\n", parts).GetHashCode().ToString("x");
+    }
+
+    // ─── 应用（接收阶段：单向 push 接收方） ───
+    public async Task<SyncApplyOutcome> ApplyAsync(
+        SyncResourceBundle bundle, SyncActor actor, SyncApplyMode mode, string? targetKey, CancellationToken ct)
+    {
+        var key = !string.IsNullOrWhiteSpace(targetKey) ? targetKey! : bundle.Item.Key;
+
+        // 解析归属：按用户名 → 邮箱 → 操作者兜底
+        var (ownerUserId, ownerName, authorMatched) = await ResolveOwnerAsync(bundle.Item, actor, ct);
+
+        var project = string.IsNullOrWhiteSpace(key)
+            ? null
+            : await _db.DefectProjects.Find(p => p.Id == key).FirstOrDefaultAsync(ct);
+        if (project == null)
+        {
+            project = new DefectProject
+            {
+                Id = !string.IsNullOrWhiteSpace(key) ? key : Guid.NewGuid().ToString("N"),
+                Name = string.IsNullOrWhiteSpace(bundle.Item.Name) ? "（来自对端的缺陷项目）" : bundle.Item.Name,
+                Key = (bundle.Item.Name ?? "imported").ToLowerInvariant().Replace(' ', '-'),
+                Description = bundle.Item.Description,
+                OwnerUserId = ownerUserId,
+                OwnerName = ownerName,
+            };
+            await _db.DefectProjects.InsertOneAsync(project, cancellationToken: ct);
+        }
+
+        int created = 0, updated = 0, skipped = 0, failed = 0;
+        var addOnly = mode == SyncApplyMode.AddOnly;
+
+        foreach (var r in bundle.Records ?? new List<SyncRecord>())
+        {
+            try
+            {
+                // 血缘 = DefectReport.Id（跨节点保留同 id 便于 test↔prod 同库识别）
+                var lineageId = r.LineageId;
+                var existing = await _db.DefectReports.Find(d => d.Id == lineageId).FirstOrDefaultAsync(ct);
+
+                var meta = r.Metadata ?? new Dictionary<string, string>();
+                string? Get(string k) => meta.TryGetValue(k, out var v) && !string.IsNullOrEmpty(v) ? v : null;
+
+                if (existing != null)
+                {
+                    if (addOnly) { skipped++; continue; }
+                    // 内容 + status 无变化 → 跳过避免无意义 bump
+                    if (existing.RawContent == r.Content
+                        && existing.Title == r.Title
+                        && existing.Status == Get("status")
+                        && existing.Severity == Get("severity"))
+                    {
+                        skipped++;
+                        continue;
+                    }
+                    var u = Builders<DefectReport>.Update
+                        .Set(x => x.Title, r.Title)
+                        .Set(x => x.RawContent, r.Content ?? string.Empty)
+                        .Set(x => x.Status, Get("status") ?? existing.Status)
+                        .Set(x => x.Severity, Get("severity") ?? existing.Severity)
+                        .Set(x => x.Priority, Get("priority") ?? existing.Priority)
+                        .Set(x => x.Resolution, Get("resolution") ?? existing.Resolution)
+                        .Set(x => x.UpdatedAt, DateTime.UtcNow);
+                    await _db.DefectReports.UpdateOneAsync(d => d.Id == lineageId, u, cancellationToken: ct);
+                    updated++;
+                }
+                else
+                {
+                    DateTime parsedCreated = DateTime.UtcNow;
+                    if (Get("createdAt") is string c && DateTime.TryParse(c, out var dt)) parsedCreated = dt.ToUniversalTime();
+
+                    var defect = new DefectReport
+                    {
+                        Id = lineageId,
+                        DefectNo = Get("defectNo") ?? string.Empty,
+                        Title = r.Title,
+                        RawContent = r.Content ?? string.Empty,
+                        Status = Get("status") ?? "submitted",
+                        Severity = Get("severity"),
+                        Priority = Get("priority"),
+                        Resolution = Get("resolution"),
+                        ReporterId = ownerUserId,
+                        ReporterName = Get("reporterName") ?? ownerName,
+                        AssigneeName = Get("assigneeName"),
+                        ProjectId = project.Id,
+                        ProjectName = project.Name,
+                        CreatedAt = parsedCreated,
+                        UpdatedAt = DateTime.UtcNow,
+                    };
+                    await _db.DefectReports.InsertOneAsync(defect, cancellationToken: ct);
+                    created++;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "[peer-sync] apply defect failed: {LineageId}", r.LineageId);
+                failed++;
+            }
+        }
+
+        return new SyncApplyOutcome
+        {
+            Created = created,
+            Updated = updated,
+            Skipped = skipped,
+            Failed = failed,
+            UnmatchedAuthors = authorMatched ? 0 : 1,
+            Message = $"新增{created}/更新{updated}/跳过{skipped}" + (failed > 0 ? $"/失败{failed}" : ""),
+        };
+    }
+
+    private async Task<(string userId, string name, bool matched)> ResolveOwnerAsync(
+        SyncBundleItem item, SyncActor actor, CancellationToken ct)
+    {
+        User? user = null;
+        if (!string.IsNullOrWhiteSpace(item.OwnerUserName))
+            user = await _db.Users.Find(u => u.Username == item.OwnerUserName).FirstOrDefaultAsync(ct);
+        if (user == null && !string.IsNullOrWhiteSpace(item.OwnerEmail))
+            user = await _db.Users.Find(u => u.Email == item.OwnerEmail).FirstOrDefaultAsync(ct);
+        if (user != null)
+        {
+            var n = !string.IsNullOrWhiteSpace(user.DisplayName) ? user.DisplayName : user.Username;
+            return (user.UserId, n, true);
+        }
+        return (actor.UserId, actor.UserName, false);
+    }
+}

--- a/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DocumentStoreSyncResource.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DocumentStoreSyncResource.cs
@@ -156,6 +156,17 @@ public class DocumentStoreSyncResource : ISyncableResource
         var target = string.IsNullOrWhiteSpace(key)
             ? null
             : await _db.DocumentStores.Find(s => s.Id == key).FirstOrDefaultAsync(ct);
+        // PR #742 review P2：apply 路径不许写入项目知识库 / 产品知识库 —— 这些走专属访问轴
+        // （PmProject 成员 / Product owner），peer-sync 不在该轴上，否则配对方可越权改它们。
+        // ListItems / Export 已排除这类库，此处兜底；命中即返回错误，不静默创建新库或写入。
+        if (target != null && (!string.IsNullOrEmpty(target.PmProjectId) || !string.IsNullOrEmpty(target.ProductKnowledgeRef)))
+        {
+            return new SyncApplyOutcome
+            {
+                Failed = bundle.Records?.Count ?? 0,
+                Message = "目标库属于项目库 / 产品库，受专属访问轴保护，peer-sync 不能写入",
+            };
+        }
         if (target == null)
         {
             target = new DocumentStore

--- a/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DocumentStoreSyncResource.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DocumentStoreSyncResource.cs
@@ -401,6 +401,12 @@ public class DocumentStoreSyncResource : ISyncableResource
     {
         var store = await _db.DocumentStores.Find(s => s.Id == storeId).FirstOrDefaultAsync(ct);
         if (store == null) return null;
+        // PR #742 review High：项目知识库 / 产品知识库走专属访问轴，本接口不放行，避免跨轴泄漏。
+        if (!string.IsNullOrEmpty(store.PmProjectId) || !string.IsNullOrEmpty(store.ProductKnowledgeRef))
+        {
+            // 项目/产品库不通过 peer-sync 导出（v1 已在 ListItemsAsync 排除，此处兜底）
+            return null;
+        }
         // 受信对端节点（node-to-node 导出，已 HMAC 验签）绕过按登录用户的访问校验。
         if (userId == SyncActor.PeerSystemUserId) return store;
         if (store.OwnerId == userId) return store;

--- a/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DocumentStoreSyncResource.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DocumentStoreSyncResource.cs
@@ -138,21 +138,29 @@ public class DocumentStoreSyncResource : ISyncableResource
         // RemoteSignature 端点对配对节点开放，若不在这里拦，对端能用 store id 探出该库存在性 + 漂移信号。
         if (!string.IsNullOrEmpty(store.PmProjectId) || !string.IsNullOrEmpty(store.ProductKnowledgeRef))
             return null;
-        // PR #742 review P2 fix：之前签名带 UpdatedAt.Ticks，apply 写入时用 DateTime.UtcNow 覆盖，
-        // 两节点同步后内容完全一致但签名永远不同 → 双向漂移检测永远报"不同步"。
-        // 改为完全基于内容稳定字段：lineageId + title + isFolder + parent + tags + ContentIndex
-        // (ContentIndex 是正文前 2000 字符，由内容派生，两节点同步后完全相同)。
+        // PR #742 review P2 fix（两轮闭环）：
+        // - 一轮：之前签名带 UpdatedAt.Ticks，apply 写入时用 DateTime.UtcNow 覆盖 → 两节点同步后内容
+        //   完全一致但签名永远不同 → 双向漂移检测永久报"不同步"。改用内容稳定字段。
+        // - 二轮：只 hash ContentIndex（前 2000 字符）会漏掉文档后段 drift。改用 ParsedPrd.RawContent
+        //   全文 sha256，确保任何内容变化都触发签名差异。代价是加载所有文档 — signature 不是高频
+        //   路径（漂移检测调用），可接受；apply 路径本来就要全量传输 RawContent，带宽匹配。
         var entries = await _db.DocumentEntries.Find(e => e.StoreId == itemId).ToListAsync(ct);
         var byId = entries.ToDictionary(e => e.Id, e => e);
         string? ParentLineage(string? parentId)
             => string.IsNullOrEmpty(parentId) || !byId.TryGetValue(parentId!, out var p) ? null : LineageOf(p);
-        var parts = entries
-            .Select(e =>
+        var parts = new List<string>(entries.Count);
+        foreach (var e in entries)
+        {
+            string contentHash = string.Empty;
+            if (!e.IsFolder && !string.IsNullOrEmpty(e.DocumentId))
             {
-                var tags = string.Join(",", (e.Tags ?? new List<string>()).OrderBy(t => t, StringComparer.Ordinal));
-                return $"{LineageOf(e)}|{(e.IsFolder ? 1 : 0)}|{e.Title}|{ParentLineage(e.ParentId) ?? string.Empty}|{tags}|{e.ContentIndex ?? string.Empty}";
-            })
-            .OrderBy(x => x, StringComparer.Ordinal);
+                var doc = await _documentService.GetByIdAsync(e.DocumentId);
+                contentHash = Sha256Hex(doc?.RawContent ?? string.Empty);
+            }
+            var tags = string.Join(",", (e.Tags ?? new List<string>()).OrderBy(t => t, StringComparer.Ordinal));
+            parts.Add($"{LineageOf(e)}|{(e.IsFolder ? 1 : 0)}|{e.Title}|{ParentLineage(e.ParentId) ?? string.Empty}|{tags}|{contentHash}");
+        }
+        parts.Sort(StringComparer.Ordinal);
         return Sha256Hex(string.Join("\n", parts));
     }
 

--- a/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DocumentStoreSyncResource.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DocumentStoreSyncResource.cs
@@ -1,0 +1,470 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using MongoDB.Driver;
+using PrdAgent.Core.Interfaces;
+using PrdAgent.Core.Models;
+using PrdAgent.Core.Sync;
+using PrdAgent.Infrastructure.Database;
+
+namespace PrdAgent.Infrastructure.Sync.Resources;
+
+/// <summary>
+/// 知识库（文档空间）的跨节点互传资源实现。
+///
+/// 复用现有 DocumentStoreSyncController 的同步算法（血缘幂等 upsert、parent-first 文件夹、
+/// 空正文兜底、全字段比对跳过），但适配到通用 SyncResourceBundle 契约，并加上「按用户名/邮箱对齐归属」。
+/// 知识库支持双向（SupportsBidirectional = true）。
+///
+/// 注意：本实现与 DocumentStoreSyncController 的 token 路径并存——两者都用 metadata.syncLineageId
+/// 作血缘键，数据互通。旧 skblink 手动配对保留，新系统级配对走本资源。见 doc/design.peer-sync.md §6.1。
+/// </summary>
+public class DocumentStoreSyncResource : ISyncableResource
+{
+    private const string SyncLineageKey = "syncLineageId";
+
+    private readonly MongoDbContext _db;
+    private readonly IDocumentService _documentService;
+    private readonly ITeamService _teams;
+    private readonly ILogger<DocumentStoreSyncResource> _logger;
+
+    public DocumentStoreSyncResource(
+        MongoDbContext db,
+        IDocumentService documentService,
+        ITeamService teams,
+        ILogger<DocumentStoreSyncResource> logger)
+    {
+        _db = db;
+        _documentService = documentService;
+        _teams = teams;
+        _logger = logger;
+    }
+
+    public string ResourceType => "document-store";
+    public string DisplayName => "知识库";
+    public bool SupportsBidirectional => true;
+    public int SchemaVersion => 1;
+
+    // ─────────────────────────────────────────────────────────────
+    // 列出可发送条目
+    // ─────────────────────────────────────────────────────────────
+
+    public async Task<IReadOnlyList<SyncItemSummary>> ListItemsAsync(SyncActor actor, CancellationToken ct)
+    {
+        var myTeamIds = await _teams.GetMyTeamIdsAsync(actor.UserId);
+        var ownerOrTeam = myTeamIds.Count == 0
+            ? Builders<DocumentStore>.Filter.Eq(s => s.OwnerId, actor.UserId)
+            : Builders<DocumentStore>.Filter.Or(
+                Builders<DocumentStore>.Filter.Eq(s => s.OwnerId, actor.UserId),
+                Builders<DocumentStore>.Filter.AnyIn(s => s.SharedTeamIds, myTeamIds));
+        // 项目库 / 产品库走各自访问轴，互传 v1 不列入（避免越权）。
+        var filter = Builders<DocumentStore>.Filter.And(
+            ownerOrTeam,
+            Builders<DocumentStore>.Filter.Eq(s => s.PmProjectId, (string?)null),
+            Builders<DocumentStore>.Filter.Eq(s => s.ProductKnowledgeRef, (string?)null));
+
+        var stores = await _db.DocumentStores.Find(filter).SortByDescending(s => s.UpdatedAt).ToListAsync(ct);
+        return stores.Select(s => new SyncItemSummary
+        {
+            ItemId = s.Id,
+            Name = s.Name,
+            Description = s.Description,
+            RecordCount = s.DocumentCount,
+            UpdatedAt = s.UpdatedAt,
+        }).ToList();
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // 导出 / 签名
+    // ─────────────────────────────────────────────────────────────
+
+    public async Task<SyncResourceBundle?> ExportAsync(string itemId, SyncActor actor, CancellationToken ct)
+    {
+        var store = await LoadAccessibleStoreAsync(itemId, actor.UserId, ct);
+        if (store == null) return null;
+
+        var owner = await _db.Users.Find(u => u.UserId == store.OwnerId).FirstOrDefaultAsync(ct);
+
+        var entries = await _db.DocumentEntries.Find(e => e.StoreId == store.Id).ToListAsync(ct);
+        var byId = entries.ToDictionary(e => e.Id, e => e);
+        var records = new List<SyncRecord>();
+        foreach (var e in entries)
+        {
+            string? content = null;
+            if (!e.IsFolder && !string.IsNullOrEmpty(e.DocumentId))
+                content = (await _documentService.GetByIdAsync(e.DocumentId))?.RawContent;
+
+            string? parentLineage = null;
+            if (!string.IsNullOrEmpty(e.ParentId) && byId.TryGetValue(e.ParentId, out var parent))
+                parentLineage = LineageOf(parent);
+
+            records.Add(new SyncRecord
+            {
+                LineageId = LineageOf(e),
+                ParentLineageId = parentLineage,
+                IsFolder = e.IsFolder,
+                Title = e.Title,
+                Summary = e.Summary,
+                ContentType = e.ContentType,
+                FileSize = e.FileSize,
+                Tags = e.Tags,
+                Metadata = e.Metadata,
+                Content = content,
+            });
+        }
+
+        return new SyncResourceBundle
+        {
+            SchemaVersion = SchemaVersion,
+            ResourceType = ResourceType,
+            Item = new SyncBundleItem
+            {
+                Key = store.Id,
+                Name = store.Name,
+                Description = store.Description,
+                Tags = store.Tags,
+                OwnerUserName = owner?.Username,
+                OwnerEmail = owner?.Email,
+            },
+            Records = records,
+        };
+    }
+
+    public async Task<string?> ComputeSignatureAsync(string itemId, CancellationToken ct)
+    {
+        var store = await _db.DocumentStores.Find(s => s.Id == itemId).FirstOrDefaultAsync(ct);
+        if (store == null) return null;
+        var entries = await _db.DocumentEntries.Find(e => e.StoreId == itemId).ToListAsync(ct);
+        var parts = entries
+            .Select(e => $"{LineageOf(e)}|{e.UpdatedAt.Ticks}|{e.Title}|{(e.IsFolder ? 1 : 0)}")
+            .OrderBy(x => x, StringComparer.Ordinal);
+        return Sha256Hex(string.Join("\n", parts));
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // 接收应用（按用户名/邮箱对齐归属 + 血缘幂等 upsert）
+    // ─────────────────────────────────────────────────────────────
+
+    public async Task<SyncApplyOutcome> ApplyAsync(
+        SyncResourceBundle bundle, SyncActor actor, SyncApplyMode mode, string? targetKey, CancellationToken ct)
+    {
+        // 1) 归属对齐：用户名 → 邮箱 → 兜底归到操作者
+        var (ownerUserId, ownerName, ownerAvatar, authorMatched) = await ResolveOwnerAsync(bundle.Item, actor, ct);
+
+        // 2) 解析 / 创建目标库（保留同一 Id 便于 test↔prod 同库）
+        var key = !string.IsNullOrWhiteSpace(targetKey) ? targetKey! : bundle.Item.Key;
+        var target = string.IsNullOrWhiteSpace(key)
+            ? null
+            : await _db.DocumentStores.Find(s => s.Id == key).FirstOrDefaultAsync(ct);
+        if (target == null)
+        {
+            target = new DocumentStore
+            {
+                Id = !string.IsNullOrWhiteSpace(key) ? key : Guid.NewGuid().ToString("N"),
+                Name = string.IsNullOrWhiteSpace(bundle.Item.Name) ? "（来自对端的知识库）" : bundle.Item.Name,
+                Description = bundle.Item.Description,
+                OwnerId = ownerUserId,
+                Tags = bundle.Item.Tags ?? new List<string>(),
+            };
+            await _db.DocumentStores.InsertOneAsync(target, cancellationToken: ct);
+        }
+
+        var outcome = await ApplyRecordsAsync(target, bundle.Records, mode, ownerUserId, ownerName, ownerAvatar, ct);
+        outcome.UnmatchedAuthors = authorMatched ? 0 : 1;
+        if (!authorMatched)
+            outcome.Message = (outcome.Message == null ? "" : outcome.Message + "；")
+                + $"作者「{bundle.Item.OwnerUserName ?? bundle.Item.OwnerEmail ?? "未知"}」在本节点无同名用户，已归到你名下";
+        return outcome;
+    }
+
+    private async Task<(string userId, string name, string? avatar, bool matched)> ResolveOwnerAsync(
+        SyncBundleItem item, SyncActor actor, CancellationToken ct)
+    {
+        User? user = null;
+        if (!string.IsNullOrWhiteSpace(item.OwnerUserName))
+            user = await _db.Users.Find(u => u.Username == item.OwnerUserName).FirstOrDefaultAsync(ct);
+        if (user == null && !string.IsNullOrWhiteSpace(item.OwnerEmail))
+            user = await _db.Users.Find(u => u.Email == item.OwnerEmail).FirstOrDefaultAsync(ct);
+
+        if (user != null)
+        {
+            var name = !string.IsNullOrWhiteSpace(user.DisplayName) ? user.DisplayName : user.Username;
+            return (user.UserId, name, user.AvatarFileName, true);
+        }
+        // 兜底归到操作者
+        var op = await _db.Users.Find(u => u.UserId == actor.UserId).FirstOrDefaultAsync(ct);
+        var opName = op != null && !string.IsNullOrWhiteSpace(op.DisplayName) ? op.DisplayName
+            : (op?.Username ?? actor.UserName ?? "同步");
+        return (actor.UserId, opName, op?.AvatarFileName, false);
+    }
+
+    /// <summary>把记录幂等 upsert 进目标库（沿用 DocumentStoreSyncController.ApplyBundleAsync 的算法）。</summary>
+    private async Task<SyncApplyOutcome> ApplyRecordsAsync(
+        DocumentStore target, List<SyncRecord> records, SyncApplyMode mode,
+        string actorUserId, string actorName, string? actorAvatar, CancellationToken ct)
+    {
+        records ??= new List<SyncRecord>();
+        var existing = await _db.DocumentEntries.Find(e => e.StoreId == target.Id).ToListAsync(ct);
+        var byLineage = new Dictionary<string, DocumentEntry>();
+        foreach (var e in existing)
+        {
+            var k = LineageOf(e);
+            if (!byLineage.ContainsKey(k)) byLineage[k] = e;
+        }
+        var lineageToTargetId = new Dictionary<string, string>();
+        int created = 0, updated = 0, skipped = 0, failed = 0;
+        var addOnly = mode == SyncApplyMode.AddOnly;
+
+        string? ResolveParent(string? parentLineage)
+        {
+            if (string.IsNullOrEmpty(parentLineage)) return null;
+            if (lineageToTargetId.TryGetValue(parentLineage, out var mapped)) return mapped;
+            if (byLineage.TryGetValue(parentLineage, out var ex)) return ex.Id;
+            return null;
+        }
+
+        async Task UpsertFolderAsync(SyncRecord f, string? parentId)
+        {
+            if (byLineage.TryGetValue(f.LineageId, out var exFolder))
+            {
+                lineageToTargetId[f.LineageId] = exFolder.Id;
+                if (addOnly) { skipped++; return; }
+                var newTags = f.Tags ?? new List<string>();
+                if (exFolder.Title != f.Title || exFolder.ParentId != parentId
+                    || !TagsEqual(exFolder.Tags, f.Tags) || !MetaEqual(exFolder.Metadata, f.Metadata))
+                {
+                    await _db.DocumentEntries.UpdateOneAsync(e => e.Id == exFolder.Id,
+                        Builders<DocumentEntry>.Update
+                            .Set(e => e.Title, f.Title)
+                            .Set(e => e.ParentId, parentId)
+                            .Set(e => e.Tags, newTags)
+                            .Set(e => e.Metadata, WithLineage(f.Metadata, f.LineageId))
+                            .Set(e => e.UpdatedBy, actorUserId)
+                            .Set(e => e.UpdatedByName, actorName)
+                            .Set(e => e.UpdatedAt, DateTime.UtcNow), cancellationToken: ct);
+                    exFolder.Title = f.Title;
+                    exFolder.ParentId = parentId;
+                    updated++;
+                }
+                else skipped++;
+                return;
+            }
+            var folder = new DocumentEntry
+            {
+                StoreId = target.Id,
+                ParentId = parentId,
+                IsFolder = true,
+                Title = f.Title,
+                SourceType = DocumentSourceType.Import,
+                ContentType = "application/x-folder",
+                Tags = f.Tags ?? new List<string>(),
+                Metadata = WithLineage(f.Metadata, f.LineageId),
+                CreatedBy = actorUserId,
+                CreatedByName = actorName,
+                CreatedByAvatarFileName = actorAvatar,
+                UpdatedBy = actorUserId,
+                UpdatedByName = actorName,
+            };
+            await _db.DocumentEntries.InsertOneAsync(folder, cancellationToken: ct);
+            byLineage[f.LineageId] = folder;
+            lineageToTargetId[f.LineageId] = folder.Id;
+            created++;
+        }
+
+        // 文件夹 parent-first 多趟扫描
+        var pendingFolders = records.Where(e => e.IsFolder).ToList();
+        var guard = 0;
+        while (pendingFolders.Count > 0 && guard++ < 5000)
+        {
+            var progressed = false;
+            foreach (var f in pendingFolders.ToList())
+            {
+                if (!string.IsNullOrEmpty(f.ParentLineageId)
+                    && !lineageToTargetId.ContainsKey(f.ParentLineageId)
+                    && !byLineage.ContainsKey(f.ParentLineageId))
+                    continue;
+                await UpsertFolderAsync(f, ResolveParent(f.ParentLineageId));
+                pendingFolders.Remove(f);
+                progressed = true;
+            }
+            if (!progressed) break;
+        }
+        foreach (var f in pendingFolders)
+            await UpsertFolderAsync(f, ResolveParent(f.ParentLineageId));
+
+        // 文件类记录
+        foreach (var fe in records.Where(e => !e.IsFolder))
+        {
+            try
+            {
+                if (fe.Content == null) { skipped++; continue; }
+                var parentId = ResolveParent(fe.ParentLineageId);
+
+                if (byLineage.TryGetValue(fe.LineageId, out var exFolderConflict) && exFolderConflict.IsFolder)
+                {
+                    skipped++;
+                    continue;
+                }
+
+                if (byLineage.TryGetValue(fe.LineageId, out var exEntry) && !exEntry.IsFolder)
+                {
+                    if (addOnly) { skipped++; continue; }
+                    var existingContent = !string.IsNullOrEmpty(exEntry.DocumentId)
+                        ? (await _documentService.GetByIdAsync(exEntry.DocumentId))?.RawContent ?? string.Empty
+                        : string.Empty;
+                    if (Sha256Hex(existingContent) == Sha256Hex(fe.Content)
+                        && exEntry.Title == fe.Title && exEntry.ParentId == parentId
+                        && TagsEqual(exEntry.Tags, fe.Tags) && exEntry.Summary == fe.Summary
+                        && MetaEqual(exEntry.Metadata, fe.Metadata))
+                    {
+                        skipped++;
+                        continue;
+                    }
+                    var oldDocId = exEntry.DocumentId;
+                    var parsed = await BuildAndSaveDocAsync(fe.Content, fe.Title);
+                    await _db.DocumentEntries.UpdateOneAsync(
+                        e => e.Id == exEntry.Id,
+                        Builders<DocumentEntry>.Update
+                            .Set(e => e.DocumentId, parsed.Id)
+                            .Set(e => e.Title, fe.Title)
+                            .Set(e => e.Summary, fe.Summary)
+                            .Set(e => e.ParentId, parentId)
+                            .Set(e => e.Tags, fe.Tags ?? new List<string>())
+                            .Set(e => e.ContentIndex, fe.Content.Length > 2000 ? fe.Content[..2000] : fe.Content)
+                            .Set(e => e.FileSize, fe.FileSize)
+                            .Set(e => e.ContentType, string.IsNullOrEmpty(fe.ContentType) ? "text/markdown" : fe.ContentType)
+                            .Set(e => e.Metadata, WithLineage(fe.Metadata, fe.LineageId))
+                            .Set(e => e.UpdatedBy, actorUserId)
+                            .Set(e => e.UpdatedByName, actorName)
+                            .Set(e => e.UpdatedAt, DateTime.UtcNow)
+                            .Set(e => e.LastChangedAt, DateTime.UtcNow), cancellationToken: ct);
+                    await CleanupReplacedDocAsync(oldDocId, parsed.Id, exEntry.Id);
+                    updated++;
+                }
+                else
+                {
+                    var parsed = await BuildAndSaveDocAsync(fe.Content, fe.Title);
+                    var entry = new DocumentEntry
+                    {
+                        StoreId = target.Id,
+                        ParentId = parentId,
+                        IsFolder = false,
+                        Title = fe.Title,
+                        Summary = fe.Summary,
+                        SourceType = DocumentSourceType.Import,
+                        ContentType = string.IsNullOrEmpty(fe.ContentType) ? "text/markdown" : fe.ContentType,
+                        FileSize = fe.FileSize,
+                        Tags = fe.Tags ?? new List<string>(),
+                        Metadata = WithLineage(fe.Metadata, fe.LineageId),
+                        DocumentId = parsed.Id,
+                        ContentIndex = fe.Content.Length > 2000 ? fe.Content[..2000] : fe.Content,
+                        CreatedBy = actorUserId,
+                        CreatedByName = actorName,
+                        CreatedByAvatarFileName = actorAvatar,
+                        UpdatedBy = actorUserId,
+                        UpdatedByName = actorName,
+                        LastChangedAt = DateTime.UtcNow,
+                    };
+                    await _db.DocumentEntries.InsertOneAsync(entry, cancellationToken: ct);
+                    byLineage[fe.LineageId] = entry;
+                    created++;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "[peer-sync] apply entry failed: {Title}", fe.Title);
+                failed++;
+            }
+        }
+
+        var count = await _db.DocumentEntries.CountDocumentsAsync(e => e.StoreId == target.Id, cancellationToken: ct);
+        await _db.DocumentStores.UpdateOneAsync(
+            s => s.Id == target.Id,
+            Builders<DocumentStore>.Update.Set(s => s.DocumentCount, (int)count).Set(s => s.UpdatedAt, DateTime.UtcNow),
+            cancellationToken: ct);
+
+        return new SyncApplyOutcome
+        {
+            Created = created,
+            Updated = updated,
+            Skipped = skipped,
+            Failed = failed,
+            Message = $"新增{created}/更新{updated}/跳过{skipped}" + (failed > 0 ? $"/失败{failed}" : ""),
+        };
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // 内部辅助（与 DocumentStoreSyncController 同口径）
+    // ─────────────────────────────────────────────────────────────
+
+    private async Task<DocumentStore?> LoadAccessibleStoreAsync(string storeId, string userId, CancellationToken ct)
+    {
+        var store = await _db.DocumentStores.Find(s => s.Id == storeId).FirstOrDefaultAsync(ct);
+        if (store == null) return null;
+        // 受信对端节点（node-to-node 导出，已 HMAC 验签）绕过按登录用户的访问校验。
+        if (userId == SyncActor.PeerSystemUserId) return store;
+        if (store.OwnerId == userId) return store;
+        var myTeamIds = await _teams.GetMyTeamIdsAsync(userId);
+        if (store.SharedTeamIds != null && store.SharedTeamIds.Any(myTeamIds.Contains)) return store;
+        return null;
+    }
+
+    private static string LineageOf(DocumentEntry e)
+        => e.Metadata != null && e.Metadata.TryGetValue(SyncLineageKey, out var l) && !string.IsNullOrEmpty(l)
+            ? l : e.Id;
+
+    private static Dictionary<string, string> WithLineage(Dictionary<string, string>? metadata, string lineageId)
+    {
+        var m = metadata != null ? new Dictionary<string, string>(metadata) : new Dictionary<string, string>();
+        m[SyncLineageKey] = lineageId;
+        return m;
+    }
+
+    private async Task<ParsedPrd> BuildAndSaveDocAsync(string content, string title)
+    {
+        ParsedPrd parsed;
+        if (string.IsNullOrWhiteSpace(content))
+            parsed = new ParsedPrd { Id = Sha256Hex(content.Replace("\r\n", "\n")), RawContent = content };
+        else
+            parsed = await _documentService.ParseAsync(content);
+        parsed.Title = title;
+        await _documentService.SaveAsync(parsed);
+        return parsed;
+    }
+
+    private async Task CleanupReplacedDocAsync(string? oldDocId, string newDocId, string keepEntryId)
+    {
+        if (string.IsNullOrEmpty(oldDocId) || oldDocId == newDocId) return;
+        try
+        {
+            var stillReferenced = await _db.DocumentEntries
+                .Find(e => e.DocumentId == oldDocId && e.Id != keepEntryId)
+                .AnyAsync(CancellationToken.None);
+            if (!stillReferenced)
+                await _db.Documents.DeleteOneAsync(d => d.Id == oldDocId, CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "[peer-sync] 清理旧 ParsedPrd 失败 docId={DocId}", oldDocId);
+        }
+    }
+
+    private static bool TagsEqual(List<string>? a, List<string>? b)
+        => (a ?? new()).OrderBy(x => x, StringComparer.Ordinal)
+            .SequenceEqual((b ?? new()).OrderBy(x => x, StringComparer.Ordinal));
+
+    private static bool MetaEqual(Dictionary<string, string>? a, Dictionary<string, string>? b)
+    {
+        static string Norm(Dictionary<string, string>? m) => string.Join("\n", (m ?? new())
+            .Where(kv => kv.Key != SyncLineageKey)
+            .OrderBy(kv => kv.Key, StringComparer.Ordinal)
+            .Select(kv => kv.Key + "=" + kv.Value));
+        return Norm(a) == Norm(b);
+    }
+
+    private static string Sha256Hex(string s)
+    {
+        using var sha = SHA256.Create();
+        return Convert.ToHexString(sha.ComputeHash(Encoding.UTF8.GetBytes(s ?? string.Empty))).ToLowerInvariant();
+    }
+}

--- a/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DocumentStoreSyncResource.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DocumentStoreSyncResource.cs
@@ -138,9 +138,20 @@ public class DocumentStoreSyncResource : ISyncableResource
         // RemoteSignature 端点对配对节点开放，若不在这里拦，对端能用 store id 探出该库存在性 + 漂移信号。
         if (!string.IsNullOrEmpty(store.PmProjectId) || !string.IsNullOrEmpty(store.ProductKnowledgeRef))
             return null;
+        // PR #742 review P2 fix：之前签名带 UpdatedAt.Ticks，apply 写入时用 DateTime.UtcNow 覆盖，
+        // 两节点同步后内容完全一致但签名永远不同 → 双向漂移检测永远报"不同步"。
+        // 改为完全基于内容稳定字段：lineageId + title + isFolder + parent + tags + ContentIndex
+        // (ContentIndex 是正文前 2000 字符，由内容派生，两节点同步后完全相同)。
         var entries = await _db.DocumentEntries.Find(e => e.StoreId == itemId).ToListAsync(ct);
+        var byId = entries.ToDictionary(e => e.Id, e => e);
+        string? ParentLineage(string? parentId)
+            => string.IsNullOrEmpty(parentId) || !byId.TryGetValue(parentId!, out var p) ? null : LineageOf(p);
         var parts = entries
-            .Select(e => $"{LineageOf(e)}|{e.UpdatedAt.Ticks}|{e.Title}|{(e.IsFolder ? 1 : 0)}")
+            .Select(e =>
+            {
+                var tags = string.Join(",", (e.Tags ?? new List<string>()).OrderBy(t => t, StringComparer.Ordinal));
+                return $"{LineageOf(e)}|{(e.IsFolder ? 1 : 0)}|{e.Title}|{ParentLineage(e.ParentId) ?? string.Empty}|{tags}|{e.ContentIndex ?? string.Empty}";
+            })
             .OrderBy(x => x, StringComparer.Ordinal);
         return Sha256Hex(string.Join("\n", parts));
     }

--- a/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DocumentStoreSyncResource.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Sync/Resources/DocumentStoreSyncResource.cs
@@ -134,6 +134,10 @@ public class DocumentStoreSyncResource : ISyncableResource
     {
         var store = await _db.DocumentStores.Find(s => s.Id == itemId).FirstOrDefaultAsync(ct);
         if (store == null) return null;
+        // PR #742 review P2 fix：项目库 / 产品库走专属访问轴，peer-sync 不放行。
+        // RemoteSignature 端点对配对节点开放，若不在这里拦，对端能用 store id 探出该库存在性 + 漂移信号。
+        if (!string.IsNullOrEmpty(store.PmProjectId) || !string.IsNullOrEmpty(store.ProductKnowledgeRef))
+            return null;
         var entries = await _db.DocumentEntries.Find(e => e.StoreId == itemId).ToListAsync(ct);
         var parts = entries
             .Select(e => $"{LineageOf(e)}|{e.UpdatedAt.Ticks}|{e.Title}|{(e.IsFolder ? 1 : 0)}")

--- a/prd-api/src/PrdAgent.Infrastructure/Sync/SyncResourceRegistry.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Sync/SyncResourceRegistry.cs
@@ -1,0 +1,31 @@
+using PrdAgent.Core.Sync;
+
+namespace PrdAgent.Infrastructure.Sync;
+
+/// <summary>
+/// 可同步资源注册表：DI 注入所有 ISyncableResource 实现，按 ResourceType 索引。
+/// 新增资源 = 加实现类 + DI 注册（AddScoped&lt;ISyncableResource, XxxResource&gt;），本类零改动。
+/// </summary>
+public class SyncResourceRegistry : ISyncResourceRegistry
+{
+    private readonly Dictionary<string, ISyncableResource> _byType;
+
+    public SyncResourceRegistry(IEnumerable<ISyncableResource> resources)
+    {
+        _byType = new Dictionary<string, ISyncableResource>(StringComparer.OrdinalIgnoreCase);
+        foreach (var r in resources)
+            _byType[r.ResourceType] = r; // 后注册覆盖同类型（允许替换实现）
+    }
+
+    public IReadOnlyList<SyncResourceCapability> Capabilities =>
+        _byType.Values.Select(r => new SyncResourceCapability
+        {
+            ResourceType = r.ResourceType,
+            DisplayName = r.DisplayName,
+            SupportsBidirectional = r.SupportsBidirectional,
+            SchemaVersion = r.SchemaVersion,
+        }).ToList();
+
+    public ISyncableResource? Resolve(string resourceType)
+        => _byType.TryGetValue(resourceType, out var r) ? r : null;
+}


### PR DESCRIPTION
## 摘要

实现系统级跨节点互传框架，支持管理员配对对端节点（一次性配对码 + HMAC 互信），用户可在任意应用一键发送/拉取/双向同步数据。知识库作为首个接入资源，支持双向同步并按用户名/邮箱对齐归属。

## 改动 diff

### 后端核心框架（prd-api）
- `PrdAgent.Core/Sync/`：通用互传契约（`SyncContracts.cs`、`ISyncableResource.cs`、`ISyncResourceRegistry.cs`）
- `PrdAgent.Core/Models/PeerNode.cs`：对端节点模型（含 RemoteNodeId、SharedSecret、状态管理）
- `PrdAgent.Core/Interfaces/IPeerNodeService.cs`：节点身份与 HMAC 鉴权接口
- `PrdAgent.Infrastructure/Services/PeerNodeService.cs`：节点 ID 生成、HMAC-SHA256 签名验证、时间戳防重放
- `PrdAgent.Infrastructure/Sync/SyncResourceRegistry.cs`：资源注册表（按 ResourceType 索引）
- `PrdAgent.Infrastructure/Sync/Resources/DocumentStoreSyncResource.cs`：知识库互传实现（血缘幂等 upsert、按用户名对齐、双向合并）
- `PrdAgent.Api/Controllers/Api/PeerSyncController.cs`：node-to-node 数据端点（握手、ping、capabilities、导出、应用）
- `PrdAgent.Api/Controllers/Api/AdminPeerNodesController.cs`：管理员配对端点（列表、生成配对码、添加对端、测试、删除）
- `PrdAgent.Api/Program.cs`：DI 注册（PeerNodeService、SyncResourceRegistry、DocumentStoreSyncResource）
- `PrdAgent.Core/Security/AdminPermissionCatalog.cs`：新增 `PeerSyncManage` 权限
- `PrdAgent.Infrastructure/Database/MongoDbContext.cs`：新增 PeerNode、PeerPairingCode 集合

### 前端管理界面（prd-admin）
- `src/pages/settings/PeerNodesSettings.tsx`：系统互联设置页面（本节点身份展示、配对码生成、对端管理、连通测试、解除配对）
- `src/components/sync/SendToPeerDialog.tsx`：通用「发送到对端」弹窗（节点选择、条目多选、方向选择、进度反馈）
- `src/services/real/peerSync.ts`：互传 API 客户端（listPeerNodes、listPeerItems、transferToPeer 等）
- `src/pages/document-store/DocumentStorePage.tsx`：知识库列表新增「发送到」按钮
- `src/pages/SettingsPage.tsx`：设置页面新增「系统互联」Tab
- `src/services/api.ts`：新增 peerSync 路由定义

### 文档与债务
- `doc/design.peer-sync.md`：完整设计文档（背景、概念、用户场景、核心能力、API 契约、版本协商）
- `doc/debt.peer-sync.md`：工程债务台账（v1 已知边界、后续可补项）
- `changelogs/2026-06-06_peer-sync.md`：更新记录碎片

## 核心设计要

https://claude.ai/code/session_01LV3d64PD9yuH8DNjcnrsPb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches cross-node auth (HMAC, anonymous endpoints), outbound HTTP/SSRF controls, and bulk data import paths for knowledge bases and defects—misconfiguration or auth bugs could leak or corrupt data across environments.
> 
> **Overview**
> Introduces **Peer Sync**: admins pair MAP nodes once (one-time pairing code + HMAC), then users transfer data without manual `skblink_` tokens.
> 
> **Backend:** New `ISyncableResource` registry, `PeerNode` / pairing storage, `PeerNodeService` (stable node id + HMAC), `PeerSyncController` (handshake, signed export/apply, user `transfer`), and `AdminPeerNodesController` under `peer-sync.manage`. **Knowledge bases** sync bidirectionally via `DocumentStoreSyncResource`; **defect projects** are **push-only** via `DefectSyncResource`. Hardening includes atomic pairing-code claim, SSRF-safe `PeerSync` HttpClient (no redirect follow), self-node guards, per-item transfer results, and `peer_nodes.RemoteNodeId` unique index docs.
> 
> **Admin UI:** **Settings → 系统互联** (`PeerNodesSettings`) for pairing codes and peer management; reusable **`SendToPeerDialog`**; knowledge library **「发送到」** entry. **Sync** tab drops cross-env `skblink_` generate/connect flows in favor of Peer Sync (local store↔store pairing kept), with a migration banner.
> 
> Design/debt changelogs and Mongo index guidance are added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36f88127c8fcf866ed7bb15a3bb66c2125ee08ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->