### PR TITLE
ops(llmgw): 增加生产文件树预检

### DIFF
--- a/.github/workflows/llmgw-prod-stage.yml
+++ b/.github/workflows/llmgw-prod-stage.yml
@@ -68,6 +68,11 @@ on:
         description: "Required reason when allow_out_of_order is true."
         required: false
         default: ""
+      allow_release_tree_mismatch:
+        description: "Emergency only: allow production runner files to differ from release commit."
+        required: true
+        default: false
+        type: boolean
       rollout_evidence_run_id:
         description: "Previous llmgw-prod-stage run id to restore .llmgw-release-evidence before continuing."
         required: false
@@ -131,6 +136,7 @@ jobs:
       INPUT_MAIN_REF: ${{ github.event.inputs.main_ref || 'origin/main' }}
       INPUT_ALLOW_OUT_OF_ORDER: ${{ github.event.inputs.allow_out_of_order || 'false' }}
       INPUT_ALLOW_OUT_OF_ORDER_REASON: ${{ github.event.inputs.allow_out_of_order_reason || '' }}
+      INPUT_ALLOW_RELEASE_TREE_MISMATCH: ${{ github.event.inputs.allow_release_tree_mismatch || 'false' }}
       INPUT_ROLLOUT_EVIDENCE_RUN_ID: ${{ github.event.inputs.rollout_evidence_run_id || '' }}
       INPUT_ROLLOUT_EVIDENCE_ARTIFACT: ${{ github.event.inputs.rollout_evidence_artifact || '' }}
       PRD_AGENT_API_KEY: ${{ secrets.PRD_AGENT_PROD_API_KEY }}
@@ -168,6 +174,7 @@ jobs:
           main_ref="$(printf '%s' "$INPUT_MAIN_REF" | xargs)"
           allow_out_of_order="$(printf '%s' "$INPUT_ALLOW_OUT_OF_ORDER" | xargs)"
           allow_out_of_order_reason="$(printf '%s' "$INPUT_ALLOW_OUT_OF_ORDER_REASON" | xargs)"
+          allow_release_tree_mismatch="$(printf '%s' "$INPUT_ALLOW_RELEASE_TREE_MISMATCH" | xargs)"
           rollout_evidence_run_id="$(printf '%s' "$INPUT_ROLLOUT_EVIDENCE_RUN_ID" | xargs)"
 
           if [ -z "$stage" ]; then
@@ -206,6 +213,10 @@ jobs:
           export PRD_AGENT_BASE="$map_base"
           export LLMGW_GATE_BASE="$gw_base"
           export LLMGW_STAGE_EVIDENCE_DIR=".llmgw-release-evidence"
