### PR TITLE
每日熵减计划 2026-07-01 — plan.llm-gateway.full-cutover 补缺 + D6 处理 5 条

### DIFF
--- a/changelogs/.entropy-manifest.yml
+++ b/changelogs/.entropy-manifest.yml
@@ -388,3 +388,8 @@ processed:
   - 2026-06-26_vision-detail-fix.md
   - 2026-06-27_gateway-isolation-design.md
   - 2026-06-27_gateway-phase0.md
+  - 2026-06-27_imagegen-request-builder.md
+  - 2026-06-27_llm-gateway-standalone.md
+  - 2026-06-27_llm-log-observability.md
+  - 2026-06-27_llmgw-deploy-scaffold.md
+  - 2026-06-27_llmgw-web-skeleton.md

--- a/changelogs/2026-07-01_entropy-cleanup.md
+++ b/changelogs/2026-07-01_entropy-cleanup.md
@@ -1,2 +1,2 @@
 | chore | doc | 每日熵减 2026-07-01：合并昨日重复 PR #967（D3 debt.llm-gateway 系列 3 条 + D6 manifest 标记 5 条）；本次新增 D2/D3 补缺 plan.llm-gateway.full-cutover 1 条，D6 changelog→doc 覆盖处理 5 条（imagegen-request-builder/llm-gateway-standalone/llm-log-observability/llmgw-deploy-scaffold/llmgw-web-skeleton，内容均已在既有 debt.llm-gateway-isolation.md / plan.llm-gateway.rollout.md 覆盖，无需新增章节） |
-| debt | doc | D5 复查：codebase-snapshot.md 声称 MongoDB 集合数（118/120）与实际 MongoDbContext.cs 统计（249）严重漂移，需人工审查后批量更新，遵循 D5 需人工确认原则本次未自动改写 |
+| docs | doc | D5 复查发现工程债务：codebase-snapshot.md 声称 MongoDB 集合数（118/120）与实际 MongoDbContext.cs 统计（249）严重漂移，需人工审查后批量更新，遵循 D5 需人工确认原则本次未自动改写 |

--- a/changelogs/2026-07-01_entropy-cleanup.md
+++ b/changelogs/2026-07-01_entropy-cleanup.md
@@ -1,0 +1,2 @@
+| chore | doc | 每日熵减 2026-07-01：合并昨日重复 PR #967（D3 debt.llm-gateway 系列 3 条 + D6 manifest 标记 5 条）；本次新增 D2/D3 补缺 plan.llm-gateway.full-cutover 1 条，D6 changelog→doc 覆盖处理 5 条（imagegen-request-builder/llm-gateway-standalone/llm-log-observability/llmgw-deploy-scaffold/llmgw-web-skeleton，内容均已在既有 debt.llm-gateway-isolation.md / plan.llm-gateway.rollout.md 覆盖，无需新增章节） |
+| debt | doc | D5 复查：codebase-snapshot.md 声称 MongoDB 集合数（118/120）与实际 MongoDbContext.cs 统计（249）严重漂移，需人工审查后批量更新，遵循 D5 需人工确认原则本次未自动改写 |

--- a/doc/guide.list.directory.md
+++ b/doc/guide.list.directory.md
@@ -627,6 +627,9 @@
 - [LLM 网关剥离上线计划](plan.llm-gateway.rollout) `plan.llm-gateway.rollout`
   > 差异化进度 + 测试纲领（A/B/C/D 四层）+ 局限范围（L1-L9 + apiyi 中转专项）+ 翻 http 上线序列
 
+- [LLM 网关全面切换执行计划](plan.llm-gateway.full-cutover) `plan.llm-gateway.full-cutover`
+  > 全面撤销 MAP 直连 LLM、清理网关旧代码、全接口 MECE 复测、遗漏排查四项诉求 + CDS 多出口面板
+
 - [PA Agent 竞品调研与改进方案](plan.product-agent.pa.competitive-improvements) `plan.product-agent.pa.competitive-improvements`
   > 四类竞品谱系、与 Phase 1 差距对照、P2～P4 分期改进包
 

--- a/doc/index.yml
+++ b/doc/index.yml
@@ -265,6 +265,7 @@ docs:
   plan.desktop.asset-features: Desktop 资产功能方案
   plan.doc.update: 文档长周期更新计划
   plan.llm-gateway.rollout: LLM 网关剥离上线计划（差异化进度 + 测试纲领 + 局限范围 + 翻 http 序列）
