### PR TITLE
fix(prd-admin): 教程抽屉自动弹出严格按页,根治无教程页面弹出全部教程

### DIFF
--- a/.claude/rules/onboarding-tips.md
+++ b/.claude/rules/onboarding-tips.md
@@ -82,6 +82,14 @@
 ### 5.6 加锚点:TabBar/PageHeader 自动注入 pill
 `PageHeader`/`TabBar` 在有 `title`/`items`/`actions` 时**自动注入** `<TipsEntryButton/>`,pill 在「本页无教程」时自隐。⇒ 用这两个组件的页面**无需手嵌** pill;自定义头部的页面才需手嵌。
 
+### 5.7 自动弹出严格按页（2026-06-11,治「无教程页面弹出全部教程」）
+- **没有教程的页面绝不自动弹任何东西**。自动出现只剩两类,且都限定在「本页有教程」的页面:
+  1. 新人没走完本页 `*-page-guide` → Spotlight 自动开讲(每 session 一次,机制不变);
+  2. 本页功能有更新(本页存在未学会的 `*-update-*` / `feature-release` tip)→ 抽屉自动展开一次,**只显示本页教程列表**。
+- 决策唯一入口:`pageGuideMatch.ts` 的 `pickAutoOpenUpdateTip(pageTips, opened)`,入参必须是 `filterPageTips` 按当前页过滤后的子集 —— 结构性保证不会在 A 页弹 B 页教程;禁止再用全量 tips 做自动弹出判定,禁止自动 `setShowAllPages(true)`。
+- **「管理员定向推送(isTargeted)自动弹抽屉」已删除**:推送管理后台 2026-06-04 已下线,该路径只剩脏数据来源 —— Track 端点会给「看过一眼」的用户补 Delivery 统计记录,`/visible` 旧逻辑 `isTargeted = TargetUserId==userId || mine != null` 把统计记录误判成"被推送",导致任何浏览过的教程永久变成"为你推送",并在无教程页面自动弹出"全部教程"面板(2026-06-11 用户反馈「莫名其妙弹出,像病毒一样」)。后端已改为仅认 `TargetUserId`,Delivery 仅作统计。
+- 守卫测试:`prd-admin/src/components/daily-tips/__tests__/pageGuideMatch.test.ts` 的 `pickAutoOpenUpdateTip` 套件(无教程页恒 null / isTargeted 不参与决策)。
+
 ## 六、相关
 
 - `.claude/skills/createzzdemo/SKILL.md` — 生成单条教程小书

--- a/changelogs/2026-06-11_tips-auto-open-page-scoped.md
+++ b/changelogs/2026-06-11_tips-auto-open-page-scoped.md
@@ -1,0 +1,2 @@
+| fix | prd-admin | 教程抽屉自动弹出严格按页:删除"定向推送(isTargeted)自动弹+切全部教程"旧路径,改为仅本页存在未学会的更新教程时自动展开本页列表,无教程页面不再弹窗 |
+| fix | prd-api | daily-tips /visible 的 isTargeted 与置顶排序不再把 Track 统计埋点产生的 Delivery 记录误判为"被推送",根治普通教程被污染成"为你推送"后到处自动弹窗 |

--- a/prd-admin/src/components/daily-tips/TipsDrawer.tsx
+++ b/prd-admin/src/components/daily-tips/TipsDrawer.tsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { Sparkles, X, Pin, PinOff, MapPin, GraduationCap } from 'lucide-react';
 import { OPEN_TIPS_DRAWER_EVENT, START_TUTORIAL_EVENT } from './TipsEntryButton';
-import { matchPageGuide, isEditorPageGuide, filterPageTips } from './pageGuideMatch';
+import { matchPageGuide, isEditorPageGuide, filterPageTips, isUpdateTip, pickAutoOpenUpdateTip } from './pageGuideMatch';
 import { difficultyMeta } from './difficultyMeta';
 import { useDailyTipsStore } from '@/stores/dailyTipsStore';
 import { writeSpotlightPayload, SPOTLIGHT_PAYLOAD_UPDATED_EVENT } from './TipsRotator';
