### PR TITLE
瀑布式加载优化：releases/current-week/github-logs 分页 + 懒加载

### DIFF
--- a/changelogs/2026-06-06_changelog-history-perf.md
+++ b/changelogs/2026-06-06_changelog-history-perf.md
@@ -1,0 +1,5 @@
+| perf | prd-api | 更新中心 `GET /api/changelog/releases` 默认 limit 从 20 降到 8，首屏 JSON 体积大幅缩小 |
+| perf | prd-admin | 更新中心首屏只拉 8 个版本，1.5s 空闲后台补到 50 个，用户滚动到底前已备好，消除首屏卡顿 |
+| perf | prd-admin | GitHub 实时日志 35s 轮询改为按需启动（仅当用户进入「实时日志」tab 时），不再抢首屏主线程 |
+| refactor | prd-api | 删除 `MergeChangelogMarkdownIntoCurrentWeek` 死代码（从未被调用） |
+| fix | prd-admin | 「待发布」chip 增加 hover tooltip，显示碎片文件数 + 合并方式提示，避免数字过大产生不切实际的错觉 |

--- a/changelogs/2026-06-06_changelog-truly-waterfall.md
+++ b/changelogs/2026-06-06_changelog-truly-waterfall.md
@@ -1,0 +1,4 @@
+| perf | prd-admin | 更新中心 ChangelogBell / AppShell / AgentLauncherPage 均改用 daysLimit=8 拉 current-week，避免每次页面加载都拉 260kB 全量碎片 |
+| perf | prd-admin | 历史发布版本详情改为 IntersectionObserver 懒加载：仅第一个版本（未发布）立即拉，其余版本卡片进视口才拉，避免一次性 700kB 详情压栈 |
+| perf | prd-admin | 历史发布渲染逻辑：summary 模式（entriesOmitted=true）下即使 days/highlights 都为空也渲染卡片，让 IntersectionObserver 能挂上 |
+| fix | prd-admin | 实时日志 chip 计数显示 0 的 bug：首屏拉一次 limit=80 让 totalCount 准确，不进入轮询 |

--- a/changelogs/2026-06-06_changelog-waterfall.md
+++ b/changelogs/2026-06-06_changelog-waterfall.md
@@ -1,0 +1,7 @@
+| perf | prd-api | 更新中心三个端点支持瀑布式分页：releases 加 summary 模式（只元数据 + 计数）+ by-version 详情端点；current-week 加 daysLimit/daysOffset；github-logs 加 before cursor |
+| perf | prd-api | 三个 DTO 新增 totalEntries/totalCount/hasMore/nextCursor，前端 chip 计数从全量取，不受分页切片影响 |
+| perf | prd-admin | 更新中心首屏 payload 从 ~474kB 砍到 ~10kB：releases summary 模式 + current-week daysLimit=4 + github-logs limit=80 |
+| perf | prd-admin | 历史发布版本详情按需懒加载：summary 到位后并发拉取 by-version，每个版本独立小请求，首屏即可见 chip 计数和高亮 |
+| perf | prd-admin | 待发布日期组瀑布加载：滚动到末尾 1 组内自动 fetch 下一批，IntersectionObserver 触发 |
+| perf | prd-admin | 实时日志 cursor 分页：首屏 80 条，滚动到末尾 10 条内自动续接更老批次 |
+| refactor | prd-admin | useIncrementalVisible 保留用户滚动进度（total 增长时不重置 visibleCount） |

--- a/changelogs/2026-06-07_bugbot-pr743-fixes.md
+++ b/changelogs/2026-06-07_bugbot-pr743-fixes.md
@@ -1,0 +1,5 @@
+| fix | prd-admin | 待发布瀑布加载 offset 计算错误：原 `fragments.length + daysOffset` 会把每批响应的 skip 值二次叠加，从第二次续接起每次跳过几天留下日期组空洞（4→14 应为 4→10），改为 `fragments.length` |
+| fix | prd-admin | summary 刷新清空 days 时，本地 `releaseDetailTriggeredRef` 记忆导致详情不再重拉、卡片留空的问题：删本地缓存，以 `entriesOmitted` 为信号，并发去重由 store 端 `loadingReleaseVersions` 兜底 |
+| fix | prd-admin | 实时日志 35s 轮询 / 手动刷新会用 first-page 80 条覆盖整个列表，丢掉 cursor 续接的更老历史：刷新路径保留 previous tail（不在 newShas 中的条目）合并 |
+| fix | prd-admin | SSE / 后台 `loadCurrentWeek({daysLimit:4})` 会把已通过 loadMoreFragments 累积的 fragments 缩回 4 个：store 端按 date 集合保留 incoming 之外的尾部 |
+| fix | prd-api | `MapReleases` 的 `TotalReleases/TotalEntries` 之前从 `view.Releases`（已被 limit 截断）算，chip 计数会偏低：controller 永远以 limit=100 拉 reader，totals 走全量、输出列表按 displayLimit 切片 |

--- a/changelogs/2026-06-07_bugbot-pr743-round2.md
+++ b/changelogs/2026-06-07_bugbot-pr743-round2.md
@@ -1,0 +1,3 @@
+| fix | prd-admin | GitHub 日志刷新合并 tail 时未保留 cursor：原本用 first-page 的 nextCursor 续接，会拉回已经在 preservedTail 里的同一批产生重复条目，改为保留 previous.hasMore / previous.nextCursor |
+| fix | prd-admin | GitHub 日志 loadMoreGitHubLogs stale-response 保护：开始时快照 githubLogsRef，若等待期间 refresh 完成（latest.logs 已不含 requestedCursor），丢弃旧 cursor 的延迟响应避免污染新列表 |
+| fix | prd-admin | 用户手动「刷新」（force=true）时不再保留旧 fragments tail：尊重用户明确的「全量重载」意图，仅 SSE/后台刷新路径保留 tail |

--- a/changelogs/2026-06-07_bugbot-pr743-round3.md
+++ b/changelogs/2026-06-07_bugbot-pr743-round3.md
@@ -1,0 +1,3 @@
+| fix | prd-admin | 铃铛 openPopover 不再 force=true：原本会清空更新中心页 loadMoreFragments 累积的尾部日期组，让正打开页面的用户瞬间「列表变短」；SWR 5min 新鲜度足够 |
+| fix | prd-admin | 已发布列表上限从 8 改为 100：原本若 CHANGELOG 版本 > 8 则永远看不到更老版本，chip 与列表数字会对不齐。summary 模式下 100 个版本元数据仍 < 10kB，几乎零成本 |
+| fix | prd-api | ChangelogRefreshWorker 的 ReleasesLimit 从 20 改为 100，与 controller 总是读 releases:100 cache key 对齐，避免 worker 预热的快照永远命中不到前端读取的 key |

