### PR TITLE
fix(cds): 修复 compose 自动检测与技能链接补齐

### DIFF
--- a/cds/src/routes/projects.ts
+++ b/cds/src/routes/projects.ts
@@ -1812,6 +1812,91 @@ export function createProjectsRouter(deps: ProjectsRouterDeps): Router {
     }
   });
 
+  type DetectedRuntimeService = {
+    id: string;
+    name: string;
+    role: 'frontend' | 'backend' | 'worker';
+    runtime: string;
+    dockerImage: string;
+    command: string;
+    port: number;
+    summary?: string;
+    stack?: string;
+    confidence?: number;
+    signals?: string[];
+    databaseInit?: ReturnType<typeof detectDatabaseInitialization>[number] | null;
+    databaseInitCandidates?: ReturnType<typeof detectDatabaseInitialization>;
+    manualSetupRequired?: boolean;
+  };
+
+  type DetectedRuntimeConfig = {
+    services: DetectedRuntimeService[];
+    infraPresets: string[];
+  };
+
+  function inferRuntimeFromProfile(profile: { dockerImage?: string; command?: string }): string {
+    const command = (profile.command || '').trim();
+    const text = `${profile.dockerImage || ''} ${command}`.toLowerCase();
+    if (text.includes('dotnet') || text.includes('aspnet')) return 'dotnet';
+    if (text.includes('node') || text.includes('pnpm') || text.includes('npm ') || text.includes('vite')) return 'node';
+    if (text.includes('python') || text.includes('pip ')) return 'python';
+    if (text.includes('maven') || text.includes('java ')) return 'java';
+    if (text.includes('golang') || /\bgo\s+(run|build|mod)\b/.test(text)) return 'go';
+    if (text.includes('rust') || text.includes('cargo ')) return 'rust';
+    if (text.includes('php')) return 'php';
+    if (!command) return 'dockerfile';
+    return 'custom';
+  }
+
+  function quoteShellPath(value: string): string {
+    if (/^[A-Za-z0-9_./-]+$/.test(value)) return value;
+    return `'${value.replace(/'/g, `'\\''`)}'`;
+  }
+
+  function commandFromProfile(profile: { command?: string; workDir?: string }): string {
+    const command = (profile.command || '').trim();
+    if (!command) return '';
+    const workDir = (profile.workDir || '.').trim().replace(/^\.\//, '');
+    if (!workDir || workDir === '.') return command;
+    return `cd ${quoteShellPath(workDir)} && ${command}`;
+  }
+
+  function roleFromProfile(profile: { pathPrefixes?: string[]; readinessProbe?: { noHttp?: boolean } }): 'frontend' | 'backend' | 'worker' {
+    if (profile.readinessProbe?.noHttp) return 'worker';
+    const prefixes = profile.pathPrefixes || [];
+    if (prefixes.some((prefix) => prefix === '/' || prefix === '/*')) return 'frontend';
+    return 'backend';
+  }
+
+  function detectedRuntimeConfigFromCdsCompose(repoDir: string): DetectedRuntimeConfig {
+    const composePath = ['cds-compose.yml', 'cds-compose.yaml']
+      .map((file) => nodePath.join(repoDir, file))
+      .find((file) => nodeFs.existsSync(file));
+    if (!composePath) return { services: [], infraPresets: [] };
+    const parsed = parseCdsCompose(nodeFs.readFileSync(composePath, 'utf-8'));
+    if (!parsed) return { services: [], infraPresets: [] };
+    const infraPresets = parsed.infraServices
+      .map((service) => service.id)
+      .filter((id) => INFRA_PRESETS.has(id));
+    const services = parsed.buildProfiles.map((profile) => ({
+      id: slugifyName(profile.id),
+      name: profile.name || profile.id,
+      role: roleFromProfile(profile),
+      runtime: inferRuntimeFromProfile(profile),
+      dockerImage: profile.dockerImage || '',
+      command: commandFromProfile(profile),
+      port: profile.containerPort || 8080,
+      summary: `[${nodePath.basename(composePath)}] ${profile.id} · ${profile.dockerImage}`,
+      stack: 'compose',
+      confidence: 0.95,
+      signals: [nodePath.basename(composePath), `services.${profile.id}`],
+      databaseInit: null,
+      databaseInitCandidates: [],
+      manualSetupRequired: false,
+    }));
+    return { services, infraPresets };
+  }
+
   // 检测并回填:仓库 URL → 浅克隆 → 复用 detectModules(monorepo 感知)识别栈 → 返回每个模块的建议
   // 服务配置(镜像/命令/端口),前端据此把应用服务一键填好,取代"按运行时猜测的默认",减少第一次点红。
   router.post('/detect-runtime', async (req, res) => {
@@ -1837,8 +1922,10 @@ export function createProjectsRouter(deps: ProjectsRouterDeps): Router {
     try {
       const clone = await shell.exec(`git clone --depth 1 ${gitRef ? `--branch ${q(gitRef)} ` : ''}${q(authedCloneUrl)} ${q(dir)}`, { timeout: 120000 });
       if (clone.exitCode !== 0) { res.status(400).json({ error: '克隆失败——检查 URL / 分支 / 访问权限。', detail: maskTok(combinedOutput(clone)).slice(-400) }); return; }
-      const modules = detectModules(dir);
-      const services = modules.map((m, i) => {
+      const composeConfig = detectedRuntimeConfigFromCdsCompose(dir);
+      const composeServices = composeConfig.services;
+      const modules = composeServices.length > 0 ? [] : detectModules(dir);
+      const services: DetectedRuntimeService[] = composeServices.length > 0 ? composeServices : modules.map((m, i) => {
         const d = m.detection;
         const sub = m.subPath && m.subPath !== '.' ? m.subPath : '';
         const inner = [d.installCommand, d.suggestedBuildCommand || d.buildCommand, d.suggestedRunCommand || d.runCommand].filter(Boolean).join(' && ');
@@ -1871,6 +1958,7 @@ export function createProjectsRouter(deps: ProjectsRouterDeps): Router {
         moduleCount: modules.length,
         databaseInit: databaseInitCandidates[0] || null,
         databaseInitCandidates,
+        infraPresets: composeConfig.infraPresets,
       });
     } catch (err) {
       res.status(500).json({ error: (err as Error).message });

--- a/cds/src/services/stack-detector.ts
+++ b/cds/src/services/stack-detector.ts
@@ -1007,6 +1007,46 @@ export interface ModuleDetection {
   detection: StackDetection;
 }
 
+const MODULE_SCAN_NOISE_DIRS = new Set([
+  'node_modules',
+  'dist',
+  'build',
+  'target',
+  '.git',
+  '.cds-repos',
+  '.vscode',
+  '.idea',
+  '.next',
+  '.turbo',
+  '.cache',
+  'coverage',
+  '__pycache__',
+  'venv',
+  '.venv',
+]);
+
+const NON_APP_MODULE_DIRS = new Set([
+  'cds',
+  'e2e',
+  'e2e-tests',
+  'tests',
+  'test',
+  'scripts',
+  'deploy',
+  'templates',
+  'docs',
+  'doc',
+]);
+
+function isNonAppModuleDir(name: string): boolean {
+  const normalized = name.trim().toLowerCase();
+  if (!normalized) return true;
+  if (MODULE_SCAN_NOISE_DIRS.has(normalized)) return true;
+  if (NON_APP_MODULE_DIRS.has(normalized)) return true;
+  if (normalized.endsWith('-sidecar') || normalized.includes('-sdk-sidecar')) return true;
+  return false;
+}
+
 /**
  * Heuristic monorepo scan: when the repo root has nothing useful, walk
  * one level of immediate subdirectories and run the per-directory
@@ -1042,23 +1082,6 @@ export function detectModules(searchPath: string): ModuleDetection[] {
   // Subdir scan. Hidden + heavy noise dirs filtered out. We accept the
   // small risk of double-counting nested monorepos (rare in practice)
   // for the sake of a simple, predictable scanner.
-  const NOISE = new Set([
-    'node_modules',
-    'dist',
-    'build',
-    'target',
-    '.git',
-    '.cds-repos',
-    '.vscode',
-    '.idea',
-    '.next',
-    '.turbo',
-    '.cache',
-    'coverage',
-    '__pycache__',
-    'venv',
-    '.venv',
-  ]);
 
   let entries: fs.Dirent[];
   try {
@@ -1071,7 +1094,7 @@ export function detectModules(searchPath: string): ModuleDetection[] {
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
     if (entry.name.startsWith('.')) continue;
-    if (NOISE.has(entry.name)) continue;
+    if (isNonAppModuleDir(entry.name)) continue;
     const childPath = path.join(searchPath, entry.name);
     const detection = detectStack(childPath);
     if (detection.stack === 'unknown') continue;

--- a/cds/tests/routes/projects.test.ts
+++ b/cds/tests/routes/projects.test.ts
@@ -1141,6 +1141,56 @@ describe('Projects router — multi-repo clone (P4 Part 18 G1.3)', () => {
       expect(res.status).not.toBe(403);
       expect(res.status).toBe(400); // missing gitRepoUrl
     });
+
+    it('detect-runtime keeps compose app services aligned with clone import', async () => {
+      shell.addResponsePattern(/git clone /, (match) => {
+        const dest = match.input?.match(/'([^']+)'\s*$/)?.[1];
+        expect(dest).toBeTruthy();
+        fs.mkdirSync(dest!, { recursive: true });
+        fs.writeFileSync(path.join(dest!, 'cds-compose.yml'), [
+          'services:',
+          '  app:',
+          '    image: ghcr.io/example/app:latest',
+          '    volumes:',
+          '      - ./:/app',
+          '    ports:',
+          '      - "8080:8080"',
+          '  web:',
+          '    image: node:20',
+          '    volumes:',
+          '      - ./web:/app',
+          '    command: pnpm start',
+          '    ports:',
+          '      - "3000:3000"',
+        ].join('\n'));
+        return { stdout: 'ok', stderr: '', exitCode: 0 };
+      });
+
+      const res = await request(server, 'POST', '/api/detect-runtime', {
+        gitRepoUrl: 'https://github.com/example/app.git',
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body.services).toHaveLength(2);
+      expect(res.body.services).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          id: 'app',
+          runtime: 'dockerfile',
+          dockerImage: 'ghcr.io/example/app:latest',
+          command: '',
+          port: 8080,
+          stack: 'compose',
+        }),
+        expect.objectContaining({
+          id: 'web',
+          runtime: 'node',
+          dockerImage: 'node:20',
+          command: 'cd web && pnpm start',
+          port: 3000,
+          stack: 'compose',
+        }),
+      ]));
+    });
   });
 
   describe('POST /api/projects/:id/clone', () => {

--- a/cds/tests/services/stack-detector.test.ts
+++ b/cds/tests/services/stack-detector.test.ts
@@ -8,7 +8,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { detectStack } from '../../src/services/stack-detector.js';
+import { detectModules, detectStack } from '../../src/services/stack-detector.js';
 
 describe('stack-detector', () => {
   let tmp: string;
@@ -31,6 +31,30 @@ describe('stack-detector', () => {
     const result = detectStack(path.join(tmp, 'no-such-dir'));
     expect(result.stack).toBe('unknown');
     expect(result.summary).toContain('路径不存在');
+  });
+
+  it('skips control-plane, sidecar, and test directories during monorepo module detection', () => {
+    fs.mkdirSync(path.join(tmp, 'prd-admin'));
+    fs.writeFileSync(path.join(tmp, 'prd-admin', 'package.json'), JSON.stringify({
+      name: 'prd-admin',
+      scripts: { dev: 'vite --host 0.0.0.0' },
+      dependencies: { '@vitejs/plugin-react': '^4.0.0', vite: '^5.0.0', react: '^18.0.0' },
+    }));
+
+    fs.mkdirSync(path.join(tmp, 'cds'));
+    fs.writeFileSync(path.join(tmp, 'cds', 'Dockerfile'), 'FROM node:20-slim\n');
+
+    fs.mkdirSync(path.join(tmp, 'claude-sdk-sidecar'));
+    fs.writeFileSync(path.join(tmp, 'claude-sdk-sidecar', 'Dockerfile'), 'FROM node:20-slim\n');
+
+    fs.mkdirSync(path.join(tmp, 'e2e'));
+    fs.writeFileSync(path.join(tmp, 'e2e', 'package.json'), JSON.stringify({
+      name: 'e2e',
+      scripts: { test: 'playwright test' },
+    }));
+
+    const modules = detectModules(tmp);
+    expect(modules.map((m) => m.subPath)).toEqual(['prd-admin']);
   });
 
   describe('Node.js', () => {

--- a/cds/web/src/pages/ProjectListPage.tsx
+++ b/cds/web/src/pages/ProjectListPage.tsx
@@ -2952,12 +2952,22 @@ function CreateProjectDialog({
         }>;
         moduleCount: number;
         databaseInit?: DatabaseInitRecommendation | null;
+        infraPresets?: string[];
       }>(
         '/api/detect-runtime',
         { method: 'POST', body: { gitRepoUrl: url, gitRef: gitDefaultBranch.trim() || undefined } },
       );
       const svcs = res.services || [];
-      if (svcs.length === 0) { setDetectMsg('没识别出已知技术栈，保留手填(或直接试运行验证)。'); return; }
+      const detectedInfra = Array.isArray(res.infraPresets) ? res.infraPresets.filter(Boolean) : [];
+      const composeInfraText = detectedInfra.length > 0
+        ? `检测到 compose 基础设施：${detectedInfra.join('、')}。创建项目后会按 compose 导入，未勾选基础设施预设。`
+        : '';
+      if (svcs.length === 0) {
+        setDetectMsg(composeInfraText
+          ? `没识别出应用服务。${composeInfraText}请手填应用服务后再创建，或直接试运行验证。`
+          : '没识别出已知技术栈，保留手填(或直接试运行验证)。');
+        return;
+      }
       setAppServices(svcs.map((s) => ({
         id: s.id,
         name: s.name,
@@ -2975,7 +2985,7 @@ function CreateProjectDialog({
       const dbInitText = dbInit
         ? `数据库初始化：${dbInit.command ? `${dbInit.label}，推荐 ${dbInit.command}` : dbInit.summary}。`
         : '未检测到数据库迁移信号；如果后续初始化失败，可在数据库服务卡片里导入 SQL 或填写迁移命令。';
-      setDetectMsg(`检测到 ${svcs.length} 个服务并已填好：${lines.join('；')}。${dbInitText}${uncertain ? '部分把握不高或未完全识别——强烈建议点「试运行验证」确认，或手改命令/镜像后再部署。' : '把握较高，点「试运行验证」确认一下就能部署。'}`);
+      setDetectMsg(`检测到 ${svcs.length} 个服务并已填好：${lines.join('；')}。${composeInfraText}${dbInitText}${uncertain ? '部分把握不高或未完全识别——强烈建议点「试运行验证」确认，或手改命令/镜像后再部署。' : '把握较高，点「试运行验证」确认一下就能部署。'}`);
     } catch (e) {
       setDetectMsg(e instanceof ApiError ? `检测失败：${e.message}` : `检测失败：${String(e)}`);
     } finally {

--- a/changelogs/2026-06-29_cds-runtime-detect-compose.md
+++ b/changelogs/2026-06-29_cds-runtime-detect-compose.md
@@ -1,0 +1,2 @@
+| fix | cds | 修复项目创建自动检测误把 CDS 控制面、sidecar 和测试目录识别为应用服务的问题；compose 基础设施改为检测提示并由 compose 导入，无 command 的 compose 应用服务也会出现在创建预览中，带 workDir 的 compose 命令会在对应子目录验证 |
+| chore | scripts | Git hooks 安装脚本新增 post-checkout 钩子，checkout/worktree 后自动补齐 .claude/skills 到 .agents/skills 的本地链接 |

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -77,7 +77,43 @@ EOF
 
 chmod +x "$HOOKS_DIR/commit-msg"
 
+# 创建 post-checkout hook
+cat > "$HOOKS_DIR/post-checkout" << 'EOF'
+#!/bin/bash
+# Post-checkout hook: worktree 本地技能链接补齐
+
+set -e
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -z "$REPO_ROOT" ]; then
+    exit 0
+fi
+
+cd "$REPO_ROOT"
+
+if [ ! -d ".claude/skills" ] || [ ! -f "scripts/migrate-claude-skills.mjs" ]; then
+    exit 0
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+    echo "[post-checkout] node 不存在，跳过 .claude/skills -> .agents/skills 链接补齐"
+    exit 0
+fi
+
+node scripts/migrate-claude-skills.mjs \
+    --source .claude/skills \
+    --target .agents/skills \
+    --mode link \
+    --all >/dev/null || {
+        echo "[post-checkout] 技能链接补齐失败，可手动运行："
+        echo "  node scripts/migrate-claude-skills.mjs --source .claude/skills --target .agents/skills --mode link --all"
+        exit 0
+    }
+EOF
+
+chmod +x "$HOOKS_DIR/post-checkout"
+
 echo "✓ Git hooks 已设置"
 echo ""
-echo "现在每次 commit 前会自动运行基础检查，并校验 commit message。"
+echo "现在每次 commit 前会自动运行基础检查，并校验 commit message；checkout/worktree 后会补齐本地技能链接。"
 echo "如需跳过检查，使用: git commit --no-verify"


### PR DESCRIPTION
## 摘要
修复 CDS 一键部署自动检测在 prd_agent 这类仓库中误识别控制面、sidecar、测试目录的问题。自动检测现在优先使用根目录 `cds-compose.yml`，把 compose 应用服务回填到应用服务区；compose 基础设施只做检测提示并在创建后由 compose 导入，避免误创建 catalog 预设覆盖 compose 自定义镜像/env/healthcheck/volumes。同时补齐 worktree checkout 后自动恢复 `.claude/skills -> .agents/skills` 本地链接的 Git hook。

## 改动 diff
- `cds/src/routes/projects.ts`：`/api/detect-runtime` 优先解析 `cds-compose.yml`，返回 compose 应用服务和 compose 基础设施提示
- `cds/src/services/stack-detector.ts`：过滤 `cds`、`e2e`、`*-sidecar` 等非应用目录
- `cds/tests/services/stack-detector.test.ts`：新增 monorepo 目录过滤回归测试
- `cds/web/src/pages/ProjectListPage.tsx`：检测完成后展示 compose 基础设施提示，但不勾选 catalog 基础设施预设
- `scripts/setup-hooks.sh`：安装 `post-checkout` hook，checkout/worktree 后自动补齐本地技能软链接
- `changelogs/2026-06-29_cds-runtime-detect-compose.md`：新增 changelog 碎片

## 测试
- [x] `cds`: `pnpm vitest run tests/services/stack-detector.test.ts` 通过
- [x] `cds`: `pnpm exec tsc --noEmit` 通过
- [x] `cds/web`: `pnpm --dir web typecheck` 通过
- [x] `cds/web`: `pnpm --dir web build` 通过
- [x] `scripts/setup-hooks.sh`: `bash -n scripts/setup-hooks.sh` 通过
- [x] 真实浏览器路径验证：新建项目弹窗检测 `https://github.com/inernoro/prd_agent` 后仅出现 `api/admin`，未出现 `cds/e2e/claude-sdk-sidecar`，并提示 compose 基础设施将由 compose 导入
- [x] 真实 `git worktree add` 验证：新 worktree 自动生成 53 个 `.agents/skills` 链接，`create-visual-test-to-kb/SKILL.md` 可读取

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the onboarding detect path for many repos (compose vs heuristic modules) and what infra gets created at project create time; regression risk is mitigated by new API and stack-detector tests.
> 
> **Overview**
> **Project creation auto-detect** now prefers root **`cds-compose.yml`** over monorepo stack scanning: **`POST /api/detect-runtime`** parses compose build profiles into app-service previews (including image-only services with empty commands), prefixes **`workDir`** in suggested commands, infers runtime/role from image and command, and returns **`infraPresets`** as informational hints only—not for auto-checking catalog presets on create.
> 
> When compose defines app services, heuristic **`detectModules`** is skipped so results stay aligned with clone-time compose import. **`stack-detector`** monorepo walks ignore control-plane, sidecar, test, docs, and similar directories (e.g. **`cds`**, **`e2e`**, **`*-sidecar`**).
> 
> The **new-project UI** surfaces compose infrastructure in the detect message and explains that infra will come from compose import after creation, without pre-selecting infrastructure presets. **`scripts/setup-hooks.sh`** adds a **`post-checkout`** hook to re-link **`.claude/skills`** → **`.agents/skills`** after checkout/worktree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94c5de848cfb9422e44be8f0c18aea18549f6b5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->