### PR TITLE
ops(llmgw): 前置 canary 状态门禁

### DIFF
--- a/changelogs/2026-07-08_llmgw-prod-stage-status-gate.md
+++ b/changelogs/2026-07-08_llmgw-prod-stage-status-gate.md
@@ -1,0 +1,1 @@
+| ops | scripts | LLM Gateway canary-intent-text 阶段前置 rollout status require-ready 门禁，覆盖窗口未满时先阻断发布脚本 |

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -652,6 +652,15 @@ public class GatewayDataDomainGuardTests
         Assert.Contains("scripts/llmgw-prod-preflight.py --mode start", readiness);
         Assert.Contains("--prod-preflight-json \\\"$prod_preflight_json\\\"", readiness);
         Assert.Contains("serving-probe.json", readiness);
+        Assert.Contains("rollout-status.json", readiness);
+        Assert.Contains("rolloutStatusRequired", readiness);
+        Assert.Contains("rolloutStatusJson", readiness);
+        Assert.Contains("run_rollout_status_ready_gate", readiness);
+        Assert.Contains("scripts/llmgw-rollout-status.py", readiness);
+        Assert.Contains("--require-ready", readiness);
+        var releaseTreeIdx = script.IndexOf("validate_release_tree", StringComparison.Ordinal);
+        var statusGateIdx = script.IndexOf("run_rollout_status_ready_gate", StringComparison.Ordinal);
+        Assert.True(releaseTreeIdx >= 0 && statusGateIdx >= 0 && releaseTreeIdx < statusGateIdx);
         Assert.Contains("GW_SMOKE_JSON_OUT", readiness);
         Assert.Contains("--smoke-required \\\"$smoke_required\\\"", readiness);
         Assert.Contains("LLMGW_GATE_RUN_SMOKE:-1", readiness);

--- a/scripts/llmgw-prod-stage.sh
+++ b/scripts/llmgw-prod-stage.sh
@@ -298,6 +298,8 @@ short_commit="$(printf '%s' "$commit" | cut -c1-12)"
 evidence_prefix="$evidence_dir/${ts}_${stage}_${short_commit}"
 release_gate_json="${evidence_prefix}.release-gate.json"
 release_gate_md="${evidence_prefix}.release-gate.md"
+rollout_status_json="${evidence_prefix}.rollout-status.json"
+rollout_status_md="${evidence_prefix}.rollout-status.md"
 serving_probe_json="${evidence_prefix}.serving-probe.json"
 serving_probe_md="${evidence_prefix}.serving-probe.md"
 smoke_json="${evidence_prefix}.gw-smoke.json"
