### PR TITLE
fix(cds): reclaim empty project docker networks

### DIFF
--- a/cds/src/services/docker-network-reclaim.ts
+++ b/cds/src/services/docker-network-reclaim.ts
@@ -31,7 +31,7 @@ export async function ensureDockerNetworkWithReclaim(
   const retry = await shell.exec(`docker network create ${network}`, timeoutOpt(opts.createTimeoutMs));
   if (retry.exitCode === 0 || isDockerAlreadyExists(retry)) return;
 
-  const cleanupNote = `已清理 ${cleanup.removed} 个空闲分支网络、断开 ${cleanup.detached} 个停止容器后重试仍失败`;
+  const cleanupNote = `已清理 ${cleanup.removed} 个空闲 CDS 网络、断开 ${cleanup.detached} 个停止容器后重试仍失败`;
   throw new Error(`创建 Docker 网络 "${network}" 失败:\n${combinedOutput(create)}\n\n${cleanupNote}:\n${combinedOutput(retry)}`);
 }
 
@@ -45,13 +45,14 @@ export async function cleanupUnusedBranchNetworks(shell: IShellExecutor): Promis
   const names = listed.stdout
     .split('\n')
     .map((line) => line.trim())
-    .filter((line) => line.startsWith('cds-br-'));
+    .filter((line) => line.startsWith('cds-br-') || line.startsWith('cds-proj-'));
 
   for (const name of names) {
     inspected += 1;
     const inspect = await shell.exec(`docker network inspect --format='{{json .Containers}}' ${shellQuote(name)}`);
     if (inspect.exitCode !== 0) continue;
     const ids = parseNetworkContainerIds(inspect.stdout);
+    if (name.startsWith('cds-proj-') && ids.length > 0) continue;
     if (ids.length > 0) {
       const states = await inspectNetworkContainerStates(shell, ids);
       if (states.length !== ids.length || states.some((s) => s.running)) continue;

--- a/cds/tests/services/docker-network-reclaim.test.ts
+++ b/cds/tests/services/docker-network-reclaim.test.ts
@@ -37,7 +37,14 @@ describe('docker network reclaim', () => {
       return { stdout: 'network-id', stderr: '', exitCode: 0 };
     });
     shell.addResponsePattern(/docker network ls --format '\{\{\.Name\}\}'/, () => ({
-      stdout: ['cds-br-empty', 'cds-br-stopped', 'cds-br-running', 'cds-proj-prd-agent'].join('\n'),
+      stdout: [
+        'cds-br-empty',
+        'cds-br-stopped',
+        'cds-br-running',
+        'cds-proj-empty',
+        'cds-proj-busy',
+        'cds-proj-prd-agent',
+      ].join('\n'),
       stderr: '',
       exitCode: 0,
     }));
@@ -53,6 +60,16 @@ describe('docker network reclaim', () => {
     }));
     shell.addResponsePattern(/docker network inspect --format='\{\{json \.Containers\}\}' 'cds-br-running'/, () => ({
       stdout: JSON.stringify({ runningcid: { Name: 'running' } }),
+      stderr: '',
+      exitCode: 0,
+    }));
+    shell.addResponsePattern(/docker network inspect --format='\{\{json \.Containers\}\}' 'cds-proj-empty'/, () => ({
+      stdout: '{}',
+      stderr: '',
+      exitCode: 0,
+    }));
+    shell.addResponsePattern(/docker network inspect --format='\{\{json \.Containers\}\}' 'cds-proj-busy'/, () => ({
+      stdout: JSON.stringify({ projectcid: { Name: 'project-busy' } }),
       stderr: '',
       exitCode: 0,
     }));
@@ -73,6 +90,7 @@ describe('docker network reclaim', () => {
     }));
     shell.addResponsePattern(/docker network rm 'cds-br-empty'/, () => ({ stdout: 'cds-br-empty', stderr: '', exitCode: 0 }));
     shell.addResponsePattern(/docker network rm 'cds-br-stopped'/, () => ({ stdout: 'cds-br-stopped', stderr: '', exitCode: 0 }));
+    shell.addResponsePattern(/docker network rm 'cds-proj-empty'/, () => ({ stdout: 'cds-proj-empty', stderr: '', exitCode: 0 }));
 
     await ensureDockerNetworkWithReclaim(shell, 'cds-proj-prd-agent');
 
@@ -81,13 +99,15 @@ describe('docker network reclaim', () => {
     expect(shell.commands.some((cmd) => cmd.includes("docker network disconnect -f 'cds-br-stopped' 'stoppedcid'"))).toBe(true);
     expect(shell.commands.some((cmd) => cmd.includes("docker network rm 'cds-br-stopped'"))).toBe(true);
     expect(shell.commands.some((cmd) => cmd.includes("docker network rm 'cds-br-running'"))).toBe(false);
+    expect(shell.commands.some((cmd) => cmd.includes("docker network rm 'cds-proj-empty'"))).toBe(true);
+    expect(shell.commands.some((cmd) => cmd.includes("docker network rm 'cds-proj-busy'"))).toBe(false);
     expect(shell.commands.some((cmd) => cmd.includes('docker network rm cds-proj-prd-agent'))).toBe(false);
   });
 
