### PR TITLE
每日熵减计划 2026-W27 — D6 归档 1 条 changelog manifest 记录

### DIFF
--- a/changelogs/.entropy-manifest.yml
+++ b/changelogs/.entropy-manifest.yml
@@ -408,4 +408,5 @@ processed:
   - 2026-06-29_gw-shadow-mode.md
   - 2026-06-29_gw-test-matrix-data-driven.md
   - 2026-06-29_gw-test-matrix.md
+  - 2026-07-05_entropy-cleanup.md
   - 2026-07-06_cds-local-prod-review-fixes.md

--- a/changelogs/.entropy-manifest.yml
+++ b/changelogs/.entropy-manifest.yml
@@ -408,3 +408,4 @@ processed:
   - 2026-06-29_gw-shadow-mode.md
   - 2026-06-29_gw-test-matrix-data-driven.md
   - 2026-06-29_gw-test-matrix.md
+  - 2026-07-06_cds-local-prod-review-fixes.md

--- a/changelogs/2026-07-05_entropy-cleanup.md
+++ b/changelogs/2026-07-05_entropy-cleanup.md
@@ -1,0 +1,1 @@
+| chore | doc | 每日熵清理：D1-D5 六维扫描无欠款，D6 处理 1 条未归档 changelog（cds 本机发布评审修复，narrow fix 无需新增设计文档章节） |


### PR DESCRIPTION
## 熵清理摘要

- D1 doc/ 命名规范：0 个违规
- D2 index.yml：+0/-0（无欠款）
- D3 guide.list.directory.md：+0/-0（无欠款；扫描命中的候选均为「变更历史」章节的历史记录或自引用，非真实幽灵条目，已逐条核实排除）
- D4 CLAUDE.md 技能表：+0/-0（无欠款）
- D5 codebase-snapshot：已发现「最后更新 2026-05-31 / 总提交数 ~375」相对当前（458 commits）已过期，按技能设计该维度需人工审阅内容后更新，本次仅标记不自动改写
- D6 changelog→doc：本次处理 1 条（`2026-07-06_cds-local-prod-review-fixes.md`，cds 本机发布评审的窄范围 bug fix，无对应设计文档需要补章节），manifest 累计 406 条

## 改动 diff

- `changelogs/.entropy-manifest.yml`：追加 1 条已处理 changelog 记录
- `changelogs/2026-07-05_entropy-cleanup.md`：本次熵清理 changelog 碎片

## 测试

- [x] 双向扫描完成，diff 核验通过（本次 diff 仅为纯追加，无删除行需要核验）
- [x] 运行两次验证：本次改动仅追加 manifest 记录，重跑不会产生新变更

## 风险与已知边界

- D5 codebase-snapshot 已过期（约 1 个月 + 83 个提交），需要人工审阅近期新增功能后专项更新，本 PR 不处理


---
_Generated by [Claude Code](https://claude.ai/code/session_01GfU1sN4M2cC2NxjgRNmnaD)_