@@ -219,18 +219,26 @@ export function TipsDrawer() {
   // 抽屉实际展示的列表:默认「本页」,用户可切「全部」浏览所有页面的教程。
   const viewTips = showAllPages ? tips : pageTips;
 
-  // ── 推送自动展开:按 tip.id 记忆,每条定向 tip 本 session 只弹一次 ──
-  // 轮询时如果管理员新推了一条,tips 里会多出一个 isTargeted 的新 id,它不在
-  // 已弹过集合里 → 再自动弹一次。解决「session 第二条推送不弹」的坑。
+  // ── 本页更新教程自动展开:抽屉唯一的自动弹出路径 ──────────────
+  // 规则(用户 2026-06-11):推送只跟页面走 —— 没教程的页面绝不自动弹任何东西;
+  // 有教程的页面只在两种情况自动出现:
+  //   1) 新人没走完本页 *-page-guide → Spotlight 自动开讲(下面的 effect,优先级更高);
+  //   2) 本页功能有更新(*-update-* / feature-release)且未学会 → 自动展开抽屉提醒一次(本 effect)。
+  // 决策只看 pageTips(filterPageTips 按页过滤后的子集),且绝不自动切「全部教程」——
+  // 这是「不会在 A 页弹 B 页教程」的结构性保证。
+  //
+  // 旧版「管理员定向推送(isTargeted)自动弹 + 不属本页就切全部教程」已删除:推送后台已下线,
+  // 而 Track 统计埋点会给「看过一眼」的 tip 建 Delivery 记录,被 /visible 误判成 isTargeted,
+  // 导致在无教程页面弹出「全部教程」面板(用户 2026-06-11 反馈「莫名其妙弹出,像病毒一样」)。
   useEffect(() => {
     if (!loaded) return;
     if (pageGuideHere) return; // 本页有未走完教程 → 由 Spotlight 自动开讲,不抢着展开抽屉(避免叠加)
     if (hasAutoOpenedToday()) return; // 每天只自动弹一次
     const opened = readAutoOpenedIds();
-    const newTargeted = tips.find((t) => t.isTargeted && !opened.has(t.id));
-    if (!newTargeted) return;
+    const updateTip = pickAutoOpenUpdateTip(pageTips, opened);
+    if (!updateTip) return;
 
-    opened.add(newTargeted.id);
+    opened.add(updateTip.id);
     writeAutoOpenedIds(opened);
     markAutoOpenedToday();
 
@@ -238,24 +246,18 @@ export function TipsDrawer() {
     if (hiddenByUser) {
       setHiddenByUser(false);
     }
-    // 被推送的 tip 若不属于当前页(filterPageTips 已按 actionUrl 页面限定将其排除在 pageTips 之外),
-    // 自动展开时切到「全部教程」,否则抽屉打开却看不到刚推送的内容(本页列表里没有它)。
-    // 属于本页则保持「本页教程」语义(showAllPages 默认 false)。
-    if (!pageTips.some((p) => p.id === newTargeted.id)) {
-      setShowAllPages(true);
-    }
-    setExpanded(true);
+    setExpanded(true); // 保持「本页教程」语义(showAllPages 默认 false),绝不自动切「全部教程」
     // pageGuideHere 必须进 deps:否则首屏若落在「有教程页」early-return 后,
-    // 切到「无教程页」时本 effect 不再 fire,自动弹窗整 session 失效(Bugbot)。
+    // 切到「有更新页」时本 effect 不再 fire,更新提醒整 session 失效(Bugbot)。
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loaded, tips, pageGuideHere]);
+  }, [loaded, pageTips, pageGuideHere]);
 
   // ── 新用户兜底自动弹抽屉:已移除 ──────────────────────────
   // 历史上「本日第一次访问且本页有任意 tip 就自动展开抽屉」会在用户没点任何按钮时
   // 自己弹出教程(例如本页 *-page-guide 已学会、却把残留的「本周改动」公告弹出来),
   // 用户 2026-06-04 反馈「没点按钮却弹窗出来教程」。教程入口已是页头常驻按钮(TipsEntryButton),
