### PR TITLE
每日熵减计划 2026-W27 — D6 归档 5 条 changelog (llmgw 控制台 + cds 配置树)

### DIFF
--- a/changelogs/.entropy-manifest.yml
+++ b/changelogs/.entropy-manifest.yml
@@ -408,3 +408,8 @@ processed:
   - 2026-06-29_gw-shadow-mode.md
   - 2026-06-29_gw-test-matrix-data-driven.md
   - 2026-06-29_gw-test-matrix.md
+  - 2026-07-04_llmgw-console-openrouter.md
+  - 2026-07-04_llmgw-independent-auth-db.md
+  - 2026-07-04_llmgw-openrouter-visual-pass.md
+  - 2026-07-06_cds-config-wave1.md
+  - 2026-07-06_cds-config-wave2.md

--- a/changelogs/2026-07-06_entropy-cleanup.md
+++ b/changelogs/2026-07-06_entropy-cleanup.md
@@ -1,0 +1,1 @@
+| chore | doc | 熵清理：D1 0 个，D2 +0/-0，D3 +0/-0（历史变更记录误报已排除），D4 +0/-0（pnpm 加粗误报已排除），D6 补 5 条（llmgw 控制台演进补入 design.llm-gateway-physical-isolation.md §9；cds 配置两波已在 design.cds.config-tree.md 覆盖，仅登记 manifest） |

--- a/doc/design.llm-gateway-physical-isolation.md
+++ b/doc/design.llm-gateway-physical-isolation.md
@@ -582,3 +582,16 @@ api:
 - **本期非目标、登记债务**：`ImageGen/ImageGenGateway.cs`、`LLM/OpenAIImageClient.cs`、`LLM/OpenAIClient.cs`、`LLM/ClaudeClient.cs` 及其 6+ 处直连构造点（ModelLabController、ArenaRunWorker、Program.cs DI、ModelDomainService）
 - 配置：`docker-compose.yml`、`cds-compose.yml`、`Program.cs`(prd-api DI 切换 + feature flag)；密钥/Mongo/LlmLogLimits 用同一份 env 锚点注入两 service
 - 集合归属（网关独占写）：`llmplatforms`、`llmmodels`、`model_groups`、`model_exchanges`、`llm_app_callers`、`llmrequestlogs`
+
+---
+
+## 9. 控制台与运维闭环（实施进展，2026-07-04）
+
+网关物理拆分落地后，`prd-llmgw-web`（观测前端）与 `prd-llmgw`（serving）本身也需要独立于 MAP 的账号体系与可观测面，避免"引擎已拆、运维还得回 MAP 借壳"：
+
+- **控制台账号独立建库**：网关控制台的登录账号与登录审计记录迁到独立的 `llm_gateway` Mongo 数据库，不再与 MAP 主库（`llmrequestlogs` 等业务集合所在库）混用，呼应 `.claude/rules/cross-project-isolation.md` 的隔离总纲——控制台鉴权是独立于日志读写的另一条数据面。
+- **修复口令被覆盖**：`LLMGW_ADMIN_PASSWORD` 此前会在服务每次启动时覆盖已存在的控制台口令，导致运维改过的密码重启后失效；已改为仅在账号不存在时用该变量初始化，不再覆盖已存在口令。
+- **只读日志 API 扩展**：网关日志只读 API 新增多维筛选、元信息与窗口汇总接口，供控制台的筛选/汇总/详情排障使用。
+- **控制台视觉重做**：`prd-llmgw-web` 的 Logs / Generation 页从早期原型样式改为 OpenRouter 风格的高密度 Activity 控制台，信息架构与筛选/汇总/详情排障字段一并打磨。
+
+以上四项均不改变 §3-§8 定义的边界与迁移方案，属于该边界内"控制台可用性"层面的补强；本节记录落地事实，供后续核对控制台功能演进历史。


### PR DESCRIPTION
## 熵清理摘要

- D1 doc/ 命名规范：0 个违规
- D2 index.yml：+0/-0（无欠款）
- D3 guide.list.directory.md：+0/-0（扫描命中的候选均为「变更历史」章节的历史记录，非真实幽灵条目，已逐条核实排除）
- D4 CLAUDE.md 技能表：+0/-0（`pnpm` 加粗文案误报，非技能表行，已核实排除）
- D5 codebase-snapshot：未改动（该维度按技能设计需人工审阅后更新，本次仅扫描不自动改写）
- D6 changelog→doc：本次处理 5 条未归档 changelog，manifest 累计 411 条
  - `2026-07-04_llmgw-console-openrouter.md`、`2026-07-04_llmgw-independent-auth-db.md`、`2026-07-04_llmgw-openrouter-visual-pass.md`：三条内容合并补入 `design.llm-gateway-physical-isolation.md` 新增 §9「控制台与运维闭环」（独立建库 / 口令覆盖修复 / 只读日志 API 扩展 / OpenRouter 风格视觉重做）
  - `2026-07-06_cds-config-wave1.md`、`2026-07-06_cds-config-wave2.md`：内容已在 `design.cds.config-tree.md`（2026-07-06 当日更新）完整覆盖，仅登记 manifest 避免重复处理

## 改动 diff

- `doc/design.llm-gateway-physical-isolation.md`：新增 §9「控制台与运维闭环（实施进展，2026-07-04）」章节
- `changelogs/.entropy-manifest.yml`：追加 5 条已处理 changelog 记录
- `changelogs/2026-07-06_entropy-cleanup.md`：本次熵清理 changelog 碎片

## 测试

- [x] 双向扫描完成，diff 核验通过（本次 diff 无删除行，纯追加）
- [x] 运行两次验证：D1/D2 重新扫描确认无新增/删除条目

## 风险与已知边界

- D5 codebase-snapshot 仍未更新（技能设计要求人工审阅后更新，非本次范围）


---
_Generated by [Claude Code](https://claude.ai/code/session_019vT8h2HGMRNcWdviVFBmQq)_