### PR TITLE
fix(cds): 分支详情抽屉补齐网关多出口（主应用入口 + 网关入口并列）

### DIFF
--- a/cds/web/src/components/BranchDetailDrawer.tsx
+++ b/cds/web/src/components/BranchDetailDrawer.tsx
@@ -184,6 +184,13 @@ interface DrawerActivityEvent {
   errorSummary?: string;
 }
 
+// GET /api/branches/:id/subdomain-aliases → gatewayUrls[]（声明了 cds.subdomain 的服务的命名入口）。
+interface GatewayUrlEntry {
+  subdomain: string;
+  name: string;
+  url: string;
+}
+
 // 2026-05-18: 分支生命周期系统日志（部署 / 停止 / 崩溃 / 重启 / 回收）。
 // 后端 GET /api/branches/:id/activity-logs 返回，已按最新在前排序。
 interface BranchActivityLog {
@@ -783,6 +790,9 @@ export function BranchDetailDrawer({
   branchStatus?: string;
 }): JSX.Element | null {
   const [branch, setBranch] = useState<BranchDetailData | null>(null);
+  // 网关入口（声明了 cds.subdomain 的服务，如 LLM 网关 console/serving 获得独立命名域名）。
+  // 与主应用入口并列展示，让「多出口」在这个抽屉里可见（用户点名的「右侧面板显示两个入口和名字」）。
+  const [gatewayUrls, setGatewayUrls] = useState<GatewayUrlEntry[]>([]);
   const [logs, setLogs] = useState<OperationLog[]>([]);
   const [loading, setLoading] = useState(false);
   const [headerRefreshing, setHeaderRefreshing] = useState(false);
@@ -864,7 +874,7 @@ export function BranchDetailDrawer({
     try {
       // The backend exposes /api/branches?project=<id> (list) but no
       // single-branch endpoint, mirroring how BranchDetailPage loads.
-      const [branchesRes, logsRes, profilesRes, infraRes, resourcesRes] = await Promise.all([
+      const [branchesRes, logsRes, profilesRes, infraRes, resourcesRes, aliasesRes] = await Promise.all([
         apiRequest<{ branches: BranchDetailData[] }>(`/api/branches?project=${encodeURIComponent(projectId)}&live=false`),
         apiRequest<{ logs: OperationLog[] }>(`/api/branches/${encodeURIComponent(branchId)}/logs`).catch(() => ({ logs: [] })),
         apiRequest<{ profiles: ProfileRow[] }>(`/api/branches/${encodeURIComponent(branchId)}/profile-overrides`)
@@ -876,6 +886,8 @@ export function BranchDetailDrawer({
           .catch(() => ({ services: [] })),
         apiRequest<{ resources: BranchResource[] }>(`/api/branches/${encodeURIComponent(branchId)}/resources?live=false`)
           .catch(() => ({ resources: [] })),
+        apiRequest<{ gatewayUrls?: GatewayUrlEntry[] }>(`/api/branches/${encodeURIComponent(branchId)}/subdomain-aliases`)
+          .catch(() => ({ gatewayUrls: [] as GatewayUrlEntry[] })),
       ]);
       const found = (branchesRes.branches || []).find((b) => b.id === branchId);
       if (!found) {
@@ -888,6 +900,7 @@ export function BranchDetailDrawer({
       setProfileState({ status: 'ok', profiles: profilesRes.profiles || [] });
       setInfraServices(infraRes.services || []);
       setResourceSnapshot(resourcesRes.resources || found?.resources || []);
+      setGatewayUrls(aliasesRes.gatewayUrls || []);
     } catch (err) {
       setError(err instanceof ApiError ? err.message : String(err));
     } finally {
@@ -1744,19 +1757,47 @@ export function BranchDetailDrawer({
             <>
               {branch.status === 'running' && branch.previewUrl ? (
                 <div className="mx-5 mt-4 flex flex-col gap-2 rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
-                  <div className="min-w-0">
+                  <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-1.5 text-sm font-semibold text-emerald-600 dark:text-emerald-400">
                       <Rocket className="h-4 w-4" />
                       应用已上线
+                    </div>
+                    {/* 主应用入口 + 网关入口:声明了 cds.subdomain 的服务(如 LLM 网关 console/serving)
+                        获得独立命名域名,与主应用入口并列展示,让「多出口」在抽屉里一眼可见。 */}
+                    <div className="mt-0.5 text-[11px] font-medium uppercase tracking-wide text-emerald-700/70 dark:text-emerald-300/70">
+                      主应用入口
                     </div>
                     <a
                       href={branch.previewUrl}
                       target="_blank"
                       rel="noreferrer"
-                      className="mt-0.5 block min-w-0 truncate font-mono text-xs text-emerald-700/90 hover:underline dark:text-emerald-300"
+                      className="block min-w-0 truncate font-mono text-xs text-emerald-700/90 hover:underline dark:text-emerald-300"
                     >
                       {branch.previewUrl}
                     </a>
+                    {gatewayUrls.length > 0 ? (
+                      <div className="mt-2 border-t border-emerald-500/20 pt-2">
+                        <div className="text-[11px] font-medium uppercase tracking-wide text-emerald-700/70 dark:text-emerald-300/70">
+                          网关入口
+                        </div>
+                        <div className="mt-0.5 flex flex-col gap-1">
+                          {gatewayUrls.map((gw) => (
+                            <div key={gw.subdomain} className="flex min-w-0 items-baseline gap-2">
+                              <span className="shrink-0 font-mono text-[11px] text-emerald-700/70 dark:text-emerald-300/70">{gw.subdomain}</span>
+                              <a
+                                href={gw.url}
+                                target="_blank"
+                                rel="noreferrer"
+                                title={`打开 ${gw.name} 网关入口`}
+                                className="block min-w-0 truncate font-mono text-xs text-emerald-700/90 hover:underline dark:text-emerald-300"
+                              >
+                                {gw.url}
+                              </a>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    ) : null}
                   </div>
                   <Button asChild size="sm" className="shrink-0 bg-emerald-600 text-white hover:bg-emerald-700">
                     <a href={branch.previewUrl} target="_blank" rel="noreferrer">

--- a/changelogs/2026-07-01_cds-drawer-gateway-entrances.md
+++ b/changelogs/2026-07-01_cds-drawer-gateway-entrances.md
@@ -1,0 +1,1 @@
+| fix | cds | 分支详情抽屉(BranchDetailDrawer,即从分支列表点开的右侧滑入面板)补齐网关多出口:fetch /subdomain-aliases 的 gatewayUrls,在「应用已上线」卡片里把主应用入口与网关入口(llmgw/llmgw-serve 命名域名)并列展示,不再只显示单个主 URL(此前多出口只落在 BranchDetailPage 全页视图,用户实际看的抽屉里看不到) |


### PR DESCRIPTION
## 摘要

PR #971 的多出口面板（`gatewayUrls`）只加进了 `BranchDetailPage`（全页视图），但用户从分支列表点开看的是 `BranchDetailDrawer`（右侧滑入抽屉），后者仍只显示单个主 `previewUrl`，导致「4 个容器都在跑、但面板只有一个预览地址」。本 PR 让抽屉也拉取 `gatewayUrls` 并把「主应用入口 + 网关入口」并列展示，多出口在用户实际看的面板里一眼可见。

## 改动 diff

- **CDS**
  - `cds/web/src/components/BranchDetailDrawer.tsx`：新增 `GatewayUrlEntry` 类型 + `gatewayUrls` state；`load()` 的 `Promise.all` 增加 `GET /api/branches/:id/subdomain-aliases` 拉取 `gatewayUrls`；「应用已上线」卡片改为「主应用入口」标签 + 主 URL，其下当 `gatewayUrls.length>0` 时并列「网关入口」列表（`llmgw` console / `llmgw-serve` serving 的命名域名 + 子域名标签 + 可点击链接）。
  - `changelogs/2026-07-01_cds-drawer-gateway-entrances.md`：碎片记录。

## 测试

- [x] `cd cds && pnpm tsc --noEmit`（后端）零错误
- [x] `cd cds/web && pnpm tsc --noEmit`（前端）零错误
- [x] 后端 `GET /api/branches/prd-agent-main/subdomain-aliases` 实测返回 2 条 `gatewayUrls`（llmgw / llmgw-serve），两个命名健康端点直连 HTTP 200（`main-prd-agent-llmgw.miduo.org/gw/healthz`、`main-prd-agent-llmgw-serve.miduo.org/gw/v1/healthz`）
- [ ] 真人在预览域名验收抽屉渲染：`https://cds.miduo.org/branch-panel?id=prd-agent-main`（从分支列表点开 main 的右侧抽屉，「应用已上线」卡片应显示 主应用入口 + 2 个网关入口）

## 风险与已知边界

- 纯前端只读展示，无数据写入 / 无破坏性。`gatewayUrls` 拉取失败时 `.catch` 回退空数组，抽屉退化为只显示主应用入口（与本 PR 前行为一致）。
- 仅当分支实际部署了声明 `cds.subdomain` 的服务（如 LLM 网关）且处于 running 时才出现网关入口；普通分支无变化。

## 后续事项

- 全量走网关的 S5/S6（翻 http + 删 inproc/legacy 直连）仍为独立后续，evidence-gated（canary + 影子比对），不在本 PR。

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZfu39CAkJevjwdZoMGHzu)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only UI wiring to an existing API; failed fetch degrades to single main URL with no write or auth changes.
> 
> **Overview**
> **BranchDetailDrawer** now loads **`gatewayUrls`** from **`GET /api/branches/:id/subdomain-aliases`** alongside existing branch data and shows them in the running **「应用已上线」** card.
> 
> The card labels the main **`previewUrl`** as **主应用入口** and, when gateways exist, adds a **网关入口** section listing each **`cds.subdomain`** service (subdomain label + clickable URL), matching the multi-entry panel already on **BranchDetailPage** so list-opened drawer users see all named exits, not only the primary preview link.
> 
> Fetch failures fall back to an empty **`gatewayUrls`** array (drawer behaves like before). Changelog entry added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4e023e638b77cbfaad03cc0dd00a53b4ba64ef6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->