### PR TITLE
[codex] 修复 CDS 发布控制面项目越权

### DIFF
--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -4634,6 +4634,15 @@ export function createBranchRouter(deps: RouterDeps): Router {
     return value;
   }
 
+  function chooseMongoCurrentDatabase(configuredDatabase: string, databases: unknown[]): string {
+    const validDatabases = databases
+      .map((item) => (item && typeof item === 'object' && 'name' in item ? String((item as { name?: unknown }).name || '') : ''))
+      .filter((name) => /^[a-zA-Z0-9_-]{1,63}$/.test(name));
+    if (validDatabases.includes(configuredDatabase)) return configuredDatabase;
+    const businessDatabase = validDatabases.find((name) => !['admin', 'config', 'local'].includes(name));
+    return businessDatabase || validDatabases[0] || configuredDatabase;
+  }
+
   function mongoCredentials(service: InfraService, branch: BranchEntry, databaseOverride?: string): { user: string; password: string; database: string; uri: string; secrets: string[] } {
     const branchEnv = stateService.getCustomEnvScope(branch.id);
     const branchUser = branchEnv.MONGODB_USERNAME || branchEnv.MONGO_USERNAME || '';
@@ -7114,9 +7123,11 @@ export function createBranchRouter(deps: RouterDeps): Router {
     const ctx = await resolveMongoDataResourceForRequest(req, res);
     if (!ctx) return;
     try {
-      const currentDatabase = mongoDatabaseForBranch(ctx.service, ctx.branch);
+      const configuredDatabase = mongoDatabaseForBranch(ctx.service, ctx.branch);
       const data = await runMongoJson(ctx.service, ctx.branch, 'JSON.stringify(db.adminCommand({ listDatabases: 1 }).databases.map(d => ({ name: d.name, sizeOnDisk: d.sizeOnDisk || 0 })))');
-      res.json({ branchId: ctx.branch.id, resourceId: ctx.resourceId, currentDatabase, databases: Array.isArray(data) ? data : [] });
+      const databases = Array.isArray(data) ? data : [];
+      const currentDatabase = chooseMongoCurrentDatabase(configuredDatabase, databases);
+      res.json({ branchId: ctx.branch.id, resourceId: ctx.resourceId, configuredDatabase, currentDatabase, databases });
     } catch (err) {
       res.status(500).json({ error: (err as Error).message });
     }

--- a/cds/src/routes/releases.ts
+++ b/cds/src/routes/releases.ts
@@ -1,10 +1,11 @@
 import crypto from 'node:crypto';
-import { Router } from 'express';
+import { Router, type Request, type Response } from 'express';
 import type { StateService } from '../services/state.js';
 import type { ReleaseTarget } from '../types.js';
 import { ReleaseService } from '../services/release-service.js';
 import { releaseEvents } from '../services/release-events.js';
 import { resolveActorFromRequest } from '../services/actor-resolver.js';
+import { assertProjectAccess } from './projects.js';
 
 export interface ReleasesRouterDeps {
   stateService: StateService;
@@ -15,7 +16,8 @@ export function createReleasesRouter(deps: ReleasesRouterDeps): Router {
   const service = new ReleaseService(deps.stateService);
 
   router.get('/releases/targets', (req, res) => {
-    const projectId = typeof req.query.project === 'string' ? req.query.project : undefined;
+    const projectId = resolveReadableProjectId(req, res);
+    if (projectId === false) return;
     if (projectId) service.ensureDefaultPlans(projectId);
     res.json({
       targets: deps.stateService.getReleaseTargets(projectId),
@@ -34,6 +36,8 @@ export function createReleasesRouter(deps: ReleasesRouterDeps): Router {
 
   router.post('/releases/targets', (req, res) => {
     const body = (req.body || {}) as Record<string, unknown>;
+    const access = rejectProjectMismatch(req, res, typeof body.projectId === 'string' ? body.projectId : undefined);
+    if (access) return;
     const validation = validateSshTargetBody(body, false);
     if (validation) {
       res.status(400).json({ error: validation });
@@ -74,6 +78,7 @@ export function createReleasesRouter(deps: ReleasesRouterDeps): Router {
       res.status(404).json({ error: 'release target not found' });
       return;
     }
+    if (rejectProjectMismatch(req, res, existing.projectId)) return;
     const body = (req.body || {}) as Record<string, unknown>;
     const mergedBody = {
       projectId: existing.projectId,
@@ -94,6 +99,7 @@ export function createReleasesRouter(deps: ReleasesRouterDeps): Router {
       res.status(400).json({ error: validation });
       return;
     }
+    if (rejectProjectMismatch(req, res, typeof mergedBody.projectId === 'string' ? mergedBody.projectId : undefined)) return;
     const updated: ReleaseTarget = {
       ...existing,
       projectId: String(mergedBody.projectId).trim(),
@@ -114,6 +120,12 @@ export function createReleasesRouter(deps: ReleasesRouterDeps): Router {
   });
 
   router.delete('/releases/targets/:id', (req, res) => {
+    const existing = deps.stateService.getReleaseTarget(req.params.id);
+    if (!existing) {
+      res.status(404).json({ error: 'release target not found' });
+      return;
+    }
+    if (rejectProjectMismatch(req, res, existing.projectId)) return;
     const runs = deps.stateService.getReleaseRuns({ targetId: req.params.id });
     if (runs.length > 0) {
       res.status(409).json({ error: 'target has release runs and cannot be deleted' });
@@ -132,6 +144,7 @@ export function createReleasesRouter(deps: ReleasesRouterDeps): Router {
       res.status(400).json({ error: 'targetId is required' });
       return;
     }
+    if (rejectBranchAndTargetMismatch(req, res, deps.stateService, req.params.branchId, body.targetId.trim())) return;
     try {
       const result = await service.preflight({
         branchId: req.params.branchId,
@@ -151,6 +164,7 @@ export function createReleasesRouter(deps: ReleasesRouterDeps): Router {
       res.status(400).json({ error: 'targetId is required' });
       return;
     }
+    if (rejectBranchAndTargetMismatch(req, res, deps.stateService, req.params.branchId, body.targetId.trim())) return;
     try {
       const run = await service.startRelease({
         branchId: req.params.branchId,
@@ -165,9 +179,11 @@ export function createReleasesRouter(deps: ReleasesRouterDeps): Router {
   });
 
   router.get('/releases/runs', (req, res) => {
+    const projectId = resolveReadableProjectId(req, res);
+    if (projectId === false) return;
     res.json({
       runs: deps.stateService.getReleaseRuns({
-        projectId: typeof req.query.project === 'string' ? req.query.project : undefined,
+        projectId,
         targetId: typeof req.query.targetId === 'string' ? req.query.targetId : undefined,
         branchId: typeof req.query.branchId === 'string' ? req.query.branchId : undefined,
       }),
@@ -180,10 +196,17 @@ export function createReleasesRouter(deps: ReleasesRouterDeps): Router {
       res.status(404).json({ error: 'release run not found' });
       return;
     }
+    if (rejectProjectMismatch(req, res, run.projectId)) return;
     res.json({ run });
   });
 
   router.post('/releases/runs/:id/rollback', async (req, res) => {
+    const existing = deps.stateService.getReleaseRun(req.params.id);
+    if (!existing) {
+      res.status(404).json({ error: 'ReleaseRun not found' });
+      return;
+    }
+    if (rejectProjectMismatch(req, res, existing.projectId)) return;
     try {
       const run = await service.startRollback(req.params.id, resolveActorFromRequest(req));
       res.status(202).json({ run, streamUrl: `/api/releases/runs/${run.releaseId}/stream` });
@@ -198,6 +221,7 @@ export function createReleasesRouter(deps: ReleasesRouterDeps): Router {
       res.status(404).json({ error: 'release run not found' });
       return;
     }
+    if (rejectProjectMismatch(req, res, run.projectId)) return;
     const afterSeq = Number(req.query.afterSeq || 0);
     res.writeHead(200, {
       'Content-Type': 'text/event-stream',
@@ -227,7 +251,8 @@ export function createReleasesRouter(deps: ReleasesRouterDeps): Router {
   });
 
   router.get('/releases/center', (req, res) => {
-    const projectId = typeof req.query.project === 'string' ? req.query.project : undefined;
+    const projectId = resolveReadableProjectId(req, res);
+    if (projectId === false) return;
     if (projectId) service.ensureDefaultPlans(projectId);
     const targets = deps.stateService.getReleaseTargets(projectId);
     const runs = deps.stateService.getReleaseRuns(projectId ? { projectId } : {});
@@ -250,6 +275,39 @@ export function createReleasesRouter(deps: ReleasesRouterDeps): Router {
   });
 
   return router;
+}
+
+function requestProjectKey(req: Request): { projectId: string; keyId: string } | undefined {
+  return (req as unknown as { cdsProjectKey?: { projectId: string; keyId: string } }).cdsProjectKey;
+}
+
+function rejectProjectMismatch(req: Request, res: Response, projectId: string | undefined): boolean {
+  const mismatch = assertProjectAccess(req as unknown as { cdsProjectKey?: { projectId: string; keyId: string } }, projectId);
+  if (!mismatch) return false;
+  res.status(mismatch.status).json(mismatch.body);
+  return true;
+}
+
+function resolveReadableProjectId(req: Request, res: Response): string | undefined | false {
+  const queryProject = typeof req.query.project === 'string' ? req.query.project : undefined;
+  const projectKey = requestProjectKey(req);
+  const projectId = queryProject || projectKey?.projectId;
+  if (rejectProjectMismatch(req, res, projectId)) return false;
+  return projectId;
+}
+
+function rejectBranchAndTargetMismatch(
+  req: Request,
+  res: Response,
+  stateService: StateService,
+  branchId: string,
+  targetId: string,
+): boolean {
+  const branch = stateService.getBranch(branchId);
+  const target = stateService.getReleaseTarget(targetId);
+  if (rejectProjectMismatch(req, res, branch?.projectId)) return true;
+  if (rejectProjectMismatch(req, res, target?.projectId)) return true;
+  return false;
 }
 
 function validateSshTargetBody(body: Record<string, unknown>, allowExisting: boolean): string | null {

--- a/cds/src/services/release-service.ts
+++ b/cds/src/services/release-service.ts
@@ -82,6 +82,7 @@ export class ReleaseService {
     const push = (check: ReleasePreflightCheck): void => { checks.push(check); };
     const branch = this.stateService.getBranch(input.branchId);
     const target = this.stateService.getReleaseTarget(input.targetId);
+    const projectMismatch = Boolean(branch && target && branch.projectId !== target.projectId);
     const projectId = branch?.projectId || target?.projectId || 'default';
     const plan = this.ensureDefaultPlans(projectId).find((item) => item.template === 'ssh-script');
 
@@ -113,28 +114,42 @@ export class ReleaseService {
       push({ id: 'target', label: '发布目标', status: 'fail', message: `${target.name} 已禁用`, blocking: true });
     } else if (target.type !== 'ssh' || !target.ssh) {
       push({ id: 'target', label: '发布目标', status: 'fail', message: 'MVP 只支持 SSH ReleaseTarget', blocking: true });
+    } else if (projectMismatch) {
+      push({
+        id: 'project-scope',
+        label: '项目一致',
+        status: 'fail',
+        message: `分支属于 ${branch?.projectId || 'default'}，发布目标属于 ${target.projectId || 'default'}，禁止跨项目发布`,
+        blocking: true,
+      });
     } else {
       push({ id: 'target', label: '发布目标', status: 'pass', message: `${target.name} (${target.ssh.user}@${target.ssh.host}:${target.ssh.port})`, blocking: false });
     }
 
-    if (target?.ssh?.deployCommand?.trim()) {
+    const canProbeTarget = Boolean(target?.ssh && target.isEnabled && target.type === 'ssh' && !projectMismatch);
+
+    if (!projectMismatch && target?.ssh?.deployCommand?.trim()) {
       push({ id: 'deploy-command', label: 'deployCommand 已配置', status: 'pass', message: target.ssh.deployCommand.trim(), blocking: false });
-    } else {
+    } else if (!projectMismatch) {
       push({ id: 'deploy-command', label: 'deployCommand 已配置', status: 'fail', message: 'SSH target 缺少 deployCommand', blocking: true });
     }
 
-    if (target?.ssh?.healthcheckUrl?.trim()) {
-      try {
-        await probeHealthcheck(target.ssh.healthcheckUrl);
-        push({ id: 'healthcheck', label: 'healthcheckUrl 可用', status: 'pass', message: target.ssh.healthcheckUrl, blocking: false });
-      } catch (err) {
-        push({ id: 'healthcheck', label: 'healthcheckUrl 可用', status: 'fail', message: (err as Error).message, blocking: true });
+    if (!projectMismatch && target?.ssh?.healthcheckUrl?.trim()) {
+      if (canProbeTarget) {
+        try {
+          await probeHealthcheck(target.ssh.healthcheckUrl);
+          push({ id: 'healthcheck', label: 'healthcheckUrl 可用', status: 'pass', message: target.ssh.healthcheckUrl, blocking: false });
+        } catch (err) {
+          push({ id: 'healthcheck', label: 'healthcheckUrl 可用', status: 'fail', message: (err as Error).message, blocking: true });
+        }
+      } else {
+        push({ id: 'healthcheck', label: 'healthcheckUrl 可用', status: 'warn', message: '目标未启用，已跳过健康检查探测', blocking: false });
       }
-    } else {
+    } else if (!projectMismatch) {
       push({ id: 'healthcheck', label: 'healthcheckUrl 可用', status: 'fail', message: 'SSH target 缺少 healthcheckUrl', blocking: true });
     }
 
-    if (target?.ssh?.privateKeyRef) {
+    if (canProbeTarget && target?.ssh?.privateKeyRef) {
       const host = this.stateService.getRemoteHost(target.ssh.privateKeyRef);
       if (!host) {
         push({ id: 'ssh', label: '目标主机可连接', status: 'fail', message: `privateKeyRef 不存在: ${target.ssh.privateKeyRef}`, blocking: true });

--- a/cds/tests/routes/releases-scope.test.ts
+++ b/cds/tests/routes/releases-scope.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Project-scope isolation for the release control plane.
+ *
+ * A project-scoped cdsp_ key must not be able to create or run releases for
+ * another project. Release targets can execute SSH commands through saved
+ * RemoteHost private keys, so missing project guards here are high impact.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { createReleasesRouter } from '../../src/routes/releases.js';
+import { StateService } from '../../src/services/state.js';
+import type { BranchEntry, ReleaseRun, ReleaseTarget } from '../../src/types.js';
+
+async function request(
+  server: http.Server,
+  method: string,
+  urlPath: string,
+  headers?: Record<string, string>,
+  body?: unknown,
+): Promise<{ status: number; body: any }> {
+  return new Promise((resolve, reject) => {
+    const addr = server.address() as { port: number };
+    const data = body !== undefined ? JSON.stringify(body) : undefined;
+    const req = http.request({
+      hostname: '127.0.0.1',
+      port: addr.port,
+      path: urlPath,
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(data ? { 'Content-Length': Buffer.byteLength(data) } : {}),
+        ...(headers || {}),
+      },
+    }, (res) => {
+      let raw = '';
+      res.on('data', (chunk: Buffer) => (raw += chunk.toString()));
+      res.on('end', () => {
+        try { resolve({ status: res.statusCode!, body: raw ? JSON.parse(raw) : null }); }
+        catch { resolve({ status: res.statusCode!, body: raw }); }
+      });
+    });
+    req.on('error', reject);
+    if (data) req.write(data);
+    req.end();
+  });
+}
+
+describe('release control plane project-scope isolation', () => {
+  let tmpDir: string;
+  let stateService: StateService;
+  let server: http.Server;
+
+  const KEY_A = 'TEST-KEY-A';
+  const KEY_B = 'TEST-KEY-B';
+
+  function releaseTarget(id: string, projectId: string): ReleaseTarget {
+    const now = new Date().toISOString();
+    return {
+      id,
+      projectId,
+      name: `${projectId} target`,
+      type: 'ssh',
+      createdAt: now,
+      updatedAt: now,
+      isEnabled: true,
+      ssh: {
+        host: `${projectId}.example.test`,
+        port: 22,
+        user: 'deploy',
+        privateKeyRef: 'prod-host-key',
+        appPath: '/srv/app',
+        deployCommand: './deploy.sh',
+        rollbackCommand: './rollback.sh',
+        healthcheckUrl: `http://${projectId}.example.test/healthz`,
+      },
+    };
+  }
+
+  function branch(id: string, projectId: string): BranchEntry {
+    const now = new Date().toISOString();
+    return {
+      id,
+      projectId,
+      branch: 'main',
+      worktreePath: path.join(tmpDir, 'worktrees', id),
+      status: 'running',
+      createdAt: now,
+      lastDeployAt: now,
+      githubCommitSha: `${id}-commit`,
+      services: {},
+    };
+  }
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cds-release-scope-'));
+    stateService = new StateService(path.join(tmpDir, 'state.json'), tmpDir);
+    stateService.load();
+    const now = new Date().toISOString();
+    stateService.addProject({ id: 'proj-a', slug: 'a', name: 'A', kind: 'git', createdAt: now, updatedAt: now });
+    stateService.addProject({ id: 'proj-b', slug: 'b', name: 'B', kind: 'git', createdAt: now, updatedAt: now });
+    stateService.addBranch(branch('branch-a', 'proj-a'));
+    stateService.addBranch(branch('branch-b', 'proj-b'));
+    stateService.upsertReleaseTarget(releaseTarget('target-a', 'proj-a'));
+    stateService.upsertReleaseTarget(releaseTarget('target-b', 'proj-b'));
+    stateService.addReleaseRun({
+      releaseId: 'run-b',
+      projectId: 'proj-b',
+      branchId: 'branch-b',
+      commitSha: 'branch-b-commit',
+      artifact: { type: 'branch-preview', commitSha: 'branch-b-commit', branchId: 'branch-b', branchName: 'main', previewUrl: 'https://b.example.test' },
+      targetId: 'target-b',
+      planId: 'proj-b:ssh-script',
+      status: 'success',
+      startedAt: now,
+      logs: [],
+      seq: 0,
+    } as ReleaseRun);
+
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      const h = req.headers['x-test-key'] as string | undefined;
+      if (h === KEY_A) (req as any).cdsProjectKey = { projectId: 'proj-a', keyId: 'k-a' };
+      if (h === KEY_B) (req as any).cdsProjectKey = { projectId: 'proj-b', keyId: 'k-b' };
+      next();
+    });
+    app.use('/api', createReleasesRouter({ stateService }));
+
+    await new Promise<void>((resolve) => { server = app.listen(0, '127.0.0.1', resolve); });
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    if (fs.existsSync(tmpDir)) fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('filters release targets to the project key scope when no ?project is provided', async () => {
+    const res = await request(server, 'GET', '/api/releases/targets', { 'X-Test-Key': KEY_A });
+    expect(res.status).toBe(200);
+    expect(res.body.targets.map((target: ReleaseTarget) => target.id)).toEqual(['target-a']);
+  });
+
+  it('refuses Project A key creating a Project B SSH release target', async () => {
+    const res = await request(server, 'POST', '/api/releases/targets', { 'X-Test-Key': KEY_A }, {
+      id: 'target-b-hijack',
+      projectId: 'proj-b',
+      name: 'B hijack',
+      host: 'prod.example.test',
+      port: 22,
+      user: 'deploy',
+      privateKeyRef: 'prod-host-key',
+      appPath: '/srv/app',
+      deployCommand: 'echo hijacked',
+      healthcheckUrl: 'https://prod.example.test/healthz',
+    });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('project_mismatch');
+    expect(stateService.getReleaseTarget('target-b-hijack')).toBeUndefined();
+  });
+
+  it('refuses Project A key patching Project B target command', async () => {
+    const res = await request(server, 'PATCH', '/api/releases/targets/target-b', { 'X-Test-Key': KEY_A }, {
+      deployCommand: 'echo hijacked',
+    });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('project_mismatch');
+    expect(stateService.getReleaseTarget('target-b')!.ssh!.deployCommand).toBe('./deploy.sh');
+  });
+
+  it('refuses Project A key starting a Project B release run', async () => {
+    const res = await request(server, 'POST', '/api/releases/branches/branch-b/runs', { 'X-Test-Key': KEY_A }, {
+      targetId: 'target-b',
+      previewUrl: 'https://b.example.test',
+    });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('project_mismatch');
+    expect(stateService.getReleaseRuns({ branchId: 'branch-b' })).toHaveLength(1);
+  });
+
+  it('refuses Project A key reading a Project B release run directly', async () => {
+    const res = await request(server, 'GET', '/api/releases/runs/run-b', { 'X-Test-Key': KEY_A });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('project_mismatch');
+  });
+
+  it('blocks branch and target from different projects even for admin callers', async () => {
+    const res = await request(server, 'POST', '/api/releases/branches/branch-a/preflight', undefined, {
+      targetId: 'target-b',
+      previewUrl: 'https://a.example.test',
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.checks.some((check: { id: string; status: string }) => (
+      check.id === 'project-scope' && check.status === 'fail'
+    ))).toBe(true);
+  });
+});

--- a/cds/tests/routes/resource-db-access.test.ts
+++ b/cds/tests/routes/resource-db-access.test.ts
@@ -129,6 +129,47 @@ describe('resource database access', () => {
     if (tmpDir && fs.existsSync(tmpDir)) fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
+  it('selects an existing business MongoDB database when the configured default is missing', async () => {
+    const harness = makeHarness();
+    tmpDir = harness.tmpDir;
+    harness.stateService.addInfraService({
+      id: 'mongo-main',
+      projectId: 'prd-agent',
+      name: 'mongo-main',
+      dockerImage: 'mongo:7',
+      containerPort: 27017,
+      hostPort: 27017,
+      containerName: 'cds-mongo-main',
+      status: 'running',
+      dbName: 'app',
+      env: {
+        MONGO_INITDB_ROOT_USERNAME: 'app',
+        MONGO_INITDB_ROOT_PASSWORD: 'pw',
+        MONGO_INITDB_DATABASE: 'app',
+      },
+      volumes: [],
+    });
+    harness.shell.addResponsePattern(/listDatabases/, () => ({
+      stdout: '[{"name":"admin","sizeOnDisk":0},{"name":"config","sizeOnDisk":0},{"name":"local","sizeOnDisk":0},{"name":"prdagent","sizeOnDisk":4096}]\n',
+      stderr: '',
+      exitCode: 0,
+    }));
+    harness.shell.addResponsePattern(/.*/, () => ({ stdout: '', stderr: '', exitCode: 0 }));
+    await new Promise<void>((resolve) => {
+      server = harness.app.listen(0, '127.0.0.1', resolve);
+    });
+
+    const res = await request(
+      server!,
+      'GET',
+      '/api/branches/main-branch/resources/infra%3Amongo-main/data/mongo/databases',
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.configuredDatabase).toBe('app');
+    expect(res.body.currentDatabase).toBe('prdagent');
+  });
+
   it('queries MongoDB collections against the selected database', async () => {
     const harness = makeHarness();
     tmpDir = harness.tmpDir;

--- a/cds/web/src/components/BranchDetailDrawer.tsx
+++ b/cds/web/src/components/BranchDetailDrawer.tsx
@@ -3417,6 +3417,16 @@ interface MongoCollectionSummary {
   type?: string;
 }
 
+const SYSTEM_MONGO_DATABASES = new Set(['admin', 'config', 'local']);
+
+function chooseMongoDatabase(databases: MongoDatabaseSummary[], preferredDatabase?: string, currentDatabase?: string): string {
+  const names = new Set(databases.map((database) => database.name));
+  if (currentDatabase && names.has(currentDatabase)) return currentDatabase;
+  if (preferredDatabase && names.has(preferredDatabase)) return preferredDatabase;
+  const businessDatabase = databases.find((database) => !SYSTEM_MONGO_DATABASES.has(database.name));
+  return businessDatabase?.name || databases[0]?.name || preferredDatabase || '';
+}
+
 function highlightedCode(value: string, language: 'sql' | 'json'): ReactNode[] {
   const pattern = language === 'sql'
     ? /\b(select|from|where|insert|into|values|update|set|delete|create|alter|drop|truncate|replace|table|index|view|limit|order|by|group|join|left|right|inner|outer|on|and|or|null|not|primary|key|default|describe|show|explain)\b|('[^']*'|"[^"]*"|`[^`]*`)|(--.*$)|(\b\d+(?:\.\d+)?\b)/gim
@@ -3497,10 +3507,11 @@ function tryFormatJsonText(value: string): string {
 }
 
 function MongoResourceDataPanel({ resource }: { resource: BranchResource }): JSX.Element {
-  const [databasesState, setDatabasesState] = useState<{ status: 'idle' | 'loading' | 'ok' | 'error'; databases: MongoDatabaseSummary[]; currentDatabase?: string; message?: string }>({ status: 'idle', databases: [] });
+  const [databasesState, setDatabasesState] = useState<{ status: 'idle' | 'loading' | 'ok' | 'error'; databases: MongoDatabaseSummary[]; currentDatabase?: string; configuredDatabase?: string; message?: string }>({ status: 'idle', databases: [] });
   const [collectionsState, setCollectionsState] = useState<{ status: 'idle' | 'loading' | 'ok' | 'error'; collections: MongoCollectionSummary[]; database?: string; message?: string }>({ status: 'idle', collections: [] });
   const [selectedDatabase, setSelectedDatabase] = useState('');
   const [selectedCollection, setSelectedCollection] = useState('');
+  const selectedDatabaseRef = useRef('');
   const [documentsState, setDocumentsState] = useState<{ status: 'idle' | 'loading' | 'ok' | 'error'; documents: unknown[]; message?: string }>({ status: 'idle', documents: [] });
   const [mode, setMode] = useState<'browse' | 'query' | 'mutate'>('browse');
   const [filter, setFilter] = useState('{}');
@@ -3517,15 +3528,27 @@ function MongoResourceDataPanel({ resource }: { resource: BranchResource }): JSX
     ? `/api/branches/${encodeURIComponent(resource.branchId)}/resources/${encodeURIComponent(resource.id)}/data/mongo`
     : '';
 
+  useEffect(() => {
+    selectedDatabaseRef.current = selectedDatabase;
+  }, [selectedDatabase]);
+
   const loadDatabases = useCallback(async () => {
     if (!basePath) return;
     setDatabasesState((current) => ({ ...current, status: 'loading', message: undefined }));
     try {
-      const res = await apiRequest<{ currentDatabase?: string; databases: MongoDatabaseSummary[] }>(`${basePath}/databases`);
+      const res = await apiRequest<{ currentDatabase?: string; configuredDatabase?: string; databases: MongoDatabaseSummary[] }>(`${basePath}/databases`);
       const databases = res.databases || [];
-      const currentDatabase = res.currentDatabase || databases[0]?.name || '';
-      setDatabasesState({ status: 'ok', databases, currentDatabase });
-      setSelectedDatabase((current) => current || currentDatabase);
+      const currentDatabase = chooseMongoDatabase(databases, res.currentDatabase, selectedDatabaseRef.current);
+      setDatabasesState({ status: 'ok', databases, currentDatabase, configuredDatabase: res.configuredDatabase });
+      setSelectedDatabase((current) => {
+        const nextDatabase = chooseMongoDatabase(databases, res.currentDatabase, current);
+        if (nextDatabase !== current) {
+          setSelectedCollection('');
+          setCollectionsState({ status: 'idle', collections: [], database: nextDatabase });
+          setDocumentsState({ status: 'idle', documents: [] });
+        }
+        return nextDatabase;
+      });
     } catch (err) {
       setDatabasesState({ status: 'error', databases: [], message: err instanceof ApiError ? err.message : String(err) });
     }
@@ -3629,6 +3652,12 @@ function MongoResourceDataPanel({ resource }: { resource: BranchResource }): JSX
   const writeTargetCollection = writeAction === 'createCollection' || writeAction === 'dropCollection'
     ? writeCollection.trim()
     : selectedCollection;
+  const databaseLabel = selectedDatabase || databasesState.currentDatabase || '-';
+  const configuredDatabaseNotice = databasesState.configuredDatabase && databaseLabel !== '-' && databasesState.configuredDatabase !== databaseLabel
+    ? `配置默认库 ${databasesState.configuredDatabase} 暂未创建，已选中 ${databaseLabel}`
+    : databasesState.configuredDatabase
+      ? `默认库 ${databasesState.configuredDatabase}`
+      : '';
 
   return (
     <div className="space-y-4 text-sm">
@@ -3636,7 +3665,8 @@ function MongoResourceDataPanel({ resource }: { resource: BranchResource }): JSX
         <div className="flex flex-wrap items-center justify-between gap-3 border-b border-[hsl(var(--hairline))] px-3 py-2">
           <div>
             <div className="text-xs font-semibold">MongoDB Workbench</div>
-            <div className="mt-0.5 font-mono text-[11px] text-muted-foreground">{selectedDatabase || databasesState.currentDatabase || '-'}.{selectedCollection || '-'}</div>
+            <div className="mt-0.5 font-mono text-[11px] text-muted-foreground">{databaseLabel}.{selectedCollection || '-'}</div>
+            {configuredDatabaseNotice ? <div className="mt-1 text-[11px] text-muted-foreground">{configuredDatabaseNotice}</div> : null}
           </div>
           <div className="flex items-center gap-2">
             {(['browse', 'query', 'mutate'] as const).map((item) => (
@@ -3665,10 +3695,15 @@ function MongoResourceDataPanel({ resource }: { resource: BranchResource }): JSX
                   key={db.name}
                   type="button"
                   className={`inline-flex h-8 shrink-0 items-center gap-2 rounded-md border px-3 text-xs ${db.name === selectedDatabase ? 'border-primary bg-primary/10 text-foreground' : 'border-[hsl(var(--hairline))] text-muted-foreground hover:text-foreground'}`}
-                  onClick={() => setSelectedDatabase(db.name)}
+                  onClick={() => {
+                    setSelectedCollection('');
+                    setCollectionsState({ status: 'idle', collections: [], database: db.name });
+                    setDocumentsState({ status: 'idle', documents: [] });
+                    setSelectedDatabase(db.name);
+                  }}
                 >
                   <span className="font-mono">{db.name}</span>
-                  <span>{db.sizeOnDisk ? formatBytes(db.sizeOnDisk) : '-'}</span>
+                  <span>{formatBytes(db.sizeOnDisk || 0)}</span>
                 </button>
               )) : (
                 <div className="text-xs text-muted-foreground">{databasesState.status === 'loading' ? '读取数据库...' : databasesState.message || '没有数据库信息。'}</div>
@@ -3695,7 +3730,13 @@ function MongoResourceDataPanel({ resource }: { resource: BranchResource }): JSX
                   <span>{collection.type || 'collection'}</span>
                 </button>
               )) : (
-                <div className="text-xs text-muted-foreground">{collectionsState.status === 'loading' ? '读取 collection...' : '没有 collection。'}</div>
+                <div className="text-xs text-muted-foreground">
+                  {collectionsState.status === 'loading'
+                    ? '读取 collection...'
+                    : selectedDatabase
+                      ? `${selectedDatabase} 暂无 collection。可在「写入 / 结构」里创建 collection，或切换其他数据库。`
+                      : '请选择数据库。'}
+                </div>
               )}
             </div>
           </div>

--- a/cds/web/src/index.css
+++ b/cds/web/src/index.css
@@ -326,70 +326,35 @@
     animation-delay: 0.36s;
   }
 
-  .cds-actor-orbit {
-    position: relative;
-    display: grid;
-    place-items: center;
-    width: 28px;
-    height: 28px;
-    overflow: visible;
+  .cds-actor-name-glow {
+    animation: cds-actor-name-breathe 1.85s ease-in-out infinite;
+    text-shadow:
+      0 0 8px var(--cds-actor-name-glow),
+      0 0 18px var(--cds-actor-name-glow-soft);
   }
 
-  .cds-actor-orbit--active {
-    width: 54px;
-    height: 54px;
-    margin-block: -8px -6px;
+  .cds-actor-name-glow--ai {
+    color: rgb(94 234 212 / 0.92);
+    --cds-actor-name-glow: rgb(45 212 191 / 0.62);
+    --cds-actor-name-glow-soft: rgb(20 184 166 / 0.34);
   }
 
-  .cds-actor-orbit__avatar {
-    z-index: 2;
-  }
-
-  .cds-actor-orbit__ring {
-    position: absolute;
-    inset: 0;
-    z-index: 1;
+  .cds-actor-name-glow--build {
     color: rgb(125 211 252 / 0.92);
-    filter: drop-shadow(0 0 5px rgb(56 189 248 / 0.5));
-    pointer-events: none;
-    animation: cds-actor-orbit-spin 12s linear infinite;
+    --cds-actor-name-glow: rgb(56 189 248 / 0.58);
+    --cds-actor-name-glow-soft: rgb(14 165 233 / 0.3);
   }
 
-  .cds-actor-orbit--ai .cds-actor-orbit__ring {
-    color: rgb(45 212 191 / 0.96);
-    filter: drop-shadow(0 0 6px rgb(20 184 166 / 0.58));
+  .cds-actor-name-glow--warning {
+    color: rgb(251 191 36 / 0.9);
+    --cds-actor-name-glow: rgb(245 158 11 / 0.5);
+    --cds-actor-name-glow-soft: rgb(217 119 6 / 0.28);
   }
 
-  .cds-actor-orbit--build .cds-actor-orbit__ring {
-    color: rgb(125 211 252 / 0.94);
-    filter: drop-shadow(0 0 6px rgb(56 189 248 / 0.58));
-  }
-
-  .cds-actor-orbit--warning .cds-actor-orbit__ring {
-    color: rgb(251 191 36 / 0.96);
-    filter: drop-shadow(0 0 6px rgb(245 158 11 / 0.52));
-  }
-
-  .cds-actor-orbit--danger .cds-actor-orbit__ring {
-    color: rgb(248 113 113 / 0.96);
-    filter: drop-shadow(0 0 6px rgb(239 68 68 / 0.52));
-  }
-
-  .cds-actor-orbit__char {
-    position: absolute;
-    left: 50%;
-    top: 50%;
-    width: 8px;
-    margin-left: -4px;
-    margin-top: -4px;
-    text-align: center;
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
-    font-size: 7px;
-    font-weight: 700;
-    line-height: 8px;
-    letter-spacing: 0;
-    text-transform: uppercase;
-    transform-origin: 50% 50%;
+  .cds-actor-name-glow--danger {
+    color: rgb(248 113 113 / 0.9);
+    --cds-actor-name-glow: rgb(239 68 68 / 0.52);
+    --cds-actor-name-glow-soft: rgb(220 38 38 / 0.28);
   }
 
   [data-theme='light'] .cds-ai-preview-beacon {
@@ -489,8 +454,19 @@
     }
   }
 
-  @keyframes cds-actor-orbit-spin {
-    to { transform: rotate(360deg); }
+  @keyframes cds-actor-name-breathe {
+    0%, 100% {
+      opacity: 0.74;
+      text-shadow:
+        0 0 4px var(--cds-actor-name-glow),
+        0 0 12px var(--cds-actor-name-glow-soft);
+    }
+    50% {
+      opacity: 1;
+      text-shadow:
+        0 0 9px var(--cds-actor-name-glow),
+        0 0 22px var(--cds-actor-name-glow-soft);
+    }
   }
 
   @keyframes cds-site-notice-pulse {
@@ -511,7 +487,7 @@
     .cds-ai-preview-beacon svg,
     .cds-ai-active-card .cds-ai-kinetic-icon,
     .cds-ai-active-card .cds-ai-kinetic-dot,
-    .cds-actor-orbit__ring,
+    .cds-actor-name-glow,
     .cds-site-notice-trigger--active {
       animation: none;
     }

--- a/cds/web/src/pages/BranchListPage.tsx
+++ b/cds/web/src/pages/BranchListPage.tsx
@@ -731,34 +731,6 @@ function rememberAvatarStatus(url: string, status: 'loaded' | 'failed'): void {
   writeAvatarStorage(url, status);
 }
 
-function circularActorText(value: string): string {
-  const base = (value || '').trim() || 'CDS';
-  const compact = base.replace(/\s+/g, '');
-  const clipped = compact.length > 18 ? compact.slice(0, 18) : compact;
-  return `${clipped} • ${clipped} •`;
-}
-
-function CircularActorText({ text }: { text: string }): JSX.Element {
-  const chars = Array.from(circularActorText(text));
-  return (
-    <span className="cds-actor-orbit__ring" aria-hidden>
-      {chars.map((char, index) => {
-        const angle = (360 / chars.length) * index;
-        return (
-          <span
-            // eslint-disable-next-line react/no-array-index-key
-            key={`${char}-${index}`}
-            className="cds-actor-orbit__char"
-            style={{ transform: `rotate(${angle}deg) translateY(-23px) rotate(90deg)` }}
-          >
-            {char}
-          </span>
-        );
-      })}
-    </span>
-  );
-}
-
 function formatBytesFromMB(value?: number): string {
   if (!value || value <= 0) return '未知';
   if (value >= 1024) return `${Math.round(value / 102.4) / 10} GB`;
@@ -4431,14 +4403,22 @@ function BranchCard({
   const [commitHistoryState, setCommitHistoryState] = useState<
     { status: 'idle' | 'loading' | 'ok' | 'error'; commits: BranchCommitSummary[]; message?: string }
   >({ status: 'idle', commits: [] });
-  const actorOrbitVisible = Boolean(footerBuilder) && (isInterim || action?.status === 'running' || isAiActive);
-  const actorOrbitTone = isError || action?.status === 'error'
+  const actorNameGlowVisible = Boolean(footerBuilder) && (isInterim || action?.status === 'running' || isAiActive);
+  const actorNameGlowTone = isError || action?.status === 'error'
     ? 'danger'
     : isAiActive
       ? 'ai'
       : branch.status === 'stopping' || action?.kind === 'stop'
         ? 'warning'
         : 'build';
+  const actorNameGlowClass = actorNameGlowVisible
+    ? {
+      ai: 'cds-actor-name-glow cds-actor-name-glow--ai',
+      build: 'cds-actor-name-glow cds-actor-name-glow--build',
+      warning: 'cds-actor-name-glow cds-actor-name-glow--warning',
+      danger: 'cds-actor-name-glow cds-actor-name-glow--danger',
+    }[actorNameGlowTone]
+    : 'text-foreground/70';
   useEffect(() => {
     if (!tagEditorOpen) return;
     const frame = window.requestAnimationFrame(() => tagInputRef.current?.focus());
@@ -5029,10 +5009,8 @@ function BranchCard({
         <div className="relative min-w-0 pr-2 text-muted-foreground">
           <div className="flex min-w-0 items-center gap-3">
             <div className="flex min-w-[54px] max-w-[94px] shrink-0 flex-col items-center gap-1" title={builderTitle}>
-            <div className={`cds-actor-orbit ${actorOrbitVisible ? `cds-actor-orbit--active cds-actor-orbit--${actorOrbitTone}` : ''}`}>
-              {actorOrbitVisible && footerBuilder ? <CircularActorText text={footerBuilder} /> : null}
               <div
-                className="cds-actor-orbit__avatar relative flex h-7 w-7 items-center justify-center overflow-hidden rounded-full border border-[hsl(var(--hairline-strong))] bg-[hsl(var(--surface-raised))] text-[11px] font-semibold text-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
+                className="relative flex h-7 w-7 items-center justify-center overflow-hidden rounded-full border border-[hsl(var(--hairline-strong))] bg-[hsl(var(--surface-raised))] text-[11px] font-semibold text-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
                 aria-label={builderTitle}
               >
                 <span className="absolute inset-0 flex items-center justify-center" aria-hidden>
@@ -5055,39 +5033,38 @@ function BranchCard({
                   />
                 ) : null}
               </div>
+              {footerBuilder ? (
+                <span className={`block max-w-full break-all text-center text-[10px] font-medium leading-tight ${actorNameGlowClass}`}>
+                  {footerBuilder}
+                </span>
+              ) : null}
             </div>
-            {footerBuilder && !actorOrbitVisible ? (
-              <span className="block max-w-full break-all text-center text-[10px] font-medium leading-tight text-foreground/70">
-                {footerBuilder}
-              </span>
-            ) : null}
-          </div>
             <div className="relative flex min-w-0 flex-1 items-center gap-2">
-            {footerSha ? (
-              <span className="shrink-0 rounded border border-[hsl(var(--hairline))] bg-[hsl(var(--surface-raised))]/70 px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground" title={`commit ${footerSha}`}>
-                {footerSha}
-              </span>
-            ) : null}
-            {footerSubject ? (
-              <span className="min-w-0 flex-1 truncate text-sm" title={footerSubject}>
-                {footerSubject}
-              </span>
-            ) : (
-              <span className="min-w-0 flex-1" aria-hidden />
-            )}
-            <button
-              type="button"
-              className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
-              title="查看提交历史"
-              aria-label={`${branch.branch} 提交历史`}
-              aria-expanded={commitMenuOpen}
-              onClick={(event) => {
-                event.stopPropagation();
-                void toggleCommitMenu();
-              }}
-            >
-              <ChevronDown className={`h-3.5 w-3.5 transition-transform ${commitMenuOpen ? 'rotate-180' : ''}`} />
-            </button>
+              {footerSha ? (
+                <span className="shrink-0 rounded border border-[hsl(var(--hairline))] bg-[hsl(var(--surface-raised))]/70 px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground" title={`commit ${footerSha}`}>
+                  {footerSha}
+                </span>
+              ) : null}
+              {footerSubject ? (
+                <span className="min-w-0 flex-1 truncate text-sm" title={footerSubject}>
+                  {footerSubject}
+                </span>
+              ) : (
+                <span className="min-w-0 flex-1" aria-hidden />
+              )}
+              <button
+                type="button"
+                className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+                title="查看提交历史"
+                aria-label={`${branch.branch} 提交历史`}
+                aria-expanded={commitMenuOpen}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  void toggleCommitMenu();
+                }}
+              >
+                <ChevronDown className={`h-3.5 w-3.5 transition-transform ${commitMenuOpen ? 'rotate-180' : ''}`} />
+              </button>
             </div>
           </div>
           {commitHistoryPanel}

--- a/cds/web/src/pages/BranchListPage.tsx
+++ b/cds/web/src/pages/BranchListPage.tsx
@@ -4787,15 +4787,14 @@ function BranchCard({
           // (端口监听了不代表流量已通,容易给用户"绿色=就绪"的错觉);
           // running 时才用 service 自身状态做精细化区分。
           const chipStatus = isInterim || isError ? branch.status : resource.status;
-          const chipClass = isError ? issueClass : statusClass(chipStatus);
           const chipRailClass = isError ? issueRailClass : statusRailClass(chipStatus);
           return (
             <button
               key={resource.id}
               type="button"
-              className={`inline-flex h-6 shrink-0 items-center gap-1.5 rounded-md border px-2 text-xs transition-[background-color,border-color,box-shadow] hover:border-primary/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/55 ${chipClass} ${
+              className={`inline-flex h-6 shrink-0 items-center gap-1.5 rounded-md border border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))]/35 px-2 text-xs text-muted-foreground/80 opacity-90 transition-[background-color,border-color,color,opacity] hover:border-[hsl(var(--hairline-strong))] hover:bg-[hsl(var(--surface-sunken))]/55 hover:text-foreground hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 ${
                 resource.access === 'external'
-                  ? 'shadow-[0_0_0_1px_rgba(56,189,248,0.28),0_0_16px_-8px_rgba(56,189,248,0.85)] ring-1 ring-sky-400/35'
+                  ? 'ring-1 ring-[hsl(var(--hairline))]'
                   : ''
               }`}
               title={`${resource.displayName}\n${resource.serviceName}${resource.containerName ? ` · ${resource.containerName}` : ''}\n点击打开资源面板`}
@@ -4805,9 +4804,9 @@ function BranchCard({
                 onResourcePanel?.(resource);
               }}
             >
-              <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${chipRailClass}`} aria-hidden />
-              {chipDisplay.icon ? <ResourceIcon resource={resource} className="h-3.5 w-3.5 shrink-0" /> : null}
-              {chipDisplay.port ? <span className="font-mono text-muted-foreground">:{resource.port}</span> : null}
+              <span className={`h-1.5 w-1.5 shrink-0 rounded-full opacity-65 ${chipRailClass}`} aria-hidden />
+              {chipDisplay.icon ? <ResourceIcon resource={resource} className="h-3.5 w-3.5 shrink-0 opacity-70 saturate-50" /> : null}
+              {chipDisplay.port ? <span className="font-mono text-muted-foreground/80">:{resource.port}</span> : null}
             </button>
           );
         }) : (

--- a/cds/web/src/pages/BranchListPage.tsx
+++ b/cds/web/src/pages/BranchListPage.tsx
@@ -4384,6 +4384,16 @@ function BranchCard({
   const timeBadge = branchTimeBadge(branch, now, busySince);
   const origin = branchOriginBadge(branch);
   const runtime = branchRuntimeBadge(branch);
+  const runtimeIconClass = runtime?.kind === 'pending'
+    ? 'text-amber-500'
+    : runtime?.kind === 'mixed'
+      ? 'text-violet-500'
+      : runtime?.kind === 'release'
+        ? 'text-emerald-500'
+        : 'text-sky-500';
+  const runtimeIconTitle = runtime
+    ? `${runtime.label}: ${runtime.title}\n来源: ${origin.label} — ${origin.title}`
+    : `源码版: 源码 / 热加载\n来源: ${origin.label} — ${origin.title}`;
   const role = branchVisualRole(branch.branch);
   const roleCardClass = branchRoleCardClass(role);
   const issueLabel = isError ? branchIssueLabel(branch) : '';
@@ -4557,10 +4567,19 @@ function BranchCard({
           - 分支名给最大宽度,truncate(必要时 hover 显示完整) */}
       <header className="flex min-w-0 items-start justify-between gap-3 px-5 pt-5">
         <div className="flex min-w-0 flex-1 items-start gap-3">
-          <Github
-            className={`mt-1.5 h-4 w-4 shrink-0 text-sky-500 ${isAiActive ? 'cds-ai-kinetic-icon cds-ai-delay-0' : isInterim ? 'animate-pulse' : ''}`}
-            aria-hidden
-          />
+          <span className="mt-1.5 shrink-0" title={runtimeIconTitle}>
+            {runtime ? (
+              <Rocket
+                className={`h-4 w-4 ${runtimeIconClass} ${isAiActive ? 'cds-ai-kinetic-icon cds-ai-delay-0' : isInterim ? 'animate-pulse' : ''}`}
+                aria-label={runtime.label}
+              />
+            ) : (
+              <Github
+                className={`h-4 w-4 ${runtimeIconClass} ${isAiActive ? 'cds-ai-kinetic-icon cds-ai-delay-0' : isInterim ? 'animate-pulse' : ''}`}
+                aria-label="源码版"
+              />
+            )}
+          </span>
           <div className="min-w-0 flex-1">
             <div className="flex min-w-0 items-center gap-1.5">
               <h3
@@ -4596,27 +4615,6 @@ function BranchCard({
                   AI
                 </button>
               ) : null}
-              {/*
-                2026-05-14：标题行的徽章从「Webhook / 手动」改为分支当前的「运行模式」
-                （发布版 / 源码 / 混合）。用户更关心的是"这个分支跑的是热加载还是 publish"，
-                而不是"来源是 webhook 还是手动"。来源信息降级到 title attribute（hover 看到）。
-                发布相关运行模式带火箭图标；源码只保留普通文字，避免误导成发布态。
-              */}
-              {runtime ? (
-                <span
-                  className={`inline-flex h-5 w-6 shrink-0 items-center justify-center rounded border text-[10px] font-medium ${runtime.className}`}
-                  title={`${runtime.title}\n来源: ${origin.label} — ${origin.title}`}
-                >
-                  <Rocket className={isAiActive ? 'cds-ai-kinetic-icon cds-ai-delay-2 h-2.5 w-2.5' : 'h-2.5 w-2.5'} aria-hidden />
-                </span>
-              ) : (
-                <span
-                  className="inline-flex h-5 w-6 shrink-0 items-center justify-center rounded border border-[hsl(var(--hairline))] text-[10px] font-medium text-muted-foreground"
-                  title={`运行模式: 源码 / 热加载\n来源: ${origin.label} — ${origin.title}`}
-                >
-                  <Github className="h-2.5 w-2.5" aria-hidden />
-                </span>
-              )}
             </div>
           </div>
         </div>

--- a/cds/web/src/pages/BranchListPage.tsx
+++ b/cds/web/src/pages/BranchListPage.tsx
@@ -5115,7 +5115,7 @@ function BranchCard({
               aria-label="发布到目标"
               className="border-emerald-500/35 bg-emerald-500/10 text-emerald-500 hover:bg-emerald-500/15 hover:text-emerald-500"
             >
-              <Rocket />
+              <ExternalLink />
             </Button>
           ) : null}
           {isRunning ? (

--- a/cds/web/src/pages/BranchListPage.tsx
+++ b/cds/web/src/pages/BranchListPage.tsx
@@ -4770,7 +4770,7 @@ function BranchCard({
             <button
               key={resource.id}
               type="button"
-              className={`inline-flex h-6 shrink-0 items-center gap-1.5 rounded-md border border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))]/35 px-2 text-xs text-muted-foreground/80 opacity-90 transition-[background-color,border-color,color,opacity] hover:border-[hsl(var(--hairline-strong))] hover:bg-[hsl(var(--surface-sunken))]/55 hover:text-foreground hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 ${
+              className={`inline-flex h-6 shrink-0 items-center gap-1.5 rounded-md border border-[hsl(var(--hairline-strong))] bg-[hsl(var(--surface-raised))]/60 px-2 text-xs text-foreground/75 transition-[background-color,border-color,color] hover:border-primary/35 hover:bg-[hsl(var(--surface-raised))]/75 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 ${
                 resource.access === 'external'
                   ? 'ring-1 ring-[hsl(var(--hairline))]'
                   : ''
@@ -4782,9 +4782,9 @@ function BranchCard({
                 onResourcePanel?.(resource);
               }}
             >
-              <span className={`h-1.5 w-1.5 shrink-0 rounded-full opacity-65 ${chipRailClass}`} aria-hidden />
-              {chipDisplay.icon ? <ResourceIcon resource={resource} className="h-3.5 w-3.5 shrink-0 opacity-70 saturate-50" /> : null}
-              {chipDisplay.port ? <span className="font-mono text-muted-foreground/80">:{resource.port}</span> : null}
+              <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${chipRailClass}`} aria-hidden />
+              {chipDisplay.icon ? <ResourceIcon resource={resource} className="h-3.5 w-3.5 shrink-0 opacity-90 saturate-90" /> : null}
+              {chipDisplay.port ? <span className="font-mono text-foreground/75">:{resource.port}</span> : null}
             </button>
           );
         }) : (


### PR DESCRIPTION
## Summary

修复 CDS release control plane 的项目级 Agent Key 越权问题。

## Root Cause

新增的 `/api/releases/*` 路由没有复用 `assertProjectAccess`。项目 A 的 `cdsp_` key 可以创建、修改、读取或启动项目 B 的 release target/run。由于 SSH release target 会通过已登记的 `RemoteHost` 私钥执行配置的发布命令，这会扩大到跨项目发布目标控制。

## Changes

- 在 release target、run、rollback、stream、center 等路由入口补项目级 key scope guard。
- 项目级 key 无 `?project` 时自动收窄到自身项目，跨项目 `?project` 返回 `403 project_mismatch`。
- 在 `ReleaseService.preflight` 增加 branch/target 项目一致性检查，并在跨项目或禁用目标时跳过外部 healthcheck/SSH 探测。
- 新增 `releases-scope` 回归测试，覆盖创建、修改、读取、启动 release 和 admin 跨项目组合。

## Validation

- `npm --prefix cds test -- tests/routes/releases-scope.test.ts tests/routes/agent-keys.test.ts tests/routes/infra-data-scope.test.ts`
- `npm --prefix cds run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Release routes now gate SSH deploy/rollback paths that use stored private keys; incorrect guards could block legitimate releases or leave gaps, though new tests target the prior cross-project hijack scenario.
> 
> **Overview**
> **Release control plane:** `/api/releases/*` now enforces project scope via `assertProjectAccess`. Project-scoped `cdsp_` keys cannot create, patch, delete, read, stream, or start releases for another project; list/center endpoints resolve project from the key when `?project` is omitted and return `403 project_mismatch` on cross-project access. Preflight/start paths also verify branch and target share the same project. `ReleaseService.preflight` adds a blocking **项目一致** check and skips healthcheck/SSH probes when branch/target projects differ or the target is not probe-safe.
> 
> **MongoDB workbench:** When the configured default database does not exist on the server, API and UI pick an existing non-system business database (e.g. `prdagent` instead of missing `app`), expose `configuredDatabase` vs `currentDatabase`, and surface a notice in the drawer.
> 
> **Branch list UI:** Replaces circular “actor orbit” with a breathing glow on the builder name; moves runtime mode (rocket vs GitHub) to the card header; softens resource port chips; release action uses an external-link icon.
> 
> **Tests:** New `releases-scope` suite plus a Mongo database-selection case in `resource-db-access`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dba5660b3cad521c21fa255196e22f99984fbb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->