### PR TITLE
feat(cds): 网关入口打开真实控制台 prd-llmgw-web（替换心跳落地）

### DIFF
--- a/cds-compose.yml
+++ b/cds-compose.yml
@@ -318,6 +318,35 @@ services:
       cds.subdomain: "llmgw-serve"
       cds.readiness-path: "/gw/v1/healthz"
 
+  # 独立 LLM 网关前端控制台 llmgw-web —— Vite React SPA（登录页 POST /gw/auth/login → JWT；
+  # LLM 日志页调 /gw/logs），容器内 nginx 监听 80：SPA 回退 index.html + /gw/* 反代到 llmgw:8090。
+  # 纯静态站点、只由 CI 预构建（.github/workflows/branch-image.yml 的 LLMGW_WEB_IMAGE），无源码热重载模式。
+  # 采用「标准形态的预构建 app service」：image + 标准 ports:["80"] + cds.prebuilt-image label，
+  # 让 compose-parser 的 isAppServiceCandidate 识别为可部署 app profile（CDS docker-PULL nginx 镜像、
+  # 非本机源码构建），命名子域 <previewSlug>-llmgw-web.<root> 正常发布。回退链走 base 级 fallbackImage
+  # （同 admin：branch-<slug> → branch-main），镜像 tag 公式 sha-${CDS_COMMIT_SHA} 与 branch-image.yml SSOT。
+  llmgw-web:
+    image: "ghcr.io/inernoro/prd_agent/prdagent-llmgw-web:sha-${CDS_COMMIT_SHA}"
+    # 容器内 nginx 监听 80（见 prd-llmgw-web/nginx.conf listen 80）。标准 ports 供 extractContainerPort 读取。
+    ports:
+      - "80"
+    # 本 commit 未构建 llmgw-web（CI 路径过滤只在 prd-llmgw-web/** 变更时构建）时按顺序回退：
+    #   ① 本分支该组件最近一次构建（branch-<slug>）② 退到固定主分支镜像（branch-main）
+    # 基础级 fallbackImage：无 express deployMode 的裸预构建站点也逐级回退（resolveEffectiveProfile 消费）。
+    fallbackImage:
+      - "ghcr.io/inernoro/prd_agent/prdagent-llmgw-web:branch-${CDS_BRANCH_SLUG}"
+      - "ghcr.io/inernoro/prd_agent/prdagent-llmgw-web:branch-main"
+    labels:
+      # 预构建镜像 app 站点标记：CDS docker-PULL 该 nginx 镜像启动，跳过源码 mount + 本机构建。
+      cds.prebuilt-image: "true"
+      # 公网命名 URL：<previewSlug>-llmgw-web.<root> 根路径直达控制台（登录后看 LLM 日志）。
+      # 浏览器同源，nginx 把 /gw/* 反代到 llmgw:8090，故 SPA 无需额外 VITE_LLMGW_API_BASE（编译期默认 /gw）。
+      cds.subdomain: "llmgw-web"
+      # SPA 站点无独立健康端点，根路径 nginx 返回 index.html 即视为就绪（与 admin 的 cds.readiness-path "/" 同）。
+      cds.readiness-path: "/"
+      # 首次拉取 nginx 镜像 + 容器起就绪窗口，给足 600s 兜底（避免慢拉镜像被误判 error）。
+      cds.readiness-timeout: "600"
+
   # ── Infrastructure Services (无相对路径 mount) ──
 
   mongodb:

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -268,9 +268,16 @@ function isSyntheticCdsManagedRuntimeBranch(
  */
 function resolveGatewayLandingPath(subdomain: string, readinessPath?: string): string {
   const sub = subdomain.toLowerCase();
-  // Serving engine (llmgw-serve): API under /gw/v1/*.
+  // Gateway console (llmgw-web): a standalone Vite SPA whose nginx falls back to
+  // index.html for any non-/gw/* path, so land on the console root — clicking it
+  // opens the real login → LLM logs UI, not a health JSON. This is the entry we
+  // want most prominent in the panel.
+  if (sub === 'llmgw-web') return '/';
+  // Serving engine (llmgw-serve): API-only, mounts under /gw/v1/* and 404s at the
+  // bare root, so land on its health endpoint.
   if (sub === 'llmgw-serve') return '/gw/v1/healthz';
-  // Console (llmgw): API under /gw/*.
+  // Backend/API engine (llmgw): API-only, mounts under /gw/* and 404s at the bare
+  // root, so land on its health endpoint.
   if (sub === 'llmgw') return '/gw/healthz';
   const trimmed = (readinessPath ?? '').trim();
   if (trimmed && trimmed.startsWith('/')) return trimmed;

--- a/cds/src/services/compose-parser.ts
+++ b/cds/src/services/compose-parser.ts
@@ -101,6 +101,13 @@ interface ComposeServiceEntry {
   command?: string | string[];
   /** docker compose 标准 `restart:` 重启策略(no/always/on-failure/unless-stopped) */
   restart?: string;
+  /**
+   * CDS extension: 预构建镜像 profile(cds.prebuilt-image label)的**基础级** fallbackImage
+   * 回退链(string | 有序数组)。挂在 base service 上,使裸站点(无 express deployMode、image-only)
+   * 也能在本 commit 的 sha 镜像缺失时逐级回退(branch-<slug> → branch-main)。语义/解析与
+   * DeployModeOverride.fallbackImage 完全一致,由 resolveEffectiveProfile → runService 消费。
+   */
+  fallbackImage?: string | string[];
   working_dir?: string;
   depends_on?: Record<string, { condition?: string }> | string[];
   labels?: Record<string, string> | string[];
@@ -204,6 +211,8 @@ export interface CdsComposeConfig {
     entrypoint?: string;
     /** Phase 7 B17 — 预构建镜像模式(对齐 BuildProfile.prebuiltImage) */
     prebuiltImage?: boolean;
+    /** 基础级镜像回退链(对齐 BuildProfile.fallbackImage);裸预构建站点用,无 express mode 也生效 */
+    fallbackImage?: string | string[];
   }>;
   envVars: Record<string, string>;
   /**
@@ -531,6 +540,9 @@ function parseStandardCompose(doc: ComposeFile): CdsComposeConfig {
           resources: parseResourceLimits(entry),
           ...(entrypoint !== undefined ? { entrypoint } : {}),
           ...(prebuiltImage ? { prebuiltImage: true } : {}),
+          // 基础级 fallbackImage(裸预构建站点):base service 上直接声明的回退链带到 profile,
+          // 使无 express deployMode 的站点(如 llmgw-web)也能逐级回退 sha → branch-<slug> → branch-main。
+          ...(entry.fallbackImage ? { fallbackImage: entry.fallbackImage } : {}),
           ...(subdomain ? { subdomain } : {}),
         });
       } else {
@@ -627,14 +639,24 @@ export function toCdsCompose(
       image: p.dockerImage,
     };
 
+    // 预构建镜像站点(prebuiltImage)无源码,不写 working_dir / 源码 volume mount ——
+    // 否则 round-trip 会给纯 image 站点合成假的 `.:/app` mount(re-parse 靠 volume 反被
+    // 归类为源码 app,虽仍是 app profile 但语义漂移)。prebuilt profile 靠 cds.prebuilt-image
+    // label + cds.subdomain 被 isAppServiceCandidate 识别,不需要源码 mount。
+    const isPrebuiltSite = p.prebuiltImage === true;
+
     // working_dir
     const containerWorkDir = p.containerWorkDir || '/app';
-    entry.working_dir = containerWorkDir;
+    if (!isPrebuiltSite) {
+      entry.working_dir = containerWorkDir;
+    }
 
-    // volumes: relative mount for source + cache mounts
+    // volumes: relative mount for source + cache mounts(prebuilt 站点跳过源码 mount)
     const volumes: string[] = [];
-    const workDir = p.workDir === '.' ? '.' : `./${p.workDir.replace(/^\.\//, '')}`;
-    volumes.push(`${workDir}:${containerWorkDir}`);
+    if (!isPrebuiltSite) {
+      const workDir = p.workDir === '.' ? '.' : `./${p.workDir.replace(/^\.\//, '')}`;
+      volumes.push(`${workDir}:${containerWorkDir}`);
+    }
     if (p.cacheMounts) {
       for (const cm of p.cacheMounts) {
         volumes.push(`${cm.hostPath}:${cm.containerPath}`);
@@ -644,10 +666,17 @@ export function toCdsCompose(
         }
       }
     }
-    entry.volumes = volumes;
+    if (volumes.length > 0) {
+      entry.volumes = volumes;
+    }
 
     // ports
     entry.ports = [`${p.containerPort}`];
+
+    // fallbackImage(基础级回退链)round-trip:裸预构建站点在 base service 上带回退链。
+    if (p.fallbackImage) {
+      entry.fallbackImage = p.fallbackImage;
+    }
 
     // command
     if (p.command) {
@@ -985,6 +1014,15 @@ function findRelativeMount(volumes?: string[]): { hostPath: string; containerPat
  */
 function isAppServiceCandidate(entry: ComposeServiceEntry): boolean {
   if (hasRelativeVolumeMount(entry.volumes)) return true;
+  // 预构建镜像站点(prd-llmgw-web 这类纯 nginx 前端):无源码 mount、无 build:,只有 image +
+  // cds.prebuilt-image label,由 CI 出镜像、CDS docker-PULL。若不识别为 app 会被丢弃(既非 app
+  // 也非 infra,无端口/无 build 直接 continue),命名子域永不发布。判定:image + 真值 prebuilt-image
+  // label + (cds.subdomain 或 cds.path-prefix) → 是一个有对外路由的预构建 app 站点。
+  const labels = extractLabels(entry.labels);
+  const prebuilt = labels['cds.prebuilt-image'];
+  const isPrebuilt = prebuilt === 'true' || prebuilt === '1';
+  const hasRoute = !!labels['cds.subdomain'] || !!labels['cds.path-prefix'];
+  if (entry.image && isPrebuilt && hasRoute) return true;
   if (!entry.build) return false;
   // Has build but ALSO has docker healthcheck → treat as custom infra
   const hasDockerHealthcheck = !!entry.healthcheck && (entry.healthcheck.test !== undefined);

--- a/cds/src/services/container.ts
+++ b/cds/src/services/container.ts
@@ -516,9 +516,14 @@ function parseFloatSafe(s: string): number {
  *   - 'mysql-mdimp'   + 'mysql'
  *   - 'web-2'         + 'web-2'(没有项目后缀,只有自己)
  *
- * 启发式去后缀:profile.id 形如 `<service>-<projectMarker>` 时,projectMarker
- * 通常包含项目 slug 的前几位或全部。我们安全的做法:**只**剥掉 `-<projectId-prefix>`
- * 或 `-<最后一个连字符段>` 当后者长度 ≤ 12,且不会产生空串。
+ * 去后缀两条路(结果并入同一 Set,profile.id 永远是第一个 alias):
+ *   1) 单段启发式(旧):剥掉最后一个连字符段,覆盖「后缀是 projectId/slug 前几位」
+ *      的模糊匹配(如 tail=`mdimp` vs marker=`mdimp`,或 tail 是 marker 前缀)。
+ *   2) 完整 marker 后缀剥离(新,2026-07):沿连字符边界切,若「切点之后 normalize
+ *      后 == 某个完整 normalizedMarker」,则切点之前的 head 就是裸 `<svc>`。这条
+ *      专治「项目 slug 自带连字符」(prd-agent):`llmgw-prd-agent → llmgw`、
+ *      `llmgw-serve-prd-agent → llmgw-serve`、`api-prd-agent → api`;head 本身
+ *      可含连字符也正确。marker 可能是 id 也可能是 slug(已 normalize),任一命中即可。
  *
  * 边界:
  *   - profile.id 不含 '-' → 只有自己一个 alias
@@ -559,6 +564,19 @@ export function computeProfileAliases(
         (m) => m.startsWith(tailNorm) || tailNorm === m.slice(0, tail.length),
       );
     if (looksLikeProjectMarker && head.length >= 2) {
+      aliases.add(head);
+    }
+  }
+
+  // 完整 marker 后缀剥离:沿连字符边界切,找到「切点之后 normalize 后恰好等于某个
+  // 完整 normalizedMarker」的切点,把切点之前的 head 作为裸 <svc> 加入。marker 自带
+  // 连字符(prd-agent)时,单段启发式够不到,靠这里补。head 可含连字符(llmgw-serve)。
+  const segments = profileId.split('-');
+  for (let cut = 1; cut < segments.length; cut++) {
+    const head = segments.slice(0, cut).join('-');
+    if (head.length < 2) continue;
+    const rest = segments.slice(cut).join('-').toLowerCase().replace(/[^a-z0-9]+/g, '');
+    if (rest.length > 0 && normalizedMarkers.includes(rest)) {
       aliases.add(head);
     }
   }

--- a/cds/tests/services/compose-parser.test.ts
+++ b/cds/tests/services/compose-parser.test.ts
@@ -452,6 +452,87 @@ services:
   });
 });
 
