### PR TITLE
ops(cds): 修复 Admin 预览源码启动目录

### DIFF
--- a/cds-compose.yml
+++ b/cds-compose.yml
@@ -61,6 +61,7 @@ x-cds-deploy-modes:
     dev:
       label: "开发模式 (Vite HMR)"
       command: >-
+        cd prd-admin &&
         corepack enable &&
         corepack prepare pnpm@10.28.2 --activate &&
         pnpm config set store-dir /pnpm/store &&
@@ -69,6 +70,7 @@ x-cds-deploy-modes:
     static:
       label: "静态部署 (vite build+serve)"
       command: >-
+        cd prd-admin &&
         corepack enable &&
         corepack prepare pnpm@10.28.2 --activate &&
         pnpm config set store-dir /pnpm/store &&
@@ -125,18 +127,16 @@ services:
 
   admin:
     image: node:20-slim
-    working_dir: /app
+    working_dir: /repo
     volumes:
-      - ./prd-admin:/app
-      # public/thirdparty/ref 是符号链接指向仓库根 thirdparty/ref（22+ 个 HTML 素材）。
-      # 单挂 ./prd-admin 时 symlink 解析到 /thirdparty/ref 找不到目录，
-      # vite build (static 模式) 的 copyPublicDir 步骤会报 ENOENT。
-      - ./thirdparty:/thirdparty:ro
+      # 挂载仓库根目录，确保 prd-admin/public 内指向仓库级资源的符号链接可解析。
+      - .:/repo
       - admin-pnpm-store:/pnpm/store
     ports:
       - "8000"
     # 默认 dev：秒级就绪，避免 static 冷构建 OOM（exitCode=137）。需要 dist 时在 CDS 切 static 模式。
     command: >-
+      cd prd-admin &&
       corepack enable &&
       corepack prepare pnpm@10.28.2 --activate &&
       pnpm config set store-dir /pnpm/store &&

--- a/changelogs/2026-06-18_changelog-defect-short-sha.md
+++ b/changelogs/2026-06-18_changelog-defect-short-sha.md
@@ -12,3 +12,4 @@
 | feat | prd-api | 新增缺陷自动化控制台接口，返回长期授权、运行历史、统计和每日计划模板 |
 | feat | prd-admin | 缺陷页面新增缺陷自动化控制台，支持一键生成并复制长期授权每日计划 |
 | docs | skills | ai-defect-resolve 改为优先使用缺陷页面自动化入口生成永不过期授权 |
+| ops | cds | Admin 预览容器改为从仓库根目录进入 prd-admin 启动，避免源码模式缺少 package.json |

--- a/changelogs/2026-06-18_changelog-defect-short-sha.md
+++ b/changelogs/2026-06-18_changelog-defect-short-sha.md
@@ -13,3 +13,4 @@
 | feat | prd-admin | 缺陷页面新增缺陷自动化控制台，支持一键生成并复制长期授权每日计划 |
 | docs | skills | ai-defect-resolve 改为优先使用缺陷页面自动化入口生成永不过期授权 |
 | ops | cds | Admin 预览容器改为从仓库根目录进入 prd-admin 启动，避免源码模式缺少 package.json |
+| fix | prd-api | 缺陷自动化 commit 回写优先使用长期 K 标识，确保发布后验收和通知可继续查询 |

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/DefectAgentController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/DefectAgentController.cs
@@ -128,6 +128,15 @@ public class DefectAgentController : ControllerBase
     private bool IsAiAccessRequest()
         => string.Equals(User.FindFirst(AiAccessKeyAuthenticationHandler.ClaimTypeIsAiSuperAccess)?.Value, "1", StringComparison.Ordinal);
 
