### PR TITLE
test(llmgw): 收口协议路由审计证据

### DIFF
--- a/assets/prototypes/llmgw-architecture-drawing-brief.md
+++ b/assets/prototypes/llmgw-architecture-drawing-brief.md
@@ -1,0 +1,60 @@
+# LLM Gateway Target Architecture Drawing Brief
+
+This drawing brief describes the target state, not a temporary production full-http snapshot.
+
+## Core Statement
+
+模型池最终归属是 GW。MAP keeps business protocol and lifecycle. MAP does not own model routing in target state.
+
+## Main Flow
+
+```text
+MAP / external systems
+  -> GW ingress adapter
+  -> GW Request IR
+  -> appCaller registry
+  -> GW router
+  -> GW model pools
+  -> provider adapter
+  -> upstream model provider
+```
+
+## Ownership
+
+| Layer | Owner | Responsibility |
+|---|---|---|
+| MAP | MAP | Business API, run lifecycle, sessions, canvas, assets, user-facing workflow state |
+| GW ingress adapter | LLM Gateway | Normalize GW Native, OpenAI-compatible, Claude-compatible, and Gemini-compatible requests |
+| GW Request IR | LLM Gateway | Preserve request type, appCallerCode, model policy, model pool id, pinned target, parameter policy, and dropped parameters |
+| appCaller registry | LLM Gateway | Passive discovery, configured/active state, budget, rate limit, owner, and drift evidence |
+| GW router | LLM Gateway | auto, pool, pinned, fallback, strict parameter policy, and provider retry decisions |
+| GW model pools | LLM Gateway | AppCaller-specific pools, pool members, model capability snapshots, provider and exchange binding |
+| provider adapter | LLM Gateway | Provider-specific body mapping, auth, raw/multipart rehydration, response normalization |
+| upstream model provider | External provider | OpenAI, Claude, Gemini, OpenRouter, Volcengine Ark, Doubao ASR, or other model APIs |
+
+## Visual Composition
+
+Use a left-to-right operational architecture diagram:
+
+1. Left band: MAP and external systems as callers.
+2. Center band: LLM Gateway as the only AI governance layer.
+3. Right band: upstream providers.
+4. Bottom band: observability and rollout gates.
+
+The diagram must make the ownership boundary obvious: MAP sends business intent plus context, while LLM Gateway owns routing, pools, keys, logs, audit, and policy.
+
+## Evidence Panels
+
+Show these evidence surfaces as secondary lanes:
+
+| Evidence | Source |
+|---|---|
+| requestId / sessionId / runId / appCallerCode | MAP to GW context |
+| routerTrace / providerAttempts / droppedParameters | GW request logs |
+| shadow comparisons | GW migration evidence |
+| config authority report | GW console |
+| release gate and rollback ledger | rollout scripts |
+
+## Non-goals
+
+This is not an OpenRouter clone. It borrows the unified-entry and provider-routing mental model, but the goal is MAP and external-system governance: no caller should need direct access to MAP internals or provider keys.

