### PR TITLE
每日熵减计划 2026-07-03 — D6 补录 5 条（CDS 任务调度+compose检测修复+网关serving登记）

### DIFF
--- a/changelogs/.entropy-manifest.yml
+++ b/changelogs/.entropy-manifest.yml
@@ -398,3 +398,8 @@ processed:
   - 2026-06-27_logs-observability-ui.md
   - 2026-06-28_llm-gateway-http-client.md
   - 2026-06-28_llm-gateway-selftest.md
+  - 2026-06-28_llm-gateway-serve-deploy.md
+  - 2026-06-28_llm-gateway-serving-process.md
+  - 2026-06-29_cds-runtime-detect-compose.md
+  - 2026-06-29_cds-task-schedule.md
+  - 2026-06-29_entropy-cleanup.md

--- a/changelogs/2026-07-03_entropy-cleanup.md
+++ b/changelogs/2026-07-03_entropy-cleanup.md
@@ -1,0 +1,1 @@
+| chore | doc | 熵清理 2026-07-03：D1 0 个，D2 +0/-0，D3 +0/-0（疑似幽灵均命中 guide.list 历史变更记录表/CLAUDE.md 加粗术语，非目录条目误报），D4 +0/-0（pnpm 为误报），D6 处理 5 条（llm-gateway serving 部署+进程已有覆盖仅登记；design.cds.onboarding.md 补「compose 服务误判修复」；design.cds.md 补 5.9 ScheduledJobService 项目级任务调度），manifest 累计 400 条 |

--- a/doc/design.cds.md
+++ b/doc/design.cds.md
@@ -265,6 +265,16 @@ CDS Compose YAML 解析与生成。
 
 默认 `enabled: false`，保持与老版本完全一致的行为。启用后按 `maxHotBranches` / `idleTTLSeconds` / `pinnedBranches` 配置工作。
 
+### 5.9 ScheduledJobService（项目级任务调度，2026-06-29 新增）
+
+项目级定时任务 MVP，`cds/src/services/scheduled-job-service.ts` + `cds/src/scheduler/`（`dispatcher.ts` / `executor-registry.ts`）+ `cds/src/routes/scheduled-jobs.ts`。
+
+- **配置模型**：一个 `ScheduledJob` = 触发器（`schedule`：cron/interval/manual）+ 一串按顺序执行的 `ScheduledJobAction`（动作步骤，支持 HTTP 请求或命令目标），纵向配置流，非单一目标。
+- **执行方式**：30s tick（`DEFAULT_TICK_MS`）扫描到期任务；命令类动作在 Docker sandbox（默认镜像 `alpine:3`）中执行，隔离宿主文件系统，透传 CDS Docker network 使其可访问项目内服务；每次执行整体共享一个超时预算（`DEFAULT_TIMEOUT_SECONDS=300`），避免多动作/重试突破任务总超时。
+- **API**：`GET /scheduled-jobs`、`GET /scheduled-jobs/runs`、`POST /scheduled-jobs/check-target`（执行前检测）、`POST /scheduled-jobs`、`PATCH /scheduled-jobs/:id`、`DELETE /scheduled-jobs/:id`、`POST /scheduled-jobs/:id/run`（手动触发）。
+- **安全**：项目级 key 的读权限已收敛到自己项目范围（修复过「项目级 key 可无范围读取任务列表与运行日志」的越权问题）；命令动作强制走 sandbox，不直接触达宿主。
+- **已知修复**：按 `retryCount` 重试失败动作；长时间任务不再因重复 tick 产生假跳过记录并覆盖运行状态；编辑非调度字段不再误触发 `nextRunAt` 重算；同一轮 tick 内任务被禁用后不再继续执行；tick 认领逻辑加固（防坏调度阻断启动、空 `nextRunAt` 重复执行、手动运行误挪动自动计划）。
+
 ---
 
 ## 6. 环境变量体系