-  it('reports cleanup counts for empty and stopped-only branch networks', async () => {
+  it('reports cleanup counts for empty and stopped-only CDS networks', async () => {
     const shell = new MockShellExecutor();
     shell.addResponsePattern(/docker network ls --format '\{\{\.Name\}\}'/, () => ({
-      stdout: ['bridge', 'cds-br-empty', 'cds-br-stopped', 'cds-br-running'].join('\n'),
+      stdout: ['bridge', 'cds-br-empty', 'cds-br-stopped', 'cds-br-running', 'cds-proj-empty', 'cds-proj-busy'].join('\n'),
       stderr: '',
       exitCode: 0,
     }));
@@ -103,6 +123,16 @@ describe('docker network reclaim', () => {
     }));
     shell.addResponsePattern(/docker network inspect --format='\{\{json \.Containers\}\}' 'cds-br-running'/, () => ({
       stdout: JSON.stringify({ runningcid: { Name: 'running' } }),
+      stderr: '',
+      exitCode: 0,
+    }));
+    shell.addResponsePattern(/docker network inspect --format='\{\{json \.Containers\}\}' 'cds-proj-empty'/, () => ({
+      stdout: '{}',
+      stderr: '',
+      exitCode: 0,
+    }));
+    shell.addResponsePattern(/docker network inspect --format='\{\{json \.Containers\}\}' 'cds-proj-busy'/, () => ({
+      stdout: JSON.stringify({ projectcid: { Name: 'project-busy' } }),
       stderr: '',
       exitCode: 0,
     }));
@@ -123,11 +153,13 @@ describe('docker network reclaim', () => {
     }));
     shell.addResponsePattern(/docker network rm 'cds-br-empty'/, () => ({ stdout: 'cds-br-empty', stderr: '', exitCode: 0 }));
     shell.addResponsePattern(/docker network rm 'cds-br-stopped'/, () => ({ stdout: 'cds-br-stopped', stderr: '', exitCode: 0 }));
+    shell.addResponsePattern(/docker network rm 'cds-proj-empty'/, () => ({ stdout: 'cds-proj-empty', stderr: '', exitCode: 0 }));
 
     await expect(cleanupUnusedBranchNetworks(shell)).resolves.toEqual({
-      inspected: 3,
-      removed: 2,
+      inspected: 5,
+      removed: 3,
       detached: 1,
     });
+    expect(shell.commands.some((cmd) => cmd.includes("docker network rm 'cds-proj-busy'"))).toBe(false);
   });
 });

--- a/changelogs/2026-07-02_cds-docker-network-reclaim-all-paths.md
+++ b/changelogs/2026-07-02_cds-docker-network-reclaim-all-paths.md
@@ -1,1 +1,2 @@
 | fix | cds | Docker address pool 耗尽时的自动回收逻辑抽成公共 helper，并覆盖项目网 / 分支网 / 资源公网 TCP proxy 等所有 `docker network create` 路径；避免只有 `cds-br-*` 分支网触发清理，`cds-proj-*` 项目网仍直接失败 |
+| fix | cds | 地址池耗尽善后增加空 `cds-proj-*` 项目网回收；线上确认空项目网会占用 Docker 子网，清理后可立即恢复 network create |


### PR DESCRIPTION
## Summary
- Extend Docker address-pool reclaim to scan `cds-proj-*` networks as well as `cds-br-*`.
- Delete only completely empty project networks; non-empty project networks are preserved.
- Keep branch-network behavior unchanged: empty or stopped-only branch networks can be reclaimed.

## Production finding
On `62.146.168.225`, all `cds-br-*` networks were actively running, but five empty `cds-proj-*` networks were consuming Docker subnets. Removing those empty project networks dropped total Docker networks from 32 to 27 and a probe `docker network create` succeeded.

## Tests
- `cds`: `npm run build`
- `cds`: `npm test -- --run tests/services/docker-network-reclaim.test.ts tests/services/container-branch-network-isolation.test.ts tests/services/container-network-isolation.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The change runs `docker network rm` on production hosts during pool exhaustion; safeguards limit project-network deletion to empty networks, but mis-detection could still remove a network that should be kept.
> 
> **Overview**
> When Docker’s address pool is exhausted, **CDS network reclaim** now scans **`cds-proj-*`** as well as **`cds-br-*`**, so empty project networks can free subnets before retrying `docker network create`.
> 
> **Project networks** are only removed when they have **no attached containers**; any **`cds-proj-*`** network with containers is skipped (no disconnect/remove). **Branch network** behavior is unchanged: empty networks and those with **stopped-only** containers can still be disconnected and removed.
> 
> Failure messaging now refers to reclaimed **CDS networks** rather than branch networks only. Tests cover empty vs busy project networks during reclaim and updated cleanup counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c0103c9eaa533ba08996d34e92fe084ee8b1669. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->