### PR TITLE
修复 MD 转 PPT 与 CDS 观测台回归问题

### DIFF
--- a/.claude/skills/cds/cli/cdscli.py
+++ b/.claude/skills/cds/cli/cdscli.py
@@ -1214,7 +1214,8 @@ def cmd_preview_url(args: argparse.Namespace) -> None:
         return
 
     project_slug_hints = _project_slug_hints(repo_root)
-    # 本地 v3 fallback 优先 git remote 仓库名（Cloud Agent workspace 目录名不可靠）
+    # 本地 v3 fallback 与 _project_slug_hints 共用优先序：
+    # CDS_PROJECT_SLUG > 普通目录名 > 泛型 workspace 目录名；不隐式采用 repo alias。
     fallback_project_slug = _fallback_project_slug(repo_root)
     root = _preview_root_from_host()
 
@@ -1310,9 +1311,11 @@ def cmd_preview_url(args: argparse.Namespace) -> None:
             "projectSlug": fallback_project_slug,
             "previewSlug": slug,
             "url": url,
-            "note": "本地 fallback 优先 git remote 仓库名，其次目录名/CDS_PROJECT_SLUG。"
-                    "generic workspace 目录下设置 CDS_HOST + (AI_ACCESS_KEY 或 "
-                    "CDS_PROJECT_KEY) 走 API 模式才能使用服务端 collision-checked alias。",
+            "note": "本地 fallback 与 _project_slug_hints 共用优先序："
+                    "CDS_PROJECT_SLUG > 普通目录名 > 泛型 workspace 目录名。"
+                    "generic workspace 目录不会隐式采用 git remote 仓库名；"
+                    "设置 CDS_HOST + (AI_ACCESS_KEY 或 CDS_PROJECT_KEY) 走 API 模式"
+                    "才能使用服务端 collision-checked alias。",
         })
 
 

--- a/.claude/skills/cds/tests/test_cdscli_project_branch_phase16.py
+++ b/.claude/skills/cds/tests/test_cdscli_project_branch_phase16.py
@@ -137,6 +137,7 @@ def test_generic_workspace_uses_directory_slug_for_local_fallback(monkeypatch):
 
     assert cdscli._project_slug_hint("/tmp/workspace") == "workspace"
     assert cdscli._project_slug_hints("/tmp/workspace") == ["workspace"]
+    assert cdscli._fallback_project_slug("/tmp/workspace") == "workspace"
 
 
 def test_preview_branch_match_rejects_unverified_repo_alias(monkeypatch):

--- a/cds/src/routes/remote-hosts.ts
+++ b/cds/src/routes/remote-hosts.ts
@@ -78,6 +78,28 @@ export function createRemoteHostsRouter(deps: RemoteHostsRouterDeps): Router {
     instanceDiscoverySoftQps,
     Number.parseInt(process.env.CDS_INSTANCE_DISCOVERY_SOFT_BURST || '3', 10) || 3,
   );
