### PR TITLE
ops(llmgw): 增加发布状态板和 readiness 门禁

### DIFF
--- a/changelogs/2026-07-08_llmgw-readiness-scoped-coverage.md
+++ b/changelogs/2026-07-08_llmgw-readiness-scoped-coverage.md
@@ -1,0 +1,1 @@
+| ops | scripts | LLM Gateway readiness 静态审计新增 scoped shadow coverage 参数守卫，防止生产脚本缺少 `--skip-global-cells` 时误入 canary gate |

--- a/changelogs/2026-07-08_llmgw-rollout-status.md
+++ b/changelogs/2026-07-08_llmgw-rollout-status.md
@@ -1,1 +1,1 @@
-| ops | scripts | 新增 LLM Gateway 只读 rollout status 汇总脚本，统一输出 health、shadow coverage、planner 下一步和进度表，并纳入 readiness 静态守卫与自测 |
+| ops | scripts | 新增 LLM Gateway 只读 rollout status 汇总脚本，统一输出 health、shadow coverage、planner 下一步和进度表，并由 readiness 执行状态板自测 |

--- a/changelogs/2026-07-08_llmgw-rollout-status.md
+++ b/changelogs/2026-07-08_llmgw-rollout-status.md
@@ -1,1 +1,1 @@
-| ops | scripts | 新增 LLM Gateway 只读 rollout status 汇总脚本，统一输出 health、shadow coverage、planner 下一步和进度表，并由 readiness 执行多 cell 状态板自测 |
+| ops | scripts | 新增 LLM Gateway 只读 rollout status 汇总脚本，统一输出 health、shadow coverage、planner 下一步和进度表，并由 readiness 执行多 cell 与 health gate 状态板自测 |

--- a/changelogs/2026-07-08_llmgw-rollout-status.md
+++ b/changelogs/2026-07-08_llmgw-rollout-status.md
@@ -1,1 +1,1 @@
-| ops | scripts | 新增 LLM Gateway 只读 rollout status 汇总脚本，统一输出 health、shadow coverage、planner 下一步和进度表，并纳入 readiness 静态守卫 |
+| ops | scripts | 新增 LLM Gateway 只读 rollout status 汇总脚本，统一输出 health、shadow coverage、planner 下一步和进度表，并纳入 readiness 静态守卫与自测 |

--- a/changelogs/2026-07-08_llmgw-rollout-status.md
+++ b/changelogs/2026-07-08_llmgw-rollout-status.md
@@ -1,0 +1,1 @@
+| ops | scripts | 新增 LLM Gateway 只读 rollout status 汇总脚本，统一输出 health、shadow coverage、planner 下一步和进度表，并纳入 readiness 静态守卫 |

--- a/changelogs/2026-07-08_llmgw-rollout-status.md
+++ b/changelogs/2026-07-08_llmgw-rollout-status.md
@@ -1,1 +1,1 @@
-| ops | scripts | 新增 LLM Gateway 只读 rollout status 汇总脚本，统一输出 health、shadow coverage、planner 下一步和进度表，并由 readiness 执行状态板自测 |
+| ops | scripts | 新增 LLM Gateway 只读 rollout status 汇总脚本，统一输出 health、shadow coverage、planner 下一步和进度表，并由 readiness 执行多 cell 状态板自测 |

--- a/doc/debt.llm-gateway.md
+++ b/doc/debt.llm-gateway.md
@@ -378,6 +378,14 @@
 - 生产只读停补验证通过：显式设置 `LLMGW_SHADOW_ACCUMULATE_ALLOW_WINDOW_EXTENSION=1`、`BATCHES=1` 运行 accumulator，preflight coverage 后 planner 输出 `remainingBatchesNeeded=0`、`recommendedBatches=0`、`canRunRecommendedBatches=false`、`reason=wait-coverage-window`，脚本在 seed 前退出，没有触发模型请求。
 - 验证后正式 `/gw/v1/healthz` 仍返回 `2f6b0658397019e809f46ceb001245c6fdb03f40`，API 容器开关仍为 `Mode=shadow`、allowlist 空、采样 `1%`。下一次最早应在首样本时间约 24 小时后再显式开启 window extension，且只允许 planner 推荐的 1 个 batch。
 
+## 最新生产脚本漂移修复（2026-07-08 20:04 CST）
+
+- 继续执行只读 gate 时发现生产机 `scripts/llmgw-shadow-coverage-report.py` 仍是旧版本，缺少 scoped gate 必需的 `--skip-global-cells` 参数；首次命令只在 argparse 阶段失败，没有触发模型请求、没有改数据库、没有重启容器。
+- 已先备份旧脚本到 `/root/backups/llmgw-shadow-coverage-script-before-sync-20260708T200400+0800`，再从当前 `main` 精确同步 `scripts/llmgw-shadow-coverage-report.py`；同步后生产 sha256 为 `106e9551b4af8651fed5c951209a857c146efd95a4311229113058b8a13c6c2b`，`python3 -m py_compile` 通过，`--help` 已显示 `--skip-global-cells`。
+- 只读复核证据目录：生产 `/tmp/llmgw-shadow-plan-now-20260708T120423Z/`。`report-agent.generate::chat/send total=30/30`、`critical=0`、`httpFail=0`，但 `coverageHours=0.716 < 24`，coverage verdict 仍为 `fail`。
+- planner 复核输出 `reason=wait-coverage-window`、`recommendedBatches=0`、`canRunRecommendedBatches=false`。因此当前不能继续补 canary-intent 样本，也不能执行 `canary-intent-text` 灰度或全量 `LLMGW_MODE=http`。
+- 下一步最早在首个目标样本 `2026-07-08T10:56:23.927Z` 之后满 24 小时时间窗后执行：先只读 coverage + planner；只有 planner 返回 `window-extension-top-up` 且推荐 `1` 个 batch，才显式开启 `LLMGW_SHADOW_ACCUMULATE_ALLOW_WINDOW_EXTENSION=1` 做 1 条低成本延展样本。
+
 ## 已还的债务（归档）
 
 > 修复后从上面表格挪到这里，保留以便复盘