+  plan.llm-gateway.full-cutover: LLM 网关全面切换执行计划（撤销 MAP 直连 + 清理旧代码 + 全接口 MECE 复测 + CDS 多出口面板）
   plan.visual-agent.merge-image-ref-resolver: 合并计划书：三入口守门员统一
   plan.skill.installation: Claude Code Skill 安装计划
   plan.skill.marketplace-open-api-next: 海鲜市场技能开放接口 — 下一程交接（P2/P3/P4 待办 + UAT 清单 + 环境准备）


### PR DESCRIPTION
## 熵清理摘要

- D1 doc/ 命名规范：0 个违规
- D2 index.yml：+1 条（`plan.llm-gateway.full-cutover`，新文档缺登记）
- D3 guide.list.directory.md：+1 条（同上）
- D4 CLAUDE.md 技能表：+0/-0 条（`pnpm` 误命中为正文加粗文本，非技能表行，已核实跳过）
- D5 codebase-snapshot：需人工审查，未自动改动（见下方风险说明）
- D6 changelog→doc：本次处理 5 条，manifest 累计 390 条。逐条核实均已在既有 `debt.llm-gateway-isolation.md` / `plan.llm-gateway.rollout.md` 中有对应章节覆盖，无需新增内容，仅标记 manifest 防止重复扫描

本次运行前发现已有重复的「每日熵减计划」PR #967（覆盖同批 `debt.llm-gateway*` D3 补缺 + 同 5 条 D6 changelog），已按技能协议先行内容核查并 squash 合并（commit `4251fecc`），本分支已 rebase 到合并后的 main，仅保留未被 #967 覆盖的增量。

## 改动 diff

- `doc/index.yml`：补登 `plan.llm-gateway.full-cutover`（D2 补缺）
- `doc/guide.list.directory.md`：补登 `plan.llm-gateway.full-cutover`（D3 补缺）
- `changelogs/.entropy-manifest.yml`：新增 5 条已核实覆盖的 changelog 记录（D6 标记：imagegen-request-builder / llm-gateway-standalone / llm-log-observability / llmgw-deploy-scaffold / llmgw-web-skeleton）
- `changelogs/2026-07-01_entropy-cleanup.md`：本次 changelog 碎片

## 测试

- [x] 双向扫描完成，diff 核验通过（本次仅追加行，无删除行）
- [x] 运行两次验证：第二次扫描 D2/D3 缺口归零、D6 待处理数从 51 降至 46（PR #967 处理过 5 条 + 本次处理 5 条）
- [x] 逐条用文件系统真实存在性核实（`[ -f ]`），非凭猜测；D3 的历史"删除幽灵"误报（guide.list.directory.md 自身变更历史表里引用的已删文档名）逐一核实为误报，未做任何删除

## 风险与已知边界

- 纯文档/索引/changelog 改动，无代码改动，不涉及 CDS 部署验证
- D5（codebase-snapshot 时效性）本轮发现 `.claude/rules/codebase-snapshot.md` 声称 MongoDB 集合数（118/120）与实际 `MongoDbContext.cs` 统计（249）严重漂移，按技能要求留待人工确认后批量更新，本次未自动改写，已记入本次 changelog 碎片作为债务提示

---
_Generated by [Claude Code](https://claude.ai/code/session_013JKD3ooUKuGWozsRseNPam)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> 仅索引、manifest 与 changelog 追加，无运行时或部署行为变化；D5 快照漂移仅作债务提示，本 PR 未改写 snapshot。
> 
> **Overview**
> **2026-07-01 每日熵减**：纯文档与索引维护，无应用代码变更。
> 
> 在 **`doc/index.yml`** 与 **`doc/guide.list.directory.md`** 的「计划与方案」中**新增** `plan.llm-gateway.full-cutover`（LLM 网关全面切换执行计划）登记，消除 D2/D3 扫描缺口。
> 
> 在 **`changelogs/.entropy-manifest.yml`** **追加** 5 条已核实被既有 `debt.llm-gateway-isolation` / `plan.llm-gateway.rollout` 覆盖的 2026-06-27 LLM 网关相关 changelog，仅作 D6 已处理标记、避免重复扫描。
> 
> 新增 **`changelogs/2026-07-01_entropy-cleanup.md`** 记录本次运行（含与 PR #967 合并后的增量说明），并**记录** D5 发现：`codebase-snapshot.md` 中 MongoDB 集合数与 `MongoDbContext.cs` 不一致，**未自动修改**，留待人工审查。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34ded0a9366d0c8a67cbab64768d32d17bec1e30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->