### PR TITLE
ops(llmgw): 增加 shadow 补样计划门

### DIFF
--- a/changelogs/2026-07-08_llmgw-shadow-sample-plan-gate.md
+++ b/changelogs/2026-07-08_llmgw-shadow-sample-plan-gate.md
@@ -1,0 +1,2 @@
+| ops | scripts | LLM Gateway shadow 补样累计脚本执行前强制读取只读 planner，拒绝超过推荐批次的过量取证 |
+| test | prd-api | 增加 shadow 补样 planner 约束守卫，防止后续回退为手工批次数 |

--- a/doc/debt.llm-gateway.md
+++ b/doc/debt.llm-gateway.md
@@ -277,6 +277,12 @@
 - 新 commit 只读 coverage 证据：`.llmgw-release-evidence/20260708T093440Z_readonly_shadow-coverage_2f6b06583970.{json,md}`。当前 `global / send / report-agent.generate::chat / report-agent.generate::chat/send` 均为 `total=0`、`critical=0`、`httpFail=0`、coverageHours `0`；planner 建议最多 `3` 批 bounded top-up，剩余目标 `30`。
 - 结论：正式环境已进入最新 commit 的 shadow 证据期，但全量迁移仍未完成；下一阶段 `canary-intent-text` 被 24 小时观察窗口正确阻断，且样本数未达 30。不得宣称“网关迁移完成”，不得直接切 http。
 
+## 最新补样预算守卫（2026-07-08 18:00 CST）
+
+- `scripts/llmgw-shadow-sample-accumulate.sh` 已在执行前接入只读 `scripts/llmgw-shadow-sample-plan.py`。当 preflight coverage 未达标时，脚本会生成 `preflight-shadow-sample-plan.json/md`，读取 `recommendedBatches` 与 `canRunRecommendedBatches`，并拒绝 `LLMGW_SHADOW_ACCUMULATE_BATCHES` 超过 planner 推荐值的运行。
+- 该守卫只影响补证据批次数，不降低 release gate，不修改 `minCoverageHours=24`，也不会绕过 `critical=0` / `httpFail=0` 要求。若 coverage 已达标、只差覆盖窗口、存在质量失败，或 preflight coverage 因 key/网关/JSON 异常/参数格式错误读不到可信计数，脚本会停止，不继续消耗模型额度。
+- 结论：后续火山/其它模型已可用时，仍必须先跑只读 coverage 和 planner，再按推荐批次数补样；不得为了追进度重复打视频、图片、ASR 或超过 planner 的文本 batch。
+
 ## 已还的债务（归档）
 
 > 修复后从上面表格挪到这里，保留以便复盘

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -1060,8 +1060,15 @@ public class GatewayDataDomainGuardTests
         Assert.Contains("超过本 profile 默认上限", script);
         Assert.Contains("LLMGW_SHADOW_ACCUMULATE_PREFLIGHT_COVERAGE:-1", script);
         Assert.Contains("LLMGW_SHADOW_ACCUMULATE_ALLOW_AFTER_PASS:-0", script);
+        Assert.Contains("LLMGW_SHADOW_ACCUMULATE_ENFORCE_PLAN:-1", script);
         Assert.Contains("coverage already satisfies gate; skip seeding", script);
         Assert.Contains("preflight-shadow-coverage.json", script);
+        Assert.Contains("llmgw-shadow-sample-plan.py", script);
+        Assert.Contains("preflight-shadow-sample-plan.json", script);
+        Assert.Contains("canRunRecommendedBatches", script);
+        Assert.Contains("recommendedBatches", script);
+        Assert.Contains("requested batches=$batches exceeds planner recommendation=$plan_recommended", script);
+        Assert.Contains("refusing to over-sample", script);
         Assert.Contains("LLMGW_SHADOW_ACCUMULATE_SEED_FLAGS", script);
         Assert.Contains("执行模式必须设置 LLMGW_SHADOW_ACCUMULATE_SEED_FLAGS", script);
         Assert.Contains("llmgw-shadow-sample-window.sh", script);
@@ -1389,6 +1396,12 @@ public class GatewayDataDomainGuardTests
         Assert.Contains("recommendedBatches", planner);
         Assert.Contains("canRunRecommendedBatches", planner);
         Assert.Contains("bounded-top-up", planner);
+        Assert.Contains("coverage-read-failure", planner);
+        Assert.Contains("coverageReadReady", planner);
+        Assert.Contains("_coverage_failure_reason", planner);
+        Assert.Contains("_is_benign_coverage_failure", planner);
+        Assert.Contains("coverageFailures", planner);
+        Assert.Contains("coverage.get(\"failures\")", planner);
         Assert.Contains("already-ready", planner);
         Assert.Contains("wait-coverage-window", planner);
         Assert.DoesNotContain("urllib.request", planner);

