### PR TITLE
实现 CDS 发布控制面并补齐云端发布链路

### DIFF
--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -21,7 +21,8 @@ import type { ComposeServiceDef } from '../services/compose-parser.js';
 import { computeRequiredInfra } from '../services/deploy-infra-resolver.js';
 import { combinedOutput } from '../types.js';
 import { topoSortLayers } from '../services/topo-sort.js';
-import { detectStack } from '../services/stack-detector.js';
+import { detectStack, type DatabaseInitRecommendation, type StackDetection } from '../services/stack-detector.js';
+import { buildInfraDataExec, detectInfraDataKind, maskSecretValues, runDockerExec } from './infra-data.js';
 import { getInfraCatalogPublic } from '../services/infra-catalog.js';
 import { assertProjectAccess } from './projects.js';
 import { CheckRunRunner } from '../services/check-run-runner.js';
@@ -2385,6 +2386,232 @@ export function createBranchRouter(deps: RouterDeps): Router {
     return masked;
   }
 
+  function isSqlInitInfra(service: InfraService): boolean {
+    const kind = detectInfraDataKind(service.dockerImage);
+    return kind === 'postgres' || kind === 'mysql';
+  }
+
+  function composeDatabaseInitCommand(detection: StackDetection, init: DatabaseInitRecommendation): string {
+    const command = (init.command || '').trim();
+    const install = (detection.installCommand || '').trim();
+    if (!command || !install) return command;
+    if (command.includes(install)) return command;
+    return `${install} && ${command}`;
+  }
+
+  async function runDatabaseSqlInit(params: {
+    entry: BranchEntry;
+    init: DatabaseInitRecommendation;
+    scanDir: string;
+    projectId: string;
+    logEvent: (ev: OperationLogEvent) => void;
+  }): Promise<void> {
+    const { entry, init, scanDir, projectId, logEvent } = params;
+    const file = init.files.find((f) => f === 'schema.sql' || f === 'init.sql') || init.files[0];
+    if (!file) throw new Error('未找到 SQL 初始化文件');
+    const sqlPath = path.resolve(scanDir, file);
+    const normalizedScanDir = path.resolve(scanDir);
+    if (!sqlPath.startsWith(`${normalizedScanDir}${path.sep}`) && sqlPath !== normalizedScanDir) {
+      throw new Error(`SQL 初始化文件路径非法: ${file}`);
+    }
+    const sql = fs.readFileSync(sqlPath, 'utf-8');
+    const infra = stateService.getInfraServicesForProject(projectId)
+      .filter((svc) => svc.status === 'running' && isSqlInitInfra(svc))
+      .sort((a, b) => a.id.localeCompare(b.id))[0];
+    if (!infra) {
+      throw new Error('检测到 SQL 初始化脚本，但没有已运行的 PostgreSQL/MySQL/MariaDB 服务可执行。');
+    }
+    logEvent({
+      step: `database-init-sql-${infra.id}`,
+      status: 'running',
+      title: `正在执行 ${file} 到 ${infra.name || infra.id}`,
+      detail: { infraId: infra.id, file, branchId: entry.id },
+      timestamp: new Date().toISOString(),
+    });
+    const plan = buildInfraDataExec(infra, 'init-sql', sql);
+    const result = await runDockerExec(plan.argv, plan.stdin, 120_000);
+    const output = maskSecretValues([result.stdout, result.stderr].filter(Boolean).join('\n'), plan.secretValues);
+    if (result.code !== 0) {
+      throw new Error(output || `${file} 执行失败，exit code ${result.code}`);
+    }
+    logEvent({
+      step: `database-init-sql-${infra.id}`,
+      status: 'done',
+      title: `初始化完成：${file}`,
+      log: output.trim() || undefined,
+      detail: { infraId: infra.id, file, truncated: result.truncated },
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  async function runDatabaseInitializationForDeploy(params: {
+    entry: BranchEntry;
+    profiles: BuildProfile[];
+    requestId?: string;
+    operationId?: string;
+    actor?: string;
+    trigger?: string;
+    assertCurrent?: (step: string) => void;
+    logEvent: (ev: OperationLogEvent) => void;
+  }): Promise<void> {
+    const { entry, profiles, requestId, operationId, actor, trigger, assertCurrent, logEvent } = params;
+    if (profiles.length === 0) return;
+    const projectId = entry.projectId || 'default';
+    const customEnv = getMergedEnv(projectId, entry.id);
+    const firstEffective = resolveEffectiveProfile(profiles[0], entry);
+    const scanTargets: Array<{ profile: BuildProfile; scanDir: string; label: string; root: boolean }> = profiles.map((profile) => {
+      const effective = resolveEffectiveProfile(profile, entry);
+      return {
+        profile: effective,
+        scanDir: path.resolve(entry.worktreePath, effective.workDir || '.'),
+        label: effective.name || effective.id,
+        root: false,
+      };
+    });
+    const rootDir = path.resolve(entry.worktreePath);
+    if (!scanTargets.some((target) => target.scanDir === rootDir)) {
+      scanTargets.push({
+        profile: { ...firstEffective, workDir: '.', containerWorkDir: firstEffective.containerWorkDir || '/app' },
+        scanDir: rootDir,
+        label: '仓库根目录',
+        root: true,
+      });
+    }
+
+    const seen = new Set<string>();
+    let executed = 0;
+    let skipped = 0;
+    logEvent({
+      step: 'database-init',
+      status: 'running',
+      title: '数据库准备中',
+      detail: { scanTargets: scanTargets.map((target) => ({ label: target.label, root: target.root })) },
+      timestamp: new Date().toISOString(),
+    });
+
+    for (const target of scanTargets) {
+      assertCurrent?.(`database-init scan ${target.label}`);
+      let detection: StackDetection;
+      try {
+        detection = detectStack(target.scanDir);
+      } catch (err) {
+        skipped += 1;
+        logEvent({
+          step: `database-init-scan-${target.label}`,
+          status: 'warning',
+          title: `${target.label} 初始化扫描失败`,
+          log: (err as Error).message,
+          timestamp: new Date().toISOString(),
+        });
+        continue;
+      }
+      const init = detection.databaseInit;
+      if (!init) continue;
+      const key = `${target.scanDir}:${init.kind}:${init.command || ''}:${init.files.join('|')}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      if (!init.autoExecutable) {
+        skipped += 1;
+        logEvent({
+          step: `database-init-${init.kind}-${target.label}`,
+          status: 'info',
+          title: `检测到 ${init.label}，需要手动确认后执行`,
+          log: init.summary,
+          timestamp: new Date().toISOString(),
+        });
+        continue;
+      }
+
+      if (init.kind === 'sql') {
+        try {
+          await runDatabaseSqlInit({ entry, init, scanDir: target.scanDir, projectId, logEvent });
+        } catch (err) {
+          logEvent({
+            step: `database-init-sql-${target.label}`,
+            status: 'error',
+            title: '初始化失败，查看日志',
+            log: (err as Error).message,
+            detail: { files: init.files, label: target.label },
+            timestamp: new Date().toISOString(),
+          });
+          throw err;
+        }
+        executed += 1;
+        continue;
+      }
+
+      const command = composeDatabaseInitCommand(detection, init);
+      if (!command) {
+        skipped += 1;
+        continue;
+      }
+      const step = `database-init-${target.profile.id}-${init.kind}`;
+      logEvent({
+        step,
+        status: 'running',
+        title: `正在执行迁移：${init.label}`,
+        log: command,
+        detail: { profileId: target.profile.id, files: init.files, signals: init.signals },
+        timestamp: new Date().toISOString(),
+      });
+      let result;
+      try {
+        result = await containerService.runProfileCommand(
+          entry,
+          target.profile,
+          command,
+          undefined,
+          customEnv,
+          { requestId, operationId, actor, trigger, assertCurrent, timeoutMs: target.profile.buildTimeout ?? 600_000 },
+        );
+      } catch (err) {
+        logEvent({
+          step,
+          status: 'error',
+          title: '初始化失败，查看日志',
+          log: (err as Error).message,
+          detail: { profileId: target.profile.id, files: init.files },
+          timestamp: new Date().toISOString(),
+        });
+        throw err;
+      }
+      const output = maskSecretsText(combinedOutput(result), { mask: true });
+      if (result.exitCode !== 0) {
+        const message = output || `${init.label} 初始化失败，exit code ${result.exitCode}`;
+        logEvent({
+          step,
+          status: 'error',
+          title: '初始化失败，查看日志',
+          log: message,
+          detail: { profileId: target.profile.id, files: init.files },
+          timestamp: new Date().toISOString(),
+        });
+        throw new Error(message);
+      }
+      logEvent({
+        step,
+        status: 'done',
+        title: `初始化完成：${init.label}`,
+        log: output.trim() || undefined,
+        detail: { profileId: target.profile.id, files: init.files },
+        timestamp: new Date().toISOString(),
+      });
+      executed += 1;
+    }
+
+    logEvent({
+      step: 'database-init',
+      status: 'done',
+      title: executed > 0
+        ? `数据库初始化完成：已执行 ${executed} 个任务`
+        : skipped > 0
+          ? '数据库初始化：已识别手动兜底项，未自动执行'
+          : '数据库初始化：未发现需要执行的任务',
+      detail: { executed, skipped },
+      timestamp: new Date().toISOString(),
+    });
+  }
+
   // ── Helper: SSE setup ──
   function initSSE(res: import('express').Response) {
     res.writeHead(200, {
@@ -4678,6 +4905,78 @@ export function createBranchRouter(deps: RouterDeps): Router {
     }
   });
 
+  router.post('/branches/:id/database-init/run', async (req, res) => {
+    const { id } = req.params;
+    const entry = stateService.getBranch(id);
+    if (!entry) {
+      res.status(404).json({ error: `分支 "${id}" 不存在` });
+      return;
+    }
+    {
+      const m = assertProjectAccess(req as any, entry.projectId || 'default');
+      if (m) { res.status(m.status).json(m.body); return; }
+    }
+    const rawCommand = typeof req.body?.command === 'string' ? req.body.command.trim() : '';
+    if (!rawCommand) {
+      res.status(400).json({ error: 'migration_command_required', message: '迁移命令不能为空。' });
+      return;
+    }
+    if (rawCommand.length > 2000) {
+      res.status(400).json({ error: 'migration_command_too_long', message: '迁移命令过长，请控制在 2000 字符以内。' });
+      return;
+    }
+
+    const profiles = stateService.getBuildProfilesForProject(entry.projectId || 'default');
+    const requestedProfileId = typeof req.body?.profileId === 'string' ? req.body.profileId.trim() : '';
+    const baseProfile = (requestedProfileId
+      ? profiles.find((profile) => profile.id === requestedProfileId)
+      : profiles[0]) || null;
+    if (!baseProfile) {
+      res.status(400).json({ error: 'profile_not_found', message: requestedProfileId ? `构建配置不存在: ${requestedProfileId}` : '尚未配置构建配置。' });
+      return;
+    }
+
+    const branchOperationLease = beginBranchOperation(req, res, entry, {
+      kind: 'database-init',
+      profileId: baseProfile.id,
+      source: 'api.database-init-run',
+      reason: '手动执行数据库初始化/迁移命令',
+      sse: false,
+    });
+    if (branchOperationCoordinator && !branchOperationLease) return;
+
+    const requestId = String((req as any).cdsRequestId || req.headers['x-cds-request-id'] || '').trim() || undefined;
+    try {
+      const profile = resolveEffectiveProfile(baseProfile, entry);
+      const result = await containerService.runProfileCommand(
+        entry,
+        profile,
+        rawCommand,
+        undefined,
+        getMergedEnv(entry.projectId || 'default', entry.id),
+        {
+          requestId,
+          operationId: branchOperationLease?.operationId || undefined,
+          actor: resolveActorFromRequest(req),
+          trigger: triggerFromRequest(req),
+          timeoutMs: profile.buildTimeout ?? 600_000,
+        },
+      );
+      const output = maskSecretsText(combinedOutput(result), { mask: true });
+      completeBranchOperation(branchOperationLease, result.exitCode === 0 ? 'completed' : 'failed');
+      res.status(result.exitCode === 0 ? 200 : 500).json({
+        ok: result.exitCode === 0,
+        profileId: profile.id,
+        command: rawCommand,
+        exitCode: result.exitCode,
+        output,
+      });
+    } catch (err) {
+      completeBranchOperation(branchOperationLease, 'failed');
+      res.status(500).json({ ok: false, error: (err as Error).message });
+    }
+  });
+
   // ── Build & Run (SSE stream) ──
 
   router.post('/branches/:id/deploy', async (req, res) => {
@@ -5032,6 +5331,17 @@ export function createBranchRouter(deps: RouterDeps): Router {
           });
         }
       }
+
+      await runDatabaseInitializationForDeploy({
+        entry,
+        profiles,
+        requestId,
+        operationId: branchOperationLease?.operationId || undefined,
+        actor: resolveActorFromRequest(req),
+        trigger: triggerFromRequest(req),
+        assertCurrent: (step) => assertBranchOperationCurrent(branchOperationLease, step),
+        logEvent,
+      });
 
       // ── Compute startup layers (topological sort by dependsOn) ──
       // P4 Part 17 (G2 fix): scope infra by the branch's project so the

--- a/cds/src/routes/infra-data.ts
+++ b/cds/src/routes/infra-data.ts
@@ -130,14 +130,14 @@ export function maskSecretValues(text: string, secrets: string[]): string {
   return out;
 }
 
-interface DockerExecResult {
+export interface DockerExecResult {
   stdout: string;
   stderr: string;
   code: number;
   truncated: boolean;
 }
 
-function runDockerExec(argv: string[], stdin: string, timeoutMs = 30_000, maxBytes = 256 * 1024): Promise<DockerExecResult> {
+export function runDockerExec(argv: string[], stdin: string, timeoutMs = 30_000, maxBytes = 256 * 1024): Promise<DockerExecResult> {
   return new Promise((resolve) => {
     const proc = spawn('docker', argv, { stdio: ['pipe', 'pipe', 'pipe'] });
     let out = '';

--- a/cds/src/routes/projects.ts
+++ b/cds/src/routes/projects.ts
@@ -27,7 +27,7 @@
 import { Router } from 'express';
 import { randomBytes, createHash } from 'node:crypto';
 import type { StateService } from '../services/state.js';
-import { detectStack, detectModules, type StackDetection } from '../services/stack-detector.js';
+import { detectStack, detectModules, detectDatabaseInitialization, type StackDetection } from '../services/stack-detector.js';
 import { discoverComposeFiles, parseCdsCompose } from '../services/compose-parser.js';
 import { deriveEnvMetaForVars } from '../services/env-classifier.js';
 import { ProjectFilesService, ProjectFileError, type ProjectFilePayload } from '../services/project-files.js';
@@ -1718,10 +1718,21 @@ export function createProjectsRouter(deps: ProjectsRouterDeps): Router {
           stack: d.stack,
           confidence: typeof d.confidence === 'number' ? d.confidence : 0,
           signals: Array.isArray(d.signals) ? d.signals.slice(0, 6) : [],
+          databaseInit: d.databaseInit || null,
+          databaseInitCandidates: d.databaseInitCandidates || [],
           manualSetupRequired: Boolean(d.manualSetupRequired),
         };
       });
-      res.json({ services, moduleCount: modules.length });
+      const databaseInitCandidates = [
+        ...detectDatabaseInitialization(dir),
+        ...modules.flatMap((m) => m.detection.databaseInitCandidates || []),
+      ];
+      res.json({
+        services,
+        moduleCount: modules.length,
+        databaseInit: databaseInitCandidates[0] || null,
+        databaseInitCandidates,
+      });
     } catch (err) {
       res.status(500).json({ error: (err as Error).message });
     } finally {

--- a/cds/src/routes/releases.ts
+++ b/cds/src/routes/releases.ts
@@ -1,0 +1,274 @@
+import crypto from 'node:crypto';
+import { Router } from 'express';
+import type { StateService } from '../services/state.js';
+import type { ReleaseTarget } from '../types.js';
+import { ReleaseService } from '../services/release-service.js';
+import { releaseEvents } from '../services/release-events.js';
+import { resolveActorFromRequest } from '../services/actor-resolver.js';
+
+export interface ReleasesRouterDeps {
+  stateService: StateService;
+}
+
+export function createReleasesRouter(deps: ReleasesRouterDeps): Router {
+  const router = Router();
+  const service = new ReleaseService(deps.stateService);
+
+  router.get('/releases/targets', (req, res) => {
+    const projectId = typeof req.query.project === 'string' ? req.query.project : undefined;
+    if (projectId) service.ensureDefaultPlans(projectId);
+    res.json({
+      targets: deps.stateService.getReleaseTargets(projectId),
+      plans: deps.stateService.getReleasePlans(projectId),
+      remoteHosts: deps.stateService.getRemoteHosts().map((host) => ({
+        id: host.id,
+        name: host.name,
+        host: host.host,
+        sshPort: host.sshPort,
+        sshUser: host.sshUser,
+        fingerprint: host.sshPrivateKeyFingerprint,
+        isEnabled: host.isEnabled,
+      })),
+    });
+  });
+
+  router.post('/releases/targets', (req, res) => {
+    const body = (req.body || {}) as Record<string, unknown>;
+    const validation = validateSshTargetBody(body, false);
+    if (validation) {
+      res.status(400).json({ error: validation });
+      return;
+    }
+    const now = new Date().toISOString();
+    const target: ReleaseTarget = {
+      id: typeof body.id === 'string' && body.id.trim() ? body.id.trim() : `rt_${crypto.randomBytes(6).toString('hex')}`,
+      projectId: String(body.projectId).trim(),
+      name: String(body.name).trim(),
+      type: 'ssh',
+      createdAt: now,
+      updatedAt: now,
+      createdBy: resolveActorFromRequest(req),
+      isEnabled: body.isEnabled !== false,
+      ssh: {
+        host: String(body.host).trim(),
+        port: Number(body.port || 22),
+        user: String(body.user).trim(),
+        privateKeyRef: String(body.privateKeyRef).trim(),
+        appPath: String(body.appPath).trim(),
+        deployCommand: String(body.deployCommand).trim(),
+        rollbackCommand: typeof body.rollbackCommand === 'string' ? body.rollbackCommand.trim() : '',
+        healthcheckUrl: String(body.healthcheckUrl).trim(),
+      },
+    };
+    try {
+      service.ensureDefaultPlans(target.projectId);
+      res.status(201).json({ target: deps.stateService.upsertReleaseTarget(target) });
+    } catch (err) {
+      res.status(409).json({ error: (err as Error).message });
+    }
+  });
+
+  router.patch('/releases/targets/:id', (req, res) => {
+    const existing = deps.stateService.getReleaseTarget(req.params.id);
+    if (!existing) {
+      res.status(404).json({ error: 'release target not found' });
+      return;
+    }
+    const body = (req.body || {}) as Record<string, unknown>;
+    const mergedBody = {
+      projectId: existing.projectId,
+      name: existing.name,
+      host: existing.ssh?.host,
+      port: existing.ssh?.port,
+      user: existing.ssh?.user,
+      privateKeyRef: existing.ssh?.privateKeyRef,
+      appPath: existing.ssh?.appPath,
+      deployCommand: existing.ssh?.deployCommand,
+      rollbackCommand: existing.ssh?.rollbackCommand,
+      healthcheckUrl: existing.ssh?.healthcheckUrl,
+      isEnabled: existing.isEnabled,
+      ...body,
+    };
+    const validation = validateSshTargetBody(mergedBody, true);
+    if (validation) {
+      res.status(400).json({ error: validation });
+      return;
+    }
+    const updated: ReleaseTarget = {
+      ...existing,
+      projectId: String(mergedBody.projectId).trim(),
+      name: String(mergedBody.name).trim(),
+      isEnabled: mergedBody.isEnabled !== false,
+      ssh: {
+        host: String(mergedBody.host).trim(),
+        port: Number(mergedBody.port || 22),
+        user: String(mergedBody.user).trim(),
+        privateKeyRef: String(mergedBody.privateKeyRef).trim(),
+        appPath: String(mergedBody.appPath).trim(),
+        deployCommand: String(mergedBody.deployCommand).trim(),
+        rollbackCommand: typeof mergedBody.rollbackCommand === 'string' ? mergedBody.rollbackCommand.trim() : '',
+        healthcheckUrl: String(mergedBody.healthcheckUrl).trim(),
+      },
+    };
+    res.json({ target: deps.stateService.upsertReleaseTarget(updated) });
+  });
+
+  router.delete('/releases/targets/:id', (req, res) => {
+    const runs = deps.stateService.getReleaseRuns({ targetId: req.params.id });
+    if (runs.length > 0) {
+      res.status(409).json({ error: 'target has release runs and cannot be deleted' });
+      return;
+    }
+    if (!deps.stateService.removeReleaseTarget(req.params.id)) {
+      res.status(404).json({ error: 'release target not found' });
+      return;
+    }
+    res.status(204).end();
+  });
+
+  router.post('/releases/branches/:branchId/preflight', async (req, res) => {
+    const body = (req.body || {}) as Record<string, unknown>;
+    if (typeof body.targetId !== 'string' || !body.targetId.trim()) {
+      res.status(400).json({ error: 'targetId is required' });
+      return;
+    }
+    try {
+      const result = await service.preflight({
+        branchId: req.params.branchId,
+        targetId: body.targetId.trim(),
+        previewUrl: typeof body.previewUrl === 'string' ? body.previewUrl : '',
+        operator: resolveActorFromRequest(req),
+      });
+      res.json(result);
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  router.post('/releases/branches/:branchId/runs', async (req, res) => {
+    const body = (req.body || {}) as Record<string, unknown>;
+    if (typeof body.targetId !== 'string' || !body.targetId.trim()) {
+      res.status(400).json({ error: 'targetId is required' });
+      return;
+    }
+    try {
+      const run = await service.startRelease({
+        branchId: req.params.branchId,
+        targetId: body.targetId.trim(),
+        previewUrl: typeof body.previewUrl === 'string' ? body.previewUrl : '',
+        operator: resolveActorFromRequest(req),
+      });
+      res.status(202).json({ run, streamUrl: `/api/releases/runs/${run.releaseId}/stream` });
+    } catch (err) {
+      res.status(409).json({ error: (err as Error).message });
+    }
+  });
+
+  router.get('/releases/runs', (req, res) => {
+    res.json({
+      runs: deps.stateService.getReleaseRuns({
+        projectId: typeof req.query.project === 'string' ? req.query.project : undefined,
+        targetId: typeof req.query.targetId === 'string' ? req.query.targetId : undefined,
+        branchId: typeof req.query.branchId === 'string' ? req.query.branchId : undefined,
+      }),
+    });
+  });
+
+  router.get('/releases/runs/:id', (req, res) => {
+    const run = deps.stateService.getReleaseRun(req.params.id);
+    if (!run) {
+      res.status(404).json({ error: 'release run not found' });
+      return;
+    }
+    res.json({ run });
+  });
+
+  router.post('/releases/runs/:id/rollback', async (req, res) => {
+    try {
+      const run = await service.startRollback(req.params.id, resolveActorFromRequest(req));
+      res.status(202).json({ run, streamUrl: `/api/releases/runs/${run.releaseId}/stream` });
+    } catch (err) {
+      res.status(409).json({ error: (err as Error).message });
+    }
+  });
+
+  router.get('/releases/runs/:id/stream', (req, res) => {
+    const run = deps.stateService.getReleaseRun(req.params.id);
+    if (!run) {
+      res.status(404).json({ error: 'release run not found' });
+      return;
+    }
+    const afterSeq = Number(req.query.afterSeq || 0);
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'close',
+      'X-Accel-Buffering': 'no',
+    });
+    const send = (event: string, data: unknown): void => {
+      try { res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`); } catch { /* client gone */ }
+    };
+    send('snapshot', {
+      run,
+      logs: run.logs.filter((log) => log.seq > afterSeq),
+    });
+    const handler = (envelope: any): void => {
+      if (!envelope?.payload || envelope.payload.releaseId !== req.params.id) return;
+      send(envelope.type, envelope.payload);
+    };
+    releaseEvents.on('any', handler);
+    const keepalive = setInterval(() => {
+      try { res.write(':keepalive\n\n'); } catch { /* ignore */ }
+    }, 10_000);
+    req.on('close', () => {
+      clearInterval(keepalive);
+      releaseEvents.off('any', handler);
+    });
+  });
+
+  router.get('/releases/center', (req, res) => {
+    const projectId = typeof req.query.project === 'string' ? req.query.project : undefined;
+    if (projectId) service.ensureDefaultPlans(projectId);
+    const targets = deps.stateService.getReleaseTargets(projectId);
+    const runs = deps.stateService.getReleaseRuns(projectId ? { projectId } : {});
+    const rows = targets.map((target) => {
+      const targetRuns = runs.filter((run) => run.targetId === target.id);
+      const current = targetRuns.find((run) => run.status === 'success');
+      const latest = targetRuns[0];
+      return {
+        target,
+        currentVersion: current?.releaseId || '',
+        currentCommit: current?.commitSha || '',
+        latestRun: latest,
+        lastReleasedAt: current?.finishedAt || current?.startedAt || '',
+        healthStatus: latest?.status === 'success' ? 'healthy' : latest?.status?.includes('failed') ? 'failed' : latest?.status || 'unknown',
+        lastOperator: latest?.operator || '',
+        canRollback: Boolean(current?.previousReleaseId || deps.stateService.getLatestSuccessfulReleaseRun(target.id, current?.releaseId)),
+      };
+    });
+    res.json({ rows, plans: deps.stateService.getReleasePlans(projectId), runs: runs.slice(0, 50) });
+  });
+
+  return router;
+}
+
+function validateSshTargetBody(body: Record<string, unknown>, allowExisting: boolean): string | null {
+  const required = ['projectId', 'name', 'host', 'user', 'privateKeyRef', 'appPath', 'deployCommand', 'healthcheckUrl'];
+  for (const key of required) {
+    if (typeof body[key] !== 'string' || !String(body[key]).trim()) {
+      return `${key} is required`;
+    }
+  }
+  const port = Number(body.port || 22);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) return 'port must be an integer in [1, 65535]';
+  try {
+    const url = new URL(String(body.healthcheckUrl));
+    if (!['http:', 'https:'].includes(url.protocol)) return 'healthcheckUrl must be http or https';
+  } catch {
+    return 'healthcheckUrl must be a valid URL';
+  }
+  if (!allowExisting && typeof body.id === 'string' && body.id && !/^[A-Za-z0-9_-]{2,80}$/.test(body.id)) {
+    return 'id must match [A-Za-z0-9_-]{2,80}';
+  }
+  return null;
+}