-  // 不需要再自动展开抽屉来「证明书的存在」。保留的自动行为只剩两类(均为明确意图):
-  //   1) 管理员定向推送(isTargeted)→ 上面的 effect 自动弹;
+  // 不需要再自动展开抽屉来「证明书的存在」。保留的自动行为只剩两类(均为明确意图、均按页限定):
+  //   1) 本页有未学会的更新教程 → 上面的 effect 自动弹(本页列表);
   //   2) 本页未走完的 *-page-guide → 下面的 effect 走 Spotlight 强制开讲(onboarding 规则)。
 
   // ── 强制新手引导:进入任意页面,若该页有「未走完」的本页教程(*-page-guide),自动开讲一次 ──
@@ -576,7 +578,7 @@ export function TipsDrawer() {
               const estMin = stepCount > 0 ? Math.max(1, Math.round(stepCount * 0.5)) : 0;
               const diff = difficultyMeta(t.difficulty);
               const xpReward = t.xpReward ?? 0;
-              const isUpdate = (t.sourceId?.includes('-update-') ?? false) || t.sourceType === 'feature-release';
+              const isUpdate = isUpdateTip(t);
               const isPageGuide = t.sourceId?.endsWith('-page-guide') ?? false;
               const accent = t.isTargeted
                 ? 'rgba(244,63,94,0.95)'

--- a/prd-admin/src/components/daily-tips/__tests__/pageGuideMatch.test.ts
+++ b/prd-admin/src/components/daily-tips/__tests__/pageGuideMatch.test.ts
@@ -8,7 +8,7 @@
  */
 import { describe, expect, it } from 'vitest';
 import type { DailyTip } from '@/services/real/dailyTips';
-import { filterPageTips, matchPageGuide } from '../pageGuideMatch';
+import { filterPageTips, matchPageGuide, isUpdateTip, pickAutoOpenUpdateTip } from '../pageGuideMatch';
 
 const NONE = new Set<string>();
 
@@ -66,6 +66,63 @@ describe('filterPageTips —— 被投递(isTargeted)的页面教程必须按页
 
   it('已 dismiss 的被投递 tip 不再出现', () => {
     expect(filterPageTips(all, new Set(['web-observability']), '/web-pages', '')).toEqual([]);
+  });
+});
+
+describe('pickAutoOpenUpdateTip —— 抽屉自动弹出严格按页(用户 2026-06-11 规则:推送只跟页面走)', () => {
+  const pageGuide = tip({
+    id: 'webpages-page-guide',
+    sourceId: 'webpages-page-guide',
+    actionUrl: '/web-pages',
+  });
+  const updateTip = tip({
+    id: 'web-update',
+    sourceId: 'webpages-update-2026w24',
+    actionUrl: '/web-pages',
+  });
+  const taskTip = tip({
+    id: 'defect-full-flow',
+    sourceId: 'defect-full-flow',
+    actionUrl: '/defect-agent',
+  });
+  const NO_OPENED = new Set<string>();
+
+  it('无教程页面(pageTips 为空)恒不弹 —— 根治「无教程页弹出全部教程」', () => {
+    // 复刻 bug 场景:全量 tips 里有被 Track 埋点污染成 isTargeted 的别页教程
+    const polluted = [{ ...updateTip, isTargeted: true }, { ...pageGuide, isTargeted: true }];
+    const pageTips = filterPageTips(polluted, NONE, '/document-store', '');
+    expect(pageTips).toEqual([]); // 别页教程不属于本页
+    expect(pickAutoOpenUpdateTip(pageTips, NO_OPENED)).toBeNull(); // → 绝不自动弹
+  });
+
+  it('本页有未学会的更新教程(*-update-*) → 弹', () => {
+    const pageTips = filterPageTips([updateTip, pageGuide], NONE, '/web-pages', '');
+    expect(pickAutoOpenUpdateTip(pageTips, NO_OPENED)?.id).toBe('web-update');
+  });
+
+  it('更新教程已学会 → 不弹', () => {
+    const learned = { ...updateTip, learned: true };
+    expect(pickAutoOpenUpdateTip([learned], NO_OPENED)).toBeNull();
+  });
+
+  it('本 session 已自动弹过(按 id 记忆) → 不再弹', () => {
+    expect(pickAutoOpenUpdateTip([updateTip], new Set(['web-update']))).toBeNull();
+  });
+
+  it('page-guide / 普通任务教程不触发抽屉自动弹(新人路径走 Spotlight,任务教程走手动入口)', () => {
+    expect(pickAutoOpenUpdateTip([pageGuide, taskTip], NO_OPENED)).toBeNull();
+  });
+
+  it('isTargeted 不再参与自动弹出决策(Track 埋点污染防护)', () => {
+    const pollutedTask = { ...taskTip, isTargeted: true };
+    expect(pickAutoOpenUpdateTip([pollutedTask], NO_OPENED)).toBeNull();
+  });
+
+  it('isUpdateTip:sourceId 带 -update- 或 sourceType=feature-release 才算更新教程', () => {
+    expect(isUpdateTip(updateTip)).toBe(true);
+    expect(isUpdateTip(tip({ id: 'x', actionUrl: '/a', sourceType: 'feature-release' }))).toBe(true);
+    expect(isUpdateTip(pageGuide)).toBe(false);
+    expect(isUpdateTip(taskTip)).toBe(false);
   });
 });
 

