### PR TITLE
feat(ccas-agent): 设备素材库支持本地上传图片

### DIFF
--- a/changelogs/2026-06-15_ccas-equipment-upload.md
+++ b/changelogs/2026-06-15_ccas-equipment-upload.md
@@ -1,2 +1,3 @@
 | feat | prd-api | CCAS 设备素材库新增本地上传接口（equipment/upload） |
 | feat | prd-admin | CCAS 设备素材库 Tab 支持上传本地图片入库 |
+| polish | prd-admin | CCAS 设备素材库 Tab 描述补充上传说明 |

--- a/changelogs/2026-06-15_ccas-equipment-upload.md
+++ b/changelogs/2026-06-15_ccas-equipment-upload.md
@@ -1,0 +1,2 @@
+| feat | prd-api | CCAS 设备素材库新增本地上传接口（equipment/upload） |
+| feat | prd-admin | CCAS 设备素材库 Tab 支持上传本地图片入库 |

--- a/prd-admin/src/pages/ccas-agent/CcasAgentPage.tsx
+++ b/prd-admin/src/pages/ccas-agent/CcasAgentPage.tsx
@@ -15,7 +15,7 @@ type Tab = 'prd' | 'equipment' | 'flow' | 'qa' | 'sql';
 
 const TABS: { key: Tab; label: string; icon: React.ReactNode; desc: string }[] = [
   { key: 'prd', label: 'PRD 文档生成', icon: <FileText className="w-4 h-4" />, desc: '按米多 product-document-generator 模板生成 / 优化产品文档（工程版 / 敏捷版）' },
-  { key: 'equipment', label: '设备素材库', icon: <ImageIcon className="w-4 h-4" />, desc: '按预设风格生成产线设备图，攒一份属于你的素材库，给流程图节点用' },
+  { key: 'equipment', label: '设备素材库', icon: <ImageIcon className="w-4 h-4" />, desc: 'AI 生成或上传本地产线设备图，攒一份属于你的素材库，给流程图节点用' },
   { key: 'flow', label: '流程示意图', icon: <GitBranch className="w-4 h-4" />, desc: 'AI 解析输入 → 节点 + 边 JSON → ReactFlow 拼装素材图，可拖动微调 + 导出' },
   { key: 'qa', label: '智能客服', icon: <MessageSquare className="w-4 h-4" />, desc: '基于知识库的严格 RAG 问答，知识库没有就明说不杜撰；可开联网开关补充模型公开知识' },
   { key: 'sql', label: 'SQL助手', icon: <Database className="w-4 h-4" />, desc: '服务 CCAS 业务的数据库 SQL 辅助工具集：IN 子句转换、列表去重等批量字符串处理；后续会继续扩展' },

--- a/prd-admin/src/pages/ccas-agent/CcasEquipmentTab.tsx
+++ b/prd-admin/src/pages/ccas-agent/CcasEquipmentTab.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useState } from 'react';
-import { Sparkles, Loader2, Star, Trash2, RefreshCw, AlertCircle, Plus } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Sparkles, Loader2, Star, Trash2, RefreshCw, AlertCircle, Plus, Upload } from 'lucide-react';
 import { Button } from '@/components/design/Button';
 import {
   generateCcasEquipment,
+  uploadCcasEquipment,
   listCcasEquipment,
   toggleCcasEquipmentFavorite,
   deleteCcasEquipment,
@@ -25,6 +26,10 @@ export function CcasEquipmentTab({ meta }: Props) {
   const [styleKey, setStyleKey] = useState(meta.equipmentStyles[0]?.key ?? 'isometric-3d');
   const [extraPrompt, setExtraPrompt] = useState('');
   const [generating, setGenerating] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [uploadFile, setUploadFile] = useState<File | null>(null);
+  const [uploadNote, setUploadNote] = useState('');
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const [items, setItems] = useState<CcasEquipmentAsset[]>([]);
   const [loading, setLoading] = useState(false);
   const [filterStyle, setFilterStyle] = useState<string>('');
@@ -72,6 +77,50 @@ export function CcasEquipmentTab({ meta }: Props) {
       toast.error(res.error?.message || '生成失败');
     }
   }, [equipmentType, styleKey, extraPrompt]);