--- a/scripts/llmgw-readiness-audit.py
+++ b/scripts/llmgw-readiness-audit.py
@@ -141,6 +141,8 @@ def _static_checks() -> list[dict]:
     shadow_accumulate = shadow_accumulate_path.read_text(encoding="utf-8") if shadow_accumulate_path.exists() else ""
     shadow_sample_plan_path = ROOT / "scripts/llmgw-shadow-sample-plan.py"
     shadow_sample_plan = shadow_sample_plan_path.read_text(encoding="utf-8") if shadow_sample_plan_path.exists() else ""
+    rollout_status_path = ROOT / "scripts/llmgw-rollout-status.py"
+    rollout_status = rollout_status_path.read_text(encoding="utf-8") if rollout_status_path.exists() else ""
     ok, detail = _contains_all(
         release_gate,
         [
@@ -182,6 +184,24 @@ def _static_checks() -> list[dict]:
         ],
     )
     checks.append(_check("shadow_coverage_report_available", ok, detail))
+
+    ok, detail = _contains_all(
+        rollout_status,
+        [
+            "Read-only LLM Gateway rollout status board",
+            "llmgw-shadow-coverage-report.py",
+            "llmgw-shadow-sample-plan.py",
+            "--coverage-json",
+            "--allow-window-extension",
+            "wait-coverage-window",
+            "run-one-window-extension",
+            "shadow 样本数",
+            "shadow 质量",
+            "覆盖窗口",
+            "全量 HTTP 发布",
+        ],
+    )
+    checks.append(_check("rollout_status_board_available", ok, detail))
 
     ok, detail = _contains_all(
         shadow_accumulate + "\n" + shadow_sample_plan,

--- a/scripts/llmgw-readiness-audit.py
+++ b/scripts/llmgw-readiness-audit.py
@@ -168,6 +168,7 @@ def _static_checks() -> list[dict]:
             "--kind",
             "--require-kind",
             "--require-app-kind",
+            "--skip-global-cells",
             "--min-per-cell",
             "--min-coverage-hours",
             "--release-commit",

--- a/scripts/llmgw-readiness-audit.py
+++ b/scripts/llmgw-readiness-audit.py
@@ -1399,6 +1399,16 @@ def _provider_audit_self_test() -> dict:
     return {"name": "provider_audit_external_blocker_self_test", "ok": ok, "detail": detail, "command": result}
 
 
+def _rollout_status_self_test() -> dict:
+    result = _run(
+        ["python3", "scripts/llmgw-rollout-status.py", "--self-test"],
+        timeout=60,
+    )
+    detail = (result["stdout"] + result["stderr"]).strip()
+    ok = result["ok"] and "LLM Gateway rollout status self-test: PASS" in detail
+    return {"name": "rollout_status_board_self_test", "ok": ok, "detail": detail, "command": result}
+
+
 def _dotnet_checks() -> list[dict]:
     checks: list[dict] = []
     tests = [
@@ -1803,6 +1813,7 @@ def main() -> int:
     checks.append(_restore_shadow_dry_run())
     checks.append(_restore_shadow_persist_env_test())
     checks.append(_provider_audit_self_test())
+    checks.append(_rollout_status_self_test())
     if args.run_dotnet:
         checks.extend(_dotnet_checks())
     if args.run_smoke:

--- a/scripts/llmgw-readiness-audit.py
+++ b/scripts/llmgw-readiness-audit.py
@@ -196,6 +196,8 @@ def _static_checks() -> list[dict]:
             "--self-test",
             "wait-coverage-window",
             "run-one-window-extension",
+            "cellSummary",
+            "multi-cell sample progress",
             "shadow 样本数",
             "shadow 质量",
             "覆盖窗口",

--- a/scripts/llmgw-readiness-audit.py
+++ b/scripts/llmgw-readiness-audit.py
@@ -193,6 +193,7 @@ def _static_checks() -> list[dict]:
             "llmgw-shadow-sample-plan.py",
             "--coverage-json",
             "--allow-window-extension",
+            "--self-test",
             "wait-coverage-window",
             "run-one-window-extension",
             "shadow 样本数",

--- a/scripts/llmgw-rollout-status.py
+++ b/scripts/llmgw-rollout-status.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Read-only LLM Gateway rollout status board.
+
+This helper composes existing read-only evidence tools:
+  - /gw/v1/healthz
+  - scripts/llmgw-shadow-coverage-report.py
+  - scripts/llmgw-shadow-sample-plan.py
+
+It never calls MAP seed endpoints and never calls model providers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _normalize_commit(value: object) -> str:
+    raw = str(value or "").strip()
+    if raw.lower().startswith("sha-"):
+        raw = raw[4:]
+    return raw.lower()
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data, dict):
+        raise SystemExit(f"JSON root must be an object: {path}")
+    return data
+
+
+def _write_json(path: str, payload: dict[str, Any]) -> None:
+    if not path:
+        return
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _request_json(url: str) -> dict[str, Any]:
+    req = urllib.request.Request(url, method="GET")
+    req.add_header("User-Agent", "Mozilla/5.0 llmgw-rollout-status/1.0")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            raw = resp.read().decode("utf-8", "replace")
+            return {"ok": resp.status == 200, "httpStatus": resp.status, "json": json.loads(raw), "raw": raw[:500]}
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8", "replace")
+        return {"ok": False, "httpStatus": exc.code, "json": {}, "raw": raw[:500]}
+    except Exception as exc:
+        return {"ok": False, "httpStatus": 0, "json": {}, "raw": str(exc)}
+
+
+def _run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=str(ROOT),
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=120,
+    )
+
+
+def _coverage_from_tool(args: argparse.Namespace, release_commit: str, tmp: Path) -> tuple[dict[str, Any], Path]:
+    coverage_path = tmp / "coverage.json"
+    cmd = [
+        "python3",
+        "scripts/llmgw-shadow-coverage-report.py",
+        "--base",
+        args.base,
+        "--key",
+        args.key,
+        "--since-hours",
+        str(args.since_hours),
+        "--min-coverage-hours",
+        str(args.min_coverage_hours),
+        "--failure-sample-limit",
+        str(args.failure_sample_limit),
+        "--json-out",
+        str(coverage_path),
+    ]
+    if release_commit:
+        cmd.extend(["--release-commit", release_commit])
+    if args.skip_global_cells:
+        cmd.append("--skip-global-cells")
+    for item in args.require_app_kind:
+        cmd.extend(["--require-app-kind", item])
+    for item in args.require_kind:
+        cmd.extend(["--require-kind", item])
+
+    proc = _run(cmd)
+    if not coverage_path.exists():
+        raise SystemExit(
+            "coverage report did not write JSON\n"
+            + proc.stdout[-2000:]
+            + proc.stderr[-2000:]
+        )
+    return _read_json(coverage_path), coverage_path
+
+
+def _plan_from_tool(args: argparse.Namespace, coverage_path: Path, tmp: Path) -> tuple[dict[str, Any], Path]:
+    plan_path = tmp / "plan.json"
+    cmd = [
+        "python3",
+        "scripts/llmgw-shadow-sample-plan.py",
+        "--coverage-json",
+        str(coverage_path),
+        "--batch-yield",
+        str(args.batch_yield),
+        "--max-batches",
+        str(args.max_batches),
+        "--json-out",
+        str(plan_path),
+    ]
+    if args.allow_window_extension:
+        cmd.append("--allow-window-extension")
+
+    proc = _run(cmd)
+    if not plan_path.exists():
+        raise SystemExit(
+            "sample planner did not write JSON\n"
+            + proc.stdout[-2000:]
+            + proc.stderr[-2000:]
+        )
+    return _read_json(plan_path), plan_path
+
+
+def _pct(done: float, total: float) -> int:
+    if total <= 0:
+        return 100 if done > 0 else 0
+    return max(0, min(100, round(done * 100 / total)))
+
+
+def _first_cell(coverage: dict[str, Any]) -> dict[str, Any]:
+    cells = coverage.get("cells") or []
+    return cells[0] if cells and isinstance(cells[0], dict) else {}
+
+
+def _item(name: str, progress: int, status: str, detail: str) -> dict[str, Any]:
+    return {"name": name, "progress": progress, "status": status, "detail": detail}
+
+
+def _decision(plan: dict[str, Any], cell: dict[str, Any]) -> tuple[str, str]:
+    reason = str(plan.get("reason") or "")
+    recommended = int(plan.get("recommendedBatches") or 0)
+    can_run = bool(plan.get("canRunRecommendedBatches"))
+    if reason == "already-ready":
+        return "ready-for-release-gate", "样本、质量、覆盖窗口均已达标；下一步跑 release gate 和阶段 dry-run。"
+    if reason == "window-extension-top-up" and can_run and recommended == 1:
+        return "run-one-window-extension", "允许补 1 条低成本窗口延展样本，之后再跑 release gate。"
+    if reason == "bounded-top-up" and can_run and recommended > 0:
+        return "run-bounded-top-up", f"允许按 planner 推荐补样，最多 {recommended} batch。"
+    if reason == "wait-coverage-window":
+        return "wait-coverage-window", "样本和质量已满足或无需补样；当前只等待覆盖窗口，不应继续 seed。"
+    if reason == "quality-failure":
+        return "stop-quality-failure", "存在 critical/httpFail，必须先归因修复，不得补样或灰度。"
+    if reason == "coverage-read-failure":
+        return "stop-coverage-read-failure", "coverage 读取或失败类型不可信，必须先修证据链。"
+    return reason or "unknown", f"planner reason={reason or 'unknown'} recommendedBatches={recommended}"
+
+
+def build_status(args: argparse.Namespace) -> dict[str, Any]:
+    tmp = Path(tempfile.mkdtemp(prefix="llmgw-rollout-status-"))
+    generated_at = datetime.now(timezone.utc).isoformat()
+
+    health: dict[str, Any] = {"ok": False, "httpStatus": 0, "json": {}, "raw": "not requested", "skipped": args.skip_health}
+    release_commit = _normalize_commit(args.release_commit)
+    if args.base and not args.skip_health:
+        health = _request_json(args.base.rstrip("/") + "/healthz")
+        health_commit = _normalize_commit((health.get("json") or {}).get("commit"))
+        if not release_commit:
+            release_commit = health_commit
+
+    if args.coverage_json:
+        coverage_path = Path(args.coverage_json)
+        coverage = _read_json(coverage_path)
+    else:
+        if not args.base or not args.key:
+            raise SystemExit("missing --base/--key when --coverage-json is not provided")
+        coverage, coverage_path = _coverage_from_tool(args, release_commit, tmp)
+
+    plan, plan_path = _plan_from_tool(args, coverage_path, tmp)
+    cell = _first_cell(coverage)
+    total = int(cell.get("total") or 0)
+    required = int(cell.get("requiredTotal") or 0)
+    critical = int(cell.get("critical") or 0)
+    http_fail = int(cell.get("httpFail") or 0)
+    coverage_hours = float(cell.get("coverageHours") or 0)
+    min_coverage_hours = float(cell.get("minCoverageHours") or 0)
+    action, action_detail = _decision(plan, cell)
+
+    health_commit = _normalize_commit((health.get("json") or {}).get("commit"))
+    health_ok = bool(health.get("skipped")) or (
+        bool(health.get("ok")) and (not release_commit or not health_commit or health_commit == release_commit)
+    )
+    samples_ok = required > 0 and total >= required
+    quality_ok = critical == 0 and http_fail == 0
+    coverage_ok = min_coverage_hours > 0 and coverage_hours >= min_coverage_hours
+
+    items = [
+        _item(
+            "生产 healthz",
+            100 if health_ok else 0,
+            "skipped" if health.get("skipped") else ("pass" if health_ok else "fail"),
+            "离线输入 coverage JSON，未请求 healthz。"
+            if health.get("skipped")
+            else f"http={health.get('httpStatus')} commit={health_commit or '<unknown>'} expected={release_commit or '<unset>'}",
+        ),
+        _item(
+            "shadow 样本数",
+            _pct(total, required),
+            "pass" if samples_ok else "pending",
+            f"{cell.get('label') or '<no-cell>'} total={total}/{required}",
+        ),
+        _item(
+            "shadow 质量",
+            100 if quality_ok else 0,
+            "pass" if quality_ok else "fail",
+            f"critical={critical} httpFail={http_fail}",
+        ),
+        _item(
+            "覆盖窗口",
+            _pct(coverage_hours, min_coverage_hours),
+            "pass" if coverage_ok else "pending",
+            f"coverageHours={coverage_hours:.3f}/{min_coverage_hours:g}",
+        ),
+        _item(
+            "planner 下一步",
+            100 if action in {"ready-for-release-gate", "run-one-window-extension", "run-bounded-top-up"} else 0,
+            action,
+            action_detail,
+        ),
+        _item(
+            "全量 HTTP 发布",
+            100 if action == "ready-for-release-gate" and coverage_ok else 0,
+            "not-ready" if action != "ready-for-release-gate" else "gate-ready",
+            "未完成全量迁移前不得切 LLMGW_MODE=http。",
+        ),
+    ]
+
+    return {
+        "generatedAt": generated_at,
+        "base": args.base,
+        "releaseCommit": release_commit,
+        "coverageJson": str(coverage_path),
+        "planJson": str(plan_path),
+        "coverageVerdict": coverage.get("verdict"),
+        "plannerReason": plan.get("reason"),
+        "recommendedBatches": plan.get("recommendedBatches"),
+        "canRunRecommendedBatches": plan.get("canRunRecommendedBatches"),
+        "action": action,
+        "actionDetail": action_detail,
+        "health": {
+            "ok": health_ok,
+            "httpStatus": health.get("httpStatus"),
+            "commit": health_commit,
+        },
+        "primaryCell": cell,
+        "items": items,
+    }
+
+
+def _write_markdown(path: str, report: dict[str, Any]) -> None:
+    if not path:
+        return
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    def cell(value: object) -> str:
+        return str(value).replace("|", "\\|")
+
+    lines = [
+        "# LLM Gateway Rollout Status",
+        "",
+        f"- generatedAt: `{cell(report.get('generatedAt'))}`",
+        f"- releaseCommit: `{cell(report.get('releaseCommit'))}`",
+        f"- action: `{cell(report.get('action'))}`",
+        f"- actionDetail: {cell(report.get('actionDetail'))}",
+        "",
+        "| item | progress | status | detail |",
+        "|---|---:|---|---|",
+    ]
+    for item in report["items"]:
+        lines.append(
+            f"| {cell(item['name'])} | {item['progress']}% | {cell(item['status'])} | {cell(item['detail'])} |"
+        )
+    out.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _print_table(report: dict[str, Any]) -> None:
+    print("LLM Gateway rollout status")
+    print(f"- releaseCommit={report.get('releaseCommit') or ''}")
+    print(f"- action={report.get('action')}")
+    print("")
+    print("| item | progress | status | detail |")
+    print("|---|---:|---|---|")
+    for item in report["items"]:
+        print(f"| {item['name']} | {item['progress']}% | {item['status']} | {item['detail']} |")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Read-only LLM Gateway rollout status board")
+    parser.add_argument("--base", default=os.environ.get("LLMGW_STATUS_BASE", os.environ.get("GW_BASE", "")).strip().rstrip("/"))
+    parser.add_argument("--key", default=os.environ.get("LLMGW_STATUS_KEY", os.environ.get("GW_KEY", "")).strip())
+    parser.add_argument("--release-commit", default=os.environ.get("LLMGW_STATUS_RELEASE_COMMIT", "").strip())
+    parser.add_argument("--coverage-json", default="")
+    parser.add_argument("--require-app-kind", action="append", default=["report-agent.generate::chat:send:30"])
+    parser.add_argument("--require-kind", action="append", default=[])
+    parser.add_argument("--since-hours", type=float, default=float(os.environ.get("LLMGW_STATUS_SINCE_HOURS", "48")))
+    parser.add_argument("--min-coverage-hours", type=float, default=float(os.environ.get("LLMGW_STATUS_MIN_COVERAGE_HOURS", "24")))
+    parser.add_argument("--failure-sample-limit", type=int, default=3)
+    parser.add_argument("--batch-yield", type=int, default=1)
+    parser.add_argument("--max-batches", type=int, default=1)
+    parser.add_argument("--allow-window-extension", action="store_true")
+    parser.add_argument("--skip-global-cells", action="store_true", default=True)
+    parser.add_argument("--include-global-cells", action="store_false", dest="skip_global_cells")
+    parser.add_argument("--skip-health", action="store_true")
+    parser.add_argument("--json-out", default="")
+    parser.add_argument("--report-md", default="")
+    parser.add_argument("--print-json", action="store_true")
+    args = parser.parse_args()
+
+    report = build_status(args)
+    _write_json(args.json_out, report)
+    _write_markdown(args.report_md, report)
+    if args.print_json:
+        print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        _print_table(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/llmgw-rollout-status.py
+++ b/scripts/llmgw-rollout-status.py
@@ -284,6 +284,12 @@ def build_status(args: argparse.Namespace) -> dict[str, Any]:
     health_ok = bool(health.get("skipped")) or (
         bool(health.get("ok")) and (not release_commit or not health_commit or health_commit == release_commit)
     )
+    release_ready = bool(health_ok and cell_summary["coverageOk"] and action == "ready-for-release-gate")
+    release_detail = (
+        "health、shadow coverage、planner 均已满足；仍需人工确认全迁移完成后才能切 LLMGW_MODE=http。"
+        if release_ready
+        else "未完成全量迁移前不得切 LLMGW_MODE=http。"
+    )
     items = [
         _item(
             "生产 healthz",
@@ -319,9 +325,9 @@ def build_status(args: argparse.Namespace) -> dict[str, Any]:
         ),
         _item(
             "全量 HTTP 发布",
-            100 if action == "ready-for-release-gate" and cell_summary["coverageOk"] else 0,
-            "not-ready" if action != "ready-for-release-gate" else "gate-ready",
-            "未完成全量迁移前不得切 LLMGW_MODE=http。",
+            100 if release_ready else 0,
+            "gate-ready" if release_ready else "not-ready",
+            release_detail,
         ),
     ]
 
@@ -408,6 +414,16 @@ def _fake_coverage(first_compared_at: str) -> dict[str, Any]:
             }
         ],
     }
