### PR TITLE
test(llmgw): 增加完成态审计回归

### DIFF
--- a/changelogs/2026-07-08_llmgw-completion-audit.md
+++ b/changelogs/2026-07-08_llmgw-completion-audit.md
@@ -1,0 +1,1 @@
+| test | prd-api | 增加 LLM Gateway readiness 完成态回归测试，确保没有 http-full rollout 台账时不能误报全量迁移完成 |

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -820,6 +820,58 @@ public class GatewayDataDomainGuardTests
     }
 
     [Fact]
+    public void ReadinessAudit_RequireRolloutCompleteFailsWithoutHttpFullLedger()
+    {
+        var root = LocateRepoRoot();
+        var tempDir = Path.Combine(Path.GetTempPath(), "llmgw-readiness-completion-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var commit = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+            var ledger = Path.Combine(tempDir, "rollout-ledger.jsonl");
+            File.WriteAllText(ledger, string.Empty);
+
+            using var process = Process.Start(new ProcessStartInfo
+            {
+                FileName = "python3",
+                WorkingDirectory = root,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                ArgumentList =
+                {
+                    "scripts/llmgw-readiness-audit.py",
+                    "--expect-commit",
+                    commit,
+                    "--rollout-ledger",
+                    ledger,
+                    "--rollout-target-stage",
+                    "http-full",
+                    "--rollout-min-observation-hours",
+                    "0",
+                    "--require-rollout-complete",
+                    "--print-json"
+                }
+            })!;
+
+            var stdout = process.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+
+            var combined = stderr + stdout;
+            Assert.NotEqual(0, process.ExitCode);
+            Assert.Contains("rollout_ledger_completion_state", combined);
+            Assert.Contains("missing success stage for commit: stage=http-full", combined);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public void RollbackScript_ReturnsApiToInprocWithoutDatabaseRollback()
     {
         var script = ReadRepoFile("scripts/llmgw-rollback-inproc.sh");


### PR DESCRIPTION
## 摘要
补一条 LLM Gateway 完成态回归测试，确保 readiness audit 在没有 http-full rollout 成功台账时必须失败，避免把代码门禁齐了误报成全量迁移完成。

## 改动 diff
- `prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs`：新增 `ReadinessAudit_RequireRolloutCompleteFailsWithoutHttpFullLedger`，实际运行 `llmgw-readiness-audit.py --require-rollout-complete` 并断言缺少 `http-full` 时失败。
- `changelogs/2026-07-08_llmgw-completion-audit.md`：新增测试类 changelog 碎片。

## 测试
- [x] `python3 -m py_compile scripts/llmgw-readiness-audit.py scripts/llmgw-rollout-ledger.py`
- [x] `cd prd-api && dotnet build --no-restore`
- [x] `cd prd-api && dotnet test tests/PrdAgent.Tests/PrdAgent.Tests.csproj --no-build --filter "FullyQualifiedName~GatewayDataDomainGuardTests.ReadinessAudit_RequireRolloutCompleteFailsWithoutHttpFullLedger|FullyQualifiedName~GatewayDataDomainGuardTests.RolloutLedgerAudit_FailsWhenTargetSuccessWasLaterRolledBack"`
- [x] `cd prd-api && dotnet build --no-restore 2>&1 | grep -E "error CS|warning CS" | head -30` 无输出

## 运行边界
- 本 PR 不触发模型请求，不切生产 `LLMGW_MODE`，不修改发布脚本运行逻辑。