### PR TITLE
[codex] cdscli 支持口令创建任务调度

### DIFF
--- a/.claude/skills/cds/SKILL.md
+++ b/.claude/skills/cds/SKILL.md
@@ -95,6 +95,67 @@ $CLI report-folder list [--project <id>]
 
 完整命令族 → `$CLI --help`，分技能用法 → `cds-project-scan` / `cds-deploy-pipeline` 各自的 SKILL.md。
 
+## Agent 使用任务调度口令的标准流程
+
+当用户说「给 CDS 加一个定时任务」「每天拉一次数据」「先测试一下这个任务」「把这段 curl 定时跑」时，Agent 必须优先走 `cdscli schedule`，不要手写 curl 调 `/api/scheduled-jobs`。
+
+### 决策流程
+
+1. **先确定项目作用域**：
+   - 用户提供 `CDS_PROJECT_ID` / `--project` / 项目名能唯一对应项目时，传 `--project <id>`。
+   - 当前环境已有 `CDS_PROJECT_ID` 时可省略 `--project`。
+   - 项目不明确时先 `project list`，仍不明确再问用户；不要创建无项目任务。
+2. **先解析口令**：
+   ```bash
+   $CLI schedule parse "每天 02:00 调用 POST /api/statistics/sync" --project <id>
+   ```
+   用解析结果确认 `schedule.type`、`timeOfDay/intervalMinutes`、`actions` 是否符合用户话术。
+3. **涉及真实外部调用或命令时，先测试**：
+   ```bash
+   $CLI schedule test "手动 执行命令 echo ok" --project <id>
+   ```
+   `test` 只调用 `/api/scheduled-jobs/check-target`，不创建任务。失败时把失败日志总结给用户，不要继续 create。
+4. **创建时默认带 `--test`**：
+   ```bash
+   $CLI schedule create "每天 03:30 curl -X POST https://old.example/sync" --project <id> --test
+   ```
+   只有用户明确说「先创建，之后再测」时才允许不带 `--test`。
+5. **创建后交付 task id 和验收命令**：
+   - 返回 `job.id`。
+   - 告知可用 `$CLI schedule run <jobId>` 手动触发一次。
+   - 告知可用 `$CLI schedule list --project <id>` 查看。
+
+### 口令格式
+
+调度部分支持：
+- `每天 02:00` / `每日 2点` / `daily 02:00`
+- `每隔 10 分钟` / `每 2 小时`
+- `手动` / `只手动`
+
+动作部分支持：
+- `curl -X POST -H 'Content-Type: application/json' -d '{"a":1}' https://example.com/sync`
+- `调用 POST /api/statistics/sync`
+- `执行命令 node scripts/sync.js`
+
+多个动作可用「然后 / 接着 / 再执行」连接，例如：
+
+```bash
+$CLI schedule create "每天 02:00 curl -X POST https://old.example/pull 然后 执行命令 node clean.js" --project <id> --test
+```
+
+### 失败处理
+
+- `未识别调度口令`：让用户补充「每天/每隔/手动」之一。
+- `未识别执行动作`：让用户提供 `curl`、HTTP URL 或命令脚本。
+- `任务动作检测未通过`：不要创建任务；总结 `checks[].result.log/error`，让用户修正 URL、鉴权、命令或服务状态。
+- `project_mismatch`：说明当前项目 key 不属于目标项目，让用户在目标项目页重新授权 Agent。
+
+### 安全边界
+
+- 命令动作由 CDS 服务端放进 Docker sandbox 执行，Agent 不要在本地代跑危险命令来“帮用户测试”。
+- 含密钥的 curl 可以交给 `schedule test/create`，但最终回复不要复述完整密钥值。
+- 用户只说「定时跑这个」但没有调度时间时，不要猜默认每天；先要求补齐调度。
+
 ## 认证：三种方式（按优先级）
 
 ### 首选：项目专属 Key（零心智）

--- a/.claude/skills/cds/SKILL.md
+++ b/.claude/skills/cds/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: cds
-version: 0.7.1
+version: 0.8.0
 description: CDS (Cloud Dev Space) core skill — hosts the canonical cdscli Python CLI, handles authentication (static AI_ACCESS_KEY / dynamic pairing / project key), manages env vars and project keys, owns CDS service self-update, defines the preview-URL slug formula, and acts as dispatcher when the user's intent is ambiguous between cold-path scanning and hot-path debugging. Activates when the user mentions CDS generically without specifying scan-or-deploy, configures CDS credentials, manages env / keys, updates the CDS service code itself, or asks about preview URL conventions. Does NOT directly perform project scanning (delegates to cds-project-scan, the cold path) or deployment debugging (delegates to cds-deploy-pipeline, the hot path). Trigger phrases include "cds 认证", "AI_ACCESS_KEY", "项目 key", "cds 自更新", "cds self-update", "预览地址公式", "配 cds 环境变量", "/cds", "/cds-auth", and the bare word "cds" when the user has not yet picked a direction.
 ---
 
 # CDS — 核心技能：鉴权 / cdscli / env / self-update / 分诊器
 
-> **版本**：v0.7.1 | **状态**：已落地 | **触发**：`/cds`、`/cds-auth`、"cds 认证"、"AI_ACCESS_KEY"、"项目 key"、"cds 自更新"、"预览地址公式"、"配 cds 环境变量"
+> **版本**：v0.8.0 | **状态**：已落地 | **触发**：`/cds`、`/cds-auth`、"cds 认证"、"AI_ACCESS_KEY"、"项目 key"、"cds 自更新"、"预览地址公式"、"配 cds 环境变量"
 
 > **冷热分离**：
 > - 接入新项目、生成 compose、上传 YAML → **`cds-project-scan`**（冷路径）
@@ -69,6 +69,15 @@ $CLI global-key create --label "for claude onboarding"
 $CLI key list --project <id>             # 项目级 cdsp_* key（只读列出）
 # 注：cdscli 无 key create。项目 Key 由用户在项目页「授权 Agent」按钮签发，
 #     明文只展示一次（见下方「认证」节）。CLI 不签发，避免密钥经 stdout 泄漏。
