### PR TITLE
每日熵减计划 2026-W27 — D2/D3 索引补录 + D6 changelog→doc 补录(5条)

### DIFF
--- a/changelogs/.entropy-manifest.yml
+++ b/changelogs/.entropy-manifest.yml
@@ -393,3 +393,8 @@ processed:
   - 2026-06-27_llm-log-observability.md
   - 2026-06-27_llmgw-deploy-scaffold.md
   - 2026-06-27_llmgw-web-skeleton.md
+  - 2026-06-27_logs-lifecycle.md
+  - 2026-06-27_logs-observability-fill.md
+  - 2026-06-27_logs-observability-ui.md
+  - 2026-06-28_llm-gateway-http-client.md
+  - 2026-06-28_llm-gateway-selftest.md

--- a/changelogs/2026-07-02_entropy-cleanup.md
+++ b/changelogs/2026-07-02_entropy-cleanup.md
@@ -1,0 +1,1 @@
+| chore | doc | 每日熵减：D2 index.yml +1，D3 guide.list +2，D6 changelog→doc 补录 5 条（LLM 网关日志可观测性 + 跨进程剥离自测），D1/D4 无违规，D3/D4 疑似幽灵条目核实后均为误报未删除 |

--- a/doc/design.llm-gateway-physical-isolation.md
+++ b/doc/design.llm-gateway-physical-isolation.md
@@ -512,6 +512,7 @@ api:
 - **关键约束（吸收评审）**：影子期日志写**统一由网关承接**（http 路径写网关；inproc 路径要么也调网关 writer、要么 prd-api 不写只透传），prd-api 侧 Watchdog 在任一 caller 走 http 时即关闭——避免双 Watchdog 互杀长请求 / 孤儿 running。
 - **可独立上线判据**：是。flag 默认 inproc，网关容器空跑待命。
 - **回滚点**：flag 切回 `inproc`，无需重新部署 prd-api。
+- **跨进程自测**（2026-06-28 新增）：`CrossProcessServingSelfTest` 起真 Kestrel + 真 `HttpLlmGatewayClient` + stub gateway，断言 resolve/send/stream/raw/pools/client-stream 的 HTTP 往返、ApiKey 不过线、密钥门 401，是"网关剥离没剥漏"的回归底线；serving 端点抽成可复用扩展 `MapGatewayServingEndpoints`（SSOT，`Program.cs` 与自测共用同一份映射），避免自测与生产路由漂移。
 
 ### 阶段 3：流量切换
 

--- a/doc/design.platform.llm-gateway.md
+++ b/doc/design.platform.llm-gateway.md
@@ -173,6 +173,14 @@
 | GET | `/api/llm-logs/{id}` | 日志详情 |
 | GET | `/api/llm-logs/meta` | 日志元数据（可用筛选维度） |
 
+### 日志可观测性增强（2026-06-27）
+
+日志页解决"看不清一次调用真实经历了什么"的问题，三处增强：
+
+- **请求生命周期可视化**：列表日期前生命周期色点 + 详情抽屉生命周期 chip，区分「已发·等响应 / 接收中 / 已完成 / 失败 / 已取消」，治"不知道是没发送还是没收到响应"的排障困惑。
+- **直连路径字段补写**：`OpenAIClient` / `ClaudeClient` 直连路径此前未写 `Protocol`（openai/claude）、`ResolutionReason`、`IsStreaming`，也未捕获 `finish_reason` / `stop_reason`，日志页这些字段恒为"—"；补齐后可按协议/终止原因排查。
+- **应用聚合视图 + 正文/图片还原**：新增按「应用前缀 + 类型」矩阵的成功率聚合视图；详情抽屉支持 COS 占位符正文一键还原（Prompt/Completion/Thinking）与生图输入/参考/输出图片缩略图渲染。
+
 ### LLM 配置（LLMConfigController）
 
 | 方法 | 路径 | 用途 |

--- a/doc/guide.list.directory.md
+++ b/doc/guide.list.directory.md
@@ -630,6 +630,12 @@
 - [LLM 网关全面切换执行计划](plan.llm-gateway.full-cutover) `plan.llm-gateway.full-cutover`
   > 全面撤销 MAP 直连 LLM、清理网关旧代码、全接口 MECE 复测、遗漏排查四项诉求 + CDS 多出口面板
 
+- [LLM 网关 GW 用户愿景与交接](plan.llm-gateway.gw-vision-handoff) `plan.llm-gateway.gw-vision-handoff`
+  > 两 web 两域名一主一副 / 简单账号密码 admin-admin / OpenRouter 风格控制台 / 替换项目所有模型请求，四点愿景与接力交接
+
+- [LLM 网关剥离活状态看板](plan.llm-gateway.status-dashboard) `plan.llm-gateway.status-dashboard`
+  > 网关剥离唯一进度真相：一句话现状 + 能不能发布 + 记分卡 + Gate + 下一步 + 验收证据
+
 - [PA Agent 竞品调研与改进方案](plan.product-agent.pa.competitive-improvements) `plan.product-agent.pa.competitive-improvements`
   > 四类竞品谱系、与 Phase 1 差距对照、P2～P4 分期改进包
 