--- a/scripts/llmgw-readiness-audit.py
+++ b/scripts/llmgw-readiness-audit.py
@@ -137,6 +137,10 @@ def _static_checks() -> list[dict]:
     asr_credential_rotate_py = asr_credential_rotate_py_path.read_text(encoding="utf-8") if asr_credential_rotate_py_path.exists() else ""
     provider_audit_path = ROOT / "scripts/llmgw-prod-provider-config-audit.py"
     provider_audit = provider_audit_path.read_text(encoding="utf-8") if provider_audit_path.exists() else ""
+    shadow_accumulate_path = ROOT / "scripts/llmgw-shadow-sample-accumulate.sh"
+    shadow_accumulate = shadow_accumulate_path.read_text(encoding="utf-8") if shadow_accumulate_path.exists() else ""
+    shadow_sample_plan_path = ROOT / "scripts/llmgw-shadow-sample-plan.py"
+    shadow_sample_plan = shadow_sample_plan_path.read_text(encoding="utf-8") if shadow_sample_plan_path.exists() else ""
     ok, detail = _contains_all(
         release_gate,
         [
@@ -177,6 +181,27 @@ def _static_checks() -> list[dict]:
         ],
     )
     checks.append(_check("shadow_coverage_report_available", ok, detail))
+
+    ok, detail = _contains_all(
+        shadow_accumulate + "\n" + shadow_sample_plan,
+        [
+            "llmgw-shadow-sample-plan.py",
+            "LLMGW_SHADOW_ACCUMULATE_ENFORCE_PLAN:-1",
+            "preflight-shadow-sample-plan.json",
+            "canRunRecommendedBatches",
+            "recommendedBatches",
+            "refusing to over-sample",
+            "LLMGW_SHADOW_SAMPLE_PLAN_MAX_BATCHES",
+            "This script is read-only",
+            "coverage-read-failure",
+            "coverageReadReady",
+            "_coverage_failure_reason",
+            "_is_benign_coverage_failure",
+            "coverageFailures",
+            "coverage.get(\"failures\")",
+        ],
+    )
+    checks.append(_check("shadow_accumulator_enforces_readonly_sample_plan", ok, detail))
 
     shadow_watch = _read(".github/workflows/llmgw-shadow-watch.yml")
     ok, detail = _contains_all(

--- a/scripts/llmgw-shadow-sample-accumulate.sh
+++ b/scripts/llmgw-shadow-sample-accumulate.sh
@@ -10,6 +10,7 @@ repo_root=$(CDPATH= cd -- "$script_dir/.." && pwd)
 window_script="$script_dir/llmgw-shadow-sample-window.sh"
 seed_script="$script_dir/llmgw-map-shadow-seed.py"
 coverage_script="$script_dir/llmgw-shadow-coverage-report.py"
+plan_script="$script_dir/llmgw-shadow-sample-plan.py"
 
 profile="${LLMGW_SHADOW_ACCUMULATE_PROFILE:-}"
 dry_run="${LLMGW_SHADOW_ACCUMULATE_DRY_RUN:-1}"
@@ -34,6 +35,7 @@ run_coverage="${LLMGW_SHADOW_ACCUMULATE_RUN_COVERAGE:-1}"
 preflight_coverage="${LLMGW_SHADOW_ACCUMULATE_PREFLIGHT_COVERAGE:-1}"
 allow_after_pass="${LLMGW_SHADOW_ACCUMULATE_ALLOW_AFTER_PASS:-0}"
 max_batches="${LLMGW_SHADOW_ACCUMULATE_MAX_BATCHES:-0}"
+enforce_plan="${LLMGW_SHADOW_ACCUMULATE_ENFORCE_PLAN:-1}"
 
 case "$profile" in
   "")
@@ -66,6 +68,11 @@ fi
 
 if [ ! -f "$coverage_script" ]; then
   echo "ERROR: 找不到 shadow coverage 脚本: $coverage_script" >&2
+  exit 1
+fi
+
+if [ ! -f "$plan_script" ]; then
+  echo "ERROR: 找不到 shadow sample plan 脚本: $plan_script" >&2
   exit 1
 fi
 
@@ -121,6 +128,7 @@ echo "  runDir: $run_dir"
 echo "  seedFlags: $(redact_seed_flags "$seed_flags")"
 echo "  runCoverage: $run_coverage"
 echo "  preflightCoverage: $preflight_coverage"