--- a/prd-admin/src/components/changelog/ChangelogBell.tsx
+++ b/prd-admin/src/components/changelog/ChangelogBell.tsx
@@ -73,7 +73,7 @@ export function ChangelogBell({ size = 18, compact = false }: ChangelogBellProps
 
   // 计算 popover 位置（基于按钮位置）
   const openPopover = () => {
-    void loadCurrentWeek(true);
+    void loadCurrentWeek({ force: true });
     const rect = buttonRef.current?.getBoundingClientRect();
     if (rect) {
       const popoverWidth = 360;

--- a/prd-admin/src/components/changelog/ChangelogBell.tsx
+++ b/prd-admin/src/components/changelog/ChangelogBell.tsx
@@ -74,8 +74,11 @@ export function ChangelogBell({ size = 18, compact = false }: ChangelogBellProps
   }, []);
 
   // 计算 popover 位置（基于按钮位置）
+  // 注意：不再用 force=true 刷新——铃铛是「看一眼最新」的辅助入口，
+  // SWR 5min 新鲜度足够；force=true 会清空更新中心页 loadMoreFragments 累积到的
+  // 更老日期组 tail，让正打开页面的用户瞬间「列表变短」（Bugbot #1 第三轮）。
   const openPopover = () => {
-    void loadCurrentWeek({ daysLimit: 8, force: true });
+    void loadCurrentWeek({ daysLimit: 8 });
     const rect = buttonRef.current?.getBoundingClientRect();
     if (rect) {
       const popoverWidth = 360;

--- a/prd-admin/src/components/changelog/ChangelogBell.tsx
+++ b/prd-admin/src/components/changelog/ChangelogBell.tsx
@@ -66,14 +66,16 @@ export function ChangelogBell({ size = 18, compact = false }: ChangelogBellProps
   );
 
   // 首次挂载：拉取本周更新（让红点提前出现）
+  // daysLimit=8 覆盖绝大多数用户的查看间隔（≤1 周），把 260kB 砍到 ~15kB；
+  // 如果用户超过 8 天没访问，红点数会偏少（罕见场景，可接受）。
   useEffect(() => {
-    void loadCurrentWeek();
+    void loadCurrentWeek({ daysLimit: 8 });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // 计算 popover 位置（基于按钮位置）
   const openPopover = () => {
-    void loadCurrentWeek({ force: true });
+    void loadCurrentWeek({ daysLimit: 8, force: true });
     const rect = buttonRef.current?.getBoundingClientRect();
     if (rect) {
       const popoverWidth = 360;

--- a/prd-admin/src/layouts/AppShell.tsx
+++ b/prd-admin/src/layouts/AppShell.tsx
@@ -223,7 +223,7 @@ export default function AppShell() {
   const changelogUnread = useChangelogStore(selectUnreadCount);
   const loadChangelogCurrentWeek = useChangelogStore((s) => s.loadCurrentWeek);
   useEffect(() => {
-    void loadChangelogCurrentWeek();
+    void loadChangelogCurrentWeek({ daysLimit: 8 });
   }, [loadChangelogCurrentWeek]);
   // 本会话已关闭的 toast id 黑名单：持久化到 sessionStorage，避免 polling/刷新后重复弹出
   const [dismissedToastIds, setDismissedToastIds] = useState<Set<string>>(() => {

--- a/prd-admin/src/pages/AgentLauncherPage.tsx
+++ b/prd-admin/src/pages/AgentLauncherPage.tsx
@@ -530,7 +530,7 @@ export default function AgentLauncherPage() {
 
   useEffect(() => {
     loadItems();
-    void loadChangelogCurrentWeek();
+    void loadChangelogCurrentWeek({ daysLimit: 8 });
     void loadHomepageAssets();
     void loadWeeklyPoster();
   }, [loadItems, loadChangelogCurrentWeek, loadHomepageAssets, loadWeeklyPoster]);

--- a/prd-admin/src/pages/changelog/ChangelogPage.tsx
+++ b/prd-admin/src/pages/changelog/ChangelogPage.tsx
@@ -281,12 +281,28 @@ export default function ChangelogPage() {
 
   // 进入页面：拉取数据 + 标记已读
   // 「本周更新」section 已下线；但仍拉 currentWeek 以驱动已读计数 & 顶部的数据源徽标
+  // releases 首屏只拉 8 个版本（与 RELEASES_INITIAL_VISIBLE=4 + step=3 对齐留 buffer），
+  // 1.5s 后空闲背景补到 50 个（见下方 backfill effect），消除大 payload 阻塞首屏渲染
   useEffect(() => {
     void loadCurrentWeek();
-    void loadReleases(20);
+    void loadReleases(8);
     markAsSeen();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // 首屏 8 个版本到位后，1.5s 空闲背景补全到 50 个，用户向下滚动时已经备好
+  // 走 stale-while-revalidate：force=false 命中后端 5 分钟缓存，绝大多数情况不真发起远端拉取
+  const [didBackfillReleases, setDidBackfillReleases] = useState(false);
+  useEffect(() => {
+    if (didBackfillReleases) return;
+    if (!releases || releases.releases.length === 0) return;
+    if (releases.releases.length >= 20) return; // 已经够多
+    const id = window.setTimeout(() => {
+      setDidBackfillReleases(true);
+      void loadReleases(50, false);
+    }, 1500);
+    return () => window.clearTimeout(id);
+  }, [releases, didBackfillReleases, loadReleases]);
 
   useEffect(() => {
     githubLogsRef.current = githubLogs;
@@ -374,16 +390,20 @@ export default function ChangelogPage() {
     refreshGitHubLogsRef.current = refreshGitHubLogs;
   }, [refreshGitHubLogs]);
 
+  // 只在用户进入「实时日志」子 tab 时才启动 35s 轮询；
+  // 默认子 tab 是「已发布」，否则首屏 mount 时 requestIdleCallback 会与初始渲染抢主线程
+  // 实时性兜底：handleServerUpdate (SSE push) 仍在常驻，后端有更新会主动推。
   useEffect(() => {
     if (activeTab !== 'update_center') return;
+    if (historySubtab !== 'github_logs') return;
     let stopped = false;
 
     const run = () => {
       if (stopped || document.visibilityState !== 'visible') return;
       void refreshGitHubLogs({
         force: true,
-        foreground: historySubtab === 'github_logs' && !githubLogsRef.current,
-        showError: historySubtab === 'github_logs',
+        foreground: !githubLogsRef.current,
+        showError: true,
       });
     };
 
@@ -902,11 +922,15 @@ export default function ChangelogPage() {
             ] as const).map((tab) => {
               const active = historySubtab === tab.key;
               const count = counts[tab.key];
+              const tabTitle = tab.key === 'fragments' && currentWeek
+                ? `${currentWeek.fragments.length} 个碎片文件 · ${count} 条改动\n来源：changelogs/*.md\n清空方式：跑 scripts/assemble-changelog.sh && 发布版本`
+                : undefined;
               return (
                 <button
                   key={tab.key}
                   type="button"
                   onClick={() => setHistorySubtab(tab.key)}
+                  title={tabTitle}
                   className="h-8 px-3 rounded-lg inline-flex items-center gap-1.5 text-[12px] font-medium transition-all"
                   style={{
                     background: active ? 'rgba(99, 102, 241, 0.14)' : 'rgba(255, 255, 255, 0.04)',

--- a/prd-admin/src/pages/changelog/ChangelogPage.tsx
+++ b/prd-admin/src/pages/changelog/ChangelogPage.tsx
@@ -74,6 +74,8 @@ const GITHUB_LOGS_LIVE_POLL_MS = 35 * 1000;
 const GITHUB_LOGS_NEW_HIGHLIGHT_MS = 5200;
 const RELEASES_INITIAL_VISIBLE = 4;
 const RELEASES_VISIBLE_STEP = 3;
+/** 每个 release 默认渲染前 N 条 entries（across days），余下走「展开全部」按需渲染 */
+const ENTRIES_PER_RELEASE_INITIAL = 12;
 const FRAGMENT_GROUPS_INITIAL_VISIBLE = 6;
 const FRAGMENT_GROUPS_VISIBLE_STEP = 5;
 const GITHUB_LOGS_INITIAL_VISIBLE = 80;
@@ -228,6 +230,8 @@ export default function ChangelogPage() {
 
   const [typeFilter, setTypeFilter] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<string>('update_center');
+  /** 已点过「展开全部」的 release 版本号集合 —— 控制每个 release 内 entries 渲染数 */
+  const [expandedReleases, setExpandedReleases] = useState<Set<string>>(() => new Set());
   const [historySubtab, setHistorySubtab] = useState<HistorySubtab>('releases');
   const [githubLogs, setGitHubLogs] = useState<GitHubLogsView | null>(() => readGitHubLogsCache());
   const [loadingGitHubLogs, setLoadingGitHubLogs] = useState(false);
@@ -1300,9 +1304,23 @@ export default function ChangelogPage() {
                         </div>
                       )}
 
-                      {visibleDays.length > 0 && (
+                      {visibleDays.length > 0 && (() => {
+                        // 默认每个 release 只渲染前 ENTRIES_PER_RELEASE_INITIAL 条 entries（跨天累加），
+                        // 余下「展开全部」按需展示。避免 638 条一次性灌进 DOM 让页面瀑布到几万 px 高。
+                        const isExpanded = expandedReleases.has(release.version);
+                        const cap = isExpanded ? Infinity : ENTRIES_PER_RELEASE_INITIAL;
+                        let remaining = cap;
+                        const truncatedDays = [] as typeof visibleDays;
+                        for (const day of visibleDays) {
+                          if (remaining <= 0) break;
+                          const take = Math.min(day.entries.length, remaining);
+                          truncatedDays.push({ ...day, entries: day.entries.slice(0, take) });
+                          remaining -= take;
+                        }
+                        const hidden = totalCount - (cap === Infinity ? totalCount : (cap - remaining));
+                        return (
                         <div className="flex flex-col gap-3">
-                          {visibleDays.map((day, dayIdx) => {
+                          {truncatedDays.map((day, dayIdx) => {
                             const dayCommitDateTime = formatCommitDateTime(day.commitTimeUtc);
                             const dayTitle = dayCommitDateTime
                               ? `CHANGELOG 日期：${day.date}\n最近一次 CHANGELOG 合并提交：${dayCommitDateTime}`
@@ -1343,8 +1361,28 @@ export default function ChangelogPage() {
                               </div>
                             );
                           })}
+                          {!isExpanded && hidden > 0 && (
+                            <button
+                              type="button"
+                              onClick={() => setExpandedReleases((s) => {
+                                const next = new Set(s);
+                                next.add(release.version);
+                                return next;
+                              })}
+                              className="self-start mt-1 px-3 py-1.5 rounded-lg text-[12px] font-medium transition-all"
+                              style={{
+                                background: 'rgba(99, 102, 241, 0.08)',
+                                border: '1px solid rgba(99, 102, 241, 0.22)',
+                                color: '#a5b4fc',
+                                cursor: 'pointer',
+                              }}
+                            >
+                              展开全部 {hidden} 条
+                            </button>
+                          )}
                         </div>
-                      )}
+                        );
+                      })()}
                     </div>
                   );
                 })}

--- a/prd-admin/src/pages/changelog/ChangelogPage.tsx
+++ b/prd-admin/src/pages/changelog/ChangelogPage.tsx
@@ -64,9 +64,12 @@ interface FlatEntry extends ChangelogEntry {
 type HistorySubtab = 'releases' | 'fragments' | 'github_logs';
 type HistorySummaryStatus = 'idle' | 'loading' | 'ready' | 'error';
 
-const GITHUB_LOGS_CACHE_KEY = 'changelog:github-logs:v1';
+const GITHUB_LOGS_CACHE_KEY = 'changelog:github-logs:v2';
 const GITHUB_LOGS_CACHE_TTL_MS = 5 * 60 * 1000;
-const GITHUB_LOGS_FETCH_LIMIT = 1000;
+/** 首屏只拉 80 条（与 visible=80 对齐），后续走 cursor 续接 */
+const GITHUB_LOGS_INITIAL_FETCH = 80;
+/** 续接每批拉 80 条 */
+const GITHUB_LOGS_PAGE_SIZE = 80;
 const GITHUB_LOGS_LIVE_POLL_MS = 35 * 1000;
 const GITHUB_LOGS_NEW_HIGHLIGHT_MS = 5200;
 const RELEASES_INITIAL_VISIBLE = 4;
@@ -178,8 +181,10 @@ function useIncrementalVisible(
   const [visibleCount, setVisibleCount] = useState(initial);
   const sentinelRef = useRef<HTMLDivElement>(null);
 
+  // 关键：total 增长（瀑布加载新批次）时**保留**当前 visibleCount，不重置回 initial，
+  // 否则用户滚动到第 8 组后触发的 backend loadMore 会把视图缩回第 6 组。
   useEffect(() => {
-    setVisibleCount(Math.min(initial, total));
+    setVisibleCount((current) => Math.min(Math.max(current, initial), total));
   }, [enabled, initial, total]);
 
   useEffect(() => {
@@ -216,7 +221,9 @@ export default function ChangelogPage() {
   const loadingReleases = useChangelogStore((s) => s.loadingReleases);
   const error = useChangelogStore((s) => s.error);
   const loadCurrentWeek = useChangelogStore((s) => s.loadCurrentWeek);
+  const loadMoreFragments = useChangelogStore((s) => s.loadMoreFragments);
   const loadReleases = useChangelogStore((s) => s.loadReleases);
+  const loadReleaseDetail = useChangelogStore((s) => s.loadReleaseDetail);
   const markAsSeen = useChangelogStore((s) => s.markAsSeen);
 
   const [typeFilter, setTypeFilter] = useState<string | null>(null);
@@ -279,30 +286,29 @@ export default function ChangelogPage() {
     return d.getTime();
   });
 
-  // 进入页面：拉取数据 + 标记已读
-  // 「本周更新」section 已下线；但仍拉 currentWeek 以驱动已读计数 & 顶部的数据源徽标
-  // releases 首屏只拉 8 个版本（与 RELEASES_INITIAL_VISIBLE=4 + step=3 对齐留 buffer），
-  // 1.5s 后空闲背景补到 50 个（见下方 backfill effect），消除大 payload 阻塞首屏渲染
+  // 进入页面：瀑布式首屏三件套
+  // - currentWeek 只拉 4 个日期组（daysLimit=4），更多走 loadMoreFragments 增量补
+  // - releases 走 summary 模式：只元数据 + 计数，体积 <5kB；每个版本详情靠 IntersectionObserver 进入视口时按需补
+  // - githubLogs 只拉首批 80 条，cursor 分页续接
   useEffect(() => {
-    void loadCurrentWeek();
-    void loadReleases(8);
+    void loadCurrentWeek({ daysLimit: 4 });
+    void loadReleases({ limit: 8, summary: true });
     markAsSeen();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // 首屏 8 个版本到位后，1.5s 空闲背景补全到 50 个，用户向下滚动时已经备好
-  // 走 stale-while-revalidate：force=false 命中后端 5 分钟缓存，绝大多数情况不真发起远端拉取
-  const [didBackfillReleases, setDidBackfillReleases] = useState(false);
+  // releases summary 到位后：自动并发拉取所有版本详情（每版本~50kB，4个版本 = 4 个独立小请求，
+  // 浏览器并发，远比单次 274kB 大请求体验好；首屏先有 chip 计数和 highlights，详情陆续就位）
+  const releaseDetailTriggeredRef = useRef<Set<string>>(new Set());
   useEffect(() => {
-    if (didBackfillReleases) return;
-    if (!releases || releases.releases.length === 0) return;
-    if (releases.releases.length >= 20) return; // 已经够多
-    const id = window.setTimeout(() => {
-      setDidBackfillReleases(true);
-      void loadReleases(50, false);
-    }, 1500);
-    return () => window.clearTimeout(id);
-  }, [releases, didBackfillReleases, loadReleases]);
+    if (!releases) return;
+    for (const r of releases.releases) {
+      if (!r.entriesOmitted) continue;
+      if (releaseDetailTriggeredRef.current.has(r.version)) continue;
+      releaseDetailTriggeredRef.current.add(r.version);
+      void loadReleaseDetail(r.version);
+    }
+  }, [releases, loadReleaseDetail]);
 
   useEffect(() => {
     githubLogsRef.current = githubLogs;
@@ -339,7 +345,8 @@ export default function ChangelogPage() {
 
     try {
       const previous = githubLogsRef.current;
-      const res = await getChangelogGitHubLogs(GITHUB_LOGS_FETCH_LIMIT, force);
+      // 刷新永远只拉首批 80 条（最新的）。续接更老的走 loadMoreGitHubLogs（cursor）。
+      const res = await getChangelogGitHubLogs({ limit: GITHUB_LOGS_INITIAL_FETCH, force });
       if (res.success) {
         // 成功就清错误横幅（无论 foreground/trailing/SSE 触发）：否则前一次前台失败留下的
         // 红色「注意」横幅会在后台成功更新后仍挂着，与实际状态不符（Bugbot Medium）。
@@ -390,6 +397,31 @@ export default function ChangelogPage() {
     refreshGitHubLogsRef.current = refreshGitHubLogs;
   }, [refreshGitHubLogs]);
 
+  // cursor 分页续接 GitHub 日志（向更老的方向）
+  const loadingMoreLogsRef = useRef(false);
+  const loadMoreGitHubLogs = useCallback(async () => {
+    if (loadingMoreLogsRef.current) return;
+    const current = githubLogsRef.current;
+    if (!current || !current.hasMore || !current.nextCursor) return;
+    loadingMoreLogsRef.current = true;
+    try {
+      const res = await getChangelogGitHubLogs({
+        limit: GITHUB_LOGS_PAGE_SIZE,
+        before: current.nextCursor,
+      });
+      if (!res.success || !res.data) return;
+      const merged: GitHubLogsView = {
+        ...res.data,
+        // 累积保留头部已展示的（最新），追加新批次（更老）
+        logs: [...current.logs, ...res.data.logs],
+      };
+      setGitHubLogs(merged);
+      writeGitHubLogsCache(merged);
+    } finally {
+      loadingMoreLogsRef.current = false;
+    }
+  }, []);
+
   // 只在用户进入「实时日志」子 tab 时才启动 35s 轮询；
   // 默认子 tab 是「已发布」，否则首屏 mount 时 requestIdleCallback 会与初始渲染抢主线程
   // 实时性兜底：handleServerUpdate (SSE push) 仍在常驻，后端有更新会主动推。
@@ -433,8 +465,8 @@ export default function ChangelogPage() {
   }, []);
 
   const handleRefresh = () => {
-    void loadCurrentWeek(true);
-    void loadReleases(20, true);
+    void loadCurrentWeek({ daysLimit: 4, force: true });
+    void loadReleases({ limit: 8, summary: true, force: true });
     void refreshGitHubLogs({ force: true, foreground: historySubtab === 'github_logs', showError: historySubtab === 'github_logs' });
   };
 
@@ -450,8 +482,8 @@ export default function ChangelogPage() {
     lastBeatRef.current = Date.now();
     const viewType = (data as { viewType?: string })?.viewType;
     // 服务器已把新数据落库，这里只做 force=false 的后台静默重读（读存量，不打 GitHub、不闪 loading）
-    if (viewType === 'current-week') void loadCurrentWeek(false);
-    else if (viewType === 'releases') void loadReleases(20, false);
+    if (viewType === 'current-week') void loadCurrentWeek({ daysLimit: 4 });
+    else if (viewType === 'releases') void loadReleases({ limit: 8, summary: true });
     else if (viewType === 'github-logs') void refreshGitHubLogs({ force: false });
     setJustUpdatedAt(Date.now());
   }, [loadCurrentWeek, loadReleases, refreshGitHubLogs]);
@@ -553,11 +585,16 @@ export default function ChangelogPage() {
   };
 
   const counts = useMemo(() => {
-    const released = releases?.releases.reduce((sum, release) => (
-      sum + (release.entryCount ?? release.days.reduce((daySum, day) => daySum + day.entries.length, 0))
-    ), 0) ?? 0;
-    const unpublished = currentWeek?.fragments.reduce((sum, fragment) => sum + fragment.entries.length, 0) ?? 0;
-    const logs = githubLogs?.logs.length ?? 0;
+    // 优先取服务器给的全量计数（summary 模式下，本地 fragments/days 只是分页切片，sum 会偏低）
+    const released = releases?.totalEntries
+      ?? releases?.releases.reduce((sum, release) => (
+        sum + (release.entryCount ?? release.days.reduce((daySum, day) => daySum + day.entries.length, 0))
+      ), 0)
+      ?? 0;
+    const unpublished = currentWeek?.totalEntries
+      ?? currentWeek?.fragments.reduce((sum, fragment) => sum + fragment.entries.length, 0)
+      ?? 0;
+    const logs = githubLogs?.totalCount ?? githubLogs?.logs.length ?? 0;
     return { releases: released, fragments: unpublished, github_logs: logs };
   }, [currentWeek, githubLogs, releases]);
 
@@ -652,6 +689,24 @@ export default function ChangelogPage() {
     GITHUB_LOGS_VISIBLE_STEP,
     scrollRootRef
   );
+
+  // ── 瀑布式 backend loadMore 触发器 ──
+  // 当用户已渲染到本地数据末尾 1 组之内 且 backend 还有更多 → preemptive fetch 下一批
+  useEffect(() => {
+    if (activeTab !== 'update_center') return;
+    if (historySubtab !== 'fragments') return;
+    if (!currentWeek?.hasMore) return;
+    if (fragmentList.visibleCount < fragmentGroups.length - 1) return;
+    void loadMoreFragments();
+  }, [activeTab, historySubtab, currentWeek, fragmentList.visibleCount, fragmentGroups.length, loadMoreFragments]);
+
+  useEffect(() => {
+    if (activeTab !== 'update_center') return;
+    if (historySubtab !== 'github_logs') return;
+    if (!githubLogs?.hasMore) return;
+    if (githubLogList.visibleCount < githubLogRows.length - 10) return;
+    void loadMoreGitHubLogs();
+  }, [activeTab, historySubtab, githubLogs, githubLogList.visibleCount, githubLogRows.length, loadMoreGitHubLogs]);
 
   // 数据源标签 + 拉取时间显示（github / local / none）
   const sourceLabel = (() => {
@@ -923,7 +978,7 @@ export default function ChangelogPage() {
               const active = historySubtab === tab.key;
               const count = counts[tab.key];
               const tabTitle = tab.key === 'fragments' && currentWeek
-                ? `${currentWeek.fragments.length} 个碎片文件 · ${count} 条改动\n来源：changelogs/*.md\n清空方式：跑 scripts/assemble-changelog.sh && 发布版本`
+                ? `${currentWeek.totalDays ?? currentWeek.fragments.length} 个碎片文件 · ${count} 条改动\n来源：changelogs/*.md\n清空方式：跑 scripts/assemble-changelog.sh && 发布版本`
                 : undefined;
               return (
                 <button
@@ -1339,8 +1394,12 @@ export default function ChangelogPage() {
                   ))}
                 <IncrementalSentinel
                   refEl={fragmentList.sentinelRef}
-                  show={fragmentList.hasMore}
-                  text={`继续加载待发布日期 ${Math.min(FRAGMENT_GROUPS_VISIBLE_STEP, fragmentGroups.length - fragmentList.visibleCount)} 组…`}
+                  show={fragmentList.hasMore || (currentWeek.hasMore ?? false)}
+                  text={
+                    fragmentList.hasMore
+                      ? `继续加载待发布日期 ${Math.min(FRAGMENT_GROUPS_VISIBLE_STEP, fragmentGroups.length - fragmentList.visibleCount)} 组…`
+                      : `从服务器加载更多日期组…`
+                  }
                 />
               </div>
             )}
@@ -1391,8 +1450,12 @@ export default function ChangelogPage() {
                 </AnimatePresence>
                 <IncrementalSentinel
                   refEl={githubLogList.sentinelRef}
-                  show={githubLogList.hasMore}
-                  text={`继续加载实时日志 ${Math.min(GITHUB_LOGS_VISIBLE_STEP, githubLogRows.length - githubLogList.visibleCount)} 条…`}
+                  show={githubLogList.hasMore || (githubLogs.hasMore ?? false)}
+                  text={
+                    githubLogList.hasMore
+                      ? `继续加载实时日志 ${Math.min(GITHUB_LOGS_VISIBLE_STEP, githubLogRows.length - githubLogList.visibleCount)} 条…`
+                      : `从服务器加载更多日志…`
+                  }
                 />
               </div>
             )}

--- a/prd-admin/src/pages/changelog/ChangelogPage.tsx
+++ b/prd-admin/src/pages/changelog/ChangelogPage.tsx
@@ -395,8 +395,16 @@ export default function ChangelogPage() {
         // 否则 35s 轮询 / 手动刷新 / SSE 会用 first-page 80 条覆盖整个列表，
         // 用户正在看的更老内容直接消失（Bugbot #3 + Codex P2）。
         const preservedTail = (previous?.logs ?? []).filter((log) => !newShas.has(log.sha));
-        const merged: GitHubLogsView = preservedTail.length > 0
-          ? { ...res.data, logs: [...res.data.logs, ...preservedTail] }
+        // ⚠️ 关键：合并 tail 时也要保留 previous 的 hasMore / nextCursor。
+        // 否则用 res.data 的 nextCursor（first-page 最后一条 sha）去续接，
+        // 会拉回已经在 preservedTail 里的同一批，产生重复（Bugbot High #1 + Codex P2）
+        const merged: GitHubLogsView = preservedTail.length > 0 && previous
+          ? {
+              ...res.data,
+              logs: [...res.data.logs, ...preservedTail],
+              hasMore: previous.hasMore,
+              nextCursor: previous.nextCursor,
+            }
           : res.data;
 
         setGitHubLogs(merged);
@@ -444,19 +452,27 @@ export default function ChangelogPage() {
   const loadingMoreLogsRef = useRef(false);
   const loadMoreGitHubLogs = useCallback(async () => {
     if (loadingMoreLogsRef.current) return;
-    const current = githubLogsRef.current;
-    if (!current || !current.hasMore || !current.nextCursor) return;
+    const startSnapshot = githubLogsRef.current;
+    if (!startSnapshot || !startSnapshot.hasMore || !startSnapshot.nextCursor) return;
     loadingMoreLogsRef.current = true;
+    const requestedCursor = startSnapshot.nextCursor;
     try {
       const res = await getChangelogGitHubLogs({
         limit: GITHUB_LOGS_PAGE_SIZE,
-        before: current.nextCursor,
+        before: requestedCursor,
       });
       if (!res.success || !res.data) return;
+      // ⚠️ 关键：读最新 ref，而不是用 startSnapshot —— refresh 可能在我们等待期间到达。
+      // 若 latest 已不包含 requestedCursor（=refresh 已用新数据完全覆盖），
+      // 本次返回的旧 cursor 数据是过时的，直接丢弃，避免用 stale 数据覆盖新列表（Bugbot #2）。
+      const latest = githubLogsRef.current;
+      if (!latest) return;
+      const latestHasCursor = latest.logs.some((l) => l.sha === requestedCursor);
+      if (!latestHasCursor) return;
       const merged: GitHubLogsView = {
         ...res.data,
         // 累积保留头部已展示的（最新），追加新批次（更老）
-        logs: [...current.logs, ...res.data.logs],
+        logs: [...latest.logs, ...res.data.logs],
       };
       setGitHubLogs(merged);
       writeGitHubLogsCache(merged);

--- a/prd-admin/src/pages/changelog/ChangelogPage.tsx
+++ b/prd-admin/src/pages/changelog/ChangelogPage.tsx
@@ -303,13 +303,16 @@ export default function ChangelogPage() {
 
   // releases summary 到位后：只对【第一个版本】立刻拉详情；
   // 其余 release 走 IntersectionObserver — 滚动到可视区才拉，避免一次性 700kB 详情压栈
-  const releaseDetailTriggeredRef = useRef<Set<string>>(new Set());
+  //
+  // 注意：不再用本地 triggeredRef 缓存「已请求」状态。SSE / 刷新会重新调用
+  // loadReleases({summary:true})，把所有版本的 days 清空（entriesOmitted=true），
+  // 若 ref 还记着「已请求过」就永远不会重拉，卡片留空（Bugbot #2）。
+  // 改为：以 `release.entriesOmitted` 本身作为「是否需要拉」的信号；store 端
+  // 用 `loadingReleaseVersions` 做并发去重，本端无需再缓存。
   useEffect(() => {
     if (!releases || releases.releases.length === 0) return;
     const first = releases.releases[0];
     if (!first.entriesOmitted) return;
-    if (releaseDetailTriggeredRef.current.has(first.version)) return;
-    releaseDetailTriggeredRef.current.add(first.version);
     void loadReleaseDetail(first.version);
   }, [releases, loadReleaseDetail]);
 
@@ -323,8 +326,7 @@ export default function ChangelogPage() {
           if (!entry.isIntersecting) continue;
           const v = (entry.target as HTMLElement).dataset.releaseVersion;
           if (!v) continue;
-          if (releaseDetailTriggeredRef.current.has(v)) continue;
-          releaseDetailTriggeredRef.current.add(v);
+          // 让 store 自己判断「是否需要拉」+ 并发去重（loadingReleaseVersions / entriesOmitted）
           void loadReleaseDetail(v);
         }
       },
@@ -383,14 +385,23 @@ export default function ChangelogPage() {
         // 成功就清错误横幅（无论 foreground/trailing/SSE 触发）：否则前一次前台失败留下的
         // 红色「注意」横幅会在后台成功更新后仍挂着，与实际状态不符（Bugbot Medium）。
         setGitHubLogsError(null);
+        const newShas = new Set(res.data.logs.map((log) => log.sha));
         const previousShas = new Set((previous?.logs ?? []).map((log) => log.sha));
         const insertedShas = previous
           ? res.data.logs.filter((log) => !previousShas.has(log.sha)).map((log) => log.sha)
           : [];
 
-        setGitHubLogs(res.data);
+        // 保留用户已通过 cursor 续接到的更老 logs（不在 newShas 里的）。
+        // 否则 35s 轮询 / 手动刷新 / SSE 会用 first-page 80 条覆盖整个列表，
+        // 用户正在看的更老内容直接消失（Bugbot #3 + Codex P2）。
+        const preservedTail = (previous?.logs ?? []).filter((log) => !newShas.has(log.sha));
+        const merged: GitHubLogsView = preservedTail.length > 0
+          ? { ...res.data, logs: [...res.data.logs, ...preservedTail] }
+          : res.data;
+
+        setGitHubLogs(merged);
         setLiveFetchedAt(res.data.fetchedAt);
-        writeGitHubLogsCache(res.data);
+        writeGitHubLogsCache(merged);
 
         if (insertedShas.length > 0) {
           setNewGitHubLogShas((current) => new Set([...current, ...insertedShas]));

--- a/prd-admin/src/pages/changelog/ChangelogPage.tsx
+++ b/prd-admin/src/pages/changelog/ChangelogPage.tsx
@@ -655,7 +655,14 @@ export default function ChangelogPage() {
 
   const releaseRenderItems = useMemo(() => {
     if (!releases) return [];
+    // 去重：CHANGELOG.md 文末有第二个 `## [未发布]` 模板锚点，parser 会重复匹配
+    const seenVersions = new Set<string>();
     return releases.releases
+      .filter((r) => {
+        if (seenVersions.has(r.version)) return false;
+        seenVersions.add(r.version);
+        return true;
+      })
       .map((release) => {
         const visibleDays = release.days
           .map((d) => ({

--- a/prd-admin/src/pages/changelog/ChangelogPage.tsx
+++ b/prd-admin/src/pages/changelog/ChangelogPage.tsx
@@ -297,18 +297,46 @@ export default function ChangelogPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // releases summary 到位后：自动并发拉取所有版本详情（每版本~50kB，4个版本 = 4 个独立小请求，
-  // 浏览器并发，远比单次 274kB 大请求体验好；首屏先有 chip 计数和 highlights，详情陆续就位）
+  // releases summary 到位后：只对【第一个版本】立刻拉详情；
+  // 其余 release 走 IntersectionObserver — 滚动到可视区才拉，避免一次性 700kB 详情压栈
   const releaseDetailTriggeredRef = useRef<Set<string>>(new Set());
   useEffect(() => {
-    if (!releases) return;
-    for (const r of releases.releases) {
-      if (!r.entriesOmitted) continue;
-      if (releaseDetailTriggeredRef.current.has(r.version)) continue;
-      releaseDetailTriggeredRef.current.add(r.version);
-      void loadReleaseDetail(r.version);
-    }
+    if (!releases || releases.releases.length === 0) return;
+    const first = releases.releases[0];
+    if (!first.entriesOmitted) return;
+    if (releaseDetailTriggeredRef.current.has(first.version)) return;
+    releaseDetailTriggeredRef.current.add(first.version);
+    void loadReleaseDetail(first.version);
   }, [releases, loadReleaseDetail]);
+
+  // 其他 release：IntersectionObserver 监视 data-release-version 元素，进视口才拉
+  useEffect(() => {
+    if (activeTab !== 'update_center' || historySubtab !== 'releases') return;
+    if (!releases) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (!entry.isIntersecting) continue;
+          const v = (entry.target as HTMLElement).dataset.releaseVersion;
+          if (!v) continue;
+          if (releaseDetailTriggeredRef.current.has(v)) continue;
+          releaseDetailTriggeredRef.current.add(v);
+          void loadReleaseDetail(v);
+        }
+      },
+      { rootMargin: '300px 0px', threshold: 0.01 },
+    );
+    const nodes = document.querySelectorAll<HTMLElement>('[data-release-version]');
+    nodes.forEach((n) => observer.observe(n));
+    return () => observer.disconnect();
+  }, [activeTab, historySubtab, releases, loadReleaseDetail]);
+
+  // GitHub logs：首屏拉一次 80 条让 chip 计数准确（不是 0），不进入轮询
+  useEffect(() => {
+    if (githubLogsRef.current) return; // sessionStorage cache 已有，跳过
+    void refreshGitHubLogs({ force: false, foreground: false, showError: false });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     githubLogsRef.current = githubLogs;
@@ -636,7 +664,9 @@ export default function ChangelogPage() {
           }))
           .filter((d) => d.entries.length > 0);
         const totalCount = visibleDays.reduce((s, d) => s + d.entries.length, 0);
-        if (totalCount === 0 && release.highlights.length === 0) {
+        // summary 模式（entriesOmitted=true）下 days 故意为空——仍然要渲染卡片，让 IntersectionObserver
+        // 能挂到 dom 上触发详情拉取。只有当 release 真的「无 entries + 无 highlights + 非 summary」时才隐藏。
+        if (totalCount === 0 && release.highlights.length === 0 && !release.entriesOmitted) {
           return null;
         }
         const entryCount = release.entryCount ?? release.days.reduce((sum, day) => sum + day.entries.length, 0);
@@ -1215,6 +1245,7 @@ export default function ChangelogPage() {
                   return (
                     <div
                       key={`${release.version}-${release.releaseDate ?? ''}`}
+                      data-release-version={release.version}
                       {...(isFirstVisible ? { 'data-tour-id': 'changelog-latest' } : {})}
                     >
                         <div className="flex items-center gap-2 mb-3">

--- a/prd-admin/src/pages/changelog/ChangelogPage.tsx
+++ b/prd-admin/src/pages/changelog/ChangelogPage.tsx
@@ -296,7 +296,7 @@ export default function ChangelogPage() {
   // - githubLogs 只拉首批 80 条，cursor 分页续接
   useEffect(() => {
     void loadCurrentWeek({ daysLimit: 4 });
-    void loadReleases({ limit: 8, summary: true });
+    void loadReleases({ limit: 100, summary: true });
     markAsSeen();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -525,7 +525,7 @@ export default function ChangelogPage() {
 
   const handleRefresh = () => {
     void loadCurrentWeek({ daysLimit: 4, force: true });
-    void loadReleases({ limit: 8, summary: true, force: true });
+    void loadReleases({ limit: 100, summary: true, force: true });
     void refreshGitHubLogs({ force: true, foreground: historySubtab === 'github_logs', showError: historySubtab === 'github_logs' });
   };
 
@@ -542,7 +542,7 @@ export default function ChangelogPage() {
     const viewType = (data as { viewType?: string })?.viewType;
     // 服务器已把新数据落库，这里只做 force=false 的后台静默重读（读存量，不打 GitHub、不闪 loading）
     if (viewType === 'current-week') void loadCurrentWeek({ daysLimit: 4 });
-    else if (viewType === 'releases') void loadReleases({ limit: 8, summary: true });
+    else if (viewType === 'releases') void loadReleases({ limit: 100, summary: true });
     else if (viewType === 'github-logs') void refreshGitHubLogs({ force: false });
     setJustUpdatedAt(Date.now());
   }, [loadCurrentWeek, loadReleases, refreshGitHubLogs]);

--- a/prd-admin/src/services/api.ts
+++ b/prd-admin/src/services/api.ts
@@ -1263,18 +1263,27 @@ export const api = {
 
   // ============ Changelog 更新中心（代码级周报） ============
   changelog: {
-    currentWeek: (force?: boolean) =>
-      `/api/changelog/current-week${force ? '?force=true' : ''}`,
-    releases: (limit?: number, force?: boolean) => {
+    currentWeek: (opts?: { daysLimit?: number; daysOffset?: number; force?: boolean }) => {
       const params: string[] = [];
-      if (limit) params.push(`limit=${limit}`);
-      if (force) params.push('force=true');
+      if (opts?.daysLimit != null) params.push(`daysLimit=${opts.daysLimit}`);
+      if (opts?.daysOffset != null && opts.daysOffset > 0) params.push(`daysOffset=${opts.daysOffset}`);
+      if (opts?.force) params.push('force=true');
+      return `/api/changelog/current-week${params.length ? `?${params.join('&')}` : ''}`;
+    },
+    releases: (opts?: { limit?: number; summary?: boolean; force?: boolean }) => {
+      const params: string[] = [];
+      if (opts?.limit != null) params.push(`limit=${opts.limit}`);
+      if (opts?.summary) params.push('summary=true');
+      if (opts?.force) params.push('force=true');
       return `/api/changelog/releases${params.length ? `?${params.join('&')}` : ''}`;
     },
-    githubLogs: (limit?: number, force?: boolean) => {
+    releaseByVersion: (version: string, force?: boolean) =>
+      `/api/changelog/releases/by-version/${encodeURIComponent(version)}${force ? '?force=true' : ''}`,
+    githubLogs: (opts?: { limit?: number; before?: string; force?: boolean }) => {
       const params: string[] = [];
-      if (limit) params.push(`limit=${limit}`);
-      if (force) params.push('force=true');
+      if (opts?.limit != null) params.push(`limit=${opts.limit}`);
+      if (opts?.before) params.push(`before=${encodeURIComponent(opts.before)}`);
+      if (opts?.force) params.push('force=true');
       return `/api/changelog/github-logs${params.length ? `?${params.join('&')}` : ''}`;
     },
     /** AI 总结（走 ILlmGateway + prd-admin.changelog.aiSummary::chat） */

--- a/prd-admin/src/services/index.ts
+++ b/prd-admin/src/services/index.ts
@@ -1440,6 +1440,7 @@ export const channelService: IChannelService = new ChannelService();
 export {
   getCurrentWeekChangelog,
   getChangelogReleases,
+  getChangelogReleaseByVersion,
   getChangelogGitHubLogs,
   postChangelogAiSummary,
   listChangelogReportSources,

--- a/prd-admin/src/services/real/changelog.ts
+++ b/prd-admin/src/services/real/changelog.ts
@@ -29,6 +29,14 @@ export interface CurrentWeekView {
   source: 'local' | 'github' | 'none';
   /** ISO 8601 拉取时间 */
   fetchedAt: string;
+  /** 全量日期组数（=碎片文件数），不受 daysLimit 影响，用于 chip 计数 */
+  totalDays?: number;
+  /** 全量 entries 总数，不受 daysLimit 影响，用于 chip 计数 */
+  totalEntries?: number;
+  /** 本次响应跳过的日期组数（用于 loadMore 续接） */
+  daysOffset?: number;
+  /** 是否还有更多日期组 */
+  hasMore?: boolean;
   fragments: ChangelogFragment[];
 }
 
@@ -51,6 +59,8 @@ export interface ChangelogRelease {
   sourceScope?: string;
   /** "用户更新项" 高亮（仅已发布版本可能有） */
   highlights: string[];
+  /** true 时 days 是空数组（summary 模式），需调 releaseByVersion 端点拉详情 */
+  entriesOmitted?: boolean;
   days: ChangelogDay[];
 }
 
@@ -58,6 +68,10 @@ export interface ReleasesView {
   dataSourceAvailable: boolean;
   source: 'local' | 'github' | 'none';
   fetchedAt: string;
+  /** 版本总数，用于 chip 计数 */
+  totalReleases?: number;
+  /** 所有版本 entries 总数，用于 chip 计数（summary 模式下仍准确） */
+  totalEntries?: number;
   releases: ChangelogRelease[];
 }
 
@@ -75,6 +89,11 @@ export interface GitHubLogsView {
   dataSourceAvailable: boolean;
   source: 'local' | 'github' | 'none';
   fetchedAt: string;
+  /** 全量 commit 总数，用于 chip 计数 */
+  totalCount?: number;
+  hasMore?: boolean;
+  /** 下一页 cursor，传给 before 参数取下一批 */
+  nextCursor?: string | null;
   logs: GitHubLogEntry[];
 }
 
@@ -82,26 +101,48 @@ export interface GitHubLogsView {
 
 /**
  * 获取待发布更新（基于全部 changelogs/*.md 碎片，按日期倒序）
- * @param force 绕过服务端缓存（GitHub 路径意味着触发真实拉取）
+ * 支持瀑布式分页：daysLimit + daysOffset
  */
-export async function getCurrentWeekChangelog(force = false): Promise<ApiResponse<CurrentWeekView>> {
-  return await apiRequest<CurrentWeekView>(api.changelog.currentWeek(force), { method: 'GET' });
+export async function getCurrentWeekChangelog(opts: {
+  daysLimit?: number;
+  daysOffset?: number;
+  force?: boolean;
+} = {}): Promise<ApiResponse<CurrentWeekView>> {
+  return await apiRequest<CurrentWeekView>(api.changelog.currentWeek(opts), { method: 'GET' });
 }
 
 /**
  * 获取历史发布（基于 CHANGELOG.md，按版本倒序）
- * @param force 绕过服务端缓存
+ * summary=true 时只返回元数据 + entryCount（首屏极轻），详情靠 getChangelogReleaseByVersion
  */
-export async function getChangelogReleases(limit = 20, force = false): Promise<ApiResponse<ReleasesView>> {
-  return await apiRequest<ReleasesView>(api.changelog.releases(limit, force), { method: 'GET' });
+export async function getChangelogReleases(opts: {
+  limit?: number;
+  summary?: boolean;
+  force?: boolean;
+} = {}): Promise<ApiResponse<ReleasesView>> {
+  return await apiRequest<ReleasesView>(api.changelog.releases(opts), { method: 'GET' });
+}
+
+/**
+ * 获取单个版本的完整 entries（按需懒加载，配合 summary 模式使用）
+ */
+export async function getChangelogReleaseByVersion(
+  version: string,
+  force = false,
+): Promise<ApiResponse<ChangelogRelease>> {
+  return await apiRequest<ChangelogRelease>(api.changelog.releaseByVersion(version, force), { method: 'GET' });
 }
 
 /**
  * 获取 GitHub 日志（优先本地 git log，失败时回退 GitHub commits API）
- * @param force 绕过服务端缓存
+ * 支持 cursor 分页：before=<sha>
  */
-export async function getChangelogGitHubLogs(limit = 30, force = false): Promise<ApiResponse<GitHubLogsView>> {
-  return await apiRequest<GitHubLogsView>(api.changelog.githubLogs(limit, force), { method: 'GET' });
+export async function getChangelogGitHubLogs(opts: {
+  limit?: number;
+  before?: string;
+  force?: boolean;
+} = {}): Promise<ApiResponse<GitHubLogsView>> {
+  return await apiRequest<GitHubLogsView>(api.changelog.githubLogs(opts), { method: 'GET' });
 }
 
 export type ChangelogAiSummarySubtab = 'releases' | 'fragments' | 'github_logs';

--- a/prd-admin/src/stores/__tests__/changelogStore.swr.test.ts
+++ b/prd-admin/src/stores/__tests__/changelogStore.swr.test.ts
@@ -51,7 +51,7 @@ describe('changelogStore: stale-while-revalidate', () => {
     let resolveFn!: (v: unknown) => void;
     (getChangelogReleases as Mock).mockReturnValue(new Promise((r) => { resolveFn = r; }));
 
-    const p = useChangelogStore.getState().loadReleases(20);
+    const p = useChangelogStore.getState().loadReleases({ limit: 20 });
     // 无缓存：拉取过程中 loading 为 true
     expect(useChangelogStore.getState().loadingReleases).toBe(true);
 
@@ -68,7 +68,7 @@ describe('changelogStore: stale-while-revalidate', () => {
     let resolveFn!: (v: unknown) => void;
     (getChangelogReleases as Mock).mockReturnValue(new Promise((r) => { resolveFn = r; }));
 
-    const p = useChangelogStore.getState().loadReleases(20);
+    const p = useChangelogStore.getState().loadReleases({ limit: 20 });
     // 有缓存：刷新过程中 loading 始终为 false（页面不会闪「正在加载」）
     expect(useChangelogStore.getState().loadingReleases).toBe(false);
     // 仍展示旧数据
@@ -86,7 +86,7 @@ describe('changelogStore: stale-while-revalidate', () => {
     useChangelogStore.setState({ releases: makeReleases('local') });
     (getChangelogReleases as Mock).mockResolvedValue({ success: false, error: { message: '网络错误' } });
 
-    await useChangelogStore.getState().loadReleases(20);
+    await useChangelogStore.getState().loadReleases({ limit: 20 });
 
     expect(useChangelogStore.getState().releases?.source).toBe('local');
     expect(useChangelogStore.getState().error).toBeNull();
@@ -96,7 +96,7 @@ describe('changelogStore: stale-while-revalidate', () => {
   it('无缓存时 loadReleases 失败会写 error', async () => {
     (getChangelogReleases as Mock).mockResolvedValue({ success: false, error: { message: '网络错误' } });
 
-    await useChangelogStore.getState().loadReleases(20);
+    await useChangelogStore.getState().loadReleases({ limit: 20 });
 
     expect(useChangelogStore.getState().error).toBe('网络错误');
     expect(useChangelogStore.getState().releases).toBeNull();

--- a/prd-admin/src/stores/changelogStore.ts
+++ b/prd-admin/src/stores/changelogStore.ts
@@ -139,10 +139,11 @@ export const useChangelogStore = create<ChangelogState>()(
         if (res.success) {
           // 保留瀑布已加载的更老日期组（用户已通过 loadMoreFragments 累积到 > daysLimit 个）。
           // 否则 SSE / 后台刷新会把 fragments 缩回 daysLimit 大小，丢掉用户已滚到的位置（Bugbot #4）。
+          // 例外：force=true 是用户明确「刷新」，期望全量重载，不再保留旧 tail（Bugbot #3 第二轮）。
           set((state) => {
             const incoming = res.data;
             const cur = state.currentWeek;
-            if (cur && cur.fragments.length > incoming.fragments.length) {
+            if (!force && cur && cur.fragments.length > incoming.fragments.length) {
               const incomingDates = new Set(incoming.fragments.map((f) => f.date));
               const tail = cur.fragments.filter((f) => !incomingDates.has(f.date));
               return {

--- a/prd-admin/src/stores/changelogStore.ts
+++ b/prd-admin/src/stores/changelogStore.ts
@@ -3,9 +3,11 @@ import { persist, createJSONStorage } from 'zustand/middleware';
 import {
   getCurrentWeekChangelog,
   getChangelogReleases,
+  getChangelogReleaseByVersion,
   type CurrentWeekView,
   type ReleasesView,
   type ChangelogEntry,
+  type ChangelogFragment,
 } from '@/services';
 
 interface ChangelogState {
@@ -15,6 +17,10 @@ interface ChangelogState {
   // 加载状态
   loadingCurrent: boolean;
   loadingReleases: boolean;
+  /** 正在按需拉取详情的版本（避免并发重复） */
+  loadingReleaseVersions: Record<string, true>;
+  /** 正在加载更多碎片日期组（避免并发重复触发） */
+  loadingMoreFragments: boolean;
   // 错误
   error: string | null;
   // 用户上次查看时间戳（ISO 字符串，sessionStorage 持久化）
@@ -22,8 +28,19 @@ interface ChangelogState {
   lastSeenAt: string | null;
 
   // Actions
-  loadCurrentWeek: (force?: boolean) => Promise<void>;
-  loadReleases: (limit?: number, force?: boolean) => Promise<void>;
+  /**
+   * 首屏只拉 daysLimit 个日期组（默认 4），全量计数走 totalEntries/totalDays。
+   * 续接走 loadMoreFragments。
+   */
+  loadCurrentWeek: (opts?: { daysLimit?: number; force?: boolean }) => Promise<void>;
+  /** 续接更多碎片日期组，append 到现有 fragments 末尾 */
+  loadMoreFragments: () => Promise<void>;
+  /**
+   * 首屏 summary=true（只元数据 + 计数，体积 <5kB），详情按需补
+   */
+  loadReleases: (opts?: { limit?: number; summary?: boolean; force?: boolean }) => Promise<void>;
+  /** 按版本懒加载 entries 并 patch 进 releases 数组 */
+  loadReleaseDetail: (version: string) => Promise<void>;
   /** 用户已查看 → 标记当前时间为 lastSeenAt（清掉红点） */
   markAsSeen: () => void;
 }
@@ -99,16 +116,17 @@ export const useChangelogStore = create<ChangelogState>()(
       releases: null,
       loadingCurrent: false,
       loadingReleases: false,
+      loadingReleaseVersions: {},
+      loadingMoreFragments: false,
       error: null,
       lastSeenAt: null,
 
       // stale-while-revalidate：有 sessionStorage 缓存时立即渲染旧数据并后台静默刷新
       //（不翻 loadingCurrent，避免每次打开都闪 loading）；无缓存时才显示 loading。
-      loadCurrentWeek: async (force?: boolean) => {
+      loadCurrentWeek: async (opts) => {
+        const { daysLimit, force } = opts || {};
         const { loadingCurrent, currentWeek } = get();
         if (loadingCurrent) {
-          // 冷加载在途：不丢弃，记 pending，待结束补跑（拿到 SSE push 后的最新存量）。
-          // force 取或：保留在途期间任一次硬刷新意图。
           pendingCurrentWeekReload = true;
           pendingCurrentWeekForce = pendingCurrentWeekForce || force === true;
           return;
@@ -116,27 +134,52 @@ export const useChangelogStore = create<ChangelogState>()(
         const hasCache = currentWeek != null;
         if (!hasCache) set({ loadingCurrent: true, error: null });
         const mySeq = ++currentWeekFetchSeq;
-        // force 透传到后端：force=true 会绕过后端 IMemoryCache，从 local/GitHub 重新拉取
-        const res = await getCurrentWeekChangelog(force === true);
-        // 乱序保护：若本次响应已被更晚的请求取代，丢弃（不覆盖更新的数据、也不抢着收尾 loading）
+        const res = await getCurrentWeekChangelog({ daysLimit, force: force === true });
         if (mySeq !== currentWeekFetchSeq) return;
         if (res.success) {
           set({ currentWeek: res.data, loadingCurrent: false });
         } else if (!hasCache) {
           set({ loadingCurrent: false, error: res.error?.message || '加载待发布更新失败' });
         } else {
-          set({ loadingCurrent: false }); // 后台刷新失败：保留旧数据，不打扰
+          set({ loadingCurrent: false });
         }
-        // trailing-edge：在途期间被合并掉的重读补跑一次，保留 force 意图（避免硬刷新被降级）
         if (pendingCurrentWeekReload) {
           pendingCurrentWeekReload = false;
           const f = pendingCurrentWeekForce;
           pendingCurrentWeekForce = false;
-          void get().loadCurrentWeek(f);
+          void get().loadCurrentWeek({ daysLimit, force: f });
         }
       },
 
-      loadReleases: async (limit = 20, force?: boolean) => {
+      loadMoreFragments: async () => {
+        const { currentWeek, loadingMoreFragments } = get();
+        if (loadingMoreFragments) return;
+        if (!currentWeek) return;
+        if (!currentWeek.hasMore) return;
+        const nextOffset = currentWeek.fragments.length + (currentWeek.daysOffset ?? 0);
+        set({ loadingMoreFragments: true });
+        try {
+          const res = await getCurrentWeekChangelog({
+            daysLimit: 6,
+            daysOffset: nextOffset,
+          });
+          if (!res.success || !res.data) return;
+          // 增量追加：保留 totals/counts 以最新响应为准
+          const merged: CurrentWeekView = {
+            ...res.data,
+            fragments: [
+              ...(get().currentWeek?.fragments ?? []),
+              ...res.data.fragments,
+            ] as ChangelogFragment[],
+          };
+          set({ currentWeek: merged });
+        } finally {
+          set({ loadingMoreFragments: false });
+        }
+      },
+
+      loadReleases: async (opts) => {
+        const { limit = 8, summary = false, force } = opts || {};
         const { loadingReleases, releases } = get();
         if (loadingReleases) {
           pendingReleasesReload = true;
@@ -146,21 +189,55 @@ export const useChangelogStore = create<ChangelogState>()(
         const hasCache = releases != null;
         if (!hasCache) set({ loadingReleases: true, error: null });
         const mySeq = ++releasesFetchSeq;
-        const res = await getChangelogReleases(limit, force === true);
-        // 乱序保护：迟到的旧响应丢弃，不覆盖更新的数据
+        const res = await getChangelogReleases({ limit, summary, force: force === true });
         if (mySeq !== releasesFetchSeq) return;
         if (res.success) {
           set({ releases: res.data, loadingReleases: false });
         } else if (!hasCache) {
           set({ loadingReleases: false, error: res.error?.message || '加载历史发布失败' });
         } else {
-          set({ loadingReleases: false }); // 后台刷新失败：保留旧数据
+          set({ loadingReleases: false });
         }
         if (pendingReleasesReload) {
           pendingReleasesReload = false;
           const f = pendingReleasesForce;
           pendingReleasesForce = false;
-          void get().loadReleases(limit, f);
+          void get().loadReleases({ limit, summary, force: f });
+        }
+      },
+
+      loadReleaseDetail: async (version: string) => {
+        const { releases, loadingReleaseVersions } = get();
+        if (!releases) return;
+        if (loadingReleaseVersions[version]) return;
+        const target = releases.releases.find((r) => r.version === version);
+        if (!target || !target.entriesOmitted) return; // 已有详情
+
+        set({ loadingReleaseVersions: { ...loadingReleaseVersions, [version]: true } });
+        try {
+          const res = await getChangelogReleaseByVersion(version);
+          if (!res.success || !res.data) return;
+          const detail = res.data;
+          // patch 进现有 releases 数组（保持引用变化触发 react 重渲染）
+          set((state) => {
+            if (!state.releases) return state;
+            return {
+              releases: {
+                ...state.releases,
+                releases: state.releases.releases.map((r) =>
+                  r.version === version
+                    ? { ...r, days: detail.days, entriesOmitted: false }
+                    : r,
+                ),
+              },
+            };
+          });
+        } finally {
+          set((state) => {
+            const next = { ...state.loadingReleaseVersions };
+            delete next[version];
+            return { loadingReleaseVersions: next };
+          });
         }
       },
 

--- a/prd-admin/src/stores/changelogStore.ts
+++ b/prd-admin/src/stores/changelogStore.ts
@@ -137,7 +137,21 @@ export const useChangelogStore = create<ChangelogState>()(
         const res = await getCurrentWeekChangelog({ daysLimit, force: force === true });
         if (mySeq !== currentWeekFetchSeq) return;
         if (res.success) {
-          set({ currentWeek: res.data, loadingCurrent: false });
+          // 保留瀑布已加载的更老日期组（用户已通过 loadMoreFragments 累积到 > daysLimit 个）。
+          // 否则 SSE / 后台刷新会把 fragments 缩回 daysLimit 大小，丢掉用户已滚到的位置（Bugbot #4）。
+          set((state) => {
+            const incoming = res.data;
+            const cur = state.currentWeek;
+            if (cur && cur.fragments.length > incoming.fragments.length) {
+              const incomingDates = new Set(incoming.fragments.map((f) => f.date));
+              const tail = cur.fragments.filter((f) => !incomingDates.has(f.date));
+              return {
+                currentWeek: { ...incoming, fragments: [...incoming.fragments, ...tail] },
+                loadingCurrent: false,
+              };
+            }
+            return { currentWeek: incoming, loadingCurrent: false };
+          });
         } else if (!hasCache) {
           set({ loadingCurrent: false, error: res.error?.message || '加载待发布更新失败' });
         } else {
@@ -156,7 +170,10 @@ export const useChangelogStore = create<ChangelogState>()(
         if (loadingMoreFragments) return;
         if (!currentWeek) return;
         if (!currentWeek.hasMore) return;
-        const nextOffset = currentWeek.fragments.length + (currentWeek.daysOffset ?? 0);
+        // 累积 fragments 的长度本身就是下一批的 offset；
+        // 之前误加 `+ currentWeek.daysOffset` 会双计：每次 merge 后 daysOffset 被新批次的
+        // skip 值覆盖（4→14 而不是 4→10），导致每次跳过几天，留下日期组空洞（Bugbot #1）。
+        const nextOffset = currentWeek.fragments.length;
         set({ loadingMoreFragments: true });
         try {
           const res = await getCurrentWeekChangelog({

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ChangelogController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ChangelogController.cs
@@ -82,9 +82,11 @@ public class ChangelogController : ControllerBase
         [FromQuery] bool force = false)
     {
         if (limit <= 0 || limit > 100) limit = 8;
-        var view = await _reader.GetReleasesAsync(limit, force).ConfigureAwait(false);
+        // reader 永远拉满 100（单一 cache key），controller 切片输出。
+        // 这样 chip 显示的 totalReleases / totalEntries 永远基于全量，不会被 limit 截断（Bugbot #5）。
+        var view = await _reader.GetReleasesAsync(100, force).ConfigureAwait(false);
         if (!force) SetClientCacheHeaders();
-        return Ok(ApiResponse<ReleasesDto>.Ok(MapReleases(view, summary)));
+        return Ok(ApiResponse<ReleasesDto>.Ok(MapReleases(view, summary, limit)));
     }
 
     /// <summary>
@@ -372,14 +374,16 @@ public class ChangelogController : ControllerBase
         };
     }
 
-    private static ReleasesDto MapReleases(ReleasesView view, bool summary = false) => new()
+    private static ReleasesDto MapReleases(ReleasesView view, bool summary = false, int displayLimit = int.MaxValue) => new()
     {
         DataSourceAvailable = view.DataSourceAvailable,
         Source = view.Source,
         FetchedAt = view.FetchedAt.ToString("o"),
+        // totals 永远从全量 view 算（与 displayLimit 解耦），让 chip 显示真实数字
         TotalReleases = view.Releases.Count,
         TotalEntries = view.Releases.Sum(r => r.Days.Sum(d => d.Entries.Count)),
-        Releases = view.Releases.ConvertAll(r => MapRelease(r, summary)),
+        // 输出列表按 displayLimit 切片
+        Releases = view.Releases.Take(displayLimit).Select(r => MapRelease(r, summary)).ToList(),
     };
 
     private static ChangelogReleaseDto MapRelease(ChangelogRelease r, bool summary) => new()

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ChangelogController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ChangelogController.cs
@@ -67,12 +67,12 @@ public class ChangelogController : ControllerBase
     /// <summary>
     /// 历史发布（从 CHANGELOG.md 读取，按版本倒序）
     /// </summary>
-    /// <param name="limit">最多返回的版本数量（1..100，默认 20）</param>
+    /// <param name="limit">最多返回的版本数量（1..100，默认 8 — 与前端首屏 visible=4 对齐，留 buffer）</param>
     /// <param name="force">true 时绕过服务端缓存，重新从源拉取</param>
     [HttpGet("releases")]
-    public async Task<IActionResult> GetReleases([FromQuery] int limit = 20, [FromQuery] bool force = false)
+    public async Task<IActionResult> GetReleases([FromQuery] int limit = 8, [FromQuery] bool force = false)
     {
-        if (limit <= 0 || limit > 100) limit = 20;
+        if (limit <= 0 || limit > 100) limit = 8;
         var view = await _reader.GetReleasesAsync(limit, force).ConfigureAwait(false);
         if (!force) SetClientCacheHeaders();
         return Ok(ApiResponse<ReleasesDto>.Ok(MapReleases(view)));

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ChangelogController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ChangelogController.cs
@@ -55,39 +55,69 @@ public class ChangelogController : ControllerBase
     /// <summary>
     /// 待发布更新（从全部 changelogs/ 碎片读取，按日期倒序）
     /// </summary>
+    /// <param name="daysLimit">分页：只返回前 N 个日期组（按日期倒序），null=全部。前端首屏建议 4</param>
+    /// <param name="daysOffset">分页：跳过前 N 个日期组（与 daysLimit 配合）</param>
     /// <param name="force">true 时绕过服务端缓存，重新从源拉取（GitHub 路径意味着真实 API 调用）</param>
     [HttpGet("current-week")]
-    public async Task<IActionResult> GetCurrentWeek([FromQuery] bool force = false)
+    public async Task<IActionResult> GetCurrentWeek(
+        [FromQuery] int? daysLimit = null,
+        [FromQuery] int daysOffset = 0,
+        [FromQuery] bool force = false)
     {
         var view = await _reader.GetCurrentWeekAsync(force).ConfigureAwait(false);
         if (!force) SetClientCacheHeaders();
-        return Ok(ApiResponse<CurrentWeekDto>.Ok(MapCurrentWeek(view)));
+        return Ok(ApiResponse<CurrentWeekDto>.Ok(MapCurrentWeek(view, daysLimit, daysOffset)));
     }
 
     /// <summary>
     /// 历史发布（从 CHANGELOG.md 读取，按版本倒序）
     /// </summary>
-    /// <param name="limit">最多返回的版本数量（1..100，默认 8 — 与前端首屏 visible=4 对齐，留 buffer）</param>
+    /// <param name="limit">最多返回的版本数量（1..100，默认 8）</param>
+    /// <param name="summary">true 时只返回每个版本的元数据（version/releaseDate/entryCount/highlights），days 为空；前端按需调 by-version 端点拉详情</param>
     /// <param name="force">true 时绕过服务端缓存，重新从源拉取</param>
     [HttpGet("releases")]
-    public async Task<IActionResult> GetReleases([FromQuery] int limit = 8, [FromQuery] bool force = false)
+    public async Task<IActionResult> GetReleases(
+        [FromQuery] int limit = 8,
+        [FromQuery] bool summary = false,
+        [FromQuery] bool force = false)
     {
         if (limit <= 0 || limit > 100) limit = 8;
         var view = await _reader.GetReleasesAsync(limit, force).ConfigureAwait(false);
         if (!force) SetClientCacheHeaders();
-        return Ok(ApiResponse<ReleasesDto>.Ok(MapReleases(view)));
+        return Ok(ApiResponse<ReleasesDto>.Ok(MapReleases(view, summary)));
+    }
+
+    /// <summary>
+    /// 单个版本详情（按需懒加载）。配合 releases?summary=true 使用：前端先拿元数据，
+    /// 卡片进入视口时调本端点拉具体 entries，瀑布式展开。
+    /// </summary>
+    [HttpGet("releases/by-version/{version}")]
+    public async Task<IActionResult> GetReleaseByVersion(string version, [FromQuery] bool force = false)
+    {
+        var view = await _reader.GetReleasesAsync(100, force).ConfigureAwait(false);
+        var release = view.Releases.FirstOrDefault(r => r.Version == version);
+        if (release == null)
+            return NotFound(ApiResponse<ChangelogReleaseDto>.Fail("RELEASE_NOT_FOUND", $"版本 {version} 不存在"));
+        if (!force) SetClientCacheHeaders();
+        return Ok(ApiResponse<ChangelogReleaseDto>.Ok(MapRelease(release, summary: false)));
     }
 
     /// <summary>
     /// GitHub 日志（优先本地 git log，失败时回退 GitHub commits API）
     /// </summary>
+    /// <param name="limit">本次返回条数（1..1000，默认 80 — 与前端首屏 visible=80 对齐）</param>
+    /// <param name="before">cursor：返回该 sha 之后的条目（按时间倒序的「之后」=更老）。空=从最新开始</param>
     [HttpGet("github-logs")]
-    public async Task<IActionResult> GetGitHubLogs([FromQuery] int limit = 30, [FromQuery] bool force = false)
+    public async Task<IActionResult> GetGitHubLogs(
+        [FromQuery] int limit = 80,
+        [FromQuery] string? before = null,
+        [FromQuery] bool force = false)
     {
-        if (limit <= 0 || limit > 1000) limit = 1000;
-        var view = await _reader.GetGitHubLogsAsync(limit, force).ConfigureAwait(false);
+        if (limit <= 0 || limit > 1000) limit = 80;
+        // reader 永远拿全量（1000 上限），controller 切片
+        var view = await _reader.GetGitHubLogsAsync(1000, force).ConfigureAwait(false);
         if (!force) SetClientCacheHeaders();
-        return Ok(ApiResponse<GitHubLogsDto>.Ok(MapGitHubLogs(view)));
+        return Ok(ApiResponse<GitHubLogsDto>.Ok(MapGitHubLogs(view, limit, before)));
     }
 
     /// <summary>
@@ -312,58 +342,98 @@ public class ChangelogController : ControllerBase
 
     // ── DTO 映射 ──────────────────────────────────────────────────────
 
-    private static CurrentWeekDto MapCurrentWeek(CurrentWeekView view) => new()
+    private static CurrentWeekDto MapCurrentWeek(CurrentWeekView view, int? daysLimit = null, int daysOffset = 0)
     {
-        WeekStart = view.WeekStart.ToString("yyyy-MM-dd"),
-        WeekEnd = view.WeekEnd.ToString("yyyy-MM-dd"),
+        var totalDays = view.Fragments.Count;
+        var totalEntries = view.Fragments.Sum(f => f.Entries.Count);
+        var offset = Math.Max(0, daysOffset);
+        var sliced = daysLimit.HasValue
+            ? view.Fragments.Skip(offset).Take(Math.Max(0, daysLimit.Value)).ToList()
+            : view.Fragments;
+        var hasMore = daysLimit.HasValue && (offset + sliced.Count) < totalDays;
+
+        return new CurrentWeekDto
+        {
+            WeekStart = view.WeekStart.ToString("yyyy-MM-dd"),
+            WeekEnd = view.WeekEnd.ToString("yyyy-MM-dd"),
+            DataSourceAvailable = view.DataSourceAvailable,
+            Source = view.Source,
+            FetchedAt = view.FetchedAt.ToString("o"),
+            TotalDays = totalDays,
+            TotalEntries = totalEntries,
+            DaysOffset = offset,
+            HasMore = hasMore,
+            Fragments = sliced.ConvertAll(f => new ChangelogFragmentDto
+            {
+                FileName = f.FileName,
+                Date = f.Date.ToString("yyyy-MM-dd"),
+                Entries = f.Entries.ConvertAll(MapEntry),
+            }),
+        };
+    }
+
+    private static ReleasesDto MapReleases(ReleasesView view, bool summary = false) => new()
+    {
         DataSourceAvailable = view.DataSourceAvailable,
         Source = view.Source,
         FetchedAt = view.FetchedAt.ToString("o"),
-        Fragments = view.Fragments.ConvertAll(f => new ChangelogFragmentDto
-        {
-            FileName = f.FileName,
-            Date = f.Date.ToString("yyyy-MM-dd"),
-            Entries = f.Entries.ConvertAll(MapEntry),
-        }),
+        TotalReleases = view.Releases.Count,
+        TotalEntries = view.Releases.Sum(r => r.Days.Sum(d => d.Entries.Count)),
+        Releases = view.Releases.ConvertAll(r => MapRelease(r, summary)),
     };
 
-    private static ReleasesDto MapReleases(ReleasesView view) => new()
+    private static ChangelogReleaseDto MapRelease(ChangelogRelease r, bool summary) => new()
     {
-        DataSourceAvailable = view.DataSourceAvailable,
-        Source = view.Source,
-        FetchedAt = view.FetchedAt.ToString("o"),
-        Releases = view.Releases.ConvertAll(r => new ChangelogReleaseDto
-        {
-            Version = r.Version,
-            ReleaseDate = r.ReleaseDate?.ToString("yyyy-MM-dd"),
-            EntryCount = r.Days.Sum(d => d.Entries.Count),
-            SourceScope = r.Version == "未发布" ? "changelog-unreleased-block" : "changelog-release-block",
-            Highlights = r.Highlights,
-            Days = r.Days.ConvertAll(d => new ChangelogDayDto
+        Version = r.Version,
+        ReleaseDate = r.ReleaseDate?.ToString("yyyy-MM-dd"),
+        EntryCount = r.Days.Sum(d => d.Entries.Count),
+        SourceScope = r.Version == "未发布" ? "changelog-unreleased-block" : "changelog-release-block",
+        Highlights = r.Highlights,
+        EntriesOmitted = summary,
+        // summary 模式：days 为空数组（节省 90%+ 体积）；详情靠 by-version 端点
+        Days = summary
+            ? new List<ChangelogDayDto>()
+            : r.Days.ConvertAll(d => new ChangelogDayDto
             {
                 Date = d.Date.ToString("yyyy-MM-dd"),
                 CommitTimeUtc = d.CommitTimeUtc?.ToString("o"),
                 Entries = d.Entries.ConvertAll(MapEntry),
             }),
-        }),
     };
 
-    private static GitHubLogsDto MapGitHubLogs(GitHubLogsView view) => new()
+    private static GitHubLogsDto MapGitHubLogs(GitHubLogsView view, int limit, string? before)
     {
-        DataSourceAvailable = view.DataSourceAvailable,
-        Source = view.Source,
-        FetchedAt = view.FetchedAt.ToString("o"),
-        Logs = view.Logs.ConvertAll(l => new GitHubLogEntryDto
+        var totalCount = view.Logs.Count;
+        var startIdx = 0;
+        if (!string.IsNullOrEmpty(before))
         {
-            Sha = l.Sha,
-            ShortSha = l.ShortSha,
-            Message = l.Message,
-            AuthorName = l.AuthorName,
-            AuthorAvatarUrl = l.AuthorAvatarUrl,
-            CommitTimeUtc = l.CommitTimeUtc.ToString("o"),
-            HtmlUrl = l.HtmlUrl,
-        }),
-    };
+            var idx = view.Logs.FindIndex(l => l.Sha == before);
+            if (idx >= 0) startIdx = idx + 1; // 跳过 cursor 自身
+        }
+        var slice = view.Logs.Skip(startIdx).Take(Math.Max(0, limit)).ToList();
+        var hasMore = (startIdx + slice.Count) < totalCount;
+        var nextCursor = slice.Count > 0 ? slice[^1].Sha : null;
+
+        return new GitHubLogsDto
+        {
+            DataSourceAvailable = view.DataSourceAvailable,
+            Source = view.Source,
+            FetchedAt = view.FetchedAt.ToString("o"),
+            TotalCount = totalCount,
+            HasMore = hasMore,
+            NextCursor = hasMore ? nextCursor : null,
+            Logs = slice.ConvertAll(l => new GitHubLogEntryDto
+            {
+                Sha = l.Sha,
+                ShortSha = l.ShortSha,
+                Message = l.Message,
+                AuthorName = l.AuthorName,
+                AuthorAvatarUrl = l.AuthorAvatarUrl,
+                CommitTimeUtc = l.CommitTimeUtc.ToString("o"),
+                HtmlUrl = l.HtmlUrl,
+            }),
+        };
+    }
 
     private static ChangelogEntryDto MapEntry(ChangelogEntry e) => new()
     {
@@ -549,6 +619,14 @@ public class ChangelogController : ControllerBase
         public string Source { get; set; } = "none";
         /// <summary>ISO 8601 时间戳</summary>
         public string FetchedAt { get; set; } = string.Empty;
+        /// <summary>全量「日期组」数（=碎片文件数），不受 daysLimit 影响，用于 chip 计数</summary>
+        public int TotalDays { get; set; }
+        /// <summary>全量 entries 总数，不受 daysLimit 影响，用于 chip 计数</summary>
+        public int TotalEntries { get; set; }
+        /// <summary>本次响应跳过的日期组数（= daysOffset）</summary>
+        public int DaysOffset { get; set; }
+        /// <summary>是否还有更多日期组，前端据此触发 loadMore</summary>
+        public bool HasMore { get; set; }
         public List<ChangelogFragmentDto> Fragments { get; set; } = new();
     }
 
@@ -569,6 +647,8 @@ public class ChangelogController : ControllerBase
         /// <summary>"changelog-unreleased-block" / "changelog-release-block"</summary>
         public string SourceScope { get; set; } = string.Empty;
         public List<string> Highlights { get; set; } = new();
+        /// <summary>true 时 Days 是空数组（summary 模式），前端需调 by-version 端点拉详情</summary>
+        public bool EntriesOmitted { get; set; }
         public List<ChangelogDayDto> Days { get; set; } = new();
     }
 
@@ -577,6 +657,10 @@ public class ChangelogController : ControllerBase
         public bool DataSourceAvailable { get; set; }
         public string Source { get; set; } = "none";
         public string FetchedAt { get; set; } = string.Empty;
+        /// <summary>版本总数（=Releases.Count，用于 chip 计数）</summary>
+        public int TotalReleases { get; set; }
+        /// <summary>所有版本的 entries 总数（用于 chip 计数，summary 模式下仍准确）</summary>
+        public int TotalEntries { get; set; }
         public List<ChangelogReleaseDto> Releases { get; set; } = new();
     }
 
@@ -596,6 +680,12 @@ public class ChangelogController : ControllerBase
         public bool DataSourceAvailable { get; set; }
         public string Source { get; set; } = "none";
         public string FetchedAt { get; set; } = string.Empty;
+        /// <summary>全量 commit 总数（不受 limit 影响，用于 chip 计数）</summary>
+        public int TotalCount { get; set; }
+        /// <summary>是否还有更多，前端据此触发 loadMore</summary>
+        public bool HasMore { get; set; }
+        /// <summary>下一页 cursor（=本批次最后一条的 sha），前端传给 before 参数取下一批</summary>
+        public string? NextCursor { get; set; }
         public List<GitHubLogEntryDto> Logs { get; set; } = new();
     }
 }

--- a/prd-api/src/PrdAgent.Infrastructure/Services/Changelog/ChangelogReader.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/Changelog/ChangelogReader.cs
@@ -1329,29 +1329,6 @@ public sealed class ChangelogReader : IChangelogReader
         view.WeekEnd = range.end;
     }
 
-    private static void MergeChangelogMarkdownIntoCurrentWeek(
-        CurrentWeekView view,
-        string changelogText,
-        DateOnly weekStart,
-        DateOnly weekEnd)
-    {
-        var releases = ParseChangelogMarkdown(changelogText, 0);
-        foreach (var release in releases)
-        {
-            foreach (var day in release.Days)
-            {
-                if (day.Date < weekStart || day.Date > weekEnd || day.Entries.Count == 0)
-                    continue;
-
-                AddCurrentWeekEntries(
-                    view,
-                    $"CHANGELOG.md#{release.Version}",
-                    day.Date,
-                    day.Entries);
-            }
-        }
-    }
-
     private static void AddCurrentWeekEntries(
         CurrentWeekView view,
         string fileName,

--- a/prd-api/src/PrdAgent.Infrastructure/Services/Changelog/ChangelogRefreshWorker.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/Changelog/ChangelogRefreshWorker.cs
@@ -20,8 +20,10 @@ public sealed class ChangelogRefreshWorker : BackgroundService
     private readonly IChangelogReader _reader;
     private readonly ILogger<ChangelogRefreshWorker> _logger;
 
-    // 与前端请求的 limit 对齐，保证预热/刷新的快照 key 正是前端会读取的那几个。
-    private const int ReleasesLimit = 20;
+    // 与 ChangelogController.GetReleases 一致（永远拉满 100，单一 cache key）：
+    // controller 总是读 releases:100 切片输出，worker 也只刷 releases:100，避免缓存键漂移
+    // 导致 worker 预热的快照永远命中不到前端读取的 key（Codex P2 align cache key）
+    private const int ReleasesLimit = 100;
     private const int GitHubLogsLimit = 1000;
 
     // 启动后首次 force 刷新的延迟：先让启动流程跑顺、用户先吃到存量，再后台对齐远端。


### PR DESCRIPTION
## 摘要

更新中心首屏 payload 从 ~474kB 砍到 ~10kB，通过三层瀑布式优化：releases 加 summary 模式（只元数据）+ by-version 懒加载详情、current-week 加分页（daysLimit/daysOffset）、github-logs 加 cursor 分页。首屏即可展示，用户滚动到底前已后台补齐数据。

## 改动 diff

### 后端 API (prd-api/)
- `ChangelogController.cs`：
  - `GetCurrentWeek` 新增 `daysLimit`/`daysOffset` 参数，支持分页
  - `GetReleases` 新增 `summary` 参数（true 时 days 为空数组，节省 90%+ 体积）
  - 新增 `GetReleaseByVersion` 端点，按需拉取单个版本详情
  - `GetGitHubLogs` 新增 `before` cursor 参数，支持向更老方向分页
  - 三个 DTO 新增 `totalEntries`/`totalCount`/`hasMore`/`nextCursor` 字段，前端 chip 计数从全量取
- `ChangelogReader.cs`：删除 `MergeChangelogMarkdownIntoCurrentWeek` 冗余方法

### 前端 store (prd-admin/)
- `changelogStore.ts`：
  - `loadCurrentWeek` 改为接收 options 对象（`daysLimit`/`force`）
  - 新增 `loadMoreFragments` action，增量追加碎片日期组
  - `loadReleases` 改为接收 options 对象（`limit`/`summary`/`force`）
  - 新增 `loadReleaseDetail` action，按版本懒加载 entries 并 patch 进数组
  - 新增 `loadingReleaseVersions` 状态，避免并发重复拉取

### 前端页面 (prd-admin/)
- `ChangelogPage.tsx`：
  - 首屏改为 `loadCurrentWeek({ daysLimit: 4 })` + `loadReleases({ limit: 8, summary: true })`
  - 新增 `expandedReleases` 状态，控制每个 release 内 entries 渲染数（默认 12 条，点「展开全部」后全展）
  - 新增 IntersectionObserver 监视 release 卡片，进视口时拉详情（首个版本立即拉，其余延迟）
  - 新增 `loadMoreGitHubLogs` callback，cursor 分页续接日志
  - 修复 `useIncrementalVisible` hook：total 增长时保留当前 visibleCount，不重置回 initial（避免瀑布加载时视图缩回）
  - GitHub logs 轮询改为按需启动（仅当用户进入「实时日志」tab 时）
  - 新增两个 useEffect 触发器，当用户滚动到本地数据末尾 1 组内时 preemptive fetch 下一批
  - 修复 release 去重（CHANGELOG.md 文末模板锚点重复匹配）
  - 修复 summary 模式下 release 卡片仍需渲染（让 IntersectionObserver 能挂到 dom）
- `ChangelogBell.tsx`：改为 `loadCurrentWeek({ daysLimit

https://claude.ai/code/session_016jSQMYfZCqDYA8WrrdeDna

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> 改动面广（API 契约、store 合并逻辑、多入口拉取参数），但以读路径与 UI 性能为主；需重点回归刷新/SSE、滚动续接与 chip 计数是否一致。
> 
> **Overview**
> **更新中心**从「一次拉全量」改为瀑布式加载，把首屏 JSON 从约 **474kB** 压到约 **10kB**，并补了一轮分页/刷新相关的回归修复。
> 
> **后端（prd-api）** 为 `current-week`、`releases`、`github-logs` 增加分页与元数据：`daysLimit`/`daysOffset`、`summary` + 新端点 `releases/by-version/{version}`、`before` cursor；DTO 增加 `totalEntries`/`totalCount`/`hasMore`/`nextCursor`，chip 计数按全量算。Controller 侧 reader 固定拉满（releases 100、github-logs 1000）再切片输出；`ChangelogRefreshWorker` 的 `ReleasesLimit` 对齐为 100。删除未使用的 `MergeChangelogMarkdownIntoCurrentWeek`。
> 
> **前端（prd-admin）** API 与 `changelogStore` 改为 options 对象，新增 `loadMoreFragments`、`loadReleaseDetail`；刷新/SSE 时保留用户已滚到的 fragment/github 尾部（`force` 手动刷新除外）。`ChangelogPage` 首屏用小批量 + summary releases（最多 100 个版本元数据）、IntersectionObserver 按版本拉详情、每 release 默认只渲染 12 条 entry；GitHub 日志首屏 80 条、仅进入「实时日志」tab 才 35s 轮询。铃铛/AppShell/首页用 `daysLimit=8` 拉 current-week，且铃铛打开不再 `force` 以免清空更新中心已加载的尾部。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ba630b10505dce71e5ee13db4de17bb3e63a59b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->