### PR TITLE
doc: 新增 Peer Sync、文档再加工路由、债务台账等文档

### DIFF
--- a/changelogs/.entropy-manifest.yml
+++ b/changelogs/.entropy-manifest.yml
@@ -170,3 +170,8 @@ processed:
   - 2026-05-26_project-route-agent-admin-md-upload.md
   - 2026-05-26_project-route-agent-branch-fallback.md
   - 2026-05-26_project-route-agent-by-repo-grouping.md
+  - 2026-06-08_business-goal-editable.md
+  - 2026-06-08_cds-login-access-console.md
+  - 2026-06-08_cds-service-chip-dot.md
+  - 2026-06-08_goal-as-milestone.md
+  - 2026-06-08_goal-drawer-and-canvas-drag.md

--- a/changelogs/2026-06-08_entropy-cleanup.md
+++ b/changelogs/2026-06-08_entropy-cleanup.md
@@ -1,0 +1,1 @@
+| chore | doc | 熵清理：D2 +7 index.yml，D3 +7 guide.list，D6 +5 changelog manifest |

--- a/doc/guide.list.directory.md
+++ b/doc/guide.list.directory.md
@@ -311,6 +311,12 @@
 - [缺陷分享与 Agent 技能修复架构](design.defect-agent-share-skill-architecture) `design.defect-agent-share-skill-architecture`
   > 缺陷分享中心、外部 Agent 技能接入与修复报告闭环的架构设计
 
+- [系统级跨节点互传（Peer Sync）设计](design.peer-sync) `design.peer-sync`
+  > 多节点间消息互传的协议设计、数据模型与同步机制
+
+- [文档再加工 · 智能体调用路由设计](design.reprocess-chat-routing) `design.reprocess-chat-routing`
+  > 文档再加工功能中不同智能体（视觉/文学）的调用路由与分发设计
+
 ### 三、指南
 
 - [Agent 开发入门指南（新手必读）](guide.agent-onboarding) `guide.agent-onboarding`
@@ -674,6 +680,9 @@
 - [视频创作 Agent 列表/详情页全面重做交接](plan.video-agent-list-detail-rebuild) `plan.video-agent-list-detail-rebuild`
   > 视频创作 Agent 列表与详情页全面重做的交接文档
 
