### PR TITLE
网页分享数字短链改为按需懒分配

### DIFF
--- a/changelogs/2026-06-11_web-share-shortlink-lazy.md
+++ b/changelogs/2026-06-11_web-share-shortlink-lazy.md
@@ -1,0 +1,3 @@
+| fix | prd-api | 网页托管分享数字短链改为按需懒分配，默认创建只发不可枚举的 /s/wp/{token} 长链，不再无脑写入 short_links 集合 |
+| feat | prd-api | 新增 POST /api/web-pages/shares/{shareId}/short-link 端点，支持事后为已存在分享按需生成数字短链（幂等） |
+| fix | prd-admin | 分享管理面板主链接/复制/预览默认走字母长链，修复「用户没选数字短链却总拿到 /s/{seq} 数字链」问题；数字短链改为单独「生成/复制」按钮主动获取 |

--- a/prd-admin/src/pages/WebPagesPage.tsx
+++ b/prd-admin/src/pages/WebPagesPage.tsx
@@ -19,6 +19,7 @@ import {
   listSiteTags,
   createSiteShareLink,
   listSiteShares,
+  ensureSiteShareShortLink,
   revokeSiteShare,
   renewSiteShare,
   listShareViewLogs,
@@ -63,6 +64,7 @@ import {
   FolderOpen,
   Eye,
   Copy,
+  Hash,
   Check,
   X,
   Lock,
@@ -2585,6 +2587,10 @@ function ShareDialog({ siteId, siteIds, onClose, onCreated }: {
         // 用户在面板中显式新建（PR 2026-05-28）：跳过服务端复用，每次都换新 token
         forceNew: true,
         visibility,
+        // 数字短链按需分配（2026-06-11）：只有用户在高级选项里主动选「数字短链」才生成
+        // /s/{seq}，否则后端不写 short_links，只发不可枚举的 /s/wp/{token} 长链——
+        // 杜绝「用户没选短链却拿到数字链」+「管理员短链页冒出几百条」。
+        allocateShortLink: isShort,
       });
       if (res.success) {
         onCreated?.();
@@ -3007,13 +3013,39 @@ function SharesPanel({ shares, setShares, onClose, scopedSiteId, scopedSiteTitle
     }
   };
 
-  const shareUrlOf = (s: ShareLinkItem) =>
-    s.shortSeq && s.shortSeq > 0
-      ? `${window.location.origin}/s/${s.shortSeq}`
-      : `${window.location.origin}/s/wp/${s.token}`;
+  // 主链接恒为不可枚举的字母长链 /s/wp/{token}（2026-06-11）：
+  // 用户创建时默认选的就是长链，复制/点击/预览都应给长链，不再因「后端碰巧分配了
+  // shortSeq」就把数字短链当主链返回——那正是「我没选数字短链却总拿到数字链」的根因。
+  // 数字短链 /s/{seq} 仅作为用户主动生成后的次级可选项单独展示。
+  const shareUrlOf = (s: ShareLinkItem) => `${window.location.origin}/s/wp/${s.token}`;
+  const shortUrlOf = (s: ShareLinkItem) =>
+    s.shortSeq && s.shortSeq > 0 ? `${window.location.origin}/s/${s.shortSeq}` : null;
 
   const handleCopy = (s: ShareLinkItem) => {
     navigator.clipboard.writeText(shareUrlOf(s));
+  };
+
+  // 事后生成数字短链（懒分配入口）：用户在某条分享上主动点「生成数字短链」时调用，
+  // 成功后把返回的 shortSeq 写回该条分享并复制数字短链。
+  const [allocatingId, setAllocatingId] = useState<string | null>(null);
+  const handleShortLink = async (s: ShareLinkItem) => {
+    const existing = shortUrlOf(s);
+    if (existing) {
+      navigator.clipboard.writeText(existing);
+      return;
+    }
+    setAllocatingId(s.id);
+    try {
+      const res = await ensureSiteShareShortLink(s.id);
+      if (res.success && res.data.shortSeq > 0) {
+        setShares(shares.map(x => x.id === s.id ? { ...x, shortSeq: res.data.shortSeq } : x));
+        navigator.clipboard.writeText(`${window.location.origin}/s/${res.data.shortSeq}`);
+      } else {
+        alert(res.error?.message || '生成数字短链失败');
+      }
+    } finally {
+      setAllocatingId(null);
+    }
   };
 
   const handleShowLogs = async (token: string) => {
@@ -3103,13 +3135,9 @@ function SharesPanel({ shares, setShares, onClose, scopedSiteId, scopedSiteTitle
                         >
                           {share.title || (share.shareType === 'collection' ? `合集 (${share.siteIds.length} 站)` : '单站点分享')}
                         </a>
-                        {share.shortSeq && share.shortSeq > 0 ? (
-                          <span title={`/s/${share.shortSeq}`}>
+                        {share.shortSeq && share.shortSeq > 0 && (
+                          <span title={`已生成数字短链 /s/${share.shortSeq}`}>
                             <Badge variant="subtle">#{share.shortSeq}</Badge>
-                          </span>
-                        ) : (
-                          <span title="老分享，仅长链可用">
-                            <Badge variant="subtle">长链</Badge>
                           </span>
                         )}
                         {visibilityChip(share.visibility)}
@@ -3159,9 +3187,24 @@ function SharesPanel({ shares, setShares, onClose, scopedSiteId, scopedSiteTitle
                       >
                         <Eye size={12} />
                       </Button>
-                      <Button size="xs" variant="ghost" onClick={() => handleCopy(share)} title="复制链接">
+                      <Button size="xs" variant="ghost" onClick={() => handleCopy(share)} title="复制链接（长链）">
                         <Copy size={12} />
                       </Button>
+                      {share.shortSeq && share.shortSeq > 0 ? (
+                        <Button size="xs" variant="ghost" onClick={() => handleShortLink(share)} title={`复制数字短链 /s/${share.shortSeq}`}>
+                          <Hash size={12} />
+                        </Button>
+                      ) : (
+                        <Button
+                          size="xs"
+                          variant="ghost"
+                          disabled={allocatingId === share.id}
+                          onClick={() => handleShortLink(share)}
+                          title="生成数字短链（自用，可枚举，建议配密码）"
+                        >
+                          {allocatingId === share.id ? <MapSpinner size={12} /> : <Hash size={12} style={{ opacity: 0.45 }} />}
+                        </Button>
+                      )}
                       <Button size="xs" variant="ghost" onClick={() => window.open(shareUrlOf(share), '_blank')} title="预览">
                         <ExternalLink size={12} />
                       </Button>

--- a/prd-admin/src/services/api.ts
+++ b/prd-admin/src/services/api.ts
@@ -1109,6 +1109,7 @@ export const api = {
     viewLogs: '/api/web-pages/shares/view-logs',
     shareLogsForSite: (siteId: string) => `/api/web-pages/${siteId}/share-logs`,
     renewShare: (shareId: string) => `/api/web-pages/shares/${shareId}/renew`,
+    shareShortLink: (shareId: string) => `/api/web-pages/shares/${shareId}/short-link`,
     shareAnalytics: '/api/web-pages/shares/analytics',
   },
   // ============ 公开主页（/u/:username 无需登录） ============

--- a/prd-admin/src/services/index.ts
+++ b/prd-admin/src/services/index.ts
@@ -1695,6 +1695,7 @@ export {
   listTags as listSiteTags,
   createShareLink as createSiteShareLink,
   listShares as listSiteShares,
+  ensureShareShortLink as ensureSiteShareShortLink,
   revokeShare as revokeSiteShare,
   viewShare as viewSiteShare,
   saveSharedSite,

--- a/prd-admin/src/services/real/webPages.ts
+++ b/prd-admin/src/services/real/webPages.ts
@@ -394,6 +394,8 @@ export async function createShareLink(data: {
   forceNew?: boolean;
   /** 访问可见性：owner-only（默认）/ logged-in / public */
   visibility?: 'owner-only' | 'logged-in' | 'public';
+  /** 是否分配数字短链 /s/{seq}。默认 false：只发 /s/wp/{token} 长链，不污染 short_links */
+  allocateShortLink?: boolean;
 }): Promise<ApiResponse<{
   id: string;
   token: string;
@@ -416,6 +418,17 @@ export async function createShareLink(data: {
 
 export async function listShares(): Promise<ApiResponse<{ items: ShareLinkItem[] }>> {
   return apiRequest(api.webPages.shares(), { method: 'GET' });
+}
+
+/**
+ * 事后为某条已存在的分享按需生成数字短链 /s/{seq}（用户点「生成数字短链」时调用）。
+ * 幂等：已有则返回原 seq。
+ */
+export async function ensureShareShortLink(shareId: string): Promise<ApiResponse<{
+  shortSeq: number;
+  shortShareUrl: string | null;
+}>> {
+  return apiRequest(api.webPages.shareShortLink(encodeURIComponent(shareId)), { method: 'POST' });
 }
 
 export async function revokeShare(shareId: string): Promise<ApiResponse<{ revoked: boolean }>> {

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/WebPagesController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/WebPagesController.cs
@@ -732,7 +732,10 @@ public class WebPagesController : ControllerBase
                 req.Password, req.ExpiresInDays,
                 purpose: isVisit ? "visit" : "share",
                 forceNew: forceNew,
-                visibility: visibility);
+                visibility: visibility,
+                // 数字短链按需分配：仅当用户在分享面板主动选「数字短链」时 client 传 true。
+                // 默认 false → 只发不可枚举的 /s/wp/{token} 长链，不污染 short_links。
+                allocateShortLink: req.AllocateShortLink ?? false);
 
             // P1 调整（2026-05-21 用户反馈）：默认 URL 保留分类前缀 /s/wp/{token}
             //   - 分类前缀有语义、利于在分享总管理面板里按类型分类
@@ -762,6 +765,37 @@ public class WebPagesController : ControllerBase
         catch (UnauthorizedAccessException ex)
         {
             return BadRequest(ApiResponse<object>.Fail(ErrorCodes.PERMISSION_DENIED, ex.Message));
+        }
+    }
+
+    /// <summary>
+    /// 事后为某条已存在的分享生成数字短链 /s/{seq}（用户在分享面板点「生成数字短链」）。
+    /// 幂等：已有短链则原样返回。仅创建者可调用。
+    /// </summary>
+    [HttpPost("shares/{shareId}/short-link")]
+    public async Task<IActionResult> EnsureShareShortLink(string shareId)
+    {
+        try
+        {
+            var seq = await _siteService.EnsureShortLinkAsync(GetUserId(), shareId);
+            return Ok(ApiResponse<object>.Ok(new
+            {
+                shortSeq = seq,
+                shortShareUrl = seq > 0 ? $"/s/{seq}" : null,
+                unifiedShareUrl = (string?)null, // 由 client 用已知 token 自行拼 /s/{token}
+            }));
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return NotFound(ApiResponse<object>.Fail(ErrorCodes.NOT_FOUND, ex.Message));
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.PERMISSION_DENIED, ex.Message));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, ex.Message));
         }
     }
 
@@ -1107,6 +1141,12 @@ public class CreateWebPageShareRequest
 
     /// <summary>访问可见性：owner-only（默认） / logged-in / public</summary>
     public string? Visibility { get; set; }
+
+    /// <summary>
+    /// 是否分配数字短链 /s/{seq}。默认 false：用户意图里没有短链就不强制生成，
+    /// 只发不可枚举的 /s/wp/{token} 长链。仅当用户在分享面板主动选「数字短链」时传 true。
+    /// </summary>
+    public bool? AllocateShortLink { get; set; }
 }
 
 public class RenewShareRequest

--- a/prd-api/src/PrdAgent.Core/Interfaces/IHostedSiteService.cs
+++ b/prd-api/src/PrdAgent.Core/Interfaces/IHostedSiteService.cs
@@ -110,7 +110,15 @@ public interface IHostedSiteService
         CancellationToken ct = default,
         string purpose = "share",
         bool forceNew = false,
-        string visibility = "owner-only");
+        string visibility = "owner-only",
+        bool allocateShortLink = false);
+
+    /// <summary>
+    /// 事后为某条已存在的分享按需分配数字短链 /s/{seq}（用户在分享面板点「生成数字短链」）。
+    /// 幂等：已有则返回原 Seq。返回分配后的 ShortSeq（&gt;0 成功）。
+    /// 仅创建者可调用；visit 便捷链不支持。
+    /// </summary>
+    Task<long> EnsureShortLinkAsync(string userId, string shareId, CancellationToken ct = default);
 
     /// <summary>
     /// 列出分享：默认包含未过期 + 过期 ≤ 7 天（允许续期）的链接。

--- a/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
@@ -742,7 +742,8 @@ public class HostedSiteService : IHostedSiteService
         CancellationToken ct = default,
         string purpose = "share",
         bool forceNew = false,
-        string visibility = "owner-only")
+        string visibility = "owner-only",
+        bool allocateShortLink = false)
     {
         // 规范化 visibility 入参（白名单），缺省回退 owner-only
         var normalizedVisibility = visibility?.ToLowerInvariant() switch
@@ -912,6 +913,10 @@ public class HostedSiteService : IHostedSiteService
                     Builders<WebPageShareLink>.Update.Combine(ups),
                     cancellationToken: ct);
             }
+            // 复用旧分享时若用户本次显式要数字短链、而旧链还没分配过 seq，则补分配
+            // （AllocateAsync 幂等：已有则返回原 seq，不会重复占号）。
+            if (allocateShortLink && reuse.Purpose != "visit" && reuse.ShortSeq <= 0)
+                await TryAllocateShortSeqAsync(reuse, ct);
             _logger.LogInformation("用户 {UserId} 复用站点分享 {ShareId}, type={Type}",
                 userId, reuse.Id, reuse.ShareType);
             return reuse;
@@ -950,31 +955,62 @@ public class HostedSiteService : IHostedSiteService
 
         await _db.WebPageShareLinks.InsertOneAsync(share, cancellationToken: ct);
 
-        // visit 便捷链只通过不可猜测的 /s/wp/{token} 暴露，绝不分配数字短链 /s/{seq}：
-        // /api/short-links/{seq} 匿名且可枚举，若给 visit 链分配 seq，攻击者枚举数字即可
-        // 访问到从未被主动分享的私有站点。仅 share 用户主动分享才分配数字短链。
-        if (effPurpose != "visit")
-        {
-            // 分配统一短链 Seq（/s/{seq}）；失败不影响主流程（用户仍可用 /s/wp/{token}）
-            try
-            {
-                var seq = await _shortLinks.AllocateAsync(ShortLinkTargetTypes.WebPage, share.Token, ct);
-                await _db.WebPageShareLinks.UpdateOneAsync(
-                    x => x.Id == share.Id,
-                    Builders<WebPageShareLink>.Update.Set(x => x.ShortSeq, seq),
-                    cancellationToken: ct);
-                share.ShortSeq = seq;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "为分享 {ShareId} 分配短链失败，将仅提供旧链接", share.Id);
-            }
-        }
+        // 数字短链 /s/{seq} 改为「按需懒分配」（2026-06-11）：用户意图里没有短链就不强制
+        // 生成，否则 short_links 集合被每条分享污染、管理员页面冒出几百条用户从没要过的短链。
+        // 默认创建的分享 ShortSeq=0，对外只用不可枚举的 /s/wp/{token} 长链即可独立访问
+        // （ViewShareAsync 直接按 token 查 WebPageShareLink，不依赖 short_links）。
+        // 仅当调用方显式 allocateShortLink=true（用户在分享面板主动选「数字短链」或事后点
+        // 「生成数字短链」）才分配 seq。
+        // visit 便捷链恒不分配：/api/short-links/{seq} 匿名且可枚举，给 visit 链分配 seq
+        // 会让攻击者枚举数字即可访问从未被主动分享的私有站点。
+        if (effPurpose != "visit" && allocateShortLink)
+            await TryAllocateShortSeqAsync(share, ct);
 
         _logger.LogInformation("用户 {UserId} 创建站点分享 {ShareId}, type={Type}, shortSeq={Seq}",
             userId, share.Id, share.ShareType, share.ShortSeq);
 
         return share;
+    }
+
+    /// <summary>
+    /// 为指定分享按需分配统一短链 Seq（/s/{seq}），并回写 ShortSeq。
+    /// AllocateAsync 幂等（同一 token 已有则返回原 seq）；失败不抛出，只记日志——
+    /// 因为分享主路径不依赖 short_links，用户仍可用 /s/wp/{token} 长链访问。
+    /// </summary>
+    private async Task TryAllocateShortSeqAsync(WebPageShareLink share, CancellationToken ct)
+    {
+        try
+        {
+            var seq = await _shortLinks.AllocateAsync(ShortLinkTargetTypes.WebPage, share.Token, ct);
+            await _db.WebPageShareLinks.UpdateOneAsync(
+                x => x.Id == share.Id,
+                Builders<WebPageShareLink>.Update.Set(x => x.ShortSeq, seq),
+                cancellationToken: ct);
+            share.ShortSeq = seq;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "为分享 {ShareId} 分配短链失败，将仅提供长链 /s/wp/{Token}", share.Id, share.Token);
+        }
+    }
+
+    /// <summary>
+    /// 事后为某条已存在的分享分配数字短链（用户在分享面板点「生成数字短链」时调用）。
+    /// 返回分配后的 ShortSeq（&gt;0 成功）；找不到 / 无权 / visit 链返回 0 或抛权限异常。
+    /// </summary>
+    public async Task<long> EnsureShortLinkAsync(string userId, string shareId, CancellationToken ct = default)
+    {
+        var share = await _db.WebPageShareLinks.Find(x => x.Id == shareId).FirstOrDefaultAsync(ct);
+        if (share == null)
+            throw new KeyNotFoundException("分享不存在");
+        if (share.CreatedBy != userId)
+            throw new UnauthorizedAccessException("只能为自己创建的分享生成短链");
+        if (share.Purpose == "visit")
+            throw new InvalidOperationException("访问便捷链不支持数字短链");
+        if (share.ShortSeq > 0)
+            return share.ShortSeq; // 已有则幂等返回
+        await TryAllocateShortSeqAsync(share, ct);
+        return share.ShortSeq;
     }
 
     public async Task<List<WebPageShareLink>> ListSharesAsync(string userId, CancellationToken ct)


