### PR TITLE
熵减计划合并策略：Agent 核查内容后手动 squash 合并（不依赖仓库 auto-merge 开关）

### DIFF
--- a/.claude/skills/entropy-cleanup/SKILL.md
+++ b/.claude/skills/entropy-cleanup/SKILL.md
@@ -225,9 +225,9 @@ git commit -m "chore: 日常熵清理 $(date +%Y-%m-%d)"
 git push -u origin $(git branch --show-current)
 ```
 
-### Step 6 — 自动创建 PR 并开启合并监控（必须执行）
+### Step 6 — 自动创建 PR、核查内容后手动合并（必须执行）
 
-推送完成后立即执行以下步骤，**不得省略**。这是本技能从"推代码"升级为"自动交付"的核心。
+推送完成后立即执行以下步骤，**不得省略**。这是本技能从"推代码"升级为"自动交付"的核心：Agent 自己建 PR、自己通读内容核查、核查通过后自己 squash 合并，**不把合并决定权交给仓库 auto-merge 开关**。
 
 #### 6.1 判断是否需要创建 PR
 
@@ -272,26 +272,38 @@ PR body 模板（从 Step 2 报告提取数字）：
 - [x] 运行两次验证：第二次净变更为 0
 ```
 
-#### 6.4 开启自动合并
+#### 6.4 检查 PR 内容（合并前强制，不得跳过）
 
-PR 创建成功后，立即调用 `mcp__github__enable_pr_auto_merge`：
+合并前必须逐项核查 PR 的真实改动，确认是「干净的文档/索引熵清理」而非误删或越界：
+
+1. 调用 `mcp__github__pull_request_read`（method=`get`）确认 `mergeable_state`：
+   - `behind` → 先调 `mcp__github__update_pull_request_branch` 把 main 合进来，再继续
+   - `dirty`（有冲突）→ 本地拉取 + 解决冲突 + force-push（manifest 冲突一律 `--ours`，guide.list/doc 内容冲突手动合并两边精华），不得盲目合并
+   - `clean` / `unstable` → 可继续
+2. 调用 `mcp__github__pull_request_read`（method=`get_diff`）通读 diff，逐条核对：
+   - 所有 `-`（删除）行：必须是真实「幽灵条目」（对应 `doc/${key}.md` / `.claude/skills/${name}/` 确实不存在）。**发现删除了仍存在的文件对应条目 → 立即停止，不合并，通知用户**
+   - 所有 `+`（追加）行：仅限 `doc/index.yml` / `doc/guide.list.directory.md` / `CLAUDE.md` 技能表 / `changelogs/` / manifest，不得有代码文件（`.cs`/`.ts`/`.tsx` 等）混入
+   - `changed_files` 应全部落在文档/索引/changelog/技能元数据范围内
+3. 任一核查不通过 → **不合并**，发通知说明问题，等用户裁决。
+
+#### 6.5 手动 squash 合并（核查通过后）
+
+内容核查全部通过后，由 Agent 直接调用 `mcp__github__merge_pull_request` 完成合并（**不依赖仓库 auto-merge 开关**）：
 ```
-owner:        inernoro
-repo:         prd_agent
-pullNumber:   <上一步返回的 PR number>
-mergeMethod:  squash
+owner:         inernoro
+repo:          prd_agent
+pullNumber:    <PR number>
+merge_method:  squash
+commit_title:  每日熵减计划 YYYY-WXX — <本次主要修复内容>
 ```
 
-若 CI 未配置（仓库无必需 check），auto-merge 可能直接触发合并，这是预期行为。
+合并成功后记录返回的 SHA。**禁止**调用 `mcp__github__enable_pr_auto_merge` 把合并决定权交给仓库设置——熵减 PR 的合并必须经过本技能 6.4 的内容核查这道闸。
 
-#### 6.5 订阅 PR 并监控到合并完成
+#### 6.6 收尾
 
