### PR TITLE
fix(llmgw): 修正 full-http 发布门禁顺序

### DIFF
--- a/changelogs/2026-07-10_llmgw-runtime-gate-order.md
+++ b/changelogs/2026-07-10_llmgw-runtime-gate-order.md
@@ -1,0 +1,2 @@
+| fix | scripts | 修正 LLM Gateway http-full 发布自举门禁，避免 runtime-gates 在 rollout ledger 写入前形成循环阻塞 |
+| test | prd-api | 补充 LLM Gateway 发布门禁顺序的静态守卫测试 |

--- a/exec_dep.sh
+++ b/exec_dep.sh
@@ -1114,6 +1114,10 @@ run_llmgw_post_deploy_verification_if_needed() {
     if [ -n "$expect_commit" ]; then
       runtime_gate_expect_arg="--expect-commit $expect_commit"
     fi
+    if [ "$mode" = "http" ] && [ "${LLMGW_PROD_STAGE:-}" = "http-full" ]; then
+      echo "LLM Gateway post-deploy runtime gates: allowing self-finalizing full_http_rollout_ledger only"
+      runtime_gate_expect_arg="$runtime_gate_expect_arg --allow-pending-http-full-ledger"
+    fi
     # shellcheck disable=SC2086
     GW_KEY="$gate_key" python3 scripts/llmgw-release-gate.py $args $runtime_gate_expect_arg --require-runtime-gates
   else

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -296,6 +296,8 @@ public class GatewayDataDomainGuardTests
         Assert.Contains("python3 scripts/llmgw-serving-probe.py $probe_args", script);
         Assert.Contains("LLM Gateway post-deploy serving probe: required", script);
         Assert.Contains("LLM Gateway post-deploy D-layer smoke: required", script);
+        Assert.Contains("LLM Gateway post-deploy runtime gates: allowing self-finalizing full_http_rollout_ledger only", script);
+        Assert.Contains("--allow-pending-http-full-ledger", script);
         Assert.Contains("LLMGW_GATE_SERVING_PROBE_SAMPLES", script);
         Assert.Contains("LLMGW_GATE_SERVING_PROBE_INTERVAL_SECONDS", script);
         Assert.Contains("LLMGW_SKIP_RELEASE_GATE=1", script);
@@ -384,6 +386,11 @@ public class GatewayDataDomainGuardTests
         Assert.Contains("--require-app-kind", releaseGate);
         Assert.Contains("--health-samples", releaseGate);
         Assert.Contains("--health-interval", releaseGate);
+        Assert.Contains("--require-runtime-gates", releaseGate);
+        Assert.Contains("--allow-pending-http-full-ledger", releaseGate);
+        Assert.Contains("allowedPendingRuntimeGates", releaseGate);
+        Assert.Contains("selfFinalizingHttpFullLedger", releaseGate);
+        Assert.Contains("remaining == [\"full_http_rollout_ledger\"]", releaseGate);
         Assert.Contains("\"stable\"", releaseGate);
         Assert.Contains("--json-out", releaseGate);
         Assert.Contains("--report-md", releaseGate);
@@ -564,6 +571,10 @@ public class GatewayDataDomainGuardTests
         Assert.Contains("_require_serving_probe_for_commit", ledger);
         Assert.Contains("_require_smoke_for_commit", ledger);
         Assert.Contains("_require_release_gate_for_commit", ledger);
+        Assert.Contains("allowedPendingRuntimeGates", ledger);
+        Assert.Contains("selfFinalizingHttpFullLedger", ledger);
+        Assert.Contains("pending_http_full_ledger_only", ledger);
+        Assert.Contains("allowedPending=", ledger);
         Assert.Contains("\"providerAuditExternalBlockers\": provider_external_blockers", ledger);
         Assert.Contains("_provider_external_blockers", ledger);
         Assert.Contains("contains external blockers", ledger);

--- a/scripts/llmgw-readiness-audit.py
+++ b/scripts/llmgw-readiness-audit.py
@@ -1286,6 +1286,8 @@ def _static_checks() -> list[dict]:
             "python3 scripts/llmgw-serving-probe.py $probe_args",
             "LLM Gateway post-deploy serving probe",
             "LLM Gateway post-deploy D-layer smoke",
+            "LLM Gateway post-deploy runtime gates: allowing self-finalizing full_http_rollout_ledger only",
+            "--allow-pending-http-full-ledger",
             "LLMGW_SKIP_RELEASE_GATE=1",
             "LLMGW_SKIP_RELEASE_GATE=1 is not allowed when LLM Gateway release evidence is required",
             "Use scripts/llmgw-rollback-inproc.sh for emergency rollback",

--- a/scripts/llmgw-release-gate.py
+++ b/scripts/llmgw-release-gate.py
@@ -403,8 +403,19 @@ def _config_authority_check(
     return result
 
 
-def _runtime_gates_check(console_base: str, token: str, expected_commit: str = "") -> dict:
-    result = _runtime_gates_result_from_data(console_base, {}, http_status=0, expected_commit=expected_commit)
+def _runtime_gates_check(
+    console_base: str,
+    token: str,
+    expected_commit: str = "",
+    allow_pending_http_full_ledger: bool = False,
+) -> dict:
+    result = _runtime_gates_result_from_data(
+        console_base,
+        {},
+        http_status=0,
+        expected_commit=expected_commit,
+        allow_pending_http_full_ledger=allow_pending_http_full_ledger,
+    )
     code, raw = _console_request("GET", console_base, "/runtime-gates", token)
     if code != 200:
         result["httpStatus"] = code
@@ -417,10 +428,22 @@ def _runtime_gates_check(console_base: str, token: str, expected_commit: str = "
         result["httpStatus"] = code
         result["failures"].append(str(exc))
         return result
-    return _runtime_gates_result_from_data(console_base, data, http_status=code, expected_commit=expected_commit)
+    return _runtime_gates_result_from_data(
+        console_base,
+        data,
+        http_status=code,
+        expected_commit=expected_commit,
+        allow_pending_http_full_ledger=allow_pending_http_full_ledger,
+    )
 
 
-def _runtime_gates_result_from_data(console_base: str, data: dict, http_status: int = 200, expected_commit: str = "") -> dict:
+def _runtime_gates_result_from_data(
+    console_base: str,
+    data: dict,
+    http_status: int = 200,
+    expected_commit: str = "",
+    allow_pending_http_full_ledger: bool = False,
+) -> dict:
     result = {
         "required": False,
         "ok": False,
@@ -437,6 +460,8 @@ def _runtime_gates_result_from_data(console_base: str, data: dict, http_status: 
         "generatedAt": None,
         "remainingRuntimeGates": [],
         "remainingRuntimeGateDetails": [],
+        "allowedPendingRuntimeGates": [],
+        "selfFinalizingHttpFullLedger": False,
         "failures": [],
     }
 
@@ -474,13 +499,18 @@ def _runtime_gates_result_from_data(console_base: str, data: dict, http_status: 
     result["generatedAt"] = _get_nested(data, "generatedAt")
     result["remainingRuntimeGates"] = remaining
     result["remainingRuntimeGateDetails"] = remaining_details
+    allowed_pending: list[str] = []
+    if allow_pending_http_full_ledger and remaining == ["full_http_rollout_ledger"]:
+        allowed_pending = ["full_http_rollout_ledger"]
+    result["allowedPendingRuntimeGates"] = allowed_pending
+    result["selfFinalizingHttpFullLedger"] = bool(allowed_pending)
 
     failures: list[str] = []
     if expected and release_commit != expected:
         failures.append(f"runtime gates releaseCommit mismatch: actual={release_commit or 'empty'} expected={expected}")
-    if not ready:
+    if not ready and not allowed_pending:
         failures.append(f"runtime gates 未 readyForHttpFull: status={status}; remaining={', '.join(remaining) or 'unknown'}")
-    if remaining:
+    if remaining and not allowed_pending:
         failures.append(f"runtime gates 仍有 blocking gate 未通过: {', '.join(remaining)}")
     result["failures"] = failures
     result["ok"] = not failures
@@ -540,6 +570,26 @@ def _self_test() -> int:
         failures.append(f"blocked runtime gates missing structured facts: {blocked}")
     if (detail_facts.get("current_commit_http_transport") or {}).get("nonHttpTransportLogs") != "1":
         failures.append(f"blocked runtime gates missing transport facts: {blocked}")
+    self_finalizing = _runtime_gates_result_from_data(
+        "http://console/gw",
+        {
+            "status": "waiting",
+            "releaseCommit": "abc123",
+            "readyForHttpFull": False,
+            "items": [
+                {
+                    "id": "full_http_rollout_ledger",
+                    "status": "waiting",
+                    "blocking": True,
+                    "facts": {"releaseCommit": "abc123"},
+                }
+            ],
+        },
+        expected_commit="abc123",
+        allow_pending_http_full_ledger=True,
+    )
+    if not self_finalizing["ok"] or self_finalizing["allowedPendingRuntimeGates"] != ["full_http_rollout_ledger"]:
+        failures.append(f"self-finalizing http-full ledger should pass only for rollout ledger gate: {self_finalizing}")
     with tempfile.TemporaryDirectory(prefix="llmgw-release-gate-self-test-") as tmp:
         md_path = os.path.join(tmp, "release-gate.md")
         _write_markdown(md_path, {
@@ -711,6 +761,8 @@ def main() -> int:
                         help="要求 GW 控制台配置权威报告 ready：MAP fallback 对象清零且 active appCaller 均绑定 GW 池")
     parser.add_argument("--require-runtime-gates", action="store_true",
                         help="要求 GW 控制台 /runtime-gates readyForHttpFull=true；用于 http-full 部署后最终放行")
+    parser.add_argument("--allow-pending-http-full-ledger", action="store_true",
+                        help="仅用于 http-full 自举：允许 runtime-gates 只剩 full_http_rollout_ledger，待本阶段成功后由 ledger 补齐")
     parser.add_argument("--config-authority-base", default=os.environ.get("LLMGW_CONSOLE_BASE", ""),
                         help="GW 控制台 API base，例如 https://host/gw；未以 /gw 结尾时自动追加")
     parser.add_argument("--config-authority-token", default=os.environ.get("LLMGW_CONSOLE_TOKEN", ""),
@@ -846,7 +898,12 @@ def main() -> int:
                 report["configAuthority"] = config_check
                 failures.extend(config_check.get("failures") or [])
             if token and args.require_runtime_gates:
-                runtime_check = _runtime_gates_check(console_base, token, expected_commit=args.expect_commit)
+                runtime_check = _runtime_gates_check(
+                    console_base,
+                    token,
+                    expected_commit=args.expect_commit,
+                    allow_pending_http_full_ledger=args.allow_pending_http_full_ledger,
+                )
                 runtime_check["required"] = True
                 report["runtimeGates"] = runtime_check
                 failures.extend(runtime_check.get("failures") or [])

--- a/scripts/llmgw-rollout-ledger.py
+++ b/scripts/llmgw-rollout-ledger.py
@@ -267,11 +267,27 @@ def _require_release_gate_for_commit(path: str, label: str, commit: str, require
             remaining = runtime.get("RemainingRuntimeGates")
         if not isinstance(remaining, list):
             remaining = []
-        if not runtime_required or not runtime_ok or not runtime_ready:
+        allowed_pending = runtime.get("allowedPendingRuntimeGates")
+        if allowed_pending is None:
+            allowed_pending = runtime.get("AllowedPendingRuntimeGates")
+        if not isinstance(allowed_pending, list):
+            allowed_pending = []
+        self_finalizing = bool(
+            runtime.get("selfFinalizingHttpFullLedger")
+            if "selfFinalizingHttpFullLedger" in runtime
+            else runtime.get("SelfFinalizingHttpFullLedger")
+        )
+        pending_http_full_ledger_only = (
+            self_finalizing
+            and remaining == ["full_http_rollout_ledger"]
+            and allowed_pending == ["full_http_rollout_ledger"]
+        )
+        if not runtime_required or not runtime_ok or (not runtime_ready and not pending_http_full_ledger_only):
             raise SystemExit(
                 f"ERROR: {label} runtimeGates is not required+ok+ready for http-full gate: "
                 f"{path} required={runtime_required} ok={runtime_ok} readyForHttpFull={runtime_ready} "
-                f"remaining={','.join(str(x) for x in remaining) or 'none'}"
+                f"remaining={','.join(str(x) for x in remaining) or 'none'} "
+                f"allowedPending={','.join(str(x) for x in allowed_pending) or 'none'}"
             )
 
 


### PR DESCRIPTION
## 摘要
修正 LLM Gateway `http-full` 发布时的 runtime gate 自举顺序，避免 `exec_dep.sh` 在 rollout ledger 写入前要求 `full_http_rollout_ledger` 已通过导致循环阻塞。新逻辑只允许 runtime-gates 唯一剩余项为 `full_http_rollout_ledger` 时自举通过，其他阻塞项仍会失败。

## 改动 diff
- `exec_dep.sh`：`http-full` 阶段 post-deploy runtime gate 增加 `--allow-pending-http-full-ledger`。
- `scripts/llmgw-release-gate.py`：新增自举参数、报告字段和 self-test 覆盖。
- `scripts/llmgw-rollout-ledger.py`：仅接受 `full_http_rollout_ledger` 单项 pending 的自举 runtime evidence。
- `scripts/llmgw-readiness-audit.py`：补静态审计守卫。
- `prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs`：补发布门禁顺序静态守卫。
- `changelogs/2026-07-10_llmgw-runtime-gate-order.md`：新增变更碎片。

## 测试
- [x] `sh -n exec_dep.sh scripts/llmgw-prod-stage.sh`
- [x] `python3 -m py_compile scripts/llmgw-release-gate.py scripts/llmgw-rollout-ledger.py scripts/llmgw-readiness-audit.py`
- [x] `python3 scripts/llmgw-release-gate.py --self-test`
- [x] `cd prd-api && dotnet test tests/PrdAgent.Tests/PrdAgent.Tests.csproj --filter GatewayDataDomainGuardTests --no-restore`
- [x] `cd prd-api && dotnet build --no-restore` 摘要无 `error CS*`，仅既有 warning
- [x] `python3 scripts/llmgw-readiness-audit.py --json-out /tmp/llmgw-readiness-runtime-gate-order.json --report-md /tmp/llmgw-readiness-runtime-gate-order.md`
