### PR TITLE
fix(cds): 修复移动端布局回退——富面板手机端不可用

### DIFF
--- a/cds/.claude/rules/mobile-layout-fallback.md
+++ b/cds/.claude/rules/mobile-layout-fallback.md
@@ -34,19 +34,19 @@
 
 ### 1. 多窗格容器：mobile `flex flex-col`，desktop `lg:grid`
 ```tsx
-// ❌ 只有 desktop fill,手机塌陷
+// 反例:只有 desktop fill,手机塌陷
 <div className="grid min-h-0 lg:grid-cols-[320px_minmax(0,1fr)]">
 
-// ✅ 手机自然堆叠,desktop 再填满
+// 正例:手机自然堆叠,desktop 再填满
 <div className="flex min-h-0 flex-col lg:grid lg:h-full lg:grid-cols-[320px_minmax(0,1fr)]">
 ```
 
 ### 2. 固定 px / `1fr` 网格行：只在 `lg:` 生效
 ```tsx
-// ❌ 245px 固定行 + 1fr 在手机单列里 → 1fr 塌成 0,结果区消失
+// 反例:245px 固定行 + 1fr 在手机单列里 → 1fr 塌成 0,结果区消失
 <main className="grid grid-rows-[245px_minmax(0,1fr)]">
 
-// ✅ 手机 flex-col 自然高度,desktop 再回到固定行布局
+// 正例:手机 flex-col 自然高度,desktop 再回到固定行布局
 <main className="flex min-h-0 flex-col lg:grid lg:grid-rows-[245px_minmax(0,1fr)]">
 ```
 
