### PR TITLE
ops(llmgw): 增加 rollout status 就绪门禁

### DIFF
--- a/changelogs/2026-07-08_llmgw-rollout-status-require-ready.md
+++ b/changelogs/2026-07-08_llmgw-rollout-status-require-ready.md
@@ -1,0 +1,1 @@
+| ops | scripts | LLM Gateway rollout status 增加 require-ready/require-action 退出码门禁，未到覆盖窗口时可直接阻断灰度推进 |

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -1466,6 +1466,24 @@ public class GatewayDataDomainGuardTests
         Assert.DoesNotContain("requests.", planner);
     }
 
+    [Fact]
+    public void RolloutStatus_CanFailAsReleaseGateWithoutCallingProviders()
+    {
+        var status = ReadRepoFile("scripts/llmgw-rollout-status.py");
+
+        Assert.Contains("Read-only LLM Gateway rollout status board", status);
+        Assert.Contains("It never calls MAP seed endpoints and never calls model providers.", status);
+        Assert.Contains("--require-ready", status);
+        Assert.Contains("--require-action", status);
+        Assert.Contains("_required_action_failure", status);
+        Assert.Contains("LLM Gateway rollout status: NOT READY", status);
+        Assert.Contains("require_release_ready", status);
+        Assert.Contains("releaseStatus=", status);
+        Assert.Contains("healthOk=", status);
+        Assert.Contains("nextEligibleAt=", status);
+        Assert.Contains("ready-for-release-gate", status);
+    }
+
     private static string ReadRepoFile(string relativePath)
     {
         var root = LocateRepoRoot();

--- a/scripts/llmgw-rollout-status.py
+++ b/scripts/llmgw-rollout-status.py
@@ -418,6 +418,37 @@ def _print_table(report: dict[str, Any]) -> None:
         print(f"| {item['name']} | {item['progress']}% | {item['status']} | {item['detail']} |")
 
 
+def _required_action_failure(
+    report: dict[str, Any],
+    required_actions: list[str],
+    *,
+    require_release_ready: bool = False,
+) -> str:
+    required = [item.strip() for item in required_actions if item.strip()]
+    if not required:
+        return ""
+    action = str(report.get("action") or "")
+    cell_summary = report.get("cellSummary") or {}
+    next_eligible_at = str(cell_summary.get("nextEligibleAt") or "")
+    suffix = f" nextEligibleAt={next_eligible_at}" if next_eligible_at else ""
+    if action not in required:
+        return (
+            "LLM Gateway rollout status: NOT READY "
+            f"action={action or '<empty>'} required={','.join(required)}{suffix}"
+        )
+    if require_release_ready:
+        release_item = next((item for item in report.get("items") or [] if item.get("name") == "全量 HTTP 发布"), {})
+        if release_item.get("status") != "gate-ready":
+            health = report.get("health") or {}
+            return (
+                "LLM Gateway rollout status: NOT READY "
+                f"action={action or '<empty>'} required={','.join(required)} "
+                f"releaseStatus={release_item.get('status') or '<empty>'} "
+                f"healthOk={bool(health.get('ok'))}{suffix}"
+            )
+    return ""
+
+
 def _fake_coverage(first_compared_at: str) -> dict[str, Any]:
     return {
         "verdict": "fail",
@@ -492,6 +523,10 @@ def _self_test() -> int:
         next_eligible_at = str((report.get("cellSummary") or {}).get("nextEligibleAt") or "")
         if not next_eligible_at:
             raise AssertionError(f"{name}: nextEligibleAt must be present while coverage is pending")
+        if expected_action == "wait-coverage-window":
+            failure = _required_action_failure(report, ["ready-for-release-gate"])
+            if "NOT READY" not in failure or "nextEligibleAt=" not in failure:
+                raise AssertionError(f"{name}: require-ready failure must include nextEligibleAt: {failure}")
 
     run_case(
         "wait-window",
@@ -588,6 +623,9 @@ def _self_test() -> int:
         raise AssertionError(f"health-fail case must record health failure: {report['health']}")
     if release_item["status"] != "not-ready" or release_item["progress"] != 0:
         raise AssertionError(f"health failure must block release gate-ready status: {release_item}")
+    failure = _required_action_failure(report, ["ready-for-release-gate"], require_release_ready=True)
+    if "healthOk=False" not in failure or "releaseStatus=not-ready" not in failure:
+        raise AssertionError(f"require-ready must fail when health is not ready: {failure}")
     print("LLM Gateway rollout status self-test: PASS")
     return 0
 
@@ -609,6 +647,8 @@ def main() -> int:
     parser.add_argument("--skip-global-cells", action="store_true", default=True)
     parser.add_argument("--include-global-cells", action="store_false", dest="skip_global_cells")
     parser.add_argument("--skip-health", action="store_true")
+    parser.add_argument("--require-ready", action="store_true", help="exit non-zero unless action is ready-for-release-gate")
+    parser.add_argument("--require-action", action="append", default=[], help="exit non-zero unless action matches one of these values")
     parser.add_argument("--json-out", default="")
     parser.add_argument("--report-md", default="")
     parser.add_argument("--print-json", action="store_true")
@@ -627,6 +667,13 @@ def main() -> int:
         print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
     else:
         _print_table(report)
+    required_actions = list(args.require_action or [])
+    if args.require_ready:
+        required_actions.append("ready-for-release-gate")
+    failure = _required_action_failure(report, required_actions, require_release_ready=bool(args.require_ready))
+    if failure:
+        print(failure, file=sys.stderr)
+        return 1
     return 0
 
 


### PR DESCRIPTION
## 摘要
给 LLM Gateway rollout status 增加显式退出码门禁：默认仍然只读展示状态，传入 `--require-ready` 或 `--require-action` 时，若当前 action 不满足要求则返回非 0，并输出 `nextEligibleAt`。这用于阻止未满覆盖窗口时继续灰度或误补样。

## 改动 diff
- `scripts/llmgw-rollout-status.py`：新增 `--require-ready` / `--require-action`，未满足目标 action 时输出 NOT READY 并 exit 1。
- `prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs`：增加静态守卫，确认 status 工具保持只读且具备门禁能力。
- `changelogs/2026-07-08_llmgw-rollout-status-require-ready.md`：新增 changelog 碎片。

## 测试
- [x] `python3 -m py_compile scripts/llmgw-rollout-status.py`
- [x] `scripts/llmgw-rollout-status.py --self-test`
- [x] 离线 coverage JSON + `--skip-health --require-ready` 断言 exit 1 且输出 `nextEligibleAt`
- [x] `cd prd-api && dotnet build --no-restore`
- [x] `cd prd-api && dotnet test tests/PrdAgent.Tests/PrdAgent.Tests.csproj --no-build --filter "FullyQualifiedName~GatewayDataDomainGuardTests.RolloutStatus_CanFailAsReleaseGateWithoutCallingProviders|FullyQualifiedName~GatewayDataDomainGuardTests.ShadowSamplePlan_IsReadOnlyAndCapsRecommendedBatches"`
- [x] `cd prd-api && dotnet build --no-restore 2>&1 | grep -E "error CS|warning CS" | head -30` 无输出

## 运行边界
- 本 PR 不调用 MAP seed，不调用模型供应商，不改生产配置，不切 `LLMGW_MODE`。