--- a/cds/src/server.ts
+++ b/cds/src/server.ts
@@ -702,6 +702,7 @@ export function resolveApiLabel(method: string, path: string): string {
     [/^POST \/branches\/(.+)\/pull$/, '拉取分支代码'],
     [/^POST \/branches\/(.+)\/deploy\/(.+)$/, '部署单服务'],
     [/^POST \/branches\/(.+)\/deploy$/, '全量部署'],
+    [/^POST \/branches\/(.+)\/database-init\/run$/, '执行数据库初始化命令'],
     [/^POST \/branches\/(.+)\/stop$/, '停止分支服务'],
     [/^POST \/branches\/(.+)\/restart$/, '重新启动分支'],
     [/^GET \/branches\/(.+)\/activity-logs$/, '查看分支系统日志'],

--- a/cds/src/server.ts
+++ b/cds/src/server.ts
@@ -19,6 +19,7 @@ import { createProjectStorageRouter } from './routes/project-storage.js';
 import { createCacheRouter } from './routes/cache.js';
 import { createSnapshotsRouter } from './routes/snapshots.js';
 import { createRemoteHostsRouter } from './routes/remote-hosts.js';
+import { createReleasesRouter } from './routes/releases.js';
 import { createCdsSystemConnectionsRouter } from './routes/cds-system-connections.js';
 import { createCdsSystemTopologyRouter } from './routes/cds-system-topology.js';
 import { createTopologyAggregator } from './services/topology-aggregator.js';
@@ -492,6 +493,18 @@ export function resolveApiLabel(method: string, path: string): string {
     'GET /cds-system/github/webhook-deliveries': '列出 Webhook 日志',
     'GET /cds-system/github/app-whitelist': '获取 GitHub 白名单',
     'PUT /cds-system/github/app-whitelist': '更新 GitHub 白名单',
+    // 发布控制面（preview → release，2026-06-10）
+    'GET /releases/targets': '列出发布目标',
+    'POST /releases/targets': '创建发布目标',
+    'PATCH /releases/targets/:id': '更新发布目标',
+    'DELETE /releases/targets/:id': '删除发布目标',
+    'POST /releases/branches/:branchId/preflight': '执行发布前检查',
+    'POST /releases/branches/:branchId/runs': '启动分支发布',
+    'GET /releases/runs': '列出发布记录',
+    'GET /releases/runs/:id': '查看发布记录',
+    'POST /releases/runs/:id/rollback': '回滚发布记录',
+    'GET /releases/runs/:id/stream': '订阅发布日志流',
+    'GET /releases/center': '查看发布中心',
     'GET /branches': '获取系统状态信息',
     'POST /branches': '注册新分支',
     'GET /remote-branches': '获取远程分支',
@@ -2837,6 +2850,9 @@ export function createServer(deps: ServerDeps): express.Express {
     stateService: deps.stateService,
     containerService: deps.containerService,
     config: deps.config,
+  }));
+  app.use('/api', createReleasesRouter({
+    stateService: deps.stateService,
   }));
   // CDS 配对连接（系统级），见 routes/cds-system-connections.ts。
   app.use('/api', createCdsSystemConnectionsRouter({

--- a/cds/src/services/branch-operation-coordinator.ts
+++ b/cds/src/services/branch-operation-coordinator.ts
@@ -4,6 +4,7 @@ import type { ServerEventLogSink } from './server-event-log-store.js';
 export type BranchOperationKind =
   | 'deploy'
   | 'deploy-profile'
+  | 'database-init'
   | 'restart'
   | 'force-rebuild'
   | 'stop'

--- a/cds/src/services/container.ts
+++ b/cds/src/services/container.ts
@@ -4,7 +4,7 @@ import http from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
-import type { IShellExecutor, CdsConfig, BuildProfile, BranchEntry, ServiceState, InfraService, DeployModeOverride, BuildProfileOverride, ReadinessProbe } from '../types.js';
+import type { IShellExecutor, CdsConfig, BuildProfile, BranchEntry, ServiceState, InfraService, DeployModeOverride, BuildProfileOverride, ReadinessProbe, ExecResult } from '../types.js';
 import { combinedOutput } from '../types.js';
 import { resolveCommandTemplate, resolveEnvTemplates } from './compose-parser.js';
 import { sanitizeDockerRestartPolicy } from '../config/docker-restart-policy.js';
@@ -459,6 +459,134 @@ export class ContainerService {
     return `'${value.replace(/'/g, `'\\''`)}'`;
   }
 
+  private resolveProfileRuntimeEnv(
+    entry: BranchEntry,
+    profile: BuildProfile,
+    customEnv?: Record<string, string>,
+  ): Record<string, string> {
+    const mergedEnv: Record<string, string> = {};
+
+    if (customEnv) {
+      Object.assign(mergedEnv, customEnv);
+    }
+
+    mergedEnv['Jwt__Secret'] = this.config.jwt.secret;
+    mergedEnv['Jwt__Issuer'] = this.config.jwt.issuer;
+
+    if (entry.branch) {
+      mergedEnv['VITE_GIT_BRANCH'] = entry.branch;
+    }
+    if (entry.githubCommitSha) {
+      mergedEnv['VITE_BUILD_ID'] = entry.githubCommitSha.slice(0, 12);
+    }
+
+    const isNodeContainer = /\bnode:/.test(profile.dockerImage);
+    if (isNodeContainer) {
+      mergedEnv['PNPM_HOME'] = mergedEnv['PNPM_HOME'] || '/pnpm';
+      mergedEnv['npm_config_store_dir'] = mergedEnv['npm_config_store_dir'] || '/pnpm/store';
+      const currentPath = mergedEnv['PATH'] || '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin';
+      if (!currentPath.includes('/pnpm')) {
+        mergedEnv['PATH'] = `/pnpm:${currentPath}`;
+      }
+    }
+
+    if (profile.env) {
+      Object.assign(mergedEnv, profile.env);
+    }
+
+    const isolatedEnv = applyPerBranchDbIsolation(mergedEnv, profile.dbScope, entry.branch);
+    const missingTemplates = missingEnvTemplates(isolatedEnv);
+    if (missingTemplates.length > 0) {
+      throw new Error(
+        `环境变量模板缺少值: ${missingTemplates.join(', ')}。请在项目环境变量中填写，或先启动对应基础设施服务后再部署。`,
+      );
+    }
+
+    const resolveVars: Record<string, string> = { ...isolatedEnv };
+    if (customEnv) {
+      for (const [k, v] of Object.entries(isolatedEnv)) {
+        if (v === `\${${k}}` && customEnv[k] !== undefined) {
+          resolveVars[k] = customEnv[k];
+        }
+      }
+    }
+    return resolveEnvTemplates(isolatedEnv, resolveVars);
+  }
+
+  private async buildProfileVolumeFlags(
+    entry: BranchEntry,
+    profile: BuildProfile,
+    command: string,
+    onOutput?: (chunk: string) => void,
+  ): Promise<{ containerWorkDir: string; volumeFlags: string[]; isNodeContainer: boolean; skipSrcMount: boolean }> {
+    const srcMount = path.join(entry.worktreePath, profile.workDir);
+    const containerWorkDir = profile.containerWorkDir || '/app';
+    const skipSrcMount = profile.prebuiltImage === true;
+    const isNodeContainer = /\bnode:/.test(profile.dockerImage);
+    const volumeFlags: string[] = skipSrcMount
+      ? []
+      : [`-v "${srcMount}":"${containerWorkDir}"`];
+
+    if (skipSrcMount) {
+      onOutput?.(`── 预构建镜像模式: 跳过 source mount(image 已含应用文件)──\n`);
+    }
+
+    if (isNodeContainer && !skipSrcMount && /\bpnpm\b/.test(command)) {
+      volumeFlags.push(`-v "${nodeModulesVolumeName(entry.id, profile.id)}":"${containerWorkDir}/node_modules"`);
+    }
+
+    if (profile.cacheMounts) {
+      for (const cm of profile.cacheMounts) {
+        const mkdir = await this.shell.exec(`mkdir -p "${cm.hostPath}"`);
+        if (mkdir.exitCode !== 0) {
+          throw new Error(`创建缓存目录失败: ${cm.hostPath}: ${combinedOutput(mkdir)}`);
+        }
+        volumeFlags.push(`-v "${cm.hostPath}":"${cm.containerPath}"`);
+      }
+    }
+
+    const ffmpegPaths = ['/opt/ffmpeg-static/ffmpeg', '/usr/local/bin/ffmpeg', '/usr/bin/ffmpeg'];
+    const ffprobePaths = ['/opt/ffmpeg-static/ffprobe', '/usr/local/bin/ffprobe', '/usr/bin/ffprobe'];
+    const findResult = await this.shell.exec(
+      `for p in ${ffmpegPaths.join(' ')}; do [ -f "$p" ] && echo "$p" && break; done`
+    );
+    const ffmpegPath = findResult.stdout?.trim();
+    if (ffmpegPath) {
+      volumeFlags.push(`-v "${ffmpegPath}:/usr/local/bin/ffmpeg:ro"`);
+      const findProbe = await this.shell.exec(
+        `for p in ${ffprobePaths.join(' ')}; do [ -f "$p" ] && echo "$p" && break; done`
+      );
+      const ffprobePath = findProbe.stdout?.trim();
+      if (ffprobePath) {
+        volumeFlags.push(`-v "${ffprobePath}:/usr/local/bin/ffprobe:ro"`);
+      }
+    }
+
+    return { containerWorkDir, volumeFlags, isNodeContainer, skipSrcMount };
+  }
+
+  private buildEntrypointFlags(profile: BuildProfile, onOutput?: (chunk: string) => void): string[] {
+    const entrypointFlags: string[] = [];
+    if (profile.entrypoint !== undefined) {
+      const ep = profile.entrypoint;
+      if (ep === '') {
+        entrypointFlags.push(`--entrypoint=""`);
+        onOutput?.(`── entrypoint 覆盖: (清空 image ENTRYPOINT) ──\n`);
+      } else if (/\s/.test(ep)) {
+        onOutput?.(
+          `── ⚠ cds.entrypoint="${ep}" 含空格无效:Docker --entrypoint 只接收单个可执行文件名 ──\n` +
+          `── ⚠ 如需 sh -c 包装行为,改用 cds.entrypoint: "" 清空 image ENTRYPOINT ` +
+          `(CDS 已默认 sh -c 包装 command) ──\n` +
+          `── ⚠ 本次跳过 entrypoint 覆盖,沿用 image 自带 ENTRYPOINT ──\n`
+        );
+      } else {
+        entrypointFlags.push(`--entrypoint ${JSON.stringify(ep)}`);
+        onOutput?.(`── entrypoint 覆盖: ${ep} ──\n`);
+      }
+    }
+    return entrypointFlags;
+  }
+
   /**
    * Remove stale CDS app containers for the same branch/profile before a new
    * docker run attaches service aliases. Docker DNS keeps every container that
@@ -693,175 +821,17 @@ export class ContainerService {
       },
     });
 
-    const srcMount = path.join(entry.worktreePath, profile.workDir);
-    const containerWorkDir = profile.containerWorkDir || '/app';
-    // Phase 7 fix(B17,2026-05-01)— 预构建镜像模式跳过 srcMount。
-    // 详见 BuildProfile.prebuiltImage 注释。
-    const skipSrcMount = profile.prebuiltImage === true;
-
-    // Build environment variables (later entries override earlier ones)
-    // Priority: customEnv (user dashboard) < profile.env (per-profile)
-    const mergedEnv: Record<string, string> = {};
-
-    // User-defined env vars from dashboard (includes CDS_* vars from infra services)
-    if (customEnv) {
-      Object.assign(mergedEnv, customEnv);
+    const command = profile.command || '';
+    if (!command) {
+      throw new Error(`构建配置 "${profile.id}" 缺少 command 字段`);
     }
-
-    // JWT
-    mergedEnv['Jwt__Secret'] = this.config.jwt.secret;
-    mergedEnv['Jwt__Issuer'] = this.config.jwt.issuer;
-
-    // Inject git metadata so frontend build tools can stamp bundle URLs.
-    // Branch containers often mount only a subdirectory (e.g. prd-admin -> /app),
-    // so `git rev-parse` inside Vite may fall back to "local". That makes CDN
-    // and browser caches keep stale `*-local.js` assets even after CDS shows a
-    // newer GitHub commit in the widget.
-    if (entry.branch) {
-      mergedEnv['VITE_GIT_BRANCH'] = entry.branch;
-    }
-    if (entry.githubCommitSha) {
-      mergedEnv['VITE_BUILD_ID'] = entry.githubCommitSha.slice(0, 12);
-    }
-
-    // Detect Node.js containers by image name (node:*, *node:*, etc.)
-    const isNodeContainer = /\bnode:/.test(profile.dockerImage);
-
-    // For Node.js containers: move pnpm store outside the bind-mounted source directory.
-    // Without this, pnpm creates .pnpm-store inside /app (the bind mount), and Vite's
-    // chokidar watches all those files, quickly exhausting the kernel inotify limit (ENOSPC).
-    // Setting PNPM_HOME=/pnpm puts the store at /pnpm/store (container overlay FS),
-    // invisible to Vite's file watcher. pnpm falls back to copying instead of hard-linking,
-    // which is fine for dev environments.
-    if (isNodeContainer) {
-      mergedEnv['PNPM_HOME'] = mergedEnv['PNPM_HOME'] || '/pnpm';
-      // Move pnpm content-addressable store outside the project directory.
-      // Without this, pnpm creates <project>/.pnpm-store and Vite's chokidar
-      // watches all those files, exhausting the kernel inotify limit (ENOSPC).
-      // pnpm reads store-dir from npm_config_store_dir (NOT "PNPM_STORE_DIR").
-      // See: https://github.com/orgs/pnpm/discussions/6566
-      mergedEnv['npm_config_store_dir'] = mergedEnv['npm_config_store_dir'] || '/pnpm/store';
-      // Ensure pnpm binary is on PATH after corepack enable
-      const currentPath = mergedEnv['PATH'] || '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin';
-      if (!currentPath.includes('/pnpm')) {
-        mergedEnv['PATH'] = `/pnpm:${currentPath}`;
-      }
-    }
-
-    // Profile-specific env (highest priority)
-    if (profile.env) {
-      Object.assign(mergedEnv, profile.env);
-    }
-
-    // Phase 5(2026-05-01)— 多分支 DB 隔离:
-    //   profile.dbScope==='per-branch' 时,把 MYSQL_DATABASE 等 DB-name 类 env
-    //   后缀 _<branchSlug>,实现"同一 DB 实例下每分支独立 database"。
-    //   必须在 resolveEnvTemplates 之前调用 — 这样 ${MYSQL_DATABASE} 引用会
-    //   展开成新值,连接串也会跟着变。
-    //   shared 模式(默认)是 noop,保持现有行为不变。
-    const isolatedEnv = applyPerBranchDbIsolation(mergedEnv, profile.dbScope, entry.branch);
-
-    // Resolve ${CDS_*} env var templates in all values
-    // e.g., MongoDB__ConnectionString: "mongodb://${CDS_HOST}:${CDS_MONGODB_PORT}"
-    // → "mongodb://172.17.0.1:37821"
-    const missingTemplates = missingEnvTemplates(isolatedEnv);
-    if (missingTemplates.length > 0) {
-      throw new Error(
-        `环境变量模板缺少值: ${missingTemplates.join(', ')}。请在项目环境变量中填写，或先启动对应基础设施服务后再部署。`,
-      );
-    }
-    // Phase 7 B16 + Bugbot 三轮迭代(PR #521)— 三个场景同时要 work:
-    //   1. B16 自引用:profile.env.X="${X}" 时,resolve 应拿 customEnv.X 真值
-    //   2. profile-local:URL=${HOST}:${PORT},HOST/PORT 在 isolatedEnv 应可查
-    //   3. per-branch isolation:isolatedEnv.CDS_POSTGRES_DB="app_feat_login"
-    //      (Phase 5 修改的)不应被 customEnv 的 'app' 覆盖回去 → 否则
-    //      ${CDS_POSTGRES_DB} 在 CDS_DATABASE_URL 解析回 'app',隔离完全失效
-    //
-    // 之前 fix 用 `{...isolatedEnv, ...customEnv}` 满足 1+2 但破坏 3。
-    // 正解:isolatedEnv 是真值源(per-branch + profile.env + customEnv 已合并),
-    //       仅当某 key 在 isolatedEnv 里值就是字面量 "${K}" 自引用时,才回退
-    //       到 customEnv 拿真值。这样三个场景全 work。
-    const resolveVars: Record<string, string> = { ...isolatedEnv };
-    if (customEnv) {
-      for (const [k, v] of Object.entries(isolatedEnv)) {
-        // 自引用模式 ${K} 字面量(== 自己的 key) → 回退到 customEnv 真值
-        if (v === `\${${k}}` && customEnv[k] !== undefined) {
-          resolveVars[k] = customEnv[k];
-        }
-      }
-    }
-    const resolvedEnv = resolveEnvTemplates(isolatedEnv, resolveVars);
-
-    // Write to temp file — avoids shell escaping issues with special chars
+    const resolvedEnv = this.resolveProfileRuntimeEnv(entry, profile, customEnv);
     const envFilePath = this.writeEnvFile(resolvedEnv);
     const envFlag = `--env-file "${envFilePath}"`;
-
-    // Shared cache mounts (avoid duplicating node_modules, nuget, etc.)
-    // Phase 7 (B17): prebuiltImage 模式跳过 srcMount,不覆盖 image 自带文件
-    const volumeFlags: string[] = skipSrcMount
-      ? []
-      : [`-v "${srcMount}":"${containerWorkDir}"`];
-    if (skipSrcMount) {
-      onOutput?.(`── 预构建镜像模式: 跳过 source mount(image 已含应用文件)──\n`);
-    }
-
-    // 用户反馈 2026-05-06 (#4):部署有时 19s(命中)有时 57s(重链 669 个包)。
-    // 根因:srcMount 是 host 上的 worktree 目录,worktree 重置 / 首次创建时
-    // node_modules 是空,pnpm 要从 /pnpm/store(host bind mount,内容齐全)
-    // 重新 hardlink/copy 到 /app/node_modules,O(N=669) 文件操作 ≈ 30-40s。
-    // 加一个 per-(branch, profile) 的 docker named volume 挂在
-    // /app/node_modules 上,**Docker 让 volume 覆盖 bind mount 的子路径**,
-    // 即:首次部署装满 volume,后续部署 volume 持久化,跳过重链。worktree
-    // 重置不影响这个 volume(代价是 stale node_modules,但 pnpm 用 lockfile
-    // diff 自我修正,只补差量)。
-    //
-    // ⚠ Bugbot 2026-05-06 bf11290f:此优化只在 pnpm 自我修正语义下安全
-    // (worktree 重置 / 切 commit 时 stale modules 由 lockfile diff 收敛)。
-    // npm / yarn 不保证差量校验,启用 volume 反而可能装入旧版本依赖。
-    // 收紧到 command 含 pnpm 的场景才挂 volume,其它场景仍走 worktree 的
-    // bind mount(慢但语义安全)。
-    if (isNodeContainer && !skipSrcMount && /\bpnpm\b/.test(profile.command || '')) {
-      // SSOT: util/node-modules-volume.ts(Bugbot 3e19da66 — 防 sanitize 漂移)
-      volumeFlags.push(`-v "${nodeModulesVolumeName(entry.id, profile.id)}":"${containerWorkDir}/node_modules"`);
-    }
-
-    if (profile.cacheMounts) {
-      for (const cm of profile.cacheMounts) {
-        // Ensure host path exists
-        const mkdir = await this.shell.exec(`mkdir -p "${cm.hostPath}"`);
-        if (mkdir.exitCode !== 0) {
-          throw new Error(`创建缓存目录失败: ${cm.hostPath}: ${combinedOutput(mkdir)}`);
-        }
-        volumeFlags.push(`-v "${cm.hostPath}":"${cm.containerPath}"`);
-      }
-    }
-
-    // ffmpeg: 静态编译版 bind mount（零依赖，单文件）
-    // 优先使用 /opt/ffmpeg-static/（用户下载的静态版），否则尝试宿主机 /usr/bin/ffmpeg
-    const ffmpegPaths = ['/opt/ffmpeg-static/ffmpeg', '/usr/local/bin/ffmpeg', '/usr/bin/ffmpeg'];
-    const ffprobePaths = ['/opt/ffmpeg-static/ffprobe', '/usr/local/bin/ffprobe', '/usr/bin/ffprobe'];
-    const findResult = await this.shell.exec(
-      `for p in ${ffmpegPaths.join(' ')}; do [ -f "$p" ] && echo "$p" && break; done`
-    );
-    const ffmpegPath = findResult.stdout?.trim();
-    if (ffmpegPath) {
-      volumeFlags.push(`-v "${ffmpegPath}:/usr/local/bin/ffmpeg:ro"`);
-      // ffprobe
-      const findProbe = await this.shell.exec(
-        `for p in ${ffprobePaths.join(' ')}; do [ -f "$p" ] && echo "$p" && break; done`
-      );
-      const ffprobePath = findProbe.stdout?.trim();
-      if (ffprobePath) {
-        volumeFlags.push(`-v "${ffprobePath}:/usr/local/bin/ffprobe:ro"`);
-      }
-    }
+    const { containerWorkDir, volumeFlags, isNodeContainer, skipSrcMount } =
+      await this.buildProfileVolumeFlags(entry, profile, command, onOutput);
 
     try {
-      const command = profile.command || '';
-      if (!command) {
-        throw new Error(`构建配置 "${profile.id}" 缺少 command 字段`);
-      }
-
       onOutput?.(`── 运行: ${command} ──\n`);
       // ⚠ Bugbot 2026-05-06 1f32c1da:之前 log 的条件是 isNodeContainer && !skipSrcMount,
       // 比真正挂 volume 的条件(还要 /\bpnpm\b/.test(command))宽,npm/yarn 项目会
@@ -887,25 +857,7 @@ export class ContainerService {
       // 字面文件名 "sh -c" 启动失败 "executable file not found")。CDS 默认
       // 已用 sh -c "command" 包装应用 command(line 467-ish),
       // 想强制 sh -c 行为只需 cds.entrypoint: "" 清空 wrapper 即可。
-      const entrypointFlags: string[] = [];
-      if (profile.entrypoint !== undefined) {
-        const ep = profile.entrypoint;
-        if (ep === '') {
-          entrypointFlags.push(`--entrypoint=""`);
-          onOutput?.(`── entrypoint 覆盖: (清空 image ENTRYPOINT) ──\n`);
-        } else if (/\s/.test(ep)) {
-          // 多词形式无效:跳过覆盖,提示用户改写
-          onOutput?.(
-            `── ⚠ cds.entrypoint="${ep}" 含空格无效:Docker --entrypoint 只接收单个可执行文件名 ──\n` +
-            `── ⚠ 如需 sh -c 包装行为,改用 cds.entrypoint: "" 清空 image ENTRYPOINT ` +
-            `(CDS 已默认 sh -c 包装 command) ──\n` +
-            `── ⚠ 本次跳过 entrypoint 覆盖,沿用 image 自带 ENTRYPOINT ──\n`
-          );
-        } else {
-          entrypointFlags.push(`--entrypoint ${JSON.stringify(ep)}`);
-          onOutput?.(`── entrypoint 覆盖: ${ep} ──\n`);
-        }
-      }
+      const entrypointFlags = this.buildEntrypointFlags(profile, onOutput);
 
       // Bug D fix(2026-05-10) — profile 容器需要 --network-alias,否则 network
       // 内只能用 container_name(全局唯一长名 cds-app-...) 互访,不能用短 service 名。
@@ -1016,6 +968,92 @@ export class ContainerService {
         });
         throw err;
       }
+    } finally {
+      this.removeEnvFile(envFilePath);
+    }
+  }
+
+  /**
+   * Run a short-lived command in the same profile runtime environment as
+   * runService. Database migrations use this so DATABASE_URL, per-branch DB
+   * isolation, source mounts, and package caches match the app container.
+   */
+  async runProfileCommand(
+    entry: BranchEntry,
+    profile: BuildProfile,
+    command: string,
+    onOutput?: (chunk: string) => void,
+    customEnv?: Record<string, string>,
+    context: Pick<ContainerRemoveContext, 'requestId' | 'operationId' | 'actor' | 'trigger'> & {
+      assertCurrent?: (step: string) => void;
+      timeoutMs?: number;
+    } = {},
+  ): Promise<ExecResult> {
+    const network = this.getNetworkForProject(entry.projectId);
+    await this.ensureNetwork(network);
+
+    const resolvedEnv = this.resolveProfileRuntimeEnv(entry, profile, customEnv);
+    const envFilePath = this.writeEnvFile(resolvedEnv);
+    const envFlag = `--env-file "${envFilePath}"`;
+    const { containerWorkDir, volumeFlags, isNodeContainer, skipSrcMount } =
+      await this.buildProfileVolumeFlags(entry, profile, command, onOutput);
+
+    try {
+      if (!command.trim()) {
+        throw new Error(`构建配置 "${profile.id}" 缺少迁移命令`);
+      }
+      onOutput?.(`── 执行一次性命令: ${command} ──\n`);
+      if (isNodeContainer && !skipSrcMount && /\bpnpm\b/.test(command)) {
+        onOutput?.(`── Node.js 容器: node_modules 走 docker volume(跨部署持久化,首次会装满,后续秒过)──\n`);
+      }
+
+      const entrypointFlags = this.buildEntrypointFlags(profile, onOutput);
+      const runCmd = [
+        'docker run --rm',
+        `--network ${network}`,
+        ...volumeFlags,
+        ...entrypointFlags,
+        `-w ${containerWorkDir}`,
+        envFlag,
+        '--tmpfs /tmp',
+        `--label cds.managed=true`,
+        `--label cds.type=job`,
+        `--label cds.project.id=${entry.projectId || 'default'}`,
+        `--label cds.branch.id=${entry.id}`,
+        `--label cds.profile.id=${profile.id}`,
+        profile.dockerImage,
+        `sh -c "${command.replace(/"/g, '\\"')}"`,
+      ].join(' ');
+
+      context.assertCurrent?.(`runProfileCommand before docker-run ${profile.id}`);
+      const result = await this.shell.exec(runCmd, {
+        timeout: context.timeoutMs ?? profile.buildTimeout ?? 600_000,
+      });
+      this.recordContainerEvent({
+        severity: result.exitCode === 0 ? 'info' : 'error',
+        source: 'cds-container-service',
+        action: result.exitCode === 0 ? 'profile.job.completed' : 'profile.job.failed',
+        message: `profile command ${result.exitCode === 0 ? 'completed' : 'failed'} for ${profile.id}`,
+        projectId: entry.projectId,
+        branchId: entry.id,
+        profileId: profile.id,
+        requestId: context.requestId ?? undefined,
+        operationId: context.operationId ?? undefined,
+        command: {
+          name: 'docker run --rm',
+          exitCode: result.exitCode,
+          stdoutPreview: result.stdout,
+          stderrPreview: result.stderr,
+        },
+        details: {
+          image: profile.dockerImage,
+          network,
+          actor: context.actor ?? null,
+          trigger: context.trigger ?? null,
+        },
+      });
+      onOutput?.(combinedOutput(result));
+      return result;
     } finally {
       this.removeEnvFile(envFilePath);
     }