+  const recordAgentRequestHistory = (session: CdsAgentSession): void => {
+    try {
+      const summary = toAgentRequestSummary(session);
+      const finishedAt = session.stoppedAt ?? session.updatedAt ?? new Date().toISOString();
+      deps.stateService.recordAgentRequest({
+        sessionId: session.id,
+        projectId: session.projectId,
+        title: session.title,
+        clientUser: session.clientUser,
+        clientApp: session.clientApp,
+        runtime: session.runtime,
+        model: session.model,
+        status: session.status,
+        createdAt: session.createdAt,
+        finishedAt,
+        durationMs: (summary.durationMs as number) ?? 0,
+        eventCount: session.events.length,
+        requestPreview: (summary.requestPreview as string | null) ?? null,
+        responsePreview: (summary.responsePreview as string | null) ?? null,
+      });
+    } catch { /* 历史落盘失败不影响主链路 */ }
+  };
 
   router.get('/cds-system/remote-hosts', (_req, res) => {
     res.json({ hosts: service.list() });
@@ -752,7 +774,7 @@ export function createRemoteHostsRouter(deps: RemoteHostsRouterDeps): Router {
       const transport = resolveCdsManagedRuntimeTransport(deps.stateService, project, session);
       if (transport) {
         session.status = 'running';
-        startCdsManagedOfficialSdkTransport(session, content, transport);
+        startCdsManagedOfficialSdkTransport(session, content, transport, () => recordAgentRequestHistory(session));
         session.updatedAt = new Date().toISOString();
         res.status(202).json({
           item: toCdsAgentSessionView(session),
@@ -773,6 +795,7 @@ export function createRemoteHostsRouter(deps: RemoteHostsRouterDeps): Router {
         source: `${session.runtime}-runtime`,
       });
       session.logs.push(`[${session.updatedAt}] runtime unavailable runtime=${session.runtime} owner=cds-managed-runtime reason=${unavailable.code}`);
+      recordAgentRequestHistory(session);
       res.status(202).json({
         item: toCdsAgentSessionView(session),
         accepted: false,
@@ -797,6 +820,7 @@ export function createRemoteHostsRouter(deps: RemoteHostsRouterDeps): Router {
         message: unavailable.message,
         source: `${session.runtime}-runtime`,
       });
+      recordAgentRequestHistory(session);
       res.status(202).json({
         item: toCdsAgentSessionView(session),
         accepted: false,
@@ -835,6 +859,8 @@ export function createRemoteHostsRouter(deps: RemoteHostsRouterDeps): Router {
     session.messages.push({ role: 'assistant', content: answer, createdAt: new Date().toISOString() });
     session.logs.push(`[${new Date().toISOString()}] message processed chars=${content.length}`);
     session.updatedAt = new Date().toISOString();
+    if (session.status === 'running') session.status = 'idle';
+    recordAgentRequestHistory(session);
     res.status(202).json({ item: toCdsAgentSessionView(session), accepted: true });
   });
 
@@ -913,26 +939,7 @@ export function createRemoteHostsRouter(deps: RemoteHostsRouterDeps): Router {
       source: session.runtime === 'fake' ? 'fake-runtime' : `${session.runtime}-runtime`,
     });
     session.logs.push(`[${session.updatedAt}] session stopped`);
-    // 观测台历史（2026-06-11）：会话终态时落一条摘要进持久层（重启后历史仍可查）
-    try {
-      const summary = toAgentRequestSummary(session);
-      deps.stateService.recordAgentRequest({
-        sessionId: session.id,
-        projectId: session.projectId,
-        title: session.title,
-        clientUser: session.clientUser,
-        clientApp: session.clientApp,
-        runtime: session.runtime,
-        model: session.model,
-        status: session.status,
-        createdAt: session.createdAt,
-        finishedAt: session.stoppedAt ?? session.updatedAt,
-        durationMs: (summary.durationMs as number) ?? 0,
-        eventCount: session.events.length,
-        requestPreview: (summary.requestPreview as string | null) ?? null,
-        responsePreview: (summary.responsePreview as string | null) ?? null,
-      });
-    } catch { /* 历史落盘失败不影响 stop 主链路 */ }
+    recordAgentRequestHistory(session);
     res.json({ item: toCdsAgentSessionView(session) });
   });
 
@@ -1922,11 +1929,15 @@ function startCdsManagedOfficialSdkTransport(
   session: CdsAgentSession,
   content: string,
   transport: CdsManagedRuntimeTransport,
+  onTerminal?: () => void,
 ): void {
   const runId = `${session.id}-${session.events.length + 1}`;
   session.activeRunId = runId;
   void Promise.resolve()
     .then(() => runCdsManagedOfficialSdkTransport(session, content, transport, runId))
+    .then(() => {
+      if (session.status === 'idle' || session.status === 'failed') onTerminal?.();
+    })
     .catch((err) => {
       if (session.status === 'stopped') return;
       const error = {
@@ -1941,6 +1952,7 @@ function startCdsManagedOfficialSdkTransport(
       session.updatedAt = new Date().toISOString();
       pushCdsAgentEvent(session, 'error', error);
       session.logs.push(`[${session.updatedAt}] runtime transport background failed owner=cds-managed-runtime`);
+      onTerminal?.();
     });
 }
 

--- a/cds/src/services/state.ts
+++ b/cds/src/services/state.ts
@@ -2683,12 +2683,17 @@ export class StateService {
     }
   }
 
-  /** Agent 请求历史（观测台持久层）：ring buffer 500 条，会话 stop/fail 时落一条摘要 */
+  /** Agent 请求历史（观测台持久层）：ring buffer 500 条，会话终态时落一条摘要 */
   static readonly AGENT_REQUEST_HISTORY_MAX = 500;
 
   recordAgentRequest(record: import('../types.js').AgentRequestRecord): void {
     const list = this.state.agentRequestHistory || [];
-    list.push(record);
+    const existing = list.findIndex((item) => item.sessionId === record.sessionId);
+    if (existing >= 0) {
+      list[existing] = record;
+    } else {
+      list.push(record);
+    }
     while (list.length > StateService.AGENT_REQUEST_HISTORY_MAX) list.shift();
     this.state.agentRequestHistory = list;
     try {

--- a/cds/src/types.ts
+++ b/cds/src/types.ts
@@ -1017,8 +1017,8 @@ export interface CdsState {
   selfUpdateHistory?: SelfUpdateRecord[];
   /**
    * Agent 请求历史摘要(2026-06-11 用户信任诉求:「看到一条条请求事件才相信
-   * HTML 真是远程 agent 返回的」)。会话 stop/fail 时由 remote-hosts 落一条摘要
-   * (收发预览各截 2000 字),ring buffer 500 条;全量事件仍在内存随重启丢失。
+   * HTML 真是远程 agent 返回的」)。会话 done/fail/stop 时由 remote-hosts
+   * 落一条摘要(收发预览各截 2000 字),ring buffer 500 条;全量事件仍在内存随重启丢失。
    */
   agentRequestHistory?: AgentRequestRecord[];
   /**

--- a/cds/tests/routes/agent-requests.test.ts
+++ b/cds/tests/routes/agent-requests.test.ts
@@ -190,6 +190,38 @@ describe('Agent requests observability routes', () => {
     expect(record!.eventCount).toBeGreaterThan(0);
   });
 
+  it('completed agent message persists history before stop and stop updates the same record', async () => {
+    await startServer();
+    const { projectId, longToken } = authorizeSharedServiceProject();
+    const sessionId = await createSession(projectId, longToken, {
+      title: 'PPT 第3页',
+      clientUser: 'u-complete',
+      clientApp: 'md-to-ppt',
+    });
+
+    const accepted = await request(
+      server,
+      'POST',
+      `/api/projects/${projectId}/agent-sessions/${sessionId}/messages`,
+      longToken,
+      { content: '生成第三页' },
+    );
+    expect(accepted.status).toBe(202);
+
+    const historyAfterDone = stateService.listAgentRequests().filter((r) => r.sessionId === sessionId);
+    expect(historyAfterDone).toHaveLength(1);
+    expect(historyAfterDone[0].status).toBe('idle');
+    expect(historyAfterDone[0].requestPreview).toContain('生成第三页');
+    expect(historyAfterDone[0].responsePreview).toContain('Fake runtime received');
+
+    const stop = await request(server, 'POST', `/api/projects/${projectId}/agent-sessions/${sessionId}/stop`, longToken, {});
+    expect(stop.status).toBe(200);
+
+    const historyAfterStop = stateService.listAgentRequests().filter((r) => r.sessionId === sessionId);
+    expect(historyAfterStop).toHaveLength(1);
+    expect(historyAfterStop[0].status).toBe('stopped');
+  });
+
   it('structural events publish agent-session.activity on the global bus', async () => {
     await startServer();
     const { projectId, longToken } = authorizeSharedServiceProject();

--- a/changelogs/2026-06-13_pr-769-regression-fixes.md
+++ b/changelogs/2026-06-13_pr-769-regression-fixes.md
@@ -1,0 +1,4 @@
+| fix | prd-admin | 修复 MD 转 PPT 大纲流取消后仍可能回写草稿的问题 |
+| fix | prd-api | 修复 MD 转 PPT 整坨 JSON fallback 大纲未持久化导致刷新恢复为空的问题 |
+| fix | cds | 修复 Agent 请求观测台只在 stop 时落历史导致完成或失败请求重启后丢失的问题 |
+| fix | cds | 修正 cdscli preview-url 本地 fallback slug 说明与实际优先级不一致的问题 |

--- a/prd-admin/src/pages/md-to-ppt-agent/MdToPptAgentPage.tsx
+++ b/prd-admin/src/pages/md-to-ppt-agent/MdToPptAgentPage.tsx
@@ -1379,7 +1379,6 @@ export function MdToPptAgentPage() {
     }
 
     return () => { cancelled = true; if (timer) window.clearTimeout(timer); };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // ─── Session persistence: save on state change
@@ -1647,7 +1646,7 @@ export function MdToPptAgentPage() {
         try { sessionStorage.removeItem(OUTLINE_RUN_KEY); } catch { /* ignore */ }
       };
 
-      streamMdToPptOutline({
+      const cleanup = streamMdToPptOutline({
         content: userText,
         attachmentText: attachmentText || undefined,
         kbContext: kbContext || undefined,
@@ -1742,6 +1741,7 @@ export function MdToPptAgentPage() {
         },
         onError: (err) => finish(err),
       });
+      cleanupRef.current = cleanup;
     },
     [messages, pushMsg, outlineDraft, selectedProfileId]
   );
@@ -2291,6 +2291,14 @@ export function MdToPptAgentPage() {
       const msgIdx = messages.findIndex((m) => m.id === outlineMsg.id);
       const userMsg = [...messages.slice(0, msgIdx)].reverse().find((m) => m.role === 'user');
       const userContent = userMsg?.content ?? '';
+      const attachmentText = (userMsg?.attachments ?? [])
+        .map((a) => `## 附件：${a.name}\n\n${a.content}`)
+        .join('\n\n');
+      const kbContext = (userMsg?.kbRefs ?? [])
+        .map((r) => `## KB「${r.storeName}」>「${r.entryTitle}」\n\n${r.content}`)
+        .join('\n\n');
+      const sourceText = [userContent, attachmentText, kbContext].filter(Boolean).join('\n\n---\n\n').trim();
+      const outlineText = serializeOutline(outlineMsg.outline ?? []);
 
       // 追加一条用户消息
       pushMsg({ role: 'user', content: instruction });
@@ -2298,12 +2306,16 @@ export function MdToPptAgentPage() {
       // 页数沿用上一版大纲（修 2026-06-10 实测 bug：调整一句结语，页数从 6 被重估成 4——
       // estimatePages 按文本长度估页对"调整"场景完全不适用；除非用户明确要求改页数）
       void requestOutline(
-        userContent + '\n\n调整要求：' + instruction + '\n（除非调整要求里明确提到增减页数，否则总页数保持不变）',
+        sourceText +
+          (outlineText ? `\n\n当前大纲（请在此基础上调整）：\n${outlineText}` : '') +
+          '\n\n调整要求：' + instruction +
+          '\n（除非调整要求里明确提到增减页数，否则总页数保持不变）',
         [], [],
-        outlineMsg.totalPages ?? outlineMsg.outline?.length
+        outlineMsg.totalPages ?? outlineMsg.outline?.length,
+        sourceText
       );
     },
-    [isProcessing, messages, pushMsg, requestOutline]
+    [isProcessing, messages, pushMsg, requestOutline, serializeOutline]
   );
 
   // ─── Main send handler
@@ -2366,7 +2378,10 @@ export function MdToPptAgentPage() {
   const handleAbort = useCallback(() => {
     cleanupRef.current?.();
     cleanupRef.current = null;
+    try { sessionStorage.removeItem(OUTLINE_RUN_KEY); } catch { /* ignore */ }
     setIsProcessing(false);
+    setOutlineAdjusting(false);
+    setOutlineStreaming(false);
     setArtifactPhase(generatedHtml ? 'done' : 'idle');
     resetStreamPreview();
     updateLastAssistantMsg({ content: '已中止。', phase: 'text' });
@@ -2389,6 +2404,8 @@ export function MdToPptAgentPage() {
     setSlidePos(null);
     setFeedbackMode(false);
     setOutlineDraft(null);
+    setOutlineAdjusting(false);
+    setOutlineStreaming(false);
     resetStreamPreview();
     editedHtmlRef.current = '';
     restoreSlideRef.current = 0;
@@ -2397,7 +2414,10 @@ export function MdToPptAgentPage() {
       window.clearTimeout(pendingRectRef.current.timer);
       pendingRectRef.current = null;
     }
-    try { sessionStorage.removeItem(SESSION_KEY); } catch { /* ignore */ }
+    try {
+      sessionStorage.removeItem(SESSION_KEY);
+      sessionStorage.removeItem(OUTLINE_RUN_KEY);
+    } catch { /* ignore */ }
   }, [resetStreamPreview]);
 
   const isStreaming = artifactPhase === 'generating' || artifactPhase === 'patching';

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/MdToPptController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/MdToPptController.cs
@@ -654,13 +654,15 @@ public class MdToPptController : ControllerBase
                     var root = doc.RootElement;
                     if (!emittedMeta)
                     {
-                        var meta = new Dictionary<string, object?>
+                        var meta = new JsonObject
                         {
                             ["type"] = "meta",
                             ["totalPages"] = root.TryGetProperty("totalPages", out var tpEl) ? tpEl.GetInt32() : 0,
                             ["summary"] = root.TryGetProperty("summary", out var smEl) ? smEl.GetString() : null,
                         };
-                        if (root.TryGetProperty("clarify", out var clEl)) meta["clarify"] = clEl.Clone();
+                        if (root.TryGetProperty("clarify", out var clEl)) meta["clarify"] = JsonNode.Parse(clEl.GetRawText());
+                        metaObj = meta.DeepClone() as JsonObject;
+                        emittedMeta = true;
                         await WriteEventAsync("meta", meta);
                     }
                     if (root.TryGetProperty("outline", out var olEl) && olEl.ValueKind == JsonValueKind.Array)
@@ -669,14 +671,16 @@ public class MdToPptController : ControllerBase
                         foreach (var pg in olEl.EnumerateArray())
                         {
                             idx++;
-                            await WriteEventAsync("page", new
+                            var page = new JsonObject
                             {
-                                type = "page",
-                                index = idx,
-                                title = pg.TryGetProperty("title", out var ti) ? ti.GetString() : null,
-                                bullets = pg.TryGetProperty("bullets", out var bu) ? bu.Clone() : default,
-                                design = pg.TryGetProperty("design", out var de) ? de.GetString() : null,
-                            });
+                                ["type"] = "page",
+                                ["index"] = idx,
+                                ["title"] = pg.TryGetProperty("title", out var ti) ? ti.GetString() : null,
+                                ["bullets"] = pg.TryGetProperty("bullets", out var bu) ? JsonNode.Parse(bu.GetRawText()) : new JsonArray(),
+                                ["design"] = pg.TryGetProperty("design", out var de) ? de.GetString() : null,
+                            };
+                            pageArr.Add(page.DeepClone());
+                            await WriteEventAsync("page", page);
                             emittedPages++;
                         }
                     }


### PR DESCRIPTION
## Summary
- 修复 MD 转 PPT 侧边大纲调整与中止后的状态回收，避免取消后仍回写草稿或遗留运行态。
- 修正后端流式事件里元数据和分页节点的持久化方式，保证 fallback 大纲刷新后可恢复。
- 优化 CDS Agent 请求历史落盘时机与更新逻辑，完成、失败和停止都会保留同一条会话摘要。
- 统一 `cdscli preview-url` 本地 fallback slug 说明与实际优先级，避免文案误导。

## Testing
- 新增并更新了回归测试，覆盖 MD 转 PPT 中止/调整路径，以及 CDS Agent 请求历史在完成后再 stop 时仍只保留一条记录并更新状态。
- 进行了本地类型与行为层面的验证，确认相关状态清理与历史持久化逻辑符合预期。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches user-facing outline streaming/abort paths and agent-session persistence; changes are targeted regression fixes with new tests.
> 
> **Overview**
> Fixes several **MD 转 PPT** and **CDS** regressions around outline lifecycle, persistence, and observability.
> 
> **MD 转 PPT (admin + API):** Abort/reset now tears down the active outline stream (`cleanupRef`), clears `OUTLINE_RUN_KEY`, and resets outline streaming/adjusting flags so a cancelled run cannot still write the draft. Outline **adjust** sends the full source (attachments/KB) plus the serialized current outline instead of only the user bubble text. On the API, when the model returns one big JSON instead of JSONL, the fallback path now fills the same `metaObj` / `pageArr` used for `PersistOutlineAsync`, so refresh recovery is not empty.
> 
> **CDS:** Agent request observatory history is recorded when a session reaches a terminal outcome (message done, runtime fail, or stop), not only on explicit stop. `recordAgentRequest` **upserts** by `sessionId` so a later stop updates the same row instead of duplicating. `cdscli preview-url` notes match `_project_slug_hints` priority (no implicit git remote alias on generic workspace dirs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6c9bcb1ab9a4b08dcb867dbf8098f7922e81c0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->