### PR DESCRIPTION
## 摘要

将网页托管分享的数字短链 `/s/{seq}` 从"创建时强制分配"改为"按需懒分配"。默认创建分享时不再无脑写入 short_links 集合，仅当用户在分享面板主动选择"数字短链"时才分配。主链接恒为不可枚举的字母长链 `/s/wp/{token}`，解决"用户没选数字短链却总拿到 /s/{seq}"的问题。

## 改动 diff

**后端（prd-api）**
- `HostedSiteService.cs`：
  - `CreateShareAsync` 新增 `allocateShortLink` 参数（默认 false），控制是否分配数字短链
  - 提取 `TryAllocateShortSeqAsync` 私有方法，统一处理短链分配逻辑（幂等、失败不抛异常）
  - 新增 `EnsureShortLinkAsync` 公开方法，支持事后为已存在分享按需生成数字短链
  - 复用旧分享时，若用户显式要数字短链且旧链未分配过 seq，则补分配

- `WebPagesController.cs`：
  - `CreateShare` 端点传递 `allocateShortLink` 参数给后端
  - 新增 `EnsureShareShortLink` 端点（POST `/api/web-pages/shares/{shareId}/short-link`），支持事后生成数字短链

- `IHostedSiteService.cs`：更新接口签名，新增 `EnsureShortLinkAsync` 方法声明