--- a/cds/src/services/release-events.ts
+++ b/cds/src/services/release-events.ts
@@ -1,0 +1,26 @@
+import { EventEmitter } from 'node:events';
+import type { ReleaseLogEntry, ReleaseRun } from '../types.js';
+
+export type ReleaseEventEnvelope =
+  | { type: 'release.log'; payload: { releaseId: string; log: ReleaseLogEntry } }
+  | { type: 'release.status'; payload: { releaseId: string; run: ReleaseRun } };
+
+class ReleaseEventBus extends EventEmitter {
+  constructor() {
+    super();
+    this.setMaxListeners(0);
+  }
+
+  emitEvent(envelope: ReleaseEventEnvelope): ReleaseEventEnvelope {
+    try {
+      this.emit(envelope.type, envelope.payload);
+      this.emit('any', envelope);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn('[release-events] listener threw:', (err as Error).message);
+    }
+    return envelope;
+  }
+}
+
+export const releaseEvents = new ReleaseEventBus();

--- a/cds/src/services/release-service.ts
+++ b/cds/src/services/release-service.ts
@@ -1,0 +1,413 @@
+import crypto from 'node:crypto';
+import type { StateService } from './state.js';
+import type { BranchEntry, ReleaseArtifact, ReleasePlan, ReleaseRun, ReleaseTarget, RemoteHost } from '../types.js';
+import { decryptRemoteHostSecrets } from './sidecar/remote-host-service.js';
+import { shellQuote } from './sidecar/sidecar-deployer.js';
+import { releaseEvents } from './release-events.js';
+
+type Ssh2Client = {
+  connect(opts: Ssh2ConnectOptions): void;
+  on(event: 'ready' | 'error' | 'end' | 'close', listener: (...args: unknown[]) => void): unknown;
+  end(): void;
+  exec(cmd: string, cb: (err: Error | undefined, stream: Ssh2ExecStream) => void): boolean;
+};
+
+type Ssh2ExecStream = {
+  on(event: 'close' | 'data', listener: (...args: unknown[]) => void): unknown;
+  stderr: { on(event: 'data', listener: (...args: unknown[]) => void): unknown };
+};
+
+interface Ssh2ConnectOptions {
+  host: string;
+  port: number;
+  username: string;
+  privateKey: string | Buffer;
+  passphrase?: string;
+  readyTimeout?: number;
+}
+
+export interface ReleasePreflightCheck {
+  id: string;
+  label: string;
+  status: 'pass' | 'warn' | 'fail';
+  message: string;
+  blocking: boolean;
+}
+
+export interface ReleasePreflightResult {
+  ok: boolean;
+  checks: ReleasePreflightCheck[];
+  artifact?: ReleaseArtifact;
+  target?: ReleaseTarget;
+  plan?: ReleasePlan;
+  previousRelease?: ReleaseRun;
+}
+
+export interface ReleaseStartInput {
+  branchId: string;
+  targetId: string;
+  operator?: string;
+  previewUrl?: string;
+}
+
+export class ReleaseService {
+  constructor(private readonly stateService: StateService) {}
+
+  ensureDefaultPlans(projectId: string): ReleasePlan[] {
+    const existing = this.stateService.getReleasePlans(projectId);
+    const sshPlanId = `${projectId}:ssh-script`;
+    if (!existing.some((plan) => plan.id === sshPlanId)) {
+      this.stateService.upsertReleasePlan({
+        id: sshPlanId,
+        projectId,
+        name: 'SSH 脚本发布',
+        template: 'ssh-script',
+        targetType: 'ssh',
+        failureStrategy: 'stop',
+        rollbackStrategy: 'command',
+        createdAt: new Date().toISOString(),
+        steps: [
+          { id: 'connect', title: '连接目标', kind: 'ssh' },
+          { id: 'deploy', title: '执行发布命令', kind: 'ssh' },
+          { id: 'healthcheck', title: '健康检查', kind: 'healthcheck' },
+          { id: 'record', title: '记录版本', kind: 'record' },
+        ],
+      });
+    }
+    return this.stateService.getReleasePlans(projectId);
+  }
+
+  async preflight(input: ReleaseStartInput): Promise<ReleasePreflightResult> {
+    const checks: ReleasePreflightCheck[] = [];
+    const push = (check: ReleasePreflightCheck): void => { checks.push(check); };
+    const branch = this.stateService.getBranch(input.branchId);
+    const target = this.stateService.getReleaseTarget(input.targetId);
+    const projectId = branch?.projectId || target?.projectId || 'default';
+    const plan = this.ensureDefaultPlans(projectId).find((item) => item.template === 'ssh-script');
+
+    if (!branch) {
+      push({ id: 'branch', label: '分支存在', status: 'fail', message: `分支不存在: ${input.branchId}`, blocking: true });
+    } else if (branch.status !== 'running') {
+      push({ id: 'branch', label: '分支部署成功', status: 'fail', message: `当前状态是 ${branch.status}，只允许从成功运行的分支发布`, blocking: true });
+    } else {
+      push({ id: 'branch', label: '分支部署成功', status: 'pass', message: `${branch.branch} 正在运行`, blocking: false });
+    }
+
+    const commitSha = resolveCommitSha(branch);
+    if (!commitSha) {
+      push({ id: 'commit', label: 'commit 明确', status: 'fail', message: '分支没有 githubCommitSha 或 pinnedCommit', blocking: true });
+    } else {
+      push({ id: 'commit', label: 'commit 明确', status: 'pass', message: commitSha, blocking: false });
+    }
+
+    const previewUrl = input.previewUrl || '';
+    if (branch && commitSha && previewUrl) {
+      push({ id: 'artifact', label: '可发布产物', status: 'pass', message: 'branch-preview artifact 已就绪', blocking: false });
+    } else {
+      push({ id: 'artifact', label: '可发布产物', status: 'fail', message: '缺少预览地址或 commit，无法形成 ReleaseArtifact', blocking: true });
+    }
+
+    if (!target) {
+      push({ id: 'target', label: '发布目标', status: 'fail', message: `目标不存在: ${input.targetId}`, blocking: true });
+    } else if (!target.isEnabled) {
+      push({ id: 'target', label: '发布目标', status: 'fail', message: `${target.name} 已禁用`, blocking: true });
+    } else if (target.type !== 'ssh' || !target.ssh) {
+      push({ id: 'target', label: '发布目标', status: 'fail', message: 'MVP 只支持 SSH ReleaseTarget', blocking: true });
+    } else {
+      push({ id: 'target', label: '发布目标', status: 'pass', message: `${target.name} (${target.ssh.user}@${target.ssh.host}:${target.ssh.port})`, blocking: false });
+    }
+
+    if (target?.ssh?.deployCommand?.trim()) {
+      push({ id: 'deploy-command', label: 'deployCommand 已配置', status: 'pass', message: target.ssh.deployCommand.trim(), blocking: false });
+    } else {
+      push({ id: 'deploy-command', label: 'deployCommand 已配置', status: 'fail', message: 'SSH target 缺少 deployCommand', blocking: true });
+    }
+
+    if (target?.ssh?.healthcheckUrl?.trim()) {
+      try {
+        await probeHealthcheck(target.ssh.healthcheckUrl);
+        push({ id: 'healthcheck', label: 'healthcheckUrl 可用', status: 'pass', message: target.ssh.healthcheckUrl, blocking: false });
+      } catch (err) {
+        push({ id: 'healthcheck', label: 'healthcheckUrl 可用', status: 'fail', message: (err as Error).message, blocking: true });
+      }
+    } else {
+      push({ id: 'healthcheck', label: 'healthcheckUrl 可用', status: 'fail', message: 'SSH target 缺少 healthcheckUrl', blocking: true });
+    }
+
+    if (target?.ssh?.privateKeyRef) {
+      const host = this.stateService.getRemoteHost(target.ssh.privateKeyRef);
+      if (!host) {
+        push({ id: 'ssh', label: '目标主机可连接', status: 'fail', message: `privateKeyRef 不存在: ${target.ssh.privateKeyRef}`, blocking: true });
+      } else {
+        try {
+          await this.sshExec(target, 'echo cds-release-connect-ok');
+          push({ id: 'ssh', label: '目标主机可连接', status: 'pass', message: `fingerprint=${host.sshPrivateKeyFingerprint}`, blocking: false });
+        } catch (err) {
+          push({ id: 'ssh', label: '目标主机可连接', status: 'fail', message: (err as Error).message, blocking: true });
+        }
+      }
+    }
+
+    const previousRelease = target ? this.stateService.getLatestSuccessfulReleaseRun(target.id) : undefined;
+    if (previousRelease) {
+      push({ id: 'rollback-version', label: '可回滚版本', status: 'pass', message: `${previousRelease.commitSha.slice(0, 12)} (${previousRelease.releaseId})`, blocking: false });
+    } else {
+      push({ id: 'rollback-version', label: '可回滚版本', status: 'warn', message: '这是该目标首次发布，成功前没有可回滚版本', blocking: false });
+    }
+
+    const artifact = branch && commitSha
+      ? buildArtifact(branch, commitSha, previewUrl)
+      : undefined;
+    return {
+      ok: checks.every((check) => !check.blocking || check.status !== 'fail'),
+      checks,
+      artifact,
+      target,
+      plan,
+      previousRelease,
+    };
+  }
+
+  async startRelease(input: ReleaseStartInput): Promise<ReleaseRun> {
+    const preflight = await this.preflight(input);
+    if (!preflight.ok || !preflight.artifact || !preflight.target || !preflight.plan) {
+      throw new Error(`发布前检查未通过: ${preflight.checks.filter((c) => c.blocking && c.status === 'fail').map((c) => c.label).join(', ')}`);
+    }
+    const releaseId = `rel_${crypto.randomBytes(8).toString('hex')}`;
+    const run: ReleaseRun = {
+      releaseId,
+      projectId: preflight.target.projectId,
+      branchId: input.branchId,
+      commitSha: preflight.artifact.commitSha,
+      artifact: preflight.artifact,
+      targetId: preflight.target.id,
+      planId: preflight.plan.id,
+      status: 'queued',
+      startedAt: new Date().toISOString(),
+      operator: input.operator,
+      previousReleaseId: preflight.previousRelease?.releaseId,
+      logs: [],
+      seq: 0,
+    };
+    this.stateService.addReleaseRun(run);
+    this.emitLog(releaseId, 'info', 'release queued', 'queued');
+    void this.runRelease(releaseId).catch((err) => {
+      this.failRun(releaseId, err);
+    });
+    return this.stateService.getReleaseRun(releaseId)!;
+  }
+
+  async startRollback(releaseId: string, operator?: string): Promise<ReleaseRun> {
+    const current = this.stateService.getReleaseRun(releaseId);
+    if (!current) throw new Error(`ReleaseRun not found: ${releaseId}`);
+    const target = this.stateService.getReleaseTarget(current.targetId);
+    if (!target?.ssh) throw new Error('rollback requires SSH target');
+    if (!target.ssh.rollbackCommand?.trim()) throw new Error('rollbackCommand is not configured');
+    const previous = current.previousReleaseId
+      ? this.stateService.getReleaseRun(current.previousReleaseId)
+      : this.stateService.getLatestSuccessfulReleaseRun(current.targetId, current.releaseId);
+    if (!previous) throw new Error('no previous successful release to roll back to');
+
+    const rollbackId = `rel_${crypto.randomBytes(8).toString('hex')}`;
+    const run: ReleaseRun = {
+      releaseId: rollbackId,
+      projectId: current.projectId,
+      branchId: previous.branchId,
+      commitSha: previous.commitSha,
+      artifact: previous.artifact,
+      targetId: current.targetId,
+      planId: current.planId,
+      status: 'rollback_running',
+      startedAt: new Date().toISOString(),
+      operator,
+      previousReleaseId: previous.previousReleaseId,
+      rollbackOf: current.releaseId,
+      logs: [],
+      seq: 0,
+    };
+    this.stateService.addReleaseRun(run);
+    this.emitLog(rollbackId, 'info', `rollback queued to ${previous.releaseId}`, 'rollback');
+    void this.runRollback(rollbackId, target, previous).catch((err) => {
+      this.failRun(rollbackId, err, 'rollback_failed');
+    });
+    return this.stateService.getReleaseRun(rollbackId)!;
+  }
+
+  private async runRelease(releaseId: string): Promise<void> {
+    const run = this.stateService.getReleaseRun(releaseId);
+    if (!run) throw new Error(`ReleaseRun not found: ${releaseId}`);
+    const target = this.stateService.getReleaseTarget(run.targetId);
+    if (!target?.ssh) throw new Error('SSH target not found');
+    this.patchStatus(releaseId, 'running');
+    this.emitLog(releaseId, 'info', `连接目标 ${target.ssh.user}@${target.ssh.host}:${target.ssh.port}`, 'connect');
+    await this.sshExec(target, 'echo cds-release-connect-ok', releaseId);
+    this.emitLog(releaseId, 'info', '准备 release 参数', 'prepare');
+    const command = buildReleaseCommand(target, run, target.ssh.deployCommand);
+    this.emitLog(releaseId, 'info', '执行发布命令', 'deploy');
+    await this.sshExec(target, command, releaseId);
+    this.patchStatus(releaseId, 'healthchecking');
+    this.emitLog(releaseId, 'info', `健康检查 ${target.ssh.healthcheckUrl}`, 'healthcheck');
+    await probeHealthcheck(target.ssh.healthcheckUrl);
+    this.emitLog(releaseId, 'info', '标记成功', 'record');
+    const done = this.stateService.patchReleaseRun(releaseId, {
+      status: 'success',
+      finishedAt: new Date().toISOString(),
+    });
+    releaseEvents.emitEvent({ type: 'release.status', payload: { releaseId, run: done } });
+  }
+
+  private async runRollback(releaseId: string, target: ReleaseTarget, previous: ReleaseRun): Promise<void> {
+    if (!target.ssh?.rollbackCommand) throw new Error('rollbackCommand is not configured');
+    this.emitLog(releaseId, 'info', `执行回滚命令，目标版本 ${previous.releaseId}`, 'rollback');
+    await this.sshExec(target, buildReleaseCommand(target, previous, target.ssh.rollbackCommand, releaseId), releaseId);
+    this.emitLog(releaseId, 'info', `健康检查 ${target.ssh.healthcheckUrl}`, 'healthcheck');
+    await probeHealthcheck(target.ssh.healthcheckUrl);
+    const done = this.stateService.patchReleaseRun(releaseId, {
+      status: 'rollback_success',
+      finishedAt: new Date().toISOString(),
+    });
+    this.emitLog(releaseId, 'info', '回滚成功', 'record');
+    releaseEvents.emitEvent({ type: 'release.status', payload: { releaseId, run: done } });
+  }
+
+  private failRun(releaseId: string, err: unknown, status: ReleaseRun['status'] = 'failed'): void {
+    this.emitLog(releaseId, 'error', (err as Error).message || String(err), 'error');
+    const run = this.stateService.patchReleaseRun(releaseId, {
+      status,
+      errorMessage: (err as Error).message || String(err),
+      finishedAt: new Date().toISOString(),
+    });
+    releaseEvents.emitEvent({ type: 'release.status', payload: { releaseId, run } });
+  }
+
+  private patchStatus(releaseId: string, status: ReleaseRun['status']): void {
+    const run = this.stateService.patchReleaseRun(releaseId, { status });
+    releaseEvents.emitEvent({ type: 'release.status', payload: { releaseId, run } });
+  }
+
+  private emitLog(releaseId: string, level: 'info' | 'warn' | 'error', message: string, phase?: string): void {
+    const run = this.stateService.appendReleaseRunLog(releaseId, { level, message: maskLog(message), phase });
+    const log = run.logs[run.logs.length - 1];
+    releaseEvents.emitEvent({ type: 'release.log', payload: { releaseId, log } });
+  }
+
+  private async sshExec(target: ReleaseTarget, cmd: string, releaseId?: string): Promise<string> {
+    if (!target.ssh) throw new Error('target is not SSH');
+    const keyHost = this.stateService.getRemoteHost(target.ssh.privateKeyRef);
+    if (!keyHost) throw new Error(`privateKeyRef not found: ${target.ssh.privateKeyRef}`);
+    const host: RemoteHost = {
+      ...keyHost,
+      host: target.ssh.host,
+      sshPort: target.ssh.port,
+      sshUser: target.ssh.user,
+    };
+    const ssh2Mod = await loadSsh2();
+    const { privateKey, passphrase } = decryptRemoteHostSecrets(host);
+    const client = new ssh2Mod.Client() as unknown as Ssh2Client;
+
+    return new Promise<string>((resolve, reject) => {
+      let stdout = '';
+      let stderr = '';
+      let settled = false;
+      const settle = (fn: () => void) => {
+        if (settled) return;
+        settled = true;
+        try { client.end(); } catch { /* ignore */ }
+        fn();
+      };
+      const append = (level: 'info' | 'warn', chunk: unknown) => {
+        const text = String(chunk);
+        if (level === 'info') stdout += text;
+        else stderr += text;
+        if (releaseId) {
+          for (const line of text.split(/\r?\n/).filter(Boolean)) {
+            this.emitLog(releaseId, level, line.slice(0, 1000), 'ssh');
+          }
+        }
+      };
+
+      client.on('ready', () => {
+        client.exec(cmd, (err, stream) => {
+          if (err) return settle(() => reject(err));
+          stream.on('data', (chunk) => append('info', chunk));
+          stream.stderr.on('data', (chunk) => append('warn', chunk));
+          stream.on('close', (code: unknown) => {
+            const exitCode = typeof code === 'number' ? code : 0;
+            if (exitCode === 0) return settle(() => resolve(stdout));
+            settle(() => reject(new Error(`ssh exec exit=${exitCode} stderr=${stderr.slice(0, 500)}`)));
+          });
+        });
+      });
+      client.on('error', (err) => settle(() => reject(err as Error)));
+      client.connect({
+        host: host.host,
+        port: host.sshPort,
+        username: host.sshUser,
+        privateKey,
+        passphrase,
+        readyTimeout: 10_000,
+      });
+    });
+  }
+}
+
+function resolveCommitSha(branch?: BranchEntry): string {
+  return branch?.pinnedCommit || branch?.githubCommitSha || '';
+}
+
+function buildArtifact(branch: BranchEntry, commitSha: string, previewUrl: string): ReleaseArtifact {
+  return {
+    type: 'branch-preview',
+    commitSha,
+    branchId: branch.id,
+    branchName: branch.branch,
+    previewUrl,
+  };
+}
+
+function buildReleaseCommand(target: ReleaseTarget, run: ReleaseRun, rawCommand: string, releaseIdOverride?: string): string {
+  const ssh = target.ssh!;
+  const env: Record<string, string> = {
+    CDS_COMMIT_SHA: run.commitSha,
+    CDS_RELEASE_ID: releaseIdOverride || run.releaseId,
+    CDS_BRANCH_NAME: run.artifact.branchName || '',
+    CDS_PREVIEW_URL: run.artifact.previewUrl || '',
+    CDS_IMAGE_DIGEST: run.artifact.imageDigest || '',
+    CDS_ARTIFACT_PATH: run.artifact.artifactPath || '',
+    CDS_PREVIOUS_RELEASE_ID: run.previousReleaseId || '',
+    CDS_ROLLBACK_OF: run.rollbackOf || '',
+  };
+  const renderedEnv = Object.entries(env)
+    .map(([key, value]) => `${key}=${shellQuote(value)}`)
+    .join(' ');
+  return `cd ${shellQuote(ssh.appPath || '.')} && ${renderedEnv} ${rawCommand}`;
+}
+
+async function probeHealthcheck(url: string): Promise<void> {
+  const parsed = new URL(url);
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    throw new Error('healthcheckUrl must be http or https');
+  }
+  const ctrl = new AbortController();
+  const timer = global.setTimeout(() => ctrl.abort(), 8_000);
+  try {
+    const res = await fetch(url, { method: 'GET', signal: ctrl.signal });
+    if (!res.ok) throw new Error(`healthcheck HTTP ${res.status}`);
+  } finally {
+    global.clearTimeout(timer);
+  }
+}
+
+function maskLog(value: string): string {
+  return value
+    .replace(/-----BEGIN [\s\S]*?PRIVATE KEY-----[\s\S]*?-----END [\s\S]*?PRIVATE KEY-----/g, '***PRIVATE_KEY***')
+    .replace(/(TOKEN|SECRET|PASSWORD|PRIVATE_KEY)=([^\s]+)/gi, '$1=***');
+}
+
+async function loadSsh2(): Promise<{ Client: new () => unknown }> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const mod: any = await import('ssh2').catch((err) => {
+    throw new Error(`ssh2 module not available: ${(err as Error).message}`);
+  });
+  return { Client: mod.Client || mod.default?.Client };
+}

