### PR TITLE
fix(prd-desktop): 清理群组标题中的 HTML 标签

### DIFF
--- a/changelogs/2026-06-23_desktop-group-title-sanitize.md
+++ b/changelogs/2026-06-23_desktop-group-title-sanitize.md
@@ -1,0 +1,1 @@
+| fix | prd-desktop | 修复群组标题显示 HTML 标签内容的问题 |

--- a/prd-desktop/src/components/Document/DocumentUpload.tsx
+++ b/prd-desktop/src/components/Document/DocumentUpload.tsx
@@ -7,7 +7,7 @@ import { useGroupListStore } from '../../stores/groupListStore';
 import { useDesktopBrandingStore } from '../../stores/desktopBrandingStore';
 import { openGroupSessionAndSetStore } from '../../lib/openGroupSession';
 import { ApiResponse, Document, Session } from '../../types';
-import { extractMarkdownTitle, isMeaninglessName, normalizeCandidateName, stripFileExtension } from '../utils/nameHeuristics';
+import { extractMarkdownTitle, isMeaninglessName, normalizeCandidateName, sanitizeGroupName, stripFileExtension } from '../utils/nameHeuristics';
 
 interface UploadResponse {
   sessionId: string;
@@ -27,10 +27,10 @@ export default function DocumentUpload() {
     // 本地启发式命名：文件名有意义则用文件名，否则用 Markdown 标题或文档标题
     // 意图模型生成群名的逻辑已移到后端异步执行，不再阻塞创建流程
     const rawFileBase = fileName ? normalizeCandidateName(stripFileExtension(fileName)) : '';
-    if (rawFileBase && !isMeaninglessName(rawFileBase)) return rawFileBase;
+    if (rawFileBase && !isMeaninglessName(rawFileBase)) return sanitizeGroupName(rawFileBase);
 
     const mdTitle = extractMarkdownTitle(content);
-    return mdTitle || (docTitle || '').trim() || '未命名群组';
+    return sanitizeGroupName(mdTitle || docTitle || '', '未命名群组');
   };
 
   const handleUpload = async (content: string, fileName?: string | null) => {

--- a/prd-desktop/src/components/Layout/Sidebar.tsx
+++ b/prd-desktop/src/components/Layout/Sidebar.tsx
@@ -11,7 +11,7 @@ import { DOCUMENT_TYPE_LABELS } from '../../types';
 import { openGroupSessionAndSetStore } from '../../lib/openGroupSession';
 import GroupList from '../Group/GroupList';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
-import { extractMarkdownTitle, isMeaninglessName, normalizeCandidateName, stripFileExtension } from '../utils/nameHeuristics';
+import { extractMarkdownTitle, isMeaninglessName, normalizeCandidateName, sanitizeGroupName, stripFileExtension } from '../utils/nameHeuristics';
 import DocumentContextMenu from '../Document/DocumentContextMenu';
 import RenameDocumentModal from '../Document/RenameDocumentModal';
 import ConfirmDialog from '../ui/ConfirmDialog';
@@ -292,7 +292,7 @@ export default function Sidebar() {
 
   const submitCreate = async () => {
     setInlineError('');
-    const explicitGroupName = groupNameInput.trim();
+    const explicitGroupName = sanitizeGroupName(groupNameInput, '');
     const hasPrd = !!createPrdContent.trim();
 
     try {
@@ -320,9 +320,9 @@ export default function Sidebar() {
         if (!groupNameFinal) {
           const base = createPrdFileName ? normalizeCandidateName(stripFileExtension(createPrdFileName)) : '';
           if (base && !isMeaninglessName(base)) {
-            groupNameFinal = base;
+            groupNameFinal = sanitizeGroupName(base, '');
           } else {
-            groupNameFinal = extractMarkdownTitle(createPrdContent) || uploadResp.data.document.title || '';
+            groupNameFinal = sanitizeGroupName(extractMarkdownTitle(createPrdContent) || uploadResp.data.document.title || '', '');
           }
         }
 

--- a/prd-desktop/src/components/utils/__tests__/nameHeuristics.test.ts
+++ b/prd-desktop/src/components/utils/__tests__/nameHeuristics.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeGroupName } from '../nameHeuristics';
+
+describe('sanitizeGroupName', () => {
+  it('strips html tags from imported group titles', () => {
+    expect(sanitizeGroupName('<font style="color:rgb(15,17,21);">Part A 产品说明</font>')).toBe('Part A 产品说明');
+  });
+
+  it('decodes escaped html before stripping tags', () => {
+    expect(sanitizeGroupName('&lt;font&gt;需求标题&lt;/font&gt;')).toBe('需求标题');
+  });
+
+  it('keeps ordinary angle-bracket text that is not an html tag', () => {
+    expect(sanitizeGroupName('A < B 需求')).toBe('A < B 需求');
+  });
+});

--- a/prd-desktop/src/components/utils/nameHeuristics.ts
+++ b/prd-desktop/src/components/utils/nameHeuristics.ts
@@ -14,6 +14,39 @@ export function normalizeCandidateName(raw: string): string {
     .trim();
 }
 
+const HTML_ENTITY_MAP: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  nbsp: ' ',
+};
+
+function decodeHtmlEntities(raw: string): string {
+  return raw.replace(/&(#x?[0-9a-f]+|[a-z]+);/gi, (match, entity: string) => {
+    const key = entity.toLowerCase();
+    if (key.startsWith('#x')) {
+      const code = Number.parseInt(key.slice(2), 16);
+      return Number.isFinite(code) && code >= 0 && code <= 0x10ffff ? String.fromCodePoint(code) : match;
+    }
+    if (key.startsWith('#')) {
+      const code = Number.parseInt(key.slice(1), 10);
+      return Number.isFinite(code) && code >= 0 && code <= 0x10ffff ? String.fromCodePoint(code) : match;
+    }
+    return HTML_ENTITY_MAP[key] ?? match;
+  });
+}
+
+export function sanitizeGroupName(raw: string, fallback = '未命名群组'): string {
+  const decoded = decodeHtmlEntities(raw || '');
+  const withoutTags = decoded
+    .replace(/<\/?[a-z][\w:-]*(?:\s[^<>]*)?>/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return withoutTags || fallback;
+}
+
 export function isMeaninglessName(raw: string): boolean {
   const s = normalizeCandidateName(stripFileExtension(raw));
   if (!s) return true;
@@ -62,5 +95,3 @@ export function extractMarkdownTitle(content: string): string {
   const m = s.match(/^#\s+(.+)\s*$/m);
   return (m?.[1] || '').trim();
 }
-
-

--- a/prd-desktop/src/stores/groupListStore.ts
+++ b/prd-desktop/src/stores/groupListStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { invoke } from '../lib/tauri';
 import type { ApiResponse, Group } from '../types';
+import { sanitizeGroupName } from '../components/utils/nameHeuristics';
 import { useAuthStore } from './authStore';
 
 interface GroupListState {
@@ -13,6 +14,13 @@ interface GroupListState {
   /** 更新指定群组的名称（用于后台 AI 生成群名后静默更新） */
   updateGroupName: (groupId: string, name: string) => void;
   clear: () => void;
+}
+
+function normalizeGroup(group: Group): Group {
+  return {
+    ...group,
+    groupName: sanitizeGroupName(group.groupName),
+  };
 }
 
 export const useGroupListStore = create<GroupListState>((set, get) => ({
@@ -33,7 +41,7 @@ export const useGroupListStore = create<GroupListState>((set, get) => ({
       const runOnce = async () => {
         const response = await invoke<ApiResponse<Group[]>>('get_groups');
         if (response.success && response.data) {
-          set({ groups: response.data });
+          set({ groups: response.data.map(normalizeGroup) });
           return { ok: true as const, code: null as string | null };
         }
         return { ok: false as const, code: response.error?.code ?? null };
@@ -67,12 +75,12 @@ export const useGroupListStore = create<GroupListState>((set, get) => ({
   },
 
   addGroup: (group) => set((state) => ({
-    groups: [group, ...state.groups],
+    groups: [normalizeGroup(group), ...state.groups],
   })),
 
   updateGroupName: (groupId, name) => set((state) => ({
     groups: state.groups.map((g) =>
-      g.groupId === groupId ? { ...g, groupName: name } : g
+      g.groupId === groupId ? { ...g, groupName: sanitizeGroupName(name) } : g
     ),
   })),
 


### PR DESCRIPTION
## 摘要
修复 DEF-2026-0118 中群组标题展示 HTML 标签内容的问题。桌面端现在会在群组名称进入状态前解码并移除 HTML 标签，避免列表和会话标题显示 `<font ...>` 等源码文本。

## 改动 diff
- `prd-desktop/src/components/utils/nameHeuristics.ts`：新增群组名称 HTML 实体解码与标签清理工具
- `prd-desktop/src/stores/groupListStore.ts`：群组加载、添加、后台改名统一标准化 groupName
- `prd-desktop/src/components/Document/DocumentUpload.tsx`：上传自动建群的标题推断结果先清理再使用
- `prd-desktop/src/components/Layout/Sidebar.tsx`：手动创建和带 PRD 创建群组时清理输入标题
- `prd-desktop/src/components/utils/__tests__/nameHeuristics.test.ts`：补充 HTML 标题回归测试
- `changelogs/2026-06-23_desktop-group-title-sanitize.md`：新增 changelog 碎片

## 测试
- [x] cd prd-desktop && pnpm test --run src/components/utils/__tests__/nameHeuristics.test.ts
- [x] cd prd-desktop && pnpm tsc --noEmit
- [x] cd prd-desktop && pnpm lint
- [x] git commit pre-commit tsc --noEmit 通过

## 预览
https://fix-desktop-group-title-sanitization-0118-codex-prd-agent.miduo.org/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only string cleanup on the desktop client; no API or persistence changes, with focused unit tests.
> 
> **Overview**
> Fixes group titles showing raw HTML (e.g. `<font ...>`) in the sidebar and chat header by **normalizing names on the client** before they enter app state.
> 
> Adds **`sanitizeGroupName`** in `nameHeuristics`: decode common HTML entities, strip tag-like markup, collapse whitespace, and apply a fallback when nothing remains. Non-tag angle brackets (e.g. `A < B`) are left alone.
> 
> **`groupListStore`** runs sanitization on every path that touches `groupName`—API load, optimistic `addGroup`, and `updateGroupName`—so list and session titles stay plain text.
> 
> **Upload and create flows** (`DocumentUpload`, `Sidebar`) sanitize inferred names from filenames, Markdown headings, and manual input before `create_group`, aligned with existing placeholder-name logic for async AI naming.
> 
> Vitest cases cover tagged titles, escaped HTML, and plain comparison text; changelog entry added for prd-desktop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66caa17b369348f75258f5aec03632371352ef35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->