### PR TITLE
feat(cds): 首页探测会话态，已登录直接进控制台

### DIFF
--- a/cds/web/src/lib/api.ts
+++ b/cds/web/src/lib/api.ts
@@ -304,6 +304,24 @@ export async function fetchBootstrapStatus(): Promise<{ needsBootstrap: boolean 
   return apiRequest<{ needsBootstrap: boolean }>('/api/auth/bootstrap-status');
 }
 
+/**
+ * Probe whether the current same-origin session cookie is still valid.
+ *
+ * `GET /api/me` 是唯一能判断「当前 HttpOnly 会话 cookie 是否还有效」的途径
+ * （cookie 设了 HttpOnly,前端 JS 读不到）。200 = 已登录;401 = 未登录。
+ * 网络/瞬时错误一律按「未登录」处理,宁可多弹一次登录框也不要把匿名用户
+ * 误判成已登录后丢进控制台再吃 401。
+ */
+export async function fetchSessionAuthed(): Promise<boolean> {
+  try {
+    await apiRequest('/api/me');
+    return true;
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 401) return false;
+    return false;
+  }
+}
+
 /** Create the first local system-owner account (only valid when zero users). */
 export async function bootstrapFirstUser(input: {
   username: string;

--- a/cds/web/src/pages/HomePage.tsx
+++ b/cds/web/src/pages/HomePage.tsx
@@ -27,9 +27,21 @@ export function HomePage(): JSX.Element {
   const [accessMode, setAccessMode] = useState(false);
   // 后台探测一次「当前会话 cookie 是否仍有效」。承诺在按钮点击前未必返回,
   // 所以 enterConsole() 会 await 这个共享 promise 再决定:已登录直接进控制台,
-  // 未登录才弹登录框。null = 探测尚未完成。
+  // 未登录才弹登录框。probeRef 缓存唯一的探测 promise,ensureProbe() 保证
+  // 「挂载预探」和「点太快时的兜底」复用同一个请求,绝不并发两次探测
+  // (并发会让其中一次的瞬时失败误把已登录用户甩进登录框)。
   const authedRef = useRef<boolean | null>(null);
   const probeRef = useRef<Promise<boolean> | null>(null);
+
+  function ensureProbe(): Promise<boolean> {
+    if (!probeRef.current) {
+      probeRef.current = fetchSessionAuthed().then((ok) => {
+        authedRef.current = ok;
+        return ok;
+      });
+    }
+    return probeRef.current;
+  }
 
   useEffect(() => {
     // 预取访问面板和控制台 lazy chunk:首页点击 Access/Enter Console 时只做本页
@@ -43,11 +55,9 @@ export function HomePage(): JSX.Element {
     else window.setTimeout(preload, 200);
 
     // 已登录的用户重新打开首页时,不应该再被甩一次登录框 —— 先探一次会话态。
-    const probe = fetchSessionAuthed().then((ok) => {
-      authedRef.current = ok;
-      return ok;
-    });
-    probeRef.current = probe;
+    void ensureProbe();
+    // ensureProbe 用 ref 缓存,本 effect 仅运行一次,无需依赖项。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   async function enterConsole() {
@@ -61,8 +71,8 @@ export function HomePage(): JSX.Element {
       setAccessMode(true);
       return;
     }
-    // 探测尚未完成(点得太快)→ 等结果再决定,避免误判。
-    const ok = await (probeRef.current ?? fetchSessionAuthed());
+    // 探测尚未完成(点得太快)→ await 同一个共享探测,避免并发误判。
+    const ok = await ensureProbe();
     if (ok) navigate('/project-list', { viewTransition: true });
     else setAccessMode(true);
   }

--- a/cds/web/src/pages/HomePage.tsx
+++ b/cds/web/src/pages/HomePage.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { useEffect, useRef, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 import ShapeGrid from '@/components/effects/ShapeGrid';
 import { CdsAccessMorphBoard } from '@/pages/LoginPage';
+import { fetchSessionAuthed } from '@/lib/api';
 import './HomePage.css';
 
 const FEED_LINES = [
@@ -20,9 +21,15 @@ const BranchIcon = (props: { className?: string }) => (
 );
 
 export function HomePage(): JSX.Element {
+  const navigate = useNavigate();
   const [feedIndex, setFeedIndex] = useState(0);
   const [feedOff, setFeedOff] = useState(false);
   const [accessMode, setAccessMode] = useState(false);
+  // 后台探测一次「当前会话 cookie 是否仍有效」。承诺在按钮点击前未必返回,
+  // 所以 enterConsole() 会 await 这个共享 promise 再决定:已登录直接进控制台,
+  // 未登录才弹登录框。null = 探测尚未完成。
+  const authedRef = useRef<boolean | null>(null);
+  const probeRef = useRef<Promise<boolean> | null>(null);
 
   useEffect(() => {
     // 预取访问面板和控制台 lazy chunk:首页点击 Access/Enter Console 时只做本页
@@ -34,10 +41,34 @@ export function HomePage(): JSX.Element {
     const ric = (window as unknown as { requestIdleCallback?: (cb: () => void) => number }).requestIdleCallback;
     if (typeof ric === 'function') ric(preload);
     else window.setTimeout(preload, 200);
+
+    // 已登录的用户重新打开首页时,不应该再被甩一次登录框 —— 先探一次会话态。
+    const probe = fetchSessionAuthed().then((ok) => {
+      authedRef.current = ok;
+      return ok;
+    });
+    probeRef.current = probe;
   }, []);
 
+  async function enterConsole() {
+    // 已知已登录 → 直接进控制台,跳过登录框。
+    if (authedRef.current === true) {
+      navigate('/project-list', { viewTransition: true });
+      return;
+    }
+    // 已知未登录 → 弹登录框。
+    if (authedRef.current === false) {
+      setAccessMode(true);
+      return;
+    }
+    // 探测尚未完成(点得太快)→ 等结果再决定,避免误判。
+    const ok = await (probeRef.current ?? fetchSessionAuthed());
+    if (ok) navigate('/project-list', { viewTransition: true });
+    else setAccessMode(true);
+  }
+
   function openAccessMode() {
-    setAccessMode(true);
+    void enterConsole();
   }
 
   function closeAccessMode() {

--- a/cds/web/src/pages/LoginPage.tsx
+++ b/cds/web/src/pages/LoginPage.tsx
@@ -12,6 +12,10 @@ function redirectTarget(): string {
   const params = new URLSearchParams(window.location.search);
   const raw = params.get('redirect') || '/project-list';
   if (!raw.startsWith('/') || raw.startsWith('//')) return '/project-list';
+  // 绝不把目标指回登录路由本身 —— 否则已登录用户从 /login 跳 /login 是 no-op,
+  // spinner 永远转、登录框永不出现(Bugbot Medium「Login redirect target loops」)。
+  const path = raw.split(/[?#]/)[0];
+  if (path === '/login') return '/project-list';
   return raw;
 }
 
@@ -277,6 +281,12 @@ export function LoginPage(): JSX.Element {
         return;
       }
       const target = redirectTarget();
+      // 兜底:若目标解析后仍等于当前路径,navigate 是 no-op,spinner 会卡死 ——
+      // 这种情况直接落到登录框(redirectTarget 已排除 /login,这里只是双保险)。
+      if (target.split(/[?#]/)[0] === window.location.pathname) {
+        setAuthPhase('anon');
+        return;
+      }
       if (/\.html(?:$|[?#])/i.test(target)) {
         // legacy server 路径:hard-load 让 Express 的 legacy→React 重定向生效。
         window.location.assign(target);

--- a/cds/web/src/pages/LoginPage.tsx
+++ b/cds/web/src/pages/LoginPage.tsx
@@ -4,7 +4,7 @@ import { ArrowRight, Github, Home, KeyRound, Loader2, Server, Shield, Terminal, 
 import ShapeGrid from '@/components/effects/ShapeGrid';
 import { ShinyText } from '@/components/effects/ShinyText';
 import { Button } from '@/components/ui/button';
-import { apiUrl, fetchBootstrapStatus, bootstrapFirstUser } from '@/lib/api';
+import { apiUrl, fetchBootstrapStatus, bootstrapFirstUser, fetchSessionAuthed } from '@/lib/api';
 import './HomePage.css';
 
 function redirectTarget(): string {
@@ -254,12 +254,40 @@ export function CdsAccessMorphBoard(props: { target?: string; onHome?: () => voi
 }
 
 export function LoginPage(): JSX.Element {
+  const navigate = useNavigate();
+  // 'checking' = 正在探会话态;'anon' = 未登录,展示登录框。已登录则直接跳走,
+  // 不会停留在此状态。探测期间用加载态占位,避免先闪一下登录框再跳转。
+  const [authPhase, setAuthPhase] = useState<'checking' | 'anon'>('checking');
+
   // 登录成功后要跳的内容页(默认控制台)是 lazy chunk:登录页一挂载就预取,
   // 提交成功 navigate 时不会触发 Suspense 白屏,配合 viewTransition 丝滑进内容页。
   useEffect(() => {
     void import('@/pages/ProjectListPage');
     void import('@/pages/HomePage');
   }, []);
+
+  // 直接访问 /login 时,若会话 cookie 仍有效,跳过登录框直达目标页
+  // (默认 /project-list,或 ?redirect= 指定的合法内部路径)。
+  useEffect(() => {
+    let alive = true;
+    fetchSessionAuthed().then((ok) => {
+      if (!alive) return;
+      if (!ok) {
+        setAuthPhase('anon');
+        return;
+      }
+      const target = redirectTarget();
+      if (/\.html(?:$|[?#])/i.test(target)) {
+        // legacy server 路径:hard-load 让 Express 的 legacy→React 重定向生效。
+        window.location.assign(target);
+      } else {
+        navigate(target, { replace: true, viewTransition: true });
+      }
+    });
+    return () => {
+      alive = false;
+    };
+  }, [navigate]);
 
   return (
     <main className="relative min-h-screen overflow-hidden bg-[#120f17] text-[#f6f6f8]">
@@ -301,7 +329,13 @@ export function LoginPage(): JSX.Element {
           </div>
 
           <div className="cdsh-login-panel cdsh-rise" style={{ animationDelay: '.18s' }}>
-            <CdsAccessMorphBoard />
+            {authPhase === 'checking' ? (
+              <div className="flex min-h-[420px] items-center justify-center" role="status" aria-label="checking session">
+                <Loader2 className="h-6 w-6 animate-spin text-white/70" />
+              </div>
+            ) : (
+              <CdsAccessMorphBoard />
+            )}
           </div>
         </div>
       </section>

--- a/changelogs/2026-06-24_cds-home-skip-login-when-authed.md
+++ b/changelogs/2026-06-24_cds-home-skip-login-when-authed.md
@@ -1,0 +1,1 @@
+| fix | cds | 首页 Enter Console/Log in 探测会话态(GET /api/me),已登录直接进控制台,不再每次重复弹登录框 |

--- a/changelogs/2026-06-24_cds-home-skip-login-when-authed.md
+++ b/changelogs/2026-06-24_cds-home-skip-login-when-authed.md
@@ -1,1 +1,2 @@
 | fix | cds | 首页 Enter Console/Log in 探测会话态(GET /api/me),已登录直接进控制台,不再每次重复弹登录框 |
+| fix | cds | /login 路由挂载时探测会话态,已登录自动跳目标页(默认 /project-list 或 ?redirect=),探测期间显示加载态不闪登录框 |


### PR DESCRIPTION
## 摘要

首页 Enter Console 按钮现在会先探测当前会话 cookie 是否仍有效。若已登录则直接跳转控制台，无需再弹登录框；若未登录或探测失败则弹登录框。避免已登录用户重新打开首页时被重复甩一次登录流程。

## 改动 diff

**CDS 前端（cds/web/src/）**：
- `pages/HomePage.tsx`：新增 `useNavigate` hook，添加 `authedRef` 和 `probeRef` 两个 ref 用于缓存会话探测结果；useEffect 中启动后台探测 `fetchSessionAuthed()`；新增 `enterConsole()` 异步函数，根据探测结果决定直接导航或弹登录框；`openAccessMode()` 改为调用 `enterConsole()` 而非直接 `setAccessMode(true)`
- `lib/api.ts`：新增 `fetchSessionAuthed()` 函数，通过 GET `/api/me` 探测会话有效性（200 = 已登录，401 = 未登录，其他错误一律按未登录处理）

**更新记录**：
- `changelogs/2026-06-24_cds-home-skip-login-when-authed.md`：记录本次修复

## 测试

- [x] 前端 `pnpm tsc --noEmit` + `pnpm lint` 通过（cds/web 零新增告警）
- [x] 已登录用户重新打开首页，点击 Enter Console 直接进控制台（无登录框）
- [x] 未登录用户点击 Enter Console，弹出登录框
- [x] 网络错误或 API 异常时，降级为弹登录框（宁可多弹一次也不误判）

## 风险与已知边界

- 探测请求在后台异步进行，若用户点击 Enter Console 时探测尚未完成，会等待探测结果再决定（避免误判）
- 网络/瞬时错误一律按未登录处理，确保不会把匿名用户误导进控制台后吃 401

https://claude.ai/code/session_017mjRq8pCEV9R4rtQZPU9Zh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only auth entry UX; session checks fail closed to showing login, with no server-side auth or cookie changes.
> 
> **Overview**
> Adds **`fetchSessionAuthed()`** in `api.ts`, which calls **`GET /api/me`** to tell whether the HttpOnly session cookie is still valid. **401** and any other failure are treated as **not logged in** so users are not sent into the console only to hit **401** later.
> 
> On the **home page**, **Enter Console** / **Log in** / **Access** now run **`enterConsole()`**: a single cached probe on mount (via **`ensureProbe()`**) decides whether to **`navigate('/project-list')`** or open the access/login morph board. Fast clicks await the same promise so two concurrent probes cannot disagree.
> 
> On **`/login`**, mount-time probing shows a **spinner** until the check finishes; valid sessions **redirect** to **`redirectTarget()`** (default **`/project-list`** or **`?redirect=`**). **`redirectTarget()`** no longer resolves to **`/login`**, and there is a guard when the target equals the current path, avoiding **redirect loops** and a stuck spinner.
> 
> Changelog entry documents both fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6141e0ce6d42c3d295566f0b3c1cb8c3ddc6c99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->