### PR TITLE
feat(cds): 配置体系三波演进 — 分支临时容器产品化 / 配置检查器 / 配置树补全

### DIFF
--- a/.claude/skills/cds/cli/cdscli.py
+++ b/.claude/skills/cds/cli/cdscli.py
@@ -2000,6 +2000,143 @@ def cmd_branch_set_mode(args: argparse.Namespace) -> None:
                   "(已保留其它覆盖字段；需重新部署生效)")
 
 
+# ── 分支级临时额外服务（branch-local extra services）────────────────────
+# 场景:某分支临时要接 Nacos/Kafka 等实验容器,只作用于本分支、不进项目配置、
+# 删分支即消失。后端契约(design.cds.branch-local-extra-services):
+#   GET  /api/branches/:id/extra-services            → {extraProfiles:[...(env 已脱敏 ***)]}
+#   PUT  /api/branches/:id/extra-services[?redeploy=1] → 整体替换(数组),空数组=清空
+# 两条服务端铁律(cds/src/routes/branches.ts PUT handler),CLI 依赖它们:
+#   1. env merge 不 replace:同 id 旧 env 为基底叠加入参,省略 env 不丢旧密钥;
+#   2. 掩码哨兵剥离:入参值为 *** 等哨兵时保留旧值 → GET 的脱敏结果直接回传 PUT 是安全的。
+# 因此 set/remove 走「GET → 本地改 → PUT 全量」读改写,无需 reveal 明文。
+
+def _parse_env_pairs(pairs: list[str] | None) -> dict[str, str]:
+    env: dict[str, str] = {}
+    for raw in pairs or []:
+        if "=" not in raw:
+            die(f"--env 需要 KEY=VALUE 形式,收到: {raw}", code=1)
+        k, _, v = raw.partition("=")
+        if not k.strip():
+            die(f"--env 的 KEY 不能为空: {raw}", code=1)
+        env[k.strip()] = v
+    return env
+
+
+def _get_extra_profiles(branch_id: str) -> list[dict]:
+    body = _call("GET", f"/api/branches/{urllib.parse.quote(branch_id)}/extra-services",
+                 timeout=30)
+    lst = (body or {}).get("extraProfiles") if isinstance(body, dict) else None
+    return [p for p in (lst or []) if isinstance(p, dict)]
+
+
+def _put_extra_profiles(branch_id: str, profiles: list[dict],
+                        redeploy: bool) -> dict:
+    path = f"/api/branches/{urllib.parse.quote(branch_id)}/extra-services"
+    if redeploy:
+        path += "?redeploy=1"
+    # PUT 触发 redeploy 时服务端会等 deploy 请求被「接受」才回包,给足超时
+    return _call("PUT", path, body={"extraProfiles": profiles},
+                 timeout=120 if redeploy else 30)
+
+
+def _extra_summary(p: dict) -> str:
+    bits = [f"{p.get('id','?')}", f"image={p.get('dockerImage','?')}",
+            f"port={p.get('containerPort','?')}"]
+    if p.get("subdomain"):
+        bits.append(f"subdomain={p['subdomain']}")
+    if p.get("dbScope"):
+        bits.append(f"dbScope={p['dbScope']}")
+    if p.get("env"):
+        bits.append(f"env×{len(p['env'])}")
+    return "  ".join(bits)
+
+
+def cmd_branch_extra_list(args: argparse.Namespace) -> None:
+    profiles = _get_extra_profiles(args.id)
+    if _HUMAN:
+        print(f"分支 {args.id} 的临时额外服务: {len(profiles)} 个")
+        for p in profiles:
+            print(f"  - {_extra_summary(p)}")
+        return
+    ok({"branchId": args.id, "extraProfiles": profiles})
+
+
+def cmd_branch_extra_set(args: argparse.Namespace) -> None:
+    """upsert 单个额外服务(--id + 字段旗标),或 --file 整体替换。
+
+    读改写:先 GET 现有列表(env 已脱敏,回传安全),再按 --id 合并字段,最后 PUT 全量。
+    --redeploy 让声明的服务真正起容器(否则纯配置落库,下次部署才生效)。
+    """
+    if args.file:
+        with open(args.file, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        profiles = data.get("extraProfiles") if isinstance(data, dict) else data
+        if not isinstance(profiles, list):
+            die("--file 内容必须是数组,或 {\"extraProfiles\": [...]} 对象", code=1)
+        body = _put_extra_profiles(args.id, profiles, args.redeploy)
+        ok(body, note=f"分支 {args.id} 额外服务已整体替换({len(profiles)} 个)"
+                      + (";已触发重部署" if body.get("redeployTriggered") else
+                         ";纯配置变更,--redeploy 或下次部署时生效"))
+        return
+    if not args.service_id:
+        die("必须提供 --id(upsert 单个服务)或 --file(整体替换)", code=1)
+    profiles = _get_extra_profiles(args.id)
+    existing = next((p for p in profiles if p.get("id") == args.service_id), None)
+    svc: dict[str, Any] = dict(existing or {"id": args.service_id})
+    if existing is None and not args.image:
+        die(f"新建额外服务 \"{args.service_id}\" 必须提供 --image", code=1)
+    if args.image:
+        svc["dockerImage"] = args.image
+    if args.port is not None:
+        svc["containerPort"] = args.port
+    if existing is None and args.port is None:
+        die(f"新建额外服务 \"{args.service_id}\" 必须提供 --port(容器端口)", code=1)
+    if args.command is not None:
+        svc["command"] = args.command
+    if args.work_dir is not None:
+        svc["workDir"] = args.work_dir
+    if args.container_work_dir is not None:
+        svc["containerWorkDir"] = args.container_work_dir
+    if args.entrypoint is not None:
+        svc["entrypoint"] = args.entrypoint
+    if args.db_scope is not None:
+        svc["dbScope"] = args.db_scope
+    if args.subdomain is not None:
+        # 显式空串 = 有意清空命名 URL;省略 = 服务端继承旧值
+        svc["subdomain"] = args.subdomain
+    env_pairs = _parse_env_pairs(args.env)
+    if env_pairs:
+        # 服务端 merge 不 replace:只需带上改动的 key(旧 env 由服务端基底保留)
+        svc["env"] = {**(svc.get("env") or {}), **env_pairs}
+    if args.depends_on:
+        svc["dependsOn"] = args.depends_on
+    if args.path_prefix:
+        svc["pathPrefixes"] = args.path_prefix
+    merged = [p for p in profiles if p.get("id") != args.service_id] + [svc]
+    body = _put_extra_profiles(args.id, merged, args.redeploy)
+    verb = "已更新" if existing else "已声明"
+    ok(body, note=f"分支 {args.id} 额外服务 \"{args.service_id}\" {verb}"
+                  + (";已触发重部署,几十秒后容器就位" if body.get("redeployTriggered") else
+                     ";纯配置变更,--redeploy 或下次部署时生效"))
+
+
+def cmd_branch_extra_remove(args: argparse.Namespace) -> None:
+    profiles = _get_extra_profiles(args.id)
+    remaining = [p for p in profiles if p.get("id") != args.service_id]
+    if len(remaining) == len(profiles):
+        die(f"分支 {args.id} 没有 id 为 \"{args.service_id}\" 的额外服务", code=2)
+    body = _put_extra_profiles(args.id, remaining, args.redeploy)
+    note = f"分支 {args.id} 额外服务 \"{args.service_id}\" 已移除"
+    if body.get("removalRolledBack"):
+        note = (f"移除被回滚:重部署被拒且该服务仍在运行,为避免幽灵服务已恢复配置"
+                f"(详见 redeployRejected)")
+    elif body.get("redeployTriggered"):
+        note += ";已触发重部署,在跑容器将被下掉"
+    else:
+        note += ";纯配置变更,若容器在跑需 --redeploy 才真正下掉"
+    ok(body, note=note)
+
+
 # ── 验收报告 / 报告文件夹（CDS 自托管，POST /api/reports + /api/report-folders）──
 # 本会话沉淀:把「视觉取证 → 自托管验收报告 → 项目/文件夹归类 → 直达深链」做成一等公民。
 # 取证管线(chromium 穿 agent 代理 + 截图入库)见 cli/acceptance/ 与 reference/acceptance-reports.md。
@@ -7109,6 +7246,41 @@ def _build_parser() -> argparse.ArgumentParser:
     bsm.add_argument("profile", help="构建配置 id(profileId)")
     bsm.add_argument("mode", help="部署模式名(须存在于该 profile 的 deployModes)")
     bsm.set_defaults(func=cmd_branch_set_mode)
+
+    bx = br.add_parser(
+        "extra-services",
+        help="分支级临时额外服务(只作用于本分支,如临时接 Nacos;删分支即消失)",
+    ).add_subparsers(dest="sub2", required=True)
+    bxl = bx.add_parser("list", help="列出分支的临时额外服务(env 已脱敏)")
+    bxl.add_argument("id", help="CDS canonical branch id")
+    bxl.set_defaults(func=cmd_branch_extra_list)
+    bxs = bx.add_parser("set", help="声明/更新一个额外服务(--id + 字段),或 --file 整体替换")
+    bxs.add_argument("id", help="CDS canonical branch id")
+    bxs.add_argument("--id", dest="service_id", help="额外服务 id(字母/数字开头,可含 - _)")
+    bxs.add_argument("--image", help="镜像引用,如 nacos/nacos-server:v2.3.2")
+    bxs.add_argument("--port", type=int, help="容器端口,如 8848")
+    bxs.add_argument("--command", help="启动命令(镜像默认 CMD 够用则省略)")
+    bxs.add_argument("--work-dir", help="宿主机相对路径挂载(纯镜像服务省略)")
+    bxs.add_argument("--container-work-dir", help="容器内工作目录(绝对路径)")
+    bxs.add_argument("--entrypoint", help="入口覆盖(单 token;空串=清空镜像 ENTRYPOINT)")
+    bxs.add_argument("--db-scope", choices=["shared", "per-branch"],
+                     help="数据库隔离档位(per-branch=DB 名追加分支后缀)")
+    bxs.add_argument("--subdomain", help="命名子域(单 DNS label;空串=清空命名 URL)")
+    bxs.add_argument("--env", action="append", metavar="KEY=VALUE",
+                     help="环境变量,可重复;服务端按 key 合并,不会丢未提及的旧值")
+    bxs.add_argument("--depends-on", action="append", metavar="SERVICE_ID",
+                     help="启动依赖,可重复")
+    bxs.add_argument("--path-prefix", action="append", metavar="PREFIX",
+                     help="路由前缀,可重复(如 /nacos)")
+    bxs.add_argument("--file", help="JSON 文件整体替换(数组或 {extraProfiles:[...]})")
+    bxs.add_argument("--redeploy", action="store_true",
+                     help="落库后立即触发分支重部署,让容器真正起来")
+    bxs.set_defaults(func=cmd_branch_extra_set)
+    bxr = bx.add_parser("remove", help="移除一个额外服务(--redeploy 才会真正下掉在跑容器)")
+    bxr.add_argument("id", help="CDS canonical branch id")
+    bxr.add_argument("service_id", help="要移除的额外服务 id")
+    bxr.add_argument("--redeploy", action="store_true", help="移除后立即重部署下掉容器")
+    bxr.set_defaults(func=cmd_branch_extra_remove)
 
     sch = sub.add_parser("schedule", help="任务调度: 口令创建 / 测试动作 / 列表 / 手动执行").add_subparsers(dest="sub", required=True)
     sp = sch.add_parser("parse", help="解析口令,不请求 CDS")

--- a/.claude/skills/cds/cli/cdscli.py
+++ b/.claude/skills/cds/cli/cdscli.py
@@ -1443,9 +1443,13 @@ def cmd_branch_create(args: argparse.Namespace) -> None:
     branch = (args.branch or "").strip()
     if not branch:
         die("--branch 必填", code=1)
-    body = _call("POST", "/api/branches",
-                 body={"projectId": project, "branch": branch},
-                 timeout=60)
+    payload: dict[str, Any] = {"projectId": project, "branch": branch}
+    # 波3 配置树:--from <sourceBranchId> = 从来源分支快照拷贝分支级配置
+    # (profileOverrides + extraProfiles,拷贝后各自独立,并写派生溯源指针)
+    source = (getattr(args, "from_branch", None) or "").strip()
+    if source:
+        payload["sourceBranchId"] = source
+    body = _call("POST", "/api/branches", body=payload, timeout=60)
     if _HUMAN:
         bid = body.get("id") if isinstance(body, dict) else "?"
         status = body.get("status") if isinstance(body, dict) else "?"
@@ -7238,6 +7242,9 @@ def _build_parser() -> argparse.ArgumentParser:
                             "API body 字段是 projectId,这里用 --project 抹平。")
     bc.add_argument("--project", help="projectId(或读 CDS_PROJECT_ID)")
     bc.add_argument("--branch", required=True, help="git 分支名(必填)")
+    bc.add_argument("--from", dest="from_branch", metavar="SOURCE_BRANCH_ID",
+                    help="从来源分支快照拷贝分支级配置(profileOverrides+extraProfiles,"
+                         "拷贝后各自独立,写派生溯源指针)")
     bc.set_defaults(func=cmd_branch_create)
     bsm = br.add_parser("set-mode",
                         help="设置单分支的部署模式覆盖(activeDeployMode)。"

--- a/.claude/skills/cds/tests/test_cdscli_extra_services.py
+++ b/.claude/skills/cds/tests/test_cdscli_extra_services.py
@@ -1,0 +1,264 @@
+"""cdscli branch extra-services 子命令单测(波1 最后一公里)
+
+覆盖 list / set(upsert + --file 整体替换) / remove 的 payload 组装、
+--redeploy query、掩码哨兵回传契约、错误场景。全部 monkeypatch _call,
+不打真 HTTP。
+
+服务端契约(cds/src/routes/branches.ts PUT /extra-services):
+  - PUT 整体替换数组;env merge 不 replace;掩码哨兵 *** 由服务端剥离恢复旧值
+  - ?redeploy=1 触发真部署,响应带 redeployTriggered / redeployRejected / removalRolledBack
+"""
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI_DIR = ROOT / "cli"
+sys.path.insert(0, str(CLI_DIR))
+
+import cdscli  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def reset_globals(monkeypatch):
+    monkeypatch.setenv("CDS_HOST", "cds.test.example")
+    monkeypatch.setenv("AI_ACCESS_KEY", "test-key-not-real")
+    monkeypatch.delenv("CDS_PROJECT_ID", raising=False)
+    monkeypatch.delenv("CDS_PROJECT_KEY", raising=False)
+    cdscli._TRACE_ID = "testtrace"
+    cdscli._HUMAN = False
+    yield
+
+
+def call_main(argv: list[str]) -> tuple[int, str]:
+    buf = io.StringIO()
+    code = 0
+    real_stdout = sys.stdout
+    sys.stdout = buf
+    try:
+        cdscli.main(argv)
+    except SystemExit as e:
+        code = e.code if isinstance(e.code, int) else 1
+    finally:
+        sys.stdout = real_stdout
+    return code, buf.getvalue()
+
+
+def parse_last(out: str) -> dict:
+    return json.loads(out.strip().split("\n")[-1])
+
+
+class FakeCall:
+    """记录 _call 调用序列,按 (method, path 前缀) 返回预置响应。"""
+
+    def __init__(self, existing: list[dict], put_response: dict | None = None):
+        self.existing = existing
+        self.put_response = put_response
+        self.calls: list[tuple[str, str, object]] = []
+
+    def __call__(self, method, path, body=None, timeout=15, quiet=False):
+        self.calls.append((method, path, body))
+        if method == "GET":
+            return {"extraProfiles": self.existing}
+        if method == "PUT":
+            if self.put_response is not None:
+                return self.put_response
+            sent = (body or {}).get("extraProfiles", [])
+            return {"extraProfiles": sent, "count": len(sent),
+                    "redeployTriggered": "redeploy=1" in path}
+        raise AssertionError(f"unexpected {method} {path}")
+
+
+NACOS = {"id": "nacos", "dockerImage": "nacos/nacos-server:v2.3.2",
+         "containerPort": 8848, "env": {"MODE": "standalone", "TOKEN": "***"}}
+
+
+# ── list ──────────────────────────────────────────────────────────────
+
+def test_list_outputs_profiles(monkeypatch):
+    fake = FakeCall([NACOS])
+    monkeypatch.setattr(cdscli, "_call", fake)
+    code, out = call_main(["branch", "extra-services", "list", "br-1"])
+    assert code == 0
+    payload = parse_last(out)
+    assert payload["ok"] is True
+    assert payload["data"]["extraProfiles"][0]["id"] == "nacos"
+    assert fake.calls == [("GET", "/api/branches/br-1/extra-services", None)]
+
+
+# ── set: 新建 upsert ─────────────────────────────────────────────────
+
+def test_set_creates_new_service(monkeypatch):
+    fake = FakeCall([])
+    monkeypatch.setattr(cdscli, "_call", fake)
+    code, out = call_main([
+        "branch", "extra-services", "set", "br-1",
+        "--id", "nacos", "--image", "nacos/nacos-server:v2.3.2",
+        "--port", "8848", "--env", "MODE=standalone",
+        "--subdomain", "nacos", "--db-scope", "per-branch",
+    ])
+    assert code == 0
+    method, path, body = fake.calls[-1]
+    assert method == "PUT"
+    assert path == "/api/branches/br-1/extra-services"  # 无 --redeploy 不带 query
+    sent = body["extraProfiles"]
+    assert len(sent) == 1
+    svc = sent[0]
+    assert svc["id"] == "nacos"
+    assert svc["dockerImage"] == "nacos/nacos-server:v2.3.2"
+    assert svc["containerPort"] == 8848
+    assert svc["env"] == {"MODE": "standalone"}
+    assert svc["subdomain"] == "nacos"
+    assert svc["dbScope"] == "per-branch"
+
+
+def test_set_new_requires_image_and_port(monkeypatch):
+    fake = FakeCall([])
+    monkeypatch.setattr(cdscli, "_call", fake)
+    code, out = call_main(["branch", "extra-services", "set", "br-1",
+                           "--id", "nacos", "--port", "8848"])
+    assert code == 1
+    assert "--image" in parse_last(out)["error"]
+
+    code, out = call_main(["branch", "extra-services", "set", "br-1",
+                           "--id", "nacos", "--image", "nacos/nacos-server:v2.3.2"])
+    assert code == 1
+    assert "--port" in parse_last(out)["error"]
+
+
+def test_set_requires_id_or_file(monkeypatch):
+    fake = FakeCall([])
+    monkeypatch.setattr(cdscli, "_call", fake)
+    code, out = call_main(["branch", "extra-services", "set", "br-1"])
+    assert code == 1
+    assert "--id" in parse_last(out)["error"]
+
+
+# ── set: 更新已有服务(掩码哨兵往返) ──────────────────────────────────
+
+def test_set_updates_existing_preserves_masked_env(monkeypatch):
+    """GET 的脱敏 env(***)原样回传 PUT 是安全契约:服务端剥哨兵恢复旧值。
+    只改 MODE 时,TOKEN 的 *** 应仍在 payload 里(交由服务端恢复),不被 CLI 丢弃。"""
+    fake = FakeCall([dict(NACOS)])
+    monkeypatch.setattr(cdscli, "_call", fake)
+    code, out = call_main([
+        "branch", "extra-services", "set", "br-1",
+        "--id", "nacos", "--env", "MODE=cluster",
+    ])
+    assert code == 0
+    _, _, body = fake.calls[-1]
+    svc = body["extraProfiles"][0]
+    assert svc["env"]["MODE"] == "cluster"      # 新值覆盖
+    assert svc["env"]["TOKEN"] == "***"          # 哨兵原样回传,服务端恢复
+    assert svc["dockerImage"] == NACOS["dockerImage"]  # 未提及字段继承
+
+
+def test_set_upsert_keeps_other_services(monkeypatch):
+    other = {"id": "kafka", "dockerImage": "bitnami/kafka:3.7",
+             "containerPort": 9092}
+    fake = FakeCall([other])
+    monkeypatch.setattr(cdscli, "_call", fake)
+    code, out = call_main([
+        "branch", "extra-services", "set", "br-1",
+        "--id", "nacos", "--image", "nacos/nacos-server:v2.3.2", "--port", "8848",
+    ])
+    assert code == 0
+    _, _, body = fake.calls[-1]
+    ids = {p["id"] for p in body["extraProfiles"]}
+    assert ids == {"kafka", "nacos"}
+
+
+# ── set: --redeploy 与 --file ────────────────────────────────────────
+
+def test_set_redeploy_appends_query(monkeypatch):
+    fake = FakeCall([])
+    monkeypatch.setattr(cdscli, "_call", fake)
+    code, out = call_main([
+        "branch", "extra-services", "set", "br-1",
+        "--id", "nacos", "--image", "nacos/nacos-server:v2.3.2",
+        "--port", "8848", "--redeploy",
+    ])
+    assert code == 0
+    _, path, _ = fake.calls[-1]
+    assert path.endswith("?redeploy=1")
+    assert parse_last(out)["data"]["redeployTriggered"] is True
+
+
+def test_set_file_replaces_wholesale(monkeypatch, tmp_path):
+    f = tmp_path / "extras.json"
+    f.write_text(json.dumps({"extraProfiles": [NACOS]}), encoding="utf-8")
+    fake = FakeCall([{"id": "old", "dockerImage": "x", "containerPort": 1}])
+    monkeypatch.setattr(cdscli, "_call", fake)
+    code, out = call_main(["branch", "extra-services", "set", "br-1",
+                           "--file", str(f)])
+    assert code == 0
+    # --file 整体替换:不做 GET 读改写,直接 PUT 文件内容
+    assert fake.calls[0][0] == "PUT"
+    assert [p["id"] for p in fake.calls[0][2]["extraProfiles"]] == ["nacos"]
+
+
+def test_set_file_rejects_non_array(monkeypatch, tmp_path):
+    f = tmp_path / "bad.json"
+    f.write_text(json.dumps({"foo": 1}), encoding="utf-8")
+    fake = FakeCall([])
+    monkeypatch.setattr(cdscli, "_call", fake)
+    code, out = call_main(["branch", "extra-services", "set", "br-1",
+                           "--file", str(f)])
+    assert code == 1
+    assert "数组" in parse_last(out)["error"]
+
+
+def test_env_pair_validation(monkeypatch):
+    fake = FakeCall([])
+    monkeypatch.setattr(cdscli, "_call", fake)
+    code, out = call_main([
+        "branch", "extra-services", "set", "br-1",
+        "--id", "nacos", "--image", "img", "--port", "1",
+        "--env", "NOEQUALS",
+    ])
+    assert code == 1
+    assert "KEY=VALUE" in parse_last(out)["error"]
+
+
+# ── remove ────────────────────────────────────────────────────────────
+
+def test_remove_filters_and_puts(monkeypatch):
+    other = {"id": "kafka", "dockerImage": "bitnami/kafka:3.7", "containerPort": 9092}
+    fake = FakeCall([dict(NACOS), other])
+    monkeypatch.setattr(cdscli, "_call", fake)
+    code, out = call_main(["branch", "extra-services", "remove", "br-1", "nacos",
+                           "--redeploy"])
+    assert code == 0
+    method, path, body = fake.calls[-1]
+    assert method == "PUT" and path.endswith("?redeploy=1")
+    assert [p["id"] for p in body["extraProfiles"]] == ["kafka"]
+
+
+def test_remove_missing_id_fails(monkeypatch):
+    fake = FakeCall([])
+    monkeypatch.setattr(cdscli, "_call", fake)
+    code, out = call_main(["branch", "extra-services", "remove", "br-1", "ghost"])
+    assert code == 2
+    assert "ghost" in parse_last(out)["error"]
+
+
+def test_remove_reports_rollback(monkeypatch):
+    fake = FakeCall(
+        [dict(NACOS)],
+        put_response={
+            "extraProfiles": [dict(NACOS)], "count": 1,
+            "redeployTriggered": False,
+            "redeployRejected": {"status": 503, "message": "owning executor offline"},
+            "removalRolledBack": True, "rolledBackServiceIds": ["nacos"],
+        },
+    )
+    monkeypatch.setattr(cdscli, "_call", fake)
+    code, out = call_main(["branch", "extra-services", "remove", "br-1", "nacos",
+                           "--redeploy"])
+    assert code == 0
+    payload = parse_last(out)
+    assert payload["data"]["removalRolledBack"] is True
+    assert "回滚" in payload["note"]

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -14,6 +14,8 @@ import { WorktreeService } from '../services/worktree.js';
 import { resolveEffectiveProfile, resolveDeployReadinessFloorSeconds, applyDeployReadinessFloor } from '../services/container.js';
 import { classifyDeployRuntime, computeServiceDrift, applyDefaultDeployModesToBranch, branchUsesPrebuiltMode } from '../services/deploy-runtime.js';
 import { isValidExtraProfileId, isValidServiceSubdomain, mergeBranchProfiles } from '../services/branch-extra-services.js';
+import { resolveProfileRuntimeEnvWithProvenance, type EnvLayer } from '../services/env-provenance.js';
+import { branchAppNetworkName, branchNetworkIsolationEnabled } from '../services/branch-network.js';
 import { classifyTriggerSource, deriveDeployMode, deriveCommitMeta, parsePulledSha, shouldRefreshCommitSha } from '../services/build-log-meta.js';
 import { acquireBuildSlot, buildGateStatus } from '../services/build-gate.js';
 import { recordBuild } from '../services/build-activity-tracker.js';
@@ -21,7 +23,7 @@ import type { ContainerService } from '../services/container.js';
 import type { SchedulerService } from '../services/scheduler.js';
 import type { JanitorService } from '../services/janitor.js';
 import type { ExecutorRegistry } from '../scheduler/executor-registry.js';
-import type { BranchEntry, CdsConfig, ExecOptions, IShellExecutor, OperationLog, OperationLogContainerSnapshot, OperationLogEvent, BuildProfile, BuildProfileOverride, ReadinessProbe, RoutingRule, ServiceState, InfraService, InfraVolume, DataMigration, MongoConnectionConfig, CdsPeer, ExecutorNode, ActiveSelfUpdate, SelfUpdateTimingBreakdown, Project, ProjectActivityLog, ResourceExternalAccessPolicy, ContainerLogArchiveEntry } from '../types.js';
+import type { BranchEntry, CdsConfig, ExecOptions, IShellExecutor, OperationLog, OperationLogContainerSnapshot, OperationLogEvent, BuildProfile, BuildProfileOverride, ReadinessProbe, RoutingRule, ServiceState, InfraService, InfraVolume, DataMigration, MongoConnectionConfig, CdsPeer, ExecutorNode, ActiveSelfUpdate, SelfUpdateTimingBreakdown, Project, ProjectActivityLog, ResourceExternalAccessPolicy, ContainerLogArchiveEntry, EnvSource, EnvKeyProvenance } from '../types.js';
 import { discoverComposeFiles, parseComposeFile, parseComposeString, resolveEnvTemplates, toComposeYaml, parseCdsCompose, toCdsCompose } from '../services/compose-parser.js';
 import type { ComposeServiceDef } from '../services/compose-parser.js';
 import { computeRequiredInfra } from '../services/deploy-infra-resolver.js';
@@ -9809,6 +9811,151 @@ export function createBranchRouter(deps: RouterDeps): Router {
       return;
     }
     res.json({ key, value: entry.value, source: entry.source });
+  });
+
+  // GET /api/branches/:id/effective-config — 分支生效配置全景(波2 配置检查器)
+  //
+  // 回答三个此前没有任何端点能回答的问题:
+  //   1. 这个分支的每个容器最终拿到的 env,**逐 key 从哪一层来**(段A customEnv 六层 +
+  //      段B profile/branch-override/deploy-mode/platform-injected/per-branch-db)
+  //   2. 每个容器的有效配置(镜像/端口/部署模式/数据库隔离)以及是否被本分支覆盖
+  //   3. CDS 预计为这个分支做什么(plan:起哪些容器、连哪些网、拉起哪些共享 infra)
+  //
+  // 溯源实现:env-provenance.ts 的纯函数(与部署路径同一条代码,部署行为逐字节不变);
+  // 段A来源口径与 effective-env 端点(buildBranchEnvMap)完全一致。
+  // 脱敏:所有 value 过 maskSecrets SSOT,不提供 reveal(要明文走既有 effective-env/reveal)。
+  // plan 的 infra 判定用**记录态**(不打 docker,stateBasis='recorded'),保持端点轻量只读。
+  router.get('/branches/:id/effective-config', (req, res) => {
+    const { id } = req.params;
+    const entry = stateService.getBranch(id);
+    if (!entry) {
+      res.status(404).json({ error: `分支 "${id}" 不存在` });
+      return;
+    }
+    const projectId = entry.projectId || 'default';
+    const m = assertProjectAccess(req as any, projectId);
+    if (m) {
+      res.status(m.status).json(m.body);
+      return;
+    }
+    const project = stateService.getProject(projectId);
+
+    // ── 段A:customEnv 六层(顺序 = 合并顺序,与 getMergedEnv/buildBranchEnvMap 一致)──
+    const cdsEnv = stateService.getCdsEnvVars(projectId);
+    const mirrorEnv = stateService.getMirrorEnvVars();
+    const rawGlobal = stateService.getCustomEnvScope('_global');
+    const rawProjectScoped = projectId === '_global' ? {} : stateService.getCustomEnvScope(projectId);
+    const rawBranchScoped = stateService.getCustomEnvScope(entry.id);
+    const derivedReserved: Record<string, string> = {};
+    if (project) {
+      derivedReserved.CDS_PROJECT_ID = project.id;
+      derivedReserved.CDS_PROJECT_SLUG = project.slug;
+    }
+    const customLayers: EnvLayer[] = [
+      { source: 'cds-builtin' as const, env: cdsEnv },
+      { source: 'mirror' as const, env: mirrorEnv },
+      { source: 'global' as const, env: rawGlobal },
+      { source: 'project' as const, env: rawProjectScoped },
+      { source: 'branch' as const, env: rawBranchScoped },
+      // 项目身份保留 key 放最后 —— 即便 global/project 写了同名 key,生效的也是系统派生真值
+      { source: 'cds-derived' as const, env: derivedReserved },
+    ].filter((l) => Object.keys(l.env).length > 0);
+
+    const envLayers = customLayers.map((l) => ({
+      source: l.source,
+      count: Object.keys(l.env).length,
+      keys: Object.keys(l.env).sort(),
+    }));
+
+    // ── 每个有效 profile(项目底座 + 分支临时额外服务)的逐 key 溯源 ──
+    const extraIds = new Set((entry.extraProfiles || []).map((p) => p.id));
+    const effectiveProfiles = stateService.getEffectiveProfilesForBranch(entry);
+    const profiles = effectiveProfiles.map((baseline) => {
+      const isExtra = extraIds.has(baseline.id);
+      const override = entry.profileOverrides?.[baseline.id];
+      const effective = resolveEffectiveProfile(baseline, entry);
+      // profile env 三层拆分,相对顺序与部署合并链一致:
+      // baseline.env → override.env(applyProfileOverride) → deployModes[mode].env(resolveProfileWithMode)
+      const activeMode = override?.activeDeployMode !== undefined
+        ? override.activeDeployMode
+        : baseline.activeDeployMode;
+      const modeEnv = (activeMode && baseline.deployModes?.[activeMode]?.env) || undefined;
+      const profileLayers: EnvLayer[] = [
+        { source: (isExtra ? 'extra-service' : 'profile') as EnvSource, env: baseline.env || {} },
+        { source: 'branch-override' as const, env: override?.env || {} },
+        { source: 'deploy-mode' as const, env: modeEnv || {} },
+      ].filter((l) => Object.keys(l.env).length > 0);
+
+      let envProvenance: EnvKeyProvenance[] = [];
+      let envError: string | undefined;
+      try {
+        const resolved = resolveProfileRuntimeEnvWithProvenance(
+          entry, effective, customLayers, profileLayers, { jwtIssuer: config.jwt.issuer },
+        );
+        // 脱敏走 maskSecrets SSOT:按 key 名或 URL 凭据值判定,provenance 的 value 同步替换
+        const maskedEnv = maskSecrets(resolved.env);
+        envProvenance = resolved.provenance.map((p) => ({ ...p, value: maskedEnv[p.key] ?? p.value }));
+      } catch (err) {
+        // 缺模板值等解析失败:不 fail 整个端点,把缺口显性化(这正是检查器要暴露的问题)
+        envError = (err as Error).message;
+      }
+      return {
+        profileId: baseline.id,
+        profileName: baseline.name || baseline.id,
+        isExtra,
+        hasOverride: !!override && Object.keys(override).some((k) => k !== 'updatedAt' && k !== 'notes'),
+        dockerImage: effective.dockerImage,
+        containerPort: effective.containerPort,
+        activeDeployMode: effective.activeDeployMode || null,
+        prebuilt: effective.prebuiltImage === true,
+        dbScope: effective.dbScope || 'shared',
+        dbScopeSource: override?.dbScope !== undefined ? 'branch-override' : (baseline.dbScope !== undefined ? 'baseline' : 'default'),
+        envProvenance,
+        ...(envError ? { envError } : {}),
+      };
+    });
+
+    // ── plan:CDS 预计为该分支做什么(记录态,不打 docker)──
+    const projectInfra = stateService.getInfraServicesForProject(projectId);
+    const recordedInfraState = new Map(
+      projectInfra.map((svc) => [svc.containerName, {
+        running: svc.status === 'running',
+        containerName: svc.containerName,
+        serviceId: svc.id,
+      }]),
+    );
+    const requiredInfraIds = computeRequiredInfra(effectiveProfiles, projectInfra, recordedInfraState);
+    const isolationOn = branchNetworkIsolationEnabled(process.env as Record<string, string | undefined>);
+    const plan = {
+      stateBasis: 'recorded' as const,
+      containers: profiles.map((p) => ({
+        profileId: p.profileId,
+        containerName: `cds-${entry.id}-${p.profileId}`,
+        dockerImage: p.dockerImage,
+        containerPort: p.containerPort,
+        deployMode: p.activeDeployMode,
+        prebuilt: p.prebuilt,
+        isExtra: p.isExtra,
+      })),
+      networks: {
+        isolation: isolationOn,
+        branchNetwork: isolationOn ? branchAppNetworkName(entry.id) : null,
+        sharedNetwork: project?.dockerNetwork || config.dockerNetwork,
+      },
+      requiredInfra: projectInfra
+        .filter((svc) => requiredInfraIds.has(svc.id))
+        .map((svc) => ({ id: svc.id, containerName: svc.containerName, status: svc.status, shared: true })),
+    };
+
+    res.json({
+      branchId: entry.id,
+      projectId,
+      projectSlug: project?.slug || projectId,
+      branchStatus: entry.status,
+      envLayers,
+      profiles,
+      plan,
+    });
   });
 
   // GET /api/branches/:id/metrics — 该分支所有 service 的 docker stats 瞬时值(Phase B)

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -12940,6 +12940,14 @@ export function createBranchRouter(deps: RouterDeps): Router {
         envOverride = cleaned;
       }
 
