### PR TITLE
fix(cds): 调度器永不降温主干分支，根治 main 空闲被自动降温

### DIFF
--- a/cds/src/services/scheduler.ts
+++ b/cds/src/services/scheduler.ts
@@ -309,7 +309,27 @@ export class SchedulerService {
     // 走 per-project default：项目级值优先，未设时兜底到旧 state.defaultBranch。
     if (this.stateService.getDefaultBranchFor(branch.projectId) === branch.id) return true;
     if (this.config.pinnedBranches?.includes(branch.id)) return true;
+    // 主分支（仓库默认分支）永不降温（用户 2026-06-23 要求）。
+    // 按 **git 分支名** 匹配,不依赖 Project.defaultBranch(存的是 CDS 分支 id,可能未配置
+    // 或与实际不符 —— 这正是 main 被误降温的根因)。优先比对远端默认分支名 gitDefaultBranch,
+    // 再兜底 main/master 字面量,保证 trunk 永远保活、不被空闲/容量降温驱逐。
+    if (this.isTrunkBranch(branch)) return true;
     return false;
+  }
+
+  /**
+   * 该分支是否为「主干分支」(仓库默认分支)。按 git 分支名判定:
+   *   - 命中项目 gitDefaultBranch(远端 reported default,如 main/master) → 是
+   *   - 兜底:分支名恰为 main / master → 是
+   * 仅依据分支名,与 Project.defaultBranch(CDS 路由 fallback 的分支 id)解耦。
+   */
+  private isTrunkBranch(branch: BranchEntry): boolean {
+    const branchName = (branch.branch || '').trim();
+    if (!branchName) return false;
+    const project = this.stateService.getProject(branch.projectId);
+    const remoteDefault = (project?.gitDefaultBranch || '').trim();
+    if (remoteDefault && branchName === remoteDefault) return true;
+    return branchName === 'main' || branchName === 'master';
   }
 
   /**

--- a/changelogs/2026-06-23_scheduler-pin-trunk.md
+++ b/changelogs/2026-06-23_scheduler-pin-trunk.md
@@ -1,0 +1,1 @@
+| fix | cds | 调度器永不降温主干分支：SchedulerService.isPinned 新增按 git 分支名判定主干（项目 gitDefaultBranch，兜底 main/master），与 Project.defaultBranch（CDS 分支 id，可能未配置/不符）解耦，根治「主分支空闲超阈值被自动降温」。空闲降温与容量驱逐两条路径均跳过主干 |


### PR DESCRIPTION
## 摘要

主分支 main 空闲超过阈值被调度器自动降温（卡片显示「调度器：空闲 N 分钟，超过 30 分钟阈值自动降温」），容器被停。本 PR 让 trunk（仓库默认分支）永不被降温/驱逐。

## 问题定位

`SchedulerService.isPinned()` 判定主干只看 `Project.defaultBranch`——它存的是 CDS 分支 id（如 `prd-agent-main`），生产实例上可能未配置或与实际分支 id 不一致，于是 main 漏判、未被保护，被空闲降温逻辑停掉。

## 改动 diff

- `cds/src/services/scheduler.ts`：`isPinned()` 新增 `isTrunkBranch()` 判定——按 **git 分支名** 识别主干（优先匹配项目 `gitDefaultBranch`，兜底 `main`/`master` 字面量），与 `Project.defaultBranch`（CDS 路由 fallback 的分支 id）解耦。空闲降温（`tick`）与容量驱逐（`selectLruVictim`）的 `markCold` 都先过 `isPinned`，故主干在两条路径下都永不降温。
- `changelogs/2026-06-23_scheduler-pin-trunk.md`：changelog 碎片。

## 测试

- TypeScript 改动仅 `scheduler.ts`，无新增类型错误（沙箱缺 @types/node，与本改动无关）。
- 现有 `scheduler.test.ts` 中名为 `main` 的分支用于「treats defaultBranch as pinned」用例，本改动保持其 pinned，无回归；其余测试分支命名为 a/b/c/feature-a 等，不受影响。

## 风险与已知边界

- trunk 始终 pinned 意味着它不参与容量驱逐——这正是预期（主干常驻保活）。
- 仅依据分支名判定，不影响 feature 分支的正常降温。
- 生效需 CDS 服务自更新到本提交（CDS 是独立服务，非随 app 分支部署）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvQjZ86Zoubx6W5S6W1V7b

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvQjZ86Zoubx6W5S6W1V7b)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized scheduler pinning logic; trunk stays hot by design and does not touch auth or data paths.
> 
> **Overview**
> Fixes **main/master being stopped** when idle TTL or hot-pool capacity eviction runs, because `isPinned()` only treated CDS `defaultBranch` (branch id) as protected—often missing or wrong for the real trunk.
> 
> **`SchedulerService.isPinned()`** now also returns true for trunk via new **`isTrunkBranch()`**: match the branch’s git name to the project’s **`gitDefaultBranch`**, else treat **`main`** / **`master`** as trunk. That pins trunk on **idle cooldown** (`tick`) and **LRU eviction** (`selectLruVictim` / `markCold`), without changing feature-branch behavior.
> 
> Adds a changelog entry under `changelogs/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57eddfbcd51fe360ce59ae7e443dc872d1545b9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->