### PR TITLE
[codex] bump CDS 技能版本到 0.6.8

### DIFF
--- a/.claude/skills/cds/SKILL.md
+++ b/.claude/skills/cds/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cds
-version: 0.6.7
+version: 0.6.8
 description: CDS (Cloud Dev Space) core skill — hosts the canonical cdscli Python CLI, handles authentication (static AI_ACCESS_KEY / dynamic pairing / project key), manages env vars and project keys, owns CDS service self-update, defines the preview-URL slug formula, and acts as dispatcher when the user's intent is ambiguous between cold-path scanning and hot-path debugging. Activates when the user mentions CDS generically without specifying scan-or-deploy, configures CDS credentials, manages env / keys, updates the CDS service code itself, or asks about preview URL conventions. Does NOT directly perform project scanning (delegates to cds-project-scan, the cold path) or deployment debugging (delegates to cds-deploy-pipeline, the hot path). Trigger phrases include "cds 认证", "AI_ACCESS_KEY", "项目 key", "cds 自更新", "cds self-update", "预览地址公式", "配 cds 环境变量", "/cds", "/cds-auth", and the bare word "cds" when the user has not yet picked a direction.
 ---
 

--- a/.claude/skills/cds/cli/cdscli.py
+++ b/.claude/skills/cds/cli/cdscli.py
@@ -43,7 +43,7 @@ import urllib.parse
 import urllib.request
 from typing import Any, Optional
 
-VERSION = "0.6.7"  # ← bumped on each SKILL.md change; 服务端自动读这一行
+VERSION = "0.6.8"  # ← bumped on each SKILL.md change; 服务端自动读这一行
 _TRACE_ID: str = ""
 _HUMAN: bool = False
 _DRIFT_WARNED: bool = False  # 全进程只提示一次，避免每个请求都刷

--- a/changelogs/2026-06-09_cds-skill-version-bump-068.md
+++ b/changelogs/2026-06-09_cds-skill-version-bump-068.md
@@ -1,0 +1,1 @@
+| fix | cds-skill | bump CDS 技能版本 0.6.7 → 0.6.8，让已合入的 `X-Cds-Cli-Latest` 更新提醒对旧 0.6.7 客户端可见 |


### PR DESCRIPTION
## What changed

- Bumped CDS skill and `cdscli` version from `0.6.7` to `0.6.8`.
- Added a changelog fragment explaining why the bump is needed.

## Why

PR #757 added the `X-Cds-Cli-Latest` update-advertising path, but kept the visible version at `0.6.7`. Without this patch bump, existing `0.6.7` clients would not see themselves as stale after the server deploys the new header behavior.

## Validation

- `pnpm vitest run tests/services/cdscli-version.test.ts`
- `python3 .claude/skills/cds/cli/cdscli.py --version`
- Manual check: `SKILL.md` frontmatter and `cdscli.py VERSION` both report `0.6.8`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version metadata and changelog only; no auth, API, or runtime behavior changes.
> 
> **Overview**
> Bumps the CDS skill and **`cdscli`** advertised version from **0.6.7** to **0.6.8** in `SKILL.md` frontmatter and the `VERSION` constant in `cdscli.py`, with a changelog note.
> 
> This is a follow-up so clients still on **0.6.7** can be flagged as behind once the server advertises **`X-Cds-Cli-Latest`** after the header behavior landed in a prior change—no functional CLI or server logic changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e886bebf6c7970f06fc55085b9ca696a6a0b7cf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->