--- a/assets/prototypes/llmgw-architecture-map.html
+++ b/assets/prototypes/llmgw-architecture-map.html
@@ -1,0 +1,210 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>LLM Gateway Target Architecture</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #0b1020;
+        --panel: #121a2c;
+        --panel-2: #172238;
+        --line: #33415f;
+        --text: #eef3ff;
+        --muted: #99a7c2;
+        --accent: #7aa2ff;
+        --ok: #55c7a5;
+        --warn: #e4b25b;
+      }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--text);
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      main {
+        max-width: 1180px;
+        margin: 0 auto;
+        padding: 40px 28px 56px;
+      }
+      h1 {
+        margin: 0 0 10px;
+        font-size: 32px;
+        font-weight: 720;
+        letter-spacing: 0;
+      }
+      .subtitle {
+        margin: 0 0 28px;
+        color: var(--muted);
+        font-size: 15px;
+        line-height: 1.7;
+      }
+      .diagram {
+        display: grid;
+        grid-template-columns: 1.05fr 1.35fr 1.35fr 1.15fr;
+        gap: 12px;
+        align-items: stretch;
+      }
+      .lane {
+        border: 1px solid var(--line);
+        background: var(--panel);
+        border-radius: 8px;
+        padding: 16px;
+        min-height: 320px;
+      }
+      .lane h2 {
+        margin: 0 0 14px;
+        font-size: 14px;
+        color: var(--accent);
+        letter-spacing: 0;
+      }
+      .node {
+        border: 1px solid var(--line);
+        background: var(--panel-2);
+        border-radius: 8px;
+        padding: 12px;
+        margin-bottom: 10px;
+      }
+      .node strong {
+        display: block;
+        font-size: 13px;
+        margin-bottom: 5px;
+      }
+      .node span {
+        display: block;
+        color: var(--muted);
+        font-size: 12px;
+        line-height: 1.55;
+      }
+      .flow {
+        margin: 22px 0;
+        padding: 16px;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: #0f1728;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+        color: #d8e4ff;
+        overflow-x: auto;
+        white-space: nowrap;
+      }
+      .evidence {
+        margin-top: 24px;
+        display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: 12px;
+      }
+      .evidence .node {
+        min-height: 100px;
+      }
+      .ownership {
+        margin-top: 24px;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        overflow: hidden;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+      th, td {
+        border-bottom: 1px solid var(--line);
+        padding: 11px 12px;
+        text-align: left;
+        font-size: 12px;
+        vertical-align: top;
+      }
+      th {
+        color: var(--accent);
+        background: #10182a;
+      }
+      tr:last-child td {
+        border-bottom: 0;
+      }
+      .tag {
+        display: inline-block;
+        border: 1px solid var(--line);
+        border-radius: 6px;
+        padding: 3px 7px;
+        margin: 2px 4px 2px 0;
+        font-size: 11px;
+        color: #dbe6ff;
+      }
+      .ok {
+        color: var(--ok);
+      }
+      .warn {
+        color: var(--warn);
+      }
+      @media (max-width: 900px) {
+        .diagram,
+        .evidence {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>LLM Gateway Target Architecture</h1>
+      <p class="subtitle">
+        This page describes the target architecture. 模型池最终归属是 GW.
+        MAP keeps business protocol and lifecycle. MAP does not own model routing in target state.
+      </p>
+
+      <div class="flow">
+        MAP / external systems -> GW ingress adapter -> GW Request IR -> appCaller registry -> GW router -> GW model pools -> provider adapter -> upstream model provider
+      </div>
+
+      <section class="diagram" aria-label="LLM Gateway architecture">
+        <div class="lane">
+          <h2>Callers</h2>
+          <div class="node"><strong>MAP</strong><span>Business API, run lifecycle, sessions, canvas, assets, and user-facing workflow state.</span></div>
+          <div class="node"><strong>External systems</strong><span>Use GW-compatible protocols instead of calling MAP internals or provider keys.</span></div>
+        </div>
+        <div class="lane">
+          <h2>Ingress and IR</h2>
+          <div class="node"><strong>GW ingress adapter</strong><span>Normalizes GW Native, OpenAI-compatible, Claude-compatible, and Gemini-compatible requests.</span></div>
+          <div class="node"><strong>GW Request IR</strong><span>Preserves appCallerCode, requestType, modelPolicy, modelPoolId, pinned target, parameterPolicy, and droppedParameters.</span></div>
+          <div class="node"><strong>appCaller registry</strong><span>Passive discovery, configured/active state, budget, rate limit, owner, and drift evidence.</span></div>
+        </div>
+        <div class="lane">
+          <h2>Gateway routing</h2>
+          <div class="node"><strong>GW router</strong><span>Owns auto, pool, pinned, fallback, strict parameter policy, and provider retry decisions.</span></div>
+          <div class="node"><strong>GW model pools</strong><span>Owns appCaller-specific pools, pool members, capability snapshots, provider and exchange binding.</span></div>
+          <div class="node"><strong>provider adapter</strong><span>Maps protocol-specific bodies, auth, raw/multipart rehydration, and response normalization.</span></div>
+        </div>
+        <div class="lane">
+          <h2>Upstream</h2>
+          <div class="node"><strong>OpenAI / Claude / Gemini</strong><span>Provider APIs reached only through Gateway-owned keys and routing decisions.</span></div>
+          <div class="node"><strong>OpenRouter / Volcengine Ark / Doubao ASR</strong><span>Exchange transformers and provider adapters keep raw protocols outside MAP.</span></div>
+        </div>
+      </section>
+
+      <section class="evidence" aria-label="Evidence surfaces">
+        <div class="node"><strong class="ok">Request linkage</strong><span>requestId, sessionId, runId, appCallerCode.</span></div>
+        <div class="node"><strong class="ok">GW observability</strong><span>routerTrace, providerAttempts, droppedParameters, transport.</span></div>
+        <div class="node"><strong class="ok">Migration evidence</strong><span>shadow comparisons, release gates, rollout ledger.</span></div>
+        <div class="node"><strong class="warn">Runtime gates</strong><span>config authority execution, active MAP fallback exit, http-full acceptance, legacy cleanup.</span></div>
+      </section>
+
+      <section class="ownership" aria-label="Ownership table">
+        <table>
+          <thead>
+            <tr>
+              <th>Domain</th>
+              <th>Owner</th>
+              <th>Responsibility</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td>Business lifecycle</td><td>MAP</td><td>Runs, workflow, canvas, business data, user-facing state.</td></tr>
+            <tr><td>Request governance</td><td>LLM Gateway</td><td><span class="tag">appCaller registry</span><span class="tag">rate limit</span><span class="tag">budget</span><span class="tag">audit</span></td></tr>
+            <tr><td>Model routing</td><td>LLM Gateway</td><td><span class="tag">GW router</span><span class="tag">GW model pools</span><span class="tag">fallback</span><span class="tag">pinned</span></td></tr>
+            <tr><td>Provider access</td><td>LLM Gateway</td><td>Provider adapter, exchange, key encryption, upstream protocol compatibility.</td></tr>
+          </tbody>
+        </table>
+      </section>
+    </main>
+  </body>
+</html>

--- a/changelogs/2026-07-09_llmgw-protocol-router.md
+++ b/changelogs/2026-07-09_llmgw-protocol-router.md
@@ -1,0 +1,4 @@
+| feat | prd-api | LLM Gateway 增加四类协议入口，统一进入 GW Request IR，并支持 appCaller 被动注册、auto/pool/pinned 路由语义与 provider attempts 观测 |
+| feat | prd-llmgw | 新增 GW 配置权威接口，覆盖 appCaller、模型池、平台、模型、exchange、密钥健康、操作审计与 runtime gates |
+| polish | prd-llmgw-web | 控制台补齐日志、调用方、模型池、平台、模型、exchange、审计与 shadow 证据页面 |
+| ops | scripts | 增加协议路由审计、配置权威备份/应用、生产发布 gate 和 inproc/shadow 回滚脚本 |

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -733,8 +733,8 @@ public class GatewayDataDomainGuardTests
         Assert.Contains("Restore previous rollout evidence", workflow);
         Assert.Contains("llmgw-prod-stage-{0}", workflow);
         Assert.Contains("default branch", ReadRepoFile("doc/plan.llm-gateway.full-cutover.md"));
-        Assert.Contains("[ \"$stage\" != \"rollback-inproc\" ] && [ \"$stage\" != \"rollback-rehearsal\" ] && [ -z \"$map_base\" ]", workflow);
-        Assert.Contains("[ \"$stage\" != \"rollback-inproc\" ] && [ \"$stage\" != \"rollback-rehearsal\" ] && [ -z \"$(printf '%s' \"${PRD_AGENT_API_KEY:-}\" | xargs)\" ]", workflow);
+        Assert.Contains("[ \"$stage\" != \"rollback-inproc\" ] && [ \"$stage\" != \"rollback-rehearsal\" ] && [ \"$stage\" != \"config-authority\" ] && [ -z \"$map_base\" ]", workflow);
+        Assert.Contains("[ \"$stage\" != \"rollback-inproc\" ] && [ \"$stage\" != \"rollback-rehearsal\" ] && [ \"$stage\" != \"config-authority\" ] && [ -z \"$(printf '%s' \"${PRD_AGENT_API_KEY:-}\" | xargs)\" ]", workflow);
         Assert.Contains("stage $stage requires rollout_evidence_run_id so prior rollout ledger evidence is restored", workflow);
         Assert.Contains("scripts/llmgw-prod-stage.sh", workflow);
         Assert.Contains("--stage \"$stage\"", workflow);


### PR DESCRIPTION
## 摘要
收口 LLM Gateway 协议路由目标实施后的合并自检缺口：补齐目标架构原型说明与 changelog 证据，并同步生产阶段 workflow 测试断言。

## 改动 diff
- `assets/prototypes/llmgw-architecture-map.html`：新增目标态架构 HTML，明确 MAP 只保留业务生命周期，GW 拥有 ingress、IR、appCaller registry、router、model pools 和 provider adapter。
- `assets/prototypes/llmgw-architecture-drawing-brief.md`：新增给设计/绘图使用的目标态 brief，避免把当前 full-http 过渡态误读成最终架构。
- `prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs`：同步 `config-authority` 阶段的生产 workflow gate 断言。
- `changelogs/2026-07-09_llmgw-protocol-router.md`：补齐协议路由目标实施记录。

## 测试
- [x] `dotnet build prd-api/PrdAgent.sln --no-restore` 通过，0 error，存在既有 warning。
- [x] `/opt/homebrew/opt/dotnet@8/bin/dotnet test prd-api/tests/PrdAgent.Tests/PrdAgent.Tests.csproj --no-restore --filter "FullyQualifiedName~GatewayDataDomainGuardTests|FullyQualifiedName~GatewayDirectClientRatchetTests|FullyQualifiedName~ModelResolverTests|FullyQualifiedName~AppCallerRegistryGoldenSnapshotTests"` 通过，89/89。
- [x] `cd prd-llmgw-web && pnpm build` 通过。
- [x] `python3 scripts/llmgw-protocol-router-audit.py --json-out /tmp/llmgw-protocol-router-audit.json --report-md /tmp/llmgw-protocol-router-audit.md` 通过，10/10。
- [x] `python3 scripts/llmgw-readiness-audit.py --print-json` 通过，39 checks。
- [x] `git diff --check` 通过；触达文件 emoji 扫描无命中。