+          if [ "$allow_release_tree_mismatch" = "true" ]; then
+            export LLMGW_STAGE_ALLOW_RELEASE_TREE_MISMATCH=1
+          fi
+          release_tree_mismatch_bypass="${LLMGW_STAGE_ALLOW_RELEASE_TREE_MISMATCH:-${LLMGW_STAGE_ALLOW_SCRIPT_TREE_MISMATCH:-0}}"
 
           args=(
             --stage "$stage"
@@ -223,6 +234,25 @@ jobs:
           fi
           if [ "$allow_out_of_order" = "true" ]; then
             args+=(--allow-out-of-order --allow-out-of-order-reason "$allow_out_of_order_reason")
+          fi
+
+          if [ "$execute" = "true" ] && [ "$stage" != "rollback-inproc" ]; then
+            tree_precheck_args=(
+              --commit "$commit"
+              --main-ref "$main_ref"
+              --json-out ".llmgw-release-evidence/tree-precheck.json"
+              --report-md ".llmgw-release-evidence/tree-precheck.md"
+            )
+            if [ "$release_tree_mismatch_bypass" = "1" ] || [ "$release_tree_mismatch_bypass" = "true" ]; then
+              tree_precheck_args+=(--allow-mismatch)
+            fi
+            if ! python3 scripts/llmgw-prod-tree-precheck.py "${tree_precheck_args[@]}"; then
+              if [ "$release_tree_mismatch_bypass" = "1" ] || [ "$release_tree_mismatch_bypass" = "true" ]; then
+                echo "WARN: release tree mismatch precheck failed but emergency bypass is enabled; continuing to stage runner."
+              else
+                exit 1
+              fi
+            fi
           fi
 
           scripts/llmgw-prod-stage.sh "${args[@]}"

--- a/changelogs/2026-07-08_llmgw-prod-tree-precheck.md
+++ b/changelogs/2026-07-08_llmgw-prod-tree-precheck.md
@@ -1,0 +1,1 @@
+| ops | scripts | 新增 LLM Gateway 生产 runner release tree 只读预检，发布阶段先输出 tree-precheck 证据以阻断混合工作树 |

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -443,6 +443,8 @@ public class GatewayDataDomainGuardTests
         Assert.Contains("cds-compose.yml", script);
         Assert.Contains("execdep.sh", script);
         Assert.Contains("deploy/nginx/conf.d/branches/_standalone.conf", script);
+        Assert.Contains("scripts/llmgw-map-shadow-seed.py", script);
+        Assert.Contains("scripts/llmgw-report-agent-shadow-seed.py", script);
         Assert.Contains("git show \"$commit:<critical rollout/deploy files>\" | cmp local files", script);
         Assert.Contains("local rollout/deploy files must match --commit", script);
         Assert.Contains("release file differs from release commit", script);
@@ -692,6 +694,7 @@ public class GatewayDataDomainGuardTests
     {
         var workflow = ReadRepoFile(".github/workflows/llmgw-prod-stage.yml");
         var readiness = ReadRepoFile("scripts/llmgw-readiness-audit.py");
+        var treePrecheck = ReadRepoFile("scripts/llmgw-prod-tree-precheck.py");
 
         Assert.Contains("LLM Gateway Production Stage", workflow);
         Assert.Contains("workflow_dispatch:", workflow);
@@ -711,6 +714,11 @@ public class GatewayDataDomainGuardTests
         Assert.Contains("commit:\n        description: \"40-char release commit. Required for every non-rollback-inproc stage.\"\n        required: false", workflow);
         Assert.Contains("runner_labels_json", workflow);
         Assert.Contains("[\\\"self-hosted\\\",\\\"prd-agent-prod\\\"]", workflow);
+        Assert.Contains("allow_release_tree_mismatch", workflow);
+        Assert.Contains("INPUT_ALLOW_RELEASE_TREE_MISMATCH", workflow);
+        Assert.Contains("LLMGW_STAGE_ALLOW_RELEASE_TREE_MISMATCH=1", workflow);
+        Assert.Contains("LLMGW_STAGE_ALLOW_SCRIPT_TREE_MISMATCH", workflow);
+        Assert.Contains("release_tree_mismatch_bypass", workflow);
         Assert.Contains("environment: production", workflow);
         Assert.Contains("PRD_AGENT_PROD_BASE", workflow);
         Assert.Contains("PRD_AGENT_PROD_API_KEY", workflow);
@@ -739,6 +747,12 @@ public class GatewayDataDomainGuardTests
         Assert.Contains("--main-ref \"$main_ref\"", workflow);
         Assert.Contains("--evidence-dir \".llmgw-release-evidence\"", workflow);
         Assert.Contains("--allow-out-of-order-reason \"$allow_out_of_order_reason\"", workflow);
+        Assert.Contains("scripts/llmgw-prod-tree-precheck.py", workflow);
+        Assert.Contains("[ \"$execute\" = \"true\" ] && [ \"$stage\" != \"rollback-inproc\" ]", workflow);
+        Assert.Contains("--allow-mismatch", workflow);
+        Assert.Contains("emergency bypass is enabled; continuing to stage runner", workflow);
+        Assert.Contains("--json-out \".llmgw-release-evidence/tree-precheck.json\"", workflow);
+        Assert.Contains("--report-md \".llmgw-release-evidence/tree-precheck.md\"", workflow);
         Assert.Contains("scripts/llmgw-rollout-ledger.py audit", workflow);
         Assert.Contains("--require-target-success", workflow);
         Assert.Contains("stage-audit.json", workflow);
@@ -751,7 +765,30 @@ public class GatewayDataDomainGuardTests
         Assert.Contains("prod_stage_workflow_runs_on_production_runner_and_uploads_rollout_evidence", readiness);
         Assert.Contains(".github/workflows/llmgw-prod-stage.yml", readiness);
         Assert.Contains("leaksStageSecret", readiness);
+        Assert.Contains("treePrecheckExecutable", readiness);
+        Assert.Contains("treePrecheckDestructive", readiness);
         Assert.Contains("Restore previous rollout evidence", readiness);
+
+        Assert.Contains("LLM Gateway production release tree precheck", treePrecheck);
+        Assert.Contains("CRITICAL_PATHS", treePrecheck);
+        Assert.Contains("scripts/llmgw-prod-stage.sh", treePrecheck);
+        Assert.Contains("scripts/llmgw-map-shadow-seed.py", treePrecheck);
+        Assert.Contains("scripts/llmgw-report-agent-shadow-seed.py", treePrecheck);
+        Assert.Contains("scripts/llmgw-rollout-status.py", treePrecheck);
+        Assert.Contains("scripts/llmgw-shadow-coverage-report.py", treePrecheck);
+        Assert.Contains("scripts/llmgw-shadow-sample-plan.py", treePrecheck);
+        Assert.Contains("allowMismatch", treePrecheck);
+        Assert.Contains("allowMismatchSource", treePrecheck);
+        Assert.Contains("LLMGW_STAGE_ALLOW_RELEASE_TREE_MISMATCH", treePrecheck);
+        Assert.Contains("LLMGW_STAGE_ALLOW_SCRIPT_TREE_MISMATCH", treePrecheck);
+        Assert.Contains("--allow-mismatch", treePrecheck);
+        Assert.Contains("pathChecks", treePrecheck);
+        Assert.Contains("missing-local", treePrecheck);
+        Assert.Contains("missing-release", treePrecheck);
+        Assert.Contains("differs", treePrecheck);
+        Assert.DoesNotContain("git reset", treePrecheck);
+        Assert.DoesNotContain("git checkout --", treePrecheck);
+        Assert.DoesNotContain("docker compose up", treePrecheck);
     }
 
     [Fact]

--- a/scripts/llmgw-prod-stage.sh
+++ b/scripts/llmgw-prod-stage.sh
@@ -469,6 +469,8 @@ scripts/llmgw-rollout-status.py
 scripts/llmgw-prod-preflight.py
 scripts/llmgw-upstream-readiness.py
 scripts/llmgw-prod-provider-config-audit.py
+scripts/llmgw-map-shadow-seed.py
+scripts/llmgw-report-agent-shadow-seed.py
 scripts/llmgw-video-exchange-canary.py
 scripts/llmgw-asr-http-canary.py
 scripts/llmgw-release-gate.py

--- a/scripts/llmgw-prod-tree-precheck.py
+++ b/scripts/llmgw-prod-tree-precheck.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Read-only production runner release tree precheck for LLM Gateway rollout."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+CRITICAL_PATHS = [
+    "docker-compose.yml",
+    "cds-compose.yml",
+    "fast.sh",
+    "exec_dep.sh",
+    "execdep.sh",
+    "deploy/nginx/Dockerfile",
+    "deploy/nginx/nginx.conf",
+    "deploy/nginx/conf.d/branches/_disconnected.conf",
+    "deploy/nginx/conf.d/branches/_standalone.conf",
+    "scripts/llmgw-prod-stage.sh",
+    "scripts/llmgw-rollout-ledger.py",
+    "scripts/llmgw-rollout-status.py",
+    "scripts/llmgw-prod-preflight.py",
+    "scripts/llmgw-upstream-readiness.py",
+    "scripts/llmgw-prod-provider-config-audit.py",
+    "scripts/llmgw-map-shadow-seed.py",
+    "scripts/llmgw-report-agent-shadow-seed.py",
+    "scripts/llmgw-shadow-coverage-report.py",
+    "scripts/llmgw-shadow-sample-plan.py",
+    "scripts/llmgw-video-exchange-canary.py",
+    "scripts/llmgw-asr-http-canary.py",
+    "scripts/llmgw-release-gate.py",
+    "scripts/llmgw-serving-probe.py",
+    "scripts/gw-smoke.py",
+    "scripts/llmgw-disk-space-guard.sh",
+    "scripts/llmgw-rollback-inproc.sh",
+    "scripts/llmgw-restore-shadow-safe.sh",
+]
+
+
+def _json_dumps(data: Any) -> str:
+    return json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True)
+
+
+def _run(args: list[str], *, input_bytes: bytes | None = None, check: bool = True) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(args, input=input_bytes, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=check)
+
+
+def _git(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[bytes]:
+    return _run(["git", *args], check=check)
+
+
+def _git_text(args: list[str], *, check: bool = True) -> str:
+    completed = _git(args, check=check)
+    return completed.stdout.decode("utf-8", errors="replace").strip()
+
+
+def _write(path: str, content: str) -> None:
+    if not path:
+        return
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(content, encoding="utf-8")
+
+
+def _git_blob(commit: str, path: str) -> bytes | None:
+    completed = _git(["show", f"{commit}:{path}"], check=False)
+    if completed.returncode != 0:
+        return None
+    return completed.stdout
+
+
+def _file_bytes(path: str) -> bytes | None:
+    local_path = Path(path)
+    if not local_path.is_file():
+        return None
+    return local_path.read_bytes()
+
+
+def _short_status() -> dict[str, Any]:
+    completed = _git(["status", "--porcelain"], check=False)
+    if completed.returncode != 0:
+        return {"available": False, "detail": completed.stderr.decode("utf-8", errors="replace").strip()}
+
+    lines = [line for line in completed.stdout.decode("utf-8", errors="replace").splitlines() if line.strip()]
+    tracked_dirty = [line for line in lines if not line.startswith("?? ")]
+    untracked = [line for line in lines if line.startswith("?? ")]
+    return {
+        "available": True,
+        "dirtyTrackedCount": len(tracked_dirty),
+        "untrackedCount": len(untracked),
+        "sample": lines[:30],
+    }
+
+
+def _compare_paths(commit: str) -> list[dict[str, Any]]:
+    checks: list[dict[str, Any]] = []
+    for path in CRITICAL_PATHS:
+        local = _file_bytes(path)
+        expected = _git_blob(commit, path)
+        if local is None:
+            checks.append({"path": path, "ok": False, "status": "missing-local"})
+            continue
+        if expected is None:
+            checks.append({"path": path, "ok": False, "status": "missing-release"})
+            continue
+        checks.append({"path": path, "ok": local == expected, "status": "match" if local == expected else "differs"})
+    return checks
+
+
+def _self_test() -> int:
+    expected = {
+        "scripts/llmgw-prod-stage.sh",
+        "scripts/llmgw-rollout-ledger.py",
+        "scripts/llmgw-rollout-status.py",
+        "scripts/llmgw-shadow-coverage-report.py",
+        "scripts/llmgw-shadow-sample-plan.py",
+        "scripts/llmgw-readiness-audit.py",
+        "scripts/llmgw-release-gate.py",
+        "scripts/gw-smoke.py",
+    }
+    missing = sorted(path for path in expected if path not in CRITICAL_PATHS and path != "scripts/llmgw-readiness-audit.py")
+    if missing:
+        print("LLM Gateway production tree precheck self-test: FAIL")
+        print("missing critical paths: " + ", ".join(missing))
+        return 1
+    print("LLM Gateway production tree precheck self-test: PASS")
+    return 0
+
+
+def _report_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "# LLM Gateway production tree precheck",
+        "",
+        f"- verdict={report['verdict']}",
+        f"- releaseCommit={report.get('releaseCommit', '')}",
+        f"- allowMismatch={report.get('allowMismatch', False)}",
+        f"- allowMismatchSource={report.get('allowMismatchSource', 'none')}",
+        f"- localHead={report.get('localHead', '')}",
+        f"- mainRef={report.get('mainRef', '')}",
+        f"- mainSha={report.get('mainSha', '')}",
+        "",
+        "| item | progress | status | detail |",
+        "|---|---:|---|---|",
+    ]
+    total = len(report.get("pathChecks", []))
+    passed = sum(1 for item in report.get("pathChecks", []) if item.get("ok"))
+    lines.append(f"| critical release files | {passed}/{total} | {'pass' if passed == total else 'fail'} | compared against release commit |")
+    status = report.get("gitStatus", {})
+    lines.append(
+        "| local git status | 100% | info | "
+        f"dirtyTracked={status.get('dirtyTrackedCount', 'n/a')} untracked={status.get('untrackedCount', 'n/a')} |"
+    )
+    for item in report.get("pathChecks", []):
+        if item.get("ok"):
+            continue
+        lines.append(f"| {item.get('path')} | 0% | {item.get('status')} | local file must match release commit before execute=true |")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="LLM Gateway production release tree precheck")
+    parser.add_argument("--commit", required=False, default="")
+    parser.add_argument("--main-ref", default="origin/main")
+    parser.add_argument("--allow-mismatch", action="store_true")
+    parser.add_argument("--json-out", default="")
+    parser.add_argument("--report-md", default="")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_test:
+        return _self_test()
+
+    commit = args.commit.strip()
+    if not commit:
+        print("ERROR: --commit is required.", file=sys.stderr)
+        return 2
+    if len(commit) != 40 or any(ch not in "0123456789abcdefABCDEF" for ch in commit):
+        print("ERROR: --commit must be a 40-char SHA.", file=sys.stderr)
+        return 2
+
+    generated_at = datetime.now(timezone.utc).isoformat()
+    local_head = _git_text(["rev-parse", "HEAD"], check=False)
+    main_sha = _git_text(["rev-parse", f"{args.main_ref}^{{commit}}"], check=False)
+    commit_available = _git(["rev-parse", "--verify", f"{commit}^{{commit}}"], check=False).returncode == 0
+
+    path_checks = _compare_paths(commit) if commit_available else []
+    failures = [item for item in path_checks if not item.get("ok")]
+    env_allow_raw = (os.environ.get("LLMGW_STAGE_ALLOW_RELEASE_TREE_MISMATCH") or "").strip().lower()
+    legacy_env_allow_raw = (os.environ.get("LLMGW_STAGE_ALLOW_SCRIPT_TREE_MISMATCH") or "").strip().lower()
+    env_allow = env_allow_raw in {"1", "true", "yes"}
+    legacy_env_allow = legacy_env_allow_raw in {"1", "true", "yes"}
+    allow_mismatch = args.allow_mismatch or env_allow or legacy_env_allow
+    allow_mismatch_source = "none"
+    if args.allow_mismatch and env_allow and legacy_env_allow:
+        allow_mismatch_source = "arg+env+legacy-env"
+    elif args.allow_mismatch and env_allow:
+        allow_mismatch_source = "arg+env"
+    elif args.allow_mismatch and legacy_env_allow:
+        allow_mismatch_source = "arg+legacy-env"
+    elif args.allow_mismatch:
+        allow_mismatch_source = "arg"
+    elif env_allow:
+        allow_mismatch_source = "env"
+    elif legacy_env_allow:
+        allow_mismatch_source = "legacy-env"
+    verdict = "pass" if commit_available and (not failures or allow_mismatch) else "fail"
+    report = {
+        "generatedAt": generated_at,
+        "verdict": verdict,
+        "releaseCommit": commit.lower(),
+        "allowMismatch": allow_mismatch,
+        "allowMismatchSource": allow_mismatch_source,
+        "localHead": local_head,
+        "mainRef": args.main_ref,
+        "mainSha": main_sha,
+        "commitAvailable": commit_available,
+        "gitStatus": _short_status(),
+        "pathChecks": path_checks,
+        "failureCount": len(failures) if commit_available else 1,
+    }
+
+    _write(args.json_out, _json_dumps(report))
+    _write(args.report_md, _report_markdown(report))
+
+    print(f"LLM Gateway production tree precheck: {verdict.upper()} failures={report['failureCount']} allowMismatch={allow_mismatch} source={allow_mismatch_source}")
+    if not commit_available:
+        print(f"- release commit is not available locally: {commit}", file=sys.stderr)
+    for item in failures[:20]:
+        print(f"- {item['path']}: {item['status']}")
+    return 0 if verdict == "pass" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/llmgw-readiness-audit.py
+++ b/scripts/llmgw-readiness-audit.py
@@ -101,6 +101,8 @@ def _static_checks() -> list[dict]:
     prod_stage_workflow = _read(".github/workflows/llmgw-prod-stage.yml")
     prod_stage_path = ROOT / "scripts/llmgw-prod-stage.sh"
     prod_stage = prod_stage_path.read_text(encoding="utf-8")
