### PR TITLE
fix(llmgw): 修正控制台日志权威库

### DIFF
--- a/changelogs/2026-07-10_llmgw-console-gw-logs.md
+++ b/changelogs/2026-07-10_llmgw-console-gw-logs.md
@@ -1,0 +1,3 @@
+| fix | prd-llmgw | 控制台日志与 runtime gates 改读 llm_gateway 自有请求日志，避免 full-http 证据被误查到 MAP 日志库 |
+| fix | docker-compose | 为 llmgw 控制台容器补齐 rollout ledger 只读挂载和 MAP fallback 退场开关环境变量 |
+| test | prd-api | 增加 LLM Gateway 数据域与 compose 配置静态守卫，防止日志权威库回退 |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -182,6 +182,7 @@ services:
       - MongoDB__ConnectionString=mongodb://mongodb:27017
       - MongoDB__DatabaseName=prdagent
       - LlmGateway__DatabaseName=${LLMGW_DATABASE_NAME:-llm_gateway}
+      - LlmGateway__DisableMapConfigFallbackForActiveAppCallers=${LLMGW_DISABLE_MAP_CONFIG_FALLBACK_FOR_ACTIVE_APP_CALLERS:-false}
       - LlmGateway__RolloutLedgerPath=/app/.llmgw-release-evidence/rollout-ledger.jsonl
       # 控制台只在已认领到 GW 的平台/模型/Exchange 上写密钥；加密密钥必须与 api / llmgw-serve 一致。
       - ApiKeyCrypto__Secret=${API_KEY_CRYPTO_SECRET:?must set API_KEY_CRYPTO_SECRET in production (platform API key encryption, shared by api, llmgw and llmgw-serve)}
@@ -197,6 +198,8 @@ services:
     read_only: true
     tmpfs:
       - /tmp
+    volumes:
+      - ./.llmgw-release-evidence:/app/.llmgw-release-evidence:ro
     depends_on:
       - mongodb
     networks:

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -41,6 +41,8 @@ public class GatewayDataDomainGuardTests
         var consoleProgram = ReadRepoFile("prd-llmgw/Program.cs");
 
         Assert.Contains("services.GetService<LlmGatewayDataContext>()?.Context", servingEndpoints);
+        Assert.Contains("var logs = gatewayDatabase.GetCollection<BsonDocument>(\"llmrequestlogs\");", consoleProgram);
+        Assert.DoesNotContain("var logs = mapDatabase.GetCollection<BsonDocument>(\"llmrequestlogs\");", consoleProgram);
         Assert.Contains("var shadows = gatewayDatabase.GetCollection<BsonDocument>(\"llmshadow_comparisons\");", consoleProgram);
         Assert.DoesNotContain("var shadows = mapDatabase.GetCollection<BsonDocument>(\"llmshadow_comparisons\");", consoleProgram);
     }
@@ -77,6 +79,9 @@ public class GatewayDataDomainGuardTests
         Assert.Contains("LlmGateway__HttpAppCallerAllowlist=${LLMGW_HTTP_APP_CALLER_ALLOWLIST:-}", dockerCompose);
         Assert.Contains("LlmGateway__ShadowFullSamplePercent=${LLMGW_SHADOW_FULL_SAMPLE_PERCENT:-0}", dockerCompose);
         Assert.Contains("LlmGateway__ShadowFullSampleAppCallerAllowlist=${LLMGW_SHADOW_FULL_SAMPLE_APP_CALLER_ALLOWLIST:-}", dockerCompose);
+        Assert.Contains("LlmGateway__DisableMapConfigFallbackForActiveAppCallers=${LLMGW_DISABLE_MAP_CONFIG_FALLBACK_FOR_ACTIVE_APP_CALLERS:-false}", dockerCompose);
+        Assert.Contains("LlmGateway__RolloutLedgerPath=/app/.llmgw-release-evidence/rollout-ledger.jsonl", dockerCompose);
+        Assert.Contains("./.llmgw-release-evidence:/app/.llmgw-release-evidence:ro", dockerCompose);
         Assert.Contains("LLMGW_ADMIN_PASSWORD=${LLMGW_ADMIN_PASSWORD:-}", dockerCompose);
         Assert.Contains("LLMGW_ADMIN_FORCE_RESET=${LLMGW_ADMIN_FORCE_RESET:-}", dockerCompose);
         Assert.DoesNotContain("LLMGW_ADMIN_PASSWORD=${LLMGW_ADMIN_PASSWORD:?", dockerCompose);

