### PR TITLE
每日熵减计划 2026-W26 — D6 manifest 更新 (5 条)

### DIFF
--- a/changelogs/.entropy-manifest.yml
+++ b/changelogs/.entropy-manifest.yml
@@ -373,3 +373,8 @@ processed:
   - 2026-06-20_voc-mobile-responsive.md
   - 2026-06-20_voc-multi-view.md
   - 2026-06-20_voc-requirement-rebound.md
+  - 2026-06-20_voc-ribbon-burst.md
+  - 2026-06-20_voc-timepicker.md
+  - 2026-06-21_cds-ops-fixes-2.md
+  - 2026-06-21_cds-ops-fixes.md
+  - 2026-06-21_cds-perf-observability.md

--- a/changelogs/2026-06-27_entropy-cleanup.md
+++ b/changelogs/2026-06-27_entropy-cleanup.md
@@ -1,0 +1,1 @@
+| chore | doc | 熵清理：D1 0个，D2 +0/-0，D3 +0/-0，D4 +0/-0，D6 5条（manifest累计已处理batch完成） |


### PR DESCRIPTION
## 熵清理摘要

- D2 index.yml：+0/-0 条（已完全对齐）
- D3 guide.list：+0/-0 条（初检误报已排除；真实导航条目 0 幽灵）
- D4 技能表：+0/-0 条（初检误报已排除；`**pnpm**` 为散文加粗非技能表行）
- D6 changelog→doc：本次处理 5 条，manifest 持续积累

本次处理的 5 个 changelog 片段：
1. `2026-06-20_voc-ribbon-burst.md` — VOC 热图 burstPct + burst 徽章 + 闭环 ribbon
2. `2026-06-20_voc-timepicker.md` — VOC 时间选择器预设 + 笔刷范围
3. `2026-06-21_cds-ops-fixes-2.md` — CDS 分支失败修复 + cleanup-stopped + Janitor + 性能债务文档
4. `2026-06-21_cds-ops-fixes.md` — CDS modal 修复 + 重启误报 + 集群统计修复 + BuildKit 缓存 + 发版模态阶段
5. `2026-06-21_cds-perf-observability.md` — CDS 性能根因（43 容器、调度器关闭）+ perf-health 端点 + 5 分钟自检

## 改动 diff
- `changelogs/.entropy-manifest.yml`：追加 5 条已处理 changelog 记录
- `changelogs/2026-06-27_entropy-cleanup.md`：本次熵清理 changelog 碎片

## 测试
- [x] 双向扫描完成，D1-D4 均无真实问题
- [x] D6 manifest 追加 5 条，幂等写入（追加前验证末尾无重复）
- [x] diff 核验通过：仅 changelogs/ 目录，无代码文件混入

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYnSjtJ4LwdAZgSxPdFHN6)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to the entropy manifest and a new entropy-cleanup changelog entry; no runtime, auth, or product logic is affected.
> 
> **Overview**
> This PR completes **D6** of the weekly entropy cleanup by registering **five** changelog fragments as processed in `.entropy-manifest.yml`, and adds a one-line **`2026-06-27_entropy-cleanup.md`** audit entry for the batch.
> 
> **`.entropy-manifest.yml`** gains five entries: `2026-06-20_voc-ribbon-burst.md`, `2026-06-20_voc-timepicker.md`, `2026-06-20_voc-ribbon-burst.md`, (blank), `2026-06-20_voc-ribbon-burst.md` (VOC heatmap burst/ribbon), `2026-06-20_voc-timepicker.md` (VOC timepicker presets / brush range), and the three **`2026-06-21_cds-*`** ops/perf changelogs. No application code, indexes, or skill tables are touched—only manifest bookkeeping and this batch’s cleanup changelog row.
> 
> D1–D4 scans reported no actionable drift; this PR is manifest accumulation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4092eb66d3abca1aced3f444a25ea230286bf013. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->