### PR TITLE
feat: 新增团队动态功能 - 全局白名单审计留痕 + 时间线展示

### DIFF
--- a/changelogs/2026-06-11_team-activity-feed.md
+++ b/changelogs/2026-06-11_team-activity-feed.md
@@ -1,0 +1,3 @@
+| feat | prd-api | 新增团队动态功能：全局白名单审计过滤器（ActivityLogActionFilter）自动留痕知识库/缺陷/周报/视觉/文学/网页托管 6 模块的关键写操作，新集合 activity_logs，新端点 /api/team-activity/logs + modules，新权限 team-activity.read |
+| feat | prd-admin | 新增「团队动态」管理页（/team-activity）：按天分组时间线流，头像 + 「谁 在 哪个模块 做了什么《对象标题》」+ 相对时间，支持按成员/模块/时间范围筛选与加载更多 |
+| test | prd-api | 新增 ActivityActionRegistryGuardTests：白名单 Controller.Action 复合键与真实 Controller 反射比对，防重命名后动态静默断流 |

--- a/doc/design.team-activity.md
+++ b/doc/design.team-activity.md
@@ -1,0 +1,134 @@
+# 团队动态（工作日志时间线）设计 · 设计
+
+> **版本**：v1.0 | **日期**：2026-06-11 | **状态**：已实现
+
+## 一、管理摘要
+
+- **解决什么问题**：管理员无法一眼看到团队成员每天在平台上做了什么（谁发布了文档、谁修复了缺陷、谁交了周报），缺少类似飞书「动态」tab 的工作日志视图
+- **方案概述**：复用项目已验证的「白名单审计 ActionFilter」模式（PmAuditActionFilter），升级为全局过滤器：白名单内的写操作成功后自动留痕到 `activity_logs` 集合，前端以按天分组的时间线流展示
+- **业务价值**：管理层零成本掌握团队工作脉搏；操作留痕兼具合规/追溯价值
+- **影响范围**：后端全局 MVC 管道加一个过滤器（白名单外请求一次字典查找即逃逸）、新集合 `activity_logs`、新权限 `team-activity.read`、管理后台新页面 `/team-activity`
+- **预计风险**：低 — 留痕写入失败不影响主请求；白名单有 CI 守卫测试防漂移
+
+## 2. 产品定位
+
+一期定位为**管理员视图**：仅持有 `team-activity.read` 权限的用户（admin 角色自动获得）可在左侧导航「系统管理 → 团队动态」查看全员动态。普通用户不可见。
+
+每条动态渲染为：
+
+```
+[头像] 张坤 在 知识库 发布了文档 《技术规范及文档》        3 分钟前
+```
+
+按天分组（今天 / 昨天 / 6月9日），支持按成员、模块、时间范围（今天/本周/本月）筛选，加载更多分页。
+
+## 3. 采集原理（核心机制）
+
+### 3.1 为什么不用全量请求日志推导
+
+系统已有 `apirequestlogs`（中间件全量记录每个 API 请求），但它语义太弱：只有 Method/Path，无法翻译成"发布了文档《XX》"，且充满读请求和心跳噪音。动态需要的是**有业务语义的精选事件**，所以走白名单声明式留痕，不走日志推导。
+
+### 3.2 三层结构
+
+```
+请求进入 MVC 管道
+    │
+    ▼
+ActivityLogActionFilter（全局挂载，Program.cs options.Filters.Add）
+    │  1. 非 GET/HEAD/OPTIONS？
+    │  2. "{Controller}.{Action}" 命中白名单字典？——未命中即逃逸（一次字典查找，零负担）
+    │  3. 条目声明了 TitleDb？→ 在 next() 之前按路由 TargetId 预读标题（删除前快照）
+    ▼
+await next()  执行真正的业务 Action
+    │  4. 响应 2xx？JWT sub 存在？
+    │  5. 标题兜底：DB 预读结果 → TitleArgs 参数反射 → null（前端降级）
+    ▼
+InsertOne activity_logs（CancellationToken.None，try/catch 包裹，失败仅 LogWarning）
+```
+
+三个关键文件：
+
+| 文件 | 职责 |
+|------|------|
+| `prd-api/src/PrdAgent.Api/Filters/ActivityActionRegistry.cs` | 白名单 SSOT：31 个动作条目 + 模块清单导出 |
+| `prd-api/src/PrdAgent.Api/Filters/ActivityLogActionFilter.cs` | 全局过滤器：匹配、预读、落库 |
+| `prd-api/src/PrdAgent.Core/Models/ActivityLog.cs` | 留痕实体（含 TargetTitle 标题快照） |
+
+### 3.3 白名单条目的声明式设计
+
+每个条目用一个 record 声明"这个动作怎么留痕"：
+
+```csharp
+["DocumentStore.AddEntry"] = new(
+    Module: "document-store", ModuleLabel: "知识库", ActionLabel: "发布了文档",
+    TargetRouteKey: "storeId",                  // 路由里取操作对象 id
+    TitleArgs: new[] { "request.Title" });      // 标题从请求 DTO 反射取
+```
+
+标题来源两条路，按动作类型选用：
+
+- **TitleArgs（创建类动作）**：标题就在请求体里（`request.Title` / 裸参数 `title` / `IFormFile` 取文件名），从 action arguments 反射提取，零额外查询
+- **TitleDb（更新/删除/状态流转类动作）**：请求体里没有标题，按 TargetId 查一次库。**预读发生在业务执行之前**——这是设计关键，保证"删除了文档《XX》"在对象物理删除后依然带标题
+
+复合键用 `Controller.Action` 而非裸 Action 名，因为 `CreateWorkspace` / `CreateTemplate` 等方法名跨 Controller 重名。
+
+### 3.4 一期覆盖范围（31 个动作 / 6 个模块）
+
+| 模块 | 动作 |
+|------|------|
+| 知识库 | 创建/删除知识库、发布/更新/删除/上传文档 |
+| 缺陷管理 | 创建/提交/指派/修复/验证通过/驳回/关闭/重开/评论/删除缺陷 |
+| 周报 | 创建/发布/审阅/退回/评论周报、提交日报 |
+| 视觉创作 | 创建/删除工作区、发起图片生成 |
+| 文学创作 | 创建/删除工作区、生成配图 |
+| 网页托管 | 发布（上传/从内容创建）/更新/删除站点 |
+
+刻意排除的噪音动作：点赞、收藏、置顶、移动、文件夹管理、分享链管理、webhook 配置、视图打点（LogEntryView 等高频端点禁止入表）。
+
+### 3.5 防漂移守卫
+
+`prd-api/tests/PrdAgent.Api.Tests/Controllers/ActivityActionRegistryGuardTests.cs` 在 CI 强制：白名单每个 `Controller.Action` 键必须能在 API 程序集反射找到对应公开方法。Controller/Action 一旦重命名而白名单未同步，CI 直接 fail——否则字典匹配不到只是"不留痕"，动态会静默断流，没人发现。
+
+## 4. 数据设计
+
+集合 `activity_logs`（注册于 `MongoDbContext.ActivityLogs`）：
+
+| 字段 | 说明 |
+|------|------|
+| Id | Guid N 格式 |
+| ActorId | 操作人 UserId（JWT sub）；显示名/头像读取时批量解析，不冗余存储 |
+| Module / ModuleLabel | 模块 key + 中文名快照（写入时固化，key 改名不影响历史） |
+| Action / ActionLabel | `DocumentStore.AddEntry` 复合键 + 「发布了文档」 |
+| TargetId / TargetTitle | 操作对象 id + 标题快照（截断 200 字符，可空） |
+| TargetUrl | 深链预留，一期留空 |
+| Method / Path | 排障用 |
+| CreatedAt | UtcNow |
+
+索引（DBA 手工执行，见 `doc/guide.mongodb-indexes.md`）：`{CreatedAt:-1}`、`{ActorId:1,CreatedAt:-1}`、`{Module:1,CreatedAt:-1}`。
+
+## 5. 接口设计
+
+| 端点 | 说明 |
+|------|------|
+| `GET /api/team-activity/logs?page&pageSize&userId&module&from&to` | 时间倒序分页；返回 items（含批量解析的 actorName/actorAvatarFileName）+ total |
+| `GET /api/team-activity/modules` | 模块筛选清单，从白名单注册表导出，前后端不漂移 |
+
+权限：Controller 标注 `[AdminController("team-activity", TeamActivityRead)]`，由 AdminPermissionMiddleware 路由级强制；菜单可见性经 `AdminMenuCatalog` Controller 扫描自动生效。
+
+## 6. 前端
+
+- 页面：`prd-admin/src/pages/team-activity/TeamActivityPage.tsx`（navRegistry 注册 `/team-activity`）
+- 复用组件：`UserAvatar` + `resolveAvatarUrl`、`RelativeTime`、`UserSearchSelect`、`PageHeader`、`GlassCard`、`MapSectionLoader`
+- service：`services/real/teamActivity.ts` + `contracts/teamActivity.ts`，经 `services/index.ts` 以 `withAuth` 导出
+
+## 7. 关联文档
+
+- `doc/guide.mongodb-indexes.md` — activity_logs 手工索引
+- `.claude/rules/data-audit.md` / `prd-api/src/PrdAgent.Api/Filters/PmAuditActionFilter.cs` — 本设计复用的审计模式源头
+
+## 8. 已知边界与后续
+
+- 动态从功能上线后开始留痕，无历史回填
+- 同人连续操作不聚合折叠；无 SSE 实时推送（页面手动刷新/重新筛选获取最新）
+- TargetUrl 深链未填充，点击动态暂不能跳转到对象详情
+- 二期开放普通用户可见时：放宽权限分配 + 查询端按数据可见性过滤即可，模型无需变更

