### PR TITLE
fix(ci): branch-image 默认分支 main 始终构建两镜像，根治极速版 main 部署 404

### DIFF
--- a/.github/workflows/branch-image.yml
+++ b/.github/workflows/branch-image.yml
@@ -11,6 +11,13 @@ name: Branch Image
 # docs 则两者都不构建。某个 commit 缺某组件镜像时，CDS 侧 runService 会**逐组件回退到固定
 # 主分支镜像**（`:branch-main`，由 main 分支构建经 `type=ref,event=branch,prefix=branch-`
 # 维护），保证预览总能起来、不硬失败。tag push 不会命中（用 branches 过滤；tag 走 desktop-release.yml）。
+#
+# 例外（2026-06-23 修复 main 部署 404）：**默认分支 main 无论改了什么都构建两镜像**，不走
+# path-filter 跳过。原因有二：① `:branch-main` 是所有 feature 分支缺组件时的**回退镜像源**，
+# 必须随 main 保持新鲜；② main 自身极速版部署只认 `sha-<commit>`，若某次 main 推送只改了
+# cds/docs 而跳过构建，该 `sha-<commit>` 镜像不存在 → CDS docker pull 404、分支显示「部署出现
+# 异常 / 无法构建」（旧版 CDS 无回退链时直接硬失败）。让 main 永远产出自身 sha 镜像，从 CI 侧
+# 根治此问题，且不依赖 CDS 服务版本。feature 分支保留 path-filter 优化（缺组件回退 `:branch-main`）。
 
 on:
   push:
@@ -49,7 +56,8 @@ jobs:
   api-image:
     name: Build prd-api image
     needs: changes
-    if: ${{ needs.changes.outputs.api == 'true' }}
+    # main 始终构建（回退镜像源 + 自身 sha 镜像必须存在，见文件头注释）；其它分支按 path-filter。
+    if: ${{ needs.changes.outputs.api == 'true' || github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -102,7 +110,8 @@ jobs:
   admin-image:
     name: Build prd-admin image
     needs: changes
-    if: ${{ needs.changes.outputs.admin == 'true' }}
+    # main 始终构建（回退镜像源 + 自身 sha 镜像必须存在，见文件头注释）；其它分支按 path-filter。
+    if: ${{ needs.changes.outputs.admin == 'true' || github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/changelogs/2026-06-23_branch-image-main-always-build.md
+++ b/changelogs/2026-06-23_branch-image-main-always-build.md
@@ -1,0 +1,1 @@
+| fix | ci | branch-image.yml 默认分支 main 无论改动路径都构建 api/admin 两镜像（不走 path-filter 跳过）：根治「main 仅改 cds/docs 时不产 sha-<commit> 镜像 → CDS 极速版 docker pull 404、分支显示部署异常/无法构建」。main 是全体分支的回退镜像源(:branch-main)且自身极速版部署只认 sha-<commit>，必须始终产出；feature 分支保留 path-filter 优化 |


### PR DESCRIPTION
## 摘要

主分支极速版部署出现「分支部署出现异常 / 无法构建」，根因是 CI 的 path-filter 让 main 跳过了自身镜像构建。本 PR 让默认分支 main 无论改动路径都构建 api/admin 两镜像，从 CI 侧根治，且不依赖运行中的 CDS 服务版本。

## 问题定位（证据）

- 失败分支 main 卡在 `prdagent-server:sha-3a3a86497165…`（合并 PR #913 的提交）。
- 该合并仅改动 `cds/` + `changelogs/`，未碰 `prd-api/` / `prd-admin/`，被 `branch-image.yml` 的 path-filter 跳过两个镜像 job；workflow 仍报 `success`。
- CDS 极速版据 `workflow_run=success` 把 `sha-<commit>` 标为就绪并 `docker pull`，但该 tag 从未推送。
- 匿名 registry 实测：`sha-3a3a8649…` → **404**（不存在）；`:branch-main` → **200**（存在且可匿名拉，包已是 public）。
- 运行中的 CDS 是极速版首版（PR #911 / `119cf157`），报错文案 `极速版镜像拉取失败: <image>`（无「(含回退)」），即 `6295be7d` 那版，缺少后续合入 main 的有序回退链。

## 改动 diff

- `.github/workflows/branch-image.yml`：`api-image` / `admin-image` 两个 job 的 `if` 增加 `|| github.ref == 'refs/heads/main'`，使默认分支 main 始终构建两镜像（不走 path-filter 跳过）；补充文件头注释说明原因（main 既是全体 feature 分支的回退源 `:branch-main`，自身极速版部署又只认 `sha-<commit>`，漏建即 404）。feature 分支保留 path-filter 优化。
- `changelogs/2026-06-23_branch-image-main-always-build.md`：新增 changelog 碎片一条。

## 测试

- `python3 -c "yaml.safe_load(...)"` 校验 workflow YAML 合法。
- 两处 `if` gate 已确认含 `github.ref == 'refs/heads/main'`。
- 合并后此 PR 的合并提交本身会改动 `.github/workflows/branch-image.yml`，触发 main 的 Branch Image 构建 → 产出 `sha-<merge-commit>` + 刷新 `:branch-main`，CDS 收到该提交的 workflow_run 后可正常 pull，main 极速版部署随之恢复。

## 风险与已知边界

- 代价：main 上仅改 cds/docs 的提交也会触发一次 api+admin 镜像构建（数分钟 CI）。这是有意取舍——main 是 keystone 回退镜像，保证它始终新鲜优先于节省 CI 分钟，且 main 提交频率不高。
- 本 PR 不改 CDS 代码；CDS 端的有序回退链 + docs-only 跳过早已合入 main，建议后续把生产 CDS 自更新到最新 main 以获得双重兜底。
- 未触及 feature 分支构建逻辑，行为不变。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvQjZ86Zoubx6W5S6W1V7b

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvQjZ86Zoubx6W5S6W1V7b)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> 仅调整 GitHub Actions 条件与文档；代价是 `main` 上非应用路径的提交也会多跑镜像构建，不改变运行时应用代码。
> 
> **Overview**
> **Branch Image** 在 `main` 上不再因 path-filter 跳过 `api-image` / `admin-image`：两个 job 的 `if` 增加 `github.ref == 'refs/heads/main'`，使默认分支每次 push 都产出 `sha-<commit>` 并刷新 `:branch-main`；feature 分支仍只在 `prd-api` / `prd-admin`（或 workflow 自身）有改动时构建。
> 
> 工作流文件头补充说明该例外（`main` 作为回退镜像源且极速版部署依赖 commit SHA 镜像，漏构建会导致 CDS `docker pull` 404）。新增一条 changelog 碎片记录此次 CI 修复。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c129584bb3d282ca27a22fd7a7db687efcd1603. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->