+    internal static string? ResolveAutomationAgentIdentifier(string? agentApiKeyId, string? appId)
+    {
+        if (!string.IsNullOrWhiteSpace(agentApiKeyId))
+            return agentApiKeyId.Trim();
+        if (!string.IsNullOrWhiteSpace(appId))
+            return appId.Trim();
+        return null;
+    }
+
     private async Task<DefectReport?> FindDefectByIdOrNoAsync(string idOrNo, CancellationToken ct)
     {
         var key = idOrNo.Trim();
@@ -2926,7 +2935,9 @@ public class DefectAgentController : ControllerBase
         var take = Math.Clamp(limit, 1, 100);
         var filter = Builders<DefectResolutionTrace>.Filter.Eq(x => x.PublishStatus, DefectResolutionPublishStatus.Published)
                      & Builders<DefectResolutionTrace>.Filter.Eq(x => x.NotifyStatus, DefectResolutionNotifyStatus.Pending);
-        var agentKeyId = User.FindFirst("agentApiKeyId")?.Value ?? User.FindFirst("appId")?.Value;
+        var agentKeyId = ResolveAutomationAgentIdentifier(
+            User.FindFirst("agentApiKeyId")?.Value,
+            User.FindFirst("appId")?.Value);
         if (!HasManagePermission() && !IsAiAccessRequest())
         {
             if (string.IsNullOrWhiteSpace(agentKeyId))
@@ -2996,7 +3007,9 @@ public class DefectAgentController : ControllerBase
         var trace = await _db.DefectResolutionTraces.Find(x => x.Id == traceId).FirstOrDefaultAsync(ct);
         if (trace == null)
             return NotFound(ApiResponse<object>.Fail(ErrorCodes.DOCUMENT_NOT_FOUND, "缺陷修复追踪记录不存在"));
-        var agentKeyId = User.FindFirst("agentApiKeyId")?.Value ?? User.FindFirst("appId")?.Value;
+        var agentKeyId = ResolveAutomationAgentIdentifier(
+            User.FindFirst("agentApiKeyId")?.Value,
+            User.FindFirst("appId")?.Value);
         if (!CanAutomationAccessTrace(trace, agentKeyId, HasManagePermission(), IsAiAccessRequest()))
             return AutomationForbidden("无权回写该修复记录的验收报告");
         if (trace.PublishStatus != DefectResolutionPublishStatus.Published)
@@ -3314,7 +3327,9 @@ public class DefectAgentController : ControllerBase
             new AutomationCommitTraceInput
             {
                 AgentName = request.AgentName?.Trim() ?? User.FindFirst("appName")?.Value,
-                AgentIdentifier = User.FindFirst("appId")?.Value,
+                AgentIdentifier = ResolveAutomationAgentIdentifier(
+                    User.FindFirst("agentApiKeyId")?.Value,
+                    User.FindFirst("appId")?.Value),
                 Repository = request.Repository?.Trim(),
                 Branch = request.Branch?.Trim(),
                 CommitSha = commitSha,

--- a/prd-api/tests/PrdAgent.Api.Tests/Controllers/ChangelogLinkedDefectsTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Controllers/ChangelogLinkedDefectsTests.cs
@@ -177,6 +177,14 @@ public class ChangelogLinkedDefectsTests
     }
 
     [Fact]
+    public void ResolveAutomationAgentIdentifier_PrefersAgentApiKeyId()
+    {
+        Assert.Equal("agent-key-1", DefectAgentController.ResolveAutomationAgentIdentifier(" agent-key-1 ", "app-1"));
+        Assert.Equal("app-1", DefectAgentController.ResolveAutomationAgentIdentifier(null, " app-1 "));
+        Assert.Null(DefectAgentController.ResolveAutomationAgentIdentifier("", " "));
+    }
+
+    [Fact]
     public void MergeAutomationCommitStructuredData_WritesCommitInfoKeys()
     {
         var structured = DefectAgentController.MergeAutomationCommitStructuredData(


### PR DESCRIPTION
## 摘要
修复 CDS Admin 预览容器在源码模式下从 `/app` 启动导致找不到 `package.json` 的问题，同时补齐缺陷自动化 commit 回写后的归属标识，确保长期 K 在正式发布后能继续查询待验收修复并通知提交人。

## 改动 diff
- `cds-compose.yml`：Admin dev/static 命令进入 `prd-admin`，服务工作目录改为 `/repo` 并挂载仓库根目录。
- `prd-api/src/PrdAgent.Api/Controllers/Api/DefectAgentController.cs`：缺陷自动化 trace 归属统一优先使用 `agentApiKeyId`，再回退 `appId`。
- `prd-api/tests/PrdAgent.Api.Tests/Controllers/ChangelogLinkedDefectsTests.cs`：补充长期 K 归属解析测试。
- `changelogs/2026-06-18_changelog-defect-short-sha.md`：补充 CDS 与缺陷自动化闭环修复记录。

## 测试
- [x] `git diff --check` 通过
- [x] `cd prd-api && dotnet build --no-restore` 无 CS 错误，仍有既有 warning
- [x] CDS 预览 `https://fix-cds-admin-workdir-codex-prd-agent.miduo.org/defect-agent` 返回 200
- [x] 缺陷自动化控制台视觉验收通过，报告已归档到知识库
- [ ] `dotnet test --no-build --filter ChangelogLinkedDefectsTests` 本机缺少 .NET 8 runtime，等待 GitHub/CDS 环境执行
