### PR TITLE
每日熵减计划 2026-W28 — D6 changelog manifest 登记(5 条)

### DIFF
--- a/changelogs/.entropy-manifest.yml
+++ b/changelogs/.entropy-manifest.yml
@@ -415,3 +415,8 @@ processed:
   - 2026-07-06_cds-config-wave1.md
   - 2026-07-06_cds-config-wave2.md
   - 2026-07-06_cds-local-prod-review-fixes.md
+  - 2026-07-06_cds-config-wave3.md
+  - 2026-07-06_cds-wave3-branch-source-selector.md
+  - 2026-07-06_cds-wave4-compose-structure-seed.md
+  - 2026-07-06_cds-wave4-d1-verified.md
+  - 2026-07-06_cds-wave5-detect-stack-ui.md

--- a/changelogs/2026-07-08_entropy-cleanup.md
+++ b/changelogs/2026-07-08_entropy-cleanup.md
@@ -1,0 +1,1 @@
+| chore | doc | 每日熵清理：D1/D2/D3/D4 净变更为 0（D3/D4 命中的 24+1 条均核实为历史变更表/文档正文中的反引号引用，非真实幽灵条目）；D6 登记 5 条已被 design.cds.config-tree.md / debt.cds.compose-secrets.md 覆盖的 CDS wave3-5 changelog 到 manifest |


### PR DESCRIPTION
## 熵清理摘要

- D1 doc/ 命名规范：0 违规
- D2 index.yml：+0/-0 条
- D3 guide.list：+0/-0 条（原始扫描命中 24 条 GHOST_GUIDE，逐条核实均为 `doc/guide.list.directory.md` 「变更历史」表格中的历史归档记录或正文反引号引用，非真实的当前目录条目，故不删除）
- D4 技能表：+0/-0 条（原始扫描命中 1 条 `pnpm`，核实为 CLAUDE.md 正文加粗强调文字，非技能表行，故不删除）
- D5 codebase-snapshot：需人工审查，本次未改动
- D6 changelog→doc：本次处理 5 条（`2026-07-06_cds-config-wave3.md` / `cds-wave3-branch-source-selector.md` / `cds-wave4-compose-structure-seed.md` / `cds-wave4-d1-verified.md` / `cds-wave5-detect-stack-ui.md`），内容已被 `doc/design.cds.config-tree.md`（波3-5 章节）与 `doc/debt.cds.compose-secrets.md`（D1 paid 记录）完整覆盖，无需追加新章节，仅登记 manifest 防止重复处理

## 改动 diff
- `changelogs/.entropy-manifest.yml`：追加 5 条已处理 changelog 记录
- `changelogs/2026-07-08_entropy-cleanup.md`：本次熵清理 changelog 碎片

## 测试
- [x] 双向扫描完成（D1-D4 全维度跑过 grep 脚本）
- [x] 每条 D3/D4 候选删除项均用 `grep -n` 读取上下文核实为误判后跳过，未做任何真实删除
- [x] D6 changelog 对应模块（cds）的现有 design/debt 文档逐条核对，确认内容已覆盖
- [x] `git diff --stat` 核验：只涉及 `changelogs/` 目录，无代码/索引文件误改


---
_Generated by [Claude Code](https://claude.ai/code/session_01NCVCNQ42691U9ZrXc8rqq7)_