@@ -75,10 +75,10 @@
 
 ### 5. 浮动 pill / 徽章：限宽 + 截断,别 `whitespace-nowrap`
 ```tsx
-// ❌ 长文案把按钮挤出屏幕
+// 反例:长文案把按钮挤出屏幕
 <div className="fixed bottom-4 left-4"><span className="whitespace-nowrap">{label}</span>…buttons</div>
 
-// ✅ 限宽 + min-w-0 链 + 截断,按钮 shrink-0 永远够得到
+// 正例:限宽 + min-w-0 链 + 截断,按钮 shrink-0 永远够得到
 <div className="fixed bottom-4 left-4 max-w-[calc(100vw-2rem)]">
   <div className="flex min-w-0 …">
     <button className="flex min-w-0 …"><span className="truncate">{label}</span></button>

--- a/cds/.claude/rules/mobile-layout-fallback.md
+++ b/cds/.claude/rules/mobile-layout-fallback.md
@@ -1,0 +1,126 @@
+# CDS 移动端布局回退（Desktop-Fill 必须有 Mobile-Flow 兜底）
+
+> CDS web 是桌面优先的。它的富面板（数据库工作台、拓扑详情、浮动徽章）默认用一套
+> 「填满有界视口」的高度契约——`h-full` + 固定 px 网格行 + `lg:grid-cols-[…]` + `whitespace-nowrap`。
+> 这套契约**只在桌面那个有界容器里成立**；一旦塞进手机窄屏，没有任何回退，面板就会
+> **重叠、塌陷、结果区消失、浮层溢出到屏幕外**。本规则把「desktop-fill 必须配 mobile-flow 兜底」
+> 固化为 CDS 的纪律。触发：编辑 `cds/web/src/**/*.tsx`、`cds/web/src/index.css`。
+
+---
+
+## 一、根因（为什么会「无法使用」）
+
+桌面富面板靠**有界高度**才能工作：模态是 `h-full`，内部用 `grid-rows-[245px_minmax(0,1fr)]`
+或 `lg:grid-cols-[320px_minmax(0,1fr)]` 把空间分给各窗格，每个窗格 `h-full overflow-auto`
+**在自己那一格内部滚动**。这一切的前提是「父级给了一个确定的高度」。
+
+手机窄屏（< `lg`）下这个前提**全部失效**：
+
+1. **多窗格网格塌成单列，但子级还按桌面高度契约渲染**：`minmax(0,1fr)` 行在没有
+   高度上界时塌成 0（结果区直接消失），固定 `245px` 行照常占位，`h-full` 子级
+   对着「内容高度」解析 → 窗格互相**堆叠重叠**（IMG_0419 里「SQL Console」压住表树就是这个）。
+2. **全屏模态 `fixed inset-0` + `overflow-hidden` 从不让堆叠内容竖向滚动** → 溢出被裁剪、够不到。
+3. **浮动 pill 里的 `whitespace-nowrap` 长文案溢出视口** → 把操作按钮（立即更新/刷新/关闭）
+   挤出屏幕右侧，用户点不到（IMG_0418 的更新徽章就是这个）。
+
+**一句话根因**：CDS 此前**没有移动端布局纪律**（prd-admin 有 `mobile-first-density.md`，CDS 没有），
+于是每个桌面优先的富面板都**只写了 fill、没写 mobile 兜底**就发布了。
+
+---
+
+## 二、强制规则：< lg 必须从「fill」切到「flow」
+
+任何「填满视口」的富面板/模态/浮层，必须提供手机回退——**默认（mobile）走自然流，`lg:` 再叠桌面 fill**：
+
+### 1. 多窗格容器：mobile `flex flex-col`，desktop `lg:grid`
+```tsx
+// ❌ 只有 desktop fill,手机塌陷
+<div className="grid min-h-0 lg:grid-cols-[320px_minmax(0,1fr)]">
+
+// ✅ 手机自然堆叠,desktop 再填满
+<div className="flex min-h-0 flex-col lg:grid lg:h-full lg:grid-cols-[320px_minmax(0,1fr)]">
+```
+
+### 2. 固定 px / `1fr` 网格行：只在 `lg:` 生效
+```tsx
+// ❌ 245px 固定行 + 1fr 在手机单列里 → 1fr 塌成 0,结果区消失
+<main className="grid grid-rows-[245px_minmax(0,1fr)]">
+
+// ✅ 手机 flex-col 自然高度,desktop 再回到固定行布局
+<main className="flex min-h-0 flex-col lg:grid lg:grid-rows-[245px_minmax(0,1fr)]">
+```
+
+### 3. 内部滚动区：手机给**有界高度**（max-h / min-h），desktop 再 `flex-1`/`h-full` 填满
+```tsx
+// 左树:手机 max-h 限高 + 自身滚动,desktop 填满列高
+<div className="min-h-0 max-h-[40vh] overflow-auto lg:max-h-none lg:flex-1">
+
+// 结果区:手机给 min-h 兜底(否则塌成 0),desktop 由 1fr 填满
+<div className="grid min-h-[300px] grid-rows-[auto_minmax(0,1fr)] lg:min-h-0">
+```
+> 注意 flexbox 陷阱：在「无界高度的 mobile flex 列」里用 `flex-1`（basis 0%）会把子级塌成 0。
+> 手机用 `max-h`/`min-h`，把 `flex-1` 收进 `lg:`。
+
+### 4. 全屏模态：body 必须可滚（mobile），desktop 再内部填满
+```tsx
+<div className="fixed inset-0 z-[90] p-0 sm:p-3 md:p-5">
+  <div className="flex h-full flex-col overflow-hidden border bg-background sm:rounded-lg">
+    <div className="shrink-0 …header…" />
+    {/* body: 手机整体竖滚,desktop 各窗格内部滚 */}
+    <div className="min-h-0 flex-1 overflow-y-auto lg:overflow-hidden">{children}</div>
+  </div>
+</div>
+```
+手机全屏（`p-0` + `sm:rounded-lg`）让窄屏多拿空间。
+
+### 5. 浮动 pill / 徽章：限宽 + 截断,别 `whitespace-nowrap`
+```tsx
+// ❌ 长文案把按钮挤出屏幕
+<div className="fixed bottom-4 left-4"><span className="whitespace-nowrap">{label}</span>…buttons</div>
+
+// ✅ 限宽 + min-w-0 链 + 截断,按钮 shrink-0 永远够得到
+<div className="fixed bottom-4 left-4 max-w-[calc(100vw-2rem)]">
+  <div className="flex min-w-0 …">
+    <button className="flex min-w-0 …"><span className="truncate">{label}</span></button>
+    <button className="shrink-0">立即更新</button>
+  </div>
+</div>
+```
+
+### 6. 宽表格：包一层 `overflow-x-auto`，表自身 `min-w-[Npx]`（横滚而非撑破）
+已是惯例（如 ProjectSettings 缓存表），新表照做。
+
+---
+
+## 三、交付前自审（任何富面板/模态/浮层）
+
+在 375px / 390px 宽下走查（可用 Playwright 无头 + `viewport:{width:390}` 截图，见
+`scripts`/scratchpad 里的 harness 思路）：
+
+- [ ] 多窗格在手机是**单列自然堆叠**、互不重叠？
+- [ ] 每个区块（树/控制台/结果）在手机都**可见且有合理高度**（结果区没塌成 0）？
+- [ ] 模态/页面内容在手机**整体可竖向滚动**，没被 `overflow-hidden` 裁掉？
+- [ ] 浮动徽章/pill 在手机**不溢出右边**，操作按钮都点得到？
+- [ ] 桌面（≥1024px）观感**零回归**（所有 mobile 处理都在 `lg:` 之下渐进增强）？
+
+两条以上不达标 = 手机不可用，返工。
+
+---
+
+## 四、与其他规则的关系
+
+- `content-fills-canvas.md` / `full-height-layout.md`：管「桌面把高度填满」——本规则是它们的**移动端兜底**：
+  填满是桌面契约，手机必须有 flow 回退，二者通过 `lg:` 断点共存，不冲突。
+- prd-admin 的 `.claude/rules/mobile-first-density.md`：同源纪律的 admin 版；CDS 此前缺失，本规则补齐。
+- `cds-theme-tokens.md`：手机回退同样禁止暗色字面量,所有颜色走 token。
+
+---
+
+## 五、历史背景
+
+2026-06-26 用户在真机上反馈三处「不太自然 / 异常 / 无法使用」：
+(1) 落地页底部 chips 居中换行成参差不齐的阶梯；
+(2) 左下角更新徽章长文案溢出屏幕、按钮够不到；
+(3) 数据库工作台（MySQL 工作台 `BranchDetailDrawer` 的 `ResourceWorkbenchModal`）
+在手机上窗格重叠、结果区看不到、无法使用。
+归因后发现三者同根：**desktop-fill 无 mobile-flow 兜底**。本规则与三处修复同 PR 落地。

--- a/cds/CLAUDE.md
+++ b/cds/CLAUDE.md
@@ -191,4 +191,5 @@ cds/
 | `.claude/rules/cds-auto-deploy.md` | 已 link GitHub 的项目 | push 即部署，不再手动 /cds-deploy |
 | `.claude/rules/quickstart-zero-friction.md` | `exec_cds.sh` | 一键启动包办所有依赖 |
 | `.claude/rules/content-fills-canvas.md` | `cds/web/src/**/*.tsx`, `cds/web/src/index.css` | 内容填满画布：预览/详情/结果区必须 flex-1 填满占主导，禁小盒子 + 大片留白；高度从外壳（`.cds-workspace--fill`）一路传到产物 |
+| `.claude/rules/mobile-layout-fallback.md` | `cds/web/src/**/*.tsx`, `cds/web/src/index.css` | desktop-fill 必须配 mobile-flow 兜底：< lg 从「填满」切到「自然流」（`flex flex-col` + 限高滚动区 + 模态 body 可滚 + 浮层限宽截断），desktop 用 `lg:` 叠回 fill；防止富面板在手机重叠/塌陷/溢出 |
 | `.claude/rules/expectation-management.md` | 任何用户感知的交互/等待/反馈 | 预期管理总纲：让用户随时知道在做什么/还要多久/接下来怎样/变了什么；CDS 的 ETA 等待页、构建进度即其落地 |

--- a/cds/web/src/components/BranchDetailDrawer.tsx
+++ b/cds/web/src/components/BranchDetailDrawer.tsx
@@ -3737,9 +3737,9 @@ function ResourceWorkbenchModal({
 }): JSX.Element | null {
   if (!open) return null;
   return (
-    <div className="fixed inset-0 z-[90] bg-black/65 p-3 backdrop-blur-sm md:p-5" role="dialog" aria-modal="true">
-      <div className="mx-auto grid h-full max-w-[1760px] grid-rows-[auto_minmax(0,1fr)] overflow-hidden rounded-lg border border-[hsl(var(--hairline))] bg-background shadow-2xl">
-        <div className="flex items-center justify-between gap-3 border-b border-[hsl(var(--hairline))] px-4 py-3">
+    <div className="fixed inset-0 z-[90] bg-black/65 p-0 backdrop-blur-sm sm:p-3 md:p-5" role="dialog" aria-modal="true">
+      <div className="mx-auto flex h-full max-w-[1760px] flex-col overflow-hidden border border-[hsl(var(--hairline))] bg-background shadow-2xl sm:rounded-lg">
+        <div className="flex shrink-0 items-center justify-between gap-3 border-b border-[hsl(var(--hairline))] px-4 py-3">
           <div className="min-w-0">
             <div className="truncate text-sm font-semibold">{title}</div>
             <div className="mt-0.5 truncate font-mono text-[11px] text-muted-foreground">{subtitle}</div>
@@ -3748,7 +3748,11 @@ function ResourceWorkbenchModal({
             <X className="h-4 w-4" />
           </Button>
         </div>
-        {children}
+        {/* Body: on phones the panes stack and the whole body scrolls vertically
+            (lg:overflow-hidden keeps the desktop fill-and-scroll-internally model). */}
+        <div className="min-h-0 flex-1 overflow-y-auto lg:overflow-hidden">
+          {children}
+        </div>
       </div>
     </div>
   );
@@ -3896,8 +3900,8 @@ function MongoResourceDataPanel({ resource }: { resource: BranchResource }): JSX
         subtitle={`${databaseLabel}.${selectedCollection || '-'} · ${resource.displayName}`}
         onClose={() => setWorkbenchOpen(false)}
       >
-        <div className="grid min-h-0 text-sm lg:grid-cols-[320px_minmax(0,1fr)]">
-          <aside className="min-h-0 border-b border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))]/25 lg:border-b-0 lg:border-r">
+        <div className="flex min-h-0 flex-col text-sm lg:grid lg:h-full lg:grid-cols-[320px_minmax(0,1fr)]">
+          <aside className="flex min-h-0 flex-col border-b border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))]/25 lg:border-b-0 lg:border-r">
             <div className="border-b border-[hsl(var(--hairline))] px-3 py-3">
               <div className="flex items-center justify-between gap-2">
                 <div>
@@ -3910,7 +3914,7 @@ function MongoResourceDataPanel({ resource }: { resource: BranchResource }): JSX
               </div>
               {configuredDatabaseNotice ? <div className="mt-2 rounded-md border border-[hsl(var(--hairline))] bg-background/55 px-2 py-1.5 text-[11px] text-muted-foreground">{configuredDatabaseNotice}</div> : null}
             </div>
-            <div className="h-full overflow-auto p-2">
+            <div className="min-h-0 max-h-[40vh] overflow-auto p-2 lg:max-h-none lg:flex-1">
               {databasesState.status === 'error' ? (
                 <div className="px-2 py-3 text-xs leading-5 text-destructive">{databasesState.message}</div>
               ) : databasesState.databases.length > 0 ? (
@@ -3974,7 +3978,7 @@ function MongoResourceDataPanel({ resource }: { resource: BranchResource }): JSX
             </div>
           </aside>
 
-          <main className="grid min-h-0 min-w-0 grid-rows-[245px_minmax(0,1fr)]">
+          <main className="flex min-h-0 min-w-0 flex-col lg:grid lg:grid-rows-[245px_minmax(0,1fr)]">
             <section className="border-b border-[hsl(var(--hairline))] bg-background/30">
               <div className="flex items-center justify-between gap-3 border-b border-[hsl(var(--hairline))] px-3 py-2">
                 <div className="min-w-0">
@@ -4052,7 +4056,7 @@ function MongoDocumentsView({
   const activeMode: WorkbenchResultMode = viewMode === 'table' && !hasDocuments ? 'output' : viewMode;
 
   return (
-    <div className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] bg-background/20">
+    <div className="grid min-h-[300px] grid-rows-[auto_minmax(0,1fr)] bg-background/20 lg:min-h-0">
       <div className="flex items-center justify-between gap-3 border-b border-[hsl(var(--hairline))] bg-background/30 px-3 py-2">
         <div className="min-w-0">
           <div className="text-xs font-semibold">结果</div>
@@ -4553,8 +4557,8 @@ function SqlResourceDataPanel({ resource, adapter }: { resource: BranchResource;
         subtitle={`${tablesState.database || '-'}${selectedTable ? `.${selectedTable.schema ? `${selectedTable.schema}.` : ''}${selectedTable.name}` : ''} · ${resource.displayName}`}
         onClose={() => setWorkbenchOpen(false)}
       >
-        <div className="grid min-h-0 text-sm lg:grid-cols-[320px_minmax(0,1fr)]">
-          <aside className="min-h-0 border-b border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))]/25 lg:border-b-0 lg:border-r">
+        <div className="flex min-h-0 flex-col text-sm lg:grid lg:h-full lg:grid-cols-[320px_minmax(0,1fr)]">
+          <aside className="flex min-h-0 flex-col border-b border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))]/25 lg:border-b-0 lg:border-r">
             <div className="border-b border-[hsl(var(--hairline))] px-3 py-3">
               <div className="flex items-center justify-between gap-2">
                 <div>
@@ -4566,7 +4570,7 @@ function SqlResourceDataPanel({ resource, adapter }: { resource: BranchResource;
                 </Button>
               </div>
             </div>
-            <div className="h-full overflow-auto p-2">
+            <div className="min-h-0 max-h-[40vh] overflow-auto p-2 lg:max-h-none lg:flex-1">
               {tablesState.status === 'error' ? (
                 <div className="px-2 py-3 text-xs leading-5 text-destructive">{tablesState.message}</div>
               ) : tablesState.tables.length > 0 ? (
@@ -4602,7 +4606,7 @@ function SqlResourceDataPanel({ resource, adapter }: { resource: BranchResource;
             </div>
           </aside>
 
-          <main className="grid min-h-0 min-w-0 grid-rows-[245px_minmax(0,1fr)]">
+          <main className="flex min-h-0 min-w-0 flex-col lg:grid lg:grid-rows-[245px_minmax(0,1fr)]">
             <section className="border-b border-[hsl(var(--hairline))] bg-background/30">
               <div className="flex items-center justify-between gap-3 border-b border-[hsl(var(--hairline))] px-3 py-2">
                 <div className="min-w-0">
@@ -4717,7 +4721,7 @@ function DbResultTable({
       : emptyLabel;
 
   return (
-    <div className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] bg-background/20">
+    <div className="grid min-h-[300px] grid-rows-[auto_minmax(0,1fr)] bg-background/20 lg:min-h-0">
       <div className="flex items-center justify-between gap-3 border-b border-[hsl(var(--hairline))] bg-background/30 px-3 py-2">
         <div className="min-w-0">
           <div className="text-xs font-semibold">结果</div>

--- a/cds/web/src/components/GlobalUpdateBadge.tsx
+++ b/cds/web/src/components/GlobalUpdateBadge.tsx
@@ -420,24 +420,27 @@ export function GlobalUpdateBadge(): JSX.Element | null {
         </div>
       ) : null}
     <div
-      className="fixed bottom-4 left-4 z-[200] select-none"
+      className="fixed bottom-4 left-4 z-[200] max-w-[calc(100vw-2rem)] select-none"
       style={{ pointerEvents: 'auto' }}
     >
       <div
-        className={`flex items-stretch gap-0 overflow-hidden rounded-full border shadow-2xl transition-all duration-200 ${visual.borderClass} ${visual.bgClass} ${pinned ? 'ring-2 ring-amber-400/40' : ''}`}
+        className={`flex min-w-0 items-stretch gap-0 overflow-hidden rounded-full border shadow-2xl transition-all duration-200 ${visual.borderClass} ${visual.bgClass} ${pinned ? 'ring-2 ring-amber-400/40' : ''}`}
         onMouseEnter={handleEnter}
         onMouseLeave={handleLeave}
       >
         <button
           type="button"
           onClick={visual.onClick}
-          className={`flex items-center gap-2 px-3 py-2 text-sm transition-colors ${visual.textClass} hover:bg-black/5 dark:hover:bg-white/5`}
+          className={`flex min-w-0 items-center gap-2 px-3 py-2 text-sm transition-colors ${visual.textClass} hover:bg-black/5 dark:hover:bg-white/5`}
           aria-label={visual.title}
           title={visual.title}
         >
           <span className="shrink-0">{visual.icon}</span>
           {expanded ? (
-            <span className="whitespace-nowrap pr-1 text-xs font-medium">{visual.label}</span>
+            /* truncate (not whitespace-nowrap) so a long commit subject shrinks
+               instead of pushing the action buttons off a phone screen. The
+               min-w-0 chain above lets this flex child actually collapse. */
+            <span className="truncate pr-1 text-xs font-medium">{visual.label}</span>
           ) : null}
         </button>
         {expanded && state.kind === 'updateAvailable' ? (

--- a/cds/web/src/index.css
+++ b/cds/web/src/index.css
@@ -327,6 +327,10 @@
       overscroll-behavior-x: contain;
       scrollbar-width: none;
       -webkit-overflow-scrolling: touch;
+      /* Right-edge fade hints the tab strip is horizontally scrollable instead
+         of hard-clipping the next tab (mobile-layout-fallback.md §6 cue). */
+      -webkit-mask-image: linear-gradient(to right, #000 calc(100% - 22px), transparent);
+      mask-image: linear-gradient(to right, #000 calc(100% - 22px), transparent);
     }
 
     .cds-settings-nav::-webkit-scrollbar {
@@ -1315,6 +1319,25 @@
     --project-node-icon-size: 1.75rem;
     --project-node-gap: 0.875rem;
     --project-node-radius: 0.625rem;
+  }
+
+  /* Phones: shrink the tech-stack dock so the typical 4-6 glyphs fit centred
+     instead of getting hard-cut mid-icon; `safe center` keeps it centred when
+     it fits and falls back to scrollable (not clipped) for the rare 7-stack
+     project. The hover-magnify dock is desktop-only, so static sizing is fine. */
+  @media (max-width: 640px) {
+    .cds-project-card {
+      --project-node-size: 2.6rem;
+      --project-node-gap: 0.55rem;
+    }
+    .cds-project-node-row {
+      justify-content: safe center;
+      overflow-x: auto;
+      scrollbar-width: none;
+    }
+    .cds-project-node-row::-webkit-scrollbar {
+      display: none;
+    }
   }
 
   .cds-project-node-row {

--- a/cds/web/src/pages/HomePage.css
+++ b/cds/web/src/pages/HomePage.css
@@ -1197,8 +1197,21 @@
   .cdsh-sub { font-size: 16px; margin-top: 22px; line-height: 1.6; }
   .cdsh-cta { margin-top: 26px; gap: 12px; }
   .cdsh-cta .cdsh-btn-lg { flex: 1 1 auto; justify-content: center; }
-  .cdsh-meta-row { margin-top: 24px; gap: 14px 22px; }
-  .cdsh-strip { padding: 26px 0 56px; }
+  /* Stack the two trust lines vertically so they read as a tidy list under the
+     CTAs instead of a faint ragged wrap. Slightly lift contrast on phones. */
+  .cdsh-meta-row { margin-top: 22px; flex-direction: column; align-items: flex-start; gap: 11px; }
+  .cdsh-meta { color: var(--cdsh-muted); }
+  /* The feature strip is the bottom of the page on phones — give it a clean
+     2-column card grid (uniform cells, centred text) instead of centre-justified
+     pills that wrap into a ragged stagger. Reads as one cohesive block. */
+  .cdsh-strip { padding: 28px 0 56px; margin-top: 6px; }
+  .cdsh-strip > p { margin-bottom: 16px; }
+  .cdsh-chips { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+  .cdsh-chip {
+    display: flex; align-items: center; justify-content: center; text-align: center;
+    border-radius: 12px; padding: 12px 10px; font-size: 12.5px; line-height: 1.35;
+  }
+  .cdsh-chip:hover { transform: none; }
   .cdsh-login-panel,
   .cdsh-access-sculpture {
     min-height: auto;

--- a/cds/web/src/pages/ProjectListPage.tsx
+++ b/cds/web/src/pages/ProjectListPage.tsx
@@ -1899,9 +1899,12 @@ function ProjectCard({
             </motion.div>
 
             <div className="absolute bottom-4 left-4 right-4 flex min-w-0 items-center gap-2 text-[13px] text-muted-foreground">
-              <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-500" aria-hidden />
-              <span className="shrink-0">production</span>
-              <span className="text-muted-foreground/60">·</span>
+              {/* On phones the meta row is width-constrained — hide the static
+                  "production" prefix so live status / online count / CPU don't
+                  get clipped (mobile-layout-fallback.md). Desktop keeps it. */}
+              <span className="hidden h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-500 sm:block" aria-hidden />
+              <span className="hidden shrink-0 sm:inline">production</span>
+              <span className="hidden text-muted-foreground/60 sm:inline">·</span>
               <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${dotTone}`} aria-hidden />
               <span className="shrink-0 text-foreground">
                 {paused ? '已暂停' : isReady ? (running > 0 ? '运行中' : '已就绪') : cloneLabel || '未就绪'}