+
+# 任务调度：一句口令生成/测试/创建任务（自然语言解析为 schedule + actions）
+$CLI schedule parse "每天 02:00 调用 POST /api/statistics/sync" --project <id>
+$CLI schedule test "手动 执行命令 echo ok" --project <id>
+$CLI schedule create "每天 03:30 curl -X POST https://old.example/sync" --project <id> --test
+$CLI schedule list --project <id>
+$CLI schedule run <scheduledJobId>
+# 支持调度口令：每天 02:00 / 每隔 10 分钟 / 手动
+# 支持动作口令：curl ... / 调用 POST https://... / 执行命令 ...
 
 # CDS 服务自更新（仅改 cds/ 代码时）
 $CLI self branches                       # 看 CDS 自身能切到哪些分支

--- a/.claude/skills/cds/cli/cdscli.py
+++ b/.claude/skills/cds/cli/cdscli.py
@@ -34,6 +34,7 @@ import json
 import os
 import re
 import secrets
+import shlex
 import socket
 import subprocess
 import sys
@@ -43,7 +44,7 @@ import urllib.parse
 import urllib.request
 from typing import Any, Optional
 
-VERSION = "0.7.1"  # ← bumped on each SKILL.md change; 服务端自动读这一行
+VERSION = "0.8.0"  # ← bumped on each SKILL.md change; 服务端自动读这一行
 _TRACE_ID: str = ""
 _HUMAN: bool = False
 _DRIFT_WARNED: bool = False  # 全进程只提示一次，避免每个请求都刷
@@ -6695,6 +6696,279 @@ def cmd_deploy(args: argparse.Namespace) -> None:
        note="deploy 流水线全绿")
 
 