+
+
+def _fake_ready_coverage() -> dict[str, Any]:
+    coverage = _fake_coverage("2026-01-01T00:00:00+00:00")
+    coverage["verdict"] = "pass"
+    coverage["failures"] = []
+    cell = coverage["cells"][0]
+    cell["coverageHours"] = 24
+    cell["failures"] = []
+    return coverage
 
 
 def _self_test() -> int:
@@ -507,6 +523,40 @@ def _self_test() -> int:
         raise AssertionError(f"multi-cell sample progress must use worst cell: {report['cellSummary']}")
     if "1/2 cells pass" not in str(report["cellSummary"]["sampleDetail"]):
         raise AssertionError(f"multi-cell sample detail must include pass count: {report['cellSummary']}")
+
+    health_fail_coverage_path = tmp / "health-fail-ready.coverage.json"
+    health_fail_coverage_path.write_text(
+        json.dumps(_fake_ready_coverage(), ensure_ascii=False),
+        encoding="utf-8",
+    )
+    args = argparse.Namespace(
+        base="http://127.0.0.1:1",
+        key="",
+        release_commit="abc123",
+        coverage_json=str(health_fail_coverage_path),
+        require_app_kind=DEFAULT_REQUIRE_APP_KIND,
+        require_kind=[],
+        since_hours=48.0,
+        min_coverage_hours=24.0,
+        failure_sample_limit=0,
+        batch_yield=1,
+        max_batches=1,
+        allow_window_extension=True,
+        skip_global_cells=True,
+        skip_health=False,
+        json_out="",
+        report_md="",
+        print_json=False,
+        self_test=False,
+    )
+    report = build_status(args)
+    release_item = next(item for item in report["items"] if item["name"] == "全量 HTTP 发布")
+    if report["action"] != "ready-for-release-gate":
+        raise AssertionError(f"health-fail case must keep planner ready: {report['action']}")
+    if report["health"]["ok"]:
+        raise AssertionError(f"health-fail case must record health failure: {report['health']}")
+    if release_item["status"] != "not-ready" or release_item["progress"] != 0:
+        raise AssertionError(f"health failure must block release gate-ready status: {release_item}")
     print("LLM Gateway rollout status self-test: PASS")
     return 0
 