+echo "  enforcePlan: $enforce_plan"
 echo "  coverageKinds: $coverage_kinds"
 echo "  coverageApps: $coverage_apps"
 echo "  coverageRequiredKinds: $coverage_required_kinds"
@@ -209,6 +217,25 @@ run_coverage_report() {
     $coverage_args
 }
 
+read_plan_field() {
+  plan_json="$1"
+  field="$2"
+  python3 - "$plan_json" "$field" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as fh:
+    data = json.load(fh)
+value = data.get(sys.argv[2])
+if isinstance(value, bool):
+    print("true" if value else "false")
+elif value is None:
+    print("")
+else:
+    print(value)
+PY
+}
+
 if [ "$run_coverage" = "1" ] || [ "$run_coverage" = "true" ]; then
   build_coverage_args
 fi
@@ -229,6 +256,42 @@ if { [ "$preflight_coverage" = "1" ] || [ "$preflight_coverage" = "true" ]; } &&
     echo "WARN: LLMGW_SHADOW_ACCUMULATE_ALLOW_AFTER_PASS is enabled; continuing despite satisfied coverage." >&2
   else
     echo "LLM Gateway shadow sample preflight coverage did not pass; continuing with bounded seed batches."
+    if [ "$enforce_plan" = "1" ] || [ "$enforce_plan" = "true" ]; then
+      plan_json="$run_dir/preflight-shadow-sample-plan.json"
+      plan_md="$run_dir/preflight-shadow-sample-plan.md"
+      plan_max_batches="$batches"
+      if [ "$max_batches" -gt 0 ]; then
+        plan_max_batches="$max_batches"
+      fi
+      python3 "$plan_script" \
+        --coverage-json "$preflight_json" \
+        --max-batches "$plan_max_batches" \
+        --json-out "$plan_json" \
+        --report-md "$plan_md"
+      plan_can_run="$(read_plan_field "$plan_json" canRunRecommendedBatches)"
+      plan_recommended="$(read_plan_field "$plan_json" recommendedBatches)"
+      plan_reason="$(read_plan_field "$plan_json" reason)"
+      echo "LLM Gateway shadow sample plan: canRun=$plan_can_run recommendedBatches=$plan_recommended reason=$plan_reason"
+      if [ "$plan_can_run" != "true" ]; then
+        if [ "$plan_reason" = "wait-coverage-window" ] || [ "$plan_reason" = "already-ready" ]; then
+          echo "LLM Gateway shadow sample accumulator: planner says no more seed batches are needed now."
+          exit 0
+        fi
+        echo "ERROR: shadow sample planner blocked seeding: $plan_reason" >&2
+        exit 1
+      fi
+      case "$plan_recommended" in
+        ''|*[!0-9]*)
+          echo "ERROR: shadow sample planner returned invalid recommendedBatches: $plan_recommended" >&2
+          exit 1
+          ;;
+      esac
+      if [ "$batches" -gt "$plan_recommended" ]; then
+        echo "ERROR: requested batches=$batches exceeds planner recommendation=$plan_recommended; refusing to over-sample." >&2
+        echo "Set LLMGW_SHADOW_ACCUMULATE_BATCHES=$plan_recommended or rerun after a fresh coverage report." >&2
+        exit 1
+      fi
+    fi
   fi
 fi
 

--- a/scripts/llmgw-shadow-sample-plan.py
+++ b/scripts/llmgw-shadow-sample-plan.py
@@ -33,6 +33,26 @@ def _positive_int(value: str, name: str) -> int:
     return parsed
 
 
+def _coverage_failure_reason(message: str) -> str:
+    reason = message.strip()
+    separator_indexes = [reason.rfind(separator) for separator in (":", "：")]
+    label_separator_index = max(separator_indexes)
+    if label_separator_index >= 0:
+        candidate = reason[label_separator_index + 1:].strip()
+        if candidate:
+            reason = candidate
+    return reason
+
+
+def _is_benign_coverage_failure(message: str) -> bool:
+    benign_prefixes = (
+        "样本不足",
+        "覆盖时长不足",
+    )
+    reason = _coverage_failure_reason(message)
+    return any(reason.startswith(prefix) for prefix in benign_prefixes)
+
+
 def _cell_gap(cell: dict, batch_yield: int) -> dict:
     label = str(cell.get("label") or "")
     total = int(cell.get("total") or 0)
