### PR TITLE
chore: 熵清理 - 补缺 plan.md-to-ppt-next-wave 文档并标记 changelog

### DIFF
--- a/changelogs/.entropy-manifest.yml
+++ b/changelogs/.entropy-manifest.yml
@@ -190,6 +190,11 @@ processed:
   - 2026-06-08_pm-goals-empty-overlap.md
   - 2026-06-08_pm-task-enhance.md
   - 2026-06-08_product-card-animation.md
+  - 2026-06-08_product-defect-and-ux-fixes.md
+  - 2026-06-08_product-defect-create-page.md
+  - 2026-06-08_product-graph-layout.md
+  - 2026-06-08_product-relation-analysis.md
+  - 2026-06-08_user-search-permission-fix.md
   - 2026-06-14_marketplace-skill-preview-and-share.md
   - 2026-06-14_short-video-card-preview.md
   - 2026-06-14_shortcuts-clipboard.md

--- a/changelogs/2026-06-14_entropy-cleanup.md
+++ b/changelogs/2026-06-14_entropy-cleanup.md
@@ -1,0 +1,1 @@
+| chore | doc | 熵清理：D3 补缺 1 条(plan.md-to-ppt-next-wave)，D6 标记已处理 5 条 changelog |

--- a/doc/guide.list.directory.md
+++ b/doc/guide.list.directory.md
@@ -637,6 +637,9 @@
 - [MD转PPT 对话式 artifact 工作台改造计划](plan.md-to-ppt-chat-redesign) `plan.md-to-ppt-chat-redesign`
   > AI 文本辅助功能的通用领域模型设计
 
+- [MD 转 PPT 下一波执行计划](plan.md-to-ppt-next-wave) `plan.md-to-ppt-next-wave`
+  > 大纲右侧编辑器/状态机/澄清问卷/编辑深修的下一波执行计划
+
 - [配图标记手动干预](plan.manual-image-marking-control) `plan.manual-image-marking-control`
   > 配图标记从"自动黑盒"升级为"提示词+位置策略+段落级操作"的分阶段计划（Phase 1/2/3）
 


### PR DESCRIPTION
## 摘要

补缺 MD 转 PPT 下一波执行计划文档，并将 5 条已处理的 changelog 碎片标记为已处理。

## 改动 diff

- `doc/guide.list.directory.md`：新增 plan.md-to-ppt-next-wave 文档条目，描述大纲右侧编辑器/状态机/澄清问卷/编辑深修的下一波执行计划
- `changelogs/.entropy-manifest.yml`：标记 5 条 D6 日期的 changelog 碎片为已处理（product-defect-and-ux-fixes、product-defect-create-page、product-graph-layout、product-relation-analysis、user-search-permission-fix）
- `changelogs/2026-06-14_entropy-cleanup.md`：新增 changelog 碎片记录本次熵清理工作

## 说明

本次变更属于文档维护和 changelog 管理的例行熵清理，无代码逻辑变更。

https://claude.ai/code/session_01Hv86ejk5rCazmSRbkMoQnE

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and changelog manifest updates only; no product code paths affected.
> 
> **Overview**
> Routine **entropy-cleanup** for docs and changelog hygiene—no runtime or API changes.
> 
> **`doc/guide.list.directory.md`** adds **`plan.md-to-ppt-next-wave`** under 计划与方案, pointing readers at the next MD→PPT wave (outline right editor, state machine, clarification questionnaire, deeper edit flows).
> 
> **`changelogs/.entropy-manifest.yml`** registers five **2026-06-08** changelog shards as processed: `product-defect-and-ux-fixes`, `product-defect-create-page`, `product-graph-layout`, `product-relation-analysis`, and `user-search-permission-fix`.
> 
> **`changelogs/2026-06-14_entropy-cleanup.md`** records this pass (D3 doc gap-fill + D6 manifest updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac7ee7b40afec77da439dd90688ae848d92db36e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->