--- a/doc/guide.list.directory.md
+++ b/doc/guide.list.directory.md
@@ -99,6 +99,8 @@
   > 三层模型(脑/技能/沙箱) + map-agent·cds-agent 命名 + 借运行时不重建 + 唯一接缝(KB 当工作目录进、改动经 diff 闸出)；md→ppt 避坑
 - [服务器权威性设计](design.server-authority) `design.server-authority`
   > 客户端断开不取消服务器任务的架构设计
+- [团队动态设计](design.team-activity) `design.team-activity`
+  > 全局白名单审计 Filter 自动留痕 + TargetTitle 标题快照（删除前预读）+ 管理员时间线页（/team-activity）
 
 - [LLM Gateway 统一调用架构设计](design.llm-gateway) `design.llm-gateway`
   > 所有 LLM 调用通过统一网关，三级调度 + 健康管理

--- a/doc/guide.mongodb-indexes.md
+++ b/doc/guide.mongodb-indexes.md
@@ -1307,3 +1307,28 @@ db.peer_nodes.createIndex(
   { name: "uniq_peer_nodes_remote_node_id", unique: true }
 )
 ```
+
+### activity_logs
+
+团队动态（全平台白名单写操作留痕，`ActivityLogActionFilter` 写入，`/api/team-activity/logs` 按
+时间倒序分页读取，支持按人（ActorId）/ 模块（Module）/ 时间范围筛选）。
+
+```js
+// 时间线主查询 — 无筛选时按时间倒序翻页
+db.activity_logs.createIndex(
+  { "CreatedAt": -1 },
+  { name: "idx_activity_logs_created_at" }
+)
+
+// 按人筛选 + 时间倒序
+db.activity_logs.createIndex(
+  { "ActorId": 1, "CreatedAt": -1 },
+  { name: "idx_activity_logs_actor_created" }
+)
+
+// 按模块筛选 + 时间倒序
+db.activity_logs.createIndex(
+  { "Module": 1, "CreatedAt": -1 },
+  { name: "idx_activity_logs_module_created" }
+)
+```

--- a/doc/index.yml
+++ b/doc/index.yml
@@ -55,6 +55,7 @@ docs:
   design.agent-universe: 智能体宇宙设计（能力契约 SSOT + 统一调用信封 + 漫威宇宙式互通）
   design.knowledge-agent-architecture: 知识库智能体架构设计（三层模型 + map/cds-agent 命名 + 借运行时不重建 + KB-as-files 进、diff 闸出）
   design.server-authority: 服务器权威性设计
+  design.team-activity: 团队动态设计（全局白名单审计 Filter + 标题快照 + 管理员时间线）
   design.unified-skill-system: 技能系统统一设计
   design.llm-gateway: LLM Gateway 统一调用架构设计
   design.llm-gateway-refactor: LLM Gateway 图片生成重构（compute-then-send）

--- a/prd-admin/src/app/navRegistry.tsx
+++ b/prd-admin/src/app/navRegistry.tsx
@@ -49,6 +49,7 @@ const ProjectRouteAgentPage = lazy(() => import('@/pages/project-route-agent').t
 const UsersPage = lazy(() => import('@/pages/UsersPage'));
 const ModelManageTabsPage = lazy(() => import('@/pages/ModelManageTabsPage').then(m => ({ default: m.ModelManageTabsPage })));
 const LlmLogsPage = lazy(() => import('@/pages/LlmLogsPage'));
+const TeamActivityPage = lazy(() => import('@/pages/team-activity/TeamActivityPage'));
 const LabPage = lazy(() => import('@/pages/LabPage'));
 const AutomationRulesPage = lazy(() => import('@/pages/AutomationRulesPage'));
 const WebPagesPage = lazy(() => import('@/pages/WebPagesPage'));
@@ -581,6 +582,19 @@ export const NAV_REGISTRY: NavRegistryEntry[] = [
       icon: 'ScrollText',
       section: 'utility',
       tags: ['日志', 'logs', '审计'],
+    },
+  },
+  {
+    path: '/team-activity',
+    permission: 'team-activity.read',
+    element: shellGuarded('team-activity.read', <TeamActivityPage />),
+    nav: {
+      label: '团队动态',
+      shortLabel: '动态',
+      description: '全员工作动态时间线（管理员）',
+      icon: 'Activity',
+      section: 'utility',
+      tags: ['动态', '活动', '工作日志', 'activity'],
     },
   },
 

--- a/prd-admin/src/lib/authzMenuMapping.ts
+++ b/prd-admin/src/lib/authzMenuMapping.ts
@@ -70,6 +70,12 @@ export const menuList: MenuDef[] = [
     permissions: ['logs.read'],
   },
   {
+    appKey: 'team-activity',
+    label: '团队动态',
+    icon: 'Activity',
+    permissions: ['team-activity.read'],
+  },
+  {
     appKey: 'data',
     label: '数据管理',
     icon: 'Database',
@@ -225,6 +231,9 @@ export const allPermissions: PermissionDef[] = [
 
   // 日志
   { key: 'logs.read', label: '日志 - 读', description: '查看请求日志', category: 'read' },
+
+  // 团队动态
+  { key: 'team-activity.read', label: '团队动态 - 读', description: '查看全员工作动态时间线', category: 'read' },
 
   // 开放平台
   { key: 'open-platform.manage', label: '开放平台 - 管理', description: '管理 API 应用', category: 'manage' },

--- a/prd-admin/src/lib/shortLabel.ts
+++ b/prd-admin/src/lib/shortLabel.ts
@@ -63,6 +63,7 @@ export const SHORT_LABEL_MAP: Record<string, string> = {
   'lab': '实验室',
   'automations': '自动化',
   'logs': '日志',
+  'team-activity': '动态',
 
   // ── 管理 / 其他 ───────────────────────
   'authz': '权限',

--- a/prd-admin/src/pages/team-activity/TeamActivityPage.tsx
+++ b/prd-admin/src/pages/team-activity/TeamActivityPage.tsx
@@ -1,0 +1,227 @@
+/**
+ * 团队动态 — 全员工作日志时间线（仅管理员，team-activity.read）。
+ * 数据由后端 ActivityLogActionFilter 按白名单自动留痕，本页只读：
+ * 按天分组的时间线流 + 按人/模块/时间筛选 + 加载更多分页。
+ */
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Activity } from 'lucide-react';
+import { PageHeader, GlassCard, Button } from '@/components/design';
+import { UserSearchSelect } from '@/components/UserSearchSelect';
+import { UserAvatar } from '@/components/ui/UserAvatar';
+import { RelativeTime } from '@/components/ui/RelativeTime';
+import { MapSectionLoader, MapSpinner } from '@/components/ui/VideoLoader';
+import { resolveAvatarUrl } from '@/lib/avatar';
+import { getTeamActivityLogs, getTeamActivityModules } from '@/services';
+import type { ActivityModuleOption, TeamActivityItem } from '@/services/contracts/teamActivity';
+
+const PAGE_SIZE = 30;
+
+type RangeKey = 'all' | 'today' | 'week' | 'month';
+
+const RANGE_OPTIONS: Array<{ key: RangeKey; label: string }> = [
+  { key: 'all', label: '全部' },
+  { key: 'today', label: '今天' },
+  { key: 'week', label: '本周' },
+  { key: 'month', label: '本月' },
+];
+
+function rangeFrom(key: RangeKey): string | undefined {
+  if (key === 'all') return undefined;
+  const now = new Date();
+  const start = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  if (key === 'week') {
+    // 周一为一周起点
+    const day = (start.getDay() + 6) % 7;
+    start.setDate(start.getDate() - day);
+  } else if (key === 'month') {
+    start.setDate(1);
+  }
+  return start.toISOString();
+}
+
+function dayKeyOf(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+function dayLabelOf(key: string): string {
+  const today = dayKeyOf(new Date().toISOString());
+  const yesterday = dayKeyOf(new Date(Date.now() - 86_400_000).toISOString());
+  if (key === today) return '今天';
+  if (key === yesterday) return '昨天';
+  const [y, m, d] = key.split('-');
+  const sameYear = y === String(new Date().getFullYear());
+  return sameYear ? `${Number(m)}月${Number(d)}日` : `${y}年${Number(m)}月${Number(d)}日`;
+}
+
+export default function TeamActivityPage() {
+  const [items, setItems] = useState<TeamActivityItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [modules, setModules] = useState<ActivityModuleOption[]>([]);
+
+  const [filterUserId, setFilterUserId] = useState('');
+  const [filterModule, setFilterModule] = useState('');
+  const [filterRange, setFilterRange] = useState<RangeKey>('all');
+
+  useEffect(() => {
+    void getTeamActivityModules().then((res) => {
+      if (res.success) setModules(res.data.items);
+    });
+  }, []);
+
+  const load = useCallback(
+    async (nextPage: number, append: boolean) => {
+      if (append) setLoadingMore(true);
+      else setLoading(true);
+      const res = await getTeamActivityLogs({
+        page: nextPage,
+        pageSize: PAGE_SIZE,
+        userId: filterUserId || undefined,
+        module: filterModule || undefined,
+        from: rangeFrom(filterRange),
+      });
+      if (res.success) {
+        setItems((prev) => (append ? [...prev, ...res.data.items] : res.data.items));
+        setTotal(res.data.total);
+        setPage(nextPage);
+      }
+      setLoading(false);
+      setLoadingMore(false);
+    },
+    [filterUserId, filterModule, filterRange]
+  );
+
+  // 筛选条件变化时重置到第一页
+  useEffect(() => {
+    void load(1, false);
+  }, [load]);
+
+  const hasMore = items.length < total;
+
+  const dayGroups = useMemo(() => {
+    const groups: Array<{ key: string; items: TeamActivityItem[] }> = [];
+    for (const item of items) {
+      const key = dayKeyOf(item.createdAt);
+      const last = groups[groups.length - 1];
+      if (last && last.key === key) last.items.push(item);
+      else groups.push({ key, items: [item] });
+    }
+    return groups;
+  }, [items]);
+
+  return (
+    <div className="flex flex-col gap-4 h-full min-h-0">
+      <PageHeader title="团队动态" description="全员工作动态时间线（按白名单动作自动留痕）" />
+
+      {/* 筛选栏：人 / 模块 / 时间快捷段 */}
+      <div className="flex items-center gap-3 flex-wrap shrink-0">
+        <div className="w-52">
+          <UserSearchSelect
+            value={filterUserId}
+            onChange={setFilterUserId}
+            showAllOption
+            allOptionLabel="全部成员"
+            placeholder="按成员筛选"
+            uiSize="sm"
+          />
+        </div>
+        <div className="flex items-center gap-1.5 flex-wrap">
+          <FilterChip active={filterModule === ''} label="全部模块" onClick={() => setFilterModule('')} />
+          {modules.map((m) => (
+            <FilterChip key={m.key} active={filterModule === m.key} label={m.label} onClick={() => setFilterModule(m.key)} />
+          ))}
+        </div>
+        <div className="flex items-center gap-1.5 ml-auto">
+          {RANGE_OPTIONS.map((r) => (
+            <FilterChip key={r.key} active={filterRange === r.key} label={r.label} onClick={() => setFilterRange(r.key)} />
+          ))}
+        </div>
+      </div>
+
+      {/* 时间线主体 */}
+      <GlassCard className="flex-1 flex flex-col" style={{ minHeight: 0 }}>
+        <div
+          className="flex-1 px-5 py-4"
+          style={{ minHeight: 0, overflowY: 'auto', overscrollBehavior: 'contain' }}
+        >
+          {loading ? (
+            <MapSectionLoader text="正在加载团队动态…" />
+          ) : items.length === 0 ? (
+            <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
+              <Activity size={36} className="text-white/15" />
+              <div className="text-sm text-white/60">还没有符合条件的动态</div>
+              <div className="text-[12px] text-white/35 max-w-md leading-relaxed">
+                团队成员在知识库、缺陷管理、周报、视觉/文学创作、网页托管中的关键操作会自动出现在这里。
+                试试切换成员、模块或时间范围。
+              </div>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-5">
+              {dayGroups.map((g) => (
+                <div key={g.key} className="flex flex-col gap-1">
+                  <div className="flex items-center gap-3 pb-1">
+                    <span className="text-[12px] font-semibold text-white/70">{dayLabelOf(g.key)}</span>
+                    <span className="flex-1 h-px bg-white/5" />
+                    <span className="text-[11px] text-white/30">{g.items.length} 条</span>
+                  </div>
+                  {g.items.map((item) => (
+                    <ActivityRow key={item.id} item={item} />
+                  ))}
+                </div>
+              ))}
+
+              {hasMore && (
+                <div className="flex justify-center pt-1 pb-2">
+                  <Button variant="secondary" size="sm" disabled={loadingMore} onClick={() => void load(page + 1, true)}>
+                    {loadingMore ? <MapSpinner size={14} /> : null}
+                    加载更多（已显示 {items.length} / {total} 条）
+                  </Button>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </GlassCard>
+    </div>
+  );
+}
+
+function FilterChip({ active, label, onClick }: { active: boolean; label: string; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`px-2.5 h-[26px] rounded-full text-[12px] border transition-colors ${
+        active
+          ? 'bg-cyan-500/20 text-cyan-200 border-cyan-500/40'
+          : 'bg-white/[0.03] text-white/50 border-white/10 hover:text-white/75 hover:border-white/20'
+      }`}
+    >
+      {label}
+    </button>
+  );
+}
+
+function ActivityRow({ item }: { item: TeamActivityItem }) {
+  return (
+    <div className="flex items-center gap-3 py-2 px-1 rounded-lg hover:bg-white/[0.03] transition-colors">
+      <UserAvatar
+        src={resolveAvatarUrl({ avatarFileName: item.actorAvatarFileName })}
+        alt={item.actorName ?? ''}
+        className="w-8 h-8 rounded-full shrink-0 object-cover"
+      />
+      <div className="flex-1 min-w-0 text-[13px] leading-relaxed">
+        <span className="text-white/85 font-medium">{item.actorName || item.actorId}</span>
+        <span className="text-white/45"> 在 </span>
+        <span className="text-white/70">{item.moduleLabel}</span>
+        <span className="text-white/45"> {item.actionLabel}</span>
+        {item.targetTitle ? <span className="text-cyan-200/90"> 《{item.targetTitle}》</span> : null}
+      </div>
+      <RelativeTime value={item.createdAt} className="text-[11px] text-white/35 shrink-0" />
+    </div>
+  );
+}

--- a/prd-admin/src/pages/team-activity/TeamActivityPage.tsx
+++ b/prd-admin/src/pages/team-activity/TeamActivityPage.tsx
@@ -61,6 +61,7 @@ export default function TeamActivityPage() {
   const [page, setPage] = useState(1);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [modules, setModules] = useState<ActivityModuleOption[]>([]);
 
   const [filterUserId, setFilterUserId] = useState('');
@@ -90,9 +91,18 @@ export default function TeamActivityPage() {
       });
       if (fetchIdRef.current !== fetchId) return;
       if (res.success) {
+        setLoadError(null);
         setItems((prev) => (append ? [...prev, ...res.data.items] : res.data.items));
         setTotal(res.data.total);
         setPage(nextPage);
+      } else if (!append) {
+        // 刷新失败时清掉旧筛选的结果，避免筛选条件与列表内容错位
+        setItems([]);
+        setTotal(0);
+        setPage(1);
+        setLoadError(res.error?.message ?? '加载失败，请重试');
+      } else {
+        setLoadError(res.error?.message ?? '加载失败，请重试');
       }
       setLoading(false);
       setLoadingMore(false);
@@ -155,6 +165,14 @@ export default function TeamActivityPage() {
         >
           {loading ? (
             <MapSectionLoader text="正在加载团队动态…" />
+          ) : loadError && items.length === 0 ? (
+            <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
+              <Activity size={36} className="text-white/15" />
+              <div className="text-sm text-white/60">{loadError}</div>
+              <Button variant="secondary" size="sm" onClick={() => void load(1, false)}>
+                重试
+              </Button>
+            </div>
           ) : items.length === 0 ? (
             <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
               <Activity size={36} className="text-white/15" />
@@ -180,7 +198,8 @@ export default function TeamActivityPage() {
               ))}
 
               {hasMore && (
-                <div className="flex justify-center pt-1 pb-2">
+                <div className="flex flex-col items-center gap-1.5 pt-1 pb-2">
+                  {loadError ? <span className="text-[11px] text-red-300/80">{loadError}</span> : null}
                   <Button variant="secondary" size="sm" disabled={loadingMore} onClick={() => void load(page + 1, true)}>
                     {loadingMore ? <MapSpinner size={14} /> : null}
                     加载更多（已显示 {items.length} / {total} 条）

--- a/prd-admin/src/pages/team-activity/TeamActivityPage.tsx
+++ b/prd-admin/src/pages/team-activity/TeamActivityPage.tsx
@@ -3,7 +3,7 @@
  * 数据由后端 ActivityLogActionFilter 按白名单自动留痕，本页只读：
  * 按天分组的时间线流 + 按人/模块/时间筛选 + 加载更多分页。
  */
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Activity } from 'lucide-react';
 import { PageHeader, GlassCard, Button } from '@/components/design';
 import { UserSearchSelect } from '@/components/UserSearchSelect';
@@ -67,6 +67,9 @@ export default function TeamActivityPage() {
   const [filterModule, setFilterModule] = useState('');
   const [filterRange, setFilterRange] = useState<RangeKey>('all');
 
+  // 过期响应守卫：快速切换筛选 / 加载更多与刷新竞态时，丢弃晚到的旧请求结果
+  const fetchIdRef = useRef(0);
+
   useEffect(() => {
     void getTeamActivityModules().then((res) => {
       if (res.success) setModules(res.data.items);
@@ -75,6 +78,7 @@ export default function TeamActivityPage() {
 
   const load = useCallback(
     async (nextPage: number, append: boolean) => {
+      const fetchId = ++fetchIdRef.current;
       if (append) setLoadingMore(true);
       else setLoading(true);
       const res = await getTeamActivityLogs({
@@ -84,6 +88,7 @@ export default function TeamActivityPage() {
         module: filterModule || undefined,
         from: rangeFrom(filterRange),
       });
+      if (fetchIdRef.current !== fetchId) return;
       if (res.success) {
         setItems((prev) => (append ? [...prev, ...res.data.items] : res.data.items));
         setTotal(res.data.total);
@@ -221,7 +226,8 @@ function ActivityRow({ item }: { item: TeamActivityItem }) {
         <span className="text-white/45"> {item.actionLabel}</span>
         {item.targetTitle ? <span className="text-cyan-200/90"> 《{item.targetTitle}》</span> : null}
       </div>
-      <RelativeTime value={item.createdAt} className="text-[11px] text-white/35 shrink-0" />
+      {/* 列表场景关闭逐行自刷新定时器（项目惯例，长列表 N 行 N 个 interval 会拖性能） */}
+      <RelativeTime value={item.createdAt} refreshIntervalMs={0} className="text-[11px] text-white/35 shrink-0" />
     </div>
   );
 }

--- a/prd-admin/src/services/api.ts
+++ b/prd-admin/src/services/api.ts
@@ -188,6 +188,12 @@ export const api = {
     },
   },
 
+  // ============ Team Activity 团队动态 ============
+  teamActivity: {
+    logs: () => '/api/team-activity/logs',
+    modules: () => '/api/team-activity/modules',
+  },
+
   // ============ Skills 技能管理 ============
   skills: {
     list: () => '/api/skills',

--- a/prd-admin/src/services/contracts/teamActivity.ts
+++ b/prd-admin/src/services/contracts/teamActivity.ts
@@ -1,0 +1,47 @@
+import type { ApiResponse } from '@/types/api';
+
+export type TeamActivityItem = {
+  id: string;
+  actorId: string;
+  actorName?: string | null;
+  actorAvatarFileName?: string | null;
+  module: string;
+  moduleLabel: string;
+  action: string;
+  actionLabel: string;
+  targetId?: string | null;
+  targetTitle?: string | null;
+  targetUrl?: string | null;
+  createdAt: string;
+};
+
+export type TeamActivityListData = {
+  items: TeamActivityItem[];
+  total: number;
+  page: number;
+  pageSize: number;
+};
+
+export type GetTeamActivityParams = {
+  page?: number;
+  pageSize?: number;
+  userId?: string;
+  module?: string;
+  from?: string;
+  to?: string;
+};
+
+export type ActivityModuleOption = {
+  key: string;
+  label: string;
+};
+
+export type TeamActivityModulesData = {
+  items: ActivityModuleOption[];
+};
+
+export type GetTeamActivityLogsContract = (
+  params?: GetTeamActivityParams
+) => Promise<ApiResponse<TeamActivityListData>>;
+
+export type GetTeamActivityModulesContract = () => Promise<ApiResponse<TeamActivityModulesData>>;

--- a/prd-admin/src/services/index.ts
+++ b/prd-admin/src/services/index.ts
@@ -40,6 +40,7 @@ import type { CreatePlatformContract, DeletePlatformContract, GetPlatformsContra
 import type { ClearImageGenModelContract, ClearIntentModelContract, ClearVisionModelContract, CreateModelContract, DeleteModelContract, GetModelsContract, SetImageGenModelContract, SetIntentModelContract, SetMainModelContract, SetVisionModelContract, TestModelContract, UpdateModelContract, UpdateModelPrioritiesContract, GetModelAdapterInfoContract, GetModelsAdapterInfoBatchContract, GetAdapterInfoByModelNameContract } from '@/services/contracts/models';
 import type { ActivateLLMConfigContract, CreateLLMConfigContract, DeleteLLMConfigContract, GetLLMConfigsContract, UpdateLLMConfigContract } from '@/services/contracts/llmConfigs';
 import type { GetLlmLogDetailContract, GetLlmLogsContract, GetLlmLogsMetaContract, GetLlmModelStatsContract, GetReplayCurlContract } from '@/services/contracts/llmLogs';
+import type { GetTeamActivityLogsContract, GetTeamActivityModulesContract } from '@/services/contracts/teamActivity';
 import type { GetAdminDocumentContentContract } from '@/services/contracts/adminDocuments';
 import type { ListUploadArtifactsContract } from '@/services/contracts/uploadArtifacts';
 import type { AdminImpersonateContract } from '@/services/contracts/lab';
@@ -315,6 +316,7 @@ import { createPlatformReal, deletePlatformReal, getPlatformsReal, updatePlatfor
 import { clearImageGenModelReal, clearIntentModelReal, clearVisionModelReal, createModelReal, deleteModelReal, getModelsReal, setImageGenModelReal, setIntentModelReal, setMainModelReal, setVisionModelReal, testModelReal, updateModelReal, updateModelPrioritiesReal, getModelAdapterInfoReal, getModelsAdapterInfoBatchReal, getAdapterInfoByModelNameReal } from '@/services/real/models';
 import { activateLLMConfigReal, createLLMConfigReal, deleteLLMConfigReal, getLLMConfigsReal, updateLLMConfigReal } from '@/services/real/llmConfigs';
 import { getLlmLogDetailReal, getLlmLogsMetaReal, getLlmLogsReal, getLlmModelStatsReal, getBatchModelStatsReal, getReplayCurlReal } from '@/services/real/llmLogs';
+import { getTeamActivityLogsReal, getTeamActivityModulesReal } from '@/services/real/teamActivity';
 import { getAdminDocumentContentReal } from '@/services/real/adminDocuments';
 import { listUploadArtifactsReal } from '@/services/real/uploadArtifacts';
 import {
@@ -879,6 +881,9 @@ export const createLLMConfig: CreateLLMConfigContract = withAuth(createLLMConfig
 export const updateLLMConfig: UpdateLLMConfigContract = withAuth(updateLLMConfigReal);
 export const deleteLLMConfig: DeleteLLMConfigContract = withAuth(deleteLLMConfigReal);
 export const activateLLMConfig: ActivateLLMConfigContract = withAuth(activateLLMConfigReal);
+
+export const getTeamActivityLogs: GetTeamActivityLogsContract = withAuth(getTeamActivityLogsReal);
+export const getTeamActivityModules: GetTeamActivityModulesContract = withAuth(getTeamActivityModulesReal);
 
 export const getLlmLogs: GetLlmLogsContract = withAuth(getLlmLogsReal);
 export const getLlmLogDetail: GetLlmLogDetailContract = withAuth(getLlmLogDetailReal);

--- a/prd-admin/src/services/real/teamActivity.ts
+++ b/prd-admin/src/services/real/teamActivity.ts
@@ -1,0 +1,35 @@
+import { apiRequest } from '@/services/real/apiClient';
+import { api } from '@/services/api';
+import type { ApiResponse } from '@/types/api';
+import type {
+  GetTeamActivityLogsContract,
+  GetTeamActivityModulesContract,
+  GetTeamActivityParams,
+  TeamActivityListData,
+  TeamActivityModulesData,
+} from '@/services/contracts/teamActivity';
+
+function toQuery(params?: GetTeamActivityParams) {
+  const sp = new URLSearchParams();
+  if (!params) return '';
+  Object.entries(params).forEach(([k, v]) => {
+    if (v === undefined || v === null) return;
+    const s = String(v).trim();
+    if (!s) return;
+    sp.set(k, s);
+  });
+  const qs = sp.toString();
+  return qs ? `?${qs}` : '';
+}
+
+export const getTeamActivityLogsReal: GetTeamActivityLogsContract = async (
+  params?: GetTeamActivityParams
+): Promise<ApiResponse<TeamActivityListData>> => {
+  return await apiRequest<TeamActivityListData>(`${api.teamActivity.logs()}${toQuery(params)}`, { method: 'GET' });
+};
+
+export const getTeamActivityModulesReal: GetTeamActivityModulesContract = async (): Promise<
+  ApiResponse<TeamActivityModulesData>
+> => {
+  return await apiRequest<TeamActivityModulesData>(api.teamActivity.modules(), { method: 'GET' });
+};

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ImageGenController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ImageGenController.cs
@@ -1330,6 +1330,7 @@ public class ImageGenController : ControllerBase
             var existed = await _db.ImageGenRuns.Find(x => x.OwnerAdminId == adminId && x.IdempotencyKey == idemKey).FirstOrDefaultAsync(ct);
             if (existed != null)
             {
+                PrdAgent.Api.Filters.ActivityLogActionFilter.Suppress(HttpContext);
                 return Ok(ApiResponse<object>.Ok(new { runId = existed.Id }));
             }
         }
@@ -1521,7 +1522,11 @@ public class ImageGenController : ControllerBase
         {
             // 幂等键并发冲突：返回已存在的 run
             var existed = await _db.ImageGenRuns.Find(x => x.OwnerAdminId == adminId && x.IdempotencyKey == idemKey).FirstOrDefaultAsync(ct);
-            if (existed != null) return Ok(ApiResponse<object>.Ok(new { runId = existed.Id }));
+            if (existed != null)
+            {
+                PrdAgent.Api.Filters.ActivityLogActionFilter.Suppress(HttpContext);
+                return Ok(ApiResponse<object>.Ok(new { runId = existed.Id }));
+            }
             throw;
         }
 

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ImageMasterController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ImageMasterController.cs
@@ -277,7 +277,11 @@ public class ImageMasterController : ControllerBase
         {
             var cacheKey = $"imageMaster:workspaces:create:{adminId}:{idemKey}";
             var cached = await _cache.GetAsync<object>(cacheKey);
-            if (cached != null) return Ok(ApiResponse<object>.Ok(cached));
+            if (cached != null)
+            {
+                PrdAgent.Api.Filters.ActivityLogActionFilter.Suppress(HttpContext);
+                return Ok(ApiResponse<object>.Ok(cached));
+            }
         }
 
         var title = (request?.Title ?? string.Empty).Trim();
@@ -500,7 +504,11 @@ public class ImageMasterController : ControllerBase
         {
             var cacheKey = $"imageMaster:workspaces:delete:{adminId}:{wid}:{idemKey}";
             var cached = await _cache.GetAsync<object>(cacheKey);
-            if (cached != null) return Ok(ApiResponse<object>.Ok(cached));
+            if (cached != null)
+            {
+                PrdAgent.Api.Filters.ActivityLogActionFilter.Suppress(HttpContext);
+                return Ok(ApiResponse<object>.Ok(cached));
+            }
         }
 
         // 1) 删除画布
@@ -1519,7 +1527,11 @@ public class ImageMasterController : ControllerBase
             if (!string.IsNullOrWhiteSpace(idemKey))
             {
                 var existed = await _db.ImageGenRuns.Find(x => x.OwnerAdminId == adminId && x.IdempotencyKey == idemKey).FirstOrDefaultAsync(ct);
-                if (existed != null) return Ok(ApiResponse<object>.Ok(new { runId = existed.Id }));
+                if (existed != null)
+                {
+                    PrdAgent.Api.Filters.ActivityLogActionFilter.Suppress(HttpContext);
+                    return Ok(ApiResponse<object>.Ok(new { runId = existed.Id }));
+                }
             }
 
             var prompt = (request?.Prompt ?? string.Empty).Trim();
@@ -1653,7 +1665,11 @@ public class ImageMasterController : ControllerBase
             catch (MongoWriteException mw) when (mw.WriteError?.Category == ServerErrorCategory.DuplicateKey && !string.IsNullOrWhiteSpace(idemKey))
             {
                 var existed = await _db.ImageGenRuns.Find(x => x.OwnerAdminId == adminId && x.IdempotencyKey == idemKey).FirstOrDefaultAsync(ct);
-                if (existed != null) return Ok(ApiResponse<object>.Ok(new { runId = existed.Id }));
+                if (existed != null)
+                {
+                    PrdAgent.Api.Filters.ActivityLogActionFilter.Suppress(HttpContext);
+                    return Ok(ApiResponse<object>.Ok(new { runId = existed.Id }));
+                }
                 throw;
             }
 

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/LiteraryAgentImageGenController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/LiteraryAgentImageGenController.cs
@@ -141,6 +141,7 @@ public class LiteraryAgentImageGenController : ControllerBase
             var existed = await _db.ImageGenRuns.Find(x => x.OwnerAdminId == adminId && x.IdempotencyKey == idemKey).FirstOrDefaultAsync(ct);
             if (existed != null)
             {
+                PrdAgent.Api.Filters.ActivityLogActionFilter.Suppress(HttpContext);
                 return Ok(ApiResponse<object>.Ok(new { runId = existed.Id }));
             }
         }
@@ -313,6 +314,7 @@ public class LiteraryAgentImageGenController : ControllerBase
             var existed = await _db.ImageGenRuns.Find(x => x.OwnerAdminId == adminId && x.IdempotencyKey == idemKey).FirstOrDefaultAsync(ct);
             if (existed != null)
             {
+                PrdAgent.Api.Filters.ActivityLogActionFilter.Suppress(HttpContext);
                 return Ok(ApiResponse<object>.Ok(new { runId = existed.Id }));
             }
             throw;

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/TeamActivityController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/TeamActivityController.cs
@@ -1,0 +1,96 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using MongoDB.Driver;
+using PrdAgent.Api.Filters;
+using PrdAgent.Core.Models;
+using PrdAgent.Core.Security;
+using PrdAgent.Infrastructure.Database;
+
+namespace PrdAgent.Api.Controllers.Api;
+
+/// <summary>
+/// 管理后台 - 团队动态（全员工作日志时间线）。
+/// 数据由 ActivityLogActionFilter 按白名单自动写入，本 Controller 只读。
+/// </summary>
+[ApiController]
+[Route("api/team-activity")]
+[Authorize]
+[AdminController("team-activity", AdminPermissionCatalog.TeamActivityRead)]
+public class TeamActivityController : ControllerBase
+{
+    private readonly MongoDbContext _db;
+
+    public TeamActivityController(MongoDbContext db)
+    {
+        _db = db;
+    }
+
+    /// <summary>
+    /// 动态列表（按时间倒序分页），支持按人 / 模块 / 时间范围筛选。
+    /// </summary>
+    [HttpGet("logs")]
+    public async Task<IActionResult> ListLogs(
+        [FromQuery] string? userId = null,
+        [FromQuery] string? module = null,
+        [FromQuery] DateTime? from = null,
+        [FromQuery] DateTime? to = null,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 30)
+    {
+        page = Math.Max(1, page);
+        pageSize = Math.Clamp(pageSize, 1, 100);
+
+        var b = Builders<ActivityLog>.Filter;
+        var filters = new List<FilterDefinition<ActivityLog>>();
+        if (!string.IsNullOrWhiteSpace(userId)) filters.Add(b.Eq(x => x.ActorId, userId));
+        if (!string.IsNullOrWhiteSpace(module)) filters.Add(b.Eq(x => x.Module, module));
+        if (from.HasValue) filters.Add(b.Gte(x => x.CreatedAt, from.Value.ToUniversalTime()));
+        if (to.HasValue) filters.Add(b.Lte(x => x.CreatedAt, to.Value.ToUniversalTime()));
+        var filter = filters.Count == 0 ? b.Empty : b.And(filters);
+
+        var total = await _db.ActivityLogs.CountDocumentsAsync(filter);
+        var logs = await _db.ActivityLogs.Find(filter)
+            .SortByDescending(x => x.CreatedAt)
+            .Skip((page - 1) * pageSize)
+            .Limit(pageSize)
+            .ToListAsync();
+
+        var actorIds = logs.Select(l => l.ActorId).Distinct().ToList();
+        var actorMap = (await _db.Users.Find(u => actorIds.Contains(u.UserId)).ToListAsync())
+            .ToDictionary(u => u.UserId, u => new { u.DisplayName, u.AvatarFileName });
+
+        var items = logs.Select(l =>
+        {
+            actorMap.TryGetValue(l.ActorId, out var actor);
+            return new
+            {
+                id = l.Id,
+                actorId = l.ActorId,
+                actorName = actor?.DisplayName,
+                actorAvatarFileName = actor?.AvatarFileName,
+                module = l.Module,
+                moduleLabel = l.ModuleLabel,
+                action = l.Action,
+                actionLabel = l.ActionLabel,
+                targetId = l.TargetId,
+                targetTitle = l.TargetTitle,
+                targetUrl = l.TargetUrl,
+                createdAt = l.CreatedAt,
+            };
+        }).ToList();
+
+        return Ok(ApiResponse<object>.Ok(new { items, total, page, pageSize }));
+    }
+
+    /// <summary>
+    /// 模块筛选清单（来自白名单注册表，避免前后端模块清单漂移）。
+    /// </summary>
+    [HttpGet("modules")]
+    public IActionResult ListModules()
+    {
+        var items = ActivityActionRegistry.Modules
+            .Select(m => new { key = m.Key, label = m.Label })
+            .ToList();
+        return Ok(ApiResponse<object>.Ok(new { items }));
+    }
+}

--- a/prd-api/src/PrdAgent.Api/Filters/ActivityActionRegistry.cs
+++ b/prd-api/src/PrdAgent.Api/Filters/ActivityActionRegistry.cs
@@ -1,0 +1,114 @@
+using MongoDB.Driver;
+using PrdAgent.Infrastructure.Database;
+
+namespace PrdAgent.Api.Filters;
+
+/// <summary>
+/// 团队动态白名单条目。
+/// 标题来源两条路：TitleArgs 从 action 参数声明式提取（创建类动作，请求体里带标题）；
+/// TitleDb 按 TargetId 预读数据库（更新/删除/状态流转类动作）——预读发生在 next() 之前，
+/// 保证删除类动作仍能拿到删除前的标题快照。
+/// </summary>
+/// <param name="Module">模块 key（如 document-store）</param>
+/// <param name="ModuleLabel">模块中文名（如「知识库」）</param>
+/// <param name="ActionLabel">动作中文标签（如「发布了文档」）</param>
+/// <param name="TargetRouteKey">路由里取 TargetId 的参数名（如 entryId），null 表示无目标对象</param>
+/// <param name="TitleArgs">按序尝试的参数路径："request.Title"（DTO 属性）/ "title"（裸 string 参数）/ "file"（IFormFile 取 FileName）</param>
+/// <param name="TitleDb">按 TargetId 预读标题的查询委托</param>
+public sealed record ActivityActionDef(
+    string Module,
+    string ModuleLabel,
+    string ActionLabel,
+    string? TargetRouteKey = null,
+    string[]? TitleArgs = null,
+    Func<MongoDbContext, string, Task<string?>>? TitleDb = null);
+
+/// <summary>
+/// 团队动态白名单注册表（SSOT）。key 为 "ControllerName.ActionName" 复合键
+/// （CreateWorkspace / CreateTemplate 等 Action 名跨 Controller 重名，单 Action 名不可用）。
+/// 不在表内的动作（含所有读接口）不产生动态。
+/// 登记原则：只登记"人做了一件值得团队知道的事"，点赞/收藏/置顶/分享链管理/视图打点等噪音动作禁止入表。
+/// </summary>
+public static class ActivityActionRegistry
+{
+    // ── TitleDb 查询委托 ──
+
+    private static readonly Func<MongoDbContext, string, Task<string?>> DocEntryTitle =
+        async (db, id) => (await db.DocumentEntries.Find(x => x.Id == id).FirstOrDefaultAsync())?.Title;
+
+    private static readonly Func<MongoDbContext, string, Task<string?>> DocStoreName =
+        async (db, id) => (await db.DocumentStores.Find(x => x.Id == id).FirstOrDefaultAsync())?.Name;
+
+    private static readonly Func<MongoDbContext, string, Task<string?>> DefectTitle =
+        async (db, id) => (await db.DefectReports.Find(x => x.Id == id).FirstOrDefaultAsync())?.Title;
+
+    private static readonly Func<MongoDbContext, string, Task<string?>> WeeklyReportTitle =
+        async (db, id) =>
+        {
+            var r = await db.WeeklyReports.Find(x => x.Id == id).FirstOrDefaultAsync();
+            return r == null ? null : $"{r.WeekYear}年第{r.WeekNumber}周";
+        };
+
+    private static readonly Func<MongoDbContext, string, Task<string?>> WorkspaceTitle =
+        async (db, id) => (await db.ImageMasterWorkspaces.Find(x => x.Id == id).FirstOrDefaultAsync())?.Title;
+
+    private static readonly Func<MongoDbContext, string, Task<string?>> HostedSiteTitle =
+        async (db, id) => (await db.HostedSites.Find(x => x.Id == id).FirstOrDefaultAsync())?.Title;
+
+    /// <summary>白名单字典："Controller.Action" → 条目定义</summary>
+    public static readonly IReadOnlyDictionary<string, ActivityActionDef> Actions =
+        new Dictionary<string, ActivityActionDef>(StringComparer.Ordinal)
+        {
+            // ── 知识库 document-store ──
+            ["DocumentStore.CreateStore"] = new("document-store", "知识库", "创建了知识库", TitleArgs: new[] { "request.Name" }),
+            ["DocumentStore.AddEntry"] = new("document-store", "知识库", "发布了文档", "storeId", TitleArgs: new[] { "request.Title" }),
+            ["DocumentStore.UpdateEntry"] = new("document-store", "知识库", "更新了文档", "entryId", TitleDb: DocEntryTitle),
+            ["DocumentStore.UpdateEntryContent"] = new("document-store", "知识库", "更新了文档内容", "entryId", TitleDb: DocEntryTitle),
+            ["DocumentStore.DeleteEntry"] = new("document-store", "知识库", "删除了文档", "entryId", TitleDb: DocEntryTitle),
+            ["DocumentStore.DeleteStore"] = new("document-store", "知识库", "删除了知识库", "storeId", TitleDb: DocStoreName),
+            ["DocumentStore.UploadFile"] = new("document-store", "知识库", "上传了文档", "storeId", TitleArgs: new[] { "file" }),
+
+            // ── 缺陷管理 defect-agent ──
+            ["DefectAgent.CreateDefect"] = new("defect-agent", "缺陷管理", "创建了缺陷", TitleArgs: new[] { "request.Title" }),
+            ["DefectAgent.SubmitDefect"] = new("defect-agent", "缺陷管理", "提交了缺陷", "id", TitleDb: DefectTitle),
+            ["DefectAgent.AssignDefect"] = new("defect-agent", "缺陷管理", "指派了缺陷", "id", TitleDb: DefectTitle),
+            ["DefectAgent.ResolveDefect"] = new("defect-agent", "缺陷管理", "标记缺陷已修复", "id", TitleDb: DefectTitle),
+            ["DefectAgent.VerifyPass"] = new("defect-agent", "缺陷管理", "验证通过了缺陷", "id", TitleDb: DefectTitle),
+            ["DefectAgent.RejectDefect"] = new("defect-agent", "缺陷管理", "驳回了缺陷", "id", TitleDb: DefectTitle),
+            ["DefectAgent.CloseDefect"] = new("defect-agent", "缺陷管理", "关闭了缺陷", "id", TitleDb: DefectTitle),
+            ["DefectAgent.ReopenDefect"] = new("defect-agent", "缺陷管理", "重新打开了缺陷", "id", TitleDb: DefectTitle),
+            ["DefectAgent.SendMessage"] = new("defect-agent", "缺陷管理", "评论了缺陷", "id", TitleDb: DefectTitle),
+            ["DefectAgent.DeleteDefect"] = new("defect-agent", "缺陷管理", "删除了缺陷", "id", TitleDb: DefectTitle),
+
+            // ── 周报/日报 report-agent ──
+            ["ReportAgent.CreateReport"] = new("report-agent", "周报", "创建了周报"),
+            ["ReportAgent.SubmitReport"] = new("report-agent", "周报", "发布了周报", "id", TitleDb: WeeklyReportTitle),
+            ["ReportAgent.ReviewReport"] = new("report-agent", "周报", "审阅了周报", "id", TitleDb: WeeklyReportTitle),
+            ["ReportAgent.ReturnReport"] = new("report-agent", "周报", "退回了周报", "id", TitleDb: WeeklyReportTitle),
+            ["ReportAgent.CreateComment"] = new("report-agent", "周报", "评论了周报", "id", TitleDb: WeeklyReportTitle),
+            ["ReportAgent.SaveDailyLog"] = new("report-agent", "周报", "提交了日报", TitleArgs: new[] { "request.Date" }),
+
+            // ── 视觉创作 visual-agent ──
+            ["ImageMaster.CreateWorkspace"] = new("visual-agent", "视觉创作", "创建了工作区", TitleArgs: new[] { "request.Title" }),
+            ["ImageMaster.DeleteWorkspace"] = new("visual-agent", "视觉创作", "删除了工作区", "id", TitleDb: WorkspaceTitle),
+            ["ImageMaster.CreateWorkspaceImageGenRun"] = new("visual-agent", "视觉创作", "发起了图片生成", "id", TitleDb: WorkspaceTitle),
+            ["ImageGen.CreateRun"] = new("visual-agent", "视觉创作", "发起了图片生成"),
+
+            // ── 文学创作 literary-agent ──
+            ["LiteraryAgentWorkspace.CreateWorkspace"] = new("literary-agent", "文学创作", "创建了工作区", TitleArgs: new[] { "request.Title" }),
+            ["LiteraryAgentWorkspace.DeleteWorkspace"] = new("literary-agent", "文学创作", "删除了工作区", "id", TitleDb: WorkspaceTitle),
+            ["LiteraryAgentImageGen.CreateRun"] = new("literary-agent", "文学创作", "生成了配图"),
+
+            // ── 网页托管 web-pages ──
+            ["WebPages.Upload"] = new("web-pages", "网页托管", "发布了站点", TitleArgs: new[] { "title", "file" }),
+            ["WebPages.CreateFromContent"] = new("web-pages", "网页托管", "发布了站点", TitleArgs: new[] { "req.Title" }),
+            ["WebPages.Update"] = new("web-pages", "网页托管", "更新了站点", "id", TitleDb: HostedSiteTitle),
+            ["WebPages.Delete"] = new("web-pages", "网页托管", "删除了站点", "id", TitleDb: HostedSiteTitle),
+        };
+
+    /// <summary>导出去重后的模块清单（前端筛选下拉用，避免前后端模块清单漂移）</summary>
+    public static IReadOnlyList<(string Key, string Label)> Modules { get; } = Actions.Values
+        .Select(d => (d.Module, d.ModuleLabel))
+        .Distinct()
+        .ToList();
+}

--- a/prd-api/src/PrdAgent.Api/Filters/ActivityLogActionFilter.cs
+++ b/prd-api/src/PrdAgent.Api/Filters/ActivityLogActionFilter.cs
@@ -1,0 +1,149 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Reflection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+using PrdAgent.Core.Models;
+using PrdAgent.Infrastructure.Database;
+
+namespace PrdAgent.Api.Filters;
+
+/// <summary>
+/// 团队动态过滤器（全局挂载）— 白名单（ActivityActionRegistry）内的写操作成功后
+/// 自动写一条 activity_logs，支撑「团队动态」时间线。
+/// 机制对照 PmAuditActionFilter：白名单外（含所有读接口）一次字典查找即逃逸；
+/// 仅记录 2xx；写入失败绝不影响主请求（全程 try/catch）。
+/// 差异点：TitleDb 类条目在 next() 之前预读标题，保证删除类动作仍能拿到删除前快照。
+/// </summary>
+public sealed class ActivityLogActionFilter : IAsyncActionFilter
+{
+    private const int MaxTitleLength = 200;
+
+    private readonly MongoDbContext _db;
+    private readonly ILogger<ActivityLogActionFilter> _logger;
+
+    public ActivityLogActionFilter(MongoDbContext db, ILogger<ActivityLogActionFilter> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+    {
+        ActivityActionDef? def = null;
+        string actionKey = string.Empty;
+        string? targetId = null;
+        string? preloadedTitle = null;
+        IDictionary<string, object?>? args = null;
+
+        try
+        {
+            var method = context.HttpContext.Request.Method;
+            if (!HttpMethods.IsGet(method) && !HttpMethods.IsHead(method) && !HttpMethods.IsOptions(method)
+                && context.ActionDescriptor is ControllerActionDescriptor cad
+                && ActivityActionRegistry.Actions.TryGetValue($"{cad.ControllerName}.{cad.ActionName}", out var found))
+            {
+                def = found;
+                actionKey = $"{cad.ControllerName}.{cad.ActionName}";
+                args = context.ActionArguments!;
+
+                if (def.TargetRouteKey != null
+                    && context.RouteData.Values.TryGetValue(def.TargetRouteKey, out var tv))
+                {
+                    targetId = tv?.ToString();
+                }
+
+                // 删除/状态流转类动作在执行前预读标题，拿删除前的快照
+                if (def.TitleDb != null && !string.IsNullOrEmpty(targetId))
+                {
+                    preloadedTitle = await def.TitleDb(_db, targetId);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "[team-activity] 预读动态标题失败");
+        }
+
+        var executed = await next();
+
+        if (def == null) return;
+
+        try
+        {
+            // 仅记录成功结果（2xx）
+            var status = (executed.Result as ObjectResult)?.StatusCode
+                         ?? (executed.Result as StatusCodeResult)?.StatusCode
+                         ?? context.HttpContext.Response?.StatusCode
+                         ?? 200;
+            if (status is < 200 or >= 300) return;
+
+            var actorId = context.HttpContext.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value ?? string.Empty;
+            if (string.IsNullOrEmpty(actorId)) return;
+
+            var title = preloadedTitle ?? ExtractTitleFromArgs(args, def.TitleArgs);
+            if (title is { Length: > MaxTitleLength })
+            {
+                title = title[..MaxTitleLength];
+            }
+
+            var entry = new ActivityLog
+            {
+                ActorId = actorId,
+                Module = def.Module,
+                ModuleLabel = def.ModuleLabel,
+                Action = actionKey,
+                ActionLabel = def.ActionLabel,
+                TargetId = targetId,
+                TargetTitle = string.IsNullOrWhiteSpace(title) ? null : title.Trim(),
+                Method = context.HttpContext.Request.Method,
+                Path = context.HttpContext.Request.Path.Value ?? string.Empty,
+            };
+            await _db.ActivityLogs.InsertOneAsync(entry, cancellationToken: CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            // 动态写入失败不得影响主流程
+            _logger.LogWarning(ex, "[team-activity] 写团队动态失败");
+        }
+    }
+
+    /// <summary>
+    /// 按白名单声明的参数路径提取标题。
+    /// 支持三种形式："request.Title"（DTO 属性反射）、"title"（裸 string 参数）、"file"（IFormFile 取 FileName）。
+    /// </summary>
+    private static string? ExtractTitleFromArgs(IDictionary<string, object?>? args, string[]? specs)
+    {
+        if (args == null || specs == null) return null;
+
+        foreach (var spec in specs)
+        {
+            var dot = spec.IndexOf('.');
+            if (dot < 0)
+            {
+                if (!args.TryGetValue(spec, out var v) || v == null) continue;
+                switch (v)
+                {
+                    case string s when !string.IsNullOrWhiteSpace(s):
+                        return s;
+                    case IFormFile f when !string.IsNullOrWhiteSpace(f.FileName):
+                        return f.FileName;
+                }
+            }
+            else
+            {
+                var argName = spec[..dot];
+                var propName = spec[(dot + 1)..];
+                if (!args.TryGetValue(argName, out var obj) || obj == null) continue;
+                var prop = obj.GetType().GetProperty(propName,
+                    BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+                if (prop?.GetValue(obj) is string val && !string.IsNullOrWhiteSpace(val))
+                {
+                    return val;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/prd-api/src/PrdAgent.Api/Filters/ActivityLogActionFilter.cs
+++ b/prd-api/src/PrdAgent.Api/Filters/ActivityLogActionFilter.cs
@@ -72,6 +72,9 @@ public sealed class ActivityLogActionFilter : IAsyncActionFilter
 
         try
         {
+            // Action 抛了未处理异常时不留痕——此时 Result 为空、响应码还停留在默认 200，不能当成功
+            if (executed.Exception != null && !executed.ExceptionHandled) return;
+
             // 仅记录成功结果（2xx）
             var status = (executed.Result as ObjectResult)?.StatusCode
                          ?? (executed.Result as StatusCodeResult)?.StatusCode

--- a/prd-api/src/PrdAgent.Api/Filters/ActivityLogActionFilter.cs
+++ b/prd-api/src/PrdAgent.Api/Filters/ActivityLogActionFilter.cs
@@ -18,6 +18,15 @@ namespace PrdAgent.Api.Filters;
 /// </summary>
 public sealed class ActivityLogActionFilter : IAsyncActionFilter
 {
+    /// <summary>HttpContext.Items 标记 key：本次请求未发生新写入（如幂等回放命中缓存），跳过留痕</summary>
+    public const string SuppressItemKey = "team-activity:suppress";
+
+    /// <summary>
+    /// 在"返回缓存结果、未发生新写入"的分支（典型：Idempotency-Key 回放命中）调用，
+    /// 避免客户端超时重试时产生重复动态。
+    /// </summary>
+    public static void Suppress(HttpContext httpContext) => httpContext.Items[SuppressItemKey] = true;
+
     private const int MaxTitleLength = 200;
 
     private readonly MongoDbContext _db;
@@ -74,6 +83,9 @@ public sealed class ActivityLogActionFilter : IAsyncActionFilter
         {
             // Action 抛了未处理异常时不留痕——此时 Result 为空、响应码还停留在默认 200，不能当成功
             if (executed.Exception != null && !executed.ExceptionHandled) return;
+
+            // 幂等回放等"未发生新写入"的成功响应不留痕（由业务分支显式打标）
+            if (context.HttpContext.Items.ContainsKey(SuppressItemKey)) return;
 
             // 仅记录成功结果（2xx）
             var status = (executed.Result as ObjectResult)?.StatusCode

--- a/prd-api/src/PrdAgent.Api/Program.cs
+++ b/prd-api/src/PrdAgent.Api/Program.cs
@@ -85,7 +85,11 @@ builder.Services.ConfigureHttpJsonOptions(options =>
 
 // 添加服务
 builder.Services.AddScoped<PrdAgent.Api.Filters.PmAuditActionFilter>();
-builder.Services.AddControllers()
+builder.Services.AddControllers(options =>
+    {
+        // 团队动态：全局白名单审计（白名单外的动作一次字典查找即逃逸）
+        options.Filters.Add<PrdAgent.Api.Filters.ActivityLogActionFilter>();
+    })
     .AddJsonOptions(options =>
     {
         options.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;

--- a/prd-api/src/PrdAgent.Core/Models/ActivityLog.cs
+++ b/prd-api/src/PrdAgent.Core/Models/ActivityLog.cs
@@ -1,0 +1,43 @@
+namespace PrdAgent.Core.Models;
+
+/// <summary>
+/// 团队动态（工作日志）— 全平台白名单写操作留痕，支撑「张三 在 知识库 发布了文档《标题》」式时间线渲染。
+/// 由 ActivityLogActionFilter 在白名单动作成功后自动写入，无需逐端点埋点。
+/// 仅存 ActorId（显示名/头像在读取时批量解析）；TargetTitle 为写入时快照（对象删除后仍可展示）。
+/// </summary>
+public class ActivityLog
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString("N");
+
+    /// <summary>操作人 UserId（JWT sub）</summary>
+    public string ActorId { get; set; } = string.Empty;
+
+    /// <summary>模块 key（document-store / defect-agent / report-agent / visual-agent / literary-agent / web-pages）</summary>
+    public string Module { get; set; } = string.Empty;
+
+    /// <summary>模块中文名快照（如「知识库」），写入时固化避免 key 改名后历史错乱</summary>
+    public string ModuleLabel { get; set; } = string.Empty;
+
+    /// <summary>动作标识（Controller.Action 复合键，如 DocumentStore.AddEntry）</summary>
+    public string Action { get; set; } = string.Empty;
+
+    /// <summary>动作中文标签（如「发布了文档」）</summary>
+    public string ActionLabel { get; set; } = string.Empty;
+
+    /// <summary>操作对象 ID（路由子实体 id，按白名单条目声明的 key 提取）</summary>
+    public string? TargetId { get; set; }
+
+    /// <summary>操作对象标题快照（知识库名/文档标题/缺陷标题等），抓不到时为空、前端降级展示</summary>
+    public string? TargetTitle { get; set; }
+
+    /// <summary>操作对象深链（预留，一期留空）</summary>
+    public string? TargetUrl { get; set; }
+
+    /// <summary>HTTP 方法（排障用）</summary>
+    public string Method { get; set; } = string.Empty;
+
+    /// <summary>请求路径（排障用）</summary>
+    public string Path { get; set; } = string.Empty;
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/prd-api/src/PrdAgent.Core/Security/AdminMenuCatalog.cs
+++ b/prd-api/src/PrdAgent.Core/Security/AdminMenuCatalog.cs
@@ -34,6 +34,7 @@ public static class AdminMenuCatalog
         // ── 系统管理 (admin) ──
         new("mds", "/mds", "模型中心", "模型、提示词与实验室", "Cpu", 50, "admin"),
         new("users", "/users", "用户权限", "用户与角色管理", "Users", 60, "admin"),
+        new("team-activity", "/team-activity", "团队动态", "全员工作动态时间线", "Activity", 65, "admin"),
         new("settings", "/settings", "设置", "账户、皮肤与导航设置", "Settings", 70, "admin"),
 
         // ── 头像面板 (无 Group，不在侧边栏显示) ──

--- a/prd-api/src/PrdAgent.Core/Security/AdminPermissionCatalog.cs
+++ b/prd-api/src/PrdAgent.Core/Security/AdminPermissionCatalog.cs
@@ -332,6 +332,11 @@ public static class AdminPermissionCatalog
     public const string PeerSyncManage = "peer-sync.manage";
 
     /// <summary>
+    /// 团队动态权限（读）：查看全员工作动态时间线（管理员级）
+    /// </summary>
+    public const string TeamActivityRead = "team-activity.read";
+
+    /// <summary>
     /// 超级权限（当路由未配置映射时，用于兜底放行；同时也可用于 root 破窗全权限）。
     /// </summary>
     public const string Super = "super";
@@ -450,6 +455,8 @@ public static class AdminPermissionCatalog
 
         new(DailyTipsRead, "小技巧-读", "查看小技巧列表（管理视图）"),
         new(DailyTipsWrite, "小技巧-写", "新建/编辑/删除首页小技巧与引导卡片"),
+
+        new(TeamActivityRead, "团队动态-读", "查看全员工作动态时间线（仅授予管理层）"),
 
         new(Super, "超级权限", "兜底放行：建议仅给 root/超级管理员"),
     };

--- a/prd-api/src/PrdAgent.Infrastructure/Database/MongoDbContext.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Database/MongoDbContext.cs
@@ -343,6 +343,9 @@ public class MongoDbContext
     public IMongoCollection<PmRisk> PmRisks => _database.GetCollection<PmRisk>("pm_risks");
     public IMongoCollection<PmAuditLog> PmAuditLogs => _database.GetCollection<PmAuditLog>("pm_audit_logs");
 
+    // 团队动态（全平台白名单写操作留痕，ActivityLogActionFilter 写入）
+    public IMongoCollection<ActivityLog> ActivityLogs => _database.GetCollection<ActivityLog>("activity_logs");
+
     // Product Management 产品管理（产品-版本-需求-功能-客户 + 通用表单/状态机引擎）
     public IMongoCollection<Product> Products => _database.GetCollection<Product>("products");
     public IMongoCollection<ProductVersion> ProductVersions => _database.GetCollection<ProductVersion>("product_versions");

--- a/prd-api/tests/PrdAgent.Api.Tests/Controllers/ActivityActionRegistryGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Controllers/ActivityActionRegistryGuardTests.cs
@@ -1,0 +1,87 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Mvc;
+using PrdAgent.Api.Filters;
+using Xunit;
+
+namespace PrdAgent.Api.Tests.Controllers;
+
+/// <summary>
+/// 团队动态白名单守卫 — 防止 Controller / Action 重命名后白名单静默失效
+/// （ActivityLogActionFilter 按 "Controller.Action" 字典匹配，匹配不到不报错只是不留痕，
+/// 没有守卫的话重命名会让动态悄悄断流）。
+/// </summary>
+public class ActivityActionRegistryGuardTests
+{
+    private static readonly Assembly ApiAssembly = typeof(ActivityActionRegistry).Assembly;
+
+    /// <summary>白名单里的每个 "Controller.Action" 复合键必须能在 API 程序集中找到对应的 Controller 类与公开 Action 方法。</summary>
+    [Fact]
+    public void EveryRegistryKey_ShouldMatchExistingControllerAction()
+    {
+        // 同名 Controller 可能在不同命名空间出现（MVC 路由用短名，留痕键也用短名），按短名分组逐一匹配
+        var controllers = ApiAssembly.GetTypes()
+            .Where(t => !t.IsAbstract && typeof(ControllerBase).IsAssignableFrom(t))
+            .ToLookup(
+                t => t.Name.EndsWith("Controller", StringComparison.Ordinal) ? t.Name[..^"Controller".Length] : t.Name,
+                StringComparer.Ordinal);
+
+        var missing = new List<string>();
+        foreach (var key in ActivityActionRegistry.Actions.Keys)
+        {
+            var parts = key.Split('.');
+            if (parts.Length != 2)
+            {
+                missing.Add($"{key}（格式应为 Controller.Action）");
+                continue;
+            }
+
+            var candidates = controllers[parts[0]].ToList();
+            if (candidates.Count == 0)
+            {
+                missing.Add($"{key}（找不到 {parts[0]}Controller）");
+                continue;
+            }
+
+            var hasAction = candidates.Any(controllerType => controllerType
+                .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                .Any(m => string.Equals(m.Name, parts[1], StringComparison.Ordinal)));
+            if (!hasAction)
+            {
+                missing.Add($"{key}（{parts[0]}Controller 上没有公开方法 {parts[1]}）");
+            }
+        }
+
+        Assert.True(missing.Count == 0,
+            "团队动态白名单存在漂移条目（Controller/Action 已重命名或删除，请同步更新 ActivityActionRegistry）:\n  " +
+            string.Join("\n  ", missing));
+    }
+
+    /// <summary>每个条目的展示字段必须完整，且至少声明一种标题来源或显式无目标对象。</summary>
+    [Fact]
+    public void EveryRegistryDef_ShouldHaveCompleteDisplayFields()
+    {
+        foreach (var (key, def) in ActivityActionRegistry.Actions)
+        {
+            Assert.False(string.IsNullOrWhiteSpace(def.Module), $"{key}: Module 不能为空");
+            Assert.False(string.IsNullOrWhiteSpace(def.ModuleLabel), $"{key}: ModuleLabel 不能为空");
+            Assert.False(string.IsNullOrWhiteSpace(def.ActionLabel), $"{key}: ActionLabel 不能为空");
+            // TitleDb 必须配合 TargetRouteKey 使用（预读需要 TargetId）
+            if (def.TitleDb != null)
+            {
+                Assert.False(string.IsNullOrWhiteSpace(def.TargetRouteKey),
+                    $"{key}: 声明了 TitleDb 却没有 TargetRouteKey，预读永远拿不到 TargetId");
+            }
+        }
+    }
+
+    /// <summary>模块清单导出应去重且与白名单一致（前端筛选下拉数据源）。</summary>
+    [Fact]
+    public void Modules_ShouldBeDistinctAndCoverAllEntries()
+    {
+        var keys = ActivityActionRegistry.Modules.Select(m => m.Key).ToList();
+        Assert.Equal(keys.Count, keys.Distinct(StringComparer.Ordinal).Count());
+
+        var registered = ActivityActionRegistry.Actions.Values.Select(d => d.Module).Distinct().ToHashSet(StringComparer.Ordinal);
+        Assert.Equal(registered, keys.ToHashSet(StringComparer.Ordinal));
+    }
+}


### PR DESCRIPTION
## 摘要

实现团队动态（工作日志时间线）功能，支持管理员查看全员在知识库、缺陷管理、周报、视觉/文学创作、网页托管等模块的关键操作。通过全局 ActionFilter 白名单机制自动留痕，无需逐端点埋点。

## 改动 diff

### 后端（prd-api）
- `src/PrdAgent.Api/Filters/ActivityLogActionFilter.cs`：全局过滤器，白名单内写操作成功后自动落库 activity_logs，支持删除前标题预读
- `src/PrdAgent.Api/Filters/ActivityActionRegistry.cs`：白名单 SSOT，声明 31 个动作条目（6 个模块），含标题来源策略（TitleArgs 参数反射 / TitleDb 数据库预读）
- `src/PrdAgent.Core/Models/ActivityLog.cs`：留痕实体，含 ActorId、Module、Action、TargetTitle 等字段
- `src/PrdAgent.Api/Controllers/Api/TeamActivityController.cs`：只读端点 `/api/team-activity/logs`（分页、筛选）+ `/api/team-activity/modules`（模块清单）
- `src/PrdAgent.Core/Security/AdminPermissionCatalog.cs`：新增 `TeamActivityRead` 权限常量
- `src/PrdAgent.Infrastructure/Database/MongoDbContext.cs`：注册 ActivityLogs 集合
- `Program.cs`：全局挂载 ActivityLogActionFilter
- `tests/PrdAgent.Api.Tests/Controllers/ActivityActionRegistryGuardTests.cs`：CI 守卫测试，防止 Controller/Action 重命名后白名单静默失效

### 前端（prd-admin）
- `src/pages/team-activity/TeamActivityPage.tsx`：管理页面，按天分组时间线 + 按人/模块/时间范围筛选 + 加载更多分页
- `src/services/contracts/teamActivity.ts`：类型定义（TeamActivityItem、GetTeamActivityParams 等）
- `src/services/real/teamActivity.ts`：API 调用实现（getTeamActivityLogsReal、getTeamActivityModulesReal）
- `src/services/index.ts`：导出 getTeamActivityLogs、getTeamActivityModules
- `src/app/navRegistry.tsx`：注册 TeamActivityPage 路由
- `src/lib/shortLabel.ts`：新增 'team-activity' 短标签映射
- `src/services/api.ts`：新增 teamActivity 端点定义

### 文档与配置
- `doc/design.team-activity.md`：完整设计文档（采集原理、三层结构、白名单条目、数据设计、接口设计、已知边界）
- `doc/guide.mongodb-indexes.md`：activity_logs 集合索引（CreatedAt、ActorId+CreatedAt、Module+CreatedAt）
- `doc/guide.list.directory.md`：新增设计文档导航
- `doc/index.yml`：新增 design.team-activity 索引
- `prd-api/src/PrdAgent.Core/Security/AdminMenuCatalog.cs`：新增菜单项
- `changelogs/2026-06-11_team-activity-feed.md`：changelog 碎片

## 核心实现细节

1. **白名单驱动**：ActivityActionRegistry 为 SSOT，31

https://claude.ai/code/session_01MK5hMRUXJYEcqr6VmGvjZ7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a global MVC filter on all write traffic (failures are isolated) and a new admin-only audit surface; DBA must apply activity_logs indexes manually per the guide.
> 
> **Overview**
> Adds **团队动态** (team activity feed): whitelisted write operations across six modules are recorded automatically and shown to admins on a timeline.
> 
> **Backend:** A global `ActivityLogActionFilter` (registered in `Program.cs`) matches `Controller.Action` keys in `ActivityActionRegistry` (~31 actions). On successful 2xx responses it inserts into MongoDB `activity_logs`, with optional **pre-delete title** reads for delete/update flows. New read API `TeamActivityController` (`/api/team-activity/logs`, `/modules`), `team-activity.read` permission, and `ActivityActionRegistryGuardTests` to catch registry drift. Idempotent replay paths in image-gen controllers call `ActivityLogActionFilter.Suppress` so retries do not duplicate events.
> 
> **Admin UI:** `/team-activity` page with day-grouped timeline, member/module/time filters, and pagination; nav, authz menu, services, and docs/index/changelog/Mongo index notes updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cb1c909194eaed4f7783d473e78724ebfa28e94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->