@@ -41,8 +61,10 @@ def _cell_gap(cell: dict, batch_yield: int) -> dict:
     http_fail = int(cell.get("httpFail") or 0)
     coverage_hours = float(cell.get("coverageHours") or 0)
     min_coverage_hours = float(cell.get("minCoverageHours") or 0)
+    failures = [str(item) for item in (cell.get("failures") or [])]
     missing = max(0, required - total)
     batches_needed = 0 if missing == 0 else (missing + max(1, batch_yield) - 1) // max(1, batch_yield)
+    coverage_read_ready = all(_is_benign_coverage_failure(item) for item in failures)
     return {
         "label": label,
         "total": total,
@@ -55,6 +77,8 @@ def _cell_gap(cell: dict, batch_yield: int) -> dict:
         "critical": critical,
         "httpFail": http_fail,
         "qualityReady": critical == 0 and http_fail == 0,
+        "coverageReadReady": coverage_read_ready,
+        "failures": failures,
     }
 
 
@@ -107,18 +131,25 @@ def _write_markdown(path: str, report: dict) -> None:
 
 def build_report(args: argparse.Namespace) -> dict:
     coverage = _load_json(args.coverage_json)
+    report_failures = [str(item) for item in (coverage.get("failures") or [])]
     cells = coverage.get("cells") or []
     if not isinstance(cells, list):
         raise SystemExit("coverage JSON field 'cells' must be a list")
 
     cell_reports = [_cell_gap(cell, args.batch_yield) for cell in cells if isinstance(cell, dict)]
     remaining_batches_needed = max((item["batchesNeeded"] for item in cell_reports), default=0)
+    report_read_ready = all(_is_benign_coverage_failure(item) for item in report_failures)
+    has_coverage_read_failure = not report_read_ready or not cell_reports or any(not item["coverageReadReady"] for item in cell_reports)
     has_quality_failure = any(not item["qualityReady"] for item in cell_reports)
     coverage_ready = all(item["coverageReady"] for item in cell_reports) if cell_reports else False
     samples_ready = remaining_batches_needed == 0
     recommended_batches = min(args.max_batches, remaining_batches_needed)
 
-    if has_quality_failure:
+    if has_coverage_read_failure:
+        reason = "coverage-read-failure"
+        can_run = False
+        recommended_batches = 0
+    elif has_quality_failure:
         reason = "quality-failure"
         can_run = False
     elif samples_ready and coverage_ready:
@@ -147,6 +178,7 @@ def build_report(args: argparse.Namespace) -> dict:
         "recommendedBatches": recommended_batches,
         "canRunRecommendedBatches": can_run,
         "reason": reason,
+        "coverageFailures": report_failures,
         "cells": cell_reports,
     }
 


### PR DESCRIPTION
## 摘要
为 LLM Gateway 生产 shadow 证据期补一层过量取证保护：累计补样脚本在执行前读取只读 planner 的推荐批次数，拒绝超过推荐值的 batch，避免火山/图片/视频/ASR 等模型在补证据时被重复消耗。

## 改动 diff
- `scripts/llmgw-shadow-sample-accumulate.sh`：preflight coverage 未达标时生成 `preflight-shadow-sample-plan.json/md`，读取 `recommendedBatches` 与 `canRunRecommendedBatches`，超过推荐批次即拒绝执行
- `scripts/llmgw-readiness-audit.py`：增加 shadow accumulator planner 约束静态检查
- `prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs`：增加 planner 约束守卫
- `doc/debt.llm-gateway.md`：记录补样预算守卫和后续操作边界
- `changelogs/2026-07-08_llmgw-shadow-sample-plan-gate.md`：新增 changelog 碎片

## 测试
- [x] `git diff --check`
- [x] `sh -n scripts/llmgw-shadow-sample-accumulate.sh`
- [x] `python3 -m py_compile scripts/llmgw-shadow-sample-plan.py scripts/llmgw-readiness-audit.py`
- [x] 伪造 coverage JSON 验证 planner 只缺 1 条时 `recommendedBatches=1`
- [x] `python3 scripts/llmgw-readiness-audit.py --json-out /tmp/llmgw-readiness-plan-gate.json --report-md /tmp/llmgw-readiness-plan-gate.md`
- [x] `dotnet test prd-api/tests/PrdAgent.Tests/PrdAgent.Tests.csproj --no-restore -m:1 --filter FullyQualifiedName~GatewayDataDomainGuardTests`
- [x] `cd prd-api && dotnet build --no-restore 2>&1 | grep -E "error CS|warning CS" | head -30`

## 发布说明
本 PR 不触发真实模型调用，不切 `LlmGateway__Mode=http`，只收紧后续补样时的预算 gate。