+# ── scheduled jobs prompt helpers ───────────────────────────────────
+
+def _prompt_text(parts: Any) -> str:
+    if isinstance(parts, list):
+        return " ".join(str(p) for p in parts).strip()
+    return str(parts or "").strip()
+
+
+def _schedule_project_id(args: argparse.Namespace, *, required: bool = True) -> str:
+    pid = (getattr(args, "project", None) or os.environ.get("CDS_PROJECT_ID", "")).strip()
+    if required and not pid:
+        die("缺少项目 ID: 请传 --project <projectId> 或设置 CDS_PROJECT_ID")
+    return pid
+
+
+def _parse_schedule_prompt(prompt: str) -> dict[str, Any]:
+    text = re.sub(r"\s+", " ", prompt.strip())
+    if not text:
+        die("口令不能为空")
+
+    timezone = "Asia/Shanghai"
+    tz_match = re.search(r"(?:timezone|tz|时区)\s*[:=：]\s*([A-Za-z0-9_./+-]+)", text, re.I)
+    if tz_match:
+        timezone = tz_match.group(1)
+
+    if re.search(r"\bmanual\b|手动|只手动|不定时", text, re.I):
+        return {"type": "manual", "timezone": timezone}
+
+    interval = re.search(r"(?:每隔|间隔|每)\s*(\d{1,5})\s*(分钟|分|小时|时|hour|hours|minute|minutes)", text, re.I)
+    if interval:
+        value = int(interval.group(1))
+        unit = interval.group(2).lower()
+        minutes = value * 60 if unit in ("小时", "时", "hour", "hours") else value
+        return {"type": "interval", "intervalMinutes": max(1, minutes), "timezone": timezone}
+
+    daily = re.search(
+        r"(?:每天|每日|天天|daily).{0,20}?([01]?\d|2[0-3])\s*(?::|点|时|:)\s*([0-5]\d)?",
+        text,
+        re.I,
+    )
+    if not daily and re.search(r"每天|每日|天天|daily", text, re.I):
+        daily = re.search(r"\b([01]?\d|2[0-3]):([0-5]\d)\b", text)
+    if daily:
+        hour = int(daily.group(1))
+        minute = int(daily.group(2) or "0")
+        return {"type": "daily", "timeOfDay": f"{hour:02d}:{minute:02d}", "timezone": timezone}
+
+    die("未识别调度口令: 请包含 '每天 02:00'、'每隔 10 分钟' 或 '手动'")
+
+
+def _parse_actions_prompt(prompt: str) -> list[dict[str, Any]]:
+    clauses = [c.strip() for c in re.split(r"\s*(?:然后|接着|再执行|并且)\s*", prompt) if c.strip()]
+    actions: list[dict[str, Any]] = []
+    for clause in clauses or [prompt]:
+        target = _parse_action_clause(clause)
+        if target:
+            actions.append({
+                **target,
+                "id": f"action_{len(actions) + 1}",
+                "name": _default_schedule_action_name(target),
+            })
+    if not actions:
+        die("未识别执行动作: 请包含 curl、HTTP URL、'/api/...' 或 '执行命令 ...'")
+    return actions
+
+
+def _parse_action_clause(text: str) -> dict[str, Any] | None:
+    if re.search(r"(^|\s)curl(\s|$)", text):
+        return _parse_curl_action(text)
+
+    command = _extract_command_action(text)
+    if command:
+        return {"type": "command", "command": command}
+
+    http = _extract_http_action(text)
+    if http:
+        return http
+    return None
+
+
+def _parse_curl_action(text: str) -> dict[str, Any]:
+    try:
+        tokens = shlex.split(text)
+    except ValueError as exc:
+        die(f"curl 解析失败: {exc}")
+    if "curl" in tokens:
+        tokens = tokens[tokens.index("curl") + 1:]
+
+    method = ""
+    headers: dict[str, str] = {}
+    body: str | None = None
+    url = ""
+    i = 0
+    while i < len(tokens):
+        token = tokens[i]
+        low = token.lower()
+        if low in ("-x", "--request") and i + 1 < len(tokens):
+            method = tokens[i + 1].upper()
+            i += 2
+            continue
+        if low.startswith("-x") and len(token) > 2:
+            method = token[2:].upper()
+            i += 1
+            continue
+        if low in ("-h", "--header") and i + 1 < len(tokens):
+            _append_header(headers, tokens[i + 1])
+            i += 2
+            continue
+        if low.startswith("-h") and len(token) > 2:
+            _append_header(headers, token[2:])
+            i += 1
+            continue
+        if low in ("-d", "--data", "--data-raw", "--data-binary", "--data-stdin") and i + 1 < len(tokens):
+            body = tokens[i + 1]
+            if not method:
+                method = "POST"
+            i += 2
+            continue
+        if low.startswith("--data="):
+            body = token.split("=", 1)[1]
+            if not method:
+                method = "POST"
+            i += 1
+            continue
+        if not token.startswith("-") and (token.startswith("http://") or token.startswith("https://") or token.startswith("/")):
+            url = token
+        i += 1
+
+    if not url:
+        die("curl 口令里没有识别到 URL")
+    return {
+        "type": "http",
+        "method": method or ("POST" if body else "GET"),
+        "url": _clean_prompt_url(url),
+        **({"headers": headers} if headers else {}),
+        **({"body": body} if body else {}),
+    }
+
+
+def _append_header(headers: dict[str, str], raw: str) -> None:
+    if ":" not in raw:
+        return
+    key, value = raw.split(":", 1)
+    key = key.strip()
+    value = value.strip()
+    if key:
+        headers[key] = value
+
+
+def _extract_command_action(text: str) -> str | None:
+    m = re.search(r"(?:执行命令|执行脚本|命令|脚本|command|cmd)\s*[:：]?\s*(.+)$", text, re.I)
+    if not m:
+        return None
+    command = m.group(1).strip()
+    if re.search(r"^curl(\s|$)", command):
+        return None
+    return command or None
+
+
+def _extract_http_action(text: str) -> dict[str, Any] | None:
+    method_match = re.search(r"\b(GET|POST|PUT|PATCH|DELETE)\b", text, re.I)
+    url_match = re.search(r"(https?://[^\s，,]+|/[A-Za-z0-9_./?=&:%+-]+)", text)
+    if not url_match:
+        return None
+    body_match = re.search(r"(?:body|请求体|数据)\s*[:=：]\s*(.+)$", text, re.I)
+    method = method_match.group(1).upper() if method_match else ("POST" if body_match else "GET")
+    body = body_match.group(1).strip() if body_match else None
+    return {
+        "type": "http",
+        "method": method,
+        "url": _clean_prompt_url(url_match.group(1)),
+        **({"body": body} if body else {}),
+    }
+
+
+def _clean_prompt_url(url: str) -> str:
+    return url.strip().strip("'\"`，,。")
+
+
+def _default_schedule_action_name(target: dict[str, Any]) -> str:
+    if target.get("type") == "command":
+        return "执行命令脚本"
+    method = target.get("method") or "POST"
+    return f"调用 HTTP 接口 {method}"
+
+
+def _infer_schedule_name(prompt: str) -> str:
+    explicit = re.search(r"(?:名称|任务名|name)\s*[:=：]\s*([^，,。]+)", prompt, re.I)
+    if explicit:
+        return explicit.group(1).strip()[:80] or "口令定时任务"
+    compact = re.sub(r"\s+", " ", prompt).strip()
+    return (compact[:40] or "口令定时任务")
+
+
+def _build_schedule_job_from_prompt(args: argparse.Namespace, *, require_project: bool) -> dict[str, Any]:
+    prompt = _prompt_text(args.prompt)
+    project_id = _schedule_project_id(args, required=require_project)
+    schedule = _parse_schedule_prompt(prompt)
+    actions = _parse_actions_prompt(prompt)
+    return {
+        **({"projectId": project_id} if project_id else {}),
+        "name": (getattr(args, "name", None) or _infer_schedule_name(prompt)).strip()[:120],
+        "description": getattr(args, "description", None) or prompt,
+        "enabled": not getattr(args, "disabled", False),
+        "schedule": schedule,
+        "actions": actions,
+        "timeoutSeconds": max(1, int(getattr(args, "timeout", 300) or 300)),
+        "retryCount": max(0, int(getattr(args, "retry", 0) or 0)),
+    }
+
+
+def _schedule_check_actions(project_id: str, actions: list[dict[str, Any]], timeout: int) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    for action in actions:
+        target = {k: v for k, v in action.items() if k not in ("id", "name")}
+        res = _call("POST", "/api/scheduled-jobs/check-target", body={
+            "projectId": project_id,
+            "target": target,
+            "timeoutSeconds": max(1, int(timeout)),
+        }, timeout=max(5, int(timeout) + 5))
+        result = res.get("result", res) if isinstance(res, dict) else res
+        results.append({"action": action, "result": result})
+    return results
+
+
+def _die_if_schedule_checks_failed(results: list[dict[str, Any]]) -> None:
+    failed = [
+        r for r in results
+        if not isinstance(r.get("result"), dict) or not r["result"].get("ok")
+    ]
+    if failed:
+        die("任务动作检测未通过", code=2, extra={"checks": results})
+
+
+def cmd_schedule_parse(args: argparse.Namespace) -> None:
+    job = _build_schedule_job_from_prompt(args, require_project=False)
+    ok(job, note="口令已解析")
+
+
+def cmd_schedule_test(args: argparse.Namespace) -> None:
+    job = _build_schedule_job_from_prompt(args, require_project=True)
+    checks = _schedule_check_actions(job["projectId"], job["actions"], job["timeoutSeconds"])
+    _die_if_schedule_checks_failed(checks)
+    ok({"job": job, "checks": checks}, note="动作检测通过")
+
+
+def cmd_schedule_create(args: argparse.Namespace) -> None:
+    job = _build_schedule_job_from_prompt(args, require_project=True)
+    checks: list[dict[str, Any]] = []
+    if args.test:
+        checks = _schedule_check_actions(job["projectId"], job["actions"], job["timeoutSeconds"])
+        _die_if_schedule_checks_failed(checks)
+    created = _call("POST", "/api/scheduled-jobs", body=job, timeout=20)
+    ok({"job": created.get("job", created), "checks": checks}, note="定时任务已创建")
+
+
+def cmd_schedule_list(args: argparse.Namespace) -> None:
+    project_id = _schedule_project_id(args, required=False)
+    qs = f"?project={urllib.parse.quote(project_id)}" if project_id else ""
+    data = _call("GET", f"/api/scheduled-jobs{qs}")
+    ok(data)
+
+
+def cmd_schedule_run(args: argparse.Namespace) -> None:
+    data = _call("POST", f"/api/scheduled-jobs/{urllib.parse.quote(args.id)}/run", timeout=max(30, args.timeout))
+    ok(data, note="任务已执行")
+
+
+def cmd_schedule_delete(args: argparse.Namespace) -> None:
+    data = _call("DELETE", f"/api/scheduled-jobs/{urllib.parse.quote(args.id)}")
+    ok(data, note="任务已删除")
+
+
 # ── argparse wiring ────────────────────────────────────────────────
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -6762,6 +7036,49 @@ def _build_parser() -> argparse.ArgumentParser:
     bsm.add_argument("profile", help="构建配置 id(profileId)")
     bsm.add_argument("mode", help="部署模式名(须存在于该 profile 的 deployModes)")
     bsm.set_defaults(func=cmd_branch_set_mode)