--- a/scripts/llmgw-rollout-status.py
+++ b/scripts/llmgw-rollout-status.py
@@ -146,16 +146,97 @@ def _pct(done: float, total: float) -> int:
     return max(0, min(100, round(done * 100 / total)))
 
 
-def _first_cell(coverage: dict[str, Any]) -> dict[str, Any]:
+def _coverage_cells(coverage: dict[str, Any]) -> list[dict[str, Any]]:
     cells = coverage.get("cells") or []
-    return cells[0] if cells and isinstance(cells[0], dict) else {}
+    return [item for item in cells if isinstance(item, dict)]
 
 
 def _item(name: str, progress: int, status: str, detail: str) -> dict[str, Any]:
     return {"name": name, "progress": progress, "status": status, "detail": detail}
 
 
-def _decision(plan: dict[str, Any], cell: dict[str, Any]) -> tuple[str, str]:
+def _cell_summary(cells: list[dict[str, Any]]) -> dict[str, Any]:
+    if not cells:
+        return {
+            "count": 0,
+            "samplePass": 0,
+            "qualityPass": 0,
+            "coveragePass": 0,
+            "sampleProgress": 0,
+            "coverageProgress": 0,
+            "critical": 0,
+            "httpFail": 0,
+            "sampleDetail": "cells=0",
+            "qualityDetail": "cells=0 critical=0 httpFail=0",
+            "coverageDetail": "cells=0",
+            "samplesOk": False,
+            "qualityOk": False,
+            "coverageOk": False,
+        }
+
+    sample_progress_values: list[int] = []
+    coverage_progress_values: list[int] = []
+    sample_pass = 0
+    coverage_pass = 0
+    quality_pass = 0
+    critical_total = 0
+    http_fail_total = 0
+    sample_worst: dict[str, Any] | None = None
+    coverage_worst: dict[str, Any] | None = None
+
+    for cell in cells:
+        total = int(cell.get("total") or 0)
+        required = int(cell.get("requiredTotal") or 0)
+        critical = int(cell.get("critical") or 0)
+        http_fail = int(cell.get("httpFail") or 0)
+        coverage_hours = float(cell.get("coverageHours") or 0)
+        min_coverage_hours = float(cell.get("minCoverageHours") or 0)
+        sample_progress = _pct(total, required)
+        coverage_progress = _pct(coverage_hours, min_coverage_hours)
+        sample_progress_values.append(sample_progress)
+        coverage_progress_values.append(coverage_progress)
+        critical_total += critical
+        http_fail_total += http_fail
+        if required > 0 and total >= required:
+            sample_pass += 1
+        if min_coverage_hours > 0 and coverage_hours >= min_coverage_hours:
+            coverage_pass += 1
+        if critical == 0 and http_fail == 0:
+            quality_pass += 1
+        if sample_worst is None or sample_progress < int(sample_worst["progress"]):
+            sample_worst = {"progress": sample_progress, "cell": cell}
+        if coverage_worst is None or coverage_progress < int(coverage_worst["progress"]):
+            coverage_worst = {"progress": coverage_progress, "cell": cell}
+
+    count = len(cells)
+    sample_worst_cell = (sample_worst or {}).get("cell") or {}
+    coverage_worst_cell = (coverage_worst or {}).get("cell") or {}
+    return {
+        "count": count,
+        "samplePass": sample_pass,
+        "qualityPass": quality_pass,
+        "coveragePass": coverage_pass,
+        "sampleProgress": min(sample_progress_values) if sample_progress_values else 0,
+        "coverageProgress": min(coverage_progress_values) if coverage_progress_values else 0,
+        "critical": critical_total,
+        "httpFail": http_fail_total,
+        "sampleDetail": (
+            f"{sample_pass}/{count} cells pass; worst={sample_worst_cell.get('label') or '<unknown>'} "
+            f"total={int(sample_worst_cell.get('total') or 0)}/{int(sample_worst_cell.get('requiredTotal') or 0)}"
+        ),
+        "qualityDetail": f"{quality_pass}/{count} cells pass; critical={critical_total} httpFail={http_fail_total}",
+        "coverageDetail": (
+            f"{coverage_pass}/{count} cells pass; worst={coverage_worst_cell.get('label') or '<unknown>'} "
+            f"coverageHours={float(coverage_worst_cell.get('coverageHours') or 0):.3f}/"
+            f"{float(coverage_worst_cell.get('minCoverageHours') or 0):g}"
+        ),
+        "samplesOk": sample_pass == count,
+        "qualityOk": quality_pass == count,
+        "coverageOk": coverage_pass == count,
+    }
+
+
+def _decision(plan: dict[str, Any]) -> tuple[str, str]:
     reason = str(plan.get("reason") or "")
     recommended = int(plan.get("recommendedBatches") or 0)
     can_run = bool(plan.get("canRunRecommendedBatches"))