-调用 `mcp__github__subscribe_pr_activity` 订阅该 PR：
-- 收到 CI 通过事件 → 确认 auto-merge 已触发
-- 收到 PR 已合并事件 → 记录合并 SHA，结束任务
-- 收到 CI 失败事件 → 分析失败原因；若是文档内容类冲突，尝试修复后 force-push；若无法自修复，发送通知给用户
-
-**重要**：订阅后不得用 `sleep` 轮询——等待 webhook 事件唤醒即可。PR 合并或关闭后自动调用 `mcp__github__unsubscribe_pr_activity` 解除订阅。
+- 合并成功 → 记录 SHA，结束任务。
+- 若 6.4 发现 PR `dirty` 需要本地解冲突，解完 force-push 后回到 6.4 重新核查再合并。
+- 全程**禁止**用 `sleep` 空转轮询；合并是同步调用，拿到结果即结束。
 
 ---
 
@@ -314,7 +326,8 @@ processed:
 
 - **标题约定**：`每日熵减计划 YYYY-WXX — <本次主要修复内容>`
 - **自动创建**：Step 6 在推送后必须自动调用 `mcp__github__create_pull_request` 创建，不需要人工触发
-- **自动合并**：创建后立即调用 `mcp__github__enable_pr_auto_merge`（squash 策略），CI 通过即自动合并
+- **合并前核查**：合并前必须走 6.4 内容核查（diff 通读 + 删除行幽灵验证 + 无代码混入），核查通过才合并
+- **手动 squash 合并**：由 Agent 调 `mcp__github__merge_pull_request`（squash）直接合并，**不依赖仓库 auto-merge 开关**，也不调 `enable_pr_auto_merge`——合并必须过技能内容核查这道闸
 - **去重保护**：创建前先查 open PR，有同类 PR 先合并再创建
 - **无净变更跳过**：当前分支没有超过 main 的 commit 时，不创建 PR（幂等运行不产生空 PR）
 


### PR DESCRIPTION
## 摘要

按用户要求，把 `/entropy` 技能的合并策略从「依赖仓库 auto-merge 开关」改为「Agent 自己核查内容后手动 squash 合并」，合并必须过内容核查这道闸。

## 改动 diff

- `.claude/skills/entropy-cleanup/SKILL.md`：
  - Step 6.4 新增合并前强制内容核查（mergeable_state 处理 + diff 通读 + 删除行幽灵验证 + 禁止代码文件混入）
  - Step 6.5 改为 Agent 直接调 `merge_pull_request`（squash），禁用 `enable_pr_auto_merge`
  - Step 6.6 收尾：dirty 需本地解冲突 force-push 后回到 6.4 重核查
  - 同步更新 Step 6 标题与「PR 工作流」章节

## 测试

- [x] 纯技能文档更新，无代码变更

---
_Generated by [Claude Code](https://claude.ai/code/session_014QwM9LiE4E4dVaDm1V4LwH)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to an agent skill workflow; no runtime code, auth, or data paths are modified.
> 
> **Overview**
> Updates **`entropy-cleanup`** Step 6 so entropy PRs are no longer merged via **`enable_pr_auto_merge`** and webhook subscription. The agent must **review the PR diff** before merging.
> 
> **Step 6.4** adds mandatory pre-merge checks: handle **`mergeable_state`** (`behind` / `dirty` / `clean`), read the full diff, verify every deletion is a true ghost entry, and block merges if application code (`.cs`/`.ts`/`.tsx`) appears in the change set.
> 
> **Step 6.5** directs the agent to call **`merge_pull_request`** (squash) after checks pass and explicitly **forbids** `enable_pr_auto_merge`. **Step 6.6** replaces the old subscribe-and-wait flow with synchronous merge, conflict re-check loops, and no **`sleep`** polling.
> 
> The **PR 工作流** section is aligned with merge-after-review and manual squash only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc7f91aeb587b3b54cfebe9ce1af6ef14a2cf83f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->