--- a/doc/index.yml
+++ b/doc/index.yml
@@ -267,6 +267,7 @@ docs:
   plan.llm-gateway.rollout: LLM 网关剥离上线计划（差异化进度 + 测试纲领 + 局限范围 + 翻 http 序列）
   plan.llm-gateway.full-cutover: LLM 网关全面切换执行计划（撤销 MAP 直连 + 清理旧代码 + 全接口 MECE 复测 + CDS 多出口面板）
   plan.llm-gateway.gw-vision-handoff: LLM 网关 GW 用户四点愿景与交接（两 web 两域名 / 简单账号密码 admin/admin / OpenRouter 风格控制台 / 替换所有模型请求）
+  plan.llm-gateway.status-dashboard: LLM 网关剥离活状态看板（唯一"现在到哪了/能不能发布"入口，记分卡 + Gate + 下一步 + 验收证据）
   plan.visual-agent.merge-image-ref-resolver: 合并计划书：三入口守门员统一
   plan.skill.installation: Claude Code Skill 安装计划
   plan.skill.marketplace-open-api-next: 海鲜市场技能开放接口 — 下一程交接（P2/P3/P4 待办 + UAT 清单 + 环境准备）


### PR DESCRIPTION
## 摘要

日常熵清理（entropy-cleanup 技能）六维度双向扫描的例行结果：新增文档补齐索引，历史 changelog 内容补录进对应设计文档。

## 熵清理摘要

- D1 doc/ 命名规范：0 违规
- D2 index.yml：补缺 1 条（`plan.llm-gateway.status-dashboard` 漏登记）；删幽灵 0 条
- D3 guide.list.directory.md：补缺 2 条（`plan.llm-gateway.gw-vision-handoff`、`plan.llm-gateway.status-dashboard`）；删幽灵 0 条（扫描命中的疑似幽灵条目逐条核实后均为「变更记录历史表引用」或「非索引位置的普通反引号文本」，非真实索引条目，未误删）
- D4 CLAUDE.md 技能表：补缺 0 条；删幽灵 0 条（命中的 `pnpm` 为加粗提示文字，非技能表行，误报未处理）
- D5 codebase-snapshot：本次无需人工更新
- D6 changelog→doc：本次处理 5 条未处理的 changelog 片段，追加进对应设计文档新章节（manifest 累计 395 条）：
  - `2026-06-27_logs-lifecycle.md` / `2026-06-27_logs-observability-fill.md` / `2026-06-27_logs-observability-ui.md` → `doc/design.platform.llm-gateway.md` 新增「日志可观测性增强（2026-06-27）」小节
  - `2026-06-28_llm-gateway-http-client.md` → 内容已被 `doc/design.llm-gateway-physical-isolation.md` 既有章节覆盖，无需补充
  - `2026-06-28_llm-gateway-selftest.md` → `doc/design.llm-gateway-physical-isolation.md` 阶段 2 小节补一条「跨进程自测」说明

净变更：+22 行 / -0 行

## 改动 diff

- `doc/index.yml`：补 `plan.llm-gateway.status-dashboard` 索引条目
- `doc/guide.list.directory.md`：补 `plan.llm-gateway.gw-vision-handoff`、`plan.llm-gateway.status-dashboard` 两条目录条目
- `doc/design.platform.llm-gateway.md`：新增「日志可观测性增强（2026-06-27）」小节（生命周期可视化 + 直连路径字段补写 + 应用聚合视图/正文还原）
- `doc/design.llm-gateway-physical-isolation.md`：阶段 2 小节补「跨进程自测（CrossProcessServingSelfTest + MapGatewayServingEndpoints SSOT）」说明
- `changelogs/.entropy-manifest.yml`：新增 5 条已处理 changelog 记录
- `changelogs/2026-07-02_entropy-cleanup.md`：本次熵清理 changelog 碎片

## 测试

- [x] 双向扫描完成，`git diff --stat` 核验：本次仅有新增行（+22/-0），无删除行，无需幽灵文件存在性校验
- [x] 全部改动限定在 `doc/` 索引 + `doc/design.*.md` 追加小节 + `changelogs/`，无代码文件混入
- [x] 幂等性：D2/D3 补缺项写入前均 `grep -q` 确认原本不存在

无需真人预览验收（纯文档/索引变更，不涉及可执行代码或 UI）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01MauCof28d8TWJ8sgy2dL3f)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and index-only changes; no runtime, auth, or data-path code.
> 
> **Overview**
> **Routine entropy cleanup** (docs/changelogs only): indexes and design backfill for LLM gateway work, no application code.
> 
> **Indexing (D2/D3):** Adds `plan.llm-gateway.status-dashboard` to `doc/index.yml` and lists both `plan.llm-gateway.gw-vision-handoff` and `plan.llm-gateway.status-dashboard` in `doc/guide.list.directory.md` so existing plan pages are discoverable from the doc SSOT.
> 
> **Changelog → design (D6):** Five manifest entries are marked processed and their substance is merged into design docs—**日志可观测性增强（2026-06-27）** in `design.platform.llm-gateway.md` (lifecycle UI, direct-client log fields, app matrix + COS/image restore), and a **跨进程自测** note under phase 2 in `design.llm-gateway-physical-isolation.md` (`CrossProcessServingSelfTest`, shared `MapGatewayServingEndpoints`).
> 
> Also adds `changelogs/2026-07-02_entropy-cleanup.md` and updates `changelogs/.entropy-manifest.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46156624909a4750471f7e4f1b1c14a6acf02e64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->