### PR TITLE
fix(cds): reclaim docker networks across create paths

### DIFF
--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -66,6 +66,7 @@ import {
   type PendingWebhookDeploy,
 } from '../services/branch-operation-coordinator.js';
 import { waitForRestartSafeBranchOperations, resolveRestartDrainTimeoutFromRequest } from '../services/restart-drain.js';
+import { ensureDockerNetworkWithReclaim } from '../services/docker-network-reclaim.js';
 
 // ── Self-status SSE 模块级状态 ────────────────────────────────────────
 // 2026-05-28 重构:状态权威源迁移到 services/self-status-cache.ts。
@@ -1457,12 +1458,7 @@ async function ensureDockerNetwork(shell: IShellExecutor, network: string): Prom
   if (!/^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$/.test(network)) {
     throw new Error(`Docker network 名称非法：${network}`);
   }
-  const inspect = await shell.exec(`docker network inspect ${routeShellQuote(network)}`, { timeout: 10_000 });
-  if (inspect.exitCode === 0) return;
-  const create = await shell.exec(`docker network create ${routeShellQuote(network)}`, { timeout: 15_000 });
-  if (create.exitCode !== 0) {
-    throw new Error(`创建 Docker 网络 "${network}" 失败：${combinedOutput(create)}`);
-  }
+  await ensureDockerNetworkWithReclaim(shell, network, { inspectTimeoutMs: 10_000, createTimeoutMs: 15_000 });
 }
 
 async function cleanupResourceExternalFirewall(shell: IShellExecutor, chain: string, port?: number): Promise<void> {

--- a/cds/src/routes/projects.ts
+++ b/cds/src/routes/projects.ts
@@ -37,6 +37,7 @@ import { isSafeGitRef } from '../services/github-webhook-dispatcher.js';
 import { resolveActorFromRequest } from '../services/actor-resolver.js';
 import { getLatestResourceUsage, type ProjectResourceUsage } from '../services/resource-usage-sampler.js';
 import { applyDefaultDeployModesToBranch } from '../services/deploy-runtime.js';
+import { ensureDockerNetworkWithReclaim } from '../services/docker-network-reclaim.js';
 import {
   getInfraCatalogEntry,
   infraCatalogIds,
@@ -503,14 +504,7 @@ export function createProjectsRouter(deps: ProjectsRouterDeps): Router {
    * the caller can roll back the state mutation.
    */
   async function ensureDockerNetwork(name: string): Promise<void> {
-    const inspect = await shell.exec(`docker network inspect ${name}`);
-    if (inspect.exitCode === 0) return;
-    const create = await shell.exec(`docker network create ${name}`);
-    if (create.exitCode !== 0) {
-      throw new Error(
-        `Failed to create Docker network "${name}": ${combinedOutput(create)}`,
-      );
-    }
+    await ensureDockerNetworkWithReclaim(shell, name);
   }
 
   /**

--- a/cds/src/services/container.ts
+++ b/cds/src/services/container.ts
@@ -11,6 +11,7 @@ import { sanitizeDockerRestartPolicy } from '../config/docker-restart-policy.js'
 import { applyPerBranchDbIsolation } from './db-scope-isolation.js';
 import { branchAppNetworkName, branchNetworkIsolationEnabled, resolveAppNetworkPlan } from './branch-network.js';
 import { nodeModulesVolumeName } from '../util/node-modules-volume.js';
+import { ensureDockerNetworkWithReclaim } from './docker-network-reclaim.js';
 import {
   collectContainerDiagnostics,
   recordContainerLifecycleIntent,
@@ -2771,95 +2772,7 @@ export class ContainerService {
    */
   private async ensureNetwork(network?: string): Promise<void> {
     const target = network || this.config.dockerNetwork;
-    const inspect = await this.shell.exec(`docker network inspect ${target}`);
-    if (inspect.exitCode !== 0) {
-      const create = await this.shell.exec(`docker network create ${target}`);
-      if (create.exitCode !== 0) {
-        // 并发竞态：同一分支的多个服务（如 api + admin 在 layer-0 同时启动）首次都发现分支网
-        // 不存在 → 同时 `docker network create` → 一个成功、其余报 "already exists"。docker 网络
-        // create 天然幂等语义下这就是成功，吞掉视为已就绪（分支网是新建的，最易触发，旧共享网因
-        // 多已预先存在而少见此竞态）。
-        const stderr = (create.stderr || '').toLowerCase();
-        if (stderr.includes('already exists')) return;
-        if (this.isBranchNetworkAddressPoolExhausted(target, create)) {
-          const cleanup = await this.cleanupUnusedBranchNetworks();
-          const retry = await this.shell.exec(`docker network create ${target}`);
-          if (retry.exitCode === 0) return;
-          if (combinedOutput(retry).toLowerCase().includes('already exists')) return;
-          const retryOutput = combinedOutput(retry);
-          const cleanupNote = `已清理 ${cleanup.removed} 个空闲分支网络、断开 ${cleanup.detached} 个停止容器后重试仍失败`;
-          throw new Error(`创建 Docker 网络 "${target}" 失败:\n${combinedOutput(create)}\n\n${cleanupNote}:\n${retryOutput}`);
-        }
-        throw new Error(`创建 Docker 网络 "${target}" 失败:\n${combinedOutput(create)}`);
-      }
-    }
-  }
-
-  private isBranchNetworkAddressPoolExhausted(network: string, result: ExecResult): boolean {
-    if (!network.startsWith('cds-br-')) return false;
-    const output = combinedOutput(result).toLowerCase();
-    return output.includes('all predefined address pools have been fully subnetted');
-  }
-
-  private async cleanupUnusedBranchNetworks(): Promise<{ inspected: number; removed: number; detached: number }> {
-    const listed = await this.shell.exec(`docker network ls --format '{{.Name}}'`);
-    if (listed.exitCode !== 0 || !listed.stdout.trim()) return { inspected: 0, removed: 0, detached: 0 };
-
-    let inspected = 0;
-    let removed = 0;
-    let detached = 0;
-    const names = listed.stdout
-      .split('\n')
-      .map((line) => line.trim())
-      .filter((line) => line.startsWith('cds-br-'));
-
-    for (const name of names) {
-      inspected += 1;
-      const inspect = await this.shell.exec(`docker network inspect --format='{{json .Containers}}' ${this.shellQuote(name)}`);
-      if (inspect.exitCode !== 0) continue;
-      const ids = this.parseNetworkContainerIds(inspect.stdout);
-      if (ids.length > 0) {
-        const states = await this.inspectNetworkContainerStates(ids);
-        if (states.length !== ids.length || states.some((s) => s.running)) continue;
-        for (const id of ids) {
-          const disconnected = await this.shell.exec(`docker network disconnect -f ${this.shellQuote(name)} ${this.shellQuote(id)}`);
-          if (disconnected.exitCode === 0) detached += 1;
-        }
-      }
-
-      const rm = await this.shell.exec(`docker network rm ${this.shellQuote(name)}`);
-      if (rm.exitCode === 0) removed += 1;
-    }
-
-    return { inspected, removed, detached };
-  }
-
-  private parseNetworkContainerIds(raw: string): string[] {
-    const text = raw.trim();
-    if (!text) return [];
-    try {
-      const parsed = JSON.parse(text);
-      if (!parsed || typeof parsed !== 'object') return [];
-      return Object.keys(parsed).filter(Boolean);
-    } catch {
-      return [];
-    }
-  }
-
-  private async inspectNetworkContainerStates(ids: string[]): Promise<Array<{ id: string; running: boolean }>> {
-    if (ids.length === 0) return [];
-    const quotedIds = ids.map((id) => this.shellQuote(id)).join(' ');
-    const inspected = await this.shell.exec(`docker inspect --format='{{.Id}} {{.State.Running}}' ${quotedIds}`);
-    if (inspected.exitCode !== 0) return [];
-    return inspected.stdout
-      .split('\n')
-      .map((line) => line.trim())
-      .filter(Boolean)
-      .map((line) => {
-        const [id, running] = line.split(/\s+/);
-        return { id, running: running === 'true' };
-      })
-      .filter((state) => !!state.id);
+    await ensureDockerNetworkWithReclaim(this.shell, target);
   }
 
   /**

--- a/cds/src/services/docker-network-reclaim.ts
+++ b/cds/src/services/docker-network-reclaim.ts
@@ -1,0 +1,118 @@
+import type { ExecResult, IShellExecutor } from '../types.js';
+import { combinedOutput } from '../types.js';
+
+export interface DockerNetworkReclaimResult {
+  inspected: number;
+  removed: number;
+  detached: number;
+}
+
+export function isDockerNetworkAddressPoolExhausted(result: ExecResult): boolean {
+  return combinedOutput(result).toLowerCase().includes('all predefined address pools have been fully subnetted');
+}
+
+export async function ensureDockerNetworkWithReclaim(
+  shell: IShellExecutor,
+  network: string,
+  opts: { inspectTimeoutMs?: number; createTimeoutMs?: number } = {},
+): Promise<void> {
+  validateDockerNetworkName(network);
+  const inspect = await shell.exec(`docker network inspect ${network}`, timeoutOpt(opts.inspectTimeoutMs));
+  if (inspect.exitCode === 0) return;
+
+  const create = await shell.exec(`docker network create ${network}`, timeoutOpt(opts.createTimeoutMs));
+  if (create.exitCode === 0 || isDockerAlreadyExists(create)) return;
+
+  if (!isDockerNetworkAddressPoolExhausted(create)) {
+    throw new Error(`创建 Docker 网络 "${network}" 失败:\n${combinedOutput(create)}`);
+  }
+
+  const cleanup = await cleanupUnusedBranchNetworks(shell);
+  const retry = await shell.exec(`docker network create ${network}`, timeoutOpt(opts.createTimeoutMs));
+  if (retry.exitCode === 0 || isDockerAlreadyExists(retry)) return;
+
+  const cleanupNote = `已清理 ${cleanup.removed} 个空闲分支网络、断开 ${cleanup.detached} 个停止容器后重试仍失败`;
+  throw new Error(`创建 Docker 网络 "${network}" 失败:\n${combinedOutput(create)}\n\n${cleanupNote}:\n${combinedOutput(retry)}`);
+}
+
+export async function cleanupUnusedBranchNetworks(shell: IShellExecutor): Promise<DockerNetworkReclaimResult> {
+  const listed = await shell.exec(`docker network ls --format '{{.Name}}'`);
+  if (listed.exitCode !== 0 || !listed.stdout.trim()) return { inspected: 0, removed: 0, detached: 0 };
+
+  let inspected = 0;
+  let removed = 0;
+  let detached = 0;
+  const names = listed.stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('cds-br-'));
+
+  for (const name of names) {
+    inspected += 1;
+    const inspect = await shell.exec(`docker network inspect --format='{{json .Containers}}' ${shellQuote(name)}`);
+    if (inspect.exitCode !== 0) continue;
+    const ids = parseNetworkContainerIds(inspect.stdout);
+    if (ids.length > 0) {
+      const states = await inspectNetworkContainerStates(shell, ids);
+      if (states.length !== ids.length || states.some((s) => s.running)) continue;
+      for (const id of ids) {
+        const disconnected = await shell.exec(`docker network disconnect -f ${shellQuote(name)} ${shellQuote(id)}`);
+        if (disconnected.exitCode === 0) detached += 1;
+      }
+    }
+
+    const rm = await shell.exec(`docker network rm ${shellQuote(name)}`);
+    if (rm.exitCode === 0) removed += 1;
+  }
+
+  return { inspected, removed, detached };
+}
+
+function validateDockerNetworkName(network: string): void {
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$/.test(network)) {
+    throw new Error(`Docker network 名称非法：${network}`);
+  }
+}
+
+function timeoutOpt(timeout?: number): { timeout: number } | undefined {
+  return timeout ? { timeout } : undefined;
+}
+
+function isDockerAlreadyExists(result: ExecResult): boolean {
+  return combinedOutput(result).toLowerCase().includes('already exists');
+}
+
+function parseNetworkContainerIds(raw: string): string[] {
+  const text = raw.trim();
+  if (!text || text === '{}' || text === 'null') return [];
+  try {
+    const parsed = JSON.parse(text);
+    if (!parsed || typeof parsed !== 'object') return [];
+    return Object.keys(parsed).filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+async function inspectNetworkContainerStates(
+  shell: IShellExecutor,
+  ids: string[],
+): Promise<Array<{ id: string; running: boolean }>> {
+  if (ids.length === 0) return [];
+  const quotedIds = ids.map((id) => shellQuote(id)).join(' ');
+  const inspected = await shell.exec(`docker inspect --format='{{.Id}} {{.State.Running}}' ${quotedIds}`);
+  if (inspected.exitCode !== 0) return [];
+  return inspected.stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [id, running] = line.split(/\s+/);
+      return { id, running: running === 'true' };
+    })
+    .filter((state) => !!state.id);
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}

--- a/cds/tests/services/docker-network-reclaim.test.ts
+++ b/cds/tests/services/docker-network-reclaim.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import { MockShellExecutor } from '../../src/services/shell-executor.js';
+import {
+  cleanupUnusedBranchNetworks,
+  ensureDockerNetworkWithReclaim,
+  isDockerNetworkAddressPoolExhausted,
+} from '../../src/services/docker-network-reclaim.js';
+
+describe('docker network reclaim', () => {
+  it('detects Docker default address pool exhaustion', () => {
+    expect(isDockerNetworkAddressPoolExhausted({
+      stdout: '',
+      stderr: 'Error response from daemon: all predefined address pools have been fully subnetted',
+      exitCode: 1,
+    })).toBe(true);
+    expect(isDockerNetworkAddressPoolExhausted({ stdout: '', stderr: 'No such network', exitCode: 1 })).toBe(false);
+  });
+
+  it('reclaims unused branch networks and retries project network creation', async () => {
+    const shell = new MockShellExecutor();
+    let createAttempts = 0;
+
+    shell.addResponsePattern(/^docker network inspect cds-proj-prd-agent$/, () => ({
+      stdout: '',
+      stderr: 'No such network',
+      exitCode: 1,
+    }));
+    shell.addResponsePattern(/^docker network create cds-proj-prd-agent$/, () => {
+      createAttempts += 1;
+      if (createAttempts === 1) {
+        return {
+          stdout: '',
+          stderr: 'Error response from daemon: all predefined address pools have been fully subnetted',
+          exitCode: 1,
+        };
+      }
+      return { stdout: 'network-id', stderr: '', exitCode: 0 };
+    });
+    shell.addResponsePattern(/docker network ls --format '\{\{\.Name\}\}'/, () => ({
+      stdout: ['cds-br-empty', 'cds-br-stopped', 'cds-br-running', 'cds-proj-prd-agent'].join('\n'),
+      stderr: '',
+      exitCode: 0,
+    }));
+    shell.addResponsePattern(/docker network inspect --format='\{\{json \.Containers\}\}' 'cds-br-empty'/, () => ({
+      stdout: '{}',
+      stderr: '',
+      exitCode: 0,
+    }));
+    shell.addResponsePattern(/docker network inspect --format='\{\{json \.Containers\}\}' 'cds-br-stopped'/, () => ({
+      stdout: JSON.stringify({ stoppedcid: { Name: 'stopped' } }),
+      stderr: '',
+      exitCode: 0,
+    }));
+    shell.addResponsePattern(/docker network inspect --format='\{\{json \.Containers\}\}' 'cds-br-running'/, () => ({
+      stdout: JSON.stringify({ runningcid: { Name: 'running' } }),
+      stderr: '',
+      exitCode: 0,
+    }));
+    shell.addResponsePattern(/docker inspect --format='\{\{\.Id\}\} \{\{\.State\.Running\}\}' 'stoppedcid'/, () => ({
+      stdout: 'stoppedcid false\n',
+      stderr: '',
+      exitCode: 0,
+    }));
+    shell.addResponsePattern(/docker inspect --format='\{\{\.Id\}\} \{\{\.State\.Running\}\}' 'runningcid'/, () => ({
+      stdout: 'runningcid true\n',
+      stderr: '',
+      exitCode: 0,
+    }));
+    shell.addResponsePattern(/docker network disconnect -f 'cds-br-stopped' 'stoppedcid'/, () => ({
+      stdout: '',
+      stderr: '',
+      exitCode: 0,
+    }));
+    shell.addResponsePattern(/docker network rm 'cds-br-empty'/, () => ({ stdout: 'cds-br-empty', stderr: '', exitCode: 0 }));
+    shell.addResponsePattern(/docker network rm 'cds-br-stopped'/, () => ({ stdout: 'cds-br-stopped', stderr: '', exitCode: 0 }));
+
+    await ensureDockerNetworkWithReclaim(shell, 'cds-proj-prd-agent');
+
+    expect(createAttempts).toBe(2);
+    expect(shell.commands.some((cmd) => cmd.includes("docker network rm 'cds-br-empty'"))).toBe(true);
+    expect(shell.commands.some((cmd) => cmd.includes("docker network disconnect -f 'cds-br-stopped' 'stoppedcid'"))).toBe(true);
+    expect(shell.commands.some((cmd) => cmd.includes("docker network rm 'cds-br-stopped'"))).toBe(true);
+    expect(shell.commands.some((cmd) => cmd.includes("docker network rm 'cds-br-running'"))).toBe(false);
+    expect(shell.commands.some((cmd) => cmd.includes('docker network rm cds-proj-prd-agent'))).toBe(false);
+  });
+
+  it('reports cleanup counts for empty and stopped-only branch networks', async () => {
+    const shell = new MockShellExecutor();
+    shell.addResponsePattern(/docker network ls --format '\{\{\.Name\}\}'/, () => ({
+      stdout: ['bridge', 'cds-br-empty', 'cds-br-stopped', 'cds-br-running'].join('\n'),
+      stderr: '',
+      exitCode: 0,
+    }));
+    shell.addResponsePattern(/docker network inspect --format='\{\{json \.Containers\}\}' 'cds-br-empty'/, () => ({
+      stdout: '{}',
+      stderr: '',
+      exitCode: 0,
+    }));
+    shell.addResponsePattern(/docker network inspect --format='\{\{json \.Containers\}\}' 'cds-br-stopped'/, () => ({
+      stdout: JSON.stringify({ stoppedcid: { Name: 'stopped' } }),
+      stderr: '',
+      exitCode: 0,
+    }));
+    shell.addResponsePattern(/docker network inspect --format='\{\{json \.Containers\}\}' 'cds-br-running'/, () => ({
+      stdout: JSON.stringify({ runningcid: { Name: 'running' } }),
+      stderr: '',
+      exitCode: 0,
+    }));
+    shell.addResponsePattern(/docker inspect --format='\{\{\.Id\}\} \{\{\.State\.Running\}\}' 'stoppedcid'/, () => ({
+      stdout: 'stoppedcid false\n',
+      stderr: '',
+      exitCode: 0,
+    }));
+    shell.addResponsePattern(/docker inspect --format='\{\{\.Id\}\} \{\{\.State\.Running\}\}' 'runningcid'/, () => ({
+      stdout: 'runningcid true\n',
+      stderr: '',
+      exitCode: 0,
+    }));
+    shell.addResponsePattern(/docker network disconnect -f 'cds-br-stopped' 'stoppedcid'/, () => ({
+      stdout: '',
+      stderr: '',
+      exitCode: 0,
+    }));
+    shell.addResponsePattern(/docker network rm 'cds-br-empty'/, () => ({ stdout: 'cds-br-empty', stderr: '', exitCode: 0 }));
+    shell.addResponsePattern(/docker network rm 'cds-br-stopped'/, () => ({ stdout: 'cds-br-stopped', stderr: '', exitCode: 0 }));
+
+    await expect(cleanupUnusedBranchNetworks(shell)).resolves.toEqual({
+      inspected: 3,
+      removed: 2,
+      detached: 1,
+    });
+  });
+});

--- a/changelogs/2026-07-02_cds-docker-network-reclaim-all-paths.md
+++ b/changelogs/2026-07-02_cds-docker-network-reclaim-all-paths.md
@@ -1,0 +1,1 @@
+| fix | cds | Docker address pool 耗尽时的自动回收逻辑抽成公共 helper，并覆盖项目网 / 分支网 / 资源公网 TCP proxy 等所有 `docker network create` 路径；避免只有 `cds-br-*` 分支网触发清理，`cds-proj-*` 项目网仍直接失败 |


### PR DESCRIPTION
## Summary
- Extract Docker network address-pool reclaim into a shared helper.
- Apply reclaim/retry to ContainerService, project creation, and branch resource TCP proxy network creation paths.
- Add tests for project-network creation retry plus empty/stopped-only branch network cleanup.

## Tests
- `cds`: `npm run build`
- `cds`: `npm test -- --run tests/services/docker-network-reclaim.test.ts tests/services/container-branch-network-isolation.test.ts tests/services/container-network-isolation.test.ts`

## Note
Route-level tests that open local HTTP ports could not run in this sandbox because `listen(0)` is denied with `EPERM`; service-level coverage and TypeScript build passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core deploy/project-creation Docker networking and can remove branch networks during pool exhaustion; behavior is refactored rather than new, with targeted tests.
> 
> **Overview**
> **Docker address-pool exhaustion** is handled in one shared helper instead of duplicated inline `docker network inspect/create` code.
> 
> The new `ensureDockerNetworkWithReclaim` path inspects, creates, treats **already exists** as success, and on **“all predefined address pools have been fully subnetted”** runs cleanup of idle `cds-br-*` networks (disconnect stopped containers, remove empty nets) then retries create. **ContainerService**, **project creation** (`cds-proj-*`), and **branch resource TCP proxy** network setup now all call this helper—previously reclaim lived only inside container branch-network creation, so **`cds-proj-*` project networks could still fail** without cleanup.
> 
> **ContainerService** drops ~100 lines of private reclaim helpers in favor of the shared module. **Vitest** covers pool-exhaustion detection, reclaim + retry for a project network, and cleanup counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27e4aff50ea24681c6259035a4af4b395917250e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->