+
+    sch = sub.add_parser("schedule", help="任务调度: 口令创建 / 测试动作 / 列表 / 手动执行").add_subparsers(dest="sub", required=True)
+    sp = sch.add_parser("parse", help="解析口令,不请求 CDS")
+    sp.add_argument("prompt", nargs="+", help="例如: 每天 02:00 调用 POST /api/jobs/sync")
+    sp.add_argument("--project", help="projectId(可选,或读 CDS_PROJECT_ID)")
+    sp.add_argument("--name", help="任务名称")
+    sp.add_argument("--description", help="任务描述")
+    sp.add_argument("--timeout", type=int, default=300, help="动作超时秒数")
+    sp.add_argument("--retry", type=int, default=0, help="失败重试次数")
+    sp.add_argument("--disabled", action="store_true", help="创建为禁用状态")
+    sp.set_defaults(func=cmd_schedule_parse)
+
+    st = sch.add_parser("test", help="按口令解析动作并调用 /check-target 检测,不创建任务")
+    st.add_argument("prompt", nargs="+")
+    st.add_argument("--project", help="projectId(或读 CDS_PROJECT_ID)")
+    st.add_argument("--name", help="任务名称")
+    st.add_argument("--description", help="任务描述")
+    st.add_argument("--timeout", type=int, default=300, help="动作超时秒数")
+    st.add_argument("--retry", type=int, default=0, help="失败重试次数")
+    st.add_argument("--disabled", action="store_true", help="按禁用任务解析")
+    st.set_defaults(func=cmd_schedule_test)
+
+    scj = sch.add_parser("create", help="按口令创建任务；加 --test 会先检测动作")
+    scj.add_argument("prompt", nargs="+")
+    scj.add_argument("--project", help="projectId(或读 CDS_PROJECT_ID)")
+    scj.add_argument("--name", help="任务名称")
+    scj.add_argument("--description", help="任务描述")
+    scj.add_argument("--timeout", type=int, default=300, help="动作超时秒数")
+    scj.add_argument("--retry", type=int, default=0, help="失败重试次数")
+    scj.add_argument("--disabled", action="store_true", help="创建为禁用状态")
+    scj.add_argument("--test", action="store_true", help="创建前先检测所有动作")
+    scj.set_defaults(func=cmd_schedule_create)
+
+    sl = sch.add_parser("list", help="列出任务调度")
+    sl.add_argument("--project", help="projectId(或读 CDS_PROJECT_ID)")
+    sl.set_defaults(func=cmd_schedule_list)
+    sr = sch.add_parser("run", help="手动执行任务")
+    sr.add_argument("id", help="scheduledJobId")
+    sr.add_argument("--timeout", type=int, default=300)
+    sr.set_defaults(func=cmd_schedule_run)
+    sd = sch.add_parser("delete", help="删除任务")
+    sd.add_argument("id", help="scheduledJobId")
+    sd.set_defaults(func=cmd_schedule_delete)
 
     # 验收报告(CDS 自托管 HTML/Markdown,登录态门控,可按项目/文件夹归类)
     rep = sub.add_parser("report", help="验收报告:列出/查看/创建/删除/直达深链").add_subparsers(dest="sub", required=True)

--- a/.claude/skills/cds/cli/cdscli.py
+++ b/.claude/skills/cds/cli/cdscli.py
@@ -6721,9 +6721,6 @@ def _parse_schedule_prompt(prompt: str) -> dict[str, Any]:
     if tz_match:
         timezone = tz_match.group(1)
 
-    if re.search(r"\bmanual\b|手动|只手动|不定时", text, re.I):
-        return {"type": "manual", "timezone": timezone}
-
     interval = re.search(r"(?:每隔|间隔|每)\s*(\d{1,5})\s*(分钟|分|小时|时|hour|hours|minute|minutes)", text, re.I)
     if interval:
         value = int(interval.group(1))
@@ -6742,6 +6739,9 @@ def _parse_schedule_prompt(prompt: str) -> dict[str, Any]:
         hour = int(daily.group(1))
         minute = int(daily.group(2) or "0")
         return {"type": "daily", "timeOfDay": f"{hour:02d}:{minute:02d}", "timezone": timezone}
+
+    if re.search(r"手动|只手动|不定时|(?:^|\s)manual(?:\s|$)", text, re.I):
+        return {"type": "manual", "timezone": timezone}
 
     die("未识别调度口令: 请包含 '每天 02:00'、'每隔 10 分钟' 或 '手动'")
 
@@ -6766,13 +6766,13 @@ def _parse_action_clause(text: str) -> dict[str, Any] | None:
     if re.search(r"(^|\s)curl(\s|$)", text):
         return _parse_curl_action(text)
 
-    command = _extract_command_action(text)
-    if command:
-        return {"type": "command", "command": command}
-
     http = _extract_http_action(text)
     if http:
         return http
+
+    command = _extract_command_action(text)
+    if command:
+        return {"type": "command", "command": command}
     return None
 
 
@@ -6786,7 +6786,7 @@ def _parse_curl_action(text: str) -> dict[str, Any]:
 
     method = ""
     headers: dict[str, str] = {}
-    body: str | None = None
+    body_parts: list[str] = []
     url = ""
     i = 0
     while i < len(tokens):
@@ -6809,13 +6809,13 @@ def _parse_curl_action(text: str) -> dict[str, Any]:
             i += 1
             continue
         if low in ("-d", "--data", "--data-raw", "--data-binary", "--data-stdin") and i + 1 < len(tokens):