- `CreateWebPageShareRequest.cs`：新增 `AllocateShortLink` 属性，允许 client 显式指定是否分配数字短链

**前端（prd-admin）**
- `WebPagesPage.tsx`：
  - `ShareDialog` 中创建分享时，根据用户是否选择"数字短链"（`isShort`）传递 `allocateShortLink` 参数
  - `SharesPanel` 中修改主链接逻辑：恒为 `/s/wp/{token}` 长链，不再因后端碰巧分配了 shortSeq 就返回数字链
  - 新增 `shortUrlOf` 函数，仅当 `shortSeq > 0` 时返回数字短链
  - 新增 `handleShortLink` 事件处理，支持用户主动点击"生成数字短链"按钮，调用后端 API 分配并复制
  - UI 调整：数字短链改为单独的"生成/复制"按钮（Hash 图标），已生成时可直接复制，未生成时点击触发分配

- `webPages.ts`：
  - `createShareLink` 函数新增 `allocateShortLink` 参数
  - 新增 `ensureShareShortLink` 函数，调用后端事后生成短链端点

- `api.ts`：新增 `shareShortLink` 路由定义

- `index.ts`：导出 `ensureSiteShareShortLink` 别名

**文档**
- `changelogs/2026-06-11_web-share-shortlink-lazy.md`：新增 changelog 碎片，记录本次改动