--- a/doc/design.cds.onboarding.md
+++ b/doc/design.cds.onboarding.md
@@ -173,6 +173,8 @@
 - **Docker Compose 迁移**：解析 services/volumes/networks 映射
 - **缺失信息**：用占位符标注 `"TODO: ..."` 并提示用户确认
 
+**误判修复（2026-06-29）**：项目创建自动检测曾把 CDS 控制面自身、sidecar 进程和测试目录误识别为「待部署应用服务」，导致创建预览里混入不该存在的服务卡片。修复后：compose 里声明的基础设施服务改为「检测提示 + 由 compose 导入」而非当作应用服务硬塞进创建流程；没有 `command` 的 compose 应用服务也会正常出现在创建预览中（此前会被静默跳过）；带 `workDir` 的 compose 命令会在其声明的子目录内做存在性验证，避免跨目录误判。配套地，仓库 Git hooks 安装脚本新增 `post-checkout` 钩子，`checkout`/`worktree add` 后自动补齐 `.claude/skills → .agents/skills` 的本地软链，避免新建 worktree 里技能目录悬空。
+
 ---
 
 ## 5. Dashboard 一键导入 UI


### PR DESCRIPTION
## 熵清理摘要

- D1 命名违规：0 个
- D2 index.yml：+0/-0
- D3 guide.list：+0/-0（疑似幽灵条目核实后均命中该文件底部「历史变更记录」表格中的历史引用，非当前目录条目误报，无需删改）
- D4 CLAUDE.md 技能表：+0/-0（`pnpm` 命中误报，是加粗术语非技能名）
- D6 changelog→doc：本次处理 5 条，manifest 累计 400 条

## 改动 diff

- `doc/design.cds.md`：新增 §5.9 ScheduledJobService（项目级任务调度）章节——配置模型（触发器+纵向动作步骤）、30s tick 执行方式、Docker sandbox 隔离、7 个 API 端点、安全收敛与已知修复清单
- `doc/design.cds.onboarding.md`：§4.3 补充「误判修复（2026-06-29）」段落——compose 基础设施误识别为应用服务的修复 + git post-checkout 钩子自动补链说明
- `changelogs/.entropy-manifest.yml`：追加本次处理的 5 条 changelog 文件名（含 2 条已确认在 `design.llm-gateway-physical-isolation.md` 中已有充分覆盖，仅登记不重复追加内容）
- `changelogs/2026-07-03_entropy-cleanup.md`：本次熵清理 changelog 碎片

## 测试

- [x] 双向扫描完成（D1-D4 全量扫描 + D6 增量处理）
- [x] `git diff` 核验：本次改动仅为纯新增（无删除行），无需幽灵校验
- [x] 运行前手动核对了每条疑似幽灵条目的真实上下文，确认均为误报（历史变更记录表 / 加粗术语），未做任何误删

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011nUuJBsV97GVyqKr34sDsB

---
_Generated by [Claude Code](https://claude.ai/code/session_011nUuJBsV97GVyqKr34sDsB)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds and updates markdown/changelog registry only; no runtime, auth, or application code changes.
> 
> **Overview**
> Documentation-only **entropy cleanup** (2026-07-03): backfills design docs from five processed changelog entries and updates the entropy manifest (400 cumulative).
> 
> **`doc/design.cds.md`** gains new **§5.9 ScheduledJobService** describing project-level scheduling (trigger + ordered actions, 30s tick, Docker sandbox for commands, REST surface, scope fixes, and known tick/retry bugs fixed).
> 
> **`doc/design.cds.onboarding.md`** §4.3 adds **compose/runtime mis-detection fixes (2026-06-29)**—infra vs app services in create preview, commandless compose apps, `workDir` validation—and notes a **`post-checkout` hook** to restore `.claude/skills → .agents/skills` after checkout/worktree.
> 
> **`changelogs/.entropy-manifest.yml`** registers five changelog filenames; **`changelogs/2026-07-03_entropy-cleanup.md`** records the cleanup run (no D1–D4 doc deletions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43e2bb0c1758b1cbc9598bdb110b468928069168. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->