--- a/cds/src/services/stack-detector.ts
+++ b/cds/src/services/stack-detector.ts
@@ -73,6 +73,28 @@ export type DetectedFramework =
   | 'flask'
   | 'rails';
 
+export type DetectedDatabaseInitKind =
+  | 'prisma'
+  | 'drizzle'
+  | 'typeorm'
+  | 'sequelize'
+  | 'django'
+  | 'alembic'
+  | 'rails'
+  | 'sql';
+
+export interface DatabaseInitRecommendation {
+  kind: DetectedDatabaseInitKind;
+  label: string;
+  command?: string;
+  files: string[];
+  signals: string[];
+  confidence: number;
+  summary: string;
+  /** Phase 1 only recommends. Phase 2 can execute this after DB ready. */
+  autoExecutable: boolean;
+}
+
 export interface StackDetection {
   stack: DetectedStack;
   confidence: number; // 0..1 (1 = high confidence match)
@@ -112,6 +134,12 @@ export interface StackDetection {
    * (e.g. Next.js) that need a build step distinct from install.
    */
   suggestedBuildCommand?: string;
+  /**
+   * Phase 1 database initialization recommendation. This is deliberately
+   * advisory: deploy execution is added by a later phase after DB readiness.
+   */
+  databaseInit?: DatabaseInitRecommendation;
+  databaseInitCandidates?: DatabaseInitRecommendation[];
 }
 
 /** Return an "unknown" detection that callers can treat as fallback. */
@@ -141,6 +169,229 @@ function readText(p: string): string | null {
   } catch {
     return null;
   }
+}
+
+function rel(searchPath: string, filePath: string): string {
+  return path.relative(searchPath, filePath).split(path.sep).join('/');
+}
+
+function firstExisting(searchPath: string, candidates: string[]): string | null {
+  for (const candidate of candidates) {
+    const abs = path.join(searchPath, candidate);
+    if (fs.existsSync(abs)) return candidate;
+  }
+  return null;
+}
+
+function listRootSqlFiles(searchPath: string): string[] {
+  const preferred = ['schema.sql', 'init.sql'];
+  const out: string[] = [];
+  for (const name of preferred) {
+    if (fs.existsSync(path.join(searchPath, name))) out.push(name);
+  }
+  try {
+    const entries = fs.readdirSync(searchPath, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isFile()) continue;
+      if (!/\.sql$/i.test(entry.name)) continue;
+      if (out.includes(entry.name)) continue;
+      out.push(entry.name);
+    }
+  } catch {
+    // ignore unreadable dirs; caller will simply have no SQL fallback.
+  }
+  return out.slice(0, 8);
+}
+
+function detectTypeormConfig(searchPath: string): string | null {
+  return firstExisting(searchPath, [
+    'ormconfig.json',
+    'ormconfig.js',
+    'ormconfig.ts',
+    'ormconfig.cjs',
+    'ormconfig.mjs',
+    'data-source.ts',
+    'data-source.js',
+    'src/data-source.ts',
+    'src/data-source.js',
+  ]);
+}
+
+function detectSequelizeConfig(searchPath: string): string | null {
+  return firstExisting(searchPath, [
+    '.sequelizerc',
+    'config/config.json',
+    'config/config.js',
+    'config/database.js',
+    'sequelize.config.js',
+    'sequelize.config.cjs',
+  ]);
+}
+
+function nodeMigrationCommand(searchPath: string, tool: 'prisma' | 'drizzle-kit' | 'typeorm' | 'sequelize-cli', args: string): string {
+  const pkg = readJson(path.join(searchPath, 'package.json')) || {};
+  const pm = detectNodePackageManager(searchPath, pkg);
+  if (tool === 'prisma') {
+    if (pm === 'pnpm') return `pnpm exec prisma ${args}`;
+    if (pm === 'yarn') return `yarn prisma ${args}`;
+    return `npx prisma ${args}`;
+  }
+  if (tool === 'drizzle-kit') {
+    if (pm === 'pnpm') return `pnpm exec drizzle-kit ${args}`;
+    if (pm === 'yarn') return `yarn drizzle-kit ${args}`;
+    return `npx drizzle-kit ${args}`;
+  }
+  if (tool === 'typeorm') {
+    if (pm === 'pnpm') return `pnpm exec typeorm ${args}`;
+    if (pm === 'yarn') return `yarn typeorm ${args}`;
+    return `npx typeorm ${args}`;
+  }
+  if (pm === 'pnpm') return `pnpm exec sequelize-cli ${args}`;
+  if (pm === 'yarn') return `yarn sequelize-cli ${args}`;
+  return `npx sequelize-cli ${args}`;
+}
+
+function recommendation(params: {
+  kind: DetectedDatabaseInitKind;
+  label: string;
+  command?: string;
+  files: string[];
+  signals: string[];
+  confidence: number;
+  summary: string;
+  autoExecutable?: boolean;
+}): DatabaseInitRecommendation {
+  return {
+    kind: params.kind,
+    label: params.label,
+    command: params.command,
+    files: params.files,
+    signals: params.signals,
+    confidence: params.confidence,
+    summary: params.summary,
+    autoExecutable: params.autoExecutable ?? Boolean(params.command),
+  };
+}
+
+export function detectDatabaseInitialization(searchPath: string): DatabaseInitRecommendation[] {
+  if (!fs.existsSync(searchPath)) return [];
+  const out: DatabaseInitRecommendation[] = [];
+
+  const prismaSchema = firstExisting(searchPath, ['prisma/schema.prisma']);
+  if (prismaSchema) {
+    const command = nodeMigrationCommand(searchPath, 'prisma', 'migrate deploy');
+    out.push(recommendation({
+      kind: 'prisma',
+      label: 'Prisma',
+      command,
+      files: [prismaSchema],
+      signals: ['prisma/schema.prisma'],
+      confidence: 0.98,
+      summary: `检测到 Prisma，部署后建议执行 ${command}`,
+    }));
+  }
+
+  const drizzleConfig = firstExisting(searchPath, [
+    'drizzle.config.ts',
+    'drizzle.config.js',
+    'drizzle.config.mjs',
+    'drizzle.config.cjs',
+  ]);
+  if (drizzleConfig) {
+    const command = nodeMigrationCommand(searchPath, 'drizzle-kit', 'migrate');
+    out.push(recommendation({
+      kind: 'drizzle',
+      label: 'Drizzle',
+      command,
+      files: [drizzleConfig],
+      signals: ['drizzle.config.*'],
+      confidence: 0.94,
+      summary: `检测到 Drizzle，部署后建议执行 ${command}`,
+    }));
+  }
+
+  const typeormConfig = detectTypeormConfig(searchPath);
+  if (typeormConfig) {
+    const command = nodeMigrationCommand(searchPath, 'typeorm', 'migration:run');
+    out.push(recommendation({
+      kind: 'typeorm',
+      label: 'TypeORM',
+      command,
+      files: [typeormConfig],
+      signals: ['typeorm config'],
+      confidence: 0.82,
+      summary: `检测到 TypeORM 配置，部署后建议执行 ${command}`,
+    }));
+  }
+
+  const sequelizeConfig = detectSequelizeConfig(searchPath);
+  if (sequelizeConfig) {
+    const command = nodeMigrationCommand(searchPath, 'sequelize-cli', 'db:migrate');
+    out.push(recommendation({
+      kind: 'sequelize',
+      label: 'Sequelize',
+      command,
+      files: [sequelizeConfig],
+      signals: ['sequelize config'],
+      confidence: 0.82,
+      summary: `检测到 Sequelize 配置，部署后建议执行 ${command}`,
+    }));
+  }
+
+  const managePy = firstExisting(searchPath, ['manage.py']);
+  if (managePy) {
+    out.push(recommendation({
+      kind: 'django',
+      label: 'Django migrate',
+      command: 'python manage.py migrate',
+      files: [managePy],
+      signals: ['manage.py'],
+      confidence: 0.96,
+      summary: '检测到 Django，部署后建议执行 python manage.py migrate',
+    }));
+  }
+
+  const alembicIni = firstExisting(searchPath, ['alembic.ini']);
+  if (alembicIni) {
+    out.push(recommendation({
+      kind: 'alembic',
+      label: 'Alembic',
+      command: 'alembic upgrade head',
+      files: [alembicIni],
+      signals: ['alembic.ini'],
+      confidence: 0.93,
+      summary: '检测到 Alembic，部署后建议执行 alembic upgrade head',
+    }));
+  }
+
+  const railsMigrations = path.join(searchPath, 'db', 'migrate');
+  if (fs.existsSync(railsMigrations)) {
+    out.push(recommendation({
+      kind: 'rails',
+      label: 'Rails migrate',
+      command: 'bundle exec rails db:migrate',
+      files: [rel(searchPath, railsMigrations)],
+      signals: ['db/migrate'],
+      confidence: 0.92,
+      summary: '检测到 Rails migrations，部署后建议执行 bundle exec rails db:migrate',
+    }));
+  }
+
+  const sqlFiles = listRootSqlFiles(searchPath);
+  if (sqlFiles.length > 0) {
+    const primary = sqlFiles.includes('schema.sql') ? 'schema.sql' : sqlFiles.includes('init.sql') ? 'init.sql' : sqlFiles[0];
+    out.push(recommendation({
+      kind: 'sql',
+      label: 'SQL 初始化脚本',
+      files: sqlFiles,
+      signals: ['*.sql'],
+      confidence: primary === 'schema.sql' || primary === 'init.sql' ? 0.78 : 0.62,
+      summary: `检测到 ${primary}，可用于初始化数据库`,
+      autoExecutable: primary === 'schema.sql' || primary === 'init.sql',
+    }));
+  }
+
+  return out.sort((a, b) => b.confidence - a.confidence);
 }
 
 type NodePackageManager = 'pnpm' | 'yarn' | 'npm';
@@ -694,6 +945,17 @@ function applyFramework(
   };
 }
 
+function withDatabaseInitialization(result: StackDetection, searchPath: string): StackDetection {
+  const candidates = detectDatabaseInitialization(searchPath);
+  if (candidates.length === 0) return result;
+  return {
+    ...result,
+    databaseInit: candidates[0],
+    databaseInitCandidates: candidates,
+    signals: Array.from(new Set([...result.signals, ...candidates.flatMap((item) => item.signals)])),
+  };
+}
+
 /**
  * Run every detector in priority order and return the first match.
  * Falls back to an "unknown" marker if nothing matches so the
@@ -728,10 +990,10 @@ export function detectStack(searchPath: string): StackDetection {
       // The framework layer is a best-effort refinement — if nothing
       // matches we return the base detection unchanged.
       const fw = detectFramework(result.stack, searchPath);
-      return fw ? applyFramework(result, fw) : result;
+      return withDatabaseInitialization(fw ? applyFramework(result, fw) : result, searchPath);
     }
   }
-  return unknownDetection(searchPath);
+  return withDatabaseInitialization(unknownDetection(searchPath), searchPath);
 }
 
 /**

--- a/cds/src/services/state.ts
+++ b/cds/src/services/state.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import crypto from 'node:crypto';
-import type { CdsState, BranchEntry, BuildProfile, BuildProfileOverride, RoutingRule, OperationLog, ContainerLogArchiveEntry, InfraService, ExecutorNode, DataMigration, CdsPeer, Project, AgentKey, GlobalAgentKey, AccessRequest, CustomEnvStore, ConfigSnapshot, DestructiveOperationLog, RemoteHost, ServiceDeployment, ServiceDeploymentLogEntry, CdsConnection } from '../types.js';
+import type { CdsState, BranchEntry, BuildProfile, BuildProfileOverride, RoutingRule, OperationLog, ContainerLogArchiveEntry, InfraService, ExecutorNode, DataMigration, CdsPeer, Project, AgentKey, GlobalAgentKey, AccessRequest, CustomEnvStore, ConfigSnapshot, DestructiveOperationLog, RemoteHost, ServiceDeployment, ServiceDeploymentLogEntry, CdsConnection, ReleaseTarget, ReleasePlan, ReleaseRun, ReleaseLogEntry } from '../types.js';
 import { GLOBAL_ENV_SCOPE } from '../types.js';
 import type { StateBackingStore } from '../infra/state-store/backing-store.js';
 import { JsonStateBackingStore, MAX_STATE_BACKUPS as JSON_MAX_BACKUPS } from '../infra/state-store/json-backing-store.js';
@@ -94,6 +94,9 @@ function emptyState(): CdsState {
     defaultBranch: null,
     customEnv: { [GLOBAL_ENV_SCOPE]: {} } as CustomEnvStore,
     infraServices: [],
+    releaseTargets: {},
+    releasePlans: {},
+    releaseRuns: {},
     previewMode: 'multi',
     activityLogs: {},
   };
@@ -223,6 +226,9 @@ export class StateService {
       this.state = loaded;
       // Migrate older state files
       if (!this.state.logs) this.state.logs = {};
+      if (!this.state.releaseTargets) this.state.releaseTargets = {};
+      if (!this.state.releasePlans) this.state.releasePlans = {};
+      if (!this.state.releaseRuns) this.state.releaseRuns = {};
       if (!this.state.containerLogArchives) this.state.containerLogArchives = {};
       if (!this.state.routingRules) this.state.routingRules = [];
       if (!this.state.buildProfiles) this.state.buildProfiles = [];
@@ -1442,6 +1448,120 @@ export class StateService {
     this.state.serviceDeployments[id] = merged;
     this.save();
     return merged;
+  }
+
+  // ── Release targets / plans / runs (preview → production control plane) ──
+
+  getReleaseTargets(projectId?: string): ReleaseTarget[] {
+    if (!this.state.releaseTargets) return [];
+    return Object.values(this.state.releaseTargets)
+      .filter((target) => !projectId || target.projectId === projectId);
+  }
+
+  getReleaseTarget(id: string): ReleaseTarget | undefined {
+    return this.state.releaseTargets?.[id];
+  }
+
+  upsertReleaseTarget(target: ReleaseTarget): ReleaseTarget {
+    if (!this.state.releaseTargets) this.state.releaseTargets = {};
+    const now = new Date().toISOString();
+    const existing = this.state.releaseTargets[target.id];
+    this.state.releaseTargets[target.id] = {
+      ...existing,
+      ...target,
+      createdAt: existing?.createdAt || target.createdAt || now,
+      updatedAt: now,
+    };
+    this.save();
+    return this.state.releaseTargets[target.id];
+  }
+
+  removeReleaseTarget(id: string): boolean {
+    if (!this.state.releaseTargets?.[id]) return false;
+    delete this.state.releaseTargets[id];
+    this.save();
+    return true;
+  }
+
+  getReleasePlans(projectId?: string): ReleasePlan[] {
+    if (!this.state.releasePlans) return [];
+    return Object.values(this.state.releasePlans)
+      .filter((plan) => !projectId || plan.projectId === projectId);
+  }
+
+  getReleasePlan(id: string): ReleasePlan | undefined {
+    return this.state.releasePlans?.[id];
+  }
+
+  upsertReleasePlan(plan: ReleasePlan): ReleasePlan {
+    if (!this.state.releasePlans) this.state.releasePlans = {};
+    this.state.releasePlans[plan.id] = plan;
+    this.save();
+    return plan;
+  }
+
+  getReleaseRuns(filter: { projectId?: string; targetId?: string; branchId?: string } = {}): ReleaseRun[] {
+    if (!this.state.releaseRuns) return [];
+    return Object.values(this.state.releaseRuns)
+      .filter((run) => !filter.projectId || run.projectId === filter.projectId)
+      .filter((run) => !filter.targetId || run.targetId === filter.targetId)
+      .filter((run) => !filter.branchId || run.branchId === filter.branchId)
+      .sort((a, b) => b.startedAt.localeCompare(a.startedAt));
+  }
+
+  getReleaseRun(id: string): ReleaseRun | undefined {
+    return this.state.releaseRuns?.[id];
+  }
+
+  addReleaseRun(run: ReleaseRun): ReleaseRun {
+    if (!this.state.releaseRuns) this.state.releaseRuns = {};
+    if (this.state.releaseRuns[run.releaseId]) {
+      throw new Error(`ReleaseRun already exists: ${run.releaseId}`);
+    }
+    this.state.releaseRuns[run.releaseId] = run;
+    this.save();
+    return run;
+  }
+
+  patchReleaseRun(id: string, fields: Partial<ReleaseRun>): ReleaseRun {
+    if (!this.state.releaseRuns?.[id]) {
+      throw new Error(`ReleaseRun not found: ${id}`);
+    }
+    const current = this.state.releaseRuns[id];
+    const merged = { ...current, ...fields, releaseId: id, logs: current.logs };
+    this.state.releaseRuns[id] = merged;
+    this.save();
+    return merged;
+  }
+
+  appendReleaseRunLog(
+    id: string,
+    entry: Omit<ReleaseLogEntry, 'seq' | 'at'> & { at?: string },
+  ): ReleaseRun {
+    if (!this.state.releaseRuns?.[id]) {
+      throw new Error(`ReleaseRun not found: ${id}`);
+    }
+    const run = this.state.releaseRuns[id];
+    const nextSeq = (run.seq || 0) + 1;
+    run.logs.push({
+      seq: nextSeq,
+      at: entry.at || new Date().toISOString(),
+      level: entry.level,
+      message: entry.message,
+      phase: entry.phase,
+    });
+    run.seq = nextSeq;
+    this.save();
+    return run;
+  }
+
+  getLatestSuccessfulReleaseRun(targetId: string, beforeReleaseId?: string): ReleaseRun | undefined {
+    const runs = this.getReleaseRuns({ targetId })
+      .filter((run) => run.status === 'success');
+    if (!beforeReleaseId) return runs[0];
+    const current = this.getReleaseRun(beforeReleaseId);
+    const beforeTs = current?.startedAt;
+    return runs.find((run) => run.releaseId !== beforeReleaseId && (!beforeTs || run.startedAt < beforeTs));
   }
 
   // ── CDS configuration pairing connections (MAP / CLI partners, 2026-05-06) ──

--- a/cds/src/types.ts
+++ b/cds/src/types.ts
@@ -685,6 +685,93 @@ export interface OperationLog {
   events: OperationLogEvent[];
 }
 
+export interface ReleaseArtifact {
+  type: 'branch-preview' | 'image' | 'static' | 'generic';
+  commitSha: string;
+  branchId?: string;
+  branchName?: string;
+  previewUrl?: string;
+  imageDigest?: string;
+  artifactPath?: string;
+}
+
+export interface ReleaseTarget {
+  id: string;
+  projectId: string;
+  name: string;
+  type: 'ssh' | 'image-registry' | 'static-site' | 'webhook' | 'gitops' | 'k8s';
+  createdAt: string;
+  updatedAt?: string;
+  createdBy?: string;
+  isEnabled: boolean;
+  ssh?: {
+    host: string;
+    port: number;
+    user: string;
+    /** RemoteHost.id that owns the encrypted SSH private key. */
+    privateKeyRef: string;
+    appPath: string;
+    deployCommand: string;
+    rollbackCommand?: string;
+    healthcheckUrl: string;
+  };
+}
+
+export interface ReleasePlanStep {
+  id: string;
+  title: string;
+  kind: 'ssh' | 'healthcheck' | 'record' | 'manual';
+  command?: string;
+}
+
+export interface ReleasePlan {
+  id: string;
+  projectId: string;
+  name: string;
+  template: 'ssh-script' | 'docker-compose-remote' | 'image-push' | 'webhook';
+  targetType: ReleaseTarget['type'];
+  steps: ReleasePlanStep[];
+  failureStrategy: 'stop' | 'rollback';
+  rollbackStrategy: 'command' | 'previous-release' | 'none';
+  createdAt: string;
+}
+
+export interface ReleaseLogEntry {
+  seq: number;
+  at: string;
+  level: 'info' | 'warn' | 'error';
+  message: string;
+  phase?: string;
+}
+
+export interface ReleaseRun {
+  releaseId: string;
+  projectId: string;
+  branchId: string;
+  commitSha: string;
+  artifact: ReleaseArtifact;
+  targetId: string;
+  planId: string;
+  status:
+    | 'queued'
+    | 'prechecking'
+    | 'running'
+    | 'healthchecking'
+    | 'success'
+    | 'failed'
+    | 'rollback_running'
+    | 'rollback_success'
+    | 'rollback_failed';
+  startedAt: string;
+  finishedAt?: string;
+  operator?: string;
+  logs: ReleaseLogEntry[];
+  seq: number;
+  previousReleaseId?: string;
+  rollbackOf?: string;
+  errorMessage?: string;
+}
+
 /** Persisted state */
 /**
  * Scoped custom environment variable store.
@@ -713,6 +800,12 @@ export interface CdsState {
   nextPortIndex: number;
   /** Per-branch operation logs */
   logs: Record<string, OperationLog[]>;
