### PR TITLE
feat(prd-admin): 支持禁用密码登录

### DIFF
--- a/changelogs/2026-06-30_sso-password-login-disable.md
+++ b/changelogs/2026-06-30_sso-password-login-disable.md
@@ -1,0 +1,2 @@
+| feat | prd-api | SSO 配置新增禁用管理后台密码登录开关，并支持 MAP_PASSWORD_LOGIN_BREAK_GLASS 破窗恢复 |
+| feat | prd-admin | 用户管理 SSO 接入弹窗新增禁用密码登录选项，登录页支持仅展示 SSO 入口 |

--- a/prd-admin/src/pages/LoginPage.tsx
+++ b/prd-admin/src/pages/LoginPage.tsx
@@ -88,6 +88,7 @@ export default function LoginPage() {
   const [error, setError] = useState<string | null>(null);
   const [ssoOptions, setSsoOptions] = useState<SsoLoginOption[]>([]);
   const [ssoLoading, setSsoLoading] = useState(false);
+  const [passwordLoginDisabled, setPasswordLoginDisabled] = useState(false);
 
   // 首次登录重置密码相关状态
   const [showResetPassword, setShowResetPassword] = useState(false);
@@ -115,9 +116,13 @@ export default function LoginPage() {
       .then((res) => {
         if (!alive) return;
         setSsoOptions(res.success ? res.data.items : []);
+        setPasswordLoginDisabled(res.success ? res.data.passwordLoginDisabled : false);
       })
       .catch(() => {
-        if (alive) setSsoOptions([]);
+        if (alive) {
+          setSsoOptions([]);
+          setPasswordLoginDisabled(false);
+        }
       });
     return () => {
       alive = false;
@@ -182,6 +187,10 @@ export default function LoginPage() {
 
   const onSubmit = async () => {
     if (!canSubmit || loading) return;
+    if (passwordLoginDisabled) {
+      setError('当前环境已禁用密码登录，请使用 SSO 登录');
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -324,6 +333,7 @@ export default function LoginPage() {
               rememberUsername={rememberUsername}
               ssoOptions={ssoOptions}
               ssoLoading={ssoLoading}
+              passwordLoginDisabled={passwordLoginDisabled}
               returnUrl={returnUrl}
               onError={setError}
               onUsernameChange={setUsername}
@@ -693,6 +703,7 @@ interface LoginCardProps {
   rememberUsername: boolean;
   ssoOptions: SsoLoginOption[];
   ssoLoading: boolean;
+  passwordLoginDisabled: boolean;
   returnUrl: string;
   onError: (message: string) => void;
   onUsernameChange: (v: string) => void;
@@ -710,6 +721,7 @@ function LoginCard({
   rememberUsername,
   ssoOptions,
   ssoLoading,
+  passwordLoginDisabled,
   returnUrl,
   onError,
   onUsernameChange,
@@ -799,97 +811,101 @@ function LoginCard({
           className="mt-3 text-[14px] text-white/62 leading-relaxed"
           style={{ fontFamily: 'var(--font-body)' }}
         >
-          使用管理员账号登录以进入控制台。
+          {passwordLoginDisabled ? '当前环境仅允许 SSO 登录。' : '使用管理员账号登录以进入控制台。'}
         </p>
       </Reveal>
 
       {/* Form */}
       <div className="mt-7 grid gap-4">
-        <Reveal delay={240}>
-          <Field
-            label="USERNAME"
-            value={username}
-            onChange={onUsernameChange}
-            placeholder="admin"
-            autoComplete="username"
-            Icon={UserIcon}
-          />
-        </Reveal>
-
-        <Reveal delay={300}>
-          <label className="block">
-            <span
-              className="mb-2 flex items-center justify-between text-[11px] uppercase text-white/55"
-              style={{ fontFamily: 'var(--font-terminal)', letterSpacing: '0.2em' }}
-            >
-              <span>PASSWORD</span>
-              {capsLockOn && (
-                <span
-                  className="normal-case tracking-normal text-[11px] text-amber-300/90"
-                  style={{ letterSpacing: 0 }}
-                >
-                  大写锁定已开启
-                </span>
-              )}
-            </span>
-            <div
-              className="relative flex items-center rounded-xl transition-colors focus-within:border-white/35"
-              style={{
-                background: 'rgba(10, 14, 22, 0.62)',
-                border: '1px solid rgba(255, 255, 255, 0.12)',
-                backdropFilter: 'blur(10px)',
-                WebkitBackdropFilter: 'blur(10px)',
-              }}
-            >
-              <span className="pl-4 pr-1 text-white/45">
-                <Lock className="w-4 h-4" />
-              </span>
-              <input
-                value={password}
-                onChange={(e) => onPasswordChange(e.target.value)}
-                onKeyDown={(e) => {
-                  if (typeof e.getModifierState === 'function') {
-                    setCapsLockOn(e.getModifierState('CapsLock'));
-                  }
-                  if (e.key === 'Enter') onSubmit();
-                }}
-                onKeyUp={(e) => {
-                  if (typeof e.getModifierState === 'function') {
-                    setCapsLockOn(e.getModifierState('CapsLock'));
-                  }
-                }}
-                onBlur={() => setCapsLockOn(false)}
-                type={showPassword ? 'text' : 'password'}
-                placeholder="••••••••"
-                autoComplete="current-password"
-                className="h-12 w-full bg-transparent px-4 text-[14.5px] text-white placeholder-white/30 outline-none"
-                style={{ fontFamily: 'var(--font-body)' }}
+        {!passwordLoginDisabled && (
+          <>
+            <Reveal delay={240}>
+              <Field
+                label="USERNAME"
+                value={username}
+                onChange={onUsernameChange}
+                placeholder="admin"
+                autoComplete="username"
+                Icon={UserIcon}
               />
-              <button
-                type="button"
-                onClick={() => setShowPassword((v) => !v)}
-                tabIndex={-1}
-                aria-label={showPassword ? '隐藏密码' : '显示密码'}
-                title={showPassword ? '隐藏密码' : '显示密码'}
-                className="mr-2 flex h-9 w-9 items-center justify-center rounded-lg text-white/55 hover:text-white/85 hover:bg-white/5 transition-colors"
-              >
-                {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
-              </button>
-            </div>
-          </label>
-        </Reveal>
+            </Reveal>
 
-        <Reveal delay={340}>
-          <label className="flex items-center gap-2 cursor-pointer select-none text-[12.5px] text-white/65 hover:text-white/85 transition-colors">
-            <input
-              type="checkbox"
-              checked={rememberUsername}
-              onChange={(e) => onRememberChange(e.target.checked)}
-              className="h-3.5 w-3.5 cursor-pointer accent-white/85"
-            />
-            <span style={{ fontFamily: 'var(--font-body)' }}>记住用户名</span>
-          </label>
-        </Reveal>
+            <Reveal delay={300}>
+              <label className="block">
+                <span
+                  className="mb-2 flex items-center justify-between text-[11px] uppercase text-white/55"
+                  style={{ fontFamily: 'var(--font-terminal)', letterSpacing: '0.2em' }}
+                >
+                  <span>PASSWORD</span>
+                  {capsLockOn && (
+                    <span
+                      className="normal-case tracking-normal text-[11px] text-amber-300/90"
+                      style={{ letterSpacing: 0 }}
+                    >
+                      大写锁定已开启
+                    </span>
+                  )}
+                </span>
+                <div
+                  className="relative flex items-center rounded-xl transition-colors focus-within:border-white/35"
+                  style={{
+                    background: 'rgba(10, 14, 22, 0.62)',
+                    border: '1px solid rgba(255, 255, 255, 0.12)',
+                    backdropFilter: 'blur(10px)',
+                    WebkitBackdropFilter: 'blur(10px)',
+                  }}
+                >
+                  <span className="pl-4 pr-1 text-white/45">
+                    <Lock className="w-4 h-4" />
+                  </span>
+                  <input
+                    value={password}
+                    onChange={(e) => onPasswordChange(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (typeof e.getModifierState === 'function') {
+                        setCapsLockOn(e.getModifierState('CapsLock'));
+                      }
+                      if (e.key === 'Enter') onSubmit();
+                    }}
+                    onKeyUp={(e) => {
+                      if (typeof e.getModifierState === 'function') {
+                        setCapsLockOn(e.getModifierState('CapsLock'));
+                      }
+                    }}
+                    onBlur={() => setCapsLockOn(false)}
+                    type={showPassword ? 'text' : 'password'}
+                    placeholder="••••••••"
+                    autoComplete="current-password"
+                    className="h-12 w-full bg-transparent px-4 text-[14.5px] text-white placeholder-white/30 outline-none"
+                    style={{ fontFamily: 'var(--font-body)' }}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword((v) => !v)}
+                    tabIndex={-1}
+                    aria-label={showPassword ? '隐藏密码' : '显示密码'}
+                    title={showPassword ? '隐藏密码' : '显示密码'}
+                    className="mr-2 flex h-9 w-9 items-center justify-center rounded-lg text-white/55 hover:text-white/85 hover:bg-white/5 transition-colors"
+                  >
+                    {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                  </button>
+                </div>
+              </label>
+            </Reveal>
+
+            <Reveal delay={340}>
+              <label className="flex items-center gap-2 cursor-pointer select-none text-[12.5px] text-white/65 hover:text-white/85 transition-colors">
+                <input
+                  type="checkbox"
+                  checked={rememberUsername}
+                  onChange={(e) => onRememberChange(e.target.checked)}
+                  className="h-3.5 w-3.5 cursor-pointer accent-white/85"
+                />
+                <span style={{ fontFamily: 'var(--font-body)' }}>记住用户名</span>
+              </label>
+            </Reveal>
+          </>
+        )}
 
         {error && (
           <Reveal delay={0}>
@@ -897,13 +913,15 @@ function LoginCard({
           </Reveal>
         )}
 
-        <Reveal delay={360}>
-          <div className="mt-2">
-            <PrimaryPill onClick={onSubmit} disabled={!canSubmit || loading} loading={loading}>
-              {loading ? '登录中…' : '进入控制台'}
-            </PrimaryPill>
-          </div>
-        </Reveal>
+        {!passwordLoginDisabled && (
+          <Reveal delay={360}>
+            <div className="mt-2">
+              <PrimaryPill onClick={onSubmit} disabled={!canSubmit || loading} loading={loading}>
+                {loading ? '登录中…' : '进入控制台'}
+              </PrimaryPill>
+            </div>
+          </Reveal>
+        )}
 
         {ssoOptions.length > 0 && (
           <Reveal delay={400}>
@@ -937,15 +955,23 @@ function LoginCard({
           </Reveal>
         )}
 
-        <Reveal delay={ssoOptions.length > 0 ? 480 : 440}>
-          <div
-            className="mt-1 inline-flex items-center gap-2 text-[11.5px] text-white/45"
-            style={{ fontFamily: 'var(--font-terminal)', letterSpacing: '0.1em' }}
-          >
-            <Terminal className="w-3 h-3" />
-            <span>DEFAULT · admin / admin · 首次登录后请修改密码</span>
-          </div>
-        </Reveal>
+        {passwordLoginDisabled && ssoOptions.length === 0 && (
+          <Reveal delay={420}>
+            <ErrorBar>当前已禁用密码登录，但没有可用 SSO。请配置 MAP_PASSWORD_LOGIN_BREAK_GLASS=true 后重启服务。</ErrorBar>
+          </Reveal>
+        )}
+
+        {!passwordLoginDisabled && (
+          <Reveal delay={ssoOptions.length > 0 ? 480 : 440}>
+            <div
+              className="mt-1 inline-flex items-center gap-2 text-[11.5px] text-white/45"
+              style={{ fontFamily: 'var(--font-terminal)', letterSpacing: '0.1em' }}
+            >
+              <Terminal className="w-3 h-3" />
+              <span>DEFAULT · admin / admin · 首次登录后请修改密码</span>
+            </div>
+          </Reveal>
+        )}
       </div>
     </GlassCard>
   );

--- a/prd-admin/src/pages/UsersPage.tsx
+++ b/prd-admin/src/pages/UsersPage.tsx
@@ -117,6 +117,8 @@ export default function UsersPage() {
   const [miduoHasSecret, setMiduoHasSecret] = useState(false);
   const [miduoRedirectUri, setMiduoRedirectUri] = useState('');
   const [miduoLabel, setMiduoLabel] = useState('米多星球');
+  const [passwordLoginDisabled, setPasswordLoginDisabled] = useState(false);
+  const [passwordLoginBreakGlassEnabled, setPasswordLoginBreakGlassEnabled] = useState(false);
   const [miduoConfigError, setMiduoConfigError] = useState<string | null>(null);
   const [miduoHandoffText, setMiduoHandoffText] = useState('');
 
@@ -242,6 +244,8 @@ export default function UsersPage() {
       setMiduoHasSecret(res.data.hasAppSecret);
       setMiduoRedirectUri(res.data.redirectUri || '');
       setMiduoLabel(res.data.label || '米多星球');
+      setPasswordLoginDisabled(res.data.passwordLoginDisabled);
+      setPasswordLoginBreakGlassEnabled(Boolean(res.data.passwordLoginBreakGlassEnabled));
     } finally {
       if (seq === miduoConfigLoadSeqRef.current) setMiduoConfigLoading(false);
     }
@@ -313,6 +317,7 @@ export default function UsersPage() {
         redirectUri: miduoRedirectUri.trim(),
         label: miduoLabel.trim() || '米多星球',
         subjectType: 'mobile',
+        passwordLoginDisabled,
         hasAppSecret: miduoHasSecret,
       });
       if (!res.success) {
@@ -320,6 +325,8 @@ export default function UsersPage() {
         return;
       }
       setMiduoHasSecret(res.data.hasAppSecret);
+      setPasswordLoginDisabled(res.data.passwordLoginDisabled);
+      setPasswordLoginBreakGlassEnabled(Boolean(res.data.passwordLoginBreakGlassEnabled));
       setMiduoAppSecret('');
       setMiduoConfigOpen(false);
       toast.success('米多星球 SSO 配置已保存');
@@ -1708,6 +1715,25 @@ export default function UsersPage() {
                   />
                   启用登录页米多星球 SSO
                 </label>
+                <label className="flex items-start gap-2 text-sm" style={{ color: 'var(--text-primary)' }}>
+                  <input
+                    type="checkbox"
+                    checked={passwordLoginDisabled}
+                    onChange={(e) => setPasswordLoginDisabled(e.target.checked)}
+                    className="mt-1 accent-[var(--accent-gold)]"
+                  />
+                  <span>
+                    <span className="block">禁用密码登录，仅允许 SSO</span>
+                    <span className="mt-0.5 block text-[12px]" style={{ color: 'var(--text-muted)' }}>
+                      保存后登录页会隐藏账号密码入口；需要破窗恢复时，在服务端设置 MAP_PASSWORD_LOGIN_BREAK_GLASS=true 并重启。
+                    </span>
+                  </span>
+                </label>
+                {passwordLoginBreakGlassEnabled && (
+                  <div className="rounded-[10px] px-3 py-2 text-[12px]" style={{ background: 'rgba(245,158,11,0.10)', border: '1px solid rgba(245,158,11,0.28)', color: 'rgba(252,211,77,0.95)' }}>
+                    当前已启用破窗环境变量，密码登录入口会临时显示。
+                  </div>
+                )}
                 <div className="grid grid-cols-2 gap-3">
                   <div>
                     <div className="text-sm font-semibold" style={{ color: 'var(--text-secondary)' }}>Base URL</div>

--- a/prd-admin/src/services/contracts/adminUsers.ts
+++ b/prd-admin/src/services/contracts/adminUsers.ts
@@ -126,6 +126,8 @@ export type MiduoSsoConfig = {
   redirectUri: string;
   label: string;
   subjectType: 'mobile' | 'wework_userid' | 'employeeNo';
+  passwordLoginDisabled: boolean;
+  passwordLoginBreakGlassEnabled?: boolean;
 };
 
 export type UpdateMiduoSsoConfigInput = MiduoSsoConfig & {

--- a/prd-admin/src/services/contracts/auth.ts
+++ b/prd-admin/src/services/contracts/auth.ts
@@ -31,6 +31,7 @@ export type SsoLoginOption = {
 
 export type SsoOptionsResponse = {
   items: SsoLoginOption[];
+  passwordLoginDisabled: boolean;
 };
 
 export type GetSsoOptionsContract = () => Promise<ApiResponse<SsoOptionsResponse>>;

--- a/prd-admin/src/services/real/adminUsers.ts
+++ b/prd-admin/src/services/real/adminUsers.ts
@@ -227,6 +227,7 @@ export const updateMiduoSsoConfigReal: UpdateMiduoSsoConfigContract = async (inp
       redirectUri: input.redirectUri,
       label: input.label,
       subjectType: input.subjectType,
+      passwordLoginDisabled: input.passwordLoginDisabled,
     },
   });
 };

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/UsersController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/UsersController.cs
@@ -1361,7 +1361,11 @@ public class UsersController : ControllerBase
             HasAppSecret = !string.IsNullOrWhiteSpace(settings?.MiduoSsoAppSecret),
             RedirectUri = settings?.MiduoSsoRedirectUri ?? string.Empty,
             Label = settings?.MiduoSsoLabel ?? "米多星球",
-            SubjectType = NormalizeMiduoSubjectType(settings?.MiduoSsoSubjectType)
+            SubjectType = NormalizeMiduoSubjectType(settings?.MiduoSsoSubjectType),
+            PasswordLoginDisabled = settings?.PasswordLoginDisabled == true,
+            PasswordLoginBreakGlassEnabled = IsTruthy(_cfg["MAP_PASSWORD_LOGIN_BREAK_GLASS"])
+                || IsTruthy(_cfg["PASSWORD_LOGIN_BREAK_GLASS"])
+                || IsTruthy(_cfg["MIDUO_SSO_PASSWORD_LOGIN_BREAK_GLASS"])
         };
         return Ok(ApiResponse<MiduoSsoConfigResponse>.Ok(response));
     }
@@ -1386,6 +1390,10 @@ public class UsersController : ControllerBase
             if (string.IsNullOrWhiteSpace(redirectUri))
                 return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "回调地址必须是有效的 http(s) 地址"));
         }
+        if (request.PasswordLoginDisabled && !request.Enabled)
+        {
+            return BadRequest(ApiResponse<object>.Fail(ErrorCodes.INVALID_FORMAT, "禁用密码登录前必须先启用 SSO"));
+        }
 
         var existing = await _db.AppSettings.Find(x => x.Id == "global").FirstOrDefaultAsync(ct);
         var secretToSave = !string.IsNullOrWhiteSpace(appSecret)
@@ -1402,6 +1410,7 @@ public class UsersController : ControllerBase
             .Set(x => x.MiduoSsoRedirectUri, redirectUri ?? string.Empty)
             .Set(x => x.MiduoSsoLabel, label)
             .Set(x => x.MiduoSsoSubjectType, subjectType)
+            .Set(x => x.PasswordLoginDisabled, request.PasswordLoginDisabled)
             .Set(x => x.UpdatedAt, DateTime.UtcNow)
             .SetOnInsert(x => x.Id, "global");
 
@@ -1614,6 +1623,8 @@ public class MiduoSsoConfigResponse
     public string RedirectUri { get; set; } = string.Empty;
     public string Label { get; set; } = string.Empty;
     public string SubjectType { get; set; } = "mobile";
+    public bool PasswordLoginDisabled { get; set; }
+    public bool PasswordLoginBreakGlassEnabled { get; set; }
 }
 
 public class UpdateMiduoSsoConfigRequest
@@ -1625,6 +1636,7 @@ public class UpdateMiduoSsoConfigRequest
     public string? RedirectUri { get; set; }
     public string? Label { get; set; }
     public string? SubjectType { get; set; }
+    public bool PasswordLoginDisabled { get; set; }
 }
 
 public class ImportMiduoSsoBindingsRequest

--- a/prd-api/src/PrdAgent.Api/Controllers/AuthController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/AuthController.cs
@@ -7,6 +7,8 @@ using PrdAgent.Api.Services;
 using PrdAgent.Core.Interfaces;
 using PrdAgent.Core.Models;
 using PrdAgent.Core.Services;
+using PrdAgent.Infrastructure.Database;
+using MongoDB.Driver;
 
 namespace PrdAgent.Api.Controllers;
 
@@ -21,6 +23,7 @@ public class AuthController : ControllerBase
     private readonly IJwtService _jwtService;
     private readonly ILoginAttemptService _loginAttemptService;
     private readonly IAuthSessionService _authSessionService;
+    private readonly MongoDbContext _db;
     private readonly IConfiguration _cfg;
     private readonly ILogger<AuthController> _logger;
 
@@ -29,6 +32,7 @@ public class AuthController : ControllerBase
         IJwtService jwtService,
         ILoginAttemptService loginAttemptService,
         IAuthSessionService authSessionService,
+        MongoDbContext db,
         IConfiguration cfg,
         ILogger<AuthController> logger)
     {
@@ -36,6 +40,7 @@ public class AuthController : ControllerBase
         _jwtService = jwtService;
         _loginAttemptService = loginAttemptService;
         _authSessionService = authSessionService;
+        _db = db;
         _cfg = cfg;
         _logger = logger;
     }
@@ -60,6 +65,28 @@ public class AuthController : ControllerBase
         var p = GetRootPassword();
         return string.Equals(u, (username ?? string.Empty).Trim(), StringComparison.Ordinal)
                && string.Equals(p, (password ?? string.Empty).Trim(), StringComparison.Ordinal);
+    }
+
+    private static bool IsTruthy(string? value)
+    {
+        return string.Equals(value, "1", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(value, "true", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(value, "yes", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(value, "on", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private bool IsPasswordLoginBreakGlassEnabled()
+    {
+        return IsTruthy(_cfg["MAP_PASSWORD_LOGIN_BREAK_GLASS"])
+            || IsTruthy(_cfg["PASSWORD_LOGIN_BREAK_GLASS"])
+            || IsTruthy(_cfg["MIDUO_SSO_PASSWORD_LOGIN_BREAK_GLASS"]);
+    }
+
+    private async Task<bool> IsPasswordLoginDisabledAsync(CancellationToken ct)
+    {
+        if (IsPasswordLoginBreakGlassEnabled()) return false;
+        var settings = await _db.AppSettings.Find(x => x.Id == "global").FirstOrDefaultAsync(ct);
+        return settings?.PasswordLoginDisabled == true;
     }
 
     /// <summary>
@@ -191,6 +218,12 @@ public class AuthController : ControllerBase
 
             _logger.LogWarning("ROOT login used (clientType=admin)");
             return Ok(ApiResponse<LoginResponse>.Ok(responseRoot));
+        }
+
+        if (ct == "admin" && await IsPasswordLoginDisabledAsync(HttpContext.RequestAborted))
+        {
+            return StatusCode(StatusCodes.Status403Forbidden,
+                ApiResponse<object>.Fail("PASSWORD_LOGIN_DISABLED", "当前环境已禁用密码登录，请使用 SSO 登录"));
         }
 
         var user = await _userService.ValidateCredentialsAsync(request.Username, request.Password);

--- a/prd-api/src/PrdAgent.Api/Controllers/MiduoPlanetSsoController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/MiduoPlanetSsoController.cs
@@ -61,7 +61,11 @@ public class MiduoPlanetSsoController : ControllerBase
             }
             : new List<SsoLoginOption>();
 
-        return Ok(ApiResponse<SsoOptionsResponse>.Ok(new SsoOptionsResponse { Items = items }));
+        return Ok(ApiResponse<SsoOptionsResponse>.Ok(new SsoOptionsResponse
+        {
+            Items = items,
+            PasswordLoginDisabled = options.PasswordLoginDisabled
+        }));
     }
 
     [HttpPost("login")]
@@ -160,6 +164,8 @@ public class MiduoPlanetSsoController : ControllerBase
         var settings = await _db.AppSettings.Find(x => x.Id == "global").FirstOrDefaultAsync(ct);
         var enabledFromConfig = IsTruthy(FirstConfig("MiduoSso:Enabled", "MIDUO_SSO_ENABLED", "MiduoPlanetSso:Enabled", "MIDUO_PLANET_SSO_ENABLED"));
         var enabled = settings?.MiduoSsoEnabled ?? enabledFromConfig;
+        var passwordLoginDisabled = settings?.PasswordLoginDisabled == true
+            && !IsTruthy(FirstConfig("MAP_PASSWORD_LOGIN_BREAK_GLASS", "PASSWORD_LOGIN_BREAK_GLASS", "MIDUO_SSO_PASSWORD_LOGIN_BREAK_GLASS"));
 
         var baseUrl = NormalizeAbsoluteHttpUrl(FirstNonEmpty(settings?.MiduoSsoBaseUrl, FirstConfig("MiduoSso:BaseUrl", "MIDUO_SSO_BASE_URL", "MiduoPlanetSso:BaseUrl", "MIDUO_PLANET_SSO_BASE_URL")), trimTrailingSlash: true);
         var appCode = FirstNonEmpty(settings?.MiduoSsoAppCode, FirstConfig("MiduoSso:AppCode", "MIDUO_SSO_APP_CODE", "MiduoPlanetSso:AppCode", "MIDUO_PLANET_SSO_APP_CODE"));
@@ -181,7 +187,8 @@ public class MiduoPlanetSsoController : ControllerBase
             AppCode = appCode ?? string.Empty,
             AppSecret = appSecret ?? string.Empty,
             RedirectUri = redirectUri ?? string.Empty,
-            SubjectType = NormalizeSubjectType(FirstNonEmpty(settings?.MiduoSsoSubjectType, FirstConfig("MiduoSso:SubjectType", "MIDUO_SSO_SUBJECT_TYPE", "MiduoPlanetSso:SubjectType", "MIDUO_PLANET_SSO_SUBJECT_TYPE")))
+            SubjectType = NormalizeSubjectType(FirstNonEmpty(settings?.MiduoSsoSubjectType, FirstConfig("MiduoSso:SubjectType", "MIDUO_SSO_SUBJECT_TYPE", "MiduoPlanetSso:SubjectType", "MIDUO_PLANET_SSO_SUBJECT_TYPE"))),
+            PasswordLoginDisabled = passwordLoginDisabled
         };
     }
 
@@ -348,6 +355,7 @@ public class MiduoPlanetSsoController : ControllerBase
         public string AppSecret { get; set; } = string.Empty;
         public string RedirectUri { get; set; } = string.Empty;
         public string SubjectType { get; set; } = "mobile";
+        public bool PasswordLoginDisabled { get; set; }
     }
 
     private sealed class MiduoPlanetProfile
@@ -360,6 +368,7 @@ public class MiduoPlanetSsoController : ControllerBase
 public class SsoOptionsResponse
 {
     public List<SsoLoginOption> Items { get; set; } = new();
+    public bool PasswordLoginDisabled { get; set; }
 }
 
 public class SsoLoginOption

--- a/prd-api/src/PrdAgent.Core/Models/AppSettings.cs
+++ b/prd-api/src/PrdAgent.Core/Models/AppSettings.cs
@@ -93,5 +93,8 @@ public class AppSettings
     /// <summary>绑定字段类型，默认 mobile</summary>
     public string? MiduoSsoSubjectType { get; set; }
 
+    /// <summary>是否禁用管理后台密码登录，仅保留 SSO/破窗入口</summary>
+    public bool? PasswordLoginDisabled { get; set; }
+
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 }


### PR DESCRIPTION
## 摘要
新增“禁用密码登录”能力：管理员可在用户配置中控制密码登录入口，SSO 登录保留独立可用路径；后端登录接口同步校验用户和系统配置，避免被禁用后仍可通过密码登录。

## 改动 diff
- `prd-admin/src/pages/LoginPage.tsx`：登录页支持根据 SSO/密码登录配置展示入口，并处理密码登录禁用态。
- `prd-admin/src/pages/UsersPage.tsx`：用户管理增加禁用密码登录配置展示与编辑。
- `prd-admin/src/services/contracts/*.ts`、`prd-admin/src/services/real/adminUsers.ts`：补齐前端服务契约字段。
- `prd-api/src/PrdAgent.Api/Controllers/AuthController.cs`：密码登录时校验禁用配置。
- `prd-api/src/PrdAgent.Api/Controllers/Api/UsersController.cs`、`MiduoPlanetSsoController.cs`：补齐管理员配置与 SSO 登录边界。
- `prd-api/src/PrdAgent.Core/Models/AppSettings.cs`：新增密码登录禁用相关配置字段。
- `changelogs/2026-06-30_sso-password-login-disable.md`：新增 changelog 碎片。

## 测试
- [x] `prd-admin`: `pnpm tsc --noEmit` 通过
- [x] `prd-admin`: `pnpm lint` 通过，存在仓库既有 warning，无 error
- [ ] `prd-api`: 本机只有 .NET 9，项目目标 `net8.0`；`dotnet build --no-restore` 与单项目 build 均无输出悬挂，已中止
- [ ] CDS 远端部署未完成：失败原因为 Docker 网络地址池耗尽 `all predefined address pools have been fully subnetted`，不是代码编译错误

## 注意
本 PR 是 draft，等待后端编译环境或 CDS 网络池恢复后再完成后端验证。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication entry points for the admin console; misconfiguration could lock out operators unless SSO or break-glass/ROOT paths work.
> 
> **Overview**
> Adds a **global “disable password login”** switch stored on SSO/app settings, so the admin console can enforce SSO-only sign-in while keeping a server-side escape hatch.
> 
> **Admin (Users → SSO 接入):** New checkbox to turn off password login (requires SSO enabled first). The UI surfaces when **break-glass** env vars (`MAP_PASSWORD_LOGIN_BREAK_GLASS` and aliases) are active so operators know password fields may reappear after restart.
> 
> **Login page:** Reads `passwordLoginDisabled` from SSO options; hides username/password/submit when set, blocks client-side submit, keeps SSO buttons, and shows guidance if password is off but no SSO is configured.
> 
> **API:** Persists `PasswordLoginDisabled` on `AppSettings`; admin miduo SSO GET/PUT expose the flag plus break-glass status. SSO options endpoint returns `passwordLoginDisabled` for the login UI. **Admin client-type password login** returns **403** `PASSWORD_LOGIN_DISABLED` when disabled (after existing ROOT credential path). Break-glass env vars override the stored setting for both API enforcement and what the UI reports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b805ee5814330250ddd55a1eaa9683f17deac4ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->