@@ -378,6 +380,7 @@ print_plan() {
     echo "  shadowFullSampleAppCallerAllowlist: ${shadow_full_sample_allowlist:-empty}"
     echo "  gateBase: ${gate_base:-none}"
     echo "  releaseGateJson: $release_gate_json"
+    echo "  rolloutStatusJson: $rollout_status_json"
     echo "  servingProbeJson: $serving_probe_json"
     echo "  smokeJson: $smoke_json"
     echo "  prodPreflightJson: $prod_preflight_json"
@@ -462,6 +465,7 @@ deploy/nginx/conf.d/branches/_disconnected.conf
 deploy/nginx/conf.d/branches/_standalone.conf
 scripts/llmgw-prod-stage.sh
 scripts/llmgw-rollout-ledger.py
+scripts/llmgw-rollout-status.py
 scripts/llmgw-prod-preflight.py
 scripts/llmgw-upstream-readiness.py
 scripts/llmgw-prod-provider-config-audit.py
@@ -582,6 +586,10 @@ write_dry_run_stage_report() {
   fi
 
   mkdir -p "$evidence_dir"
+  rollout_status_gate_enabled=0
+  if rollout_status_ready_gate_required; then
+    rollout_status_gate_enabled=1
+  fi
   LLMGW_DRY_RUN_STAGE_JSON="$stage_json" \
   LLMGW_DRY_RUN_STAGE_MD="$stage_md" \
   LLMGW_DRY_RUN_STAGE="$stage" \
@@ -591,6 +599,8 @@ write_dry_run_stage_report() {
   LLMGW_DRY_RUN_ALLOWLIST="${allowlist:-}" \
   LLMGW_DRY_RUN_SHADOW_PERCENT="${shadow_percent:-}" \
   LLMGW_DRY_RUN_GATE_BASE="${gate_base:-}" \
+  LLMGW_DRY_RUN_ROLLOUT_STATUS_JSON="${rollout_status_json:-}" \
+  LLMGW_DRY_RUN_ROLLOUT_STATUS_ENABLED="$rollout_status_gate_enabled" \
   LLMGW_DRY_RUN_REUSE_STATIC_DIST="${PRD_AGENT_REUSE_EXISTING_STATIC_DIST:-0}" \
   LLMGW_DRY_RUN_RELEASE_GATE_REQUIRED="${release_gate_required:-0}" \
   LLMGW_DRY_RUN_PROD_PREFLIGHT_JSON="${prod_preflight_json:-}" \
@@ -633,6 +643,16 @@ else:
     commands.append(
         preflight
     )
+    if os.environ.get("LLMGW_DRY_RUN_ROLLOUT_STATUS_ENABLED", "0") == "1":
+        commands.append(
+            "GW_KEY=${LLMGW_GATE_KEY} "
+            "python3 scripts/llmgw-rollout-status.py --base ${LLMGW_GATE_BASE} "
+            "--release-commit "
+            + commit
+            + " --skip-global-cells --allow-window-extension --json-out "
+            + os.environ.get("LLMGW_DRY_RUN_ROLLOUT_STATUS_JSON", "")
+            + " --require-ready"
+        )
     if os.environ.get("LLMGW_DRY_RUN_UPSTREAM_READINESS_ENABLED", "0") == "1":
         commands.append(
             "python3 scripts/llmgw-upstream-readiness.py --gw-base ${LLMGW_GATE_BASE} "
@@ -687,6 +707,8 @@ report = {
     "allowlist": os.environ.get("LLMGW_DRY_RUN_ALLOWLIST", ""),
     "shadowFullSamplePercent": os.environ.get("LLMGW_DRY_RUN_SHADOW_PERCENT", ""),
     "gateBase": os.environ.get("LLMGW_DRY_RUN_GATE_BASE", ""),
+    "rolloutStatusJson": os.environ.get("LLMGW_DRY_RUN_ROLLOUT_STATUS_JSON", ""),
+    "rolloutStatusRequired": os.environ.get("LLMGW_DRY_RUN_ROLLOUT_STATUS_ENABLED", "0") == "1",
     "reuseExistingStaticDist": os.environ.get("LLMGW_DRY_RUN_REUSE_STATIC_DIST", "0") in ("1", "true", "yes"),
     "releaseGateRequired": os.environ.get("LLMGW_DRY_RUN_RELEASE_GATE_REQUIRED", "0") == "1",
     "prodPreflightJson": os.environ.get("LLMGW_DRY_RUN_PROD_PREFLIGHT_JSON", ""),
@@ -728,6 +750,8 @@ with open(md_path, "w", encoding="utf-8") as fh:
         "mode",
         "canaryStage",
         "allowlist",
+        "rolloutStatusRequired",
+        "rolloutStatusJson",
         "releaseGateRequired",
         "shadowSeedEnabled",
         "shadowSeedJson",
@@ -987,6 +1011,45 @@ run_or_print() {
   fi
 }
 
+rollout_status_ready_gate_required() {
+  case "$stage" in
+    canary-intent-text)
+      return 0
+      ;;
+    *)
+      [ "${LLMGW_STAGE_RUN_ROLLOUT_STATUS_GATE:-0}" = "1" ]
+      ;;
+  esac
+}
+
+run_rollout_status_ready_gate() {
+  if ! rollout_status_ready_gate_required; then
+    return 0
+  fi
+  if [ ! -f "scripts/llmgw-rollout-status.py" ]; then
+    echo "ERROR: missing scripts/llmgw-rollout-status.py; cannot check rollout readiness before $stage." >&2
+    exit 1
+  fi
+  status_since_hours="${LLMGW_STATUS_SINCE_HOURS:-${LLMGW_GATE_SHADOW_SINCE_HOURS:-48}}"
+  status_min_coverage_hours="${LLMGW_STATUS_MIN_COVERAGE_HOURS:-${LLMGW_GATE_MIN_COVERAGE_HOURS:-24}}"
+  if [ "$execute" = "1" ]; then
+    mkdir -p "$evidence_dir"
+    GW_KEY="$gate_key" \
+    python3 scripts/llmgw-rollout-status.py \
+      --base "$gate_base" \
+      --release-commit "$commit" \
+      --since-hours "$status_since_hours" \
+      --min-coverage-hours "$status_min_coverage_hours" \
+      --skip-global-cells \
+      --allow-window-extension \
+      --json-out "$rollout_status_json" \
+      --report-md "$rollout_status_md" \
+      --require-ready
+  else
+    echo "+ GW_KEY=\"***\" python3 scripts/llmgw-rollout-status.py --base \"$gate_base\" --release-commit \"$commit\" --since-hours \"$status_since_hours\" --min-coverage-hours \"$status_min_coverage_hours\" --skip-global-cells --allow-window-extension --json-out \"$rollout_status_json\" --report-md \"$rollout_status_md\" --require-ready"
+  fi
+}
+
 print_plan
 
 if [ "$stage" = "rollback-inproc" ]; then
@@ -1007,6 +1070,7 @@ run_stage_disk_guard
 validate_ledger_order
 validate_main_ancestry
 validate_release_tree
+run_rollout_status_ready_gate
 
 if [ "$stage" = "rollback-rehearsal" ]; then
   release_gate_required=0

--- a/scripts/llmgw-readiness-audit.py
+++ b/scripts/llmgw-readiness-audit.py
@@ -193,9 +193,12 @@ def _static_checks() -> list[dict]:
             "llmgw-shadow-sample-plan.py",
             "--coverage-json",
             "--allow-window-extension",
+            "--require-ready",
+            "--require-action",
             "--self-test",
             "wait-coverage-window",
             "run-one-window-extension",
+            "_required_action_failure",
             "cellSummary",
             "multi-cell sample progress",
             "shadow 样本数",
@@ -786,6 +789,9 @@ def _static_checks() -> list[dict]:
             "append_ledger_entry rollback",
             "rollout_ledger_status=\"rollback\"",
             "release-gate.json",
+            "rollout-status.json",
+            "rolloutStatusRequired",
+            "rolloutStatusJson",
             "prod-preflight.json",
             "serving-probe.json",
             "gw-smoke.json",
@@ -818,6 +824,9 @@ def _static_checks() -> list[dict]:
             "run_prod_preflight",
             "scripts/llmgw-prod-preflight.py --mode start",
             "--prod-preflight-json \"$prod_preflight_json\"",
+            "run_rollout_status_ready_gate",
+            "scripts/llmgw-rollout-status.py",
+            "--require-ready",
             "--upstream-readiness-json \"$upstream_readiness_json\"",
             "--upstream-readiness-required \"$run_upstream_readiness\"",
             "--provider-audit-json \"$provider_audit_json\"",
@@ -856,6 +865,7 @@ def _static_checks() -> list[dict]:
     fast_idx = prod_stage.find("run_or_print ./fast.sh")
     video_canary_idx = prod_stage.find("run_video_canary_evidence\n\nrun_asr_http_canary_evidence")
     asr_canary_idx = prod_stage.find("run_asr_http_canary_evidence\n\nrun_shadow_seed_evidence")
+    release_tree_before_status_idx = prod_stage.find("validate_release_tree\nrun_rollout_status_ready_gate")
     upstream_before_deploy = (
         preflight_idx >= 0
         and upstream_idx >= 0
@@ -864,6 +874,7 @@ def _static_checks() -> list[dict]:
         and asr_canary_idx >= 0
         and preflight_idx < upstream_idx < provider_idx < fast_idx < video_canary_idx < asr_canary_idx
     )
+    release_tree_before_status = release_tree_before_status_idx >= 0
     ledger_ok, ledger_detail = _contains_all(
         rollout_ledger,
         [
@@ -996,8 +1007,8 @@ def _static_checks() -> list[dict]:
     leaks_key_arg = "--key" in prod_stage or "--gateway-key" in prod_stage or "--key" in rollout_ledger
     checks.append(_check(
         "prod_stage_runner_sequences_shadow_canary_http_and_rollback",
-        ok and ledger_ok and preflight_ok and upstream_ok and upstream_before_deploy and executable and ledger_executable and preflight_executable and upstream_executable and not leaks_key_arg,
-        f"{detail}; ledger={ledger_detail}; preflight={preflight_detail}; upstream={upstream_detail}; upstreamBeforeDeploy={upstream_before_deploy}; executable={executable}; ledgerExecutable={ledger_executable}; preflightExecutable={preflight_executable}; upstreamExecutable={upstream_executable}; leaksKeyArg={leaks_key_arg}",
+        ok and ledger_ok and preflight_ok and upstream_ok and upstream_before_deploy and release_tree_before_status and executable and ledger_executable and preflight_executable and upstream_executable and not leaks_key_arg,
+        f"{detail}; ledger={ledger_detail}; preflight={preflight_detail}; upstream={upstream_detail}; upstreamBeforeDeploy={upstream_before_deploy}; releaseTreeBeforeStatus={release_tree_before_status}; executable={executable}; ledgerExecutable={ledger_executable}; preflightExecutable={preflight_executable}; upstreamExecutable={upstream_executable}; leaksKeyArg={leaks_key_arg}",
     ))
 
     fast = _read("fast.sh")


### PR DESCRIPTION
## 摘要
让 LLM Gateway 生产阶段脚本在 `canary-intent-text` 执行前先跑只读 `llmgw-rollout-status.py --require-ready`。如果 shadow 样本数量/质量/覆盖窗口或 health 未 ready，脚本会先失败并写出 rollout-status 证据，避免继续进入部署和 release gate。

## 改动 diff
- `scripts/llmgw-prod-stage.sh`：新增 rollout status 证据文件、dry-run 计划记录、`run_rollout_status_ready_gate`，默认作用于 `canary-intent-text`，key 仅通过环境变量传递。
- `scripts/llmgw-readiness-audit.py`：静态检查新增 rollout status ready gate 相关关键词。
- `prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs`：补充守卫断言，防止 stage runner 丢失前置状态门禁。
- `changelogs/2026-07-08_llmgw-prod-stage-status-gate.md`：新增 changelog 碎片。

## 测试
- [x] `sh -n scripts/llmgw-prod-stage.sh`
- [x] `python3 -m py_compile scripts/llmgw-readiness-audit.py scripts/llmgw-rollout-status.py scripts/llmgw-rollout-ledger.py`
- [x] `scripts/llmgw-rollout-status.py --self-test`
- [x] `scripts/llmgw-prod-stage.sh --stage canary-intent-text ... --dry-run` 输出 `GW_KEY="***" python3 scripts/llmgw-rollout-status.py ... --require-ready`
- [x] `python3 scripts/llmgw-readiness-audit.py --json-out /tmp/llmgw-readiness-status-gate.clean.json` 通过
- [x] `cd prd-api && dotnet build --no-restore`
- [x] `cd prd-api && dotnet test tests/PrdAgent.Tests/PrdAgent.Tests.csproj --no-build --filter "FullyQualifiedName~GatewayDataDomainGuardTests.ProdStageRunner_SequencesShadowCanaryHttpAndRollback|FullyQualifiedName~GatewayDataDomainGuardTests.RolloutStatus_CanFailAsReleaseGateWithoutCallingProviders"`
- [x] `cd prd-api && dotnet build --no-restore 2>&1 | grep -E "error CS|warning CS" | head -30` 无输出

## 运行边界
- 本 PR 不调用模型供应商，不 seed，不改生产环境，不切 `LLMGW_MODE`。