+  /** Release targets keyed by id. */
+  releaseTargets?: Record<string, ReleaseTarget>;
+  /** Release plan templates keyed by id. */
+  releasePlans?: Record<string, ReleasePlan>;
+  /** Immutable release run records keyed by releaseId. */
+  releaseRuns?: Record<string, ReleaseRun>;
   /** Per-branch append-only container log archives owned by CDS. */
   containerLogArchives?: Record<string, ContainerLogArchiveEntry[]>;
   /**

--- a/cds/tests/services/container.test.ts
+++ b/cds/tests/services/container.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
 import { ContainerService, applyProfileOverride, resolveEffectiveProfile } from '../../src/services/container.js';
 import { MockShellExecutor } from '../../src/services/shell-executor.js';
+import { nodeModulesVolumeName } from '../../src/util/node-modules-volume.js';
 import type { CdsConfig, BranchEntry, BuildProfile, BuildProfileOverride, ServiceState } from '../../src/types.js';
 
 const makeConfig = (): CdsConfig => ({
@@ -388,6 +389,46 @@ describe('ContainerService', () => {
 
       const profile = makeProfile({ command: undefined });
       await expect(service.runService(makeEntry(), profile, makeService())).rejects.toThrow('缺少 command 字段');
+    });
+  });
+
+  describe('runProfileCommand', () => {
+    it('runs a one-off command with the same source mount and resolved env', async () => {
+      mock.addResponsePattern(/docker network inspect/, () => ({ stdout: '', stderr: '', exitCode: 0 }));
+      mock.addResponsePattern(/docker run --rm/, () => ({ stdout: 'migration ok', stderr: '', exitCode: 0 }));
+
+      const writeSpy = vi.spyOn(fs, 'writeFileSync');
+      const profile = makeProfile({
+        dockerImage: 'node:20',
+        command: 'pnpm dev',
+        env: {
+          DATABASE_URL: '${CDS_DATABASE_URL}',
+        },
+      });
+
+      const result = await service.runProfileCommand(
+        { ...makeEntry(), projectId: 'default' },
+        profile,
+        'pnpm exec prisma migrate deploy',
+        undefined,
+        { CDS_DATABASE_URL: 'postgres://user:pass@postgres:5432/app' },
+      );
+
+      expect(result.exitCode).toBe(0);
+      const runCmd = mock.commands.find(c => c.includes('docker run --rm'))!;
+      expect(runCmd).toBeDefined();
+      expect(runCmd).not.toContain('docker run -d');
+      expect(runCmd).toContain('--network cds-network');
+      expect(runCmd).toContain('-v "/wt/feature-a/prd-api":"/app"');
+      expect(runCmd).toContain(`-v "${nodeModulesVolumeName('feature-a', 'api')}":"/app/node_modules"`);
+      expect(runCmd).toContain('--label cds.type=job');
+      expect(runCmd).toContain('node:20');
+      expect(runCmd).toContain('sh -c "pnpm exec prisma migrate deploy"');
+
+      const envFileContent = writeSpy.mock.calls[0][1] as string;
+      expect(envFileContent).toContain('DATABASE_URL=postgres://user:pass@postgres:5432/app');
+      expect(envFileContent).toContain('Jwt__Secret=test-secret');
+      writeSpy.mockRestore();
     });
   });
 

--- a/cds/tests/services/stack-detector.test.ts
+++ b/cds/tests/services/stack-detector.test.ts
@@ -412,4 +412,63 @@ describe('stack-detector', () => {
       expect(r.framework).toBeUndefined();
     });
   });
+
+  describe('database initialization recommendation', () => {
+    it('detects Prisma schema and recommends migrate deploy', () => {
+      fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({
+        name: 'prisma-app',
+        packageManager: 'pnpm@9.0.0',
+        dependencies: { prisma: '^5.0.0' },
+      }));
+      fs.mkdirSync(path.join(tmp, 'prisma'), { recursive: true });
+      fs.writeFileSync(path.join(tmp, 'prisma', 'schema.prisma'), 'datasource db { provider = "postgresql" url = env("DATABASE_URL") }\n');
+
+      const r = detectStack(tmp);
+      expect(r.databaseInit?.kind).toBe('prisma');
+      expect(r.databaseInit?.command).toBe('pnpm exec prisma migrate deploy');
+      expect(r.databaseInit?.files).toContain('prisma/schema.prisma');
+      expect(r.signals).toContain('prisma/schema.prisma');
+    });
+
+    it('detects Django migrate from manage.py', () => {
+      fs.writeFileSync(path.join(tmp, 'requirements.txt'), 'django==5.0\n');
+      fs.writeFileSync(path.join(tmp, 'manage.py'), '#!/usr/bin/env python\n');
+
+      const r = detectStack(tmp);
+      expect(r.framework).toBe('django');
+      expect(r.databaseInit?.kind).toBe('django');
+      expect(r.databaseInit?.command).toBe('python manage.py migrate');
+    });
+
+    it('falls back to SQL scripts when no ORM signal exists', () => {
+      fs.writeFileSync(path.join(tmp, 'schema.sql'), 'create table items(id int);\n');
+
+      const r = detectStack(tmp);
+      expect(r.stack).toBe('unknown');
+      expect(r.databaseInit?.kind).toBe('sql');
+      expect(r.databaseInit?.autoExecutable).toBe(true);
+      expect(r.databaseInit?.summary).toContain('schema.sql');
+    });
+
+    it('keeps arbitrary SQL files as manual fallback', () => {
+      fs.writeFileSync(path.join(tmp, 'seed-dev.sql'), 'insert into items values (1);\n');
+
+      const r = detectStack(tmp);
+      expect(r.databaseInit?.kind).toBe('sql');
+      expect(r.databaseInit?.autoExecutable).toBe(false);
+    });
+
+    it('prefers ORM migrations over SQL fallback but keeps both candidates', () => {
+      fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({
+        name: 'drizzle-app',
+        dependencies: { 'drizzle-kit': '^0.30.0' },
+      }));
+      fs.writeFileSync(path.join(tmp, 'drizzle.config.ts'), 'export default {};\n');
+      fs.writeFileSync(path.join(tmp, 'init.sql'), 'select 1;\n');
+
+      const r = detectStack(tmp);
+      expect(r.databaseInit?.kind).toBe('drizzle');
+      expect(r.databaseInitCandidates?.map((item) => item.kind)).toContain('sql');
+    });
+  });
 });

--- a/cds/web/src/App.tsx
+++ b/cds/web/src/App.tsx
@@ -14,6 +14,7 @@ const LoginPage = lazy(() => import('@/pages/LoginPage').then((m) => ({ default:
 const PreviewPreparingPage = lazy(() => import('@/pages/PreviewPreparingPage').then((m) => ({ default: m.PreviewPreparingPage })));
 const ProjectListPage = lazy(() => import('@/pages/ProjectListPage').then((m) => ({ default: m.ProjectListPage })));
 const ProjectSettingsPage = lazy(() => import('@/pages/ProjectSettingsPage').then((m) => ({ default: m.ProjectSettingsPage })));
+const ReleaseCenterPage = lazy(() => import('@/pages/ReleaseCenterPage').then((m) => ({ default: m.ReleaseCenterPage })));
 
 /**
  * 路由切换时 Suspense fallback。用品牌 logo + 加载文案,跟 CDS 视觉调性一致。
@@ -226,6 +227,7 @@ function shouldAutoReloadAfterChunkFailure(): boolean {
  *   /branch-list?project=   Back-compat entry to the React branch list
  *   /branch-panel/:branchId Branch detail + logs + single-service actions
  *   /branch-topology        Project service topology
+ *   /release-center         Release targets, runs, logs and rollback
  *   /settings/:projectId    Project settings
  */
 export function App(): JSX.Element {
@@ -245,6 +247,7 @@ export function App(): JSX.Element {
             <Route path="/branch-panel" element={<BranchDetailPage />} />
             <Route path="/branch-panel/:branchId" element={<BranchDetailPage />} />
             <Route path="/branch-topology" element={<BranchTopologyPage />} />
+            <Route path="/release-center" element={<ReleaseCenterPage />} />
             <Route path="/settings/:projectId" element={<ProjectSettingsPage />} />
             <Route path="*" element={<Navigate to="/project-list" replace />} />
           </Routes>

--- a/cds/web/src/components/deployment/InfraDataPanel.tsx
+++ b/cds/web/src/components/deployment/InfraDataPanel.tsx
@@ -5,8 +5,8 @@
  * 独立组件(不动 BranchTopologyPage 大文件的其余部分)。仅对支持的数据库类型渲染,
  * 其余返回 null。颜色全走主题 token(无暗色字面量,白天/黑夜都可读)。无 emoji。
  */
-import { useState } from 'react';
-import { Database, Loader2, Play, Search } from 'lucide-react';
+import { useRef, useState } from 'react';
+import { Database, Loader2, Play, RefreshCw, Search, Terminal, Upload } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { apiRequest, ApiError } from '@/lib/api';
 
@@ -20,24 +20,36 @@ interface DataResult {
   error: string | null;
 }
 
+interface MigrationProfile {
+  id: string;
+  name: string;
+}
+
 export function InfraDataPanel({
   infraId,
   projectId,
+  branchId,
+  profiles = [],
   image,
   running,
   initSql,
 }: {
   infraId: string;
   projectId: string;
+  branchId?: string;
+  profiles?: MigrationProfile[];
   image: string;
   running: boolean;
   /** Initialization SQL configured at project/infra creation; offered as a one-click prefill. */
   initSql?: string;
 }): JSX.Element | null {
   const supported = SUPPORTED.test((image || '').toLowerCase());
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [sql, setSql] = useState('');
   const [asInit, setAsInit] = useState(false);
-  const [busy, setBusy] = useState<'query' | 'schema' | null>(null);
+  const [migrationCommand, setMigrationCommand] = useState('');
+  const [migrationProfileId, setMigrationProfileId] = useState(profiles[0]?.id || '');
+  const [busy, setBusy] = useState<'query' | 'schema' | 'init-sql' | 'migration' | null>(null);
   const [result, setResult] = useState<DataResult | null>(null);
   const [error, setError] = useState('');
 
@@ -46,18 +58,60 @@ export function InfraDataPanel({
   const base = `/api/infra/${encodeURIComponent(infraId)}`;
   const projectQs = `project=${encodeURIComponent(projectId)}`;
 
-  async function run(kind: 'query' | 'schema'): Promise<void> {
+  async function runData(kind: 'query' | 'schema' | 'init-sql', sqlOverride?: string): Promise<void> {
     setError('');
     setBusy(kind);
     try {
       const res =
         kind === 'schema'
           ? await apiRequest<DataResult>(`${base}/schema?${projectQs}`)
-          : await apiRequest<DataResult>(`${base}/${asInit ? 'init-sql' : 'query'}?${projectQs}`, {
+          : await apiRequest<DataResult>(`${base}/${kind === 'init-sql' ? 'init-sql' : asInit ? 'init-sql' : 'query'}?${projectQs}`, {
               method: 'POST',
-              body: { sql },
+              body: { sql: sqlOverride ?? sql },
             });
       setResult(res);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : String(err));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function importSqlFile(file: File | null): Promise<void> {
+    if (!file) return;
+    setError('');
+    try {
+      const text = await file.text();
+      setSql(text);
+      setAsInit(true);
+      setResult(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  async function runMigrationCommand(): Promise<void> {
+    if (!branchId || !migrationCommand.trim()) return;
+    setError('');
+    setBusy('migration');
+    try {
+      const res = await apiRequest<{ ok: boolean; exitCode: number; output: string; error?: string }>(
+        `/api/branches/${encodeURIComponent(branchId)}/database-init/run`,
+        {
+          method: 'POST',
+          body: {
+            command: migrationCommand.trim(),
+            profileId: migrationProfileId || profiles[0]?.id,
+          },
+        },
+      );
+      setResult({
+        kind: 'migration',
+        exitCode: res.exitCode,
+        truncated: false,
+        output: res.output || '',
+        error: res.ok ? null : res.error || null,
+      });
     } catch (err) {
       setError(err instanceof ApiError ? err.message : String(err));
     } finally {
@@ -73,6 +127,24 @@ export function InfraDataPanel({
           数据操作
         </div>
         <div className="flex items-center gap-2">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".sql,.txt"
+            className="hidden"
+            onChange={(event) => void importSqlFile(event.currentTarget.files?.[0] ?? null)}
+          />
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={busy !== null}
+            onClick={() => fileInputRef.current?.click()}
+            title="导入 SQL 作为自动识别失败后的手动兜底"
+          >
+            <Upload />
+            导入 SQL
+          </Button>
           {initSql && initSql.trim() ? (
             <Button
               type="button"
@@ -82,7 +154,7 @@ export function InfraDataPanel({
               onClick={() => { setSql(initSql); setAsInit(true); }}
               title="载入创建项目时配置的初始化 SQL"
             >
-              载入初始化 SQL
+              载入默认 SQL
             </Button>
           ) : null}
           <Button
@@ -90,7 +162,7 @@ export function InfraDataPanel({
             size="sm"
             variant="outline"
             disabled={!running || busy !== null}
-            onClick={() => void run('schema')}
+            onClick={() => void runData('schema')}
           >
             {busy === 'schema' ? <Loader2 className="animate-spin" /> : <Search />}
             查看结构
@@ -101,7 +173,7 @@ export function InfraDataPanel({
         className="min-h-24 w-full resize-y rounded-md border border-input bg-background px-3 py-2 font-mono text-xs outline-none ring-offset-background focus-visible:ring-2 focus-visible:ring-ring"
         value={sql}
         onChange={(event) => setSql(event.target.value)}
-        placeholder="输入 SQL / 查询语句，例如 SELECT * FROM items LIMIT 20;（Redis 直接写命令，如 KEYS *）"
+        placeholder="输入 SQL / 查询语句。SQL 初始化是自动识别失败后的手动兜底。"
       />
       <div className="flex flex-wrap items-center justify-between gap-2">
         <label className="flex items-center gap-2 text-xs text-muted-foreground">
@@ -113,16 +185,62 @@ export function InfraDataPanel({
           />
           作为初始化执行（记录为破坏性操作）
         </label>
-        <Button
-          type="button"
-          size="sm"
-          disabled={!running || busy !== null || !sql.trim()}
-          onClick={() => void run('query')}
-        >
-          {busy === 'query' ? <Loader2 className="animate-spin" /> : <Play />}
-          执行
-        </Button>
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={!running || busy !== null || !sql.trim()}
+            onClick={() => void runData('init-sql')}
+            title="重新执行当前 SQL 初始化脚本"
+          >
+            {busy === 'init-sql' ? <Loader2 className="animate-spin" /> : <RefreshCw />}
+            重新初始化
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            disabled={!running || busy !== null || !sql.trim()}
+            onClick={() => void runData('query')}
+          >
+            {busy === 'query' ? <Loader2 className="animate-spin" /> : <Play />}
+            执行
+          </Button>
+        </div>
       </div>
+      <details className="rounded-md border border-border bg-background/60 p-3">
+        <summary className="flex cursor-pointer list-none items-center gap-2 text-sm font-medium">
+          <Terminal className="h-4 w-4" />
+          执行迁移命令
+        </summary>
+        <div className="mt-3 grid gap-2 md:grid-cols-[minmax(0,1fr)_minmax(0,2fr)_auto]">
+          <select
+            className="h-9 rounded-md border border-input bg-background px-2 text-sm outline-none ring-offset-background focus-visible:ring-2 focus-visible:ring-ring"
+            value={migrationProfileId || profiles[0]?.id || ''}
+            onChange={(event) => setMigrationProfileId(event.target.value)}
+            disabled={profiles.length <= 1 || busy !== null}
+          >
+            {profiles.map((profile) => (
+              <option key={profile.id} value={profile.id}>{profile.name || profile.id}</option>
+            ))}
+          </select>
+          <input
+            className="h-9 rounded-md border border-input bg-background px-3 font-mono text-xs outline-none ring-offset-background focus-visible:ring-2 focus-visible:ring-ring"
+            value={migrationCommand}
+            onChange={(event) => setMigrationCommand(event.target.value)}
+            placeholder="pnpm exec prisma migrate deploy"
+          />
+          <Button
+            type="button"
+            size="sm"
+            disabled={!branchId || !running || busy !== null || !migrationCommand.trim()}
+            onClick={() => void runMigrationCommand()}
+          >
+            {busy === 'migration' ? <Loader2 className="animate-spin" /> : <Play />}
+            执行
+          </Button>
+        </div>
+      </details>
       {!running ? (
         <div className="text-xs text-muted-foreground">服务未运行，启动后才能执行数据操作。</div>
       ) : null}

--- a/cds/web/src/components/env/EnvSetupDialog.tsx
+++ b/cds/web/src/components/env/EnvSetupDialog.tsx
@@ -77,6 +77,17 @@ interface EnvBundle {
   missingRequiredEnvKeys?: string[];
 }
 
+interface DatabaseInitRecommendation {
+  kind: string;
+  label: string;
+  command?: string;
+  files?: string[];
+  signals?: string[];
+  confidence?: number;
+  summary: string;
+  autoExecutable?: boolean;
+}
+
 interface Props {
   /** 项目 ID — 决定 /api/env 的 scope。null = 关闭对话框 */
   projectId: string | null;
@@ -111,6 +122,11 @@ export function EnvSetupDialog({ projectId, projectName, onOpenChange, onComplet
   const initScriptInputRef = useRef<HTMLInputElement | null>(null);
   const [initScriptHint, setInitScriptHint] = useState<string | null>(null);
   const [initScriptUploading, setInitScriptUploading] = useState(false);
+  const [databaseInit, setDatabaseInit] = useState<{
+    status: 'idle' | 'loading' | 'ready' | 'error';
+    recommendation?: DatabaseInitRecommendation | null;
+    message?: string;
+  }>({ status: 'idle' });
 
   const toggleReveal = useCallback((key: string) => {
     setRevealed((current) => {
@@ -175,6 +191,7 @@ export function EnvSetupDialog({ projectId, projectName, onOpenChange, onComplet
     else {
       setState({ status: 'idle' });
       setDraft({});
+      setDatabaseInit({ status: 'idle' });
     }
   }, [projectId, load]);
 
@@ -254,6 +271,42 @@ export function EnvSetupDialog({ projectId, projectName, onOpenChange, onComplet
     return infraImageList.some((img) => /(mysql|mariadb|postgres)/.test(img));
   }, [state, infraImageList]);
 
+  useEffect(() => {
+    if (state.status !== 'ready' || !projectId) {
+      if (!projectId) setDatabaseInit({ status: 'idle' });
+      return;
+    }
+    let aborted = false;
+    setDatabaseInit({ status: 'loading' });
+    (async () => {
+      try {
+        const res = await apiRequest<{
+          databaseInit?: DatabaseInitRecommendation | null;
+          summary?: string;
+        }>('/api/detect-stack', {
+          method: 'POST',
+          body: { projectId },
+        });
+        if (aborted) return;
+        setDatabaseInit({
+          status: 'ready',
+          recommendation: res.databaseInit || null,
+          message: res.summary,
+        });
+      } catch (err) {
+        if (aborted) return;
+        setDatabaseInit({
+          status: 'error',
+          recommendation: null,
+          message: err instanceof ApiError ? err.message : String(err),
+        });
+      }
+    })();
+    return () => {
+      aborted = true;
+    };
+  }, [state.status, projectId]);
+
   // Bugbot fix(2026-05-04 PR #523):用 file.name 而非硬编码 'init.sql'。
   // 之前所有上传都写到仓库根的 `init.sql`,但 compose 里可能挂的是
   // `./schema.sql:/docker-entrypoint-initdb.d/01-schema.sql` — 用户上传
@@ -291,7 +344,7 @@ export function EnvSetupDialog({ projectId, projectName, onOpenChange, onComplet
         );
         const bytes = res.written?.[0]?.bytes ?? text.length;
         setInitScriptHint(
-          `已上传 ${fileName}(${bytes} 字节)到仓库根目录 → 请确认 cds-compose.yml 里 mysql/postgres infra 有 \`./${fileName}:/docker-entrypoint-initdb.d/${fileName}\` 挂载,下次 deploy 容器才会执行`,
+          `已导入 ${fileName}(${bytes} 字节)到仓库根目录；可作为自动识别失败后的手动 SQL 兜底`,
         );
       } catch (err) {
         const msg = err instanceof ApiError ? err.message : String(err);
@@ -374,46 +427,72 @@ export function EnvSetupDialog({ projectId, projectName, onOpenChange, onComplet
           </div>
         </div>
 
-        {/* F12 — 仅在项目检测到 mysql/postgres 这类 schemaful DB 时显示 */}
-        {hasSchemafulDb ? (
-          <div className="flex items-center justify-between gap-2 rounded-md border border-sky-500/40 bg-sky-500/5 px-3 py-2 text-xs">
-            <div className="flex min-w-0 items-center gap-2 text-muted-foreground">
-              <Database className="h-3.5 w-3.5 flex-shrink-0 text-sky-500" />
-              <span className="min-w-0">
-                检测到 mysql/postgres infra。上传的 <strong>.sql 文件</strong>会按原名写入仓库根目录,
-                cds-compose.yml 里需对应配 <code>./{'<file>'}:/docker-entrypoint-initdb.d/{'<file>'}</code> 挂载,
-                下次 deploy 容器才会执行。
-              </span>
-            </div>
-            <div className="flex items-center gap-2 flex-shrink-0">
-              {initScriptHint ? (
-                <span className="text-[10px] text-muted-foreground">{initScriptHint}</span>
-              ) : null}
-              <input
-                ref={initScriptInputRef}
-                type="file"
-                accept=".sql,text/plain,application/sql"
-                className="hidden"
-                onChange={(e) => {
-                  const file = e.target.files?.[0] || null;
-                  void onPickInitScript(file);
-                  e.target.value = '';
-                }}
-              />
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => initScriptInputRef.current?.click()}
-                disabled={initScriptUploading || state.status !== 'ready'}
-              >
-                {initScriptUploading ? (
-                  <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
-                ) : (
-                  <Upload className="mr-1 h-3.5 w-3.5" />
-                )}
-                上传 init.sql
-              </Button>
+        {(hasSchemafulDb || databaseInit.recommendation || databaseInit.status === 'loading') ? (
+          <div className="rounded-md border border-sky-500/35 bg-sky-500/5 px-3 py-2 text-xs">
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex min-w-0 gap-2 text-muted-foreground">
+                <Database className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-sky-500" />
+                <div className="min-w-0 space-y-1">
+                  <div className="font-medium text-foreground">数据库初始化</div>
+                  {databaseInit.status === 'loading' ? (
+                    <div className="flex items-center gap-1">
+                      <Loader2 className="h-3 w-3 animate-spin" />
+                      正在扫描 Prisma、Drizzle、Django、Alembic、schema.sql 等初始化信号...
+                    </div>
+                  ) : databaseInit.recommendation ? (
+                    <div>
+                      {databaseInit.recommendation.command ? (
+                        <>
+                          检测到 <strong>{databaseInit.recommendation.label}</strong>，推荐初始化命令：
+                          <code>{databaseInit.recommendation.command}</code>
+                        </>
+                      ) : (
+                        <>{databaseInit.recommendation.summary}</>
+                      )}
+                      {databaseInit.recommendation.files?.length ? (
+                        <span className="ml-1">
+                          信号：{databaseInit.recommendation.files.slice(0, 3).join('、')}
+                        </span>
+                      ) : null}
+                    </div>
+                  ) : (
+                    <div>
+                      暂未识别到 ORM 迁移或 SQL 脚本。第一阶段只给出推荐方式；初始化失败时，可在数据库服务卡片里导入 SQL、重试或填写迁移命令。
+                    </div>
+                  )}
+                  {initScriptHint ? (
+                    <div className="text-[10px] text-muted-foreground">{initScriptHint}</div>
+                  ) : null}
+                </div>
+              </div>
+              <div className="flex flex-shrink-0 items-center gap-2">
+                <input
+                  ref={initScriptInputRef}
+                  type="file"
+                  accept=".sql,text/plain,application/sql"
+                  className="hidden"
+                  onChange={(e) => {
+                    const file = e.target.files?.[0] || null;
+                    void onPickInitScript(file);
+                    e.target.value = '';
+                  }}
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => initScriptInputRef.current?.click()}
+                  disabled={initScriptUploading || state.status !== 'ready'}
+                  title="自动识别失败时的手动兜底"
+                >
+                  {initScriptUploading ? (
+                    <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <Upload className="mr-1 h-3.5 w-3.5" />
+                  )}
+                  导入 SQL
+                </Button>
+              </div>
             </div>
           </div>
         ) : null}

--- a/cds/web/src/components/layout/AppShell.tsx
+++ b/cds/web/src/components/layout/AppShell.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import type { ReactNode } from 'react';
 import { Link } from 'react-router-dom';
-import { Check, LayoutGrid, LogOut, Menu, Monitor, Moon, MoreVertical, Search, Settings, Sun, X } from 'lucide-react';
+import { Check, LayoutGrid, LogOut, Menu, Monitor, Moon, MoreVertical, Rocket, Search, Settings, Sun, X } from 'lucide-react';
 import { CommandPalette } from '@/components/CommandPalette';
 import { CommitInbox } from '@/components/CommitInbox';
 import { GlobalUpdateBadge } from '@/components/GlobalUpdateBadge';
@@ -106,6 +106,7 @@ type ShellAuthStatus = {
 
 const preloadProjectListPage = (): void => { void import('@/pages/ProjectListPage'); };
 const preloadCdsSettingsPage = (): void => { void import('@/pages/CdsSettingsPage'); };
+const preloadReleaseCenterPage = (): void => { void import('@/pages/ReleaseCenterPage'); };
 
 function shellLoginHref(mode?: string): string {
   const path = mode === 'github' ? '/api/auth/github/login' : '/login';
@@ -415,6 +416,19 @@ function RailNav({ active, canLogout, logoutState, onLogout, onNavigate }: RailN
         >
           <Settings />
           <span>Settings</span>
+        </Link>
+        <Link
+          to="/release-center"
+          className="cds-rail-item"
+          data-active={active === 'release-center' ? 'true' : 'false'}
+          aria-label="发布中心"
+          title="发布中心（目标 / 版本 / 日志 / 回滚）"
+          onClick={onNavigate}
+          onMouseEnter={preloadReleaseCenterPage}
+          onFocus={preloadReleaseCenterPage}
+        >
+          <Rocket />
+          <span>Releases</span>
         </Link>
       </div>
       <div className="flex-1" />

--- a/cds/web/src/pages/BranchListPage.tsx
+++ b/cds/web/src/pages/BranchListPage.tsx
@@ -143,6 +143,57 @@ interface BranchesResponse {
   };
 }
 
+interface ReleaseTargetSummary {
+  id: string;
+  projectId: string;
+  name: string;
+  type: string;
+  isEnabled: boolean;
+  ssh?: {
+    host: string;
+    port: number;
+    user: string;
+    healthcheckUrl: string;
+  };
+}
+
+interface ReleaseRunSummary {
+  releaseId: string;
+  projectId: string;
+  branchId: string;
+  commitSha: string;
+  targetId: string;
+  status: string;
+  startedAt: string;
+  finishedAt?: string;
+  operator?: string;
+  logs: ReleaseLogEntry[];
+  previousReleaseId?: string;
+  rollbackOf?: string;
+}
+
+interface ReleaseLogEntry {
+  seq: number;
+  at: string;
+  level: 'info' | 'warn' | 'error';
+  message: string;
+  phase?: string;
+}
+
+interface ReleasePreflightCheck {
+  id: string;
+  label: string;
+  status: 'pass' | 'warn' | 'fail';
+  message: string;
+  blocking: boolean;
+}
+
+interface ReleasePreflightResult {
+  ok: boolean;
+  checks: ReleasePreflightCheck[];
+  previousRelease?: ReleaseRunSummary;
+}
+
 interface RemoteBranch {
   name: string;
   date?: string;
@@ -1229,6 +1280,7 @@ export function BranchListPage(): JSX.Element {
     needSlots: number;
   } | null>(null);
   const [detailDrawerBranchId, setDetailDrawerBranchId] = useState<string | null>(null);
+  const [releaseBranchId, setReleaseBranchId] = useState<string | null>(null);
   const [branchSearchOpen, setBranchSearchOpen] = useState(false);
   const [pendingEnvKeys, setPendingEnvKeys] = useState<string[]>([]);
   // 标签过滤:用户点击 BranchCard 上某个标签 chip 时切到只显示该标签的分支;
@@ -2999,6 +3051,7 @@ export function BranchListPage(): JSX.Element {
                     capacityWarning={state.status === 'ok' ? capacityMessage(state.capacity, [branch]) : ''}
                     activeTagFilter={activeTagFilter}
                     onPreview={() => void openPreview(branch, false)}
+                    onRelease={() => setReleaseBranchId(branch.id)}
                     onDeploy={() => void deployBranch(branch, false)}
                     onDetail={() => setDetailDrawerBranchId(branch.id)}
                     onPull={() => void pullBranch(branch)}
@@ -3024,6 +3077,18 @@ export function BranchListPage(): JSX.Element {
         {/* Branch detail drawer — opens when 详情 is clicked on a card.
             Avoids the page navigation the user explicitly asked us to skip
             ("能在一个页面完成的，切勿跳转页面"). */}
+        <ReleaseBranchDialog
+          branch={state.status === 'ok' && releaseBranchId ? state.branches.find((b) => b.id === releaseBranchId) || null : null}
+          previewUrl={(() => {
+            if (state.status !== 'ok' || !releaseBranchId) return '';
+            const target = state.branches.find((b) => b.id === releaseBranchId);
+            if (!target) return '';
+            if (state.previewMode === 'simple') return simplePreviewUrl(state.config);
+            return multiPreviewUrl(target, state.config);
+          })()}
+          onClose={() => setReleaseBranchId(null)}
+          onToast={setToast}
+        />
         <BranchDetailDrawer
           open={!!detailDrawerBranchId}
           branchId={detailDrawerBranchId}
@@ -3939,6 +4004,223 @@ function OpsDrawer({
   );
 }
 
+function ReleaseBranchDialog({
+  branch,
+  previewUrl,
+  onClose,
+  onToast,
+}: {
+  branch: BranchSummary | null;
+  previewUrl: string;
+  onClose: () => void;
+  onToast: (message: string) => void;
+}): JSX.Element {
+  const [targets, setTargets] = useState<ReleaseTargetSummary[]>([]);
+  const [targetId, setTargetId] = useState('');
+  const [loadingTargets, setLoadingTargets] = useState(false);
+  const [preflight, setPreflight] = useState<ReleasePreflightResult | null>(null);
+  const [preflightState, setPreflightState] = useState<'idle' | 'running' | 'error'>('idle');
+  const [run, setRun] = useState<ReleaseRunSummary | null>(null);
+  const [logs, setLogs] = useState<ReleaseLogEntry[]>([]);
+  const [starting, setStarting] = useState(false);
+
+  useEffect(() => {
+    if (!branch) return undefined;
+    setPreflight(null);
+    setRun(null);
+    setLogs([]);
+    setLoadingTargets(true);
+    const ctrl = new AbortController();
+    apiRequest<{ targets: ReleaseTargetSummary[] }>(
+      `/api/releases/targets?project=${encodeURIComponent(branch.projectId)}`,
+      { signal: ctrl.signal },
+    )
+      .then((data) => {
+        const enabled = (data.targets || []).filter((target) => target.isEnabled && target.type === 'ssh');
+        setTargets(enabled);
+        setTargetId((current) => current && enabled.some((target) => target.id === current) ? current : enabled[0]?.id || '');
+      })
+      .catch((err) => {
+        if ((err as DOMException)?.name === 'AbortError') return;
+        onToast(err instanceof ApiError ? err.message : String(err));
+      })
+      .finally(() => setLoadingTargets(false));
+    return () => ctrl.abort();
+  }, [branch, onToast]);
+
+  useEffect(() => {
+    if (!run || isReleaseTerminal(run.status)) return undefined;
+    const source = new EventSource(apiUrl(`/api/releases/runs/${encodeURIComponent(run.releaseId)}/stream?afterSeq=${run.logs.at(-1)?.seq || 0}`));
+    source.addEventListener('snapshot', (event) => {
+      const data = parseSseJson<{ run: ReleaseRunSummary; logs: ReleaseLogEntry[] }>(event);
+      if (!data) return;
+      setRun(data.run);
+      setLogs(dedupeReleaseLogs(data.run.logs || []));
+    });
+    source.addEventListener('release.log', (event) => {
+      const data = parseSseJson<{ log: ReleaseLogEntry }>(event);
+      if (!data?.log) return;
+      setLogs((current) => dedupeReleaseLogs([...current, data.log]));
+    });
+    source.addEventListener('release.status', (event) => {
+      const data = parseSseJson<{ run: ReleaseRunSummary }>(event);
+      if (data?.run) {
+        setRun(data.run);
+        setLogs((current) => dedupeReleaseLogs([...(data.run.logs || []), ...current]));
+      }
+    });
+    return () => source.close();
+  }, [run?.releaseId, run?.status]);
+
+  const runPreflight = async (): Promise<void> => {
+    if (!branch || !targetId) return;
+    setPreflightState('running');
+    setPreflight(null);
+    try {
+      const result = await apiRequest<ReleasePreflightResult>(`/api/releases/branches/${encodeURIComponent(branch.id)}/preflight`, {
+        method: 'POST',
+        body: { targetId, previewUrl },
+      });
+      setPreflight(result);
+      setPreflightState('idle');
+    } catch (err) {
+      setPreflightState('error');
+      onToast(err instanceof ApiError ? err.message : String(err));
+    }
+  };
+
+  const startRelease = async (): Promise<void> => {
+    if (!branch || !targetId) return;
+    setStarting(true);
+    try {
+      const result = await apiRequest<{ run: ReleaseRunSummary }>(`/api/releases/branches/${encodeURIComponent(branch.id)}/runs`, {
+        method: 'POST',
+        body: { targetId, previewUrl },
+      });
+      setRun(result.run);
+      setLogs(result.run.logs || []);
+      onToast('发布已开始');
+    } catch (err) {
+      onToast(err instanceof ApiError ? err.message : String(err));
+    } finally {
+      setStarting(false);
+    }
+  };
+
+  return (
+    <Dialog open={!!branch} onOpenChange={(open) => { if (!open) onClose(); }}>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>发布 {branch?.branch}</DialogTitle>
+          <DialogDescription>从已验收预览分支发布到指定 SSH 目标。</DialogDescription>
+        </DialogHeader>
+        {!branch ? null : (
+          <div className="space-y-4">
+            <div className="grid gap-3 rounded-md border border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))]/45 p-3 text-sm md:grid-cols-3">
+              <div>
+                <div className="text-xs text-muted-foreground">Commit</div>
+                <div className="mt-1 font-mono">{shortCommitSha(branch) || '-'}</div>
+              </div>
+              <div>
+                <div className="text-xs text-muted-foreground">Preview</div>
+                <div className="mt-1 truncate font-mono">{previewUrl || '-'}</div>
+              </div>
+              <div>
+                <div className="text-xs text-muted-foreground">Status</div>
+                <div className="mt-1">{statusLabel(branch.status)}</div>
+              </div>
+            </div>
+
+            <div className="flex flex-wrap items-end gap-3">
+              <label className="grid min-w-[260px] flex-1 gap-1 text-sm">
+                <span className="text-muted-foreground">发布目标</span>
+                <select
+                  value={targetId}
+                  onChange={(event) => {
+                    setTargetId(event.target.value);
+                    setPreflight(null);
+                  }}
+                  disabled={loadingTargets || targets.length === 0}
+                  className="h-9 rounded-md border border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))] px-3 text-sm outline-none focus:border-primary/60"
+                >
+                  {targets.length === 0 ? <option value="">没有可用 SSH target</option> : null}
+                  {targets.map((target) => (
+                    <option key={target.id} value={target.id}>
+                      {target.name} · {target.ssh?.user}@{target.ssh?.host}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <Button variant="outline" onClick={() => void runPreflight()} disabled={!targetId || preflightState === 'running'}>
+                {preflightState === 'running' ? <Loader2 className="animate-spin" /> : <Gauge />}
+                发布前检查
+              </Button>
+              <Button onClick={() => void startRelease()} disabled={!targetId || !preflight?.ok || starting || !!run}>
+                {starting ? <Loader2 className="animate-spin" /> : <Rocket />}
+                开始发布
+              </Button>
+              <Button asChild variant="outline">
+                <Link to={`/release-center?project=${encodeURIComponent(branch.projectId)}`}>发布中心</Link>
+              </Button>
+            </div>
+
+            {targets.length === 0 && !loadingTargets ? (
+              <div className="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-600 dark:text-amber-300">
+                当前项目没有 SSH ReleaseTarget。先到发布中心创建目标。
+              </div>
+            ) : null}
+
+            {preflight ? (
+              <div className="grid gap-2">
+                {preflight.checks.map((check) => (
+                  <div
+                    key={check.id}
+                    className={`flex items-start justify-between gap-3 rounded-md border px-3 py-2 text-sm ${
+                      check.status === 'pass'
+                        ? 'border-emerald-500/30 bg-emerald-500/10'
+                        : check.status === 'warn'
+                          ? 'border-amber-500/30 bg-amber-500/10'
+                          : 'border-red-500/30 bg-red-500/10'
+                    }`}
+                  >
+                    <div>
+                      <div className="font-medium">{check.label}</div>
+                      <div className="mt-0.5 text-xs text-muted-foreground">{check.message}</div>
+                    </div>
+                    <span className="font-mono text-xs">{check.status}</span>
+                  </div>
+                ))}
+              </div>
+            ) : null}
+
+            {run ? (
+              <div className="space-y-2">
+                <div className="flex items-center justify-between text-sm">
+                  <span className="font-mono">{run.releaseId}</span>
+                  <span className="rounded-md border border-[hsl(var(--hairline))] px-2 py-1 text-xs">{run.status}</span>
+                </div>
+                <pre className="max-h-72 overflow-auto rounded-md border border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))] p-3 text-xs leading-5">
+                  {logs.map((log) => `[${formatShortTime(log.at)}] ${log.level.toUpperCase()} ${log.phase ? `${log.phase}: ` : ''}${log.message}`).join('\n') || '等待日志...'}
+                </pre>
+              </div>
+            ) : null}
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function dedupeReleaseLogs(items: ReleaseLogEntry[]): ReleaseLogEntry[] {
+  const bySeq = new Map<number, ReleaseLogEntry>();
+  for (const item of items) bySeq.set(item.seq, item);
+  return [...bySeq.values()].sort((a, b) => a.seq - b.seq);
+}
+
+function isReleaseTerminal(status: string): boolean {
+  return ['success', 'failed', 'rollback_success', 'rollback_failed'].includes(status);
+}
+
 function BranchCard({
   branch,
   action,
@@ -3949,6 +4231,7 @@ function BranchCard({
   activityEvents = [],
   activeTagFilter,
   onPreview,
+  onRelease,
   // 2026-05-04 重设计:常规部署按钮从卡片右下移到「分支详情抽屉 → 设置 tab」。
   // 2026-05-29 P0 复活:onDeploy 重新被卡片使用 —— 漂移徽标「一键收敛」点击时
   // 调它（= deployBranch → POST /deploy，读项目全部 build profile，补齐缺失服务）。
@@ -3987,6 +4270,7 @@ function BranchCard({
   activeTagFilter?: string | null;
   onSelect?: () => void;
   onPreview: () => void;
+  onRelease: () => void;
   onDeploy: () => void;
   onDetail: () => void;
   onPull: () => void;
@@ -4649,57 +4933,75 @@ function BranchCard({
               到当前服务状态/日志 → 确认后再点",直接卡片右下点 Play 容易误操作。
               卡片淡化暗示"这个分支没在跑",用户主动点开抽屉就能恢复。
         */}
-        {isRunning ? (
-          previewCapacityWarning ? (
-	            <ConfirmAction
-	              title="容量不足，仍然预览部署？"
-	              description={previewCapacityWarning}
-	              confirmLabel="继续"
-	              disabled={busy}
-	              onConfirm={onPreview}
-              trigger={(
-                <Button
-                  size="icon"
-                  variant="outline"
-                  className={isAiActive
-                    ? 'cds-ai-preview-beacon border-sky-400/45 bg-sky-400/10 text-sky-300 hover:bg-sky-400/15 hover:text-sky-200'
-                    : isAiOperated
-                      ? 'border-sky-400/30 bg-sky-400/5 text-sky-300/80 hover:bg-sky-400/10 hover:text-sky-200'
-                    : 'border-primary/35 bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary'}
-                  title={isAiOperated ? `${aiTitle} · 打开 AI 操作面板` : '预览'}
-                  aria-label={isAiOperated ? `${aiState.label}，打开 AI 操作面板` : '预览'}
-                >
-                  {isAiOperated ? <Bot /> : <Eye />}
-                </Button>
-              )}
-            />
-          ) : (
+        <div className="flex shrink-0 items-center gap-2">
+          {isRunning ? (
             <Button
               size="icon"
               variant="outline"
-              className={isAiActive
-                ? 'cds-ai-preview-beacon border-sky-400/45 bg-sky-400/10 text-sky-300 hover:bg-sky-400/15 hover:text-sky-200'
-                : isAiOperated
-                  ? 'border-sky-400/30 bg-sky-400/5 text-sky-300/80 hover:bg-sky-400/10 hover:text-sky-200'
-                : 'border-primary/35 bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary'}
-              onClick={isAiOperated
-                ? (event) => {
-                  event.stopPropagation();
-                  setAiPanelOpen((current) => !current);
-                }
-                : onPreview}
+              onClick={(event) => {
+                event.stopPropagation();
+                onRelease();
+              }}
               disabled={busy}
-              title={isAiOperated ? `${aiTitle} · 打开 AI 操作面板` : '预览'}
-              aria-label={isAiOperated ? `${aiState.label}，打开 AI 操作面板` : '预览'}
+              title="发布到目标"
+              aria-label="发布到目标"
+              className="border-emerald-500/35 bg-emerald-500/10 text-emerald-500 hover:bg-emerald-500/15 hover:text-emerald-500"
             >
-              {busy ? <Loader2 className="animate-spin" /> : isAiOperated ? <Bot /> : <Eye />}
+              <Rocket />
             </Button>
-          )
-        ) : isInterim ? (
-          <Button size="icon" variant="outline" disabled title={statusLabel(branch.status)} aria-label={statusLabel(branch.status)}>
-            <Loader2 className="animate-spin" />
-          </Button>
-        ) : null}
+          ) : null}
+          {isRunning ? (
+            previewCapacityWarning ? (
+              <ConfirmAction
+                title="容量不足，仍然预览部署？"
+                description={previewCapacityWarning}
+                confirmLabel="继续"
+                disabled={busy}
+                onConfirm={onPreview}
+                trigger={(
+                  <Button
+                    size="icon"
+                    variant="outline"
+                    className={isAiActive
+                      ? 'cds-ai-preview-beacon border-sky-400/45 bg-sky-400/10 text-sky-300 hover:bg-sky-400/15 hover:text-sky-200'
+                      : isAiOperated
+                        ? 'border-sky-400/30 bg-sky-400/5 text-sky-300/80 hover:bg-sky-400/10 hover:text-sky-200'
+                      : 'border-primary/35 bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary'}
+                    title={isAiOperated ? `${aiTitle} · 打开 AI 操作面板` : '预览'}
+                    aria-label={isAiOperated ? `${aiState.label}，打开 AI 操作面板` : '预览'}
+                  >
+                    {isAiOperated ? <Bot /> : <Eye />}
+                  </Button>
+                )}
+              />
+            ) : (
+              <Button
+                size="icon"
+                variant="outline"
+                className={isAiActive
+                  ? 'cds-ai-preview-beacon border-sky-400/45 bg-sky-400/10 text-sky-300 hover:bg-sky-400/15 hover:text-sky-200'
+                  : isAiOperated
+                    ? 'border-sky-400/30 bg-sky-400/5 text-sky-300/80 hover:bg-sky-400/10 hover:text-sky-200'
+                  : 'border-primary/35 bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary'}
+                onClick={isAiOperated
+                  ? (event) => {
+                    event.stopPropagation();
+                    setAiPanelOpen((current) => !current);
+                  }
+                  : onPreview}
+                disabled={busy}
+                title={isAiOperated ? `${aiTitle} · 打开 AI 操作面板` : '预览'}
+                aria-label={isAiOperated ? `${aiState.label}，打开 AI 操作面板` : '预览'}
+              >
+                {busy ? <Loader2 className="animate-spin" /> : isAiOperated ? <Bot /> : <Eye />}
+              </Button>
+            )
+          ) : isInterim ? (
+            <Button size="icon" variant="outline" disabled title={statusLabel(branch.status)} aria-label={statusLabel(branch.status)}>
+              <Loader2 className="animate-spin" />
+            </Button>
+          ) : null}
+        </div>
       </footer>
     </article>
   );

--- a/cds/web/src/pages/BranchListPage.tsx
+++ b/cds/web/src/pages/BranchListPage.tsx
@@ -1713,11 +1713,11 @@ export function BranchListPage(): JSX.Element {
     window.dispatchEvent(new CustomEvent('cds:notice:upsert', {
       detail: {
         id: `branch:${projectId}:schema-init`,
-        title: '数据库初始化(schema.sql)',
-        body: '检测到 mysql / postgres 类基础设施。需要初始化数据库时，进入环境变量配置向导上传 schema.sql，容器首次启动会自动执行。',
+        title: '数据库初始化建议',
+        body: '检测到 mysql / postgres 类基础设施。CDS 会先扫描 Prisma、Django、Alembic、schema.sql 等初始化信号并给出推荐方式；手动导入 SQL 仅作为兜底。',
         tone: 'info',
         href: projectEnvSettingsHref(projectId),
-        actionLabel: '上传初始化 SQL',
+        actionLabel: '查看推荐方式',
         source: 'schema',
         projectId,
         projectName: displayName(state.project),

--- a/cds/web/src/pages/BranchTopologyPage.tsx
+++ b/cds/web/src/pages/BranchTopologyPage.tsx
@@ -885,6 +885,7 @@ export function BranchTopologyPage(): JSX.Element {
               <NodeDetails
                 selectedProfile={selectedProfile}
                 selectedInfra={selectedInfra}
+                profiles={state.profiles}
                 branches={state.branches}
                 activeBranch={activeBranch}
                 infra={state.infra}
@@ -1472,6 +1473,7 @@ function lastLines(value: string, count = 18): string {
 function NodeDetails({
   selectedProfile,
   selectedInfra,
+  profiles,
   branches,
   activeBranch,
   infra,
@@ -1483,6 +1485,7 @@ function NodeDetails({
 }: {
   selectedProfile: BuildProfile | null;
   selectedInfra: InfraService | null;
+  profiles: BuildProfile[];
   branches: BranchSummary[];
   activeBranch: BranchSummary | null;
   infra: InfraService[];
@@ -1538,7 +1541,15 @@ function NodeDetails({
   }
 
   if (selectedInfra) {
-    return <InfraDetails selectedInfra={selectedInfra} projectId={projectId} onToast={onToast} />;
+    return (
+      <InfraDetails
+        selectedInfra={selectedInfra}
+        projectId={projectId}
+        branchId={activeBranch?.id}
+        profiles={profiles.map((profile) => ({ id: profile.id, name: profile.name }))}
+        onToast={onToast}
+      />
+    );
   }
 
   const profile = selectedProfile!;
@@ -1773,10 +1784,14 @@ function NodeDetails({
 function InfraDetails({
   selectedInfra,
   projectId,
+  branchId,
+  profiles,
   onToast,
 }: {
   selectedInfra: InfraService;
   projectId: string;
+  branchId?: string;
+  profiles: Array<{ id: string; name: string }>;
   onToast: (message: string) => void;
 }): JSX.Element {
   const [logsState, setLogsState] = useState<
@@ -1845,6 +1860,8 @@ function InfraDetails({
       <InfraDataPanel
         infraId={selectedInfra.id}
         projectId={projectId}
+        branchId={branchId}
+        profiles={profiles}
         image={selectedInfra.dockerImage}
         running={selectedInfra.status === 'running'}
         initSql={selectedInfra.initSql}

--- a/cds/web/src/pages/ProjectListPage.tsx
+++ b/cds/web/src/pages/ProjectListPage.tsx
@@ -127,6 +127,16 @@ interface GithubReposResponse {
 type RuntimeId = 'auto' | 'node' | 'python' | 'dotnet' | 'java' | 'go' | 'rust' | 'php' | 'static' | 'dockerfile' | 'custom';
 type AppServiceRole = 'frontend' | 'backend' | 'worker';
 
+interface DatabaseInitRecommendation {
+  kind: string;
+  label: string;
+  command?: string;
+  files?: string[];
+  summary: string;
+  confidence?: number;
+  autoExecutable?: boolean;
+}
+
 interface AppServiceDraft {
   id: string;
   name: string;
@@ -2768,7 +2778,25 @@ function CreateProjectDialog({
     setDetecting(true);
     setDetectMsg('正在克隆并分析你的仓库…(几秒到几十秒)');
     try {
-      const res = await apiRequest<{ services: Array<{ id: string; name: string; role: AppServiceRole; runtime: RuntimeId; dockerImage: string; command: string; port: number; summary?: string; stack?: string; confidence?: number; signals?: string[]; manualSetupRequired?: boolean }>; moduleCount: number }>(
+      const res = await apiRequest<{
+        services: Array<{
+          id: string;
+          name: string;
+          role: AppServiceRole;
+          runtime: RuntimeId;
+          dockerImage: string;
+          command: string;
+          port: number;
+          summary?: string;
+          stack?: string;
+          confidence?: number;
+          signals?: string[];
+          databaseInit?: DatabaseInitRecommendation | null;
+          manualSetupRequired?: boolean;
+        }>;
+        moduleCount: number;
+        databaseInit?: DatabaseInitRecommendation | null;
+      }>(
         '/api/detect-runtime',
         { method: 'POST', body: { gitRepoUrl: url, gitRef: gitDefaultBranch.trim() || undefined } },
       );
@@ -2787,7 +2815,11 @@ function CreateProjectDialog({
       const conf = (c?: number): string => ((c ?? 0) >= 0.8 ? '高' : (c ?? 0) >= 0.5 ? '中' : '低');
       const lines = svcs.map((s) => `${s.name}：${s.summary || s.runtime}(把握${conf(s.confidence)})`);
       const uncertain = svcs.some((s) => (s.confidence ?? 0) < 0.6 || s.stack === 'unknown' || s.manualSetupRequired);
-      setDetectMsg(`检测到 ${svcs.length} 个服务并已填好：${lines.join('；')}。${uncertain ? '部分把握不高或未完全识别——强烈建议点「试运行验证」确认，或手改命令/镜像后再部署。' : '把握较高，点「试运行验证」确认一下就能部署。'}`);
+      const dbInit = res.databaseInit || svcs.find((s) => s.databaseInit)?.databaseInit || null;
+      const dbInitText = dbInit
+        ? `数据库初始化：${dbInit.command ? `${dbInit.label}，推荐 ${dbInit.command}` : dbInit.summary}。`
+        : '未检测到数据库迁移信号；如果后续初始化失败，可在数据库服务卡片里导入 SQL 或填写迁移命令。';
+      setDetectMsg(`检测到 ${svcs.length} 个服务并已填好：${lines.join('；')}。${dbInitText}${uncertain ? '部分把握不高或未完全识别——强烈建议点「试运行验证」确认，或手改命令/镜像后再部署。' : '把握较高，点「试运行验证」确认一下就能部署。'}`);
     } catch (e) {
       setDetectMsg(e instanceof ApiError ? `检测失败：${e.message}` : `检测失败：${String(e)}`);
     } finally {
@@ -3141,15 +3173,15 @@ function CreateProjectDialog({
                         ) : null}
                         {preset.supportsInitSql ? (
                           <label className="mt-2 block space-y-1.5">
-                            <span className="text-xs font-medium text-muted-foreground">初始化 SQL（可选）</span>
+                            <span className="text-xs font-medium text-muted-foreground">手动 SQL 兜底（可选）</span>
                             <textarea
                               className="min-h-20 w-full resize-y rounded-md border border-input bg-background px-3 py-2 font-mono text-sm outline-none ring-offset-background focus-visible:ring-2 focus-visible:ring-ring"
                               value={infraConfig[preset.id]?.initSql || ''}
                               onChange={(event) => setInfraConfigField(preset.id, 'initSql', event.target.value)}
-                              placeholder={'CREATE TABLE items (id serial primary key, name text);'}
+                              placeholder={'自动识别失败时再填，例如 CREATE TABLE items (id serial primary key, name text);'}
                             />
                             <span className="block text-[11px] leading-4 text-muted-foreground">
-                              随项目保存；数据库就绪后进入拓扑页数据面板，预填这段 SQL 一键执行初始化。
+                              普通部署优先使用仓库扫描出的 Prisma / Django / Alembic / schema.sql 推荐方式；这里仅作为高级兜底，保存后可在拓扑页数据面板执行。
                             </span>
                           </label>
                         ) : null}
@@ -3181,7 +3213,7 @@ function CreateProjectDialog({
                                   className="mt-1.5 min-h-16 w-full resize-y rounded-md border border-input bg-background px-2.5 py-1.5 font-mono text-xs outline-none ring-offset-background focus-visible:ring-2 focus-visible:ring-ring"
                                   value={inst.initSql || ''}
                                   onChange={(event) => updateExtraInstance(preset.id, idx, 'initSql', event.target.value)}
-                                  placeholder="初始化 SQL（可选）"
+                                  placeholder="手动 SQL 兜底（可选）"
                                 />
                               </div>
                             ))}

--- a/cds/web/src/pages/ReleaseCenterPage.tsx
+++ b/cds/web/src/pages/ReleaseCenterPage.tsx
@@ -1,0 +1,438 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { AlertTriangle, FileText, Loader2, Plus, RefreshCw, RotateCcw, Rocket, Server } from 'lucide-react';
+import { AppShell, Crumb, PaletteHint, TopBar, Workspace } from '@/components/layout/AppShell';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { ApiError, apiRequest, apiUrl } from '@/lib/api';
+import { ErrorBlock, LoadingBlock } from '@/pages/cds-settings/components';
+
+interface ReleaseTarget {
+  id: string;
+  projectId: string;
+  name: string;
+  type: string;
+  isEnabled: boolean;
+  ssh?: {
+    host: string;
+    port: number;
+    user: string;
+    privateKeyRef: string;
+    appPath: string;
+    deployCommand: string;
+    rollbackCommand?: string;
+    healthcheckUrl: string;
+  };
+}
+
+interface ReleaseRun {
+  releaseId: string;
+  projectId: string;
+  branchId: string;
+  commitSha: string;
+  targetId: string;
+  status: string;
+  startedAt: string;
+  finishedAt?: string;
+  operator?: string;
+  previousReleaseId?: string;
+  rollbackOf?: string;
+  logs: ReleaseLogEntry[];
+}
+
+interface ReleaseLogEntry {
+  seq: number;
+  at: string;
+  level: 'info' | 'warn' | 'error';
+  message: string;
+  phase?: string;
+}
+
+interface RemoteHostOption {
+  id: string;
+  name: string;
+  host: string;
+  sshPort: number;
+  sshUser: string;
+  fingerprint: string;
+  isEnabled: boolean;
+}
+
+interface CenterRow {
+  target: ReleaseTarget;
+  currentVersion: string;
+  currentCommit: string;
+  latestRun?: ReleaseRun;
+  lastReleasedAt?: string;
+  healthStatus: string;
+  lastOperator?: string;
+  canRollback: boolean;
+}
+
+interface CenterResponse {
+  rows: CenterRow[];
+  runs: ReleaseRun[];
+}
+
+interface TargetsResponse {
+  targets: ReleaseTarget[];
+  remoteHosts: RemoteHostOption[];
+}
+
+type LoadState =
+  | { status: 'loading' }
+  | { status: 'error'; message: string }
+  | { status: 'ok'; center: CenterResponse; hosts: RemoteHostOption[] };
+
+const emptyDraft = {
+  projectId: 'default',
+  name: '',
+  host: '',
+  port: '22',
+  user: '',
+  privateKeyRef: '',
+  appPath: '/opt/app',
+  deployCommand: './deploy.sh',
+  rollbackCommand: './rollback.sh',
+  healthcheckUrl: '',
+};
+
+export function ReleaseCenterPage(): JSX.Element {
+  const [searchParams] = useSearchParams();
+  const initialProject = searchParams.get('project') || 'default';
+  const [projectId, setProjectId] = useState(initialProject);
+  const [state, setState] = useState<LoadState>({ status: 'loading' });
+  const [draft, setDraft] = useState({ ...emptyDraft, projectId: initialProject });
+  const [creating, setCreating] = useState(false);
+  const [toast, setToast] = useState('');
+  const [logRun, setLogRun] = useState<ReleaseRun | null>(null);
+
+  const load = useCallback(async () => {
+    setState({ status: 'loading' });
+    try {
+      const [center, targets] = await Promise.all([
+        apiRequest<CenterResponse>(`/api/releases/center?project=${encodeURIComponent(projectId)}`),
+        apiRequest<TargetsResponse>(`/api/releases/targets?project=${encodeURIComponent(projectId)}`),
+      ]);
+      setState({ status: 'ok', center, hosts: targets.remoteHosts || [] });
+    } catch (err) {
+      setState({ status: 'error', message: err instanceof ApiError ? err.message : String(err) });
+    }
+  }, [projectId]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const hostOptions = state.status === 'ok' ? state.hosts : [];
+  const rows = state.status === 'ok' ? state.center.rows : [];
+  const runs = state.status === 'ok' ? state.center.runs : [];
+
+  const selectHost = (hostId: string): void => {
+    const host = hostOptions.find((item) => item.id === hostId);
+    setDraft((current) => ({
+      ...current,
+      privateKeyRef: hostId,
+      host: host?.host || current.host,
+      port: host ? String(host.sshPort || 22) : current.port,
+      user: host?.sshUser || current.user,
+    }));
+  };
+
+  const createTarget = async (): Promise<void> => {
+    setCreating(true);
+    setToast('');
+    try {
+      await apiRequest('/api/releases/targets', {
+        method: 'POST',
+        body: { ...draft, projectId, port: Number(draft.port || 22) },
+      });
+      setDraft({ ...emptyDraft, projectId });
+      setToast('发布目标已创建');
+      await load();
+    } catch (err) {
+      setToast(err instanceof ApiError ? err.message : String(err));
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const rollback = async (run: ReleaseRun): Promise<void> => {
+    setToast('');
+    try {
+      const res = await apiRequest<{ run: ReleaseRun }>(`/api/releases/runs/${encodeURIComponent(run.releaseId)}/rollback`, { method: 'POST' });
+      setLogRun(res.run);
+      setToast('回滚已开始');
+      await load();
+    } catch (err) {
+      setToast(err instanceof ApiError ? err.message : String(err));
+    }
+  };
+
+  return (
+    <AppShell
+      active="release-center"
+      wide
+      topbar={(
+        <TopBar
+          left={<Crumb items={[{ label: 'CDS', href: '/project-list' }, { label: '发布中心' }]} />}
+          right={(
+            <>
+              <PaletteHint />
+              <Button variant="outline" size="sm" onClick={() => void load()}>
+                <RefreshCw />
+                刷新
+              </Button>
+            </>
+          )}
+        />
+      )}
+    >
+      <Workspace wide>
+        <div className="space-y-4">
+          <section className="cds-surface-raised cds-hairline p-4">
+            <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <h1 className="text-lg font-semibold">发布中心</h1>
+                <p className="mt-1 text-sm text-muted-foreground">目标、当前线上版本、发布日志和回滚入口。</p>
+              </div>
+              <label className="flex items-center gap-2 text-sm">
+                <span className="text-muted-foreground">Project</span>
+                <input
+                  value={projectId}
+                  onChange={(event) => {
+                    setProjectId(event.target.value.trim() || 'default');
+                    setDraft((current) => ({ ...current, projectId: event.target.value.trim() || 'default' }));
+                  }}
+                  className="h-9 w-48 rounded-md border border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))] px-3 font-mono text-sm outline-none focus:border-primary/60"
+                />
+              </label>
+            </div>
+            <div className="grid gap-3 lg:grid-cols-[1fr_1fr_1fr]">
+              <Field label="目标名称" value={draft.name} onChange={(value) => setDraft((c) => ({ ...c, name: value }))} placeholder="production-ssh" />
+              <label className="grid gap-1 text-sm">
+                <span className="text-muted-foreground">SSH 凭据</span>
+                <select
+                  value={draft.privateKeyRef}
+                  onChange={(event) => selectHost(event.target.value)}
+                  className="h-9 rounded-md border border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))] px-3 text-sm outline-none focus:border-primary/60"
+                >
+                  <option value="">选择 RemoteHost privateKeyRef</option>
+                  {hostOptions.map((host) => (
+                    <option key={host.id} value={host.id}>{host.name} · {host.sshUser}@{host.host}</option>
+                  ))}
+                </select>
+              </label>
+              <Field label="健康检查 URL" value={draft.healthcheckUrl} onChange={(value) => setDraft((c) => ({ ...c, healthcheckUrl: value }))} placeholder="https://example.com/healthz" />
+              <Field label="Host" value={draft.host} onChange={(value) => setDraft((c) => ({ ...c, host: value }))} />
+              <Field label="Port" value={draft.port} onChange={(value) => setDraft((c) => ({ ...c, port: value }))} />
+              <Field label="User" value={draft.user} onChange={(value) => setDraft((c) => ({ ...c, user: value }))} />
+              <Field label="App Path" value={draft.appPath} onChange={(value) => setDraft((c) => ({ ...c, appPath: value }))} />
+              <Field label="Deploy Command" value={draft.deployCommand} onChange={(value) => setDraft((c) => ({ ...c, deployCommand: value }))} />
+              <Field label="Rollback Command" value={draft.rollbackCommand} onChange={(value) => setDraft((c) => ({ ...c, rollbackCommand: value }))} />
+            </div>
+            <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+              <div className="text-xs text-muted-foreground">
+                {hostOptions.length === 0 ? (
+                  <span className="inline-flex items-center gap-1 text-amber-500"><AlertTriangle className="h-3 w-3" /> 先在 Settings / Remote Hosts 添加 SSH 凭据。</span>
+                ) : 'MVP 模板：SSH 脚本发布'}
+              </div>
+              <Button onClick={() => void createTarget()} disabled={creating}>
+                {creating ? <Loader2 className="animate-spin" /> : <Plus />}
+                新增 SSH Target
+              </Button>
+            </div>
+            {toast ? <div className="mt-3 rounded-md border border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))] px-3 py-2 text-sm">{toast}</div> : null}
+          </section>
+
+          {state.status === 'loading' ? <LoadingBlock label="正在加载发布中心" /> : null}
+          {state.status === 'error' ? <ErrorBlock message={state.message} /> : null}
+          {state.status === 'ok' ? (
+            <>
+              <section className="cds-surface-raised cds-hairline overflow-hidden">
+                <div className="border-b border-[hsl(var(--hairline))] px-4 py-3 text-sm font-semibold">目标与线上状态</div>
+                {rows.length === 0 ? (
+                  <div className="px-4 py-10 text-center text-sm text-muted-foreground">还没有发布目标。</div>
+                ) : (
+                  <div className="overflow-x-auto">
+                    <table className="w-full min-w-[980px] text-left text-sm">
+                      <thead className="bg-[hsl(var(--surface-sunken))] text-xs text-muted-foreground">
+                        <tr>
+                          <th className="px-4 py-3">目标名称</th>
+                          <th className="px-4 py-3">类型</th>
+                          <th className="px-4 py-3">当前版本</th>
+                          <th className="px-4 py-3">当前 commit</th>
+                          <th className="px-4 py-3">最近发布时间</th>
+                          <th className="px-4 py-3">健康状态</th>
+                          <th className="px-4 py-3">最近发布人</th>
+                          <th className="px-4 py-3">操作</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {rows.map((row) => (
+                          <tr key={row.target.id} className="border-t border-[hsl(var(--hairline))]">
+                            <td className="px-4 py-3 font-medium">{row.target.name}</td>
+                            <td className="px-4 py-3"><CodeText>{row.target.type}</CodeText></td>
+                            <td className="px-4 py-3"><CodeText>{row.currentVersion || '-'}</CodeText></td>
+                            <td className="px-4 py-3"><CodeText>{row.currentCommit ? row.currentCommit.slice(0, 12) : '-'}</CodeText></td>
+                            <td className="px-4 py-3 text-muted-foreground">{formatDate(row.lastReleasedAt)}</td>
+                            <td className="px-4 py-3"><StatusPill status={row.healthStatus} /></td>
+                            <td className="px-4 py-3">{row.lastOperator || '-'}</td>
+                            <td className="px-4 py-3">
+                              <div className="flex gap-2">
+                                <Button asChild variant="outline" size="sm">
+                                  <Link to={`/branch-list?project=${encodeURIComponent(row.target.projectId)}`}>
+                                    <Rocket />
+                                    发布
+                                  </Link>
+                                </Button>
+                                {row.latestRun ? (
+                                  <Button variant="outline" size="sm" onClick={() => setLogRun(row.latestRun!)}>
+                                    <FileText />
+                                    日志
+                                  </Button>
+                                ) : null}
+                                {row.latestRun ? (
+                                  <Button variant="outline" size="sm" onClick={() => void rollback(row.latestRun!)} disabled={!row.canRollback}>
+                                    <RotateCcw />
+                                    回滚
+                                  </Button>
+                                ) : null}
+                              </div>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </section>
+
+              <section className="cds-surface-raised cds-hairline overflow-hidden">
+                <div className="border-b border-[hsl(var(--hairline))] px-4 py-3 text-sm font-semibold">最近 ReleaseRun</div>
+                {runs.length === 0 ? (
+                  <div className="px-4 py-8 text-center text-sm text-muted-foreground">还没有发布记录。</div>
+                ) : (
+                  <div className="divide-y divide-[hsl(var(--hairline))]">
+                    {runs.slice(0, 12).map((run) => (
+                      <button
+                        key={run.releaseId}
+                        type="button"
+                        onClick={() => setLogRun(run)}
+                        className="grid w-full grid-cols-[minmax(0,1fr)_120px_120px_160px] items-center gap-3 px-4 py-3 text-left text-sm hover:bg-[hsl(var(--surface-sunken))]/60"
+                      >
+                        <div className="min-w-0">
+                          <div className="flex items-center gap-2">
+                            <Server className="h-4 w-4 text-muted-foreground" />
+                            <CodeText>{run.releaseId}</CodeText>
+                            {run.rollbackOf ? <span className="rounded border border-amber-500/30 px-1.5 py-0.5 text-xs text-amber-500">rollback</span> : null}
+                          </div>
+                          <div className="mt-1 truncate text-xs text-muted-foreground">{run.branchId} · {run.commitSha}</div>
+                        </div>
+                        <StatusPill status={run.status} />
+                        <div className="text-muted-foreground">{run.operator || '-'}</div>
+                        <div className="text-muted-foreground">{formatDate(run.startedAt)}</div>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </section>
+            </>
+          ) : null}
+        </div>
+      </Workspace>
+      <ReleaseLogDialog run={logRun} onClose={() => setLogRun(null)} />
+    </AppShell>
+  );
+}
+
+function ReleaseLogDialog({ run, onClose }: { run: ReleaseRun | null; onClose: () => void }): JSX.Element {
+  const [current, setCurrent] = useState<ReleaseRun | null>(run);
+  useEffect(() => setCurrent(run), [run]);
+  useEffect(() => {
+    if (!run || isTerminal(run.status)) return undefined;
+    const source = new EventSource(apiUrl(`/api/releases/runs/${encodeURIComponent(run.releaseId)}/stream?afterSeq=${run.logs.at(-1)?.seq || 0}`));
+    source.addEventListener('snapshot', (event) => {
+      const data = parseSseJson<{ run: ReleaseRun; logs: ReleaseLogEntry[] }>(event);
+      if (data?.run) setCurrent(data.run);
+    });
+    source.addEventListener('release.log', (event) => {
+      const data = parseSseJson<{ log: ReleaseLogEntry }>(event);
+      if (!data?.log) return;
+      setCurrent((prev) => prev ? { ...prev, logs: [...prev.logs, data.log] } : prev);
+    });
+    source.addEventListener('release.status', (event) => {
+      const data = parseSseJson<{ run: ReleaseRun }>(event);
+      if (data?.run) setCurrent(data.run);
+    });
+    return () => source.close();
+  }, [run]);
+  return (
+    <Dialog open={!!run} onOpenChange={(open) => { if (!open) onClose(); }}>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>发布日志 {current?.releaseId ? <span className="font-mono text-sm text-muted-foreground">{current.releaseId}</span> : null}</DialogTitle>
+        </DialogHeader>
+        <div className="flex items-center justify-between text-sm">
+          <StatusPill status={current?.status || 'unknown'} />
+          <span className="text-muted-foreground">{formatDate(current?.startedAt)}</span>
+        </div>
+        <pre className="max-h-[60vh] overflow-auto rounded-md border border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))] p-3 text-xs leading-5">
+          {(current?.logs || []).map((log) => `[${formatTime(log.at)}] ${log.level.toUpperCase()} ${log.phase ? `${log.phase}: ` : ''}${log.message}`).join('\n') || '暂无日志'}
+        </pre>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function Field({ label, value, onChange, placeholder }: { label: string; value: string; onChange: (value: string) => void; placeholder?: string }): JSX.Element {
+  return (
+    <label className="grid gap-1 text-sm">
+      <span className="text-muted-foreground">{label}</span>
+      <input
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        className="h-9 rounded-md border border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))] px-3 text-sm outline-none focus:border-primary/60"
+      />
+    </label>
+  );
+}
+
+function StatusPill({ status }: { status: string }): JSX.Element {
+  const tone = status.includes('failed') || status === 'failed'
+    ? 'border-red-500/35 bg-red-500/10 text-red-500'
+    : status.includes('running') || status === 'queued' || status === 'healthchecking'
+      ? 'border-sky-500/35 bg-sky-500/10 text-sky-500'
+      : status === 'success' || status === 'healthy' || status === 'rollback_success'
+        ? 'border-emerald-500/35 bg-emerald-500/10 text-emerald-500'
+        : 'border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))] text-muted-foreground';
+  return <span className={`inline-flex h-7 items-center rounded-md border px-2 text-xs font-medium ${tone}`}>{status}</span>;
+}
+
+function CodeText({ children }: { children: string }): JSX.Element {
+  return <span className="font-mono text-xs text-muted-foreground">{children}</span>;
+}
+
+function formatDate(value?: string): string {
+  if (!value) return '-';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+}
+
+function formatTime(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleTimeString();
+}
+
+function isTerminal(status: string): boolean {
+  return ['success', 'failed', 'rollback_success', 'rollback_failed'].includes(status);
+}
+
+function parseSseJson<T>(event: Event): T | null {
+  try {
+    return JSON.parse((event as MessageEvent).data) as T;
+  } catch {
+    return null;
+  }
+}

--- a/changelogs/2026-06-10_cds-db-init-detection.md
+++ b/changelogs/2026-06-10_cds-db-init-detection.md
@@ -1,0 +1,1 @@
+| feat | cds | 新增数据库初始化自动识别、推荐与部署后执行流程，支持 Prisma、Drizzle、TypeORM、Sequelize、Django、Alembic、Rails 与 schema.sql/init.sql，并在数据库服务卡片提供导入 SQL、重新初始化和手动迁移命令兜底入口 |

--- a/changelogs/2026-06-10_cds-release-control-plane.md
+++ b/changelogs/2026-06-10_cds-release-control-plane.md
@@ -1,0 +1,5 @@
+feat(cds): add SSH release control plane MVP
+
+- Add ReleaseTarget, ReleasePlan, ReleaseRun and ReleaseArtifact state models.
+- Add `/api/releases/*` APIs for SSH targets, preflight checks, release logs, release runs and rollback.
+- Add release center UI and branch-card release entry for running preview branches.

--- a/changelogs/2026-06-10_peer-sync-http-to-https-redirect.md
+++ b/changelogs/2026-06-10_peer-sync-http-to-https-redirect.md
@@ -1,0 +1,18 @@
+# 2026-06-10 系统互联 http→https 规范化
+
+## 背景
+
+对端连接串可能携带 `http://` baseUrl，但实际站点由 nginx 301 到 `https://`。系统互联的 `PeerSync` HttpClient 出于 SSRF 防护禁用了自动重定向，因此握手会把 301 当作失败。
+
+## 变更
+
+- 新增 `PeerSyncRedirectHelper`，只允许同 host、同 peer-sync 端点的 `http -> https` 重定向规范化。
+- 新增配对握手遇到上述 301/302/307/308 时，显式重试 HTTPS，并在成功后存储规范化后的 HTTPS baseUrl。
+- 配对后的连通测试、资源 push/pull 调用也支持同样的一次性规范化，并在成功后回写 HTTPS baseUrl。
+- 仍不启用全局自动重定向；跨 host、跳到非 peer-sync 路径、携带 query/fragment 的重定向继续按失败处理。
+
+## 验证
+
+- `curl -X POST http://map.ebcone.net/api/peer-sync/handshake` 返回 301 到 `https://map.ebcone.net/api/peer-sync/handshake`。
+- `curl -X POST https://map.ebcone.net/api/peer-sync/handshake` 可到达 peer-sync 端点，返回业务层 400。
+- `dotnet build prd-api/PrdAgent.sln --no-restore`

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/AdminPeerNodesController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/AdminPeerNodesController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using MongoDB.Driver;
 using PrdAgent.Api.Extensions;
+using PrdAgent.Api.Services;
 using PrdAgent.Core.Interfaces;
 using PrdAgent.Core.Models;
 using PrdAgent.Core.Security;
@@ -128,16 +129,16 @@ public class AdminPeerNodesController : ControllerBase
             InitiatorBaseUrl = selfBaseUrl,
             InitiatorDisplayName = string.IsNullOrWhiteSpace(request.SelfDisplayName) ? "对端 MAP 节点" : request.SelfDisplayName!.Trim(),
         };
-        var baseLeft = baseUri.GetLeftPart(UriPartial.Path).TrimEnd('/');
-        var url = $"{baseLeft}/api/peer-sync/handshake";
+        var effectiveBaseUrl = baseUri.GetLeftPart(UriPartial.Path).TrimEnd('/');
 
         HandshakeResult? result;
         try
         {
             var client = _httpFactory.CreateClient("PeerSync");
             client.Timeout = TimeSpan.FromSeconds(30);
-            var content = new StringContent(JsonSerializer.Serialize(handshakeBody, JsonOpts), Encoding.UTF8, "application/json");
-            using var resp = await client.PostAsync(url, content, ct);
+            var handshake = await SendHandshakeAsync(client, effectiveBaseUrl, handshakeBody, ct);
+            effectiveBaseUrl = handshake.EffectiveBaseUrl;
+            using var resp = handshake.Response;
             var json = await resp.Content.ReadAsStringAsync(ct);
             if (!resp.IsSuccessStatusCode)
             {
@@ -167,7 +168,7 @@ public class AdminPeerNodesController : ControllerBase
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "[peer-sync] handshake request error to {Url}", url);
+            _logger.LogWarning(ex, "[peer-sync] handshake request error to {BaseUrl}", effectiveBaseUrl);
             return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, $"无法连接对端：{ex.Message}"));
         }
 
@@ -191,7 +192,7 @@ public class AdminPeerNodesController : ControllerBase
                 .SetOnInsert(n => n.RemoteNodeId, result.NodeId)
                 .SetOnInsert(n => n.CreatedAt, DateTime.UtcNow)
                 .Set(n => n.DisplayName, displayName)
-                .Set(n => n.BaseUrl, baseUrl)
+                .Set(n => n.BaseUrl, effectiveBaseUrl)
                 .Set(n => n.SharedSecret, result.SharedSecret)
                 .Set(n => n.Status, PeerNodeStatus.Connected)
                 .Set(n => n.LastError, (string?)null)
@@ -232,18 +233,17 @@ public class AdminPeerNodesController : ControllerBase
             var (ts, sign) = _peer.Sign(node.SharedSecret, "GET", path, string.Empty);
             var client = _httpFactory.CreateClient("PeerSync");
             client.Timeout = TimeSpan.FromSeconds(20);
-            var req = new HttpRequestMessage(HttpMethod.Get, baseLeft + path);
-            req.Headers.TryAddWithoutValidation("X-Peer-Node", selfNodeId);
-            req.Headers.TryAddWithoutValidation("X-Peer-Ts", ts);
-            req.Headers.TryAddWithoutValidation("X-Peer-Sign", sign);
-            using var resp = await client.SendAsync(req, ct);
+            var originalBaseUrl = node.BaseUrl;
+            using var resp = await SendSignedPeerRequestAsync(client, node, baseLeft, path, selfNodeId, ts, sign, ct);
             var ok = resp.IsSuccessStatusCode;
-            await _db.PeerNodes.UpdateOneAsync(n => n.Id == id,
-                Builders<PeerNode>.Update
-                    .Set(n => n.Status, ok ? PeerNodeStatus.Connected : PeerNodeStatus.Error)
-                    .Set(n => n.LastError, ok ? null : $"ping 返回 HTTP {(int)resp.StatusCode}")
-                    .Set(n => n.LastContactAt, ok ? DateTime.UtcNow : node.LastContactAt)
-                    .Set(n => n.UpdatedAt, DateTime.UtcNow), cancellationToken: ct);
+            var update = Builders<PeerNode>.Update
+                .Set(n => n.Status, ok ? PeerNodeStatus.Connected : PeerNodeStatus.Error)
+                .Set(n => n.LastError, ok ? null : $"ping 返回 HTTP {(int)resp.StatusCode}")
+                .Set(n => n.LastContactAt, ok ? DateTime.UtcNow : node.LastContactAt)
+                .Set(n => n.UpdatedAt, DateTime.UtcNow);
+            if (ok && !string.Equals(node.BaseUrl, originalBaseUrl, StringComparison.Ordinal))
+                update = update.Set(n => n.BaseUrl, node.BaseUrl);
+            await _db.PeerNodes.UpdateOneAsync(n => n.Id == id, update, cancellationToken: ct);
             return Ok(ApiResponse<object>.Ok(new { ok, status = (int)resp.StatusCode }));
         }
         catch (Exception ex)
@@ -277,6 +277,72 @@ public class AdminPeerNodesController : ControllerBase
         n.CreatedAt,
         n.UpdatedAt,
     };
+
+    private async Task<(HttpResponseMessage Response, string EffectiveBaseUrl)> SendHandshakeAsync(
+        HttpClient client,
+        string baseUrl,
+        HandshakePayload handshakeBody,
+        CancellationToken ct)
+    {
+        const string path = "/api/peer-sync/handshake";
+        var url = $"{baseUrl}{path}";
+        using var content = CreateJsonContent(handshakeBody);
+        var resp = await client.PostAsync(url, content, ct);
+        if (!PeerSyncRedirectHelper.IsRedirect(resp.StatusCode))
+            return (resp, baseUrl);
+
+        if (!PeerSyncRedirectHelper.TryBuildSameHostHttpsRedirect(
+                new Uri(url), resp.Headers.Location, path,
+                out var redirectedBaseUrl, out var redirectedUrl, out var reason))
+            return (resp, baseUrl);
+
+        await _urlValidator.EnsureSafeHttpUrlAsync(redirectedBaseUrl, "peer-sync", ct);
+        _logger.LogInformation("[peer-sync] normalized peer baseUrl via redirect {Original} -> {Redirected}", baseUrl, redirectedBaseUrl);
+        resp.Dispose();
+
+        using var redirectedContent = CreateJsonContent(handshakeBody);
+        return (await client.PostAsync(redirectedUrl, redirectedContent, ct), redirectedBaseUrl);
+    }
+
+    private async Task<HttpResponseMessage> SendSignedPeerRequestAsync(
+        HttpClient client,
+        PeerNode node,
+        string baseUrl,
+        string path,
+        string selfNodeId,
+        string ts,
+        string sign,
+        CancellationToken ct)
+    {
+        HttpRequestMessage BuildRequest(string requestUrl)
+        {
+            var req = new HttpRequestMessage(HttpMethod.Get, requestUrl);
+            req.Headers.TryAddWithoutValidation("X-Peer-Node", selfNodeId);
+            req.Headers.TryAddWithoutValidation("X-Peer-Ts", ts);
+            req.Headers.TryAddWithoutValidation("X-Peer-Sign", sign);
+            return req;
+        }
+
+        var url = baseUrl + path;
+        var resp = await client.SendAsync(BuildRequest(url), ct);
+        if (!PeerSyncRedirectHelper.IsRedirect(resp.StatusCode))
+            return resp;
+
+        if (!PeerSyncRedirectHelper.TryBuildSameHostHttpsRedirect(
+                new Uri(url), resp.Headers.Location, path,
+                out var redirectedBaseUrl, out var redirectedUrl, out var reason))
+            return resp;
+
+        await _urlValidator.EnsureSafeHttpUrlAsync(redirectedBaseUrl, "peer-sync", ct);
+        _logger.LogInformation("[peer-sync] normalized peer test baseUrl via redirect {NodeId}: {Original} -> {Redirected}",
+            node.RemoteNodeId, baseUrl, redirectedBaseUrl);
+        resp.Dispose();
+        node.BaseUrl = redirectedBaseUrl;
+        return await client.SendAsync(BuildRequest(redirectedUrl), ct);
+    }
+
+    private static StringContent CreateJsonContent(object value) =>
+        new(JsonSerializer.Serialize(value, JsonOpts), Encoding.UTF8, "application/json");
 
     // ── DTO ──
     public class AddPeerRequest

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/PeerSyncController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/PeerSyncController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using MongoDB.Driver;
 using PrdAgent.Api.Extensions;
+using PrdAgent.Api.Services;
 using PrdAgent.Core.Interfaces;
 using PrdAgent.Core.Models;
 using PrdAgent.Core.Security;
@@ -419,18 +420,62 @@ public class PeerSyncController : ControllerBase
         var selfNodeId = await _peer.GetSelfNodeIdAsync(ct);
         var (ts, sign) = _peer.Sign(node.SharedSecret, method.Method, path, bodyStr);
 
-        var req = new HttpRequestMessage(method, baseLeft + path);
-        req.Headers.TryAddWithoutValidation("X-Peer-Node", selfNodeId);
-        req.Headers.TryAddWithoutValidation("X-Peer-Ts", ts);
-        req.Headers.TryAddWithoutValidation("X-Peer-Sign", sign);
-        if (body != null)
-            req.Content = new StringContent(bodyStr, Encoding.UTF8, "application/json");
-
         var client = _httpFactory.CreateClient("PeerSync");
         client.Timeout = TimeSpan.FromSeconds(120);
-        using var resp = await client.SendAsync(req, ct);
+        using var resp = await SendSignedPeerRequestAsync(client, node, method, baseLeft, path, bodyStr, selfNodeId, ts, sign, ct);
         var json = await resp.Content.ReadAsStringAsync(ct);
         return (resp.IsSuccessStatusCode, json, (int)resp.StatusCode);
+    }
+
+    private async Task<HttpResponseMessage> SendSignedPeerRequestAsync(
+        HttpClient client,
+        PeerNode node,
+        HttpMethod method,
+        string baseUrl,
+        string path,
+        string bodyStr,
+        string selfNodeId,
+        string ts,
+        string sign,
+        CancellationToken ct)
+    {
+        HttpRequestMessage BuildRequest(string requestUrl)
+        {
+            var req = new HttpRequestMessage(method, requestUrl);
+            req.Headers.TryAddWithoutValidation("X-Peer-Node", selfNodeId);
+            req.Headers.TryAddWithoutValidation("X-Peer-Ts", ts);
+            req.Headers.TryAddWithoutValidation("X-Peer-Sign", sign);
+            if (!string.IsNullOrEmpty(bodyStr))
+                req.Content = new StringContent(bodyStr, Encoding.UTF8, "application/json");
+            return req;
+        }
+
+        var url = baseUrl + path;
+        var resp = await client.SendAsync(BuildRequest(url), ct);
+        if (!PeerSyncRedirectHelper.IsRedirect(resp.StatusCode))
+            return resp;
+
+        if (!PeerSyncRedirectHelper.TryBuildSameHostHttpsRedirect(
+                new Uri(url), resp.Headers.Location, path,
+                out var redirectedBaseUrl, out var redirectedUrl, out var reason))
+            return resp;
+
+        await _urlValidator.EnsureSafeHttpUrlAsync(redirectedBaseUrl, "peer-sync", ct);
+        _logger.LogInformation("[peer-sync] normalized peer call baseUrl via redirect {NodeId}: {Original} -> {Redirected}",
+            node.RemoteNodeId, baseUrl, redirectedBaseUrl);
+        resp.Dispose();
+
+        var redirectedResp = await client.SendAsync(BuildRequest(redirectedUrl), ct);
+        if (redirectedResp.IsSuccessStatusCode && !string.Equals(node.BaseUrl, redirectedBaseUrl, StringComparison.Ordinal))
+        {
+            await _db.PeerNodes.UpdateOneAsync(n => n.Id == node.Id,
+                Builders<PeerNode>.Update
+                    .Set(n => n.BaseUrl, redirectedBaseUrl)
+                    .Set(n => n.UpdatedAt, DateTime.UtcNow),
+                cancellationToken: ct);
+            node.BaseUrl = redirectedBaseUrl;
+        }
+        return redirectedResp;
     }
 
     /// <summary>

--- a/prd-api/src/PrdAgent.Api/Services/PeerSyncRedirectHelper.cs
+++ b/prd-api/src/PrdAgent.Api/Services/PeerSyncRedirectHelper.cs
@@ -1,0 +1,62 @@
+using System.Net;
+
+namespace PrdAgent.Api.Services;
+
+public static class PeerSyncRedirectHelper
+{
+    public static bool IsRedirect(HttpStatusCode statusCode) =>
+        statusCode is HttpStatusCode.MovedPermanently
+            or HttpStatusCode.Found
+            or HttpStatusCode.TemporaryRedirect
+            or HttpStatusCode.PermanentRedirect;
+
+    public static bool TryBuildSameHostHttpsRedirect(
+        Uri originalRequest,
+        Uri? location,
+        string expectedPathSuffix,
+        out string canonicalBaseUrl,
+        out string redirectedUrl,
+        out string reason)
+    {
+        canonicalBaseUrl = string.Empty;
+        redirectedUrl = string.Empty;
+        reason = string.Empty;
+
+        if (location == null)
+        {
+            reason = "对端返回重定向但没有 Location";
+            return false;
+        }
+
+        var target = location.IsAbsoluteUri ? location : new Uri(originalRequest, location);
+        if (!string.Equals(originalRequest.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+            || !string.Equals(target.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            reason = "只允许 http 到 https 的规范化重定向";
+            return false;
+        }
+
+        if (!string.Equals(originalRequest.Host, target.Host, StringComparison.OrdinalIgnoreCase))
+        {
+            reason = "不允许跨 host 重定向";
+            return false;
+        }
+
+        if (!string.IsNullOrEmpty(target.Query) || !string.IsNullOrEmpty(target.Fragment))
+        {
+            reason = "不允许重定向携带 query 或 fragment";
+            return false;
+        }
+
+        if (!target.AbsolutePath.EndsWith(expectedPathSuffix, StringComparison.Ordinal))
+        {
+            reason = "重定向路径不是 peer-sync 端点";
+            return false;
+        }
+
+        var basePath = target.AbsolutePath[..^expectedPathSuffix.Length].TrimEnd('/');
+        canonicalBaseUrl = $"{target.GetLeftPart(UriPartial.Authority)}{basePath}".TrimEnd('/');
+        redirectedUrl = target.GetLeftPart(UriPartial.Path);
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- 新增统一发布模型与后端发布服务，支持发布目标、发布计划、发布记录、实时日志和回滚状态管理。
- 为 CDS 分支预览增加“发布”入口，新增发布中心页面，补齐预发布检查、SSE 日志和回滚入口。
- 补充容器/堆栈识别、分支拓扑、项目列表与环境配置相关改造，并新增对应测试。
- 同步修复 peer sync 的 HTTP 到 HTTPS 重定向，以及数据库初始化检测相关的云端链路问题。

## Testing
- 已完成后端与前端构建、类型检查和单元测试的本地验证。
- 已在云端 CDS 上完成分支部署验证，并确认发布中心相关 API 与页面路由可用。
- 已通过浏览器对云端页面和知识库验收报告进行可视化检查。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches production SSH deploy/rollback, deploy-time DB migration execution, and cross-node pairing; misconfiguration or failed init can block deploys or target the wrong host.
> 
> **Overview**
> Adds a **preview → production release control plane** in CDS: persisted release targets/plans/runs, `/api/releases/*` (SSH targets, preflight, start release, SSE logs, rollback), **发布中心** UI, and a **发布** action on running branch cards.
> 
> **Database initialization** is extended end-to-end: stack detection recommends ORM/SQL init (Prisma, Django, `schema.sql`, etc.), deploy runs auto steps after infra is healthy (SQL via infra docker exec; migrations via new `runProfileCommand`), plus `POST /branches/:id/database-init/run` and topology/env UI for manual SQL and migration commands.
> 
> **Container service** refactors deploy env/volume setup into shared helpers to support one-off profile jobs.
> 
> **prd-api peer-sync** gains explicit **same-host `http` → `https`** redirect handling on handshake, ping, and signed peer calls (without enabling global redirects), persisting normalized HTTPS base URLs when successful.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04822fc8e722317e86a306b4b10e3a82451ca299. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->