@@ -195,23 +276,14 @@ def build_status(args: argparse.Namespace) -> dict[str, Any]:
         coverage, coverage_path = _coverage_from_tool(args, release_commit, tmp)
 
     plan, plan_path = _plan_from_tool(args, coverage_path, tmp)
-    cell = _first_cell(coverage)
-    total = int(cell.get("total") or 0)
-    required = int(cell.get("requiredTotal") or 0)
-    critical = int(cell.get("critical") or 0)
-    http_fail = int(cell.get("httpFail") or 0)
-    coverage_hours = float(cell.get("coverageHours") or 0)
-    min_coverage_hours = float(cell.get("minCoverageHours") or 0)
-    action, action_detail = _decision(plan, cell)
+    cells = _coverage_cells(coverage)
+    cell_summary = _cell_summary(cells)
+    action, action_detail = _decision(plan)
 
     health_commit = _normalize_commit((health.get("json") or {}).get("commit"))
     health_ok = bool(health.get("skipped")) or (
         bool(health.get("ok")) and (not release_commit or not health_commit or health_commit == release_commit)
     )
-    samples_ok = required > 0 and total >= required
-    quality_ok = critical == 0 and http_fail == 0
-    coverage_ok = min_coverage_hours > 0 and coverage_hours >= min_coverage_hours
-
     items = [
         _item(
             "生产 healthz",
@@ -223,21 +295,21 @@ def build_status(args: argparse.Namespace) -> dict[str, Any]:
         ),
         _item(
             "shadow 样本数",
-            _pct(total, required),
-            "pass" if samples_ok else "pending",
-            f"{cell.get('label') or '<no-cell>'} total={total}/{required}",
+            int(cell_summary["sampleProgress"]),
+            "pass" if cell_summary["samplesOk"] else "pending",
+            str(cell_summary["sampleDetail"]),
         ),
         _item(
             "shadow 质量",
-            100 if quality_ok else 0,
-            "pass" if quality_ok else "fail",
-            f"critical={critical} httpFail={http_fail}",
+            100 if cell_summary["qualityOk"] else 0,
+            "pass" if cell_summary["qualityOk"] else "fail",
+            str(cell_summary["qualityDetail"]),
         ),
         _item(
             "覆盖窗口",
-            _pct(coverage_hours, min_coverage_hours),
-            "pass" if coverage_ok else "pending",
-            f"coverageHours={coverage_hours:.3f}/{min_coverage_hours:g}",
+            int(cell_summary["coverageProgress"]),
+            "pass" if cell_summary["coverageOk"] else "pending",
+            str(cell_summary["coverageDetail"]),
         ),
         _item(
             "planner 下一步",
@@ -247,7 +319,7 @@ def build_status(args: argparse.Namespace) -> dict[str, Any]:
         ),
         _item(
             "全量 HTTP 发布",
-            100 if action == "ready-for-release-gate" and coverage_ok else 0,
+            100 if action == "ready-for-release-gate" and cell_summary["coverageOk"] else 0,
             "not-ready" if action != "ready-for-release-gate" else "gate-ready",
             "未完成全量迁移前不得切 LLMGW_MODE=http。",
         ),
@@ -270,7 +342,8 @@ def build_status(args: argparse.Namespace) -> dict[str, Any]:
             "httpStatus": health.get("httpStatus"),
             "commit": health_commit,
         },