+    prod_tree_precheck_path = ROOT / "scripts/llmgw-prod-tree-precheck.py"
+    prod_tree_precheck = prod_tree_precheck_path.read_text(encoding="utf-8") if prod_tree_precheck_path.exists() else ""
     rollout_ledger_path = ROOT / "scripts/llmgw-rollout-ledger.py"
     rollout_ledger = rollout_ledger_path.read_text(encoding="utf-8") if rollout_ledger_path.exists() else ""
     prod_preflight_path = ROOT / "scripts/llmgw-prod-preflight.py"
@@ -320,6 +322,11 @@ def _static_checks() -> list[dict]:
             "default: false",
             "runner_labels_json",
             "[\\\"self-hosted\\\",\\\"prd-agent-prod\\\"]",
+            "allow_release_tree_mismatch",
+            "INPUT_ALLOW_RELEASE_TREE_MISMATCH",
+            "LLMGW_STAGE_ALLOW_RELEASE_TREE_MISMATCH=1",
+            "LLMGW_STAGE_ALLOW_SCRIPT_TREE_MISMATCH",
+            "release_tree_mismatch_bypass",
             "environment: production",
             "PRD_AGENT_PROD_BASE",
             "PRD_AGENT_PROD_API_KEY",
@@ -334,6 +341,14 @@ def _static_checks() -> list[dict]:
             "llmgw-prod-stage-{0}",
             "default branch",
             "scripts/llmgw-prod-stage.sh",