--- a/prd-llmgw/Program.cs
+++ b/prd-llmgw/Program.cs
@@ -3,7 +3,7 @@
 // 设计意图（见 doc/design.llm-gateway-physical-isolation.md）：
 //   - 本服务与 prd-api 完全解耦，不引用任何 PrdAgent.* 项目，仅依赖 NuGet 包。
 //   - MAP 继续负责 MAP 自己的业务日志；GW 控制台账号、登录审计等自有状态落独立数据库 llm_gateway。
-//   - 当前控制台仍读取 MAP 的 llmrequestlogs/模型配置作为观测视图，但不把账号状态写进 MAP 库。
+//   - 控制台读取 GW 自有 llmrequestlogs / shadow / 审计作为权威观测；MAP 业务日志只作为跨系统关联来源。
 //   - 共享集合 llmrequestlogs 由 .NET 驱动以 PascalCase 字段名序列化；为规避历史文档里
 //     数值/日期类型混存导致的反序列化异常，日志查询统一以 BsonDocument 读取并手动安全映射。
 
@@ -136,7 +136,8 @@ var adminBootstrapPwd = Environment.GetEnvironmentVariable("LLMGW_ADMIN_PASSWORD
 var operationAudits = gatewayDatabase.GetCollection<BsonDocument>("llmgw_operation_audits");
 await SeedAdminAsync(gatewayDatabase, operationAudits, AdminUser, DefaultAdminPwd, forceResetAdmin, adminBootstrapPwd);
 
-var logs = mapDatabase.GetCollection<BsonDocument>("llmrequestlogs");
+// GW 请求日志由 llmgw-serve 写入独立 llm_gateway 库；控制台和 runtime gates 必须读取同一权威来源。
+var logs = gatewayDatabase.GetCollection<BsonDocument>("llmrequestlogs");
 // GW 自有账号和审计落独立库 llm_gateway，避免被 MAP 项目 env / shared DB 状态覆盖。
 var users = gatewayDatabase.GetCollection<LlmGwUser>("llmgw_console_users");
 var loginAudits = gatewayDatabase.GetCollection<LlmGwLoginAudit>("llmgw_login_audits");


### PR DESCRIPTION
## 摘要
修正 LLM Gateway 控制台和 runtime gates 的日志数据源，让 GW 控制台读取 llm_gateway 自有请求日志，而不是 MAP 业务日志库。同步补齐 llmgw 控制台容器的 rollout ledger 只读挂载和 fallback 退场开关，避免生产 full-http gate 查不到证据。

## 改动 diff
- `prd-llmgw/Program.cs`：`/gw/logs` 与 runtime gates 的 logs 集合改读 `llm_gateway.llmrequestlogs`。
- `docker-compose.yml`：llmgw 控制台服务补 `LlmGateway__DisableMapConfigFallbackForActiveAppCallers` 和 `.llmgw-release-evidence` 只读挂载。
- `prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs`：增加日志权威库与 compose 配置静态守卫。
- `changelogs/2026-07-10_llmgw-console-gw-logs.md`：新增 changelog 碎片。

## 测试
- [x] `cd prd-api && dotnet build --no-restore 2>&1 | grep -E "error CS|warning CS" | head -30`：无 error CS，仅既有 warning
- [x] `git diff --check` 通过
- [ ] `dotnet test tests/PrdAgent.Tests/PrdAgent.Tests.csproj --filter GatewayDataDomainGuardTests --no-restore`：本机缺 .NET 8 runtime，testhost 无法启动，交给 CI 标准环境验证

## 生产背景
正式环境已切到 `4d3f2a529641a79f703059c4747d5a7e75d4aa69`，MAP->GW HTTP ModelLab 最小请求成功并在 `llm_gateway.llmrequestlogs` 产生 `GatewayTransport=http` 日志；当前 PR 修复控制台读取不到这份证据的问题。