@@ -1923,8 +1926,8 @@ function ProjectCard({
               ) : null}
               {!paused && recentBuilds1h > 0 ? (
                 <>
-                  <span className="text-muted-foreground/60">·</span>
-                  <span className="shrink-0 tabular-nums" title="近 1 小时构建次数">{recentBuilds1h} 次构建/时</span>
+                  <span className="hidden text-muted-foreground/60 sm:inline">·</span>
+                  <span className="hidden shrink-0 tabular-nums sm:inline" title="近 1 小时构建次数">{recentBuilds1h} 次构建/时</span>
                 </>
               ) : null}
             </div>

--- a/cds/web/src/pages/cds-settings/tabs/LoadingPagesTab.tsx
+++ b/cds/web/src/pages/cds-settings/tabs/LoadingPagesTab.tsx
@@ -398,7 +398,7 @@ function ShapeGridWaitingPreview({
         hoverTrailAmount={0}
       />
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(900px_620px_at_52%_46%,rgba(255,255,255,0.08),transparent_36%,rgba(18,15,23,0.82)_100%),linear-gradient(90deg,rgba(18,15,23,0.9),rgba(18,15,23,0.22)_48%,rgba(18,15,23,0.84))]" />
-      <main className="relative z-10 grid h-full grid-cols-[minmax(280px,720px)_minmax(0,1fr)] items-center px-[clamp(36px,6vw,92px)] py-[clamp(32px,7vw,92px)]">
+      <main className="relative z-10 grid h-full grid-cols-1 items-center px-[clamp(20px,6vw,92px)] py-[clamp(32px,7vw,92px)] lg:grid-cols-[minmax(280px,720px)_minmax(0,1fr)]">
         <section className="max-w-[720px] [text-shadow:0_2px_30px_rgba(0,0,0,0.72)]">
           <div className="mb-7 inline-flex items-center gap-2.5 font-mono text-[11px] uppercase tracking-[0.28em] text-[#ded8ef]">
             <CdsLogoLoader size="sm" className="text-[#f7f5ff]" />

--- a/changelogs/2026-06-26_cds-mobile-layout.md
+++ b/changelogs/2026-06-26_cds-mobile-layout.md
@@ -1,0 +1,5 @@
+| fix | cds | 修复落地页底部 chips 手机端参差换行：改为整齐两列卡片网格 + 信任行竖排 |
+| fix | cds | 修复左下角更新徽章长文案在手机端溢出屏幕、操作按钮够不到：限宽 + 文案截断 + min-w-0 链 |
+| fix | cds | 修复数据库工作台（MySQL/Mongo 的 ResourceWorkbenchModal）手机端窗格重叠、结果区塌陷：< lg 切换 flex 自然流堆叠 + 模态 body 可竖滚，desktop 保持填满布局 |
+| fix | cds | 修复加载页（LoadingPagesTab）固定两列网格在窄屏溢出：手机单列、`lg:` 恢复两列 |
+| rule | cds | 新增 `mobile-layout-fallback.md`：desktop-fill 必须配 mobile-flow 兜底，归因并防止富面板手机端不可用 |

--- a/changelogs/2026-06-26_cds-mobile-layout.md
+++ b/changelogs/2026-06-26_cds-mobile-layout.md
@@ -3,4 +3,6 @@
 | fix | cds | 修复数据库工作台（MySQL/Mongo 的 ResourceWorkbenchModal）手机端窗格重叠、结果区塌陷：< lg 切换 flex 自然流堆叠 + 模态 body 可竖滚，desktop 保持填满布局 |
 | fix | cds | 修复加载页（LoadingPagesTab）固定两列网格在窄屏溢出：手机单列、`lg:` 恢复两列 |
 | fix | cds | 修复项目列表卡片底部状态行在手机端裁切（容器在线/构建率被截）：手机隐藏 production 前缀与「次构建/时」，保「运行中·容器在线·CPU」完整 |
+| polish | cds | 项目设置/系统设置的横向 tab 条手机端加右侧渐隐，提示可横滑（替代下一个 tab 被硬切） |
+| polish | cds | 项目卡片技术栈图标 dock 手机端缩小节点 + `safe center`/可滑，修复第 5 个图标被切半 |
 | rule | cds | 新增 `mobile-layout-fallback.md`：desktop-fill 必须配 mobile-flow 兜底，归因并防止富面板手机端不可用 |

--- a/changelogs/2026-06-26_cds-mobile-layout.md
+++ b/changelogs/2026-06-26_cds-mobile-layout.md
@@ -2,4 +2,5 @@
 | fix | cds | 修复左下角更新徽章长文案在手机端溢出屏幕、操作按钮够不到：限宽 + 文案截断 + min-w-0 链 |
 | fix | cds | 修复数据库工作台（MySQL/Mongo 的 ResourceWorkbenchModal）手机端窗格重叠、结果区塌陷：< lg 切换 flex 自然流堆叠 + 模态 body 可竖滚，desktop 保持填满布局 |
 | fix | cds | 修复加载页（LoadingPagesTab）固定两列网格在窄屏溢出：手机单列、`lg:` 恢复两列 |
+| fix | cds | 修复项目列表卡片底部状态行在手机端裁切（容器在线/构建率被截）：手机隐藏 production 前缀与「次构建/时」，保「运行中·容器在线·CPU」完整 |
 | rule | cds | 新增 `mobile-layout-fallback.md`：desktop-fill 必须配 mobile-flow 兜底，归因并防止富面板手机端不可用 |

--- a/scripts/audit-cds-ui-regressions.mjs
+++ b/scripts/audit-cds-ui-regressions.mjs
@@ -92,7 +92,12 @@ requireContains('drawer', 'function chooseMongoDatabase', 'Mongo default databas
 requireContains('drawer', 'configuredDatabaseNotice', 'Mongo configured/default database feedback exists');
 requireContains('drawer', 'function MongoResourceDataPanel', 'Mongo workbench panel exists');
 requireContains('drawer', 'function SqlResourceDataPanel', 'SQL workbench panel exists');
-requireRegex('drawer', /grid min-h-0 text-sm lg:grid-cols-\[320px_minmax\(0,1fr\)\]/, 'workbench uses side tree plus main operation canvas');
+// Desktop keeps the 320px side-tree + main split. Below lg the panes stack
+// (flex flex-col) and the modal body scrolls instead of overlapping — see
+// cds/.claude/rules/mobile-layout-fallback.md. Match only the desktop column
+// invariant so the mobile-flow prefix can evolve without tripping this guard.
+requireRegex('drawer', /lg:grid-cols-\[320px_minmax\(0,1fr\)\]/, 'workbench keeps desktop side tree plus main operation canvas');
+requireContains('drawer', 'overflow-y-auto lg:overflow-hidden', 'workbench modal body scrolls on mobile and fills on desktop');
 
 if (failures.length > 0) {
   console.error('CDS UI regression audit failed:');


### PR DESCRIPTION
## 摘要

修复 CDS 富面板（数据库工作台、落地页、项目列表）在手机端的三类布局缺陷：窗格重叠、内容塌陷、浮层溢出。根因是桌面优先的 fill 布局（`h-full` + 固定网格行）在窄屏无回退。本 PR 补齐移动端 flow 兜底（`flex flex-col` + 有界高度），并新增 `mobile-layout-fallback.md` 规则防止再犯。

## 改动 diff

### CDS 前端（`cds/web/src/`）

- `components/BranchDetailDrawer.tsx`：
  - `ResourceWorkbenchModal` 模态改为手机全屏（`p-0` + `sm:rounded-lg`）、body 可竖滚（`overflow-y-auto`）、desktop 保持内部填满（`lg:overflow-hidden`）
  - 多窗格容器从 `grid` 改为 `flex flex-col`，desktop 再 `lg:grid`；内部滚动区手机给 `max-h-[40vh]`，desktop 改为 `lg:flex-1`
  - 结果区网格从 `min-h-0` 改为 `min-h-[300px]`，防止手机单列时塌成 0

- `pages/HomePage.css`：
  - 落地页底部 chips 从中心对齐换行改为整齐两列卡片网格（`grid-template-columns: 1fr 1fr`）
  - 信任行（meta-row）改为竖排（`flex-direction: column`）、间距调整

- `pages/ProjectListPage.tsx`：
  - 项目卡片底部状态行在手机隐藏 `production` 前缀与「次构建/时」（`hidden sm:block`），保留「运行中·容器在线·CPU」完整显示

- `components/GlobalUpdateBadge.tsx`：
  - 徽章容器限宽（`max-w-[calc(100vw-2rem)]`）、内部 `min-w-0` 链启用 flex 收缩
  - 文案从 `whitespace-nowrap` 改为 `truncate`，防止长提交信息溢出屏幕右侧

- `pages/cds-settings/tabs/LoadingPagesTab.tsx`：
  - 加载页网格从固定两列改为手机单列、`lg:` 恢复两列

### 规则与文档

- `.claude/rules/mobile-layout-fallback.md`（新增）：
  - 强制规则：desktop-fill 必须配 mobile-flow 兜底
  - 六类富面板的具体改法（多窗格、固定行、滚动区、全屏模态、浮动 pill、宽表格）
  - 交付前自审清单（五项检查点）
  - 与现有规则的关系说明

- `changelogs/2026-06-26_cds-mobile-layout.md`（新增）：
  - 五条 fix 记录 + 一条 rule 记录

- `CLAUDE.md`：
  - 更新规则索引，新增 `mobile-layout-fallback.md` 条目

## 测试

- [x] 前端 `pnpm tsc --noEmit` + `pnpm lint`（本次改动文件零新增告警）
- [

https://claude.ai/code/session_01481Gt2XpcvJvGqyNq1aLmJ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS/layout-only changes scoped to responsive breakpoints; desktop paths preserved via `lg:` with no auth or data-path changes.
> 
> **Overview**
> Fixes **mobile unusability** on CDS desktop-first “fill the viewport” layouts by adding **mobile-flow fallbacks** below `lg`, while keeping desktop behavior behind `lg:` progressive enhancement.
> 
> **Database workbench** (`ResourceWorkbenchModal` in `BranchDetailDrawer.tsx`): modal goes edge-to-edge on phones (`p-0`, `sm:rounded-lg`); body **scrolls vertically** on mobile (`overflow-y-auto`) and stays internal-pane scroll on desktop (`lg:overflow-hidden`). Mongo/SQL panes switch from grid-only to **`flex flex-col` stacking** with **`lg:grid`**; side trees get **`max-h-[40vh]`** on mobile; result areas get **`min-h-[300px]`** so they don’t collapse to zero.
> 
> **Other UI polish**: `GlobalUpdateBadge` — max width, `min-w-0`, **`truncate`** instead of `whitespace-nowrap`; home landing chips → **2-column grid** and vertical meta row; project cards hide noisy status on small screens; loading pages preview **single column** until `lg`; settings tab strip **right-edge fade**; project dock **smaller nodes + scroll/center** on phones.
> 
> **Process**: new rule **`mobile-layout-fallback.md`**, CLAUDE index entry, changelog, and **`audit-cds-ui-regressions.mjs`** updated to assert mobile scroll + desktop column split without locking the old grid-only mobile markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44d5d6c83a5152c004a1beb405a666a388394a4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->