+      // dbScope 透传 + 枚举校验（波1 W1c）：BuildProfileOverride.dbScope 与合并端 applyProfileOverride
+      // 早已支持按分支覆盖数据库隔离档位，但此白名单一直漏透传——UI/API 设了也会被静默丢弃，
+      // per-branch DB 开关因此永远无法按分支生效。合法值仅 'shared' | 'per-branch'，其余显式 400。
+      if (body.dbScope !== undefined && body.dbScope !== 'shared' && body.dbScope !== 'per-branch') {
+        res.status(400).json({ error: `dbScope 非法（仅允许 'shared' 或 'per-branch'）` });
+        return;
+      }
+
       const override = {
         dockerImage: typeof body.dockerImage === 'string' ? body.dockerImage : undefined,
         command: typeof body.command === 'string' ? body.command : undefined,
@@ -12950,6 +12958,7 @@ export function createBranchRouter(deps: RouterDeps): Router {
         resources: body.resources && typeof body.resources === 'object' && !Array.isArray(body.resources) ? body.resources as { memoryMB?: number; cpus?: number } : undefined,
         activeDeployMode: typeof body.activeDeployMode === 'string' ? body.activeDeployMode : undefined,
         startupSignal: typeof body.startupSignal === 'string' ? body.startupSignal : undefined,
+        dbScope: body.dbScope as 'shared' | 'per-branch' | undefined,
         notes: typeof body.notes === 'string' ? body.notes : undefined,
       };
       stateService.setBranchProfileOverride(id, profileId, override);

--- a/cds/src/routes/branches.ts
+++ b/cds/src/routes/branches.ts
@@ -4905,7 +4905,7 @@ export function createBranchRouter(deps: RouterDeps): Router {
 
   router.post('/branches', async (req, res) => {
     try {
-      const { branch, projectId } = req.body as { branch?: string; projectId?: string };
+      const { branch, projectId, sourceBranchId } = req.body as { branch?: string; projectId?: string; sourceBranchId?: string };
       if (!branch) {
         res.status(400).json({ error: '分支名称不能为空' });
         return;
@@ -5003,6 +5003,27 @@ export function createBranchRouter(deps: RouterDeps): Router {
       await shell.exec(`mkdir -p "${path.posix.dirname(worktreePath)}"`);
       await worktreeService.create(branchRepoRoot, branch, worktreePath);
 
+      // 波3 配置树:分支从分支派生(快照拷贝语义,design.cds.config-tree)。
+      // sourceBranchId 必须在建 worktree 之前校验,避免坏参数留下孤儿 worktree。
+      let sourceBranch: BranchEntry | undefined;
+      if (sourceBranchId !== undefined) {
+        if (typeof sourceBranchId !== 'string' || !sourceBranchId.trim()) {
+          res.status(400).json({ error: 'sourceBranchId 必须是非空字符串(来源分支的 CDS branch id)' });
+          return;
+        }
+        sourceBranch = stateService.getBranch(sourceBranchId.trim());
+        if (!sourceBranch) {
+          res.status(400).json({ error: `来源分支 "${sourceBranchId}" 不存在` });
+          return;
+        }
+        // 跨项目派生禁止:profileOverrides 引用的 profileId、extraProfiles 的 projectId
+        // 都是项目内语义,跨项目拷贝会产出悬空引用 + 隔离穿透。
+        if ((sourceBranch.projectId || 'default') !== effectiveProjectId) {
+          res.status(400).json({ error: `来源分支 "${sourceBranchId}" 属于项目 "${sourceBranch.projectId}",不能跨项目派生配置` });
+          return;
+        }
+      }
+
       const entry: BranchEntry = {
         id,
         projectId: effectiveProjectId,
@@ -5012,11 +5033,29 @@ export function createBranchRouter(deps: RouterDeps): Router {
         status: 'idle',
         createdAt: new Date().toISOString(),
       };
+      // 先套项目模板(保底),再用来源分支快照覆盖(拷贝赢模板)——之后两分支各自独立。
       applyProjectDefaultDeployModes(
         entry,
         targetProject.defaultDeployModes,
         stateService.getBuildProfilesForProject(effectiveProjectId),
       );
+      if (sourceBranch) {
+        // 深拷贝:改新分支不得串改来源分支(JSON round-trip 对这两个纯数据字段安全)。
+        if (sourceBranch.profileOverrides && Object.keys(sourceBranch.profileOverrides).length > 0) {
+          entry.profileOverrides = {
+            ...(entry.profileOverrides || {}),
+            ...JSON.parse(JSON.stringify(sourceBranch.profileOverrides)),
+          };
+        }
+        if (sourceBranch.extraProfiles && sourceBranch.extraProfiles.length > 0) {
+          // extraProfiles 的 subdomain 是分支内约束(命名 URL 按各自 previewSlug 拼),
+          // 原样拷贝跨分支不撞车,无需改写。
+          entry.extraProfiles = JSON.parse(JSON.stringify(sourceBranch.extraProfiles));
+        }
+        entry.derivedFromBranchId = sourceBranch.id;
+        entry.derivedFromBranchName = sourceBranch.branch;
+        entry.derivedAt = new Date().toISOString();
+      }
       stateService.addBranch(entry);
       // Phase 8 — 新分支自动继承项目级 defaultEnv → 写入项目级 customEnv。
       //
@@ -9947,14 +9986,127 @@ export function createBranchRouter(deps: RouterDeps): Router {
         .map((svc) => ({ id: svc.id, containerName: svc.containerName, status: svc.status, shared: true })),
     };
 
+    // 波3 配置树:派生溯源指针(快照拷贝语义,来源被删后 branchName 仍可展示)
+    const derivedFrom = entry.derivedFromBranchId
+      ? {
+          branchId: entry.derivedFromBranchId,
+          branchName: entry.derivedFromBranchName || entry.derivedFromBranchId,
+          derivedAt: entry.derivedAt || null,
+          sourceStillExists: !!stateService.getBranch(entry.derivedFromBranchId),
+        }
+      : null;
+
     res.json({
       branchId: entry.id,
       projectId,
       projectSlug: project?.slug || projectId,
       branchStatus: entry.status,
+      derivedFrom,
       envLayers,
       profiles,
       plan,
+    });
+  });
+
+  // POST /api/branches/:id/copy-config-from/:sourceId — 显式一键拉取来源分支配置(波3)
+  //
+  // 派生三层策略的补偿路径:PR opened 只回填溯源指针不拷贝配置(最小惊讶),
+  // 用户想真拷贝时走这里显式触发。语义 = 快照拷贝:
+  //   - 深拷贝来源分支的 profileOverrides + extraProfiles **整体替换**本分支现有分支层配置
+  //   - 拷贝前自动拍 ConfigSnapshot(误拷可从快照回滚,快照含分支层)
+  //   - 写 derivedFrom* 指针(显式拷贝允许覆盖已有指针)
+  //   - ?redeploy=1 时落库后触发一次重部署让配置真正生效
+  router.post('/branches/:id/copy-config-from/:sourceId', async (req, res) => {
+    const entry = stateService.getBranch(req.params.id);
+    if (!entry) {
+      res.status(404).json({ error: `分支 "${req.params.id}" 不存在` });
+      return;
+    }
+    const projectId = entry.projectId || 'default';
+    const m = assertProjectAccess(req as any, projectId);
+    if (m) {
+      res.status(m.status).json(m.body);
+      return;
+    }
+    const source = stateService.getBranch(req.params.sourceId);
+    if (!source) {
+      res.status(404).json({ error: `来源分支 "${req.params.sourceId}" 不存在` });
+      return;
+    }
+    if (source.id === entry.id) {
+      res.status(400).json({ error: '不能从自己拷贝配置' });
+      return;
+    }
+    if ((source.projectId || 'default') !== projectId) {
+      res.status(400).json({ error: `来源分支 "${source.id}" 属于项目 "${source.projectId}",不能跨项目拷贝配置(profileId 引用与隔离语义均为项目内)` });
+      return;
+    }
+    // 拷贝前自动快照(含分支层),误拷可回滚
+    const snapshot = stateService.createConfigSnapshot({
+      trigger: 'pre-destructive',
+      label: `分支 ${entry.id} 拉取 ${source.id} 配置前的自动备份`,
+      projectId,
+      triggeredBy: resolveActorFromRequest(req) || undefined,
+    });
+    // 深拷贝整体替换(快照拷贝语义:之后各自独立)。getBranch 返回内存权威对象,
+    // 直改后统一 save(与 setBranchProfileOverride 等既有写路径同一口径)。
+    const target = stateService.getBranch(entry.id)!;
+    if (source.profileOverrides && Object.keys(source.profileOverrides).length > 0) {
+      target.profileOverrides = JSON.parse(JSON.stringify(source.profileOverrides));
+    } else {
+      delete target.profileOverrides;
+    }
+    stateService.setBranchExtraProfiles(entry.id, JSON.parse(JSON.stringify(source.extraProfiles || [])));
+    target.derivedFromBranchId = source.id;
+    target.derivedFromBranchName = source.branch;
+    target.derivedAt = new Date().toISOString();
+    stateService.save();
+
+    // ?redeploy=1 → 与 extra-services 同款 localhost 自 POST,等 deploy 被「接受」再回包
+    const wantRedeploy = req.query?.redeploy === '1' || req.query?.redeploy === 'true';
+    let redeployTriggered = false;
+    let redeployRejected: { status: number; message: string } | null = null;
+    if (wantRedeploy) {
+      const url = `http://127.0.0.1:${config.masterPort}/api/branches/${encodeURIComponent(entry.id)}/deploy`;
+      try {
+        const upstream = await fetch(url, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CDS-Internal': '1',
+            'X-CDS-Trigger': 'system',
+            ...(entry.projectId ? { 'X-CDS-Source-Project-Id': entry.projectId } : {}),
+            'X-CDS-Source-Branch-Id': entry.id,
+          },
+          body: JSON.stringify({}),
+        });
+        if (upstream.ok) {
+          redeployTriggered = true;
+          void upstream.text().catch(() => { /* drain best-effort */ });
+        } else {
+          const errText = await upstream.text().catch(() => '');
+          let msg = errText;
+          try { const j = JSON.parse(errText) as { error?: unknown }; if (typeof j?.error === 'string') msg = j.error; } catch { /* 保留原文 */ }
+          redeployRejected = { status: upstream.status, message: (msg || '').slice(0, 300) };
+        }
+      } catch (err) {
+        redeployRejected = { status: 0, message: (err as Error).message };
+      }
+    }
+
+    const refreshed = stateService.getBranch(entry.id)!;
+    res.json({
+      copied: true,
+      sourceBranchId: source.id,
+      sourceBranchName: source.branch,
+      snapshotId: snapshot.id,
+      profileOverrideCount: Object.keys(refreshed.profileOverrides || {}).length,
+      extraProfileCount: (refreshed.extraProfiles || []).length,
+      redeployTriggered,
+      ...(redeployRejected ? { redeployRejected } : {}),
+      hint: redeployTriggered
+        ? '配置已拷贝并触发重部署;误拷可用 snapshotId 回滚(快照含分支层)'
+        : '配置已拷贝(纯配置变更,重新部署后生效);误拷可用 snapshotId 回滚',
     });
   });
 

--- a/cds/src/server.ts
+++ b/cds/src/server.ts
@@ -1031,6 +1031,7 @@ export function resolveApiLabel(method: string, path: string): string {
     [/^GET \/branches\/[^/]+\/effective-env$/, '查看生效环境变量'],
     [/^GET \/branches\/[^/]+\/effective-env\/reveal$/, '查看密钥明文'],
     [/^GET \/branches\/[^/]+\/effective-config$/, '查分支生效配置'],
+    [/^POST \/branches\/[^/]+\/copy-config-from\/[^/]+$/, '拉取来源分支配置'],
     [/^GET \/branches\/[^/]+\/metrics$/, '查看分支指标'],
     [/^GET \/branches\/[^/]+\/failure-diagnosis$/, '诊断失败原因'],
     // 构建 Profile 扩展

--- a/cds/src/server.ts
+++ b/cds/src/server.ts
@@ -1030,6 +1030,7 @@ export function resolveApiLabel(method: string, path: string): string {
     [/^GET \/branches\/[^/]+$/, '查看分支详情'],
     [/^GET \/branches\/[^/]+\/effective-env$/, '查看生效环境变量'],
     [/^GET \/branches\/[^/]+\/effective-env\/reveal$/, '查看密钥明文'],
+    [/^GET \/branches\/[^/]+\/effective-config$/, '查分支生效配置'],
     [/^GET \/branches\/[^/]+\/metrics$/, '查看分支指标'],
     [/^GET \/branches\/[^/]+\/failure-diagnosis$/, '诊断失败原因'],
     // 构建 Profile 扩展

--- a/cds/src/services/container.ts
+++ b/cds/src/services/container.ts
@@ -8,7 +8,7 @@ import type { IShellExecutor, CdsConfig, BuildProfile, BranchEntry, ServiceState
 import { combinedOutput } from '../types.js';
 import { resolveCommandTemplate, resolveEnvTemplates } from './compose-parser.js';
 import { sanitizeDockerRestartPolicy } from '../config/docker-restart-policy.js';
-import { applyPerBranchDbIsolation } from './db-scope-isolation.js';
+import { resolveProfileRuntimeEnvWithProvenance } from './env-provenance.js';
 import { branchAppNetworkName, branchNetworkIsolationEnabled, resolveAppNetworkPlan } from './branch-network.js';
 import { nodeModulesVolumeName } from '../util/node-modules-volume.js';
 import { ensureDockerNetworkWithReclaim } from './docker-network-reclaim.js';
@@ -453,18 +453,7 @@ export function applyDeployReadinessFloor(
   return { ...(probe ?? {}), timeoutSeconds: floorSeconds };
 }
 
-function missingEnvTemplates(env: Record<string, string>): string[] {
-  const missing = new Set<string>();
-  for (const value of Object.values(env)) {
-    value.replace(/\$\{(\w+)(?::-(.*?))?\}/g, (_match, name: string, defaultVal: string | undefined) => {
-      if (env[name] === undefined && process.env[name] === undefined && defaultVal === undefined) {
-        missing.add(name);
-      }
-      return '';
-    });
-  }
-  return Array.from(missing).sort();
-}
+// missingEnvTemplates 迁到 env-provenance.ts(波2:溯源解析需要同一份校验,单处 SSOT)。
 
 /** docker stats 单容器瞬时值(2026-05-04 Phase B) */
 export interface ContainerStats {
@@ -742,76 +731,25 @@ export class ContainerService {
     return `'${value.replace(/'/g, `'\\''`)}'`;
   }
 
+  /**
+   * 波2 重构:方法体抽为 env-provenance.ts 的纯函数(带逐 key 溯源),这里退化为
+   * 「单层包装 + 只取 .env」。**部署行为与旧实现逐字节一致**——步骤顺序/条件/
+   * 异常消息全部由纯函数保留,container.test.ts 既有断言即回归护栏。
+   * JWT 兜底语义不变:只允许项目 scope 自己提供 Jwt__Secret(兼容旧 compose 的
+   * JWT_SECRET 也必须来自项目 env),Jwt__Issuer 缺省用 CDS config 值。
+   */
   private resolveProfileRuntimeEnv(
     entry: BranchEntry,
     profile: BuildProfile,
     customEnv?: Record<string, string>,
   ): Record<string, string> {
-    const mergedEnv: Record<string, string> = {};
-
-    if (customEnv) {
-      Object.assign(mergedEnv, customEnv);
-    }
-
-    // JWT — CDS 自身鉴权密钥不得穿透进项目容器。
-    // 历史行为曾把 CDS_JWT_SECRET 兜底映射为项目 Jwt__Secret，导致 CDS
-    // 自身密钥轮换会破坏业务项目登录签名和 prd-agent 存量平台密文。
-    // 现在只允许项目 scope 自己提供 Jwt__Secret；兼容旧 compose 的
-    // JWT_SECRET 也必须来自项目 env，而不是 CDS 全局 config.jwt.secret。
-    if (!mergedEnv['Jwt__Secret'] && mergedEnv['JWT_SECRET']) {
-      mergedEnv['Jwt__Secret'] = mergedEnv['JWT_SECRET'];
-    }
-    if (!mergedEnv['Jwt__Issuer']) mergedEnv['Jwt__Issuer'] = this.config.jwt.issuer;
-
-    const isNodeContainer = /\bnode:/.test(profile.dockerImage);
-    if (isNodeContainer) {
-      mergedEnv['PNPM_HOME'] = mergedEnv['PNPM_HOME'] || '/pnpm';
-      mergedEnv['npm_config_store_dir'] = mergedEnv['npm_config_store_dir'] || '/pnpm/store';
-      const currentPath = mergedEnv['PATH'] || '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin';
-      if (!currentPath.includes('/pnpm')) {
-        mergedEnv['PATH'] = `/pnpm:${currentPath}`;
-      }
-    }
-
-    if (profile.env) {
-      Object.assign(mergedEnv, profile.env);
-    }
-
-    const deployCommit = entry.pinnedCommit || entry.githubCommitSha || entry.lastDeployDispatchCommitSha;
-    if (entry.branch) {
-      mergedEnv['VITE_GIT_BRANCH'] = entry.branch;
-    }
-    if (deployCommit) {
-      // 平台版本元数据必须覆盖项目 env，供发布中心和 /api/version 判断当前部署 commit。
-      mergedEnv['GIT_COMMIT'] = deployCommit;
-      mergedEnv['COMMIT_SHA'] = deployCommit;
-      mergedEnv['GITHUB_SHA'] = deployCommit;
-      mergedEnv['SOURCE_VERSION'] = deployCommit;
-      mergedEnv['CDS_COMMIT_SHA'] = deployCommit;
-      mergedEnv['VITE_BUILD_ID'] = deployCommit.slice(0, 12);
-    }
-    const deployTime = entry.lastDeployDispatchAt || entry.lastPushAt || entry.createdAt;
-    if (deployTime) {
-      mergedEnv['CDS_BUILD_TIME'] = deployTime;
-    }
-
-    const isolatedEnv = applyPerBranchDbIsolation(mergedEnv, profile.dbScope, entry.branch);
-    const missingTemplates = missingEnvTemplates(isolatedEnv);
-    if (missingTemplates.length > 0) {
-      throw new Error(
-        `环境变量模板缺少值: ${missingTemplates.join(', ')}。请在项目环境变量中填写，或先启动对应基础设施服务后再部署。`,
-      );
-    }
-
-    const resolveVars: Record<string, string> = { ...isolatedEnv };
-    if (customEnv) {
-      for (const [k, v] of Object.entries(isolatedEnv)) {
-        if (v === `\${${k}}` && customEnv[k] !== undefined) {
-          resolveVars[k] = customEnv[k];
-        }
-      }
-    }
-    return resolveEnvTemplates(isolatedEnv, resolveVars);
+    return resolveProfileRuntimeEnvWithProvenance(
+      entry,
+      profile,
+      customEnv ? [{ source: 'project', env: customEnv }] : [],
+      profile.env ? [{ source: 'profile', env: profile.env }] : [],
+      { jwtIssuer: this.config.jwt.issuer },
+    ).env;
   }
 
   private async buildProfileVolumeFlags(

--- a/cds/src/services/env-provenance.ts
+++ b/cds/src/services/env-provenance.ts
@@ -1,0 +1,219 @@
+/*
+ * env-provenance — 容器运行时 env 的「带溯源」解析(波2 配置检查器核心)。
+ *
+ * 背景:容器最终拿到的 env 是两段式合并的产物 ——
+ *   段A getMergedEnv(branches.ts):cdsEnv → mirror → global/project customEnv → branch env
+ *   段B resolveProfileRuntimeEnv(container.ts):customEnv → JWT 兜底 → node PATH →
+ *       profile.env → 版本元数据 → per-branch DB 改写 → ${VAR} 模板展开
+ * 此前没有任何地方能回答「容器里这个 JWT_SECRET 到底是哪一层给的」。
+ *
+ * 本模块把段B重写为**分层纯函数** resolveProfileRuntimeEnvWithProvenance:
+ *   - 输入是「层数组」(每层带来源标注),输出 { env, provenance }
+ *   - container.ts 的部署路径退化为「单层包装 + 只取 .env」——一条代码路径,
+ *     部署行为与旧实现逐字节一致(顺序/条件/异常消息全部保留)
+ *   - 检查器端点把段A/段B按真实来源拆层传入,免费获得逐 key 溯源
+ *
+ * 纯函数、不读 state、不碰 docker,可直接单测。
+ */
+
+import type { BuildProfile, EnvKeyProvenance, EnvSource } from '../types.js';
+import { resolveEnvTemplates } from './compose-parser.js';
+import { applyPerBranchDbIsolation } from './db-scope-isolation.js';
+
+/** 一层 env 来源。合并顺序 = 数组顺序,靠后覆盖靠前(last-writer-wins)。 */
+export interface EnvLayer {
+  source: EnvSource;
+  env: Record<string, string>;
+  detail?: string;
+}
+
+/**
+ * 值里引用了不存在的 ${VAR} 模板 → 返回缺失变量名列表。
+ * 从 container.ts 迁来的 SSOT(container.ts 现在从这里 import,避免两份漂移)。
+ */
+export function missingEnvTemplates(env: Record<string, string>): string[] {
+  const missing = new Set<string>();
+  for (const value of Object.values(env)) {
+    value.replace(/\$\{(\w+)(?::-(.*?))?\}/g, (_match, name: string, defaultVal: string | undefined) => {
+      if (env[name] === undefined && process.env[name] === undefined && defaultVal === undefined) {
+        missing.add(name);
+      }
+      return '';
+    });
+  }
+  return Array.from(missing).sort();
+}
+
+/** 分支上下文:只取解析需要的字段,避免依赖完整 BranchEntry(便于单测)。 */
+export interface EnvResolveBranchContext {
+  branch: string;
+  pinnedCommit?: string;
+  githubCommitSha?: string;
+  lastDeployDispatchCommitSha?: string;
+  lastDeployDispatchAt?: string;
+  lastPushAt?: string;
+  createdAt?: string;
+}
+
+export interface EnvResolveResult {
+  /** 与旧 resolveProfileRuntimeEnv 逐字节一致的最终 env(部署路径直接用) */
+  env: Record<string, string>;
+  /** 逐 key 溯源(检查器端点用;输出 API 前必须过 maskSecrets) */
+  provenance: EnvKeyProvenance[];
+}
+
+interface TrackedEntry {
+  value: string;
+  source: EnvSource;
+  detail?: string;
+  shadowed: EnvSource[];
+  templated?: boolean;
+}
+
+/** 往追踪 map 写一个 key:记录覆盖链(相同来源连续覆盖不重复记 shadow)。 */
+function trackSet(
+  map: Map<string, TrackedEntry>,
+  key: string,
+  value: string,
+  source: EnvSource,
+  detail?: string,
+): void {
+  const prev = map.get(key);
+  if (prev) {
+    const shadowed = prev.source === source
+      ? prev.shadowed
+      : [...prev.shadowed, prev.source];
+    map.set(key, { value, source, detail, shadowed });
+  } else {
+    map.set(key, { value, source, detail, shadowed: [] });
+  }
+}
+
+/**
+ * 段B运行时 env 解析(带溯源)。**与旧 container.ts#resolveProfileRuntimeEnv 行为等价**:
+ * 步骤顺序、条件判断、异常消息一字不差,只是把「合并」换成「带来源追踪的合并」。
+ *
+ * @param entry           分支上下文(版本元数据 + per-branch slug 来源)
+ * @param profile         已解析的有效 profile(只读 dockerImage / dbScope;env 不从这读,
+ *                        由 profileLayers 显式传入 —— 这样检查器可以拆 baseline/override/mode 层)
+ * @param customEnvLayers 段A的 customEnv 层(部署路径传单层;检查器按真实来源拆层)。
+ *                        flatten 后必须与部署路径的 getMergedEnv 输出一致。
+ * @param profileLayers   profile env 层(部署路径传单层 profile.env;检查器拆
+ *                        baseline/extra-service → branch-override → deploy-mode)
+ * @param opts.jwtIssuer  Jwt__Issuer 兜底值(config.jwt.issuer)
+ */
+export function resolveProfileRuntimeEnvWithProvenance(
+  entry: EnvResolveBranchContext,
+  profile: Pick<BuildProfile, 'dockerImage' | 'dbScope'>,
+  customEnvLayers: EnvLayer[],
+  profileLayers: EnvLayer[],
+  opts: { jwtIssuer: string },
+): EnvResolveResult {
+  const tracked = new Map<string, TrackedEntry>();
+
+  // 1. 段A customEnv(旧实现:Object.assign(mergedEnv, customEnv))
+  for (const layer of customEnvLayers) {
+    for (const [k, v] of Object.entries(layer.env)) {
+      trackSet(tracked, k, v, layer.source, layer.detail);
+    }
+  }
+  const view = (): Record<string, string> => {
+    const out: Record<string, string> = {};
+    for (const [k, e] of tracked) out[k] = e.value;
+    return out;
+  };
+  // 段A合并结果快照 —— 旧实现末段 resolveVars 的 customEnv 语义(profile.env 之前的状态)
+  const customEnvSnapshot = customEnvLayers.length > 0 ? view() : undefined;
+
+  // 2. JWT 兜底(在 profile.env 合并**之前**,与旧实现一致)
+  const afterCustom = view();
+  if (!afterCustom['Jwt__Secret'] && afterCustom['JWT_SECRET']) {
+    trackSet(tracked, 'Jwt__Secret', afterCustom['JWT_SECRET'], 'platform-injected', 'jwt-fallback');
+  }
+  if (!tracked.get('Jwt__Issuer')?.value) {
+    trackSet(tracked, 'Jwt__Issuer', opts.jwtIssuer, 'platform-injected', 'jwt-fallback');
+  }
+
+  // 3. node 容器 PATH / pnpm(同样在 profile.env 之前)
+  const isNodeContainer = /\bnode:/.test(profile.dockerImage);
+  if (isNodeContainer) {
+    if (!tracked.get('PNPM_HOME')?.value) {
+      trackSet(tracked, 'PNPM_HOME', '/pnpm', 'platform-injected', 'node-runtime');
+    }
+    if (!tracked.get('npm_config_store_dir')?.value) {
+      trackSet(tracked, 'npm_config_store_dir', '/pnpm/store', 'platform-injected', 'node-runtime');
+    }
+    const currentPath = tracked.get('PATH')?.value || '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin';
+    if (!currentPath.includes('/pnpm')) {
+      trackSet(tracked, 'PATH', `/pnpm:${currentPath}`, 'platform-injected', 'node-runtime');
+    }
+  }
+
+  // 4. profile env 层(旧实现:Object.assign(mergedEnv, profile.env))
+  for (const layer of profileLayers) {
+    for (const [k, v] of Object.entries(layer.env)) {
+      trackSet(tracked, k, v, layer.source, layer.detail);
+    }
+  }
+
+  // 5. 平台版本元数据(强制覆盖)
+  const deployCommit = entry.pinnedCommit || entry.githubCommitSha || entry.lastDeployDispatchCommitSha;
+  if (entry.branch) {
+    trackSet(tracked, 'VITE_GIT_BRANCH', entry.branch, 'platform-injected', 'version-metadata');
+  }
+  if (deployCommit) {
+    for (const key of ['GIT_COMMIT', 'COMMIT_SHA', 'GITHUB_SHA', 'SOURCE_VERSION', 'CDS_COMMIT_SHA']) {
+      trackSet(tracked, key, deployCommit, 'platform-injected', 'version-metadata');
+    }
+    trackSet(tracked, 'VITE_BUILD_ID', deployCommit.slice(0, 12), 'platform-injected', 'version-metadata');
+  }
+  const deployTime = entry.lastDeployDispatchAt || entry.lastPushAt || entry.createdAt;
+  if (deployTime) {
+    trackSet(tracked, 'CDS_BUILD_TIME', deployTime, 'platform-injected', 'version-metadata');
+  }
+
+  // 6. per-branch DB 隔离改写(复用 SSOT applyPerBranchDbIsolation,对比 diff 打标)
+  const beforeIsolation = view();
+  const isolatedEnv = applyPerBranchDbIsolation(beforeIsolation, profile.dbScope, entry.branch);
+  for (const [k, v] of Object.entries(isolatedEnv)) {
+    if (beforeIsolation[k] !== v) {
+      trackSet(tracked, k, v, 'per-branch-db', 'per-branch-db-suffix');
+    }
+  }
+
+  // 7. 缺失模板校验(异常消息与旧实现一字不差 —— 调用方按消息文案兜底提示)
+  const missingTemplates = missingEnvTemplates(isolatedEnv);
+  if (missingTemplates.length > 0) {
+    throw new Error(
+      `环境变量模板缺少值: ${missingTemplates.join(', ')}。请在项目环境变量中填写，或先启动对应基础设施服务后再部署。`,
+    );
+  }
+
+  // 8. ${VAR} 模板展开(resolveVars 语义保留:值为自引用模板且 customEnv 有真值时用后者)
+  const resolveVars: Record<string, string> = { ...isolatedEnv };
+  if (customEnvSnapshot) {
+    for (const [k, v] of Object.entries(isolatedEnv)) {
+      if (v === `\${${k}}` && customEnvSnapshot[k] !== undefined) {
+        resolveVars[k] = customEnvSnapshot[k];
+      }
+    }
+  }
+  const resolvedEnv = resolveEnvTemplates(isolatedEnv, resolveVars);
+
+  const provenance: EnvKeyProvenance[] = [];
+  for (const [key, entryTracked] of tracked) {
+    const finalValue = resolvedEnv[key];
+    if (finalValue === undefined) continue;
+    provenance.push({
+      key,
+      value: finalValue,
+      source: entryTracked.source,
+      ...(entryTracked.detail ? { detail: entryTracked.detail } : {}),
+      ...(entryTracked.shadowed.length > 0 ? { shadowed: entryTracked.shadowed } : {}),
+      ...(finalValue !== entryTracked.value ? { templated: true } : {}),
+    });
+  }
+  provenance.sort((a, b) => a.key.localeCompare(b.key));
+
+  return { env: resolvedEnv, provenance };
+}

--- a/cds/src/services/github-webhook-dispatcher.ts
+++ b/cds/src/services/github-webhook-dispatcher.ts
@@ -1044,6 +1044,23 @@ export class GitHubWebhookDispatcher {
           githubSenderLogin: event.sender?.login,
           githubSenderAvatarUrl: event.sender?.avatar_url,
         });
+        // 波3 配置树:PR base 分支是可靠的派生信号 → **仅回填溯源指针,不拷贝配置**
+        // (分支往往已按项目模板部署,静默改写 overrides 违反最小惊讶;要拷贝走显式
+        // POST /branches/:id/copy-config-from/:sourceId)。已设指针不覆盖(idempotent)。
+        const baseRef = event.pull_request.base?.ref;
+        if (baseRef && baseRef !== branchName) {
+          const baseSlug = StateServiceClass.slugify(baseRef);
+          const baseCanonicalId = project.legacyFlag ? baseSlug : `${project.slug}-${baseSlug}`;
+          const baseEntry =
+            this.deps.stateService.getBranch(baseCanonicalId) ??
+            this.deps.stateService.findBranchByProjectAndName(project.id, baseRef);
+          if (baseEntry && baseEntry.id !== branchId) {
+            this.deps.stateService.setBranchDerivedFrom(branchId, {
+              branchId: baseEntry.id,
+              branchName: baseEntry.branch,
+            });
+          }
+        }
         this.deps.stateService.save();
       }
       return {

--- a/cds/src/services/state.ts
+++ b/cds/src/services/state.ts
@@ -1616,6 +1616,23 @@ export class StateService {
     if ('ciImageError' in updates) branch.ciImageError = updates.ciImageError;
   }
 
+  /**
+   * 波3 配置树:写分支派生指针(derivedFrom*)。仅当尚未设置时写入(idempotent,
+   * 不覆盖已有溯源——手动创建时写的显式来源优先于 PR base 推断)。
+   * 必须走本方法改内存权威对象再由调用方 save() —— mongo-split 下 getBranch
+   * 可能返回副本,直接改返回值不落盘(见 dispatcher 既往教训)。
+   * @returns 是否发生写入
+   */
+  setBranchDerivedFrom(branchId: string, source: { branchId: string; branchName: string }): boolean {
+    const branch = this.state.branches[branchId];
+    if (!branch) return false;
+    if (branch.derivedFromBranchId) return false;
+    branch.derivedFromBranchId = source.branchId;
+    branch.derivedFromBranchName = source.branchName;
+    branch.derivedAt = new Date().toISOString();
+    return true;
+  }
+
   // ── Remote hosts (shared-service deployment targets, 2026-05-06) ──
   //
   // 系统级登记表。SSH 凭据已 seal（infra/secret-seal.ts），明文不出库。
@@ -3532,11 +3549,32 @@ export class StateService {
     projectId?: string | null;
     triggeredBy?: string;
   }): ConfigSnapshot {
+    // 波3 配置树:分支层配置一并入快照(只收有配置的分支,控体积;projectId 过滤对齐快照 scope)。
+    const branchConfigs: NonNullable<ConfigSnapshot['payload']['branchConfigs']> = {};
+    for (const [branchId, branch] of Object.entries(this.state.branches)) {
+      if (params.projectId && (branch.projectId || 'default') !== params.projectId) continue;
+      const hasOverrides = branch.profileOverrides && Object.keys(branch.profileOverrides).length > 0;
+      const hasExtras = branch.extraProfiles && branch.extraProfiles.length > 0;
+      if (!hasOverrides && !hasExtras && !branch.derivedFromBranchId) continue;
+      branchConfigs[branchId] = JSON.parse(JSON.stringify({
+        ...(hasOverrides ? { profileOverrides: branch.profileOverrides } : {}),
+        ...(hasExtras ? { extraProfiles: branch.extraProfiles } : {}),
+        ...(branch.derivedFromBranchId ? {
+          derivedFromBranchId: branch.derivedFromBranchId,
+          derivedFromBranchName: branch.derivedFromBranchName,
+          derivedAt: branch.derivedAt,
+        } : {}),
+      }));
+    }
+    // branchConfigs **总是**写入(即使空对象):回滚的对称语义依赖它区分「新快照拍照时
+    // 确无分支配置(空对象 → 回滚要清掉事后新增的配置)」vs「旧快照没拍过分支层
+    // (字段缺失 → 回滚 no-op,向后兼容)」。
     const payload = {
       buildProfiles: JSON.parse(JSON.stringify(this.state.buildProfiles)),
       customEnv: JSON.parse(JSON.stringify(this.state.customEnv)),
       infraServices: JSON.parse(JSON.stringify(this.state.infraServices)),
       routingRules: JSON.parse(JSON.stringify(this.state.routingRules)),
+      branchConfigs,
     };
     const serialized = JSON.stringify(payload);
     const snapshot: ConfigSnapshot = {
@@ -3578,6 +3616,38 @@ export class StateService {
     this.state.customEnv = JSON.parse(JSON.stringify(target.payload.customEnv));
     this.state.infraServices = JSON.parse(JSON.stringify(target.payload.infraServices));
     this.state.routingRules = JSON.parse(JSON.stringify(target.payload.routingRules));
+    // 波3 配置树:分支层回滚。仅恢复**仍存在**的分支(快照后新建的不动、已删的不复活);
+    // 旧快照无 branchConfigs → no-op(向后兼容,零迁移)。快照 scope 为项目时,
+    // 该项目下「快照里没有配置、现在有了」的分支也要清掉(对称恢复到拍照时刻)。
+    if (target.payload.branchConfigs) {
+      const snapConfigs = target.payload.branchConfigs;
+      for (const [branchId, branch] of Object.entries(this.state.branches)) {
+        if (target.projectId && (branch.projectId || 'default') !== target.projectId) continue;
+        const snap = snapConfigs[branchId];
+        if (snap) {
+          if (snap.profileOverrides) branch.profileOverrides = JSON.parse(JSON.stringify(snap.profileOverrides));
+          else delete branch.profileOverrides;
+          if (snap.extraProfiles) branch.extraProfiles = JSON.parse(JSON.stringify(snap.extraProfiles));
+          else delete branch.extraProfiles;
+          if (snap.derivedFromBranchId) {
+            branch.derivedFromBranchId = snap.derivedFromBranchId;
+            branch.derivedFromBranchName = snap.derivedFromBranchName;
+            branch.derivedAt = snap.derivedAt;
+          } else {
+            delete branch.derivedFromBranchId;
+            delete branch.derivedFromBranchName;
+            delete branch.derivedAt;
+          }
+        } else {
+          // 拍照时该分支没有任何分支层配置 → 恢复为无配置
+          delete branch.profileOverrides;
+          delete branch.extraProfiles;
+          delete branch.derivedFromBranchId;
+          delete branch.derivedFromBranchName;
+          delete branch.derivedAt;
+        }
+      }
+    }
     this.save();
     return target;
   }

--- a/cds/src/types.ts
+++ b/cds/src/types.ts
@@ -645,6 +645,24 @@ export interface BranchEntry {
    */
   extraProfiles?: BuildProfile[];
   /**
+   * 波3 配置树:分支派生溯源(2026-07-06,快照拷贝语义)。
+   *
+   * 三层判定策略(design.cds.config-tree):
+   *   1. 手动创建(POST /branches 带 sourceBranchId)= 显式选择、**真拷贝**:
+   *      深拷贝来源分支的 profileOverrides + extraProfiles(拷贝赢项目模板),之后各自独立;
+   *   2. webhook push 自动建分支 = 保持项目模板,**不猜**来源(push payload 无可靠派生信号);
+   *   3. PR opened/reopened = 仅回填指针(base 分支),**不拷贝配置**(分支往往已按模板部署,
+   *      静默改写违反最小惊讶);要拷贝走显式端点 POST /branches/:id/copy-config-from/:sourceId。
+   *
+   * 快照拷贝(用户拍板):拷贝后两分支各自独立,父分支后续改动**不会**跟随;
+   * 指针仅用于溯源展示与「一键拉取配置」入口。纯增量可选字段,旧数据零迁移。
+   */
+  derivedFromBranchId?: string;
+  /** 来源分支的 git 分支名(来源被删后仍可展示) */
+  derivedFromBranchName?: string;
+  /** 派生指针写入时间(ISO) */
+  derivedAt?: string;
+  /**
    * GitHub Checks integration — populated when the branch was
    * auto-created by a webhook push or the user linked a repo to the
    * owning project. Used to post check-run status back to GitHub
@@ -2083,6 +2101,18 @@ export interface ConfigSnapshot {
     customEnv: CustomEnvStore;
     infraServices: InfraService[];
     routingRules: RoutingRule[];
+    /**
+     * 波3 配置树:分支层配置(profileOverrides / extraProfiles / 派生指针)。
+     * 只收「有配置」的分支(控体积);旧快照无此字段 → 回滚时分支层 no-op。
+     * 回滚语义:仅恢复**仍存在**的分支(快照后新建的不动、已删的不复活)。
+     */
+    branchConfigs?: Record<string, {
+      profileOverrides?: Record<string, BuildProfileOverride>;
+      extraProfiles?: BuildProfile[];
+      derivedFromBranchId?: string;
+      derivedFromBranchName?: string;
+      derivedAt?: string;
+    }>;
   };
   /** 快照字节数（存 state.json 时粗略统计，用于 UI 展示） */
   sizeBytes?: number;

--- a/cds/src/types.ts
+++ b/cds/src/types.ts
@@ -240,6 +240,39 @@ export interface EnvMeta {
 }
 
 /**
+ * 波2 配置检查器 — env 逐 key 溯源(公开契约,GET /branches/:id/effective-config)。
+ *
+ * 来源枚举分两段(与容器注入的两段式一致):
+ *   段A 分支 customEnv 合并(与既有 effective-env 端点口径完全一致):
+ *     cds-builtin(CDS_HOST 等系统注入) / cds-derived(CDS_PROJECT_ID/SLUG 项目身份,
+ *     保留 key 不可覆盖) / mirror(镜像加速) / global(CDS 全局变量 _global) /
+ *     project(项目环境变量) / branch(分支级 env scope)
+ *   段B 单容器运行时注入(resolveProfileRuntimeEnv 的分层):
+ *     profile(项目 BuildProfile.env 底座) / extra-service(分支临时额外服务自带 env) /
+ *     branch-override(分支 profileOverrides[x].env) / deploy-mode(部署模式 env) /
+ *     platform-injected(JWT 兜底 / node PATH / 版本元数据等平台注入,detail 细分) /
+ *     per-branch-db(per-branch DB 隔离对库名 key 的改写)
+ */
+export type EnvSource =
+  | 'cds-builtin' | 'cds-derived' | 'mirror' | 'global' | 'project' | 'branch'
+  | 'profile' | 'extra-service' | 'branch-override' | 'deploy-mode'
+  | 'platform-injected' | 'per-branch-db';
+
+export interface EnvKeyProvenance {
+  key: string;
+  /** 输出到 API 前必须过 maskSecrets SSOT,状态层保持明文 */
+  value: string;
+  /** 最终生效值来自哪一层(last-writer-wins) */
+  source: EnvSource;
+  /** 细分说明:'jwt-fallback' | 'node-runtime' | 'version-metadata' | 'per-branch-db-suffix' 等 */
+  detail?: string;
+  /** 被更高层覆盖(shadow)的更低层来源,按合并顺序排列 — 继承链展示用 */
+  shadowed?: EnvSource[];
+  /** 值经过 ${VAR} 模板展开 */
+  templated?: boolean;
+}
+
+/**
  * Phase 9.5 — env 修改审计条目。
  *
  * 每次 PUT /env 或 PUT /env/:key 时追加一条,记录"谁、何时、改了哪些 key"。

--- a/cds/tests/routes/branches.test.ts
+++ b/cds/tests/routes/branches.test.ts
@@ -919,6 +919,72 @@ describe('Branch Routes', () => {
       expect(stateService.getBranch('b1')!.profileOverrides?.['api']?.dbScope).toBe('shared');
     });
 
+    describe('GET /api/branches/:id/effective-config(波2 配置检查器)', () => {
+      it('返回逐 key 溯源:extra-service/branch-override 打标 + 密钥脱敏 + plan 形状', async () => {
+        stateService.addBuildProfile({ id: 'api', name: 'API', dockerImage: 'img', workDir: 'api', command: 'run', containerPort: 8080, projectId: 'default', env: { FROM_PROFILE: 'p' } });
+        seedBranch('b1');
+        // 项目级 env + 分支级临时服务(带密钥 env)+ 分支覆盖
+        stateService.setCustomEnvVar('API_TOKEN', 'tok_supersecret_value', 'default');
+        stateService.setCustomEnvVar('PLAIN', 'visible', 'default');
+        await request(server, 'PUT', '/api/branches/b1/extra-services', {
+          extraProfiles: [{ id: 'nacos', name: 'nacos', dockerImage: 'nacos/nacos-server:v2.3.2', containerPort: 8848, env: { MODE: 'standalone' }, prebuiltImage: true }],
+        });
+        await request(server, 'PUT', '/api/branches/b1/profile-overrides/api', { env: { FROM_PROFILE: 'overridden' }, dbScope: 'per-branch' });
+
+        const res = await request(server, 'GET', '/api/branches/b1/effective-config');
+        expect(res.status).toBe(200);
+        const body = res.body as any;
+        expect(body.branchId).toBe('b1');
+        // envLayers 是段A分层摘要(至少含 project 层)
+        expect(body.envLayers.some((l: any) => l.source === 'project' && l.keys.includes('API_TOKEN'))).toBe(true);
+        // profiles 含项目底座 + 临时服务
+        const api = body.profiles.find((p: any) => p.profileId === 'api');
+        const nacos = body.profiles.find((p: any) => p.profileId === 'nacos');
+        expect(api).toBeTruthy();
+        expect(nacos).toBeTruthy();
+        expect(nacos.isExtra).toBe(true);
+        // 溯源打标:被 branch-override 覆盖的 key 记录 shadow 链
+        const fromProfile = api.envProvenance.find((p: any) => p.key === 'FROM_PROFILE');
+        expect(fromProfile).toMatchObject({ source: 'branch-override', shadowed: ['profile'] });
+        // 临时服务自带 env 打 extra-service
+        const mode = nacos.envProvenance.find((p: any) => p.key === 'MODE');
+        expect(mode).toMatchObject({ source: 'extra-service' });
+        // 项目 env 到达容器,来源 project
+        const plain = api.envProvenance.find((p: any) => p.key === 'PLAIN');
+        expect(plain).toMatchObject({ source: 'project', value: 'visible' });
+        // 密钥脱敏:API_TOKEN 不得以明文出现
+        const token = api.envProvenance.find((p: any) => p.key === 'API_TOKEN');
+        expect(token.value).not.toBe('tok_supersecret_value');
+        // dbScope 覆盖生效 + 来源标注
+        expect(api.dbScope).toBe('per-branch');
+        expect(api.dbScopeSource).toBe('branch-override');
+        // plan 形状:容器清单含两个服务,infra 判定为记录态
+        expect(body.plan.stateBasis).toBe('recorded');
+        expect(body.plan.containers.map((c: any) => c.profileId).sort()).toEqual(['api', 'nacos']);
+        expect(body.plan.networks.sharedNetwork).toBeTruthy();
+      });
+
+      it('缺失 ${VAR} 模板值时不 fail 端点,该 profile 带 envError 显性化缺口', async () => {
+        stateService.addBuildProfile({ id: 'api', name: 'API', dockerImage: 'img', workDir: 'api', command: 'run', containerPort: 8080, projectId: 'default', env: { DB_URL: 'mysql://h:${NOT_SET_ANYWHERE_XYZ}/app' } });
+        seedBranch('b1');
+        const res = await request(server, 'GET', '/api/branches/b1/effective-config');
+        expect(res.status).toBe(200);
+        const api = (res.body as any).profiles.find((p: any) => p.profileId === 'api');
+        expect(api.envError).toContain('NOT_SET_ANYWHERE_XYZ');
+        expect(api.envProvenance).toEqual([]);
+      });
+
+      it('跨项目 agent key 越权拿不到别的项目分支的生效配置(assertProjectAccess)', async () => {
+        const now = new Date().toISOString();
+        stateService.addProject({ id: 'proj-a', slug: 'proj-a', name: 'A', kind: 'git', createdAt: now, updatedAt: now });
+        stateService.addBranch({ id: 'ba', projectId: 'proj-a', branch: 'ba', worktreePath: '/tmp/wt/ba', services: {}, status: 'idle', createdAt: now });
+        const denied = await request(server, 'GET', '/api/branches/ba/effective-config', undefined, { 'x-test-key': 'B' });
+        expect(denied.status).toBe(403);
+        const ok = await request(server, 'GET', '/api/branches/ba/effective-config', undefined, { 'x-test-key': 'A' });
+        expect(ok.status).toBe(200);
+      });
+    });
+
     it('PUT /profile-overrides rejects a shell-injecting dockerImage override (Codex P1)', async () => {
       seedBranch('b1');
       await request(server, 'PUT', '/api/branches/b1/extra-services', {

--- a/cds/tests/routes/branches.test.ts
+++ b/cds/tests/routes/branches.test.ts
@@ -897,6 +897,28 @@ describe('Branch Routes', () => {
       expect(stateService.getBranch('b1')!.profileOverrides?.['demo-extra']?.env?.FOO).toBe('bar');
     });
 
+    it('PUT /profile-overrides passes dbScope through and enforces the enum (波1 W1c)', async () => {
+      // dbScope 在 BuildProfileOverride/applyProfileOverride 早已支持,但 PUT 白名单一直漏透传,
+      // per-branch DB 开关因此永远无法按分支生效——本测试钉死透传 + 枚举校验。
+      stateService.addBuildProfile({ id: 'api', name: 'API', dockerImage: 'img', workDir: 'api', command: 'run', containerPort: 8080, projectId: 'default' });
+      seedBranch('b1');
+      // 合法值落库
+      const put = await request(server, 'PUT', '/api/branches/b1/profile-overrides/api', { dbScope: 'per-branch' });
+      expect(put.status).toBe(200);
+      expect(stateService.getBranch('b1')!.profileOverrides?.['api']?.dbScope).toBe('per-branch');
+      // 覆盖生效链:resolveEffectiveProfile 合并出的有效 profile 带 per-branch
+      expect(((put.body as any).effective as any).dbScope).toBe('per-branch');
+      // 切回 shared 同样生效
+      const back = await request(server, 'PUT', '/api/branches/b1/profile-overrides/api', { dbScope: 'shared' });
+      expect(back.status).toBe(200);
+      expect(stateService.getBranch('b1')!.profileOverrides?.['api']?.dbScope).toBe('shared');
+      // 非法值 400,且不改动已存覆盖
+      const bad = await request(server, 'PUT', '/api/branches/b1/profile-overrides/api', { dbScope: 'everything' });
+      expect(bad.status).toBe(400);
+      expect(String((bad.body as any).error)).toContain('dbScope');
+      expect(stateService.getBranch('b1')!.profileOverrides?.['api']?.dbScope).toBe('shared');
+    });
+
     it('PUT /profile-overrides rejects a shell-injecting dockerImage override (Codex P1)', async () => {
       seedBranch('b1');
       await request(server, 'PUT', '/api/branches/b1/extra-services', {

--- a/cds/tests/routes/branches.test.ts
+++ b/cds/tests/routes/branches.test.ts
@@ -985,6 +985,106 @@ describe('Branch Routes', () => {
       });
     });
 
+    describe('分支派生快照拷贝(波3 配置树)', () => {
+      const seedSourceWithConfig = async (id: string) => {
+        seedBranch(id);
+        await request(server, 'PUT', `/api/branches/${id}/extra-services`, {
+          extraProfiles: [{ id: 'nacos', name: 'nacos', dockerImage: 'nacos/nacos-server:v2.3.2', containerPort: 8848, env: { MODE: 'standalone' }, prebuiltImage: true }],
+        });
+        stateService.addBuildProfile({ id: 'api', name: 'API', dockerImage: 'img', workDir: 'api', command: 'run', containerPort: 8080, projectId: 'default' });
+        await request(server, 'PUT', `/api/branches/${id}/profile-overrides/api`, { env: { KEY: 'from-source' }, dbScope: 'per-branch' });
+      };
+
+      it('POST /branches 带 sourceBranchId:深拷贝 overrides+extraProfiles,写派生指针,改新不串旧', async () => {
+        await seedSourceWithConfig('src-branch');
+        const res = await request(server, 'POST', '/api/branches', { branch: 'derived-x', sourceBranchId: 'src-branch' });
+        expect(res.status).toBe(201);
+        const created = stateService.getBranch('derived-x')!;
+        expect(created.derivedFromBranchId).toBe('src-branch');
+        expect(created.derivedFromBranchName).toBe('src-branch');
+        expect(created.derivedAt).toBeTruthy();
+        expect(created.profileOverrides?.['api']?.env?.KEY).toBe('from-source');
+        expect(created.profileOverrides?.['api']?.dbScope).toBe('per-branch');
+        expect(created.extraProfiles?.map((p) => p.id)).toEqual(['nacos']);
+        // 深拷贝隔离:改新分支的配置不得串改来源分支
+        created.profileOverrides!['api']!.env!.KEY = 'mutated';
+        created.extraProfiles![0].env!.MODE = 'mutated';
+        const source = stateService.getBranch('src-branch')!;
+        expect(source.profileOverrides?.['api']?.env?.KEY).toBe('from-source');
+        expect(source.extraProfiles?.[0].env?.MODE).toBe('standalone');
+      });
+
+      it('POST /branches sourceBranchId 校验:不存在 400,跨项目 400,且不留孤儿分支', async () => {
+        const now = new Date().toISOString();
+        const missing = await request(server, 'POST', '/api/branches', { branch: 'd1', sourceBranchId: 'ghost' });
+        expect(missing.status).toBe(400);
+        expect(stateService.getBranch('d1')).toBeUndefined();
+        stateService.addProject({ id: 'proj-a', slug: 'proj-a', name: 'A', kind: 'git', createdAt: now, updatedAt: now });
+        stateService.addBranch({ id: 'other', projectId: 'proj-a', branch: 'other', worktreePath: '/tmp/wt/other', services: {}, status: 'idle', createdAt: now });
+        const cross = await request(server, 'POST', '/api/branches', { branch: 'd2', sourceBranchId: 'other' });
+        expect(cross.status).toBe(400);
+        expect(String((cross.body as any).error)).toContain('跨项目');
+      });
+
+      it('POST /branches/:id/copy-config-from/:sourceId:先拍快照再整体替换,可从快照回滚', async () => {
+        await seedSourceWithConfig('src-branch');
+        seedBranch('target');
+        // target 先有自己的配置(将被替换)
+        await request(server, 'PUT', '/api/branches/target/profile-overrides/api', { env: { KEY: 'target-own' } });
+
+        const res = await request(server, 'POST', '/api/branches/target/copy-config-from/src-branch');
+        expect(res.status).toBe(200);
+        const body = res.body as any;
+        expect(body.copied).toBe(true);
+        expect(body.snapshotId).toBeTruthy();
+        const target = stateService.getBranch('target')!;
+        expect(target.profileOverrides?.['api']?.env?.KEY).toBe('from-source');
+        expect(target.extraProfiles?.map((p) => p.id)).toEqual(['nacos']);
+        expect(target.derivedFromBranchId).toBe('src-branch');
+
+        // 误拷回滚:快照分支层恢复 target 拷贝前的配置
+        const rollback = await request(server, 'POST', `/api/config-snapshots/${body.snapshotId}/rollback`, {});
+        // snapshots 路由不在本测试 app 里 → 直接走 state 层验证回滚语义
+        if (rollback.status === 404 || typeof rollback.body === 'string') {
+          stateService.rollbackToConfigSnapshot(body.snapshotId);
+        }
+        const restored = stateService.getBranch('target')!;
+        expect(restored.profileOverrides?.['api']?.env?.KEY).toBe('target-own');
+        expect(restored.extraProfiles).toBeUndefined();
+        expect(restored.derivedFromBranchId).toBeUndefined();
+      });
+
+      it('copy-config-from 校验:自拷 400 / 跨项目 400', async () => {
+        const now = new Date().toISOString();
+        seedBranch('b1');
+        const self = await request(server, 'POST', '/api/branches/b1/copy-config-from/b1');
+        expect(self.status).toBe(400);
+        stateService.addProject({ id: 'proj-a', slug: 'proj-a', name: 'A', kind: 'git', createdAt: now, updatedAt: now });
+        stateService.addBranch({ id: 'other', projectId: 'proj-a', branch: 'other', worktreePath: '/tmp/wt/other', services: {}, status: 'idle', createdAt: now });
+        const cross = await request(server, 'POST', '/api/branches/b1/copy-config-from/other');
+        expect(cross.status).toBe(400);
+      });
+
+      it('快照分支层:旧快照(无 branchConfigs)回滚分支层 no-op;新快照不复活已删分支', async () => {
+        seedBranch('keeper');
+        await request(server, 'PUT', '/api/branches/keeper/extra-services', {
+          extraProfiles: [{ id: 'svc', name: 'svc', dockerImage: 'nginx:alpine', containerPort: 80, prebuiltImage: true }],
+        });
+        // 旧格式快照:手工去掉 branchConfigs 字段 → 回滚不碰分支层
+        const legacySnap = stateService.createConfigSnapshot({ trigger: 'manual', label: 'legacy', projectId: null });
+        delete (legacySnap.payload as any).branchConfigs;
+        stateService.rollbackToConfigSnapshot(legacySnap.id);
+        expect(stateService.getBranch('keeper')!.extraProfiles?.length).toBe(1);
+
+        // 新快照:拍照后删分支,回滚不复活分支
+        const snap = stateService.createConfigSnapshot({ trigger: 'manual', label: 'with-branches', projectId: null });
+        expect(snap.payload.branchConfigs?.['keeper']?.extraProfiles?.length).toBe(1);
+        stateService.removeBranch('keeper');
+        stateService.rollbackToConfigSnapshot(snap.id);
+        expect(stateService.getBranch('keeper')).toBeUndefined();
+      });
+    });
+
     it('PUT /profile-overrides rejects a shell-injecting dockerImage override (Codex P1)', async () => {
       seedBranch('b1');
       await request(server, 'PUT', '/api/branches/b1/extra-services', {

--- a/cds/tests/services/env-provenance.test.ts
+++ b/cds/tests/services/env-provenance.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveProfileRuntimeEnvWithProvenance,
+  missingEnvTemplates,
+  type EnvLayer,
+} from '../../src/services/env-provenance.js';
+
+/*
+ * env-provenance 单测(波2 配置检查器核心)。
+ *
+ * 两个目标:
+ *  1. 溯源语义:last-writer-wins + shadowed 链 + platform-injected/per-branch-db 打标 + templated
+ *  2. 行为等价:单层调用(部署路径的包装方式)输出与旧 container.ts#resolveProfileRuntimeEnv
+ *     行为一致 —— 步骤顺序/条件/异常消息逐条钉死
+ */
+
+const BRANCH = {
+  branch: 'claude/feat-x',
+  githubCommitSha: 'abc123def4567890',
+  lastPushAt: '2026-07-06T08:00:00.000Z',
+  createdAt: '2026-07-01T00:00:00.000Z',
+};
+
+const OPTS = { jwtIssuer: 'cds-issuer' };
+
+function envOf(layers: EnvLayer[], profileLayers: EnvLayer[] = [], profile: { dockerImage: string; dbScope?: 'shared' | 'per-branch' } = { dockerImage: 'img' }) {
+  return resolveProfileRuntimeEnvWithProvenance(BRANCH, profile, layers, profileLayers, OPTS);
+}
+
+function prov(result: ReturnType<typeof envOf>, key: string) {
+  return result.provenance.find((p) => p.key === key);
+}
+
+describe('resolveProfileRuntimeEnvWithProvenance — 溯源语义', () => {
+  it('last-writer-wins:靠后层覆盖靠前层,shadowed 记录被覆盖来源链', () => {
+    const r = envOf([
+      { source: 'global', env: { FOO: 'from-global', ONLY_GLOBAL: 'g' } },
+      { source: 'project', env: { FOO: 'from-project' } },
+      { source: 'branch', env: { FOO: 'from-branch' } },
+    ]);
+    expect(r.env.FOO).toBe('from-branch');
+    expect(prov(r, 'FOO')).toMatchObject({ source: 'branch', shadowed: ['global', 'project'] });
+    expect(prov(r, 'ONLY_GLOBAL')).toMatchObject({ source: 'global' });
+    expect(prov(r, 'ONLY_GLOBAL')?.shadowed).toBeUndefined();
+  });
+
+  it('JWT 兜底:JWT_SECRET 存在且无 Jwt__Secret 时映射,打 platform-injected/jwt-fallback', () => {
+    const r = envOf([{ source: 'project', env: { JWT_SECRET: 's3cret' } }]);
+    expect(r.env['Jwt__Secret']).toBe('s3cret');
+    expect(prov(r, 'Jwt__Secret')).toMatchObject({ source: 'platform-injected', detail: 'jwt-fallback' });
+    expect(r.env['Jwt__Issuer']).toBe('cds-issuer');
+    expect(prov(r, 'Jwt__Issuer')).toMatchObject({ source: 'platform-injected', detail: 'jwt-fallback' });
+  });
+
+  it('JWT 兜底只看段A:profile.env 的 Jwt__Secret 在兜底之后合并,最终覆盖兜底值', () => {
+    const r = envOf(
+      [{ source: 'project', env: { JWT_SECRET: 'custom-secret' } }],
+      [{ source: 'profile', env: { Jwt__Secret: 'profile-wins' } }],
+    );
+    expect(r.env['Jwt__Secret']).toBe('profile-wins');
+    expect(prov(r, 'Jwt__Secret')).toMatchObject({ source: 'profile', shadowed: ['platform-injected'] });
+  });
+
+  it('node 容器注入 PNPM_HOME / PATH,非 node 镜像不注入', () => {
+    const node = envOf([], [], { dockerImage: 'node:20-slim' });
+    expect(node.env['PNPM_HOME']).toBe('/pnpm');
+    expect(node.env['PATH']).toContain('/pnpm:');
+    expect(prov(node, 'PNPM_HOME')).toMatchObject({ source: 'platform-injected', detail: 'node-runtime' });
+    const plain = envOf([], [], { dockerImage: 'nginx:alpine' });
+    expect(plain.env['PNPM_HOME']).toBeUndefined();
+  });
+
+  it('profile 层拆分:baseline → branch-override → deploy-mode,靠后覆盖并记 shadow', () => {
+    const r = envOf(
+      [],
+      [
+        { source: 'extra-service', env: { MODE: 'standalone', KEEP: 'x' } },
+        { source: 'branch-override', env: { MODE: 'cluster' } },
+        { source: 'deploy-mode', env: { MODE: 'prod' } },
+      ],
+    );
+    expect(r.env.MODE).toBe('prod');
+    expect(prov(r, 'MODE')).toMatchObject({
+      source: 'deploy-mode',
+      shadowed: ['extra-service', 'branch-override'],
+    });
+    expect(prov(r, 'KEEP')).toMatchObject({ source: 'extra-service' });
+  });
+
+  it('版本元数据强制覆盖 profile env,打 version-metadata', () => {
+    const r = envOf([], [{ source: 'profile', env: { GIT_COMMIT: 'user-set' } }]);
+    expect(r.env['GIT_COMMIT']).toBe('abc123def4567890');
+    expect(prov(r, 'GIT_COMMIT')).toMatchObject({
+      source: 'platform-injected',
+      detail: 'version-metadata',
+      shadowed: ['profile'],
+    });
+    expect(r.env['VITE_BUILD_ID']).toBe('abc123def456');
+    expect(r.env['VITE_GIT_BRANCH']).toBe('claude/feat-x');
+    expect(r.env['CDS_BUILD_TIME']).toBe('2026-07-06T08:00:00.000Z');
+  });
+
+  it('per-branch DB 改写:dbScope=per-branch 的库名 key 打 per-branch-db,原来源进 shadowed', () => {
+    const r = envOf(
+      [{ source: 'project', env: { MYSQL_DATABASE: 'app' } }],
+      [],
+      { dockerImage: 'img', dbScope: 'per-branch' },
+    );
+    expect(r.env['MYSQL_DATABASE']).toBe('app_claude_feat_x');
+    expect(prov(r, 'MYSQL_DATABASE')).toMatchObject({
+      source: 'per-branch-db',
+      detail: 'per-branch-db-suffix',
+      shadowed: ['project'],
+    });
+  });
+
+  it('dbScope=shared 不改写库名', () => {
+    const r = envOf(
+      [{ source: 'project', env: { MYSQL_DATABASE: 'app' } }],
+      [],
+      { dockerImage: 'img', dbScope: 'shared' },
+    );
+    expect(r.env['MYSQL_DATABASE']).toBe('app');
+    expect(prov(r, 'MYSQL_DATABASE')).toMatchObject({ source: 'project' });
+  });
+
+  it('${VAR} 模板展开后打 templated,值来自展开结果', () => {
+    const r = envOf([
+      { source: 'project', env: { CDS_MYSQL_PORT: '13306', DB_URL: 'mysql://host:${CDS_MYSQL_PORT}/app' } },
+    ]);
+    expect(r.env['DB_URL']).toBe('mysql://host:13306/app');
+    expect(prov(r, 'DB_URL')).toMatchObject({ source: 'project', templated: true });
+    expect(prov(r, 'CDS_MYSQL_PORT')?.templated).toBeUndefined();
+  });
+
+  it('缺失模板值抛错,消息与旧实现一字不差', () => {
+    expect(() => envOf([
+      { source: 'project', env: { DB_URL: 'mysql://host:${NOT_DEFINED_ANYWHERE_XYZ}/app' } },
+    ])).toThrow('环境变量模板缺少值: NOT_DEFINED_ANYWHERE_XYZ。请在项目环境变量中填写，或先启动对应基础设施服务后再部署。');
+  });
+});
+
+describe('resolveProfileRuntimeEnvWithProvenance — 与旧部署路径行为等价(单层包装)', () => {
+  it('复合场景:customEnv + profile.env + JWT + node + per-branch + 模板,env 输出与旧实现手算一致', () => {
+    // 旧实现语义手算:
+    //   merged = {...customEnv}                                 → JWT_SECRET/MYSQL_DATABASE/CDS_MYSQL_PORT/DB_URL
+    //   Jwt__Secret = JWT_SECRET(无 Jwt__Secret)                → 's'
+    //   Jwt__Issuer = issuer                                    → 'cds-issuer'
+    //   node: PNPM_HOME=/pnpm, npm_config_store_dir, PATH 前缀   → 注入
+    //   profile.env 合并                                         → EXTRA=1 且覆盖 CDS_MYSQL_PORT=23306
+    //   版本元数据                                                → GIT_COMMIT 等
+    //   per-branch: MYSQL_DATABASE=app_claude_feat_x
+    //   模板展开: DB_URL 用 23306(profile 覆盖后的值)
+    const customEnv = {
+      JWT_SECRET: 's',
+      MYSQL_DATABASE: 'app',
+      CDS_MYSQL_PORT: '13306',
+      DB_URL: 'mysql://h:${CDS_MYSQL_PORT}/${MYSQL_DATABASE}',
+    };
+    const r = resolveProfileRuntimeEnvWithProvenance(
+      BRANCH,
+      { dockerImage: 'node:20', dbScope: 'per-branch' },
+      [{ source: 'project', env: customEnv }],
+      [{ source: 'profile', env: { EXTRA: '1', CDS_MYSQL_PORT: '23306' } }],
+      OPTS,
+    );
+    expect(r.env).toMatchObject({
+      JWT_SECRET: 's',
+      Jwt__Secret: 's',
+      Jwt__Issuer: 'cds-issuer',
+      PNPM_HOME: '/pnpm',
+      npm_config_store_dir: '/pnpm/store',
+      EXTRA: '1',
+      CDS_MYSQL_PORT: '23306',
+      MYSQL_DATABASE: 'app_claude_feat_x',
+      DB_URL: 'mysql://h:23306/app_claude_feat_x',
+      GIT_COMMIT: 'abc123def4567890',
+      VITE_BUILD_ID: 'abc123def456',
+    });
+    expect(r.env['PATH']).toMatch(/^\/pnpm:/);
+  });
+
+  it('自引用模板保留 customEnv 真值(resolveVars 兼容语义)', () => {
+    // 旧实现:isolatedEnv 里 v === '${K}' 且 customEnv 有 K → resolveVars 用 customEnv 值。
+    // profile.env 把 K 覆盖成字面模板 '${K}' 时,展开结果应回落到 customEnv 的真值。
+    const r = resolveProfileRuntimeEnvWithProvenance(
+      BRANCH,
+      { dockerImage: 'img' },
+      [{ source: 'project', env: { TOKEN: 'real-token' } }],
+      [{ source: 'profile', env: { TOKEN: '${TOKEN}' } }],
+      OPTS,
+    );
+    expect(r.env['TOKEN']).toBe('real-token');
+  });
+
+  it('空输入:无 customEnv 无 profile.env 时只有平台注入项', () => {
+    const r = envOf([]);
+    expect(Object.keys(r.env).sort()).toEqual([
+      'CDS_BUILD_TIME', 'COMMIT_SHA', 'GITHUB_SHA', 'GIT_COMMIT', 'Jwt__Issuer',
+      'SOURCE_VERSION', 'VITE_BUILD_ID', 'VITE_GIT_BRANCH',
+    ].sort().concat(['CDS_COMMIT_SHA']).sort());
+  });
+});
+
+describe('missingEnvTemplates(从 container.ts 迁来的 SSOT)', () => {
+  it('识别缺失模板、忽略有默认值/env 内可解析/process.env 存在的', () => {
+    expect(missingEnvTemplates({ A: '${MISSING_XYZ_123}' })).toEqual(['MISSING_XYZ_123']);
+    expect(missingEnvTemplates({ A: '${B}', B: 'x' })).toEqual([]);
+    expect(missingEnvTemplates({ A: '${MISSING_XYZ_123:-default}' })).toEqual([]);
+    expect(missingEnvTemplates({ A: 'no-template' })).toEqual([]);
+  });
+});

--- a/cds/tests/services/github-webhook-dispatcher.test.ts
+++ b/cds/tests/services/github-webhook-dispatcher.test.ts
@@ -595,6 +595,57 @@ describe('GitHubWebhookDispatcher', () => {
       expect(result.branchId).toBe('proj-feature');
       const branch = stateService.getBranch('proj-feature');
       expect(branch!.githubPrNumber).toBe(99);
+      // base 分支(main)不在 CDS 里 → 派生指针不回填(不猜)
+      expect(branch!.derivedFromBranchId).toBeUndefined();
+    });
+
+    it('backfills derivedFrom pointer from PR base when the base branch exists (波3,只回填指针不拷贝配置)', async () => {
+      stateService.addBranch({
+        id: 'proj-main',
+        projectId: 'p1',
+        branch: 'main',
+        worktreePath: '/tmp/wt-main',
+        services: {},
+        status: 'running',
+        createdAt: new Date().toISOString(),
+        profileOverrides: { web: { env: { FROM_MAIN: '1' } } },
+      });
+      const d = buildDispatcher();
+      const prEvent = {
+        action: 'opened',
+        number: 100,
+        pull_request: {
+          number: 100,
+          state: 'open',
+          head: { ref: 'feature', sha: 'abc' },
+          base: { ref: 'main' },
+          html_url: 'https://github.com/octocat/repo/pull/100',
+          title: 'Feature',
+        },
+        repository: { full_name: 'octocat/repo' },
+        installation: { id: 42 },
+      };
+      await d.handle('pull_request', prEvent);
+      const branch = stateService.getBranch('proj-feature')!;
+      expect(branch.derivedFromBranchId).toBe('proj-main');
+      expect(branch.derivedFromBranchName).toBe('main');
+      expect(branch.derivedAt).toBeTruthy();
+      // 只回填指针,不拷贝配置(最小惊讶)
+      expect(branch.profileOverrides).toBeUndefined();
+
+      // idempotent:已设指针不被后续事件覆盖
+      const firstAt = branch.derivedAt;
+      stateService.addBranch({
+        id: 'proj-develop', projectId: 'p1', branch: 'develop', worktreePath: '/tmp/wt-dev',
+        services: {}, status: 'idle', createdAt: new Date().toISOString(),
+      });
+      await d.handle('pull_request', {
+        ...prEvent,
+        pull_request: { ...prEvent.pull_request, base: { ref: 'develop' } },
+      });
+      const after = stateService.getBranch('proj-feature')!;
+      expect(after.derivedFromBranchId).toBe('proj-main');
+      expect(after.derivedAt).toBe(firstAt);
     });
 
     it('returns pr-branch-stopped on closed with stopRequest', async () => {

--- a/cds/web/src/components/BranchDetailDrawer.tsx
+++ b/cds/web/src/components/BranchDetailDrawer.tsx
@@ -10,6 +10,7 @@ import { EnvEditor } from '@/pages/cds-settings/EnvEditor';
 import { ActiveDeployment } from '@/components/deployment/ActiveDeployment';
 import { HistoryRow } from '@/components/deployment/HistoryRow';
 import { PreviewActionSplitButton } from '@/components/branch/PreviewActionSplitButton';
+import { ExtraServicesPanel } from '@/components/branch/ExtraServicesPanel';
 import { deriveBranchPhases, type PhaseKey } from '@/lib/deploymentPhases';
 import { normalizeContainerLogsForDisplay } from '@/lib/containerLogs';
 import { pickActiveDeployment } from './branchDeploymentSelection';
@@ -94,6 +95,7 @@ interface BuildProfileOverride {
   resources?: { memoryMB?: number; cpus?: number };
   activeDeployMode?: string;
   startupSignal?: string;
+  dbScope?: 'shared' | 'per-branch';
   notes?: string;
 }
 
@@ -105,6 +107,7 @@ interface ProfileRow {
     name: string;
     deployModes?: Record<string, { label?: string }>;
     activeDeployMode?: string;
+    dbScope?: 'shared' | 'per-branch';
   };
   override?: BuildProfileOverride | null;
   effective?: {
@@ -115,6 +118,7 @@ interface ProfileRow {
     dependsOn?: string[];
     activeDeployMode?: string;
     deployModes?: Record<string, { label?: string }>;
+    dbScope?: 'shared' | 'per-branch';
   };
   hasOverride?: boolean;
 }
@@ -1326,6 +1330,40 @@ export function BranchDetailDrawer({
     }
   }, [branchId, load, onActionComplete, onToast]);
 
+  // 波1 W1c:按分支切换数据库隔离档位(dbScope)。与部署模式不同,**只保存不自动重部署**——
+  // 切库是重操作(应用重启后连到另一个 database),用户应自己决定重部署时机(最小惊讶)。
+  const setProfileDbScope = useCallback(async (profile: ProfileRow, scope: '' | 'shared' | 'per-branch'): Promise<void> => {
+    if (!branchId) return;
+    setModeSavingProfileId(profile.profileId);
+    try {
+      const next: BuildProfileOverride = { ...(profile.override || {}) };
+      if (scope === '') delete next.dbScope;
+      else next.dbScope = scope;
+      const compacted = compactProfileOverride(next);
+      if (!hasProfileOverrideFields(compacted)) {
+        await apiRequest(`/api/branches/${encodeURIComponent(branchId)}/profile-overrides/${encodeURIComponent(profile.profileId)}`, {
+          method: 'DELETE',
+        });
+      } else {
+        await apiRequest(`/api/branches/${encodeURIComponent(branchId)}/profile-overrides/${encodeURIComponent(profile.profileId)}`, {
+          method: 'PUT',
+          body: compacted,
+        });
+      }
+      onToast?.(scope === 'per-branch'
+        ? '已切为分支独立库(DB 名加分支后缀),重新部署后生效'
+        : scope === 'shared'
+          ? '已切为共享库,重新部署后生效'
+          : '已恢复继承项目配置,重新部署后生效');
+      await load();
+    } catch (err) {
+      const message = err instanceof ApiError ? err.message : String(err);
+      onToast?.(`切换数据库隔离失败:${message}`);
+    } finally {
+      setModeSavingProfileId(null);
+    }
+  }, [branchId, load, onToast]);
+
   const loadServiceLogs = useCallback(async (profileId: string) => {
     if (!branchId) return;
     setSelectedServiceId(profileId);
@@ -2325,6 +2363,8 @@ export function BranchDetailDrawer({
                     onConfirmDelete={setConfirmDelete}
                     onRunAction={runBranchAction}
                     onSetProfileDeployMode={setProfileDeployMode}
+                    onSetProfileDbScope={setProfileDbScope}
+                    onToast={onToast}
                   />
                 ) : null}
 
@@ -5984,6 +6024,7 @@ function compactProfileOverride(override: BuildProfileOverride): BuildProfileOve
   if (override.resources && Object.keys(override.resources).length > 0) next.resources = override.resources;
   if (override.activeDeployMode !== undefined) next.activeDeployMode = override.activeDeployMode.trim();
   if (override.startupSignal?.trim()) next.startupSignal = override.startupSignal.trim();
+  if (override.dbScope === 'shared' || override.dbScope === 'per-branch') next.dbScope = override.dbScope;
   if (override.notes?.trim()) next.notes = override.notes.trim();
   return next;
 }
@@ -6019,6 +6060,8 @@ function SettingsPanel({
   onConfirmDelete,
   onRunAction,
   onSetProfileDeployMode,
+  onSetProfileDbScope,
+  onToast,
 }: {
   branch: BranchDetailData | null;
   projectId: string;
@@ -6032,6 +6075,8 @@ function SettingsPanel({
     label: string,
   ) => void;
   onSetProfileDeployMode: (profile: ProfileRow, mode: string) => void;
+  onSetProfileDbScope: (profile: ProfileRow, scope: '' | 'shared' | 'per-branch') => void;
+  onToast?: (message: string) => void;
 }): JSX.Element {
   if (!branch) {
     return (
@@ -6085,6 +6130,9 @@ function SettingsPanel({
               const activeMode = hasBranchModeOverride
                 ? (profile.override?.activeDeployMode || '')
                 : (profile.effective?.activeDeployMode || '');
+              // 波1 W1c:数据库隔离档位。override 有值 = 本分支覆盖;否则显示「继承」。
+              const dbScopeOverride = profile.override?.dbScope;
+              const inheritedDbScope = profile.baseline?.dbScope || 'shared';
               return (
                 <div key={profile.profileId} className="flex flex-wrap items-center gap-2 rounded-md border border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))]/45 px-3 py-2">
                   <div className="min-w-0 flex-1">
@@ -6094,6 +6142,11 @@ function SettingsPanel({
                       <span className={`rounded border px-1.5 py-0.5 ${hasBranchModeOverride ? 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300' : 'border-[hsl(var(--hairline))]'}`}>
                         {hasBranchModeOverride ? '本分支覆盖' : '继承默认'}
                       </span>
+                      {(dbScopeOverride ?? inheritedDbScope) === 'per-branch' ? (
+                        <span className="rounded border border-emerald-500/30 bg-emerald-500/10 px-1.5 py-0.5 text-emerald-700 dark:text-emerald-300">
+                          分支独立库
+                        </span>
+                      ) : null}
                     </div>
                   </div>
                   <select
@@ -6110,6 +6163,17 @@ function SettingsPanel({
                       </option>
                     ))}
                   </select>
+                  <select
+                    className="h-9 min-w-[150px] rounded-md border border-input bg-background px-3 text-sm"
+                    value={dbScopeOverride ?? ''}
+                    onChange={(event) => onSetProfileDbScope(profile, event.target.value as '' | 'shared' | 'per-branch')}
+                    disabled={modeSavingProfileId === profile.profileId}
+                    title="数据库隔离:分支独立库会给 DB 名追加分支后缀;切换后需重新部署生效"
+                  >
+                    <option value="">{`数据库:继承(${inheritedDbScope === 'per-branch' ? '分支独立库' : '共享库'})`}</option>
+                    <option value="shared">数据库:共享库</option>
+                    <option value="per-branch">数据库:分支独立库</option>
+                  </select>
                   {modeSavingProfileId === profile.profileId ? <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" /> : null}
                 </div>
               );
@@ -6117,6 +6181,10 @@ function SettingsPanel({
           </div>
         ) : null}
       </div>
+
+      {/* 波1 W1b:分支级临时额外服务(Nacos 场景)。运行模式卡讲「怎么跑项目服务」,
+          这张卡讲「本分支额外多跑什么」,同属分支级配置,放一起。 */}
+      <ExtraServicesPanel branchId={branch.id} onToast={onToast} />
 
       {/* 主操作 */}
       <div className="rounded-md border border-[hsl(var(--hairline))] bg-card px-4 py-3">

--- a/cds/web/src/components/BranchDetailDrawer.tsx
+++ b/cds/web/src/components/BranchDetailDrawer.tsx
@@ -11,6 +11,7 @@ import { ActiveDeployment } from '@/components/deployment/ActiveDeployment';
 import { HistoryRow } from '@/components/deployment/HistoryRow';
 import { PreviewActionSplitButton } from '@/components/branch/PreviewActionSplitButton';
 import { ExtraServicesPanel } from '@/components/branch/ExtraServicesPanel';
+import { EffectiveConfigPanel } from '@/components/branch/EffectiveConfigPanel';
 import { deriveBranchPhases, type PhaseKey } from '@/lib/deploymentPhases';
 import { normalizeContainerLogsForDisplay } from '@/lib/containerLogs';
 import { pickActiveDeployment } from './branchDeploymentSelection';
@@ -266,7 +267,7 @@ export interface BranchDeploymentItem {
   deployMode?: string;
 }
 
-type DrawerTab = 'overview' | 'deployments' | 'services' | 'logs' | 'variables' | 'metrics' | 'settings';
+type DrawerTab = 'overview' | 'deployments' | 'services' | 'logs' | 'variables' | 'config' | 'metrics' | 'settings';
 export type BranchResourceDetailTab = 'overview' | 'connection' | 'data' | 'backups' | 'variables' | 'metrics' | 'logs' | 'settings';
 type ResourceCloneMode = 'empty' | 'clone-main' | 'restore-backup' | 'connect-existing';
 
@@ -297,6 +298,7 @@ const drawerTabs: Array<{ key: DrawerTab; label: string; planned?: boolean }> = 
   { key: 'services', label: '资源' },
   { key: 'logs', label: '日志' },
   { key: 'variables', label: '变量' },           // 2026-05-04 Phase A 落地
+  { key: 'config', label: '配置' },              // 2026-07-06 波2 配置检查器(逐 key 溯源 + 部署计划)
   { key: 'metrics', label: '指标' },             // 2026-05-04 Phase B 落地
   { key: 'settings', label: '设置' },            // 2026-05-04 Phase C 落地
 ];
@@ -2350,6 +2352,10 @@ export function BranchDetailDrawer({
                     onEnvChanged={() => void loadEnv()}
                     onToast={(message) => onToast?.(message)}
                   />
+                ) : null}
+
+                {activeTab === 'config' && branchId ? (
+                  <EffectiveConfigPanel branchId={branchId} />
                 ) : null}
 
                 {activeTab === 'settings' ? (

--- a/cds/web/src/components/BranchDetailDrawer.tsx
+++ b/cds/web/src/components/BranchDetailDrawer.tsx
@@ -2355,7 +2355,7 @@ export function BranchDetailDrawer({
                 ) : null}
 
                 {activeTab === 'config' && branchId ? (
-                  <EffectiveConfigPanel branchId={branchId} />
+                  <EffectiveConfigPanel branchId={branchId} onToast={onToast} />
                 ) : null}
 
                 {activeTab === 'settings' ? (

--- a/cds/web/src/components/branch/EffectiveConfigPanel.tsx
+++ b/cds/web/src/components/branch/EffectiveConfigPanel.tsx
@@ -49,6 +49,12 @@ interface EffectiveConfigResponse {
   projectId: string;
   projectSlug: string;
   branchStatus: string;
+  derivedFrom: {
+    branchId: string;
+    branchName: string;
+    derivedAt: string | null;
+    sourceStillExists: boolean;
+  } | null;
   envLayers: Array<{ source: EnvSource; count: number; keys: string[] }>;
   profiles: EffectiveConfigProfile[];
   plan: {
@@ -169,8 +175,9 @@ function ProfileConfigCard({ profile }: { profile: EffectiveConfigProfile }): JS
   );
 }
 
-export function EffectiveConfigPanel({ branchId }: { branchId: string }): JSX.Element {
+export function EffectiveConfigPanel({ branchId, onToast }: { branchId: string; onToast?: (message: string) => void }): JSX.Element {
   const [state, setState] = useState<PanelState>({ status: 'idle' });
+  const [copying, setCopying] = useState(false);
 
   const load = useCallback(async (): Promise<void> => {
     setState({ status: 'loading' });
@@ -185,6 +192,23 @@ export function EffectiveConfigPanel({ branchId }: { branchId: string }): JSX.El
   }, [branchId]);
 
   useEffect(() => { void load(); }, [load]);
+
+  // 波3:显式一键拉取来源分支配置(拷贝前服务端自动拍快照,误拷可回滚)
+  const copyFromSource = useCallback(async (sourceId: string): Promise<void> => {
+    setCopying(true);
+    try {
+      const res = await apiRequest<{ copied: boolean; snapshotId: string; hint?: string }>(
+        `/api/branches/${encodeURIComponent(branchId)}/copy-config-from/${encodeURIComponent(sourceId)}`,
+        { method: 'POST' },
+      );
+      onToast?.(res.hint || '配置已从来源分支拷贝(重新部署后生效)');
+      await load();
+    } catch (err) {
+      onToast?.(`拷贝失败:${err instanceof ApiError ? err.message : String(err)}`);
+    } finally {
+      setCopying(false);
+    }
+  }, [branchId, load, onToast]);
 
   return (
     <section className="space-y-3">
@@ -218,6 +242,30 @@ export function EffectiveConfigPanel({ branchId }: { branchId: string }): JSX.El
 
       {state.status === 'ok' ? (
         <>
+          {/* 波3:派生溯源(快照拷贝语义 —— 指针仅溯源展示,配置各自独立) */}
+          {state.data.derivedFrom ? (
+            <div className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-[hsl(var(--hairline))] bg-card px-4 py-2.5">
+              <div className="min-w-0 text-xs text-muted-foreground">
+                派生自分支
+                <span className="mx-1 font-mono text-foreground">{state.data.derivedFrom.branchName}</span>
+                {state.data.derivedFrom.derivedAt ? `(${new Date(state.data.derivedFrom.derivedAt).toLocaleString('zh-CN')})` : ''}
+                {!state.data.derivedFrom.sourceStillExists ? <span className="ml-1">;来源分支已删除</span> : null}
+                <span className="ml-1">配置为快照拷贝,两边各自独立。</span>
+              </div>
+              {state.data.derivedFrom.sourceStillExists ? (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={copying}
+                  onClick={() => void copyFromSource(state.data.derivedFrom!.branchId)}
+                  title="用来源分支当前的分支级配置整体替换本分支(拷贝前自动拍快照,误拷可回滚)"
+                >
+                  {copying ? '拉取中…' : '重新拉取来源配置'}
+                </Button>
+              ) : null}
+            </div>
+          ) : null}
+
           {/* 继承链概览:段A customEnv 分层(合并顺序从左到右,靠右覆盖靠左) */}
           <div className="rounded-md border border-[hsl(var(--hairline))] bg-card px-4 py-3">
             <div className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">

--- a/cds/web/src/components/branch/EffectiveConfigPanel.tsx
+++ b/cds/web/src/components/branch/EffectiveConfigPanel.tsx
@@ -1,0 +1,300 @@
+/*
+ * EffectiveConfigPanel — 分支生效配置检查器(波2)。
+ *
+ * 回答用户三个此前答不了的问题(配置可观测性,重建信任的关键):
+ *   1. 这个分支每个容器最终拿到的配置/env,逐 key 从哪一层来
+ *      (全局 → 项目 → 分支 → profile → 分支覆盖 → 部署模式 → 平台注入 → per-branch 改写)
+ *   2. 哪些被本分支覆盖了、覆盖掉了谁(shadowed 链)
+ *   3. CDS 预计为该分支做什么(起哪些容器 / 连哪些网 / 拉起哪些共享 infra)
+ *
+ * 数据源:GET /api/branches/:id/effective-config(值已服务端脱敏,本面板不做 reveal)。
+ * 挂载点:BranchDetailDrawer 的「配置」tab + BranchDetailPage。
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { ChevronDown, ChevronRight, Layers, Loader2, RefreshCw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { apiRequest, ApiError } from '@/lib/api';
+
+type EnvSource =
+  | 'cds-builtin' | 'cds-derived' | 'mirror' | 'global' | 'project' | 'branch'
+  | 'profile' | 'extra-service' | 'branch-override' | 'deploy-mode'
+  | 'platform-injected' | 'per-branch-db';
+
+interface EnvKeyProvenance {
+  key: string;
+  value: string;
+  source: EnvSource;
+  detail?: string;
+  shadowed?: EnvSource[];
+  templated?: boolean;
+}
+
+interface EffectiveConfigProfile {
+  profileId: string;
+  profileName: string;
+  isExtra: boolean;
+  hasOverride: boolean;
+  dockerImage: string;
+  containerPort: number;
+  activeDeployMode: string | null;
+  prebuilt: boolean;
+  dbScope: 'shared' | 'per-branch';
+  dbScopeSource: 'branch-override' | 'baseline' | 'default';
+  envProvenance: EnvKeyProvenance[];
+  envError?: string;
+}
+
+interface EffectiveConfigResponse {
+  branchId: string;
+  projectId: string;
+  projectSlug: string;
+  branchStatus: string;
+  envLayers: Array<{ source: EnvSource; count: number; keys: string[] }>;
+  profiles: EffectiveConfigProfile[];
+  plan: {
+    stateBasis: 'recorded';
+    containers: Array<{ profileId: string; containerName: string; dockerImage: string; containerPort: number; deployMode: string | null; prebuilt: boolean; isExtra: boolean }>;
+    networks: { isolation: boolean; branchNetwork: string | null; sharedNetwork: string };
+    requiredInfra: Array<{ id: string; containerName: string; status: string; shared: boolean }>;
+  };
+}
+
+type PanelState =
+  | { status: 'idle' | 'loading' }
+  | { status: 'ok'; data: EffectiveConfigResponse }
+  | { status: 'error'; message: string };
+
+// 来源标签 + 徽标配色(双主题 token,与 VariablesPanel 的 envSourceClass 视觉语言一致)
+const SOURCE_META: Record<EnvSource, { label: string; cls: string }> = {
+  'cds-builtin': { label: 'CDS 注入', cls: 'border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))] text-muted-foreground' },
+  'cds-derived': { label: '项目身份', cls: 'border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))] text-muted-foreground' },
+  mirror: { label: '镜像加速', cls: 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300' },
+  global: { label: '全局', cls: 'border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-300' },
+  project: { label: '项目', cls: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300' },
+  branch: { label: '分支', cls: 'border-amber-500/45 bg-amber-500/15 text-amber-700 dark:text-amber-300' },
+  profile: { label: '服务底座', cls: 'border-violet-500/30 bg-violet-500/10 text-violet-700 dark:text-violet-300' },
+  'extra-service': { label: '临时服务', cls: 'border-cyan-500/30 bg-cyan-500/10 text-cyan-700 dark:text-cyan-300' },
+  'branch-override': { label: '分支覆盖', cls: 'border-orange-500/40 bg-orange-500/10 text-orange-700 dark:text-orange-300' },
+  'deploy-mode': { label: '部署模式', cls: 'border-fuchsia-500/30 bg-fuchsia-500/10 text-fuchsia-700 dark:text-fuchsia-300' },
+  'platform-injected': { label: '平台注入', cls: 'border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))] text-muted-foreground' },
+  'per-branch-db': { label: '分支库改写', cls: 'border-emerald-500/40 bg-emerald-500/15 text-emerald-700 dark:text-emerald-300' },
+};
+
+function SourceBadge({ source }: { source: EnvSource }): JSX.Element {
+  const meta = SOURCE_META[source] || { label: source, cls: 'border-[hsl(var(--hairline))]' };
+  return (
+    <span className={`inline-flex shrink-0 items-center rounded border px-1.5 py-0.5 text-[11px] leading-none ${meta.cls}`}>
+      {meta.label}
+    </span>
+  );
+}
+
+function ProfileConfigCard({ profile }: { profile: EffectiveConfigProfile }): JSX.Element {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="rounded-md border border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))]/45">
+      <button
+        type="button"
+        className="flex w-full flex-wrap items-center gap-2 px-3 py-2 text-left"
+        onClick={() => setOpen((v) => !v)}
+      >
+        {open ? <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" /> : <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
+        <span className="min-w-0 truncate text-sm font-medium">{profile.profileName}</span>
+        <span className="flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+          {profile.isExtra ? <SourceBadge source="extra-service" /> : null}
+          {profile.hasOverride ? <SourceBadge source="branch-override" /> : null}
+          {profile.dbScope === 'per-branch' ? (
+            <span className="rounded border border-emerald-500/30 bg-emerald-500/10 px-1.5 py-0.5 text-[11px] text-emerald-700 dark:text-emerald-300">
+              分支独立库{profile.dbScopeSource === 'branch-override' ? '(本分支覆盖)' : ''}
+            </span>
+          ) : null}
+          <span className="font-mono">:{profile.containerPort}</span>
+          {profile.activeDeployMode ? <span className="rounded border border-[hsl(var(--hairline))] px-1.5 py-0.5 text-[11px]">{profile.activeDeployMode}</span> : null}
+          <span className="rounded border border-[hsl(var(--hairline))] px-1.5 py-0.5 text-[11px]">env×{profile.envProvenance.length}</span>
+        </span>
+      </button>
+      {open ? (
+        <div className="border-t border-[hsl(var(--hairline))] px-3 py-2">
+          <div className="mb-2 truncate font-mono text-xs text-muted-foreground" title={profile.dockerImage}>
+            镜像 {profile.dockerImage}{profile.prebuilt ? '(预构建)' : ''}
+          </div>
+          {profile.envError ? (
+            <div className="mb-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
+              该服务 env 解析失败(部署时也会以同样原因被拦):{profile.envError}
+            </div>
+          ) : null}
+          {profile.envProvenance.length > 0 ? (
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[520px] text-xs">
+                <thead>
+                  <tr className="text-left text-muted-foreground">
+                    <th className="py-1 pr-3 font-medium">变量</th>
+                    <th className="py-1 pr-3 font-medium">值(已脱敏)</th>
+                    <th className="py-1 pr-3 font-medium">来源</th>
+                    <th className="py-1 font-medium">覆盖了</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {profile.envProvenance.map((p) => (
+                    <tr key={p.key} className="border-t border-[hsl(var(--hairline))]/60 align-top">
+                      <td className="max-w-[180px] truncate py-1.5 pr-3 font-mono" title={p.key}>{p.key}</td>
+                      <td className="max-w-[220px] truncate py-1.5 pr-3 font-mono text-muted-foreground" title={p.value}>
+                        {p.value}
+                        {p.templated ? <span className="ml-1 rounded border border-blue-500/30 bg-blue-500/10 px-1 text-[10px] text-blue-700 dark:text-blue-300">模板展开</span> : null}
+                      </td>
+                      <td className="py-1.5 pr-3">
+                        <SourceBadge source={p.source} />
+                        {p.detail === 'per-branch-db-suffix' ? <span className="ml-1 text-[10px] text-muted-foreground">库名加分支后缀</span> : null}
+                      </td>
+                      <td className="py-1.5">
+                        {p.shadowed && p.shadowed.length > 0 ? (
+                          <span className="flex flex-wrap gap-1">
+                            {p.shadowed.map((s, i) => <SourceBadge key={`${p.key}-${s}-${i}`} source={s} />)}
+                          </span>
+                        ) : (
+                          <span className="text-muted-foreground">—</span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : !profile.envError ? (
+            <div className="py-1 text-xs text-muted-foreground">该服务没有任何环境变量。</div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function EffectiveConfigPanel({ branchId }: { branchId: string }): JSX.Element {
+  const [state, setState] = useState<PanelState>({ status: 'idle' });
+
+  const load = useCallback(async (): Promise<void> => {
+    setState({ status: 'loading' });
+    try {
+      const data = await apiRequest<EffectiveConfigResponse>(
+        `/api/branches/${encodeURIComponent(branchId)}/effective-config`,
+      );
+      setState({ status: 'ok', data });
+    } catch (err) {
+      setState({ status: 'error', message: err instanceof ApiError ? err.message : String(err) });
+    }
+  }, [branchId]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  return (
+    <section className="space-y-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            <Layers className="h-3.5 w-3.5" />
+            生效配置检查器
+          </div>
+          <div className="mt-1 text-xs text-muted-foreground">
+            这个分支实际生效的完整配置:每一项从哪继承、被谁覆盖、CDS 接下来会做什么。
+          </div>
+        </div>
+        <Button size="sm" variant="ghost" onClick={() => void load()} disabled={state.status === 'loading'} title="刷新">
+          <RefreshCw className={state.status === 'loading' ? 'animate-spin' : ''} />
+        </Button>
+      </div>
+
+      {state.status === 'loading' || state.status === 'idle' ? (
+        <div className="flex items-center gap-2 rounded-md border border-[hsl(var(--hairline))] bg-card px-4 py-4 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          正在解析生效配置…
+        </div>
+      ) : null}
+
+      {state.status === 'error' ? (
+        <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {state.message}
+        </div>
+      ) : null}
+
+      {state.status === 'ok' ? (
+        <>
+          {/* 继承链概览:段A customEnv 分层(合并顺序从左到右,靠右覆盖靠左) */}
+          <div className="rounded-md border border-[hsl(var(--hairline))] bg-card px-4 py-3">
+            <div className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              环境变量继承链(靠右的层覆盖靠左)
+            </div>
+            {state.data.envLayers.length === 0 ? (
+              <div className="text-xs text-muted-foreground">没有任何自定义环境变量层。</div>
+            ) : (
+              <div className="flex flex-wrap items-center gap-1.5">
+                {state.data.envLayers.map((layer, idx) => (
+                  <span key={layer.source} className="flex items-center gap-1.5">
+                    {idx > 0 ? <span className="text-xs text-muted-foreground">→</span> : null}
+                    <span className="inline-flex items-center gap-1">
+                      <SourceBadge source={layer.source} />
+                      <span className="text-xs text-muted-foreground">×{layer.count}</span>
+                    </span>
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* 每个容器的逐 key 溯源 */}
+          <div className="space-y-2">
+            {state.data.profiles.map((profile) => (
+              <ProfileConfigCard key={profile.profileId} profile={profile} />
+            ))}
+            {state.data.profiles.length === 0 ? (
+              <div className="rounded-md border border-dashed border-[hsl(var(--hairline))] px-4 py-5 text-center text-sm text-muted-foreground">
+                该分支还没有任何服务配置。先在项目设置添加构建配置,或在本分支添加临时额外服务。
+              </div>
+            ) : null}
+          </div>
+
+          {/* CDS 预计做什么(部署计划预览,记录态) */}
+          <div className="rounded-md border border-[hsl(var(--hairline))] bg-card px-4 py-3">
+            <div className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              部署这个分支时,CDS 会做什么
+            </div>
+            <div className="space-y-1.5 text-xs">
+              {state.data.plan.containers.map((c) => (
+                <div key={c.profileId} className="flex flex-wrap items-center gap-1.5">
+                  <span className="text-muted-foreground">起容器</span>
+                  <span className="font-mono">{c.containerName}</span>
+                  <span className="max-w-[240px] truncate font-mono text-muted-foreground" title={c.dockerImage}>({c.dockerImage}:{c.containerPort})</span>
+                  {c.isExtra ? <SourceBadge source="extra-service" /> : null}
+                  {c.prebuilt ? <span className="rounded border border-[hsl(var(--hairline))] px-1.5 py-0.5 text-[10px]">预构建</span> : null}
+                </div>
+              ))}
+              <div className="flex flex-wrap items-center gap-1.5">
+                <span className="text-muted-foreground">网络</span>
+                {state.data.plan.networks.isolation && state.data.plan.networks.branchNetwork ? (
+                  <>
+                    <span className="font-mono">{state.data.plan.networks.branchNetwork}</span>
+                    <span className="text-muted-foreground">(分支专属)+</span>
+                  </>
+                ) : null}
+                <span className="font-mono">{state.data.plan.networks.sharedNetwork}</span>
+                <span className="text-muted-foreground">(项目共享)</span>
+              </div>
+              {state.data.plan.requiredInfra.length > 0 ? (
+                <div className="flex flex-wrap items-center gap-1.5">
+                  <span className="text-muted-foreground">确保共享基础设施在跑</span>
+                  {state.data.plan.requiredInfra.map((svc) => (
+                    <span key={svc.id} className="rounded border border-[hsl(var(--hairline))] px-1.5 py-0.5 font-mono">
+                      {svc.id}{svc.status !== 'running' ? '(将启动)' : ''}
+                    </span>
+                  ))}
+                </div>
+              ) : null}
+              <div className="pt-1 text-[11px] text-muted-foreground">
+                以上基于当前记录状态推算;共享基础设施(数据库/缓存)为项目级容器,所有分支共用同一实例。
+              </div>
+            </div>
+          </div>
+        </>
+      ) : null}
+    </section>
+  );
+}

--- a/cds/web/src/components/branch/ExtraServiceFormDialog.tsx
+++ b/cds/web/src/components/branch/ExtraServiceFormDialog.tsx
@@ -1,0 +1,448 @@
+/*
+ * ExtraServiceFormDialog — 分支级临时额外服务的新建/编辑表单（波1 W1b）。
+ *
+ * 服务端契约：PUT /api/branches/:id/extra-services（整体替换数组），字段校验与
+ * cds/src/routes/branches.ts 的 PUT handler 一一对齐（id/镜像/端口/subdomain/
+ * workDir/containerWorkDir/entrypoint/dbScope）。这里做同款客户端预校验，
+ * 让用户在提交前就看到具体哪个字段不合法，而不是等 400 才知道。
+ *
+ * 零摩擦（zero-friction-input）：预设下拉（Nacos/Kafka/RabbitMQ/Redis/MinIO）
+ * 一键填入镜像/端口/默认 env/建议子域，用户改差异即可，不必从空白表单开始。
+ *
+ * 掩码契约：编辑已有服务时 env 值可能是 ***（服务端脱敏）。保持原样回传是安全的
+ * ——服务端 PUT 会剥离掩码哨兵并恢复旧值，绝不落库字面 ***。
+ */
+import { useEffect, useMemo, useState } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+export interface ExtraServiceProfile {
+  id: string;
+  name?: string;
+  dockerImage: string;
+  containerPort: number;
+  command?: string;
+  workDir?: string;
+  containerWorkDir?: string;
+  entrypoint?: string;
+  dbScope?: 'shared' | 'per-branch';
+  subdomain?: string;
+  env?: Record<string, string>;
+  pathPrefixes?: string[];
+  dependsOn?: string[];
+  prebuiltImage?: boolean;
+}
+
+interface PresetDef {
+  key: string;
+  label: string;
+  id: string;
+  dockerImage: string;
+  containerPort: number;
+  command?: string;
+  subdomain?: string;
+  env?: Record<string, string>;
+  note?: string;
+}
+
+// 预设都是「起点」不是「终点」：填入后所有字段仍可改（anti-detour：智能默认 + 可编辑）。
+const PRESETS: PresetDef[] = [
+  {
+    key: 'nacos',
+    label: 'Nacos（注册/配置中心）',
+    id: 'nacos',
+    dockerImage: 'nacos/nacos-server:v2.3.2',
+    containerPort: 8848,
+    subdomain: 'nacos',
+    env: { MODE: 'standalone' },
+    note: '单机模式，控制台路径 /nacos',
+  },
+  {
+    key: 'kafka',
+    label: 'Kafka（消息队列，KRaft 单节点）',
+    id: 'kafka',
+    dockerImage: 'bitnami/kafka:3.7',
+    containerPort: 9092,
+    env: {
+      KAFKA_CFG_NODE_ID: '0',
+      KAFKA_CFG_PROCESS_ROLES: 'controller,broker',
+      KAFKA_CFG_LISTENERS: 'PLAINTEXT://:9092,CONTROLLER://:9093',
+      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: 'CONTROLLER',
+      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: '0@localhost:9093',
+    },
+  },
+  {
+    key: 'rabbitmq',
+    label: 'RabbitMQ（消息队列，带管理台）',
+    id: 'rabbitmq',
+    dockerImage: 'rabbitmq:3.13-management',
+    containerPort: 15672,
+    subdomain: 'mq',
+    note: '路由端口指向 15672 管理台；AMQP 走容器网 5672',
+  },
+  {
+    key: 'redis',
+    label: 'Redis（缓存，分支独享实例）',
+    id: 'redis-local',
+    dockerImage: 'redis:7-alpine',
+    containerPort: 6379,
+  },
+  {
+    key: 'minio',
+    label: 'MinIO（对象存储）',
+    id: 'minio',
+    dockerImage: 'minio/minio:latest',
+    containerPort: 9001,
+    command: 'server /data --console-address :9001',
+    subdomain: 'minio',
+    env: { MINIO_ROOT_USER: 'admin', MINIO_ROOT_PASSWORD: 'change-me-now' },
+    note: '路由端口指向 9001 控制台；S3 API 走容器网 9000',
+  },
+];
+
+// 与服务端校验一一对齐（cds/src/routes/branches.ts PUT /extra-services +
+// cds/src/services/branch-extra-services.ts）。
+const ID_RE = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,62}$/;
+const IMAGE_RE = /^[a-zA-Z0-9][a-zA-Z0-9._:/@-]*$/;
+const SUBDOMAIN_RE = /^[a-z0-9]([a-z0-9-]{0,38}[a-z0-9])?$/;
+const RESERVED_SUBDOMAINS = new Set(['null', 'undefined', 'none', 'true', 'false', 'nan']);
+const WORKDIR_RE = /^[a-zA-Z0-9._/-]+$/;
+const CONTAINER_WORKDIR_RE = /^\/[a-zA-Z0-9._/-]*$/;
+
+function envToText(env?: Record<string, string>): string {
+  return Object.entries(env || {}).map(([k, v]) => `${k}=${v}`).join('\n');
+}
+
+function textToEnv(text: string): { env: Record<string, string>; error?: string } {
+  const env: Record<string, string> = {};
+  for (const raw of text.split('\n')) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq <= 0) return { env, error: `环境变量需要 KEY=VALUE 形式：${line}` };
+    env[line.slice(0, eq).trim()] = line.slice(eq + 1);
+  }
+  return { env };
+}
+
+function validateDraft(draft: ExtraServiceProfile): string | null {
+  if (!ID_RE.test(draft.id)) return '服务 id 非法：字母/数字开头，可含 - _，长度 1..63';
+  if (!draft.dockerImage.trim()) return '镜像不能为空';
+  if (!IMAGE_RE.test(draft.dockerImage.trim())) return '镜像引用仅允许字母/数字/._:/@-';
+  if (!Number.isInteger(draft.containerPort) || draft.containerPort <= 0 || draft.containerPort > 65535) {
+    return '容器端口须为 1..65535 的整数';
+  }
+  if (draft.subdomain) {
+    const sd = draft.subdomain.trim().toLowerCase();
+    if (!SUBDOMAIN_RE.test(sd) || RESERVED_SUBDOMAINS.has(sd)) {
+      return '命名子域须为单个 DNS label（小写字母/数字/连字符，不以连字符开头/结尾，长度 1..40）';
+    }
+  }
+  if (draft.workDir && (!WORKDIR_RE.test(draft.workDir) || draft.workDir.split('/').includes('..'))) {
+    return '挂载目录仅允许相对路径（字母/数字/._-/），禁 .. 穿越';
+  }
+  if (draft.containerWorkDir && (!CONTAINER_WORKDIR_RE.test(draft.containerWorkDir) || draft.containerWorkDir.split('/').includes('..'))) {
+    return '容器工作目录须为容器内绝对路径（字母/数字/._-/），禁 .. 穿越';
+  }
+  if (draft.entrypoint && draft.entrypoint !== '' && (/\s/.test(draft.entrypoint) || !/^\/?[a-zA-Z0-9._/-]+$/.test(draft.entrypoint))) {
+    return 'entrypoint 须为单个可执行名/路径（无空格与 shell 元字符），或留空';
+  }
+  return null;
+}
+
+export function ExtraServiceFormDialog({
+  open,
+  initial,
+  existingIds,
+  saving,
+  onClose,
+  onSubmit,
+}: {
+  open: boolean;
+  /** 编辑时传入现有服务（env 可能已脱敏为 ***，原样保留即可）；新建传 null。 */
+  initial: ExtraServiceProfile | null;
+  /** 本分支已存在的额外服务 id（新建时用于撞名预警）。 */
+  existingIds: string[];
+  saving: boolean;
+  onClose: () => void;
+  onSubmit: (draft: ExtraServiceProfile, redeploy: boolean) => void;
+}): JSX.Element {
+  const isEdit = initial != null;
+  const [serviceId, setServiceId] = useState('');
+  const [image, setImage] = useState('');
+  const [port, setPort] = useState('');
+  const [subdomain, setSubdomain] = useState('');
+  const [dbScope, setDbScope] = useState<'' | 'shared' | 'per-branch'>('');
+  const [command, setCommand] = useState('');
+  const [envText, setEnvText] = useState('');
+  const [workDir, setWorkDir] = useState('');
+  const [containerWorkDir, setContainerWorkDir] = useState('');
+  const [entrypoint, setEntrypoint] = useState('');
+  const [pathPrefixes, setPathPrefixes] = useState('');
+  const [dependsOn, setDependsOn] = useState('');
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [presetNote, setPresetNote] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [redeploy, setRedeploy] = useState(true);
+
+  useEffect(() => {
+    if (!open) return;
+    setServiceId(initial?.id || '');
+    setImage(initial?.dockerImage || '');
+    setPort(initial?.containerPort ? String(initial.containerPort) : '');
+    setSubdomain(initial?.subdomain || '');
+    setDbScope(initial?.dbScope || '');
+    setCommand(initial?.command || '');
+    setEnvText(envToText(initial?.env));
+    setWorkDir(initial?.workDir || '');
+    setContainerWorkDir(initial?.containerWorkDir || '');
+    setEntrypoint(initial?.entrypoint ?? '');
+    setPathPrefixes((initial?.pathPrefixes || []).join(', '));
+    setDependsOn((initial?.dependsOn || []).join(', '));
+    setShowAdvanced(Boolean(initial?.workDir || initial?.containerWorkDir || initial?.entrypoint || initial?.pathPrefixes?.length || initial?.dependsOn?.length));
+    setPresetNote('');
+    setError(null);
+    setRedeploy(true);
+  }, [open, initial]);
+
+  const idCollision = useMemo(
+    () => !isEdit && serviceId !== '' && existingIds.includes(serviceId),
+    [isEdit, serviceId, existingIds],
+  );
+
+  const applyPreset = (key: string): void => {
+    const preset = PRESETS.find((p) => p.key === key);
+    if (!preset) return;
+    // 撞已有 id 时给 -2 后缀，避免用户直接提交被拒
+    let id = preset.id;
+    let n = 2;
+    while (existingIds.includes(id)) id = `${preset.id}-${n++}`;
+    setServiceId(id);
+    setImage(preset.dockerImage);
+    setPort(String(preset.containerPort));
+    setSubdomain(preset.subdomain || '');
+    setCommand(preset.command || '');
+    setEnvText(envToText(preset.env));
+    setPresetNote(preset.note || '');
+    setError(null);
+  };
+
+  const handleSubmit = (): void => {
+    const { env, error: envError } = textToEnv(envText);
+    if (envError) { setError(envError); return; }
+    const draft: ExtraServiceProfile = {
+      ...(initial || {}),
+      id: serviceId.trim(),
+      name: initial?.name || serviceId.trim(),
+      dockerImage: image.trim(),
+      containerPort: Number(port),
+      command: command.trim(),
+      workDir: workDir.trim(),
+      // subdomain 契约：空串=有意清空命名 URL；非空=采用。编辑时字段总是显式携带，
+      // 让「清空」也能表达（服务端把缺省视为继承旧值）。
+      subdomain: subdomain.trim().toLowerCase(),
+      ...(dbScope ? { dbScope } : {}),
+      ...(containerWorkDir.trim() ? { containerWorkDir: containerWorkDir.trim() } : {}),
+      // UI 简化：非空才发送 entrypoint；清空输入框 = 移除覆盖（PUT 整体替换，缺省字段即删除）。
+      // 「空串清空镜像 ENTRYPOINT」的极端场景走 cdscli / API。
+      ...(entrypoint.trim() ? { entrypoint: entrypoint.trim() } : {}),
+      ...(Object.keys(env).length > 0 ? { env } : {}),
+      ...(pathPrefixes.trim()
+        ? { pathPrefixes: pathPrefixes.split(',').map((s) => s.trim()).filter(Boolean) }
+        : {}),
+      ...(dependsOn.trim()
+        ? { dependsOn: dependsOn.split(',').map((s) => s.trim()).filter(Boolean) }
+        : {}),
+      // 无源码挂载的纯镜像服务按 prebuilt 处理（跳过源码构建阶段）
+      ...(workDir.trim() === '' ? { prebuiltImage: true } : {}),
+    };
+    const validationError = validateDraft(draft);
+    if (validationError) { setError(validationError); return; }
+    setError(null);
+    onSubmit(draft, redeploy);
+  };
+
+  const inputClass = 'h-9 w-full rounded-md border border-input bg-background px-3 text-sm';
+  const labelClass = 'mb-1 block text-xs font-medium text-muted-foreground';
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => { if (!next) onClose(); }}>
+      <DialogContent className="max-h-[90vh] w-full max-w-lg overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{isEdit ? `编辑临时服务：${initial?.id}` : '添加临时服务'}</DialogTitle>
+          <DialogDescription>
+            只作用于当前分支的实验容器，不影响项目配置和其他分支；删除分支时一并清理。
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          {!isEdit ? (
+            <div>
+              <label className={labelClass}>常用预设（选后可改）</label>
+              <select
+                className={inputClass}
+                defaultValue=""
+                onChange={(e) => { if (e.target.value) applyPreset(e.target.value); }}
+              >
+                <option value="">自定义（从空白开始）</option>
+                {PRESETS.map((p) => (
+                  <option key={p.key} value={p.key}>{p.label}</option>
+                ))}
+              </select>
+              {presetNote ? <div className="mt-1 text-xs text-muted-foreground">{presetNote}</div> : null}
+            </div>
+          ) : null}
+
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <div>
+              <label className={labelClass}>服务 id</label>
+              <input
+                className={inputClass}
+                value={serviceId}
+                onChange={(e) => setServiceId(e.target.value)}
+                placeholder="nacos"
+                disabled={isEdit}
+              />
+              {idCollision ? (
+                <div className="mt-1 text-xs text-amber-700 dark:text-amber-300">该 id 已存在，保存将覆盖同名服务</div>
+              ) : null}
+            </div>
+            <div>
+              <label className={labelClass}>容器端口</label>
+              <input
+                className={inputClass}
+                value={port}
+                onChange={(e) => setPort(e.target.value)}
+                placeholder="8848"
+                inputMode="numeric"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className={labelClass}>镜像</label>
+            <input
+              className={`${inputClass} font-mono`}
+              value={image}
+              onChange={(e) => setImage(e.target.value)}
+              placeholder="nacos/nacos-server:v2.3.2"
+            />
+          </div>
+
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <div>
+              <label className={labelClass}>命名子域（可选）</label>
+              <input
+                className={inputClass}
+                value={subdomain}
+                onChange={(e) => setSubdomain(e.target.value)}
+                placeholder="nacos"
+              />
+              <div className="mt-1 text-xs text-muted-foreground">设置后获得独立入口 URL</div>
+            </div>
+            <div>
+              <label className={labelClass}>数据库隔离</label>
+              <select
+                className={inputClass}
+                value={dbScope}
+                onChange={(e) => setDbScope(e.target.value as '' | 'shared' | 'per-branch')}
+              >
+                <option value="">默认（共享库）</option>
+                <option value="shared">共享库</option>
+                <option value="per-branch">分支独立库（DB 名加分支后缀）</option>
+              </select>
+            </div>
+          </div>
+
+          <div>
+            <label className={labelClass}>启动命令（可选，镜像默认 CMD 够用则留空）</label>
+            <input
+              className={`${inputClass} font-mono`}
+              value={command}
+              onChange={(e) => setCommand(e.target.value)}
+              placeholder=""
+            />
+          </div>
+
+          <div>
+            <label className={labelClass}>环境变量（每行一条 KEY=VALUE；已保存密钥显示为 ***，保持不动即保留原值）</label>
+            <textarea
+              className="min-h-[88px] w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-xs"
+              value={envText}
+              onChange={(e) => setEnvText(e.target.value)}
+              placeholder={'MODE=standalone'}
+            />
+          </div>
+
+          <button
+            type="button"
+            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+            onClick={() => setShowAdvanced((v) => !v)}
+          >
+            {showAdvanced ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+            高级选项（挂载 / 入口 / 路由前缀 / 启动依赖）
+          </button>
+          {showAdvanced ? (
+            <div className="space-y-3 rounded-md border border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))]/45 p-3">
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <div>
+                  <label className={labelClass}>源码挂载目录（相对仓库根；纯镜像服务留空）</label>
+                  <input className={`${inputClass} font-mono`} value={workDir} onChange={(e) => setWorkDir(e.target.value)} placeholder="" />
+                </div>
+                <div>
+                  <label className={labelClass}>容器工作目录（绝对路径，默认 /app）</label>
+                  <input className={`${inputClass} font-mono`} value={containerWorkDir} onChange={(e) => setContainerWorkDir(e.target.value)} placeholder="/app" />
+                </div>
+              </div>
+              <div>
+                <label className={labelClass}>entrypoint 覆盖（单个可执行名/路径；留空表示不覆盖）</label>
+                <input className={`${inputClass} font-mono`} value={entrypoint} onChange={(e) => setEntrypoint(e.target.value)} placeholder="" />
+              </div>
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <div>
+                  <label className={labelClass}>路由前缀（逗号分隔）</label>
+                  <input className={`${inputClass} font-mono`} value={pathPrefixes} onChange={(e) => setPathPrefixes(e.target.value)} placeholder="/nacos" />
+                </div>
+                <div>
+                  <label className={labelClass}>启动依赖（逗号分隔的服务 id）</label>
+                  <input className={`${inputClass} font-mono`} value={dependsOn} onChange={(e) => setDependsOn(e.target.value)} placeholder="mysql, redis" />
+                </div>
+              </div>
+            </div>
+          ) : null}
+
+          {error ? (
+            <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {error}
+            </div>
+          ) : null}
+
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={redeploy}
+              onChange={(e) => setRedeploy(e.target.checked)}
+              className="h-4 w-4"
+            />
+            保存后立即重新部署本分支（让容器真正起来；不勾则下次部署时生效）
+          </label>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={saving}>取消</Button>
+          <Button onClick={handleSubmit} disabled={saving}>
+            {saving ? '保存中…' : redeploy ? '保存并重新部署' : '仅保存配置'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/cds/web/src/components/branch/ExtraServicesPanel.tsx
+++ b/cds/web/src/components/branch/ExtraServicesPanel.tsx
@@ -1,0 +1,267 @@
+/*
+ * ExtraServicesPanel — 分支级临时额外服务管理（波1 W1b，最后一公里）。
+ *
+ * 能力 2026-06-29 已在后端落地（BranchEntry.extraProfiles + PUT /extra-services），
+ * 但此前只有裸 HTTP API，无任何 UI 入口——本面板把它推到产品可用：
+ *   - 列表：id / 镜像 / 端口 / 命名子域 / 数据库隔离 徽标，env 已脱敏
+ *   - 添加/编辑：ExtraServiceFormDialog（预设 + 校验与服务端对齐）
+ *   - 移除：二次确认；「移除并重部署」才会真正下掉在跑容器
+ *   - 响应处理：redeployTriggered / redeployRejected / removalRolledBack 显性化
+ *     （expectation-management：重部署被拒 + 破坏性移除被回滚时用户必须知道）
+ *
+ * 挂载点：BranchDetailDrawer 的「设置」tab + BranchDetailPage。
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { FlaskConical, Loader2, Pencil, Plus, RefreshCw, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { ConfirmAction } from '@/components/ui/confirm-action';
+import { apiRequest, ApiError } from '@/lib/api';
+import { ExtraServiceFormDialog, type ExtraServiceProfile } from './ExtraServiceFormDialog';
+
+interface ExtraServicesPutResponse {
+  extraProfiles: ExtraServiceProfile[];
+  count: number;
+  redeployTriggered: boolean;
+  redeployRejected?: { status: number; message: string };
+  removalRolledBack?: boolean;
+  rolledBackServiceIds?: string[];
+  hint?: string;
+}
+
+type PanelState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'ok'; profiles: ExtraServiceProfile[] }
+  | { status: 'error'; message: string };
+
+export function ExtraServicesPanel({
+  branchId,
+  onToast,
+  onChanged,
+}: {
+  branchId: string;
+  onToast?: (message: string) => void;
+  onChanged?: () => void;
+}): JSX.Element {
+  const [state, setState] = useState<PanelState>({ status: 'idle' });
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editing, setEditing] = useState<ExtraServiceProfile | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [removingId, setRemovingId] = useState<string | null>(null);
+  const [notice, setNotice] = useState<{ kind: 'warn' | 'info'; text: string } | null>(null);
+
+  const load = useCallback(async (): Promise<void> => {
+    setState({ status: 'loading' });
+    try {
+      const res = await apiRequest<{ extraProfiles: ExtraServiceProfile[] }>(
+        `/api/branches/${encodeURIComponent(branchId)}/extra-services`,
+      );
+      setState({ status: 'ok', profiles: res.extraProfiles || [] });
+    } catch (err) {
+      setState({ status: 'error', message: err instanceof ApiError ? err.message : String(err) });
+    }
+  }, [branchId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const putProfiles = useCallback(async (
+    profiles: ExtraServiceProfile[],
+    redeploy: boolean,
+  ): Promise<ExtraServicesPutResponse> => {
+    const query = redeploy ? '?redeploy=1' : '';
+    return apiRequest<ExtraServicesPutResponse>(
+      `/api/branches/${encodeURIComponent(branchId)}/extra-services${query}`,
+      { method: 'PUT', body: { extraProfiles: profiles } },
+    );
+  }, [branchId]);
+
+  // 把 PUT 响应翻译成用户可读的结果通告（重部署被拒 / 回滚都必须显性化，不许静默）。
+  const digestResponse = useCallback((res: ExtraServicesPutResponse, successText: string): void => {
+    setState({ status: 'ok', profiles: res.extraProfiles || [] });
+    if (res.removalRolledBack) {
+      setNotice({
+        kind: 'warn',
+        text: `重部署被拒（${res.redeployRejected?.message || '未知原因'}），且本次移除的服务仍在运行——`
+          + `配置已自动回滚以避免幽灵服务（${(res.rolledBackServiceIds || []).join(', ')}）。请先处理拒因再重试。`,
+      });
+      return;
+    }
+    if (res.redeployRejected) {
+      setNotice({
+        kind: 'warn',
+        text: `配置已保存，但重部署被拒：${res.redeployRejected.message}。处理后可手动重新部署本分支。`,
+      });
+      return;
+    }
+    setNotice(null);
+    onToast?.(res.redeployTriggered
+      ? `${successText}，已触发重部署，几十秒后容器就位`
+      : `${successText}（纯配置变更，下次部署时生效）`);
+    if (res.redeployTriggered) onChanged?.();
+  }, [onChanged, onToast]);
+
+  const handleSubmit = useCallback(async (draft: ExtraServiceProfile, redeploy: boolean): Promise<void> => {
+    if (state.status !== 'ok') return;
+    setSaving(true);
+    try {
+      const merged = [...state.profiles.filter((p) => p.id !== draft.id), draft];
+      const res = await putProfiles(merged, redeploy);
+      digestResponse(res, editing ? `临时服务 ${draft.id} 已更新` : `临时服务 ${draft.id} 已声明`);
+      setDialogOpen(false);
+      setEditing(null);
+    } catch (err) {
+      onToast?.(`保存失败：${err instanceof ApiError ? err.message : String(err)}`);
+    } finally {
+      setSaving(false);
+    }
+  }, [digestResponse, editing, onToast, putProfiles, state]);
+
+  const handleRemove = useCallback(async (serviceId: string, redeploy: boolean): Promise<void> => {
+    if (state.status !== 'ok') return;
+    setRemovingId(serviceId);
+    try {
+      const remaining = state.profiles.filter((p) => p.id !== serviceId);
+      const res = await putProfiles(remaining, redeploy);
+      digestResponse(res, `临时服务 ${serviceId} 已移除`);
+    } catch (err) {
+      onToast?.(`移除失败：${err instanceof ApiError ? err.message : String(err)}`);
+    } finally {
+      setRemovingId(null);
+    }
+  }, [digestResponse, onToast, putProfiles, state]);
+
+  return (
+    <div className="rounded-md border border-[hsl(var(--hairline))] bg-card px-4 py-3">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            <FlaskConical className="h-3.5 w-3.5" />
+            临时额外服务
+          </div>
+          <div className="mt-1 text-xs text-muted-foreground">
+            只作用于本分支的实验容器（如临时接 Nacos），不影响其他分支，删分支即消失。
+          </div>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => void load()}
+            disabled={state.status === 'loading'}
+            title="刷新列表"
+          >
+            <RefreshCw className={state.status === 'loading' ? 'animate-spin' : ''} />
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => { setEditing(null); setDialogOpen(true); }}
+            disabled={state.status !== 'ok'}
+          >
+            <Plus />
+            添加服务
+          </Button>
+        </div>
+      </div>
+
+      {notice ? (
+        <div className={`mb-3 rounded-md border px-3 py-2 text-sm ${notice.kind === 'warn'
+          ? 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300'
+          : 'border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))]/45 text-muted-foreground'}`}
+        >
+          {notice.text}
+        </div>
+      ) : null}
+
+      {state.status === 'loading' || state.status === 'idle' ? (
+        <div className="flex items-center gap-2 py-3 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          正在加载临时服务…
+        </div>
+      ) : null}
+
+      {state.status === 'error' ? (
+        <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {state.message}
+        </div>
+      ) : null}
+
+      {state.status === 'ok' && state.profiles.length === 0 ? (
+        <div className="rounded-md border border-dashed border-[hsl(var(--hairline))] px-4 py-5 text-center text-sm text-muted-foreground">
+          <div>本分支还没有临时服务。</div>
+          <div className="mt-1 text-xs">
+            典型场景：这个分支要试 Nacos / Kafka / MinIO，但不想影响别的分支——点「添加服务」，
+            选个预设改两下就能起容器。
+          </div>
+        </div>
+      ) : null}
+
+      {state.status === 'ok' && state.profiles.length > 0 ? (
+        <div className="space-y-2">
+          {state.profiles.map((profile) => (
+            <div
+              key={profile.id}
+              className="flex flex-wrap items-center gap-2 rounded-md border border-[hsl(var(--hairline))] bg-[hsl(var(--surface-sunken))]/45 px-3 py-2"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="truncate text-sm font-medium">{profile.id}</div>
+                <div className="mt-1 flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+                  <span className="max-w-[220px] truncate font-mono" title={profile.dockerImage}>{profile.dockerImage}</span>
+                  <span className="font-mono">:{profile.containerPort}</span>
+                  {profile.subdomain ? (
+                    <span className="rounded border border-blue-500/30 bg-blue-500/10 px-1.5 py-0.5 text-blue-700 dark:text-blue-300">
+                      子域 {profile.subdomain}
+                    </span>
+                  ) : null}
+                  {profile.dbScope === 'per-branch' ? (
+                    <span className="rounded border border-emerald-500/30 bg-emerald-500/10 px-1.5 py-0.5 text-emerald-700 dark:text-emerald-300">
+                      分支独立库
+                    </span>
+                  ) : null}
+                  {profile.env && Object.keys(profile.env).length > 0 ? (
+                    <span className="rounded border border-[hsl(var(--hairline))] px-1.5 py-0.5">
+                      env×{Object.keys(profile.env).length}
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+              <div className="flex shrink-0 items-center gap-1">
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => { setEditing(profile); setDialogOpen(true); }}
+                  title="编辑"
+                >
+                  <Pencil />
+                </Button>
+                <ConfirmAction
+                  trigger={(
+                    <Button size="sm" variant="ghost" title="移除" disabled={removingId === profile.id}>
+                      {removingId === profile.id ? <Loader2 className="animate-spin" /> : <Trash2 />}
+                    </Button>
+                  )}
+                  title={`移除临时服务 ${profile.id}？`}
+                  description="将同时触发重部署把在跑容器下掉。只想改配置不动容器可在编辑弹窗里取消勾选重部署。"
+                  confirmLabel="移除并重部署"
+                  pending={removingId === profile.id}
+                  onConfirm={() => handleRemove(profile.id, true)}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      <ExtraServiceFormDialog
+        open={dialogOpen}
+        initial={editing}
+        existingIds={state.status === 'ok' ? state.profiles.map((p) => p.id) : []}
+        saving={saving}
+        onClose={() => { if (!saving) { setDialogOpen(false); setEditing(null); } }}
+        onSubmit={(draft, redeploy) => void handleSubmit(draft, redeploy)}
+      />
+    </div>
+  );
+}

--- a/cds/web/src/pages/BranchDetailPage.tsx
+++ b/cds/web/src/pages/BranchDetailPage.tsx
@@ -11,6 +11,7 @@ import {
   Router as RouterIcon,
   FileText,
   GitCommitHorizontal,
+  Layers,
   Loader2,
   Network,
   Play,
@@ -31,6 +32,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { apiRequest, ApiError, apiUrl } from '@/lib/api';
 import { BranchDetailLoadingSkeleton, CodePill, ErrorBlock, LoadingBlock, MetricTile } from '@/pages/cds-settings/components';
 import { ExtraServicesPanel } from '@/components/branch/ExtraServicesPanel';
+import { EffectiveConfigPanel } from '@/components/branch/EffectiveConfigPanel';
 
 interface ProjectSummary {
   id: string;
@@ -1579,6 +1581,16 @@ export function BranchDetailPage(): JSX.Element {
                 onToast={setToast}
                 onChanged={() => void load(false)}
               />
+
+              {/* 波2:配置检查器(逐 key 溯源 + 部署计划预览)。 */}
+              <DisclosurePanel
+                icon={<Layers className="h-4 w-4" />}
+                title="生效配置"
+                subtitle="每项配置从哪继承、被谁覆盖、部署时 CDS 会做什么"
+                contentClassName="p-5"
+              >
+                <EffectiveConfigPanel branchId={state.branch.id} />
+              </DisclosurePanel>
 
               <DisclosurePanel
                 icon={<FileText className="h-4 w-4" />}

--- a/cds/web/src/pages/BranchDetailPage.tsx
+++ b/cds/web/src/pages/BranchDetailPage.tsx
@@ -30,6 +30,7 @@ import { DisclosurePanel } from '@/components/ui/disclosure-panel';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { apiRequest, ApiError, apiUrl } from '@/lib/api';
 import { BranchDetailLoadingSkeleton, CodePill, ErrorBlock, LoadingBlock, MetricTile } from '@/pages/cds-settings/components';
+import { ExtraServicesPanel } from '@/components/branch/ExtraServicesPanel';
 
 interface ProjectSummary {
   id: string;
@@ -144,6 +145,7 @@ interface BuildProfileOverride {
   pathPrefixes?: string[];
   activeDeployMode?: string;
   startupSignal?: string;
+  dbScope?: 'shared' | 'per-branch';
   notes?: string;
 }
 
@@ -1570,6 +1572,13 @@ export function BranchDetailPage(): JSX.Element {
                   })}
                 </CardContent>
               </Card>
+
+              {/* 波1 W1b:分支级临时额外服务(只作用于本分支的实验容器,如 Nacos)。 */}
+              <ExtraServicesPanel
+                branchId={state.branch.id}
+                onToast={setToast}
+                onChanged={() => void load(false)}
+              />
 
               <DisclosurePanel
                 icon={<FileText className="h-4 w-4" />}

--- a/cds/web/src/pages/BranchDetailPage.tsx
+++ b/cds/web/src/pages/BranchDetailPage.tsx
@@ -1589,7 +1589,7 @@ export function BranchDetailPage(): JSX.Element {
                 subtitle="每项配置从哪继承、被谁覆盖、部署时 CDS 会做什么"
                 contentClassName="p-5"
               >
-                <EffectiveConfigPanel branchId={state.branch.id} />
+                <EffectiveConfigPanel branchId={state.branch.id} onToast={setToast} />
               </DisclosurePanel>
 
               <DisclosurePanel

--- a/changelogs/2026-07-06_cds-config-wave1.md
+++ b/changelogs/2026-07-06_cds-config-wave1.md
@@ -1,0 +1,5 @@
+| feat | cds | 分支级临时额外服务产品化:分支抽屉/详情页新增「临时额外服务」管理面板(预设 Nacos/Kafka/RabbitMQ/Redis/MinIO + 表单校验与服务端对齐 + 保存即重部署) |
+| feat | cds | cdscli 新增 branch extra-services list/set/remove 子命令(读改写 PUT + --redeploy + 掩码哨兵安全往返) |
+| fix | cds | 分支 profile-overrides PUT 白名单补 dbScope 透传 + 枚举校验,per-branch DB 开关首次可按分支生效(F16 收尾) |
+| feat | cds | 分支抽屉「本分支运行模式」每行新增数据库隔离选择器(继承/共享库/分支独立库),切换只保存不自动重部署 |
+| docs | cds | plan.cds.status.md 活看板重建:补 2026-05-03 以来里程碑 + 配置体系三波演进六列轨道表 |

--- a/changelogs/2026-07-06_cds-config-wave2.md
+++ b/changelogs/2026-07-06_cds-config-wave2.md
@@ -1,0 +1,3 @@
+| feat | cds | 新增分支「生效配置检查器」:GET /branches/:id/effective-config 端点输出逐 key env 溯源(12 种来源:全局/项目/分支/服务底座/分支覆盖/部署模式/临时服务/平台注入/分支库改写等)+ 覆盖链(shadowed)+ 部署计划预览(起哪些容器/连哪些网/拉起哪些共享 infra) |
+| feat | cds | 分支抽屉新增「配置」tab + 分支详情页新增「生效配置」区,继承链树视图 + 来源徽标 + 密钥脱敏 |
+| refactor | cds | 容器运行时 env 解析抽为纯函数 env-provenance.ts(带溯源分层),部署路径退化为单层包装,行为逐字节等价(container.test.ts 43 例护栏 + 等价断言) |

--- a/changelogs/2026-07-06_cds-config-wave3.md
+++ b/changelogs/2026-07-06_cds-config-wave3.md
@@ -1,0 +1,5 @@
+| feat | cds | 分支从分支派生(快照拷贝):POST /branches 支持 sourceBranchId 深拷贝来源分支的 profileOverrides+extraProfiles 并写派生溯源指针;cdscli branch create 新增 --from |
+| feat | cds | PR opened/reopened 自动回填派生指针(base 分支,只回填不拷贝配置);新增 POST /branches/:id/copy-config-from/:sourceId 显式一键拉取(拷贝前自动拍快照,可回滚,支持 ?redeploy=1) |
+| feat | cds | ConfigSnapshot 快照覆盖分支层(profileOverrides/extraProfiles/派生指针):回滚仅恢复仍存在的分支、不复活已删分支、旧快照零迁移 no-op |
+| feat | cds | 生效配置检查器新增派生溯源行(派生自哪个分支/何时/来源是否还在)+ 「重新拉取来源配置」按钮 |
+| docs | cds | 新增 design.cds.config-tree.md:四层配置树模型 + 派生三层策略 + 溯源契约 + 波4(repo compose 纯结构种子/漂移巡检)波5(无 Agent 接入)方向;同步 index.yml 与 guide.list |

--- a/doc/design.cds.config-tree.md
+++ b/doc/design.cds.config-tree.md
@@ -1,0 +1,147 @@
+# CDS 配置树 · 技术设计
+
+> **类型**:design(怎么做) · **更新**:2026-07-06 · **状态**:波1-3 已实现,波4-5 方向已定
+>
+> 对应工程看板:`doc/plan.cds.status.md` §〇「配置体系三波演进」。
+
+---
+
+## 一、管理摘要
+
+CDS 的配置此前是「项目为中心的两层继承」:项目底座 + 分支覆盖,能力存在但**不可见、不可达、不可派生**——分支临时容器只有裸 HTTP API、没人能回答「容器里这个变量是哪一层给的」、新分支永远从项目模板起步而无法继承来源分支的配置。
+
+本设计把配置体系定型为**四层配置树**:
+
+```
+CDS 全局默认(_global 变量层)
+  → 项目配置(customEnv / BuildProfile 底座 / 虚拟 compose)
+    → 分支配置(profileOverrides 覆盖 + extraProfiles 临时追加)
+      → 派生分支(从来源分支快照拷贝,之后各自独立)
+```
+
+三个已拍板的关键决策:
+
+1. **派生 = 快照拷贝**,不是活继承。建分支时把来源分支的分支级配置深拷贝一份,之后两边独立;保留 `derivedFrom*` 指针仅做溯源展示与「一键重新拉取」入口。理由:活继承的远程副作用(父分支改动静默影响子分支)与排障复杂度远超收益。
+2. **仓库 `cds-compose.yml` = 纯结构种子**(波4 方向):只声明服务/依赖/路由结构,零密钥零环境值;CDS 配置树是运行时 SSOT;repo 变更走漂移巡检出「同步建议」,人审落地。
+3. **配置必须可观测**:任何分支能一屏回答「生效配置是什么、每项从哪继承、被谁覆盖、CDS 接下来会做什么」(生效配置检查器)。
+
+---
+
+## 二、背景与定位
+
+用户诉求(2026-07-06):CDS 能力上限在涨,使用下限没降。核心痛点:
+
+- `cds-compose.yml` 是静态文件,难一次生成准确,且与项目真实状态渐行渐远 → 不信任;
+- 分支临时接一个 Nacos 不应影响其他分支,且要能快速撤销;
+- 配置的继承/覆盖/新增全程黑盒,用户和 Agent 都看不见;
+- 产品经理等非后端角色无法低成本获得「分支级独立可测环境」。
+
+调研结论:一半能力已存在但停在 API 层(`extraProfiles`、`resolveEffectiveProfile` 合并链、虚拟 compose 版本化、快照回滚)。本工程的主体是**把存量能力产品化 + 补齐树的缺口(派生/溯源/分支层快照)**,不是重写。
+
+---
+
+## 三、四层配置树模型
+
+| 层 | 载体 | 作用域 | 改动方式 |
+|---|---|---|---|
+| 全局默认 | `customEnv._global`(CDS 全局变量) | 所有项目 | CDS 系统设置 |
+| 项目 | `Project.customEnv / defaultEnv / defaultDeployModes` + `BuildProfile`(项目底座) + 虚拟 compose(`composeYaml` 带版本/来源) | 单项目全分支 | 项目设置 / pending-import 审批 |
+| 分支 | `BranchEntry.profileOverrides`(逐字段覆盖底座) + `BranchEntry.extraProfiles`(临时追加服务) + 分支级 env scope | 单分支 | 分支抽屉「设置」tab / cdscli / API |
+| 派生分支 | 建分支时从来源分支深拷贝分支层配置 + `derivedFrom*` 指针 | 单分支 | `POST /branches` 带 `sourceBranchId` / cdscli `branch create --from` |
+
+合并中枢不变:`resolveEffectiveProfile`(baseline → 分支覆盖 → 部署模式)与 `mergeBranchProfiles`(项目底座 + 分支追加,撞 id 底座赢)。字段权威边界由 `config-authority.ts` 三级(repo/platform/user)把守。
+
+### 派生的三层判定策略(W3a)
+
+| 场景 | 行为 | 理由 |
+|---|---|---|
+| 手动创建(`sourceBranchId`) | **真拷贝** + 写指针 | 用户显式选择,预期明确 |
+| webhook push 自动建分支 | 保持项目模板,不拷贝不回填 | push payload 无可靠派生信号,不猜 |
+| PR opened/reopened | **仅回填指针**(base 分支),不拷贝 | 分支往往已按模板部署,静默改写违反最小惊讶;要拷贝走显式端点 |
+
+补偿路径:`POST /branches/:id/copy-config-from/:sourceId` —— 显式一键拉取,**拷贝前自动拍含分支层的 ConfigSnapshot**,误拷可回滚;`?redeploy=1` 让配置立即生效。
+
+### 已知边界
+
+- 派生拷贝会把来源分支覆盖里**硬编码的连接串原样带过来**(per-branch DB 名会自动按新分支后缀化,但硬编码串穿透)。检查器把这类 key 的来源显示为「分支覆盖」,用户可辨;后续可对 `PER_BRANCH_DB_ENV_KEYS` 命中的覆盖 key 加警示徽标。
+- 跨项目派生被显式拒绝(profileId 引用与隔离语义均为项目内)。
+- 分支列表页的「新建分支」对话框暂未提供来源分支选择器(API 与 cdscli 已支持),待补 UI 入口。
+
+---
+
+## 四、配置可观测性(生效配置检查器,波2)
+
+**逐 key 溯源**是本工程的可信基座。容器 env 是两段式合并:
+
+- 段A 分支 customEnv:`cds-builtin → mirror → global → project → branch → cds-derived(保留 key)`
+- 段B 单容器运行时:`customEnv → JWT 兜底 → node PATH → profile 层(底座/分支覆盖/部署模式) → 版本元数据 → per-branch DB 改写 → ${VAR} 模板展开`
+
+实现原则:**单一代码路径**。段B抽为纯函数 `resolveProfileRuntimeEnvWithProvenance`(`cds/src/services/env-provenance.ts`),输入「带来源标注的层数组」,输出 `{env, provenance}`;部署路径退化为单层包装只取 `.env`,行为与旧实现逐字节一致(container.test.ts 43 例护栏)。检查器端点把两段按真实来源拆层传入,免费获得溯源——不存在第二份合并逻辑,永不漂移。
+
+`EnvSource` 12 值枚举 + `EnvKeyProvenance`(value/source/detail/shadowed/templated)是公开契约,定义在 `cds/src/types.ts`。
+
+消费面:
+
+- `GET /api/branches/:id/effective-config`:envLayers 分层摘要 + 每 profile 的 envProvenance(maskSecrets 脱敏,缺模板值不 fail 而是 `envError` 显性化)+ `plan`(将起的容器/网络/需拉起的共享 infra,记录态不打 docker)+ `derivedFrom` 溯源。
+- 前端 `EffectiveConfigPanel`:分支抽屉「配置」tab + 分支详情页「生效配置」区。继承链树、来源徽标、shadowed 覆盖链、部署计划、派生行(含「重新拉取来源配置」按钮)。
+
+---
+
+## 五、快照与回滚(W3d)
+
+`ConfigSnapshot.payload` 新增可选 `branchConfigs`(分支层:profileOverrides / extraProfiles / derivedFrom*),只收有配置的分支控体积。回滚语义:
+
+- 仅恢复**仍存在**的分支;快照后新建的不动、已删的不复活;
+- 新快照总是带 `branchConfigs`(空对象也带)——区分「拍照时确无分支配置(回滚要清掉事后新增)」与「旧快照没拍过分支层(回滚 no-op,零迁移)」;
+- 快照 scope 为项目时只拍/只回滚该项目的分支。
+
+---
+
+## 六、接口与入口一览
+
+| 能力 | API | CLI | UI |
+|---|---|---|---|
+| 分支临时服务 | GET/PUT `/branches/:id/extra-services[?redeploy=1]` | `cdscli branch extra-services list/set/remove` | 分支抽屉「设置」tab + 详情页面板(预设:Nacos/Kafka/RabbitMQ/Redis/MinIO) |
+| per-branch DB 开关 | PUT `/branches/:id/profile-overrides/:pid`(dbScope) | — | 分支抽屉运行模式区选择器 |
+| 生效配置检查器 | GET `/branches/:id/effective-config` | — | 抽屉「配置」tab / 详情页「生效配置」 |
+| 派生建分支 | POST `/branches`(sourceBranchId) | `branch create --from <id>` | 待补(见已知边界) |
+| 显式拉取配置 | POST `/branches/:id/copy-config-from/:sourceId[?redeploy=1]` | — | 检查器派生行按钮 |
+| 快照/回滚 | `/api/config-snapshots*`(含分支层) | — | 项目设置快照 tab |
+
+---
+
+## 七、波4 / 波5 方向(未实施,只定方向)
+
+**波4 双 SSOT 收敛(repo compose = 纯结构种子)**
+
+- 仓库 `cds-compose.yml` 只声明结构(服务/依赖/路由/资源),密钥与环境值全部剥离到 CDS env scope → 直接偿还 `debt.cds.compose-secrets.md` D1(TODO 占位卡死全量 import);
+- `composeSource='repo-sync'` 枚举落地:repo 侧 compose 变更触发漂移巡检,diff 出「同步建议」进 pending-import 审批流,人审后落 CDS 配置树;CDS 侧的运行时改动不回写 repo(单向种子);
+- `config-authority` 增加 seed 级:结构字段以 repo 为权威、运行时字段以 CDS 为权威,漂移检测按权威分级分别报告;
+- 「CDS 级默认 profile 片段」与结构种子一起设计,避免出现第二个结构默认源。
+
+**波5 无 Agent 接入**
+
+- 把 cdscli scan 的检测逻辑(栈识别/infra 识别/env 三色)以服务端等价物进 onboarding 向导,解决「无 compose 项目 clone 后停在保留为手动配置」的断头路;
+- 解决 ghost profile race(服务端 detect 与 cdscli scan 并发)后重新默认打开 clone 后自动检测;
+- 目标画像:产品经理不借 Claude,也能 UI 三步完成「选仓库 → 确认检测结果 → 首个分支预览」。
+
+---
+
+## 八、关联文档
+
+- `doc/plan.cds.status.md` §〇 —— 工程看板(进度/blocker/证据)
+- `doc/design.cds.branch-local-extra-services.md` —— 分支临时服务的底层设计
+- `doc/design.cds.branch-network-isolation.md` —— 分支专属网(cds-br-*)
+- `doc/spec.cds.compose-contract.md` —— compose 契约(波4 的改造对象)
+- `doc/debt.cds.compose-secrets.md` —— D1 债务(波4 偿还)
+- `doc/guide.cds.multi-branch-db.md` —— per-branch DB 用法
+- `.claude/rules/cross-project-isolation.md` —— 隔离穿透审计(派生拷贝的风险对照)
+
+## 九、风险
+
+| 风险 | 等级 | 缓解 |
+|---|---|---|
+| 段B重构触部署热路径 | 高 | 纯函数单一代码路径 + 行为等价断言 + container.test.ts 护栏;灰度真机验证是合并前置门槛 |
+| 溯源端点泄密 | 高 | maskSecrets SSOT + 不提供 reveal + vitest 脱敏断言 |
+| 派生拷贝隔离穿透(硬编码连接串) | 中 | 检查器来源可辨 + 后续警示徽标;跨项目派生直接拒绝 |
+| 快照回滚不重建容器 | 中 | 响应 hint 明示「重新部署后生效」 |

--- a/doc/guide.list.directory.md
+++ b/doc/guide.list.directory.md
@@ -229,6 +229,9 @@
 - [CDS 分支级临时额外服务](design.cds.branch-local-extra-services) `design.cds.branch-local-extra-services`
   > 项目底座稳定（审批改、影响全体）+ 分支可自助加临时额外服务（只在本分支部署、跑分支专属网、删分支即消失、不影响别的分支）；纯增量可选、老行为零回归
 
+- [CDS 配置树](design.cds.config-tree) `design.cds.config-tree`
+  > 全局→项目→分支→派生分支四层继承；派生=快照拷贝（保留溯源指针）；生效配置检查器（env 逐 key 溯源 + 部署计划预览）；快照覆盖分支层；波4/5 方向（repo compose 纯结构种子、无 Agent 接入）
+
 - [CDS Agent API 契约设计](design.cds.agent.api) `design.cds.agent.api`
   > MAP/CDS 会话、事件、工具审批、Hook、runtime profile 与工作流调用的 API 契约
 

--- a/doc/index.yml
+++ b/doc/index.yml
@@ -105,6 +105,7 @@ docs:
   design.cds.build-time: CDS 构建耗时与发布版/热加载机制设计
   design.cds.branch-network-isolation: CDS 分支级网络隔离（每分支专属 app 网 + 共享 infra 网，杜绝跨分支服务发现串流）
   design.cds.branch-local-extra-services: CDS 分支级临时额外服务（分支可在项目底座之上自助加服务，只在本分支部署、删分支即消失、不影响别的分支）
+  design.cds.config-tree: CDS 配置树（全局→项目→分支→派生分支四层继承、派生=快照拷贝、env 逐 key 溯源检查器、快照分支层；波4 repo compose 纯结构种子方向）
   design.cds.agent.api: CDS Agent API 契约设计
   design.cds.agent.runtime-architecture: CDS Agent 运行时架构设计
   design.cds.agent.official-sdk-adapter: CDS Agent 官方 SDK Adapter 设计

--- a/doc/plan.cds.status.md
+++ b/doc/plan.cds.status.md
@@ -1,10 +1,28 @@
 # CDS 当前状态看板 · 计划
 
-> **类型**:plan(总览看板) · **更新**:2026-05-03 · **状态**:活的 — 每次 handoff 必须更新本文件
+> **类型**:plan(总览看板) · **更新**:2026-07-06 · **状态**:活的 — 每次 handoff 必须更新本文件
 >
 > 这是 **CDS 唯一的"我在哪"入口**。任何 AI / 人类接手 CDS 改动前先读本页 30 秒,然后按需深入子文档。
 >
 > **不要**给 CDS 新建额外的 handoff/进度文档 — 全部归口本文件 + `plan.cds.backlog-matrix.md`(碎片项 SSOT)。
+
+---
+
+## 〇、配置体系三波演进看板(2026-07-06 起,当前主线)
+
+> 背景:用户 2026-07-06 提出「拔高上限的同时降低下限」——配置树(全局→项目→分支→派生分支)、
+> 分支临时容器产品化、配置可观测性。方案定盘:派生=快照拷贝、repo compose=纯结构种子(波4)。
+> 分支:`claude/session-y2bpgw`。
+
+| 阶段 | 进度% | 状态 | 当前 blocker | 下一步 | 验收证据 |
+|---|---|---|---|---|---|
+| 波1 最后一公里(extraProfiles UI+CLI / dbScope 开关 / 看板) | 90 | 进行中 | 无 | push 后灰度真机验证(添加 Nacos 预设 → redeploy → 分支网 → 命名 URL 可达) | vitest 180 文件绿 + pytest 149 绿 + tsc 双侧绿(2026-07-06 本地);真机证据待补 |
+| 波2 配置检查器(env 逐 key 溯源 + effective-config 端点 + 面板) | 0 | 未开始 | 依赖波1 dbScope 透传合入 | env-provenance.ts 段A拆层 → container.ts 段B带溯源变体 → GET /effective-config | — |
+| 波3 配置树补全(分支派生快照拷贝 + 快照分支层 + design.cds.config-tree) | 0 | 未开始 | 依赖波2 溯源数据模型 | BranchEntry.derivedFrom* 字段 + POST sourceBranchId + PR opened 指针回填 | — |
+| 波4 双SSOT收敛(repo compose 纯结构种子 + drift 巡检 + 还 D1 债) | 0 | 未开始(方向已定) | 等波1-3 | 见 design.cds.config-tree.md(波3产出)「波4方向」 | — |
+| 波5 无 Agent 接入(scan 逻辑进 onboarding 向导) | 0 | 未开始(方向已定) | 等波1-3 | 同上 | — |
+
+**距离可发布**:波1 代码完成待真机验证;波2/3 未开始。
 
 ---
 
@@ -46,14 +64,17 @@
 | **mongo-split storage** | 2026-05 | 默认 `CDS_STORAGE_MODE=mongo-split` |
 | **per-branch DB 隔离机制(代码层)** | 2026-05 | `applyPerBranchDbIsolation` + `dbScope='per-branch'` |
 | **Onboarding 收尾第二波(F11/F12 + 3 UI bug)** | 2026-05-03 | `claude/cds-loose-ends-wrap-up` |
+| **分支专属网络隔离(cds-br-*)** | 2026-06-29 | `branch-network.ts`(见 design.cds.branch-network-isolation) |
+| **分支级临时额外服务(后端+API)** | 2026-06-29 | `BranchEntry.extraProfiles` + PUT /extra-services(见 design.cds.branch-local-extra-services) |
+| **临时额外服务产品化(UI+cdscli)+ dbScope 分支开关(波1)** | 2026-07-06 | `claude/session-y2bpgw`(ExtraServicesPanel + cdscli branch extra-services + override 白名单补 dbScope) |
 
 ### 进行中
 
 | 项 | 进度 | 阻塞 |
 |---|---|---|
+| **配置体系三波演进(§〇)** | 波1 90% | 见顶部看板 |
 | **Onboarding UAT 真人验收剩余 22%** | 待真人浏览器跑 | 需用户跑[剩余清单](report.cds.onboarding-uat.md#真人-uat-剩余清单) |
 | **React 迁移**(`cds/web-legacy/` → `cds/web/`) | ~60% | 见 [plan.cds.web-migration](plan.cds.web-migration.md) |
-| **F16-UI**(BuildProfile 暴露 dbScope toggle) | 后端能力齐 / React 编辑器缺 | 等 React 迁移更进一步 |
 
 ### 未启动
 
@@ -86,11 +107,11 @@
 | F13 | P4 | cdscli scan 不识别 init.sql | ✅ 已修 2026-05-03(verify INFO `infra-init-script-detected`) |
 | F14 | P4 | `schemaful-db-no-migration` 误报 | ✅ 已修 2026-05-03(挂 init.sql 时不再 WARN) |
 | F15 | HIGH | container-exec 输出回显 secret | ✅ 已修(`secret-masker.ts`) |
-| F16 | P2 | per-branch DB 后缀未实施 | 🔨 后端能力齐(`dbScope='per-branch'`),UI 入口缺(F16-UI) |
+| F16 | P2 | per-branch DB 后缀未实施 | ✅ 已修 2026-07-06(波1:override 白名单补 dbScope 透传 + 分支抽屉「数据库隔离」选择器) |
 | F17 | 契约违反 | 预览过渡页是纯文本 | ✅ 已修(SVG 双圈+CDS 字样) |
 | F18 | P4 | repo picker 命名歧义(Tab vs Dialog) | ✅ 已修 2026-05-03(dropdown 直接弹 picker) |
 
-**F 系列状态**:18 项中 **17 项已修**,剩 F16-UI(后端齐 / 前端 React 端没 BuildProfile 编辑器,等迁移)。
+**F 系列状态**:18 项 **全部已修**(F16 于 2026-07-06 波1 收尾)。
 
 ### Bug 系列(2026-05-03 用户反馈的 UI bug)
 

--- a/doc/plan.cds.status.md
+++ b/doc/plan.cds.status.md
@@ -18,7 +18,7 @@
 |---|---|---|---|---|---|
 | 波1 最后一公里(extraProfiles UI+CLI / dbScope 开关 / 看板) | 90 | 进行中 | 无 | push 后灰度真机验证(添加 Nacos 预设 → redeploy → 分支网 → 命名 URL 可达) | vitest 180 文件绿 + pytest 149 绿 + tsc 双侧绿(2026-07-06 本地);真机证据待补 |
 | 波2 配置检查器(env 逐 key 溯源 + effective-config 端点 + 面板) | 90 | 进行中 | 无 | 灰度真机验证(部署热路径重构是合并前置门槛);验证通过后波1+2 一并收 | env-provenance.test.ts 14 例绿 + effective-config 端点 3 例绿 + container.test.ts 43 例行为等价护栏绿 + 全量 vitest 181 文件绿(2026-07-06 本地) |
-| 波3 配置树补全(分支派生快照拷贝 + 快照分支层 + design.cds.config-tree) | 0 | 未开始 | 依赖波2 溯源数据模型 | BranchEntry.derivedFrom* 字段 + POST sourceBranchId + PR opened 指针回填 | — |
+| 波3 配置树补全(分支派生快照拷贝 + 快照分支层 + design.cds.config-tree) | 90 | 进行中 | 无 | 灰度真机验证(与波1/2 一并);建分支对话框的来源分支选择器待补 UI(API/cdscli 已支持) | 派生拷贝/copy-config/快照分支层/PR 回填 7 例新测试绿 + 全量 vitest 绿(2026-07-06 本地);design.cds.config-tree.md 已归档 |
 | 波4 双SSOT收敛(repo compose 纯结构种子 + drift 巡检 + 还 D1 债) | 0 | 未开始(方向已定) | 等波1-3 | 见 design.cds.config-tree.md(波3产出)「波4方向」 | — |
 | 波5 无 Agent 接入(scan 逻辑进 onboarding 向导) | 0 | 未开始(方向已定) | 等波1-3 | 同上 | — |
 

--- a/doc/plan.cds.status.md
+++ b/doc/plan.cds.status.md
@@ -17,7 +17,7 @@
 | 阶段 | 进度% | 状态 | 当前 blocker | 下一步 | 验收证据 |
 |---|---|---|---|---|---|
 | 波1 最后一公里(extraProfiles UI+CLI / dbScope 开关 / 看板) | 90 | 进行中 | 无 | push 后灰度真机验证(添加 Nacos 预设 → redeploy → 分支网 → 命名 URL 可达) | vitest 180 文件绿 + pytest 149 绿 + tsc 双侧绿(2026-07-06 本地);真机证据待补 |
-| 波2 配置检查器(env 逐 key 溯源 + effective-config 端点 + 面板) | 0 | 未开始 | 依赖波1 dbScope 透传合入 | env-provenance.ts 段A拆层 → container.ts 段B带溯源变体 → GET /effective-config | — |
+| 波2 配置检查器(env 逐 key 溯源 + effective-config 端点 + 面板) | 90 | 进行中 | 无 | 灰度真机验证(部署热路径重构是合并前置门槛);验证通过后波1+2 一并收 | env-provenance.test.ts 14 例绿 + effective-config 端点 3 例绿 + container.test.ts 43 例行为等价护栏绿 + 全量 vitest 181 文件绿(2026-07-06 本地) |
 | 波3 配置树补全(分支派生快照拷贝 + 快照分支层 + design.cds.config-tree) | 0 | 未开始 | 依赖波2 溯源数据模型 | BranchEntry.derivedFrom* 字段 + POST sourceBranchId + PR opened 指针回填 | — |
 | 波4 双SSOT收敛(repo compose 纯结构种子 + drift 巡检 + 还 D1 债) | 0 | 未开始(方向已定) | 等波1-3 | 见 design.cds.config-tree.md(波3产出)「波4方向」 | — |
 | 波5 无 Agent 接入(scan 逻辑进 onboarding 向导) | 0 | 未开始(方向已定) | 等波1-3 | 同上 | — |


### PR DESCRIPTION
## 摘要

把 CDS 配置体系定型为「全局默认 → 项目 → 分支 → 派生分支」四层配置树，一次三波：

- **波1 最后一公里**：把 2026-06-29 已落地但只有裸 HTTP API 的分支级临时额外服务（`extraProfiles`）推到产品可用，并收尾 F16 per-branch DB 开关。
- **波2 配置检查器**：补齐配置可观测性——env 逐 key 溯源 + 分支生效配置全景端点与面板，回答「容器里这个变量是哪一层给的」。
- **波3 配置树补全**：补上配置树缺的「派生」一环——分支从分支快照拷贝 + 快照覆盖分支层。

方案与演进路径见 `doc/design.cds.config-tree.md`（含波4/5 方向）与 `doc/plan.cds.status.md` §〇。用户拍板：派生 = 快照拷贝（非活继承）、repo compose = 纯结构种子（波4，本 PR 不实施）。

## 改动 diff

**CDS 后端（`cds/src/`）**
- `routes/branches.ts`：profile-overrides PUT 白名单补 `dbScope` 透传 + 枚举校验（此前静默丢弃，per-branch DB 开关首次可按分支生效）；新增 `GET /branches/:id/effective-config`（逐 key 溯源 + 部署计划预览 + 派生溯源）；`POST /branches` 新增 `sourceBranchId`（派生快照拷贝）；新增 `POST /branches/:id/copy-config-from/:sourceId`（显式一键拉取，拷贝前自动拍快照）
- `services/env-provenance.ts`（新增）：容器运行时 env 的带溯源纯函数解析（两段式分层 + last-writer-wins + shadowed 链 + templated 打标）；`missingEnvTemplates` 迁入作单处 SSOT
- `services/container.ts`：`resolveProfileRuntimeEnv` 重构为纯函数单层包装，部署行为逐字节等价
- `services/state.ts`：`setBranchDerivedFrom`（派生指针，idempotent）；`ConfigSnapshot` 快照覆盖分支层（拍/回滚，旧快照零迁移 no-op）
- `services/github-webhook-dispatcher.ts`：PR opened/reopened 回填 base 分支派生指针（只回填不拷贝配置，最小惊讶）
- `types.ts`：`EnvSource`/`EnvKeyProvenance` 公开契约；`BranchEntry.derivedFrom*`；`ConfigSnapshot.payload.branchConfigs`（均 optional，旧数据零迁移）
- `server.ts`：新端点的 Activity Monitor 中文 label

**CDS 前端（`cds/web/src/`）**
- `components/branch/ExtraServicesPanel.tsx` + `ExtraServiceFormDialog.tsx`（新增）：分支临时服务管理面板 + 表单（预设 Nacos/Kafka/RabbitMQ/Redis/MinIO，校验与服务端 PUT 逐条对齐，redeployRejected/removalRolledBack 显性化）
- `components/branch/EffectiveConfigPanel.tsx`（新增）：生效配置检查器（继承链树 + 12 种来源徽标 + shadowed 覆盖链 + 部署计划 + 派生溯源行「重新拉取来源配置」）
- `components/BranchDetailDrawer.tsx`：新增「配置」tab；「设置」tab 挂临时服务面板 + 每 profile「数据库隔离」选择器
- `pages/BranchDetailPage.tsx`：详情页复用临时服务面板 + 「生效配置」折叠区

**cdscli（`.claude/skills/cds/cli/cdscli.py`）**
- 新增 `branch extra-services list/set/remove`（读改写 PUT + `--redeploy` + 掩码哨兵安全往返）
- `branch create` 新增 `--from <sourceBranchId>`（派生快照拷贝）

**文档**
- `doc/design.cds.config-tree.md`（新增）：四层树模型 + 派生三层策略 + 溯源契约 + 波4/5 方向；同步 `doc/index.yml` + `doc/guide.list.directory.md`
- `doc/plan.cds.status.md`：活看板重建（六列三波轨道表 + 补 2026-05 以来里程碑，F 系列 18 项全清）
- `changelogs/2026-07-06_cds-config-wave{1,2,3}.md`（新增）

## 测试

- [x] 前端 `pnpm tsc --noEmit`（CDS 后端 + web 双侧）通过 + web 生产构建通过
- [x] 单元/集成测试：vitest 全量 181 文件 / 2581 例绿；新增覆盖——env-provenance 14 例（溯源语义 + 行为等价）、effective-config 端点 3 例（打标/脱敏/越权 403/envError）、dbScope 透传 1 例、派生拷贝/copy-config/快照分支层 5 例、PR opened 回填 2 例、cdscli extra-services 13 例（pytest 149 绿）
- [x] container.test.ts 43 例作部署热路径重构的行为等价护栏
- [ ] 真人通过预览域名验收（**CDS self-update 到本分支后**才可见 CDS Dashboard 改动）：https://session-y2bpgw-claude-prd-agent.miduo.org

> 注：`server-integration.test.ts` 10 例为存量环境性失败，已用改动前的干净树复验确认与本 PR 无关。

## 风险与已知边界

- **无 Breaking Change**：所有新字段 optional，旧数据零迁移；部署路径 env 解析虽重构为纯函数但行为逐字节等价（container.test.ts 护栏）。
- **部署热路径重构**：`resolveProfileRuntimeEnv` 触部署热路径 → 已用行为等价断言 + 既有测试护栏兜住；**灰度真机部署验证是合并前的建议门槛**。
- **派生拷贝隔离穿透**：源分支覆盖里硬编码的连接串会原样拷贝（per-branch DB 名自动后缀化，硬编码串穿透）；检查器里来源可辨，警示徽标留作后续。跨项目派生已显式拒绝。
- **回滚**：三个 commit 独立可 revert；copy-config 操作服务端自动拍含分支层的快照，可从 `/api/config-snapshots` 回滚。

## 后续事项

- 【P1】分支列表「新建分支」对话框加来源分支选择器（API/cdscli 已支持 `--from`，纯前端）
- 【P1】波4：repo `cds-compose.yml` 剥密钥降为纯结构种子 + 漂移巡检（顺路还 `debt.cds.compose-secrets` D1 债）
- 【P2】波5：无 Agent 接入向导（scan 逻辑进 onboarding）