+- [CDS PR #684 审查修复计划](plan.cds-pr684-review-remediation) `plan.cds-pr684-review-remediation`
+  > CDS PR #684 代码审查发现问题的分阶段修复计划与进度追踪
+
 ### 六、技术债务台账
 
 > 模块级未还工程债（已知边界 / 后续可补 / 留尾风险）。命名规范见 `rule.doc-naming.md` 「debt.* 专项约定」。
@@ -744,6 +753,18 @@
   > ReportDetailPage 900 行业务实体（成员×周次矩阵 + 多 tabs + 计划对比 + 右栏面板），不是文档库语义；融合需先给 DocBrowser 加 leftSidebar/rightPanel/entryBadges 三 slot 系统
 - [开放接口对外网关债务台账](debt.open-api) `debt.open-api`
   > Phase 1 落地网关 + 按 Key 绑定 + 默认回落 + 导航修复；伞形 appCallerCode 静态注册不变量（守卫测试）；限流按 Key 桶 / 降级预警 / 配额 / embeddings 分到 Phase 2
+
+- [日报技能债务台账](debt.daily-report) `debt.daily-report`
+  > daily-report-summary 技能与 reference/publish.py 的已知边界与待补项
+
+- [系统级跨节点互传（Peer Sync）债务台账](debt.peer-sync) `debt.peer-sync`
+  > prd-api PeerSync + prd-admin 系统互联的已知边界与 Phase 2 待补功能
+
+- [个人任务树 Agent · 债务台账](debt.task-tree) `debt.task-tree`
+  > TaskTreeController + prd-admin pages/task-tree 的已知边界与后续可补项
+
+- [网页托管评论 · 债务台账](debt.web-hosting-comments) `debt.web-hosting-comments`
+  > 网页托管评论功能的已知边界与待补实现
 
 ### 七、周报
 

--- a/doc/index.yml
+++ b/doc/index.yml
@@ -127,6 +127,8 @@ docs:
   design.cds-railway-onboarding-flow: CDS Railway 式部署向导设计
   design.cds-visual-deploy: CDS 绝对可视化一键部署设计（检测回填+把握度+试运行沙箱+多DB实例+env粘贴+应用已上线，含架构图）
   design.speech-agent: 演讲智能体技术设计（数据模型 / Controller / Service / SSE 协议）
+  design.peer-sync: 系统级跨节点互传（Peer Sync）设计
+  design.reprocess-chat-routing: 文档再加工 · 智能体调用路由设计
 
   # ── 三、指南 ──
   # 先看全貌索引，再看部署/开发，然后是 Agent 使用教程，最后是专题指南
@@ -258,6 +260,7 @@ docs:
   plan.emergence-1-tiktok-douyin-poster: 涌现 1 · TikTok / 抖音博主订阅首页广告海报
   plan.prd-admin-surface-style-migration: prd-admin 样式统一迁移看板
   plan.video-agent-list-detail-rebuild: 视频创作 Agent 列表 / 详情页全面重做交接
+  plan.cds-pr684-review-remediation: CDS PR #684 审查修复计划
 
   # ── 六、技术债务台账（按模块）──
   # 已知边界 / 后续可补 / 留尾风险，命名规范见 rule.doc-naming.md「debt.* 专项约定」
@@ -289,6 +292,10 @@ docs:
   debt.report-detail: 周报详情页（异构数据 + 多 tabs + 右栏面板）保留独立实现的债务台账
   debt.open-api: 开放接口对外网关债务台账（伞形 code 不变量 + 限流/降级/预警/配额 Phase 2 留尾）
   debt.document-store-sync: 知识库跨环境/本地库↔库同步 · 债务台账（删除传播/附件/冲突合并/教程未补）
+  debt.daily-report: 日报技能（daily-report-summary）债务台账
+  debt.peer-sync: 系统级跨节点互传（Peer Sync）债务台账
+  debt.task-tree: 个人任务树 Agent · 债务台账
+  debt.web-hosting-comments: 网页托管评论 · 债务台账
 
   # ── 七、周报（降序：最新在前）──
   report.agent-universe-completeness: 智能体宇宙 · 各智能体完备度看板（终极目标 vs 当前进度）


### PR DESCRIPTION
## 摘要

补充文档索引与债务台账记录，涵盖系统级跨节点互传（Peer Sync）设计、文档再加工智能体调用路由、CDS PR #684 审查修复计划，以及日报、任务树、网页托管评论等模块的债务台账。

## 改动 diff

- `doc/guide.list.directory.md`：新增 2 条设计文档索引（Peer Sync、文档再加工路由）、1 条计划索引（CDS PR #684）、4 条债务台账索引（日报、Peer Sync、任务树、网页托管评论）
- `doc/index.yml`：同步更新 YAML 索引，新增 4 条设计文档、1 条计划、4 条债务台账条目
- `changelogs/.entropy-manifest.yml`：记录 5 个新增 changelog 碎片文件（2026-06-08 日期）
- `changelogs/2026-06-08_entropy-cleanup.md`：新增 changelog 碎片，记录本次文档熵清理

## 说明

本次变更为纯文档维护，涉及：
1. 新增设计文档占位符（`design.peer-sync`、`design.reprocess-chat-routing`）
2. 新增计划文档占位符（`plan.cds-pr684-review-remediation`）
3. 新增债务台账占位符（`debt.daily-report`、`debt.peer-sync`、`debt.task-tree`、`debt.web-hosting-comments`）
4. 同步 `index.yml` 与 `guide.list.directory.md` 保持一致性

所有新增文档条目均遵循 `doc/rule.doc-naming.md` 命名规范，使用标准前缀与描述格式。

https://claude.ai/code/session_01GmdsnaMtUMjYaDFXHcipBx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> 仅文档与 changelog 元数据变更，无应用代码、配置或数据路径影响。
> 
> **Overview**
> 本次为 **文档熵清理 / 索引同步**，不改动运行时逻辑。
> 
> **`doc/guide.list.directory.md` 与 `doc/index.yml`** 对齐新增条目：设计侧登记 **Peer Sync**、**文档再加工智能体路由**；计划侧登记 **CDS PR #684 审查修复**；债务台账侧登记 **日报技能**、**Peer Sync**、**个人任务树**、**网页托管评论**（含简短说明行）。
> 
> **Changelog 侧**：在 **`changelogs/.entropy-manifest.yml`** 将 5 个 `2026-06-08_*` 碎片标为已处理，并新增 **`changelogs/2026-06-08_entropy-cleanup.md`** 记录本次 D2/D3/D6 清理动作。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc4d1384ab4b49d69dfe679d82bf0c2455b9b00b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->