+
+  const onPickUploadFile = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.currentTarget.value = '';
+    if (!file) return;
+    if (!file.type.startsWith('image/')) {
+      toast.error('仅支持图片文件（jpg / png / webp / gif）');
+      return;
+    }
+    if (file.size > 10 * 1024 * 1024) {
+      toast.error('图片不能超过 10MB');
+      return;
+    }
+    setUploadFile(file);
+    setError(null);
+  }, []);
+
+  const onUpload = useCallback(async () => {
+    const t = equipmentType.trim();
+    if (!t) {
+      toast.error('请输入设备类型');
+      return;
+    }
+    if (!uploadFile) {
+      toast.error('请选择要上传的图片');
+      return;
+    }
+    setUploading(true);
+    setError(null);
+    const res = await uploadCcasEquipment(uploadFile, {
+      equipmentType: t,
+      note: uploadNote.trim() || undefined,
+    });
+    setUploading(false);
+    if (res.success && res.data) {
+      toast.success(`已上传「${t}」素材`);
+      setItems((prev) => [res.data!.asset, ...prev]);
+      setUploadFile(null);
+      setUploadNote('');
+    } else {
+      setError(res.error?.message || '上传失败');
+      toast.error(res.error?.message || '上传失败');
+    }
+  }, [equipmentType, uploadFile, uploadNote]);
 
   const onToggleFav = useCallback(async (id: string, current: boolean) => {
     const res = await toggleCcasEquipmentFavorite(id, !current);
@@ -160,6 +209,53 @@ export function CcasEquipmentTab({ meta }: Props) {
             提示：生成的素材保存在你的私人库中，可在「流程图」Tab 选用。模型选择由后台模型池决定。
           </div>
         </section>
+
+        <section className="rounded-lg border border-white/10 bg-white/5 p-4">
+          <h2 className="text-sm font-medium text-white mb-3 flex items-center gap-1.5">
+            <Upload className="w-4 h-4" /> 上传本地图片
+          </h2>
+
+          <p className="text-[11px] text-white/45 mb-2 leading-relaxed">
+            有现场实拍或设计稿时可直接上传，设备类型与上方共用；流程图会按设备名自动匹配。
+          </p>
+
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/jpeg,image/png,image/webp,image/gif"
+            className="hidden"
+            onChange={onPickUploadFile}
+          />
+
+          <Button
+            variant="ghost"
+            onClick={() => fileInputRef.current?.click()}
+            className="!h-8 !w-full !text-xs !mb-2"
+          >
+            {uploadFile ? `已选：${uploadFile.name}` : '选择图片（≤ 10MB）'}
+          </Button>
+
+          <label className="block text-xs text-white/65 mb-1">备注（可选）</label>
+          <textarea
+            value={uploadNote}
+            onChange={(e) => setUploadNote(e.target.value)}
+            rows={2}
+            placeholder="如：石湾 2 号线现场实拍"
+            className="w-full mb-3 rounded-md bg-black/30 border border-white/15 px-3 py-1.5 text-sm text-white placeholder:text-white/30 focus:outline-none focus:border-amber-400/60"
+          />
+
+          <Button
+            onClick={onUpload}
+            disabled={uploading || !equipmentType.trim() || !uploadFile}
+            className="!h-9 !w-full !text-xs"
+          >
+            {uploading ? (
+              <><Loader2 className="w-3.5 h-3.5 animate-spin mr-1" /> 上传中…</>
+            ) : (
+              <><Upload className="w-3.5 h-3.5 mr-1" /> 上传入库</>
+            )}
+          </Button>
+        </section>
       </div>
 
       {/* 右：素材网格 */}
@@ -199,7 +295,7 @@ export function CcasEquipmentTab({ meta }: Props) {
             <div className="col-span-full text-center text-sm text-white/40 py-12">加载中…</div>
           ) : items.length === 0 ? (
             <div className="col-span-full text-center text-sm text-white/40 py-12">
-              暂无素材，去左侧生成第一张
+              暂无素材，去左侧生成或上传第一张
             </div>
           ) : (
             items.map((it) => (

--- a/prd-admin/src/pages/ccas-agent/CcasFlowTab.tsx
+++ b/prd-admin/src/pages/ccas-agent/CcasFlowTab.tsx
@@ -414,7 +414,7 @@ function FlowInner({ meta }: Props) {
             </div>
           )}
           <div className="text-[11px] text-white/40 leading-relaxed">
-            提示：节点的设备图来自「设备素材库」（按设备名匹配）。先在素材库 Tab 生成对应风格的设备图，再回来生成流程图，节点会自动套图。
+            提示：节点的设备图来自「设备素材库」（按设备名匹配）。先在素材库 Tab 生成或上传对应设备图，再回来生成流程图，节点会自动套图。
           </div>
         </section>
 

--- a/prd-admin/src/services/index.ts
+++ b/prd-admin/src/services/index.ts
@@ -2164,6 +2164,7 @@ export type {
 export {
   getCcasMeta,
   generateCcasEquipment,
+  uploadCcasEquipment,
   listCcasEquipment,
   toggleCcasEquipmentFavorite,
   deleteCcasEquipment,

--- a/prd-admin/src/services/real/ccasAgent.ts
+++ b/prd-admin/src/services/real/ccasAgent.ts
@@ -1,4 +1,5 @@
 import { apiRequest } from './apiClient';
+import { useAuthStore } from '@/stores/authStore';
 import type { ApiResponse } from '@/types/api';
 
 // ──────────────────────────────────────────────
@@ -89,6 +90,37 @@ export async function generateCcasEquipment(body: {
     method: 'POST',
     body,
   });
+}
+
+/** 上传本地设备图片：FormData 必须走原生 fetch（apiRequest 会 JSON 序列化） */
+export async function uploadCcasEquipment(
+  file: File,
+  body: { equipmentType: string; note?: string }
+): Promise<ApiResponse<{ asset: CcasEquipmentAsset }>> {
+  const token = useAuthStore.getState().token;
+  const headers: Record<string, string> = { Accept: 'application/json' };
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  const fd = new FormData();
+  fd.append('file', file);
+  fd.append('equipmentType', body.equipmentType);
+  if (body.note?.trim()) fd.append('note', body.note.trim());
+
+  const rawBase = ((import.meta.env.VITE_API_BASE_URL as string | undefined) ?? '').trim().replace(/\/+$/, '');
+  const path = '/api/ccas-agent/equipment/upload';
+  const url = rawBase ? `${rawBase}${path}` : path;
+
+  const res = await fetch(url, { method: 'POST', headers, body: fd, credentials: 'include' });
+  const text = await res.text();
+  try {
+    return JSON.parse(text) as ApiResponse<{ asset: CcasEquipmentAsset }>;
+  } catch {
+    return {
+      success: false,
+      data: null,
+      error: { code: 'INVALID_FORMAT', message: `响应解析失败（HTTP ${res.status}）` },
+    };
+  }
 }
 
 export async function listCcasEquipment(params: {

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/CcasAgentController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/CcasAgentController.cs
@@ -11,6 +11,8 @@ using PrdAgent.Infrastructure.LLM;
 using PrdAgent.Infrastructure.LlmGateway;
 using PrdAgent.Infrastructure.Services.AssetStorage;
 using PrdAgent.Infrastructure.Services.CcasAgent;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -21,7 +23,7 @@ namespace PrdAgent.Api.Controllers.Api;
 /// 赋码采集关联系统综合智能体（ccas-agent）
 /// 三大子能力：
 ///   1) PRD 文档生成（按米多 product-document-generator skill 模板，工程版 / 敏捷版双模板）
-///   2) 设备素材库（按预设风格生成 + 复用，供流程图节点引用）
+///   2) 设备素材库（按预设风格生成 / 本地上传 + 复用，供流程图节点引用）
 ///   3) 流程示意图绘制（LLM 解析输入 → 节点 + 边 JSON → 前端 ReactFlow 拼装素材图渲染）
 /// </summary>
 [ApiController]
@@ -288,6 +290,12 @@ public class CcasAgentController : ControllerBase
     // 子能力 2：设备素材库
     // ──────────────────────────────────────────────
 
+    private const long MaxEquipmentUploadBytes = 10 * 1024 * 1024;
+    private static readonly HashSet<string> AllowedEquipmentUploadMimeTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "image/jpeg", "image/jpg", "image/png", "image/webp", "image/gif",
+    };
+
     public class GenerateEquipmentRequest
     {
         /// <summary>设备类型/中文名（必填，例如：裹包机 / 龙门架 / 工业相机）</summary>
@@ -445,6 +453,91 @@ public class CcasAgentController : ControllerBase
             model = resolution.ActualModel,
             platform = resolution.ActualPlatformName,
         }));
+    }
+
+    /// <summary>
+    /// 上传本地设备图片并入库。风格固定为 user-upload，供流程图按设备名匹配。
+    /// </summary>
+    [HttpPost("equipment/upload")]
+    [RequestSizeLimit(MaxEquipmentUploadBytes)]
+    public async Task<IActionResult> UploadEquipment(
+        [FromForm] IFormFile file,
+        [FromForm] string equipmentType,
+        [FromForm] string? note,
+        CancellationToken ct)
+    {
+        var userId = GetUserId();
+        var equipType = (equipmentType ?? string.Empty).Trim();
+        if (string.IsNullOrWhiteSpace(equipType))
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.CONTENT_EMPTY, "equipmentType 不能为空"));
+
+        if (file == null || file.Length == 0)
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "请选择图片文件"));
+        if (file.Length > MaxEquipmentUploadBytes)
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "图片大小不能超过 10MB"));
+
+        var mimeType = (file.ContentType ?? string.Empty).Trim().ToLowerInvariant();
+        if (string.IsNullOrWhiteSpace(mimeType) || !AllowedEquipmentUploadMimeTypes.Contains(mimeType))
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, $"不支持的图片类型：{mimeType}"));
+
+        byte[] bytes;
+        await using (var ms = new MemoryStream())
+        {
+            await file.CopyToAsync(ms, ct);
+            bytes = ms.ToArray();
+        }
+
+        if (bytes.Length == 0)
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "图片内容为空"));
+
+        StoredAsset stored;
+        try
+        {
+            stored = await _assetStorage.SaveAsync(
+                bytes,
+                mimeType,
+                CancellationToken.None,
+                domain: AppDomainPaths.DomainCcasAgent,
+                type: AppDomainPaths.TypeImg);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "CcasAgent equipment 上传落盘失败 user={UserId}", userId);
+            return StatusCode(StatusCodes.Status502BadGateway,
+                ApiResponse<object>.Fail(ErrorCodes.LLM_ERROR, "图片上传失败，请稍后重试"));
+        }
+
+        var width = 0;
+        var height = 0;
+        try
+        {
+            using var image = Image.Load<Rgba32>(bytes);
+            width = image.Width;
+            height = image.Height;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "CcasAgent equipment 上传图片尺寸解析失败，继续入库");
+        }
+
+        var noteText = (note ?? string.Empty).Trim();
+        var asset = new CcasEquipmentAsset
+        {
+            OwnerUserId = userId,
+            EquipmentType = equipType,
+            StyleKey = "user-upload",
+            Prompt = "[用户上传]",
+            OriginalUserInput = string.IsNullOrWhiteSpace(noteText) ? null : noteText,
+            Url = stored.Url,
+            OriginalUrl = stored.Url,
+            Mime = mimeType,
+            Width = width,
+            Height = height,
+            SizeBytes = stored.SizeBytes,
+        };
+        await _db.CcasEquipmentAssets.InsertOneAsync(asset, cancellationToken: CancellationToken.None);
+
+        return Ok(ApiResponse<object>.Ok(new { asset }));
     }
 
     /// <summary>

