### PR TITLE
refactor(cds): 统一 nginx 等待页 HTML 生成到 TypeScript SSOT

### DIFF
--- a/cds/exec_cds.sh
+++ b/cds/exec_cds.sh
@@ -746,7 +746,7 @@ write_waiting_html() {
   # Primary path: render from TypeScript SSOT (always used after first build)
   if [ -f "$SCRIPT_DIR/dist/cli/render-page.js" ]; then
     local rendered
-    rendered="$(node "$SCRIPT_DIR/dist/cli/render-page.js" nginx-waiting 2>/dev/null)"
+    rendered="$(node "$SCRIPT_DIR/dist/cli/render-page.js" nginx-waiting 2>/dev/null)" || rendered=""
     if [ -n "$rendered" ]; then
       write_if_changed "$target" "$rendered"
       return 0

--- a/cds/exec_cds.sh
+++ b/cds/exec_cds.sh
@@ -735,42 +735,60 @@ emit_server_blocks() {
 # For every other half-ready state CDS's own proxy renders a richer loading
 # page with service-level progress; this file is the last-resort safety net.
 # See .claude/rules/cds-auto-deploy.md.
+# HTML SSOT: cds/src/loading-pages/index.ts buildNginxWaitingHtml()
+# exec_cds.sh calls the TypeScript renderer when dist/ is available;
+# falls back to a minimal heredoc only when dist/ hasn't been built yet
+# (e.g., cold-start before the first `pnpm build`).
 write_waiting_html() {
   local target="$NGINX_WWW_DIR/cds-waiting.html"
   mkdir -p "$NGINX_WWW_DIR"
+
+  # Primary path: render from TypeScript SSOT (always used after first build)
+  if [ -f "$SCRIPT_DIR/dist/cli/render-page.js" ]; then
+    local rendered
+    rendered="$(node "$SCRIPT_DIR/dist/cli/render-page.js" nginx-waiting 2>/dev/null)"
+    if [ -n "$rendered" ]; then
+      write_if_changed "$target" "$rendered"
+      return 0
+    fi
+    warn "[nginx] render-page.js failed, falling back to built-in template"
+  fi
+
+  # Fallback: minimal static HTML (cold-start only, before first build).
+  # Keep this in sync with src/loading-pages/index.ts buildNginxWaitingHtml()
+  # when making style changes — this path should rarely be seen in production.
   local content
   content=$(cat <<'WAITING_HTML'
 <!DOCTYPE html>
 <html lang="zh"><head>
 <meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>预览环境准备中</title>
+<title>CDS 自升级中</title>
 <style>
+:root{--bg-page:#0d1117;--bg-card:#161b22;--bg-elevated:#21262d;--border:#30363d;--border-subtle:#21262d;--text-primary:#f0f6fc;--text-muted:#8b949e;--text-subtle:#6e7681;--accent:#58a6ff;--accent-bg:rgba(88,166,255,.14);--shadow-card:0 12px 32px rgba(0,0,0,.45)}
+@media(prefers-color-scheme:light){:root{--bg-page:#f4efe9;--bg-card:#ffffff;--bg-elevated:#f1eae4;--border:#d8cfc6;--border-subtle:#e6ddd3;--text-primary:#2a1f19;--text-muted:#7a6a5e;--text-subtle:#9c8e82;--accent:#1f6feb;--accent-bg:rgba(31,111,235,.10);--shadow-card:0 8px 24px rgba(43,33,28,.10)}}
 *{margin:0;padding:0;box-sizing:border-box}
-body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;background:#0d1117;color:#c9d1d9;display:flex;align-items:center;justify-content:center;min-height:100vh;padding:20px}
-.card{position:relative;overflow:hidden;max-width:460px;width:100%;padding:32px;background:#161b22;border:1px solid #30363d;border-radius:16px;text-align:center;box-shadow:0 24px 80px rgba(0,0,0,.34),0 0 40px -24px #58a6ff}
-.card::before{content:"";position:absolute;inset:0 auto 0 -40%;width:34%;background:linear-gradient(90deg,transparent,rgba(88,166,255,.13),transparent);transform:skewX(-18deg);animation:glint 3.2s ease-in-out infinite}
-.spinner{position:relative;width:34px;height:34px;border:3px solid #30363d;border-top-color:#58a6ff;border-radius:50%;animation:spin .9s linear infinite;margin:0 auto 16px;box-shadow:0 0 24px -6px #58a6ff}
-.spinner::after{content:"";position:absolute;inset:-9px;border-radius:50%;border:1px solid rgba(88,166,255,.32);animation:halo 1.7s ease-in-out infinite}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;background:var(--bg-page);color:var(--text-muted);display:flex;align-items:center;justify-content:center;min-height:100vh;padding:20px}
+.card{max-width:480px;width:100%;padding:28px 30px;background:var(--bg-card);border:1px solid var(--border);border-radius:14px;box-shadow:var(--shadow-card)}
+.header{display:flex;align-items:center;gap:12px;margin-bottom:6px}
+.spinner{width:22px;height:22px;border:2.5px solid var(--border);border-top-color:var(--accent);border-radius:50%;animation:spin .8s linear infinite;flex-shrink:0}
 @keyframes spin{to{transform:rotate(360deg)}}
-@keyframes halo{0%,100%{opacity:.28;transform:scale(.82)}50%{opacity:1;transform:scale(1.16)}}
-@keyframes glint{0%,36%{transform:translateX(0) skewX(-18deg);opacity:0}52%{opacity:1}78%,100%{transform:translateX(420%) skewX(-18deg);opacity:0}}
-h2{font-size:16px;font-weight:600;color:#f0f6fc;margin-bottom:8px}
-.tag{display:inline-block;font-size:11px;padding:2px 8px;border-radius:99px;background:#1f6feb22;color:#58a6ff;border:1px solid #1f6feb55;margin-bottom:16px}
-.desc{font-size:13px;color:#8b949e;line-height:1.6;margin-bottom:16px}
-.kbd{font-family:ui-monospace,SFMono-Regular,monospace;font-size:12px;color:#c9d1d9;background:#21262d;padding:2px 6px;border-radius:4px}
-.hint{font-size:12px;color:#6e7681}
-@media (prefers-reduced-motion:reduce){*,*::before,*::after{animation:none!important}}
+h1{font-size:18px;font-weight:600;color:var(--text-primary)}
+.sub{font-size:12px;color:var(--text-muted);margin-bottom:18px;padding-left:34px;line-height:1.55}
+.chip{display:inline-flex;align-items:center;gap:6px;font-family:ui-monospace,monospace;font-size:11px;color:var(--accent);background:var(--accent-bg);padding:4px 10px;border-radius:99px;border:1px solid rgba(88,166,255,.22);margin-bottom:18px}
+.hint{font-size:12px;color:var(--text-subtle);line-height:1.6}
+.hint code{font-family:ui-monospace,monospace;background:var(--bg-elevated);color:var(--text-muted);padding:1px 6px;border-radius:4px;font-size:11px}
+.bar{margin-top:18px;height:2px;border-radius:1px;background:var(--border-subtle);overflow:hidden}
+.bar-fill{height:100%;width:0%;background:var(--accent);border-radius:1px;animation:fill 3s linear forwards}
+@keyframes fill{to{width:100%}}
+@media(prefers-reduced-motion:reduce){*{animation:none!important}.bar-fill{width:100%}}
 </style>
 </head><body>
 <div class="card">
-  <div class="spinner"></div>
-  <h2>预览环境准备中</h2>
-  <div class="tag">CDS 控制面暂时不可达</div>
-  <div class="desc">
-    分支预览正在构建或 CDS 正在自升级，几秒钟后会自动恢复。<br>
-    本页面每 <span class="kbd">3s</span> 自动刷新。
-  </div>
-  <div class="hint">如果持续看到此页面，请在 PR Checks 面板查看 CDS Deploy 状态。</div>
+  <div class="header"><div class="spinner"></div><h1>CDS 自升级中</h1></div>
+  <div class="sub">控制面正在重启，分支预览几秒后自动恢复</div>
+  <div class="chip">自动升级进行中</div>
+  <div class="hint">如持续停留，请在 <code>PR Checks</code> 面板查看 CDS Deploy 状态。</div>
+  <div class="bar"><div class="bar-fill"></div></div>
 </div>
 <script>setTimeout(function(){location.reload()},3000)</script>
 </body></html>

--- a/cds/src/cli/render-page.ts
+++ b/cds/src/cli/render-page.ts
@@ -1,0 +1,19 @@
+/**
+ * Minimal CLI for exec_cds.sh to generate static HTML files from TypeScript sources.
+ * Usage: node dist/cli/render-page.js <page-name>
+ *
+ * Called by exec_cds.sh write_waiting_html() during nginx-render:
+ *   node "$SCRIPT_DIR/dist/cli/render-page.js" nginx-waiting > /var/www/html/cds-waiting.html
+ */
+import { buildNginxWaitingHtml } from '../loading-pages/index.js';
+
+const page = process.argv[2];
+
+switch (page) {
+  case 'nginx-waiting':
+    process.stdout.write(buildNginxWaitingHtml());
+    break;
+  default:
+    process.stderr.write(`render-page: unknown page "${page ?? ''}"\nAvailable: nginx-waiting\n`);
+    process.exit(1);
+}

--- a/cds/src/cli/render-page.ts
+++ b/cds/src/cli/render-page.ts
@@ -5,15 +5,19 @@
  * Called by exec_cds.sh write_waiting_html() during nginx-render:
  *   node "$SCRIPT_DIR/dist/cli/render-page.js" nginx-waiting > /var/www/html/cds-waiting.html
  */
+import { fileURLToPath } from 'node:url';
 import { buildNginxWaitingHtml } from '../loading-pages/index.js';
 
-const page = process.argv[2];
+// Guard: only run CLI logic when executed directly, not when imported by tests.
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const page = process.argv[2];
 
-switch (page) {
-  case 'nginx-waiting':
-    process.stdout.write(buildNginxWaitingHtml());
-    break;
-  default:
-    process.stderr.write(`render-page: unknown page "${page ?? ''}"\nAvailable: nginx-waiting\n`);
-    process.exit(1);
+  switch (page) {
+    case 'nginx-waiting':
+      process.stdout.write(buildNginxWaitingHtml());
+      break;
+    default:
+      process.stderr.write(`render-page: unknown page "${page ?? ''}"\nAvailable: nginx-waiting\n`);
+      process.exit(1);
+  }
 }

--- a/cds/src/loading-pages/index.ts
+++ b/cds/src/loading-pages/index.ts
@@ -1,0 +1,181 @@
+/**
+ * CDS loading-pages SSOT
+ *
+ * All user-visible waiting / error HTML pages are generated here.
+ * exec_cds.sh calls `node dist/cli/render-page.js nginx-waiting` to write
+ * /var/www/html/cds-waiting.html instead of maintaining a separate heredoc.
+ *
+ * When updating styles, change the CSS tokens at the top of each builder —
+ * they all share the same dual-theme token set.
+ *
+ * Migration status (see doc/debt.cds-nginx-loading-pages.md):
+ *   buildNginxWaitingHtml       - DONE (was exec_cds.sh heredoc)
+ *   buildForwarderWaitingHtml   - pending migration from forwarder/waiting-page.ts
+ *   buildLegacyWaitingHtml      - pending migration from routes/branches.ts
+ *   buildLoadingPreviewBranchGoneHtml - pending migration from routes/branches.ts
+ *   buildBranchGoneHtml         - pending migration from index.ts
+ *   buildTransitPageHtml        - pending migration from index.ts
+ *   serveDeployErrorHtml        - pending migration from services/proxy.ts
+ */
+
+/** Shared CSS token block — include verbatim at the top of every page's <style>. */
+const DUAL_THEME_TOKENS = `
+:root{
+  --bg-page:#0d1117;
+  --bg-card:#161b22;
+  --bg-elevated:#21262d;
+  --bg-base:#0d1117;
+  --bg-terminal:#010409;
+  --border:#30363d;
+  --border-subtle:#21262d;
+  --text-primary:#f0f6fc;
+  --text-secondary:#c9d1d9;
+  --text-muted:#8b949e;
+  --text-subtle:#6e7681;
+  --accent:#58a6ff;
+  --accent-bg:rgba(88,166,255,.14);
+  --success:#3fb950;
+  --success-bg:rgba(63,185,80,.14);
+  --danger:#f85149;
+  --danger-bg:rgba(248,81,73,.12);
+  --shadow-card:0 12px 32px rgba(0,0,0,.45);
+}
+@media(prefers-color-scheme:light){
+  :root{
+    --bg-page:#f4efe9;
+    --bg-card:#ffffff;
+    --bg-elevated:#f1eae4;
+    --bg-base:#efe7df;
+    --bg-terminal:#efe7df;
+    --border:#d8cfc6;
+    --border-subtle:#e6ddd3;
+    --text-primary:#2a1f19;
+    --text-secondary:#3f3128;
+    --text-muted:#7a6a5e;
+    --text-subtle:#9c8e82;
+    --accent:#1f6feb;
+    --accent-bg:rgba(31,111,235,.10);
+    --success:#1a7f37;
+    --success-bg:rgba(26,127,55,.10);
+    --danger:#cf222e;
+    --danger-bg:rgba(207,34,46,.08);
+    --shadow-card:0 8px 24px rgba(43,33,28,.10);
+  }
+}`.trim();
+
+/** Shared animated square-grid canvas background (identical to buildTransitPageHtml). */
+const GRID_CANVAS_SCRIPT = `
+(function(){
+  var canvas=document.getElementById('shapeGridBg');
+  if(!canvas)return;
+  var ctx=canvas.getContext('2d');
+  if(!ctx)return;
+  var offset={x:0,y:0};
+  var size=42;
+  var reduced=window.matchMedia&&window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  function resize(){
+    var d=Math.min(window.devicePixelRatio||1,2);
+    canvas.width=Math.max(1,Math.floor(window.innerWidth*d));
+    canvas.height=Math.max(1,Math.floor(window.innerHeight*d));
+    canvas.style.width='100%';
+    canvas.style.height='100%';
+    ctx.setTransform(d,0,0,d,0,0);
+  }
+  function draw(){
+    var w=window.innerWidth,h=window.innerHeight;
+    ctx.clearRect(0,0,w,h);
+    if(!reduced){
+      offset.x=(offset.x-.14+size)%size;
+      offset.y=(offset.y-.14+size)%size;
+    }
+    var ox=((offset.x%size)+size)%size;
+    var oy=((offset.y%size)+size)%size;
+    ctx.strokeStyle='rgba(232,237,242,.085)';
+    ctx.lineWidth=1;
+    for(var x=-size+ox;x<w+size;x+=size){
+      for(var y=-size+oy;y<h+size;y+=size){
+        ctx.strokeRect(x,y,size,size);
+      }
+    }
+    var gr=ctx.createRadialGradient(w/2,h/2,0,w/2,h/2,Math.sqrt(w*w+h*h)/2);
+    gr.addColorStop(0,'rgba(0,0,0,0)');
+    gr.addColorStop(.75,'rgba(0,0,0,.16)');
+    gr.addColorStop(1,'rgba(0,0,0,.58)');
+    ctx.fillStyle=gr;
+    ctx.fillRect(0,0,w,h);
+    requestAnimationFrame(draw);
+  }
+  resize();
+  window.addEventListener('resize',resize);
+  requestAnimationFrame(draw);
+}());`.trim();
+
+function escape(value: string): string {
+  return value.replace(/[&<>"']/g, (c) => {
+    switch (c) {
+      case '&': return '&amp;';
+      case '<': return '&lt;';
+      case '>': return '&gt;';
+      case '"': return '&quot;';
+      default: return '&#39;';
+    }
+  });
+}
+
+/**
+ * nginx waiting page — served at /var/www/html/cds-waiting.html.
+ * nginx returns this file for 502/504 upstream errors (CDS master down).
+ * Written by exec_cds.sh via `node dist/cli/render-page.js nginx-waiting`.
+ *
+ * Auto-refreshes every 3 s. No external dependencies (must work before CDS starts).
+ */
+export function buildNginxWaitingHtml(): string {
+  return `<!DOCTYPE html>
+<html lang="zh"><head>
+<meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>CDS 自升级中</title>
+<style>
+${DUAL_THEME_TOKENS}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;background:var(--bg-page);color:var(--text-secondary);display:flex;align-items:center;justify-content:center;min-height:100vh;padding:20px}
+.shape-grid-bg{position:fixed;inset:0;width:100%;height:100%;border:0;display:block;pointer-events:none;opacity:.44}
+.shape-grid-vignette{position:fixed;inset:0;pointer-events:none;background:radial-gradient(900px 620px at 24% 18%,rgba(255,255,255,.08),transparent 60%),radial-gradient(circle at center,transparent 0%,rgba(0,0,0,.2) 56%,rgba(0,0,0,.78) 100%)}
+.card{position:relative;z-index:1;max-width:480px;width:100%;padding:28px 30px;background:var(--bg-card);border:1px solid var(--border);border-radius:14px;box-shadow:var(--shadow-card)}
+.header{display:flex;align-items:center;gap:12px;margin-bottom:6px}
+.spinner{width:22px;height:22px;border:2.5px solid var(--border);border-top-color:var(--accent);border-radius:50%;animation:spin .8s linear infinite;flex-shrink:0}
+@keyframes spin{to{transform:rotate(360deg)}}
+h1{font-size:18px;font-weight:600;color:var(--text-primary);letter-spacing:.2px}
+.subtitle{font-size:12px;color:var(--text-muted);margin-bottom:18px;padding-left:34px;line-height:1.55}
+.status-row{display:flex;flex-wrap:wrap;gap:8px;margin-bottom:18px}
+.chip{display:inline-flex;align-items:center;gap:6px;font-family:ui-monospace,SFMono-Regular,monospace;font-size:11px;color:var(--accent);background:var(--accent-bg);padding:4px 10px;border-radius:99px;border:1px solid rgba(88,166,255,.22)}
+.chip::before{content:"";width:6px;height:6px;border-radius:50%;background:var(--accent);box-shadow:0 0 0 3px var(--accent-bg);flex-shrink:0;animation:pulse 1.6s ease-in-out infinite}
+@keyframes pulse{0%,100%{box-shadow:0 0 0 3px var(--accent-bg)}50%{box-shadow:0 0 0 6px var(--accent-bg)}}
+.hint{font-size:12px;color:var(--text-subtle);line-height:1.6}
+.hint code{font-family:ui-monospace,monospace;background:var(--bg-elevated);color:var(--text-secondary);padding:1px 6px;border-radius:4px;font-size:11px}
+.refresh-bar{margin-top:18px;height:2px;border-radius:1px;background:var(--border-subtle);overflow:hidden}
+.refresh-bar-fill{height:100%;width:0%;background:var(--accent);border-radius:1px;animation:refill 3s linear forwards}
+@keyframes refill{to{width:100%}}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation:none!important}.refresh-bar-fill{width:100%}}
+</style>
+</head><body>
+<canvas class="shape-grid-bg" id="shapeGridBg" aria-hidden="true"></canvas>
+<div class="shape-grid-vignette" aria-hidden="true"></div>
+<div class="card">
+  <div class="header">
+    <div class="spinner"></div>
+    <h1>CDS 自升级中</h1>
+  </div>
+  <div class="subtitle">控制面正在重启，分支预览几秒后自动恢复</div>
+  <div class="status-row">
+    <span class="chip">自动升级进行中</span>
+    <span class="chip">3s 后刷新</span>
+  </div>
+  <div class="hint">如持续停留，请在 <code>PR Checks</code> 面板查看 CDS Deploy 状态。</div>
+  <div class="refresh-bar"><div class="refresh-bar-fill"></div></div>
+</div>
+<script>
+${GRID_CANVAS_SCRIPT}
+setTimeout(function(){location.reload()},3000);
+</script>
+</body></html>`;
+}

--- a/doc/debt.cds-nginx-loading-pages.md
+++ b/doc/debt.cds-nginx-loading-pages.md
@@ -1,0 +1,72 @@
+---
+title: "CDS loading pages 债务台账"
+type: debt
+module: cds
+status: partial
+updated: 2026-06-08
+---
+
+## 已知债务
+
+### D1 — forwarder 硬重启（~3s 预览抖动）
+
+**现状**：`master-run` 启动时检测到 `dist/ mtime > forwarder 进程启动时间`，直接执行
+`systemctl restart cds-forwarder.service`（硬重启，非 graceful drain）。
+每次 CDS self-update 重建 dist 后，forwarder 重启期间所有预览流量 502 约 3 秒。
+
+**位置**：`exec_cds.sh` L2916-2925
+
+**修法（待做）**：
+1. forwarder 监听 `SIGUSR2` → 开始 graceful drain（停接新连接，等进行中请求完成）
+2. `master-run` 改为发 `SIGUSR2` 替代 `systemctl restart`
+3. 或：`cds-forwarder.service` 启用 `ExecStop` graceful timeout + socket 继承（`SO_REUSEPORT`）
+
+**优先级**：低（3s 抖动用户感知不强，且已有 nginx 等待页兜底）
+
+---
+
+### D2 — nginx waiting page 有多个散落的硬编码 HTML 模板
+
+**现状**：8 个 loading/waiting HTML 页面分散在 5 个文件中，没有统一的 SSOT：
+
+| # | 文件 | 函数/位置 |
+|---|------|-----------|
+| 1 | `cds/web/src/pages/PreviewPreparingPage.tsx` | React 组件（已迁移） |
+| 2 | `exec_cds.sh` L738 | `write_waiting_html()` heredoc |
+| 3 | `src/forwarder/waiting-page.ts` | `buildForwarderWaitingPageHtml()` |
+| 4 | `src/routes/branches.ts` L13935 | `buildLegacyWaitingPreviewHtml()` |
+| 5 | `src/routes/branches.ts` L14108 | `buildLoadingPreviewBranchGoneHtml()` |
+| 6 | `src/index.ts` L2351 | `buildBranchGonePageHtml()` |
+| 7 | `src/index.ts` L2435 | `buildTransitPageHtml()` |
+| 8 | `src/services/proxy.ts` L890 | `serveDeployErrorLightPillarPage()` |
+
+各自的 CSS token / 色值 / 双主题支持程度不一致，导致每次"更新样式"只能改到几个，
+其余继续用旧风格，被用户发现后再修再遗漏，循环往复。
+
+**已完成**：#2（`write_waiting_html`）已迁移到 `src/loading-pages/index.ts`，
+`exec_cds.sh` 调用 `node dist/cli/render-page.js nginx-waiting` 生成，SSOT 统一到 TypeScript。
+
+**待做（按优先级）**：
+- [ ] #3 `buildForwarderWaitingPageHtml` 迁移到 `src/loading-pages/index.ts`
+- [ ] #4 `buildLegacyWaitingPreviewHtml` 迁移并统一双主题
+- [ ] #5 `buildLoadingPreviewBranchGoneHtml` 已有双主题，迁移到统一模块
+- [ ] #6 `buildBranchGonePageHtml` 升级样式 + 迁移
+- [ ] #7 `buildTransitPageHtml` 迁移（这个是最现代的，作为样式基准）
+- [ ] #8 `serveDeployErrorLightPillarPage` 迁移
+
+**完成标准**：所有 loading page HTML 都从 `src/loading-pages/index.ts` 导出，
+`exec_cds.sh` 调用 TypeScript CLI 渲染，添加 vitest 快照测试防止各自漂移。
+
+---
+
+### D3 — CDS_USE_FORWARDER 默认 0（隔离未启用）
+
+**现状**：`exec_cds.sh` 默认 `CDS_USE_FORWARDER=0`，`cds_worker` upstream 指向 master 9900。
+CDS self-update 重启 master 期间（pnpm install + tsc 编译，约 30s~2min），
+所有预览流量 502，nginx 返回 `cds-waiting.html`。
+
+**修法（待评估）**：
+在 `init` 向导中主动询问用户是否启用 forwarder，或改为默认 1 + 自动安装 systemd service。
+需确认所有生产部署节点的 systemd 版本兼容性。
+
+**优先级**：中（影响所有自升级窗口的预览可用性）


### PR DESCRIPTION
## 摘要

将 nginx 等待页 HTML 从 shell heredoc 迁移到 TypeScript 单一信息源（SSOT），建立 `src/loading-pages/index.ts` 模块统一管理所有用户可见的加载/等待页面。`exec_cds.sh` 现通过 `node dist/cli/render-page.js nginx-waiting` 调用 TypeScript 渲染器生成页面，冷启动时才回退到 shell 内置模板。

## 改动 diff

- `cds/src/loading-pages/index.ts`（新增）：
  - 导出 `buildNginxWaitingHtml()` 函数，包含完整的 HTML + 双主题 CSS token + 动画网格背景脚本
  - 定义共享的 `DUAL_THEME_TOKENS`（深色/浅色主题 CSS 变量）和 `GRID_CANVAS_SCRIPT`（canvas 动画）
  - 添加 `escape()` 工具函数用于 HTML 转义

- `cds/src/cli/render-page.ts`（新增）：
  - 最小化 CLI 入口，接收 `nginx-waiting` 参数调用对应构建函数
  - 输出到 stdout，供 `exec_cds.sh` 重定向到文件

- `cds/exec_cds.sh`（修改）：
  - `write_waiting_html()` 改为两层策略：
    1. 优先路径：调用 `node dist/cli/render-page.js nginx-waiting` 从 TypeScript SSOT 渲染
    2. 回退路径：若 dist/ 未构建（冷启动），使用 shell 内置最小化模板
  - 更新 shell 内置模板的 CSS，与 TypeScript 版本保持同步（使用 CSS 变量、双主题支持）
  - 更新页面文案："预览环境准备中" → "CDS 自升级中"，更准确反映 nginx 返回此页的场景

- `doc/debt.cds-nginx-loading-pages.md`（新增）：
  - 记录 8 个散落的 loading page HTML 的迁移债务台账
  - D1：forwarder 硬重启导致 3s 预览抖动（待优化）
  - D2：loading page SSOT 统一进度（已完成 #2，待迁移 #3-#8）
  - D3：CDS_USE_FORWARDER 默认值评估（影响自升级窗口可用性）

## 实现细节

1. **双主题支持**：所有 CSS 变量在 `:root` 和 `@media(prefers-color-scheme:light)` 中定义，自动适配系统主题偏好

2. **动画网格背景**：复用 `buildTransitPageHtml` 的 canvas 脚本，支持 `prefers-reduced-motion` 无障碍模式

3. **冷启动兜底**：shell 内置模板仅在 `dist/cli/render-page.js` 不存在时使用，生产环境几乎总是走 TypeScript 路径

4. **债务追踪**：新增 `doc/debt.cds-nginx-loading-pages.md` 记录剩余 7 个 loading page 的迁移计划，为后续统一奠定基础

## 测试

- [x] `pn

https://claude.ai/code/session_01844cdJ1o2ctaUY4TN6GiPD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> 主要影响 nginx 静态兜底页生成路径与展示文案；有 dist 未构建时的 heredoc 回退，不改变认证或数据面。
> 
> **Overview**
> **nginx 等待页**从 `exec_cds.sh` 内联 heredoc 迁到 TypeScript 单一来源：`src/loading-pages/index.ts` 提供 `buildNginxWaitingHtml()`（双主题 token、网格背景、文案改为「CDS 自升级中」），`src/cli/render-page.js` 供 shell 调用。
> 
> `write_waiting_html()` 在存在 `dist/cli/render-page.js` 时用 Node 渲染并写入 `cds-waiting.html`；否则仍用同步过的精简 heredoc 兜底。
> 
> 新增 `doc/debt.cds-nginx-loading-pages.md` 记录其余 7 处 loading HTML 的迁移债务与 forwarder/自升级相关待办。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 218ca3bedd1ff7be0a5ac3d40be5512015bf86fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->