+            "scripts/llmgw-prod-tree-precheck.py",
+            "tree-precheck.json",
+            "tree-precheck.md",
+            '[ "$execute" = "true" ] && [ "$stage" != "rollback-inproc" ]',
+            "--allow-mismatch",
+            "emergency bypass is enabled; continuing to stage runner",
+            "--json-out \".llmgw-release-evidence/tree-precheck.json\"",
+            "--report-md \".llmgw-release-evidence/tree-precheck.md\"",
             "stage $stage requires rollout_evidence_run_id so prior rollout ledger evidence is restored",
             "--stage \"$stage\"",
             "--commit \"$commit\"",
@@ -354,10 +369,38 @@ def _static_checks() -> list[dict]:
         ],
     )
     leaks_stage_secret = "echo \"$PRD_AGENT_API_KEY\"" in prod_stage_workflow or "echo \"$LLMGW_GATE_KEY\"" in prod_stage_workflow
+    tree_precheck_executable = bool(prod_tree_precheck_path.exists() and (prod_tree_precheck_path.stat().st_mode & stat.S_IXUSR))
+    tree_precheck_ok, tree_precheck_detail = _contains_all(
+        prod_tree_precheck,
+        [
+            "LLM Gateway production release tree precheck",
+            "CRITICAL_PATHS",
+            "scripts/llmgw-prod-stage.sh",
+            "scripts/llmgw-map-shadow-seed.py",
+            "scripts/llmgw-report-agent-shadow-seed.py",
+            "scripts/llmgw-rollout-status.py",
+            "scripts/llmgw-shadow-coverage-report.py",
+            "scripts/llmgw-shadow-sample-plan.py",
+            "scripts/llmgw-readiness-audit.py",
+            "allowMismatch",
+            "allowMismatchSource",
+            "LLMGW_STAGE_ALLOW_RELEASE_TREE_MISMATCH",
+            "LLMGW_STAGE_ALLOW_SCRIPT_TREE_MISMATCH",
+            "--allow-mismatch",
+            "gitStatus",
+            "pathChecks",
+            "missing-local",
+            "missing-release",
+            "differs",
+            "report-md",
+            "self-test",
+        ],
+    )
+    tree_precheck_destructive = any(item in prod_tree_precheck for item in ["git reset", "git checkout --", "rm -rf", "docker compose up", "docker compose down", "updateOne", "deleteMany"])
     checks.append(_check(
         "prod_stage_workflow_runs_on_production_runner_and_uploads_rollout_evidence",
-        ok and not leaks_stage_secret,
-        f"{detail}; leaksStageSecret={leaks_stage_secret}",
+        ok and tree_precheck_ok and tree_precheck_executable and not tree_precheck_destructive and not leaks_stage_secret,
+        f"{detail}; treePrecheck={tree_precheck_detail}; treePrecheckExecutable={tree_precheck_executable}; treePrecheckDestructive={tree_precheck_destructive}; leaksStageSecret={leaks_stage_secret}",
     ))
 
     ok, detail = _contains_all(
@@ -764,6 +807,8 @@ def _static_checks() -> list[dict]:
             "docker-compose.yml",
             "cds-compose.yml",
             "execdep.sh",
+            "scripts/llmgw-map-shadow-seed.py",
+            "scripts/llmgw-report-agent-shadow-seed.py",
             "deploy/nginx/conf.d/branches/_standalone.conf",
             "git show \"$commit:<critical rollout/deploy files>\" | cmp local files",
             "local rollout/deploy files must match --commit",


### PR DESCRIPTION
## 摘要
为 LLM Gateway 分阶段发布新增生产 runner release tree 只读预检，提前发现生产工作树与 release commit 不一致的问题，避免混合脚本或源码生成发布证据。

## 改动 diff
- llmgw-prod-stage workflow：stage job 调用 tree precheck 并产出 tree-precheck.json/md。
- scripts/llmgw-prod-tree-precheck.py：新增只读 critical release 文件比对脚本，输出 JSON/Markdown。
- scripts/llmgw-readiness-audit.py：将 tree precheck 纳入 readiness 静态守卫。
- GatewayDataDomainGuardTests：补 workflow 和脚本守卫断言。
- changelog：新增碎片。

## 测试
- PASS: llmgw-prod-tree-precheck self-test
- PASS: llmgw-readiness-audit
- PASS: llmgw-prod-tree-precheck against current commit
- PASS: GatewayDataDomainGuardTests 2 条定点测试
- PASS: prd-api dotnet build --no-restore
- PASS: CSharp error/warning grep check

## 说明
本 PR 不执行生产发布、不重启服务、不调用任何模型供应商接口。