--- a/prd-api/src/PrdAgent.Core/Models/CcasAgent/CcasEquipmentAsset.cs
+++ b/prd-api/src/PrdAgent.Core/Models/CcasAgent/CcasEquipmentAsset.cs
@@ -72,6 +72,9 @@ public static class CcasEquipmentStyles
         new("3d-render",
             "3D 渲染",
             "high-quality 3D rendered industrial equipment, octane render, studio lighting, neutral grey background, photo-realistic textures, no text, no watermark"),
+        new("user-upload",
+            "用户上传",
+            "user uploaded equipment photograph or illustration"),
     };
 
     public static StylePreset? FindByKey(string key)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
CCAS 设备素材库原先仅支持 AI 生图，现新增本地上传能力：用户可上传现场实拍或设计稿，按设备类型入库，流程图 Tab 继续按设备名自动匹配配图。

## 改动 diff
- `prd-api/src/PrdAgent.Api/Controllers/Api/CcasAgentController.cs`：新增 `POST /api/ccas-agent/equipment/upload`（jpg/png/webp/gif，≤10MB）
- `prd-api/src/PrdAgent.Core/Models/CcasAgent/CcasEquipmentAsset.cs`：新增 `user-upload` 风格预设
- `prd-admin/src/pages/ccas-agent/CcasEquipmentTab.tsx`：左侧新增「上传本地图片」区块
- `prd-admin/src/services/real/ccasAgent.ts`：新增 `uploadCcasEquipment`（FormData fetch）
- `prd-admin/src/pages/ccas-agent/CcasFlowTab.tsx`：提示文案同步
- `changelogs/2026-06-15_ccas-equipment-upload.md`：changelog 碎片

## 测试
- [x] `dotnet build --no-restore` 零 error CS
- [x] `pnpm tsc --noEmit` 通过
- [x] CDS 部署后真人上传验收
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ce965e6-248e-4f04-a40c-7d57a4515ab2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ce965e6-248e-4f04-a40c-7d57a4515ab2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

