### PR TITLE
每日熵减计划 2026-W24 — doc 索引补缺 + changelog manifest 更新

### DIFF
--- a/changelogs/.entropy-manifest.yml
+++ b/changelogs/.entropy-manifest.yml
@@ -175,3 +175,8 @@ processed:
   - 2026-06-08_cds-service-chip-dot.md
   - 2026-06-08_goal-as-milestone.md
   - 2026-06-08_goal-drawer-and-canvas-drag.md
+  - 2026-06-03_home-a2-deepspace-glass.md
+  - 2026-06-05_kb-agent-diff-gate.md
+  - 2026-06-06_cds-agent-ux-fixes.md
+  - 2026-06-07_cds-agent-multi-turn-context.md
+  - 2026-06-07_md-to-ppt-agent.md

--- a/changelogs/2026-06-10_entropy-cleanup.md
+++ b/changelogs/2026-06-10_entropy-cleanup.md
@@ -1,0 +1,1 @@
+| chore | doc | 熵清理：D2 index.yml +3 条，D3 guide.list +2 条，D6 manifest +5 条 |

--- a/doc/guide.list.directory.md
+++ b/doc/guide.list.directory.md
@@ -1016,3 +1016,5 @@
 | 2026-03-11 | 重排 | `index.yml` + `guide.list.directory.md` | 按阅读优先级重新排序文档索引 |
 | 2026-03-10 | 新增 | `index.yml` | 文档元数据索引 |
 | 2026-03-10 | 新增 | `guide.list.directory.md` | 文档索引目录页 |
+| 2026-06-10 | 新增 | `debt.cds-nginx-loading-pages` | CDS loading pages 债务台账 |
+| 2026-06-10 | 新增 | `design.cds-skill-version-update` | CDS 技能版本与更新架构 |

--- a/doc/index.yml
+++ b/doc/index.yml
@@ -353,3 +353,12 @@ docs:
   report.skill-eval-sample-diataxis: 文档技能评测·documentation-writer（Diátaxis）样本输出
   report.cds-mongo-log-split-incident-2026-05-23: CDS Mongo 日志拆分事故复盘（2026-05-23）
   report.tutorial-coverage: 页面教程全量路由覆盖审计（2026-06-04）
+  debt.cds-nginx-loading-pages:
+    title: "CDS loading pages 债务台账"
+    status: partial
+  design.cds-skill-version-update:
+    title: "CDS 技能版本与更新架构"
+    status: active
+  report.cds-agent-ux-acceptance-2026-06-06:
+    title: "CDS Agent 体验修复验收报告（2026-06-06）"
+    status: active


### PR DESCRIPTION
## 摘要

每日熵减例行清理，修复文档索引与 changelog manifest 的不同步。无功能代码变更。

## 改动 diff

- `doc/index.yml`：补缺 3 条新文档的元数据条目（debt.cds-nginx-loading-pages / design.cds-skill-version-update / report.cds-agent-ux-acceptance-2026-06-06）
- `doc/guide.list.directory.md`：补缺 2 条目录行（debt.cds-nginx-loading-pages / design.cds-skill-version-update）
- `changelogs/.entropy-manifest.yml`：标记 5 条 changelog 已处理（06-03 首页深空 / 06-05 知识库 diff 闸 / 06-06 CDS Agent UX / 06-07 多轮上下文 / 06-07 MD 转 PPT）
- `changelogs/2026-06-10_entropy-cleanup.md`：本次熵清理碎片记录

## 测试

- [x] 双向扫描：D1 命名 0 违规，D2/D3 仅追加无删除，D4 幽灵为规则正文粗体跳过
- [x] diff 核验：只有 +16 行，无删除行
- [x] 幂等性：所有追加前均经 grep -q 二次确认不存在

https://claude.ai/code/session_012gNmk27NtvSUkrju7EPSn6

---
_Generated by [Claude Code](https://claude.ai/code/session_012gNmk27NtvSUkrju7EPSn6)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> 仅文档与 changelog 元数据追加，不涉及运行时、鉴权或数据面。
> 
> **Overview**
> 例行 **熵清理**：把文档索引、目录变更史与 changelog manifest 重新对齐，**无应用代码改动**。
> 
> 在 **`doc/index.yml`** 末尾补了 3 条元数据（`debt.cds-nginx-loading-pages`、`design.cds-skill-version-update`、`report.cds-agent-ux-acceptance-2026-06-06`），其中两条带 `title`/`status` 嵌套结构。在 **`doc/guide.list.directory.md`** 变更历史里追加 2 行（上述 debt / design；验收报告正文区此前已有链接）。**`changelogs/.entropy-manifest.yml`** 将 5 份 06-03～06-07 的 changelog 标为已处理，并新增 **`changelogs/2026-06-10_entropy-cleanup.md`** 记录本次清理范围。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df681c3d1d5858aa8174a6e3332fcfdca0504964. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->