-            body = tokens[i + 1]
+            body_parts.append(tokens[i + 1])
             if not method:
                 method = "POST"
             i += 2
             continue
         if low.startswith("--data="):
-            body = token.split("=", 1)[1]
+            body_parts.append(token.split("=", 1)[1])
             if not method:
                 method = "POST"
             i += 1
@@ -6826,6 +6826,7 @@ def _parse_curl_action(text: str) -> dict[str, Any]:
 
     if not url:
         die("curl 口令里没有识别到 URL")
+    body = "&".join(body_parts) if body_parts else None
     return {
         "type": "http",
         "method": method or ("POST" if body else "GET"),
@@ -6846,7 +6847,9 @@ def _append_header(headers: dict[str, str], raw: str) -> None:
 
 
 def _extract_command_action(text: str) -> str | None:
-    m = re.search(r"(?:执行命令|执行脚本|命令|脚本|command|cmd)\s*[:：]?\s*(.+)$", text, re.I)
+    m = re.search(r"(?:^|\s)(?:执行命令|执行脚本|command|cmd)\s*[:：]?\s*(.+)$", text, re.I)
+    if not m:
+        m = re.search(r"^\s*(?:命令|脚本)\s*[:：]?\s*(.+)$", text, re.I)
     if not m:
         return None
     command = m.group(1).strip()
@@ -6886,25 +6889,78 @@ def _infer_schedule_name(prompt: str) -> str:
     explicit = re.search(r"(?:名称|任务名|name)\s*[:=：]\s*([^，,。]+)", prompt, re.I)
     if explicit:
         return explicit.group(1).strip()[:80] or "口令定时任务"
-    compact = re.sub(r"\s+", " ", prompt).strip()
+    compact = re.sub(r"\s+", " ", _redact_schedule_prompt(prompt)).strip()
     return (compact[:40] or "口令定时任务")
 
 
 def _build_schedule_job_from_prompt(args: argparse.Namespace, *, require_project: bool) -> dict[str, Any]:
     prompt = _prompt_text(args.prompt)
+    safe_prompt = _redact_schedule_prompt(prompt)
     project_id = _schedule_project_id(args, required=require_project)
     schedule = _parse_schedule_prompt(prompt)
     actions = _parse_actions_prompt(prompt)
+    explicit_name = getattr(args, "name", None)
+    explicit_description = getattr(args, "description", None)
     return {
         **({"projectId": project_id} if project_id else {}),
-        "name": (getattr(args, "name", None) or _infer_schedule_name(prompt)).strip()[:120],
-        "description": getattr(args, "description", None) or prompt,
+        "name": (_redact_schedule_prompt(explicit_name) if explicit_name else _infer_schedule_name(prompt)).strip()[:120],
+        "description": _redact_schedule_prompt(explicit_description) if explicit_description else safe_prompt,
         "enabled": not getattr(args, "disabled", False),
         "schedule": schedule,
         "actions": actions,
         "timeoutSeconds": max(1, int(getattr(args, "timeout", 300) or 300)),
         "retryCount": max(0, int(getattr(args, "retry", 0) or 0)),
     }
+
+
+def _redact_schedule_prompt(prompt: str) -> str:
+    text = prompt
+    text = re.sub(
+        r"(?i)(-H\s+['\"]?\s*Authorization\s*:\s*(?:Bearer\s+)?)('?[^\s'\"]+\"?)",
+        r"\1[redacted]",
+        text,
+    )
+    text = re.sub(
+        r"(?i)(-H\s+['\"]?\s*Cookie\s*:\s*)('?[^\"]+\"?)",
+        r"\1[redacted]",
+        text,
+    )
+    text = re.sub(r"(?i)(Authorization\s*:\s*(?:Bearer\s+)?)[^\s'\"]+", r"\1[redacted]", text)
+    text = re.sub(r"(?i)(Cookie\s*:\s*)[^'\"]+", r"\1[redacted]", text)
+    text = re.sub(r"(?i)((?:X-Api-Key|X-AI-Access-Key|X-CDS-AI-Token)\s*:\s*)[^\s'\"]+", r"\1[redacted]", text)
+    return text
+
+
+def _redact_schedule_job_for_output(job: Any) -> Any:
+    if not isinstance(job, dict):
+        return job
+    redacted = json.loads(json.dumps(job, ensure_ascii=False))
+    actions = redacted.get("actions")
+    if isinstance(actions, list):
+        for action in actions:
+            _redact_schedule_action(action)
+    target = redacted.get("target")
+    if isinstance(target, dict):
+        _redact_schedule_action(target)
+    return redacted
+
+
+def _redact_schedule_action(action: dict[str, Any]) -> None:
+    headers = action.get("headers")
+    if not isinstance(headers, dict):
+        return
+    for key in list(headers.keys()):
+        if re.search(r"^(authorization|cookie|set-cookie|x-api-key|x-ai-access-key|x-cds-ai-token|x-api-token|token)$", str(key), re.I):
+            headers[key] = "[redacted]"
+
+
+def _redact_schedule_checks_for_output(checks: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    redacted = json.loads(json.dumps(checks, ensure_ascii=False))
+    for item in redacted:
+        action = item.get("action")
+        if isinstance(action, dict):
+            _redact_schedule_action(action)
+    return redacted
 
 
 def _schedule_check_actions(project_id: str, actions: list[dict[str, Any]], timeout: int) -> list[dict[str, Any]]:
@@ -6927,19 +6983,22 @@ def _die_if_schedule_checks_failed(results: list[dict[str, Any]]) -> None:
         if not isinstance(r.get("result"), dict) or not r["result"].get("ok")
     ]
     if failed:
-        die("任务动作检测未通过", code=2, extra={"checks": results})
+        die("任务动作检测未通过", code=2, extra={"checks": _redact_schedule_checks_for_output(results)})
 
 
 def cmd_schedule_parse(args: argparse.Namespace) -> None:
     job = _build_schedule_job_from_prompt(args, require_project=False)
-    ok(job, note="口令已解析")
+    ok(_redact_schedule_job_for_output(job), note="口令已解析")
 
 
 def cmd_schedule_test(args: argparse.Namespace) -> None:
     job = _build_schedule_job_from_prompt(args, require_project=True)
     checks = _schedule_check_actions(job["projectId"], job["actions"], job["timeoutSeconds"])
     _die_if_schedule_checks_failed(checks)
-    ok({"job": job, "checks": checks}, note="动作检测通过")
+    ok({
+        "job": _redact_schedule_job_for_output(job),
+        "checks": _redact_schedule_checks_for_output(checks),
+    }, note="动作检测通过")
 
 
 def cmd_schedule_create(args: argparse.Namespace) -> None:
@@ -6949,7 +7008,10 @@ def cmd_schedule_create(args: argparse.Namespace) -> None:
         checks = _schedule_check_actions(job["projectId"], job["actions"], job["timeoutSeconds"])
         _die_if_schedule_checks_failed(checks)
     created = _call("POST", "/api/scheduled-jobs", body=job, timeout=20)
-    ok({"job": created.get("job", created), "checks": checks}, note="定时任务已创建")
+    ok({
+        "job": _redact_schedule_job_for_output(created.get("job", created)),
+        "checks": _redact_schedule_checks_for_output(checks),
+    }, note="定时任务已创建")
 
 
 def cmd_schedule_list(args: argparse.Namespace) -> None:
@@ -7074,7 +7136,7 @@ def _build_parser() -> argparse.ArgumentParser:
     sl.set_defaults(func=cmd_schedule_list)
     sr = sch.add_parser("run", help="手动执行任务")
     sr.add_argument("id", help="scheduledJobId")
-    sr.add_argument("--timeout", type=int, default=300)
+    sr.add_argument("--timeout", type=int, default=3700, help="CLI 等待任务执行完成的 HTTP 超时秒数")
     sr.set_defaults(func=cmd_schedule_run)
     sd = sch.add_parser("delete", help="删除任务")
     sd.add_argument("id", help="scheduledJobId")

--- a/.claude/skills/cds/tests/test_cdscli_schedule_prompt.py
+++ b/.claude/skills/cds/tests/test_cdscli_schedule_prompt.py
@@ -77,6 +77,32 @@ class CdsCliSchedulePromptTest(unittest.TestCase):
         self.assertEqual(job["actions"][0]["method"], "POST")
         self.assertEqual(job["actions"][0]["url"], "/api/statistics/sync")
 
+    def test_schedule_daily_path_with_manual_keeps_daily(self) -> None:
+        code, out = call_main([
+            "schedule", "parse",
+            "每天 02:00 调用 POST /api/manual-sync",
+            "--project", "demo",
+        ])
+
+        self.assertEqual(code, 0, out)
+        job = parse_last_json(out)["data"]
+        self.assertEqual(job["schedule"]["type"], "daily")
+        self.assertEqual(job["schedule"]["timeOfDay"], "02:00")
+        self.assertEqual(job["actions"][0]["url"], "/api/manual-sync")
+
+    def test_schedule_http_prompt_with_command_line_word_not_command(self) -> None:
+        code, out = call_main([
+            "schedule", "parse",
+            "每天 02:00 命令行调用 POST /api/statistics/sync",
+            "--project", "demo",
+        ])
+
+        self.assertEqual(code, 0, out)
+        action = parse_last_json(out)["data"]["actions"][0]
+        self.assertEqual(action["type"], "http")
+        self.assertEqual(action["method"], "POST")
+        self.assertEqual(action["url"], "/api/statistics/sync")
+
     def test_schedule_parse_interval_command_prompt(self) -> None:
         code, out = call_main([
             "schedule", "parse",
@@ -90,6 +116,19 @@ class CdsCliSchedulePromptTest(unittest.TestCase):
         self.assertEqual(job["schedule"]["intervalMinutes"], 10)
         self.assertEqual(job["actions"][0]["type"], "command")
         self.assertEqual(job["actions"][0]["command"], "echo ok")
+
+    def test_curl_multiple_data_flags_are_joined(self) -> None:
+        code, out = call_main([
+            "schedule", "parse",
+            "手动 curl -d a=1 -d b=2 https://old.example/sync",
+            "--project", "demo",
+        ])
+
+        self.assertEqual(code, 0, out)
+        action = parse_last_json(out)["data"]["actions"][0]
+        self.assertEqual(action["type"], "http")
+        self.assertEqual(action["method"], "POST")
+        self.assertEqual(action["body"], "a=1&b=2")
 
     def test_schedule_create_with_test_checks_actions_before_post(self) -> None:
         calls: list[tuple[str, str, dict | None]] = []
@@ -127,6 +166,30 @@ class CdsCliSchedulePromptTest(unittest.TestCase):
         payload = parse_last_json(out)
         self.assertEqual(payload["data"]["job"]["id"], "sjob_1")
 
+    def test_schedule_create_redacts_secret_metadata_but_sends_header(self) -> None:
+        calls: list[tuple[str, str, dict | None]] = []
+
+        def fake_call(method, path, body=None, timeout=15, quiet=False):
+            calls.append((method, path, body))
+            return {"job": {"id": "sjob_1", **body}}
+
+        prompt = "每天 02:00 curl -H 'Authorization: Bearer SECRET' https://old.example/sync"
+        with mock.patch.object(cdscli, "_call", fake_call):
+            code, out = call_main([
+                "schedule", "create",
+                prompt,
+                "--project", "demo",
+            ])
+
+        self.assertEqual(code, 0, out)
+        create_body = calls[0][2]
+        self.assertNotIn("SECRET", create_body["name"])
+        self.assertNotIn("SECRET", create_body["description"])
+        self.assertEqual(create_body["actions"][0]["headers"]["Authorization"], "Bearer SECRET")
+        self.assertNotIn("SECRET", out)
+        payload = parse_last_json(out)
+        self.assertEqual(payload["data"]["job"]["actions"][0]["headers"]["Authorization"], "[redacted]")
+
     def test_schedule_test_fails_when_check_target_fails(self) -> None:
         with mock.patch.object(
             cdscli,
@@ -144,6 +207,24 @@ class CdsCliSchedulePromptTest(unittest.TestCase):
         self.assertFalse(payload["ok"])
         self.assertIn("检测未通过", payload["error"])
 
+    def test_schedule_test_failure_redacts_header(self) -> None:
+        with mock.patch.object(
+            cdscli,
+            "_call",
+            lambda *a, **kw: {"result": {"ok": False, "httpStatus": 401, "log": "bad"}},
+        ):
+            code, out = call_main([
+                "schedule", "test",
+                "手动 curl -H 'Authorization: Bearer SECRET' https://old.example/sync",
+                "--project", "demo",
+            ])
+
+        self.assertEqual(code, 2)
+        self.assertNotIn("SECRET", out)
+        payload = parse_last_json(out)
+        action = payload["checks"][0]["action"]
+        self.assertEqual(action["headers"]["Authorization"], "[redacted]")
+
     def test_schedule_prompt_without_schedule_dies(self) -> None:
         def fail_call(*_args, **_kwargs):
             raise AssertionError("不应请求 CDS")
@@ -159,6 +240,19 @@ class CdsCliSchedulePromptTest(unittest.TestCase):
         payload = parse_last_json(out)
         self.assertFalse(payload["ok"])
         self.assertIn("未识别调度口令", payload["error"])
+
+    def test_schedule_run_default_timeout_covers_long_jobs(self) -> None:
+        timeouts: list[int] = []
+
+        def fake_call(method, path, body=None, timeout=15, quiet=False):
+            timeouts.append(timeout)
+            return {"jobRun": {"id": "run_1"}}
+
+        with mock.patch.object(cdscli, "_call", fake_call):
+            code, out = call_main(["schedule", "run", "sjob_1"])
+
+        self.assertEqual(code, 0, out)
+        self.assertGreaterEqual(timeouts[0], 3600)
 
 
 if __name__ == "__main__":

--- a/.claude/skills/cds/tests/test_cdscli_schedule_prompt.py
+++ b/.claude/skills/cds/tests/test_cdscli_schedule_prompt.py
@@ -1,0 +1,165 @@
+"""cdscli schedule prompt tests.
+
+用标准库 unittest 覆盖口令解析、动作检测和创建 payload，不访问真实 CDS。
+"""
+import io
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI_DIR = ROOT / "cli"
+sys.path.insert(0, str(CLI_DIR))
+
+import cdscli  # noqa: E402
+
+
+def call_main(argv: list[str]) -> tuple[int, str]:
+    buf = io.StringIO()
+    code = 0
+    real_stdout = sys.stdout
+    sys.stdout = buf
+    try:
+        cdscli.main(argv)
+    except SystemExit as e:
+        code = e.code if isinstance(e.code, int) else 1
+    finally:
+        sys.stdout = real_stdout
+    return code, buf.getvalue()
+
+
+def parse_last_json(out: str) -> dict:
+    return json.loads(out.strip().split("\n")[-1])
+
+
+class CdsCliSchedulePromptTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.env = mock.patch.dict(
+            os.environ,
+            {
+                "CDS_HOST": "cds.test.example",
+                "AI_ACCESS_KEY": "test-key-not-real",
+            },
+            clear=False,
+        )
+        self.env.start()
+        os.environ.pop("CDS_PROJECT_ID", None)
+        os.environ.pop("CDS_PROJECT_KEY", None)
+        cdscli._TRACE_ID = "testtrace"
+        cdscli._HUMAN = False
+
+    def tearDown(self) -> None:
+        self.env.stop()
+
+    def test_schedule_parse_daily_http_prompt(self) -> None:
+        code, out = call_main([
+            "schedule", "parse",
+            "每天 02:00 调用 POST /api/statistics/sync",
+            "--project", "demo",
+            "--name", "生码统计",
+        ])
+
+        self.assertEqual(code, 0, out)
+        payload = parse_last_json(out)
+        self.assertTrue(payload["ok"])
+        job = payload["data"]
+        self.assertEqual(job["projectId"], "demo")
+        self.assertEqual(job["name"], "生码统计")
+        self.assertEqual(job["schedule"], {
+            "type": "daily",
+            "timeOfDay": "02:00",
+            "timezone": "Asia/Shanghai",
+        })
+        self.assertEqual(job["actions"][0]["type"], "http")
+        self.assertEqual(job["actions"][0]["method"], "POST")
+        self.assertEqual(job["actions"][0]["url"], "/api/statistics/sync")
+
+    def test_schedule_parse_interval_command_prompt(self) -> None:
+        code, out = call_main([
+            "schedule", "parse",
+            "每隔 10 分钟 执行命令 echo ok",
+            "--project", "demo",
+        ])
+
+        self.assertEqual(code, 0, out)
+        job = parse_last_json(out)["data"]
+        self.assertEqual(job["schedule"]["type"], "interval")
+        self.assertEqual(job["schedule"]["intervalMinutes"], 10)
+        self.assertEqual(job["actions"][0]["type"], "command")
+        self.assertEqual(job["actions"][0]["command"], "echo ok")
+
+    def test_schedule_create_with_test_checks_actions_before_post(self) -> None:
+        calls: list[tuple[str, str, dict | None]] = []
+
+        def fake_call(method, path, body=None, timeout=15, quiet=False):
+            calls.append((method, path, body))
+            if path == "/api/scheduled-jobs/check-target":
+                return {"result": {"ok": True, "httpStatus": 200, "log": "ok"}}
+            if path == "/api/scheduled-jobs":
+                return {"job": {"id": "sjob_1", **body}}
+            raise AssertionError(path)
+
+        with mock.patch.object(cdscli, "_call", fake_call):
+            code, out = call_main([
+                "schedule", "create",
+                "每天 03:30 curl -X POST -H 'Content-Type: application/json' -d '{\"a\":1}' https://old.example/sync",
+                "--project", "demo",
+                "--test",
+                "--retry", "1",
+            ])
+
+        self.assertEqual(code, 0, out)
+        self.assertEqual([c[1] for c in calls], [
+            "/api/scheduled-jobs/check-target",
+            "/api/scheduled-jobs",
+        ])
+        check_body = calls[0][2]
+        self.assertEqual(check_body["projectId"], "demo")
+        self.assertEqual(check_body["target"]["method"], "POST")
+        self.assertEqual(check_body["target"]["headers"], {"Content-Type": "application/json"})
+        self.assertEqual(check_body["target"]["body"], '{"a":1}')
+        create_body = calls[1][2]
+        self.assertEqual(create_body["retryCount"], 1)
+        self.assertEqual(create_body["schedule"]["timeOfDay"], "03:30")
+        payload = parse_last_json(out)
+        self.assertEqual(payload["data"]["job"]["id"], "sjob_1")
+
+    def test_schedule_test_fails_when_check_target_fails(self) -> None:
+        with mock.patch.object(
+            cdscli,
+            "_call",
+            lambda *a, **kw: {"result": {"ok": False, "exitCode": 2, "log": "bad"}},
+        ):
+            code, out = call_main([
+                "schedule", "test",
+                "手动 执行命令 exit 2",
+                "--project", "demo",
+            ])
+
+        self.assertEqual(code, 2)
+        payload = parse_last_json(out)
+        self.assertFalse(payload["ok"])
+        self.assertIn("检测未通过", payload["error"])
+
+    def test_schedule_prompt_without_schedule_dies(self) -> None:
+        def fail_call(*_args, **_kwargs):
+            raise AssertionError("不应请求 CDS")
+
+        with mock.patch.object(cdscli, "_call", fail_call):
+            code, out = call_main([
+                "schedule", "create",
+                "调用 POST /api/statistics/sync",
+                "--project", "demo",
+            ])
+
+        self.assertEqual(code, 1)
+        payload = parse_last_json(out)
+        self.assertFalse(payload["ok"])
+        self.assertIn("未识别调度口令", payload["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/changelogs/2026-07-02_cdscli-schedule-prompt.md
+++ b/changelogs/2026-07-02_cdscli-schedule-prompt.md
@@ -1,0 +1,2 @@
+| feat | cds | cdscli 升级到 v0.8.0，新增 schedule 口令解析、动作检测和创建任务命令 |
+| test | cds | 新增 cdscli schedule 口令解析与创建前检测单元测试 |

--- a/changelogs/2026-07-02_cdscli-schedule-prompt.md
+++ b/changelogs/2026-07-02_cdscli-schedule-prompt.md
@@ -1,2 +1,3 @@
 | feat | cds | cdscli 升级到 v0.8.0，新增 schedule 口令解析、动作检测和创建任务命令 |
 | test | cds | 新增 cdscli schedule 口令解析与创建前检测单元测试 |
+| docs | cds | 补充 Agent 使用 cdscli schedule 的标准流程、口令格式、失败处理和安全边界 |

--- a/changelogs/2026-07-02_cdscli-schedule-prompt.md
+++ b/changelogs/2026-07-02_cdscli-schedule-prompt.md
@@ -1,3 +1,4 @@
 | feat | cds | cdscli 升级到 v0.8.0，新增 schedule 口令解析、动作检测和创建任务命令 |
+| fix | cds | 修复 cdscli schedule 口令误判、curl 多数据段丢失、敏感头泄露和 run 默认等待过短问题 |
 | test | cds | 新增 cdscli schedule 口令解析与创建前检测单元测试 |
 | docs | cds | 补充 Agent 使用 cdscli schedule 的标准流程、口令格式、失败处理和安全边界 |


### PR DESCRIPTION
## 摘要
为 CDS 核心技能的 `cdscli` 增加 `schedule` 命令族，让 Agent 可以通过自然语言口令解析、测试并创建任务调度。同步升级技能版本到 v0.8.0，并补充 Agent 使用该 CLI 的标准流程说明。

## 改动 diff
- `.claude/skills/cds/cli/cdscli.py`：新增 `schedule parse/test/create/list/run/delete` 命令，支持每天/间隔/手动调度口令，以及 curl、HTTP、命令动作解析。
- `.claude/skills/cds/SKILL.md`：升级到 v0.8.0，补充 Agent 使用 `cdscli schedule` 的流程、口令格式、失败处理和安全边界。
- `.claude/skills/cds/tests/test_cdscli_schedule_prompt.py`：新增标准库单测覆盖口令解析、创建前检测、检测失败和缺少调度的失败路径。
- `changelogs/2026-07-02_cdscli-schedule-prompt.md`：新增 changelog 碎片。

## 测试
- [x] `python3 .claude/skills/cds/tests/test_cdscli_schedule_prompt.py` 通过
- [x] `python3 -m py_compile .claude/skills/cds/cli/cdscli.py .claude/skills/cds/tests/test_cdscli_schedule_prompt.py` 通过
- [x] `python3 .claude/skills/cds/cli/cdscli.py schedule --help` 通过
- [x] 本地 CDS 验证 `schedule test "手动 调用 GET /api/projects"` 通过
- [x] 本地 CDS 验证 `schedule create ... --test` 成功创建并已清理测试任务/项目
- [x] `pnpm --dir cds test tests/services/scheduled-job-service.test.ts tests/routes/scheduled-jobs-scope.test.ts tests/web/curl-import.test.ts` 通过
- [x] `pnpm --dir cds build` 通过

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> 新能力会创建并远程执行 HTTP/命令类定时任务，虽含 check-target 与输出脱敏，仍涉及项目作用域与凭据在请求中的传递。
> 
> **Overview**
> **cdscli v0.8.0** 新增 **`schedule`** 命令族：Agent 可用中文/混合口令解析定时任务（每天/间隔/手动 + curl、HTTP、命令动作），经 **`parse` → `test`（`/check-target`）→ `create`（默认 `--test`）** 创建任务，并支持 **`list` / `run` / `delete`**，替代手写 REST 调 `/api/scheduled-jobs`。
> 
> 实现侧包含口令解析与 curl 分词、多动作串联、创建前动作检测，以及 **Authorization/Cookie 等敏感头在 CLI 输出中的脱敏**（请求仍带真实头）；`schedule run` 默认 HTTP 等待时间加长以覆盖长任务。
> 
> **`SKILL.md`** 同步升级版本并规定 Agent 标准流程、口令格式、失败处理与安全边界；新增 **`test_cdscli_schedule_prompt.py`** 单测与 changelog 条目。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 805159e41f5b925773966fc857d2d1aa4a07ca48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->