--- a/prd-admin/src/components/daily-tips/pageGuideMatch.ts
+++ b/prd-admin/src/components/daily-tips/pageGuideMatch.ts
@@ -74,6 +74,34 @@ export function matchPageGuide(
 }
 
 /**
+ * 是否为「更新教程」(*-update-YYYYwNN / feature-release)——本页功能本周有更新时的提醒类 tip。
+ * TipsDrawer 的卡片 chip 与「本页更新自动展开」共用,避免两处 inline 判定漂移。
+ */
+export function isUpdateTip(t: DailyTip): boolean {
+  return (t.sourceId?.includes('-update-') ?? false) || t.sourceType === 'feature-release';
+}
+
+/**
+ * 「本页更新教程自动展开」的唯一决策函数(用户 2026-06-11 规则:推送只跟页面走)。
+ *
+ * 自动弹出仅两类,且都严格限定在「本页有教程」的页面:
+ *   1) 新人没走完本页 *-page-guide → Spotlight 自动开讲(matchPageGuide,优先级更高,由调用方先判);
+ *   2) 本页功能有更新(*-update-* / feature-release)且未学会 → 自动展开抽屉提醒一次(本函数)。
+ * 没有教程的页面 pageTips 为空 → 恒返回 null,绝不弹任何东西。
+ *
+ * 入参 pageTips 必须是 filterPageTips 按当前页过滤后的子集 —— 这是「不会在 A 页弹 B 页教程」的
+ * 结构性保证;历史 bug:旧版用全量 tips + isTargeted 判定,而 Track 统计埋点会给「看过一眼」的 tip
+ * 建 Delivery 记录,被 /visible 误判成 isTargeted → 在无教程页面弹出「全部教程」面板
+ * (用户 2026-06-11 反馈「莫名其妙弹出,像病毒一样」)。
+ */
+export function pickAutoOpenUpdateTip(
+  pageTips: DailyTip[],
+  alreadyOpened: Set<string>,
+): DailyTip | null {
+  return pageTips.find((t) => isUpdateTip(t) && !t.learned && !alreadyOpened.has(t.id)) ?? null;
+}
+
+/**
  * 当前路由「本页教程」集合 —— TipsDrawer(抽屉作用域)与 TipsEntryButton(按钮是否显示)
  * 共用的单一过滤逻辑(SSOT,避免两份 inline 拷贝随规则漂移)。
  *

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/DailyTipsController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/DailyTipsController.cs
@@ -143,10 +143,12 @@ public sealed class DailyTipsController : ControllerBase
         // 上方 seedFillers 已经覆盖空 DB 场景（dbSourceIds 为空集，seedFillers = 全套合规 seed），
         // 旧 fallback 会绕过 dbSourceIds 让 admin 禁用 (IsActive=false) 的 seed 复活 (Codex P2)。
 
-        // 定向 tip / 被投递 tip 永远置顶,保证「为你修复」类消息被最先看到
+        // 定向 tip(TargetUserId = 当前用户)置顶,保证「为你修复」类消息被最先看到。
+        // 注意:Deliveries 里有当前用户 != 被定向推送 —— Track 端点会给「看过一眼」的用户补一条
+        // Delivery 记录纯做统计(seen/viewCount),若把它算进置顶/isTargeted,任何被浏览过的普通教程
+        // 都会变成「为你推送」,并触发前端定向自动弹窗(2026-06-11 用户反馈:无教程页面弹「全部教程」)。
         var ordered = items
-            .OrderByDescending(x => x.TargetUserId == userId
-                                    || (x.Deliveries != null && x.Deliveries.Any(d => d.UserId == userId)))
+            .OrderByDescending(x => x.TargetUserId == userId)
             .ThenBy(x => x.DisplayOrder)
             .ThenByDescending(x => x.CreatedAt)
             .Select(x =>
@@ -164,7 +166,8 @@ public sealed class DailyTipsController : ControllerBase
                     x.CtaText,
                     x.TargetSelector,
                     x.AutoAction,
-                    isTargeted = x.TargetUserId == userId || mine != null,
+                    // 仅 TargetUserId 命中才算定向;mine(Delivery)只是 Track 统计记录,不代表被推送
+                    isTargeted = x.TargetUserId == userId,
                     x.SourceType,
                     x.SourceId,
                     x.Version,


### PR DESCRIPTION
根因两层:
1. 后端 /visible 把 Track 统计埋点创建的 Delivery 记录误判成定向推送
   (isTargeted = TargetUserId==userId || mine != null),任何被看过一眼的
   普通教程都会永久变成"为你推送";
2. 前端 TipsDrawer 的"定向推送自动展开"用全量 tips 判定,且 tip 不属于
   当前页时自动切"全部教程",于是在无教程页面弹出 19 套教程的面板。

修复:
- 前端删除 isTargeted 自动弹路径,改为 pickAutoOpenUpdateTip(pageTips):
  仅本页存在未学会的更新教程(*-update-* / feature-release)时自动展开
  本页教程列表;新人路径(page-guide -> Spotlight)不变;无教程页面零弹窗
- 后端 isTargeted 与置顶排序仅认 TargetUserId,Delivery 仅作统计
- pageGuideMatch 新增 isUpdateTip / pickAutoOpenUpdateTip 纯函数 + 7 条
  守卫测试(无教程页恒 null / isTargeted 不参与决策)
- onboarding-tips.md 固化 5.7 节"自动弹出严格按页"规则

自测: pnpm tsc 零错误; pnpm test 25 文件 387 用例全绿; eslint 零告警

https://claude.ai/code/session_01UBqY81hUsiTipYqNoktVN3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes daily-tips visibility flags and auto-open behavior for all logged-in users; incorrect filtering could hide legitimate targeted messages or miss update reminders.
> 
> **Overview**
> Fixes tutorial drawers auto-opening on pages with no local tips and showing the full catalog.
> 
> **API:** `GET /visible` now sets **`isTargeted`** and pin order only when `TargetUserId` matches the user. **Track**-created **Delivery** rows (seen/view stats) no longer count as a push, so browsed tips are not permanently labeled「为你推送」.
> 
> **Admin:** Removes the old **isTargeted** auto-expand path (including flipping to「全部教程」). Drawer auto-open is **`pickAutoOpenUpdateTip(pageTips)`** only: unlearned **`*-update-*`** / **`feature-release`** tips on the **current page**, after **`filterPageTips`**. Unfinished **`*-page-guide`** → Spotlight is unchanged. Pages with empty **`pageTips`** never auto-open.
> 
> Adds **`isUpdateTip`** / **`pickAutoOpenUpdateTip`**, guard tests, onboarding rule **5.7**, and a changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc8873ad0c9fa14475eb648dee369e1015009837. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->