## 测试

- [x] pnpm tsc --noEmit 通过（前端类型检查）
- [x] 后端编译通

https://claude.ai/code/session_017UxdEHQ2o3sHbggdw5YjKg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> 改变分享创建与短链分配默认行为，影响分享 URL 与 `short_links` 写入；新增鉴权端点但逻辑边界清晰（visit 链仍不分配 seq）。
> 
> **Overview**
> **网页托管分享**的数字短链 `/s/{seq}` 从「创建分享时默认写入 `short_links`」改为**按需懒分配**：默认只提供不可枚举的长链 `/s/wp/{token}`，仅在用户明确要数字短链时才占号。
> 
> **后端**：`CreateShareAsync` 增加 `allocateShortLink`（默认 `false`），新建/复用分享时仅在 `allocateShortLink=true` 且非 `visit` 链时调用 `TryAllocateShortSeqAsync`；新增 `EnsureShortLinkAsync` 与 **POST** `/api/web-pages/shares/{shareId}/short-link`（创建者、幂等）。请求体增加 `AllocateShortLink`。
> 
> **前端**：创建分享时高级选项选「数字短链」才传 `allocateShortLink`；分享管理里**主链**固定为 `/s/wp/{token}`（复制/预览不再因已有 `shortSeq` 变成数字链），数字短链通过 **Hash** 按钮事后生成或复制。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fc5ec0762846b4166354e3107864818f0791107. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->