+describe('parseStandardCompose — 预构建镜像 app 站点(cds.prebuilt-image + subdomain)', () => {
+  it('纯 image + cds.prebuilt-image + cds.subdomain（无 volume/build）→ 解析为 app BuildProfile', () => {
+    const yaml = `
+services:
+  llmgw-web:
+    image: "ghcr.io/acme/app-web:sha-\${CDS_COMMIT_SHA}"
+    ports:
+      - "80"
+    fallbackImage:
+      - "ghcr.io/acme/app-web:branch-\${CDS_BRANCH_SLUG}"
+      - "ghcr.io/acme/app-web:branch-main"
+    labels:
+      cds.prebuilt-image: "true"
+      cds.subdomain: "llmgw-web"
+      cds.readiness-path: "/"
+      cds.readiness-timeout: "600"
+`;
+    const cfg = parseCdsCompose(yaml);
+    expect(cfg).not.toBeNull();
+    // 核心断言:llmgw-web 出现在 app buildProfiles(此前被 isAppServiceCandidate 丢弃)。
+    const bp = cfg!.buildProfiles.find((p) => p.id === 'llmgw-web');
+    expect(bp).toBeDefined();
+    expect(bp!.subdomain).toBe('llmgw-web');
+    expect(bp!.prebuiltImage).toBe(true);
+    expect(bp!.containerPort).toBe(80);
+    // 基础级 fallbackImage 回退链带到 profile(无 express deployMode 也生效)。
+    expect(bp!.fallbackImage).toEqual([
+      'ghcr.io/acme/app-web:branch-${CDS_BRANCH_SLUG}',
+      'ghcr.io/acme/app-web:branch-main',
+    ]);
+    // readiness 从 label 解析。
+    expect(bp!.readinessProbe?.path).toBe('/');
+    expect(bp!.readinessProbe?.timeoutSeconds).toBe(600);
+    // 不应被误归类为 infra。
+    expect(cfg!.infraServices.map((s) => s.id)).not.toContain('llmgw-web');
+  });
+
+  it('round-trip：导出回 compose 再解析，prebuiltImage/subdomain/fallbackImage 不丢，且不合成假源码 mount', () => {
+    const yaml = `
+services:
+  llmgw-web:
+    image: "ghcr.io/acme/app-web:sha-\${CDS_COMMIT_SHA}"
+    ports:
+      - "80"
+    fallbackImage:
+      - "ghcr.io/acme/app-web:branch-main"
+    labels:
+      cds.prebuilt-image: "true"
+      cds.subdomain: "llmgw-web"
+      cds.readiness-path: "/"
+`;
+    const cfg = parseCdsCompose(yaml);
+    expect(cfg).not.toBeNull();
+    const serialized = toCdsCompose(cfg!.buildProfiles, cfg!.envVars, cfg!.infraServices, cfg!.routingRules);
+    // 预构建站点不应被写出源码 volume mount。
+    expect(serialized).not.toMatch(/\.:\/app/);
+    const back = parseCdsCompose(serialized);
+    expect(back).not.toBeNull();
+    const bp = back!.buildProfiles.find((p) => p.id === 'llmgw-web');
+    expect(bp).toBeDefined();
+    expect(bp!.prebuiltImage).toBe(true);
+    expect(bp!.subdomain).toBe('llmgw-web');
+    expect(bp!.fallbackImage).toEqual(['ghcr.io/acme/app-web:branch-main']);
+  });
+
+  it('image + prebuilt-image label 但无 subdomain/path-prefix（无对外路由）→ 不识别为 app', () => {
+    const yaml = `
+services:
+  bare:
+    image: "ghcr.io/acme/x:latest"
+    labels:
+      cds.prebuilt-image: "true"
+`;
+    const cfg = parseCdsCompose(yaml);
+    // 无端口/无 build/无 subdomain/无 path-prefix → 既不进 app 也不进 infra(与旧行为一致)。
+    if (cfg) {
+      expect(cfg.buildProfiles.map((p) => p.id)).not.toContain('bare');
+    }
+  });
+});
+
 describe('parseStandardCompose — agent runtime sidecar isolation', () => {
   it('does not import claude-agent-sdk runtime sidecar as a branch BuildProfile', () => {
     const yaml = `

--- a/cds/tests/services/container-profile-aliases.test.ts
+++ b/cds/tests/services/container-profile-aliases.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { computeProfileAliases } from '../../src/services/container.js';
+
+describe('computeProfileAliases', () => {
+  it('剥离带连字符的项目 slug 后缀,产出裸 <svc>(核心回归:llmgw)', () => {
+    const aliases = computeProfileAliases('llmgw-prd-agent', ['prd-agent']);
+    expect(aliases).toContain('llmgw-prd-agent'); // profile.id 永远在
+    expect(aliases).toContain('llmgw');           // ← nginx 反代 http://llmgw:8090 依赖此裸名
+  });
+
+  it('多段服务名 + 带连字符 slug: llmgw-serve-prd-agent → llmgw-serve', () => {
+    const aliases = computeProfileAliases('llmgw-serve-prd-agent', ['prd-agent']);
+    expect(aliases).toContain('llmgw-serve-prd-agent');
+    expect(aliases).toContain('llmgw-serve');
+    expect(aliases).not.toContain('llmgw'); // 只到服务名边界,不过度剥离
+  });
+
+  it('单段服务名 + 带连字符 slug: api-prd-agent → api', () => {
+    expect(computeProfileAliases('api-prd-agent', ['prd-agent'])).toContain('api');
+    expect(computeProfileAliases('admin-prd-agent', ['prd-agent'])).toContain('admin');
+  });
+
+  it('marker 是 projectId(随机后缀)时也剥离: llmgw-defd4695ab5f → llmgw', () => {
+    const aliases = computeProfileAliases('llmgw-defd4695ab5f', ['defd4695ab5f', 'prd-agent']);
+    expect(aliases).toContain('llmgw');
+  });
+
+  it('保留旧单段启发式: mysql-mdimp → mysql(marker 传 [id, slug])', () => {
+    const aliases = computeProfileAliases('mysql-mdimp', ['defd4695ab5f', 'mdimp']);
+    expect(aliases).toContain('mysql-mdimp');
+    expect(aliases).toContain('mysql');
+  });
+
+  it('服务名恰好等于项目名时不产生空/裸别名', () => {
+    expect(computeProfileAliases('prd-agent', ['prd-agent'])).toEqual(['prd-agent']);
+  });
+
+  it('无项目后缀时只有自己一个别名', () => {
+    expect(computeProfileAliases('redis', ['prd-agent'])).toEqual(['redis']);
+    expect(computeProfileAliases('web-2', ['prd-agent'])).toEqual(['web-2']);
+  });
+
+  it('歧义短 marker(prd) 不误命中: llmgw-serve-prd-agent 仍只到 llmgw-serve', () => {
+    const aliases = computeProfileAliases('llmgw-serve-prd-agent', ['prd-agent', 'prd']);
+    expect(aliases).toContain('llmgw-serve');
+    // 不存在 profileId 上「-prd」结尾的切点,故不会误剥出 llmgw-serve-agent 之类
+    expect(aliases).not.toContain('llmgw-serve-agent');
+  });
+
+  it('profileId 为空数组 marker 时安全', () => {
+    expect(computeProfileAliases('llmgw-prd-agent', [])).toEqual(['llmgw-prd-agent']);
+  });
+
+  it('llmgw-web-prd-agent → llmgw-web(前端站裸别名)', () => {
+    const aliases = computeProfileAliases('llmgw-web-prd-agent', ['prd-agent']);
+    expect(aliases).toContain('llmgw-web-prd-agent');
+    expect(aliases).toContain('llmgw-web');
+  });
+});

--- a/cds/web/src/components/BranchDetailDrawer.tsx
+++ b/cds/web/src/components/BranchDetailDrawer.tsx
@@ -1780,28 +1780,69 @@ export function BranchDetailDrawer({
                       </span>
                       <ExternalLink className="h-4 w-4 shrink-0 text-emerald-600/60 transition group-hover:text-emerald-600 dark:text-emerald-400/60 dark:group-hover:text-emerald-300" />
                     </a>
-                    {gatewayUrls.map((gw) => (
-                      <a
-                        key={gw.subdomain}
-                        href={gw.url}
-                        target="_blank"
-                        rel="noreferrer"
-                        title={`打开 ${gw.name} 网关入口`}
-                        className="group flex items-center gap-3 rounded-lg border border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))]/50 px-3 py-2 transition hover:border-emerald-500/40 hover:bg-emerald-500/[0.08]"
-                      >
-                        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-[hsl(var(--surface-raised))] text-muted-foreground">
-                          <Server className="h-4 w-4" />
-                        </span>
-                        <span className="min-w-0 flex-1">
-                          <span className="flex items-center gap-1.5">
-                            <span className="text-xs font-semibold text-foreground">网关入口</span>
-                            <span className="rounded bg-[hsl(var(--surface-raised))] px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">{gw.subdomain}</span>
-                          </span>
-                          <span className="block min-w-0 truncate font-mono text-[11px] text-muted-foreground">{gw.url}</span>
-                        </span>
-                        <ExternalLink className="h-4 w-4 shrink-0 text-muted-foreground/60 transition group-hover:text-emerald-600" />
-                      </a>
-                    ))}
+                    {[...gatewayUrls]
+                      .sort((a, b) => {
+                        // 网关控制台(真实可登录页面)排在引擎/健康入口之前。
+                        const rank = (s: string) => (s.toLowerCase() === 'llmgw-web' ? 0 : 1);
+                        return rank(a.subdomain) - rank(b.subdomain) || a.subdomain.localeCompare(b.subdomain);
+                      })
+                      .map((gw) => {
+                        const isConsole = gw.subdomain.toLowerCase() === 'llmgw-web';
+                        return (
+                          <a
+                            key={gw.subdomain}
+                            href={gw.url}
+                            target="_blank"
+                            rel="noreferrer"
+                            title={isConsole ? `打开 ${gw.name} 网关控制台` : `打开 ${gw.name} 网关引擎健康检查`}
+                            className={
+                              isConsole
+                                ? 'group flex items-center gap-3 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 transition hover:border-emerald-500/60 hover:bg-emerald-500/[0.18]'
+                                : 'group flex items-center gap-3 rounded-lg border border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))]/50 px-3 py-2 transition hover:border-emerald-500/40 hover:bg-emerald-500/[0.08]'
+                            }
+                          >
+                            <span
+                              className={
+                                isConsole
+                                  ? 'flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-emerald-600 text-white'
+                                  : 'flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-[hsl(var(--surface-raised))] text-muted-foreground'
+                              }
+                            >
+                              {isConsole ? <Terminal className="h-4 w-4" /> : <Server className="h-4 w-4" />}
+                            </span>
+                            <span className="min-w-0 flex-1">
+                              <span className="flex items-center gap-1.5">
+                                <span
+                                  className={
+                                    isConsole
+                                      ? 'text-xs font-semibold text-emerald-700 dark:text-emerald-300'
+                                      : 'text-xs font-semibold text-foreground'
+                                  }
+                                >
+                                  {isConsole ? '网关控制台' : '网关引擎 · 健康'}
+                                </span>
+                                <span className="rounded bg-[hsl(var(--surface-raised))] px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">{gw.subdomain}</span>
+                              </span>
+                              <span
+                                className={
+                                  isConsole
+                                    ? 'block min-w-0 truncate font-mono text-[11px] text-emerald-700/70 dark:text-emerald-300/70'
+                                    : 'block min-w-0 truncate font-mono text-[11px] text-muted-foreground'
+                                }
+                              >
+                                {gw.url}
+                              </span>
+                            </span>
+                            <ExternalLink
+                              className={
+                                isConsole
+                                  ? 'h-4 w-4 shrink-0 text-emerald-600/60 transition group-hover:text-emerald-600 dark:text-emerald-400/60 dark:group-hover:text-emerald-300'
+                                  : 'h-4 w-4 shrink-0 text-muted-foreground/60 transition group-hover:text-emerald-600'
+                              }
+                            />
+                          </a>
+                        );
+                      })}
                   </div>
                 </div>
               ) : null}

--- a/changelogs/2026-07-01_cds-llmgw-console.md
+++ b/changelogs/2026-07-01_cds-llmgw-console.md
@@ -1,0 +1,4 @@
+| feat | cds | 网关入口打开真实控制台 prd-llmgw-web（登录→LLM日志），替换 /gw/healthz 心跳落地：compose 新增 llmgw-web 预构建镜像服务（子域 llmgw-web）+ branches.ts 落地路径 llmgw-web→/ + BranchDetailDrawer 网关卡片分层（控制台主色置顶 / 引擎中性） |
+| fix | cds | compose-parser 识别「预构建镜像 app 站点」：isAppServiceCandidate 对 image + cds.prebuilt-image + (cds.subdomain\|path-prefix) 判为 app（否则纯 nginx 前端站无源码 mount/无 build 被丢弃，命名子域永不发布）；ComposeServiceEntry/BuildProfile 支持基础级 fallbackImage 逐级回退 + 序列化跳过预构建站点的假源码 mount |
+| fix | cds | computeProfileAliases 剥离完整项目 slug/id 后缀，llmgw-prd-agent→裸别名 llmgw（llmgw-serve→llmgw-serve、api→api…），让同分支网内 llmgw-web 的 nginx 反代 http://llmgw:8090 可解析（零回归，保留旧单段启发式） |
+| fix | cds | prd-llmgw-web/nginx.conf 反代改运行时 DNS 解析（resolver 127.0.0.11 + 变量 upstream），消除 nginx 启动期缓存 llmgw IP 导致的「别名未就绪崩溃 / llmgw 换 IP 后持久 502」竞态 |

--- a/prd-llmgw-web/nginx.conf
+++ b/prd-llmgw-web/nginx.conf
@@ -1,5 +1,6 @@
 # prd-llmgw-web 站点 nginx 配置：SPA 回退 + /gw 反代到独立网关后端容器 llmgw:8090。
 # 监听 80（与 deploy/nginx/conf.d/branches/_standalone.conf 的 llmgw-web:80 反代约定一致）。
+# rev: 2026-07-01 网关入口指向真实控制台（触碰 prd-llmgw-web/** 触发 llmgw-web 镜像构建）
 server {
     listen 80;
     server_name _;
@@ -7,8 +8,15 @@ server {
     index index.html;
 
     # 网关后端 API：/gw/* 反代到 llmgw 容器（SSE 关闭缓冲 + 长超时）。
+    # 用 Docker 内嵌 DNS(127.0.0.11) + 变量 upstream 做「每请求解析」：literal upstream
+    # (proxy_pass http://llmgw:8090) 会在 worker 启动时解析一次并永久缓存 —— CDS 逐分支网络
+    # 隔离下 llmgw 别名此刻可能尚未注册(nginx 报 host not found in upstream 直接拒启动)，且
+    # llmgw 重部署换 IP 后 console 会持续 502。改为 set 变量 + resolver：nginx 在请求时经
+    # resolver 解析，NXDOMAIN 时只对该请求返 502(而非启动失败)，IP 变更 10s 内自动跟随。
     location ^~ /gw/ {
-        proxy_pass http://llmgw:8090;
+        resolver 127.0.0.11 valid=10s ipv6=off;
+        set $llmgw_upstream llmgw;
+        proxy_pass http://$llmgw_upstream:8090;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## 摘要

用户反馈：分支面板「网关入口」点开落地 `/gw/healthz`（心跳 JSON），不是真实网关控制台。本 PR 让网关入口打开**真实控制台 `prd-llmgw-web`**（登录 → LLM 日志）。真实控制台此前从未部署，且部署它有两处经对抗审查发现的真实阻塞，一并修掉。

## 改动 diff

- **CDS**
  - `cds/src/services/compose-parser.ts`：`isAppServiceCandidate` 识别「预构建镜像 app 站点」（`image` + `cds.prebuilt-image` + `cds.subdomain`/`cds.path-prefix`）。**修阻塞1**：纯 nginx 前端站无源码 mount、无 `build:`，原逻辑判为「既非 app 也非 infra」直接丢弃 → 命名子域永不发布、前端卡片全是死代码。`ComposeServiceEntry`/`BuildProfile` 增基础级 `fallbackImage`（逐级回退），序列化对预构建站点跳过假源码 mount。
  - `cds-compose.yml`：新增 `llmgw-web` 预构建镜像服务（`image: ...prdagent-llmgw-web:sha-${CDS_COMMIT_SHA}` + `fallbackImage[branch-${CDS_BRANCH_SLUG}, branch-main]` + `ports:["80"]` + labels `cds.prebuilt-image/subdomain=llmgw-web/readiness-path=/`）。nginx 托管 SPA + 反代 `/gw/*`→llmgw 后端。
  - `cds/src/services/container.ts`：`computeProfileAliases` 剥离**完整**项目 slug/id 后缀，`llmgw-prd-agent`→裸别名 `llmgw`（保留旧单段启发式，零回归），使同分支网内 llmgw-web 的 nginx 反代 `http://llmgw:8090` 可解析。
  - `cds/src/routes/branches.ts`：`resolveGatewayLandingPath` 增 `llmgw-web`→`/`（控制台根＝真实页面）。
  - `cds/web/src/components/BranchDetailDrawer.tsx`：网关入口卡片分层——控制台（llmgw-web）主色 + Terminal 图标 +「网关控制台」+ 置顶；引擎（llmgw/llmgw-serve）中性 + Server +「网关引擎 · 健康」。
  - `prd-llmgw-web/nginx.conf`：**修阻塞2**：`/gw/` 反代改运行时 DNS 解析（`resolver 127.0.0.11 valid=10s` + 变量 upstream），消除 nginx 启动期缓存 `llmgw` IP 的竞态（别名未就绪即崩溃 / llmgw 换 IP 后持久 502）。
  - 测试：`compose-parser.test.ts` 新增 llmgw-web 被识别为 app（subdomain=llmgw-web、prebuiltImage=true、port 80、fallback 链、round-trip 不吐假 mount、负样本）；`container-profile-aliases.test.ts` 新增裸别名断言。

## 测试

- [x] `cd cds && pnpm tsc --noEmit` 零错误；`cd cds/web && pnpm tsc --noEmit` 零错误。
- [x] `pnpm vitest run` compose-parser（59）+ container-profile-aliases（10）+ container（43）+ 迁移/隔离全绿。
- [x] 对真实 `cds-compose.yml` 跑解析器：`llmgw-web | subdomain=llmgw-web | prebuiltImage=true | port=80 | fallback=[...]`（原先被丢弃，现已识别）。
- [ ] **真机端到端（合并 + CI 出镜像后由我收尾）**：import 更新后的 compose → 部署 prd-agent-main → 访问 `<slug>-llmgw-web.<root>` 控制台加载 → 用 CDS 账号登录 → LLM 日志页拉到数据。预览：`https://cds.miduo.org/branch-panel?id=prd-agent-main`

## 风险与已知边界

- 依赖 CI 构建 `prdagent-llmgw-web` 镜像（本 PR 改了 `prd-llmgw-web/nginx.conf` 触发 path-filter 构建 `sha-`/`branch-` tag；合并后 main CI 出 `sha-<merge>`/`branch-main`）。三个 tag 都缺才会硬失败（nginx-only 站无源码回退，设计如此）。
- nginx 变量 upstream：`llmgw` 别名就绪前的极短窗口内 `/gw/*` 返回 502（客户端重试，`valid=10s` 内自愈），优于旧的启动崩溃。
- 别名剥离仅对「后缀完全等于项目 marker」触发，比旧启发式更窄；当前 per-project 网络隔离下裸别名唯一无冲突。

## 后续事项

- 我在合并 + 镜像就绪后完成真机部署 + 登录 + 日志渲染的端到端取证，再确认闭环。

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZfu39CAkJevjwdZoMGHzu)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CDS deploy/compose parsing, Docker network aliases, and nginx reverse-proxy behavior; depends on CI llmgw-web images but no auth or payment logic changes.
> 
> **Overview**
> Branch panel **gateway links** now open the real **`prd-llmgw-web`** login/LLM-logs UI instead of **`/gw/healthz` JSON**. **`cds-compose.yml`** adds **`llmgw-web`** as a CI-pulled nginx SPA on subdomain **`llmgw-web`**, with **`fallbackImage`** and readiness on **`/`**.
> 
> **CDS compose-parser** now treats **image + `cds.prebuilt-image` + routing label** as an app profile (so pure nginx fronts aren’t dropped), carries **base-level `fallbackImage`**, and **skips fake `.:/app` mounts** on export. **`computeProfileAliases`** strips full project markers (e.g. **`llmgw-prd-agent` → `llmgw`**) so **`llmgw-web`** can proxy **`http://llmgw:8090`**. **`resolveGatewayLandingPath`** lands **`llmgw-web`** on **`/`**; **BranchDetailDrawer** highlights the console link above engine health URLs.
> 
> **`prd-llmgw-web/nginx.conf`** uses Docker DNS + variable **`proxy_pass`** to avoid startup/upstream IP cache **502s**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4b73f477bf6b171d5937121edbcfb6055fe5a04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->