### PR TITLE
feat(prd-agent): 支持多 HTML 文件上传

### DIFF
--- a/changelogs/2026-06-25_multi-html-upload.md
+++ b/changelogs/2026-06-25_multi-html-upload.md
@@ -1,0 +1,2 @@
+| feat | prd-admin | 网页托管上传弹窗支持一次选择多个 HTML 文件 |
+| feat | prd-api | 网页托管上传与重传接口支持多 HTML 文件自动打包 |

--- a/prd-admin/src/pages/WebPagesPage.tsx
+++ b/prd-admin/src/pages/WebPagesPage.tsx
@@ -791,11 +791,10 @@ export default function WebPagesPage() {
         compactSlots
         dropzone={{
           hint: '拖文件到此上传',
-          accept: ['.html', '.zip', '.md', '.pdf', '.mp4', '.webm'],
+          accept: ['.html', '.htm', '.zip', '.md', '.pdf', '.mp4', '.webm'],
           // 两阶段：先只上传，再由用户在 dock 内二选一（无密码 / 有密码）创建分享并自动复制链接
           onFiles: async (files) => {
-            const f = files[0];
-            if (!f) return;
+            if (files.length === 0) return;
             // 在 await 之前快照「发起上传时」的空间：上传期间用户若切换个人/其它团队空间，
             // 仍按发起时的目标投送，避免归属到错误团队（异步竞态防护）
             const targetSpace = currentSpace;
@@ -809,7 +808,7 @@ export default function WebPagesPage() {
               toast.error('无权限', '你在该团队空间是只读角色，无法上传网页');
               return;
             }
-            const up = await uploadSite({ file: f });
+            const up = await uploadSite(files.length > 1 ? { files } : { file: files[0] });
             if (!up.success || !up.data) {
               toast.error('上传失败', up.error?.message || '请稍后重试');
               return;
@@ -2424,7 +2423,8 @@ function UploadEditDialog({ item, folders, onClose, onSaved, initialFile }: {
   const [description, setDescription] = useState(item?.description ?? '');
   const [tagInput, setTagInput] = useState((item?.tags ?? []).join(', '));
   const [folder, setFolder] = useState(item?.folder ?? '');
-  const [file, setFile] = useState<File | null>(initialFile ?? null);
+  const [files, setFiles] = useState<File[]>(initialFile ? [initialFile] : []);
+  const file = files[0] ?? null;
   // 用户是否亲自编辑过标题；编辑过则不再自动同步文件名
   const titleEditedRef = useRef(false);
   // 新增上传场景下，文件类型为 .md/.markdown 时把"文件名（去扩展名）"作为默认标题
@@ -2444,17 +2444,17 @@ function UploadEditDialog({ item, folders, onClose, onSaved, initialFile }: {
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault();
     setDragOver(false);
-    const f = e.dataTransfer.files[0];
-    if (f) setFile(f);
+    const dropped = Array.from(e.dataTransfer.files ?? []);
+    if (dropped.length > 0) setFiles(dropped);
   };
 
   const handleSave = async () => {
     setSaving(true);
 
     if (isEdit) {
-      if (file) {
+      if (files.length > 0) {
         // Reupload
-        const res = await reuploadSite(item.id, file);
+        const res = await reuploadSite(item.id, files.length === 1 ? files[0] : files);
         if (!res.success) { setSaving(false); return; }
       }
       // Update metadata
@@ -2468,10 +2468,11 @@ function UploadEditDialog({ item, folders, onClose, onSaved, initialFile }: {
       setSaving(false);
       if (res.success) onSaved(res.data, /*isCreate*/ false);
     } else {
-      if (!file) { setSaving(false); return; }
+      if (files.length === 0) { setSaving(false); return; }
       const tags = tagInput.split(/[,，]/).map(t => t.trim()).filter(Boolean);
       const res = await uploadSite({
-        file,
+        file: files.length === 1 ? files[0] : undefined,
+        files: files.length > 1 ? files : undefined,
         title: title.trim() || undefined,
         description: description.trim() || undefined,
         folder: folder.trim() || undefined,
@@ -2511,23 +2512,35 @@ function UploadEditDialog({ item, folders, onClose, onSaved, initialFile }: {
                 onDrop={handleDrop}
               >
                 <UploadCloud size={32} style={{ color: 'var(--text-muted)' }} />
-                {file ? (
+                {files.length > 0 ? (
                   <div className="text-center">
-                    <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>{file.name}</p>
-                    <p className="text-xs" style={{ color: 'var(--text-muted)' }}>{fmtSize(file.size)}</p>
+                    {files.length === 1 ? (
+                      <>
+                        <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>{files[0].name}</p>
+                        <p className="text-xs" style={{ color: 'var(--text-muted)' }}>{fmtSize(files[0].size)}</p>
+                      </>
+                    ) : (
+                      <>
+                        <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>已选择 {files.length} 个 HTML 文件</p>
+                        <p className="text-xs" style={{ color: 'var(--text-muted)' }}>
+                          {files.slice(0, 3).map(f => f.name).join('、')}{files.length > 3 ? ` 等 ${files.length} 个` : ''}
+                        </p>
+                      </>
+                    )}
                   </div>
                 ) : (
                   <div className="text-center">
                     <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>拖拽文件到此处，或点击选择</p>
-                    <p className="text-xs" style={{ color: 'var(--text-muted)' }}>支持 .html / .zip / .md / .pdf / 视频（.mp4/.webm/.mov），最大 500MB</p>
+                    <p className="text-xs" style={{ color: 'var(--text-muted)' }}>支持单文件或多个 HTML 文件；ZIP / Markdown / PDF / 视频仍按单文件上传，最大 500MB</p>
                   </div>
                 )}
                 <input
                   ref={fileInputRef}
                   type="file"
                   accept=".html,.htm,.zip,.md,.markdown,.pdf,.mp4,.webm,.mov,.m4v"
+                  multiple
                   className="hidden"
-                  onChange={e => { const f = e.target.files?.[0]; if (f) setFile(f); }}
+                  onChange={e => { const selected = Array.from(e.target.files ?? []); if (selected.length > 0) setFiles(selected); }}
                 />
               </div>
             ) : (
@@ -2544,8 +2557,9 @@ function UploadEditDialog({ item, folders, onClose, onSaved, initialFile }: {
                   ref={fileInputRef}
                   type="file"
                   accept=".html,.htm,.zip,.md,.markdown,.pdf,.mp4,.webm,.mov,.m4v"
+                  multiple
                   className="hidden"
-                  onChange={e => { const f = e.target.files?.[0]; if (f) setFile(f); }}
+                  onChange={e => { const selected = Array.from(e.target.files ?? []); if (selected.length > 0) setFiles(selected); }}
                 />
               </div>
             )}
@@ -2605,7 +2619,7 @@ function UploadEditDialog({ item, folders, onClose, onSaved, initialFile }: {
 
           <div className="flex justify-end gap-2 mt-4 pt-3" style={{ borderTop: '1px solid var(--border-default)' }}>
             <Button variant="ghost" onClick={onClose}>取消</Button>
-            <Button onClick={handleSave} disabled={saving || (!isEdit && !file)}>
+            <Button onClick={handleSave} disabled={saving || (!isEdit && files.length === 0)}>
               {saving ? '处理中...' : isEdit ? '保存' : '上传并创建'}
             </Button>
           </div>

--- a/prd-admin/src/services/real/webPages.ts
+++ b/prd-admin/src/services/real/webPages.ts
@@ -176,7 +176,8 @@ function joinUrl(base: string, path: string) {
 // ─── Upload (FormData) ───
 
 export async function uploadSite(input: {
-  file: File;
+  file?: File;
+  files?: File[];
   title?: string;
   description?: string;
   folder?: string;
@@ -187,7 +188,12 @@ export async function uploadSite(input: {
   if (token) headers.Authorization = `Bearer ${token}`;
 
   const fd = new FormData();
-  fd.append('file', input.file);
+  const files = input.files && input.files.length > 0 ? input.files : (input.file ? [input.file] : []);
+  if (files.length > 1) {
+    files.forEach(f => fd.append('files', f));
+  } else if (files[0]) {
+    fd.append('file', files[0]);
+  }
   if (input.title) fd.append('title', input.title);
   if (input.description) fd.append('description', input.description);
   if (input.folder) fd.append('folder', input.folder);
@@ -203,13 +209,18 @@ export async function uploadSite(input: {
   }
 }
 
-export async function reuploadSite(id: string, file: File): Promise<ApiResponse<HostedSite>> {
+export async function reuploadSite(id: string, fileOrFiles: File | File[]): Promise<ApiResponse<HostedSite>> {
   const token = useAuthStore.getState().token;
   const headers: Record<string, string> = { Accept: 'application/json' };
   if (token) headers.Authorization = `Bearer ${token}`;
 
   const fd = new FormData();
-  fd.append('file', file);
+  const files = Array.isArray(fileOrFiles) ? fileOrFiles : [fileOrFiles];
+  if (files.length > 1) {
+    files.forEach(f => fd.append('files', f));
+  } else if (files[0]) {
+    fd.append('file', files[0]);
+  }
 
   const url = joinUrl(getApiBaseUrl(), api.webPages.reupload(encodeURIComponent(id)));
   const res = await fetch(url, { method: 'POST', headers, body: fd });

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/WebPagesController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/WebPagesController.cs
@@ -83,25 +83,21 @@ public class WebPagesController : ControllerBase
     [RequestSizeLimit(MaxSingleFileSize)]
     [RequestFormLimits(MultipartBodyLengthLimit = MaxSingleFileSize)]
     public async Task<IActionResult> Upload(
-        IFormFile file,
+        [FromForm] IFormFile? file,
+        [FromForm] List<IFormFile>? files,
         [FromForm] string? title,
         [FromForm] string? description,
         [FromForm] string? folder,
         [FromForm] string? tags)
     {
-        if (file == null || file.Length == 0)
+        var uploadFiles = NormalizeUploadFiles(file, files);
+        if (uploadFiles.Count == 0)
             return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "请上传文件"));
 
-        if (file.Length > MaxSingleFileSize)
+        if (uploadFiles.Sum(f => f.Length) > MaxSingleFileSize)
             return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, $"文件大小不能超过 {MaxSingleFileSize / 1024 / 1024}MB"));
 
         var userId = GetUserId();
-        var ext = Path.GetExtension(file.FileName).ToLowerInvariant();
-
-        using var ms = new MemoryStream();
-        await file.CopyToAsync(ms);
-        var fileBytes = ms.ToArray();
-
         var tagList = string.IsNullOrWhiteSpace(tags)
             ? new List<string>()
             : tags.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
@@ -109,13 +105,30 @@ public class WebPagesController : ControllerBase
         try
         {
             HostedSite site;
+            if (uploadFiles.Count > 1)
+            {
+                var zipBytes = await BuildMultiHtmlZipAsync(uploadFiles);
+                var effectiveTitle = string.IsNullOrWhiteSpace(title)
+                    ? BuildMultiHtmlDefaultTitle(uploadFiles)
+                    : title!.Trim();
+                site = await _siteService.CreateFromZipAsync(userId, zipBytes, effectiveTitle, description, folder, tagList);
+                return Ok(ApiResponse<object>.Ok(site));
+            }
+
+            var single = uploadFiles[0];
+            var ext = Path.GetExtension(single.FileName).ToLowerInvariant();
+
+            using var ms = new MemoryStream();
+            await single.CopyToAsync(ms);
+            var fileBytes = ms.ToArray();
+
             if (ext == ".zip")
             {
                 site = await _siteService.CreateFromZipAsync(userId, fileBytes, title, description, folder, tagList);
             }
             else if (ext is ".html" or ".htm")
             {
-                site = await _siteService.CreateFromHtmlAsync(userId, fileBytes, file.FileName, title, description, folder, tagList);
+                site = await _siteService.CreateFromHtmlAsync(userId, fileBytes, single.FileName, title, description, folder, tagList);
             }
             else if (VideoExtensions.Contains(ext) || MarkdownExtensions.Contains(ext) || ext == ".pdf")
             {
@@ -123,9 +136,9 @@ public class WebPagesController : ControllerBase
                 // 标题留空时用文件名（去扩展名）兜底，避免 ZIP 路径把视频/PDF 全落成"未命名站点"
                 // （前端 UploadEditDialog 仅对 .md 自动预填标题；其它媒体类型靠后端兜底）
                 var effectiveTitle = string.IsNullOrWhiteSpace(title)
-                    ? Path.GetFileNameWithoutExtension(file.FileName)
+                    ? Path.GetFileNameWithoutExtension(single.FileName)
                     : title!.Trim();
-                var zipBytes = BuildWrapperZip(file.FileName, fileBytes, ext, effectiveTitle);
+                var zipBytes = BuildWrapperZip(single.FileName, fileBytes, ext, effectiveTitle);
                 // 写 marker，下游靠它判定包装站，避免"用户上传的 index.html + report.pdf"被误判
                 var assetType = ext == ".pdf" ? "pdf"
                     : VideoExtensions.Contains(ext) ? "video"
@@ -835,27 +848,42 @@ public class WebPagesController : ControllerBase
     [HttpPost("{id}/reupload")]
     [RequestSizeLimit(MaxSingleFileSize)]
     [RequestFormLimits(MultipartBodyLengthLimit = MaxSingleFileSize)]
-    public async Task<IActionResult> Reupload(string id, IFormFile file)
+    public async Task<IActionResult> Reupload(string id, [FromForm] IFormFile? file, [FromForm] List<IFormFile>? files)
     {
-        if (file == null || file.Length == 0)
+        var uploadFiles = NormalizeUploadFiles(file, files);
+        if (uploadFiles.Count == 0)
             return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "请上传文件"));
+        if (uploadFiles.Sum(f => f.Length) > MaxSingleFileSize)
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, $"文件大小不能超过 {MaxSingleFileSize / 1024 / 1024}MB"));
 
-        using var ms = new MemoryStream();
-        await file.CopyToAsync(ms);
-        var fileBytes = ms.ToArray();
-        var ext = Path.GetExtension(file.FileName).ToLowerInvariant();
-        var uploadName = file.FileName;
-
-        // 视频 / PDF / Markdown：包装成 ZIP（保持与 Upload 一致的行为）
+        byte[] fileBytes;
+        string uploadName;
         string? wrappedAssetType = null;
-        if (VideoExtensions.Contains(ext) || MarkdownExtensions.Contains(ext) || ext == ".pdf")
+
+        if (uploadFiles.Count > 1)
         {
-            fileBytes = BuildWrapperZip(file.FileName, fileBytes, ext, title: null);
-            uploadName = Path.ChangeExtension(file.FileName, ".zip");
-            wrappedAssetType = ext == ".pdf" ? "pdf"
-                : VideoExtensions.Contains(ext) ? "video"
-                : MarkdownExtensions.Contains(ext) ? "markdown"
-                : null;
+            fileBytes = await BuildMultiHtmlZipAsync(uploadFiles);
+            uploadName = "multi-html.zip";
+        }
+        else
+        {
+            var single = uploadFiles[0];
+            using var ms = new MemoryStream();
+            await single.CopyToAsync(ms);
+            fileBytes = ms.ToArray();
+            var ext = Path.GetExtension(single.FileName).ToLowerInvariant();
+            uploadName = single.FileName;
+
+            // 视频 / PDF / Markdown：包装成 ZIP（保持与 Upload 一致的行为）
+            if (VideoExtensions.Contains(ext) || MarkdownExtensions.Contains(ext) || ext == ".pdf")
+            {
+                fileBytes = BuildWrapperZip(single.FileName, fileBytes, ext, title: null);
+                uploadName = Path.ChangeExtension(single.FileName, ".zip");
+                wrappedAssetType = ext == ".pdf" ? "pdf"
+                    : VideoExtensions.Contains(ext) ? "video"
+                    : MarkdownExtensions.Contains(ext) ? "markdown"
+                    : null;
+            }
         }
 
         try
@@ -873,6 +901,52 @@ public class WebPagesController : ControllerBase
         {
             return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, ex.Message));
         }
+    }
+
+    private static List<IFormFile> NormalizeUploadFiles(IFormFile? file, List<IFormFile>? files)
+    {
+        var result = new List<IFormFile>();
+        if (files is { Count: > 0 })
+            result.AddRange(files.Where(f => f is { Length: > 0 }));
+        if (result.Count == 0 && file is { Length: > 0 })
+            result.Add(file);
+        return result;
+    }
+
+    private static async Task<byte[]> BuildMultiHtmlZipAsync(IReadOnlyList<IFormFile> files)
+    {
+        if (files.Count < 2)
+            throw new InvalidOperationException("多文件上传至少需要选择 2 个 HTML 文件");
+
+        var usedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        using var ms = new MemoryStream();
+        using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            foreach (var file in files)
+            {
+                var ext = Path.GetExtension(file.FileName).ToLowerInvariant();
+                if (ext is not (".html" or ".htm"))
+                    throw new InvalidOperationException("多文件上传仅支持 .html / .htm 文件；其他资源请上传 ZIP");
+
+                var safeName = SanitizeFileName(file.FileName);
+                if (!usedNames.Add(safeName))
+                    throw new InvalidOperationException($"存在同名文件：{safeName}");
+
+                var entry = zip.CreateEntry(safeName, CompressionLevel.Optimal);
+                await using var target = entry.Open();
+                await file.CopyToAsync(target);
+            }
+        }
+        return ms.ToArray();
+    }
+
+    private static string BuildMultiHtmlDefaultTitle(IReadOnlyList<IFormFile> files)
+    {
+        var entry = files.FirstOrDefault(f =>
+                string.Equals(Path.GetFileName(f.FileName), "index.html", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(Path.GetFileName(f.FileName), "index.htm", StringComparison.OrdinalIgnoreCase))
+            ?? files[0];
+        return Path.GetFileNameWithoutExtension(entry.FileName);
     }
 
     /// <summary>删除站点（含 COS 文件清理）</summary>

--- a/prd-api/tests/PrdAgent.Api.Tests/Controllers/WebPagesControllerMultiHtmlUploadTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Controllers/WebPagesControllerMultiHtmlUploadTests.cs
@@ -1,0 +1,57 @@
+using System.IO.Compression;
+using System.Reflection;
+using System.Text;
+using Microsoft.AspNetCore.Http;
+using PrdAgent.Api.Controllers.Api;
+using Xunit;
+
+namespace PrdAgent.Api.Tests.Controllers;
+
+public class WebPagesControllerMultiHtmlUploadTests
+{
+    [Fact]
+    public async Task BuildMultiHtmlZipAsync_PreservesMultipleHtmlFiles()
+    {
+        var files = new List<IFormFile>
+        {
+            FormFile("index.html", "<html><body>index</body></html>"),
+            FormFile("balance-detail.html", "<html><body>detail</body></html>"),
+        };
+
+        var zipBytes = await InvokeBuildMultiHtmlZipAsync(files);
+
+        using var zip = new ZipArchive(new MemoryStream(zipBytes), ZipArchiveMode.Read);
+        var names = zip.Entries.Select(e => e.FullName).OrderBy(x => x).ToList();
+        Assert.Equal(new[] { "balance-detail.html", "index.html" }, names);
+    }
+
+    [Fact]
+    public async Task BuildMultiHtmlZipAsync_RejectsMixedFileTypes()
+    {
+        var files = new List<IFormFile>
+        {
+            FormFile("index.html", "<html></html>"),
+            FormFile("style.css", "body{}"),
+        };
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => InvokeBuildMultiHtmlZipAsync(files));
+        Assert.Contains("仅支持 .html / .htm", ex.Message);
+    }
+
+    private static async Task<byte[]> InvokeBuildMultiHtmlZipAsync(IReadOnlyList<IFormFile> files)
+    {
+        var method = typeof(WebPagesController).GetMethod(
+            "BuildMultiHtmlZipAsync",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+
+        var task = (Task<byte[]>)method!.Invoke(null, new object[] { files })!;
+        return await task;
+    }
+
+    private static IFormFile FormFile(string fileName, string content)
+    {
+        var bytes = Encoding.UTF8.GetBytes(content);
+        return new FormFile(new MemoryStream(bytes), 0, bytes.Length, "files", fileName);
+    }
+}


### PR DESCRIPTION
## 摘要
支持网页托管上传弹窗一次选择多个 HTML 文件，后端自动打包为 ZIP 后沿用现有站点创建与重传流程。ZIP、Markdown、PDF、视频仍按单文件上传，避免改变既有资源包装逻辑。

## 改动 diff
- `prd-admin/src/pages/WebPagesPage.tsx`：上传弹窗和 dock 上传支持多文件选择与展示
- `prd-admin/src/services/real/webPages.ts`：上传和重传接口支持 `files` FormData 字段
- `prd-api/src/PrdAgent.Api/Controllers/Api/WebPagesController.cs`：多 HTML 文件上传自动校验并打包为 ZIP
- `prd-api/tests/PrdAgent.Api.Tests/Controllers/WebPagesControllerMultiHtmlUploadTests.cs`：补充多 HTML 打包与混合类型拒绝测试
- `changelogs/2026-06-25_multi-html-upload.md`：新增 changelog 碎片

## 测试
- [x] `DOTNET_ROLL_FORWARD=Major dotnet test tests/PrdAgent.Api.Tests/PrdAgent.Api.Tests.csproj --no-restore --filter WebPagesControllerMultiHtmlUploadTests` 通过
- [x] `cd prd-api && dotnet build --no-restore 2>&1 | grep -E "error CS|warning CS" | head -30` 无输出
- [x] `cd prd-admin && pnpm tsc --noEmit` 通过
- [x] `cd prd-admin && pnpm lint` 通过，未见本次改动文件新增告警
- [x] `git diff --check` 通过

## 预览
https://defect-0178-multi-html-upload-automation-prd-agent-defect-daily.miduo.org/web-pages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> 扩展上传/重传 API 与站点内容覆盖路径，但单文件行为保持兼容，多文件仅限 HTML 并带校验。
> 
> **Overview**
> **网页托管**现在可以在上传弹窗和投放面板拖放区一次选择多个 `.html` / `.htm`，多选时走 `files` 字段；单文件仍用原来的 `file` 字段，ZIP / Markdown / PDF / 视频逻辑不变。
> 
> 后端 `upload` 与 `reupload` 同时接受 `file` 或 `files`，**2 个及以上**文件会先校验全部为 HTML、无同名，再在内存里打成 ZIP，走现有 `CreateFromZipAsync` / `ReuploadAsync`。合计大小仍受 500MB 限制；未填标题时优先用 `index.html` 的文件名 stem。新增单元测试覆盖多 HTML 打包与混合类型拒绝。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e9f01a7291cded073cffd089b00fe5ed8810d90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->