-        "primaryCell": cell,
+        "primaryCell": cells[0] if cells else {},
+        "cellSummary": cell_summary,
         "items": items,
     }
 
@@ -387,6 +460,53 @@ def _self_test() -> int:
         "run-one-window-extension",
         1,
     )
+
+    multi_coverage_path = tmp / "multi-cell.coverage.json"
+    multi_coverage = _fake_coverage("2026-01-01T00:00:00+00:00")
+    multi_coverage["failures"] = ["样本不足 total=3, required=6"]
+    multi_coverage["cells"].append({
+        "label": "custom.app::chat/send",
+        "appCallerCode": "custom.app::chat",
+        "kind": "send",
+        "requiredTotal": 6,
+        "total": 3,
+        "critical": 0,
+        "httpFail": 0,
+        "coverageHours": 0.1,
+        "minCoverageHours": 24,
+        "firstComparedAt": "2026-01-01T00:00:00+00:00",
+        "lastComparedAt": "2026-01-01T00:06:00+00:00",
+        "failures": ["样本不足 total=3, required=6", "覆盖时长不足 coverageHours=0.1, required=24"],
+    })
+    multi_coverage_path.write_text(
+        json.dumps(multi_coverage, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    args = argparse.Namespace(
+        base="",
+        key="",
+        release_commit="abc123",
+        coverage_json=str(multi_coverage_path),
+        require_app_kind=DEFAULT_REQUIRE_APP_KIND,
+        require_kind=[],
+        since_hours=48.0,
+        min_coverage_hours=24.0,
+        failure_sample_limit=0,
+        batch_yield=1,
+        max_batches=1,
+        allow_window_extension=True,
+        skip_global_cells=True,
+        skip_health=True,
+        json_out="",
+        report_md="",
+        print_json=False,
+        self_test=False,
+    )
+    report = build_status(args)
+    if int(report["cellSummary"]["sampleProgress"]) != 50:
+        raise AssertionError(f"multi-cell sample progress must use worst cell: {report['cellSummary']}")
+    if "1/2 cells pass" not in str(report["cellSummary"]["sampleDetail"]):
+        raise AssertionError(f"multi-cell sample detail must include pass count: {report['cellSummary']}")
     print("LLM Gateway rollout status self-test: PASS")
     return 0
 

--- a/scripts/llmgw-rollout-status.py
+++ b/scripts/llmgw-rollout-status.py
@@ -25,6 +25,7 @@ from typing import Any
 
 
 ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_REQUIRE_APP_KIND = ["report-agent.generate::chat:send:30"]
 
 
 def _normalize_commit(value: object) -> str:
@@ -312,13 +313,91 @@ def _print_table(report: dict[str, Any]) -> None:
         print(f"| {item['name']} | {item['progress']}% | {item['status']} | {item['detail']} |")
 
 
+def _fake_coverage(first_compared_at: str) -> dict[str, Any]:
+    return {
+        "verdict": "fail",
+        "releaseCommit": "abc123",
+        "failures": ["覆盖时长不足 coverageHours=0.72, required=24"],
+        "cells": [
+            {
+                "label": "report-agent.generate::chat/send",
+                "appCallerCode": "report-agent.generate::chat",
+                "kind": "send",
+                "requiredTotal": 30,
+                "total": 30,
+                "critical": 0,
+                "httpFail": 0,
+                "coverageHours": 0.72,
+                "minCoverageHours": 24,
+                "firstComparedAt": first_compared_at,
+                "lastComparedAt": "2026-01-01T00:43:00+00:00",
+                "failures": ["覆盖时长不足 coverageHours=0.72, required=24"],
+            }
+        ],
+    }
+
+
+def _self_test() -> int:
+    tmp = Path(tempfile.mkdtemp(prefix="llmgw-rollout-status-self-test-"))
+
+    def run_case(name: str, first_compared_at: str, expected_action: str, expected_batches: int) -> None:
+        coverage_path = tmp / f"{name}.coverage.json"
+        coverage_path.write_text(
+            json.dumps(_fake_coverage(first_compared_at), ensure_ascii=False),
+            encoding="utf-8",
+        )
+        args = argparse.Namespace(
+            base="",
+            key="",
+            release_commit="abc123",
+            coverage_json=str(coverage_path),
+            require_app_kind=DEFAULT_REQUIRE_APP_KIND,
+            require_kind=[],
+            since_hours=48.0,
+            min_coverage_hours=24.0,
+            failure_sample_limit=0,
+            batch_yield=1,
+            max_batches=1,
+            allow_window_extension=True,
+            skip_global_cells=True,
+            skip_health=True,
+            json_out="",
+            report_md="",
+            print_json=False,
+            self_test=False,
+        )
+        report = build_status(args)
+        action = str(report.get("action") or "")
+        batches = int(report.get("recommendedBatches") or 0)
+        if action != expected_action or batches != expected_batches:
+            raise AssertionError(
+                f"{name}: action={action} batches={batches}, "
+                f"expected action={expected_action} batches={expected_batches}"
+            )
+
+    run_case(
+        "wait-window",
+        "2099-01-01T00:00:00+00:00",
+        "wait-coverage-window",
+        0,
+    )
+    run_case(
+        "extend-window",
+        "2026-01-01T00:00:00+00:00",
+        "run-one-window-extension",
+        1,
+    )
+    print("LLM Gateway rollout status self-test: PASS")
+    return 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Read-only LLM Gateway rollout status board")
     parser.add_argument("--base", default=os.environ.get("LLMGW_STATUS_BASE", os.environ.get("GW_BASE", "")).strip().rstrip("/"))
     parser.add_argument("--key", default=os.environ.get("LLMGW_STATUS_KEY", os.environ.get("GW_KEY", "")).strip())
     parser.add_argument("--release-commit", default=os.environ.get("LLMGW_STATUS_RELEASE_COMMIT", "").strip())
     parser.add_argument("--coverage-json", default="")
-    parser.add_argument("--require-app-kind", action="append", default=["report-agent.generate::chat:send:30"])
+    parser.add_argument("--require-app-kind", action="append", default=[])
     parser.add_argument("--require-kind", action="append", default=[])
     parser.add_argument("--since-hours", type=float, default=float(os.environ.get("LLMGW_STATUS_SINCE_HOURS", "48")))
     parser.add_argument("--min-coverage-hours", type=float, default=float(os.environ.get("LLMGW_STATUS_MIN_COVERAGE_HOURS", "24")))
@@ -332,7 +411,13 @@ def main() -> int:
     parser.add_argument("--json-out", default="")
     parser.add_argument("--report-md", default="")
     parser.add_argument("--print-json", action="store_true")
+    parser.add_argument("--self-test", action="store_true")
     args = parser.parse_args()
+
+    if args.self_test:
+        return _self_test()
+    if not args.require_app_kind:
+        args.require_app_kind = list(DEFAULT_REQUIRE_APP_KIND)
 
     report = build_status(args)
     _write_json(args.json_out, report)


### PR DESCRIPTION
## 摘要
补齐 LLM Gateway 全量迁移发布前的只读状态板和 readiness 自检，避免在 shadow 覆盖窗口未达标时误推进 http 灰度。该 PR 不切换生产模式，不触发模型请求。

## 改动 diff
- `scripts/llmgw-rollout-status.py`：新增只读 rollout 状态板，汇总 health、shadow coverage、planner 下一步和全量 HTTP 发布状态。
- `scripts/llmgw-readiness-audit.py`：把状态板自测和 scoped coverage 参数支持纳入 readiness 门禁。
- `doc/debt.llm-gateway.md`：记录生产脚本漂移修复和当前覆盖窗口等待状态。
- `changelogs/2026-07-08_llmgw-readiness-scoped-coverage.md`、`changelogs/2026-07-08_llmgw-rollout-status.md`：新增更新碎片。

## 测试
- [x] `python3 -m py_compile scripts/llmgw-rollout-status.py scripts/llmgw-readiness-audit.py` 通过
- [x] `scripts/llmgw-rollout-status.py --self-test` 通过
- [x] `python3 scripts/llmgw-readiness-audit.py --json-out /tmp/llmgw-readiness-current.json --report-md /tmp/llmgw-readiness-current.md --print-json` 通过
- [x] GitHub Actions `Branch Image` success

## 发布说明
- 当前生产仍保持 `LlmGateway__Mode=shadow`，allowlist 为空。
- shadow 样本数已够，但 24h 覆盖窗口未达标前不得执行 http 灰度。
- 不新增视频、图片、ASR 测试请求，避免 provider 费用重复消耗。