### PR TITLE
fix(llmgw): 排除冒烟探针日志门禁污染

### DIFF
--- a/changelogs/2026-07-10_llmgw-smoke-health-probe.md
+++ b/changelogs/2026-07-10_llmgw-smoke-health-probe.md
@@ -1,0 +1,3 @@
+| fix | prd-llmgw | runtime gates 统计当前 commit transport 证据时排除 GW smoke health probe，避免 D 层冒烟日志污染 full-http 门禁 |
+| fix | scripts | gw-smoke 的 send/stream/client-stream/canary 请求显式标记 IsHealthProbe |
+| test | prd-api | 增加 GW smoke health probe 与 runtime gates 排除逻辑静态守卫 |

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -39,12 +39,15 @@ public class GatewayDataDomainGuardTests
     {
         var servingEndpoints = ReadRepoFile("prd-api/src/PrdAgent.LlmGateway/GatewayHttpEndpoints.cs");
         var consoleProgram = ReadRepoFile("prd-llmgw/Program.cs");
+        var smoke = ReadRepoFile("scripts/gw-smoke.py");
 
         Assert.Contains("services.GetService<LlmGatewayDataContext>()?.Context", servingEndpoints);
         Assert.Contains("var logs = gatewayDatabase.GetCollection<BsonDocument>(\"llmrequestlogs\");", consoleProgram);
         Assert.DoesNotContain("var logs = mapDatabase.GetCollection<BsonDocument>(\"llmrequestlogs\");", consoleProgram);
         Assert.Contains("var shadows = gatewayDatabase.GetCollection<BsonDocument>(\"llmshadow_comparisons\");", consoleProgram);
         Assert.DoesNotContain("var shadows = mapDatabase.GetCollection<BsonDocument>(\"llmshadow_comparisons\");", consoleProgram);
+        Assert.Contains("Builders<BsonDocument>.Filter.Ne(\"IsHealthProbe\", true)", consoleProgram);
+        Assert.Contains("\"IsHealthProbe\": True", smoke);
     }
 
     [Fact]

--- a/prd-llmgw/Program.cs
+++ b/prd-llmgw/Program.cs
@@ -888,7 +888,9 @@ app.MapGet("/gw/runtime-gates", async () =>
     var shadowHttpFail = runtimeCommit is null ? 0 : await shadows.CountDocumentsAsync(Builders<BsonDocument>.Filter.And(shadowFilter, Builders<BsonDocument>.Filter.Eq("HttpOk", false)));
     var logReleaseFilter = runtimeCommit is null
         ? FilterDefinition<BsonDocument>.Empty
-        : Builders<BsonDocument>.Filter.Eq("ReleaseCommit", runtimeCommit);
+        : Builders<BsonDocument>.Filter.And(
+            Builders<BsonDocument>.Filter.Eq("ReleaseCommit", runtimeCommit),
+            Builders<BsonDocument>.Filter.Ne("IsHealthProbe", true));
     var releaseLogTotal = runtimeCommit is null ? 0 : await logs.CountDocumentsAsync(logReleaseFilter);
     var httpTransportLogs = runtimeCommit is null
         ? 0

--- a/scripts/gw-smoke.py
+++ b/scripts/gw-smoke.py
@@ -318,7 +318,7 @@ def main():
         body = {
             "AppCallerCode": accode, "ModelType": mtype, "Stream": False,
             "RequestBody": {"messages": [{"role": "user", "content": "ping, reply OK"}], "max_tokens": 16},
-            "Context": {"UserId": "smoke-test"},
+            "Context": {"UserId": "smoke-test", "IsHealthProbe": True},
         }
         code, raw = _req("POST", "/send", body)
         d = _envelope_data(raw) or {}
@@ -340,7 +340,7 @@ def main():
                 "max_tokens": 16,
                 "stream": True,
             },
-            "Context": {"UserId": "smoke-test"},
+            "Context": {"UserId": "smoke-test", "IsHealthProbe": True},
         }
         code, raw, events = _sse_req("/stream", stream_body)
         stream_text = "".join(str(e.get("Content") or "") for e in events if isinstance(e, dict))
@@ -371,7 +371,7 @@ def main():
             "SystemPrompt": "Reply briefly.",
             "Messages": [{"Role": "user", "Content": "ping, client stream reply OK"}],
             "EnablePromptCache": True,
-            "Context": {"UserId": "smoke-test"},
+            "Context": {"UserId": "smoke-test", "IsHealthProbe": True},
         }
         code, raw, events = _sse_req("/client-stream", client_stream_body)
         client_stream_text = "".join(str(e.get("Content") or "") for e in events if isinstance(e, dict))
@@ -433,7 +433,7 @@ def main():
 
     # 7) canary：指向不存在的入口，必须失败（证明探测有效）
     body = {"AppCallerCode": "nonexistent.canary::chat", "ModelType": "chat",
-            "RequestBody": {"messages": [{"role": "user", "content": "x"}]}, "Context": {"UserId": "smoke-test"}}
+            "RequestBody": {"messages": [{"role": "user", "content": "x"}]}, "Context": {"UserId": "smoke-test", "IsHealthProbe": True}}
     code, raw = _req("POST", "/send", body)
     d = _envelope_data(raw) or {}
     canary_caught = not (code == 200 and d.get("Success") is True)


### PR DESCRIPTION
## 摘要
修正 LLM Gateway full-http runtime gates 的证据统计口径：GW 冒烟脚本产生的健康探针日志不应计入当前 commit 的业务 transport 证据，否则会把自测 inproc 探针误判为生产流量回退。

## 改动 diff
- `scripts/gw-smoke.py`：send/stream/client-stream/canary 请求写入 `Context.IsHealthProbe=true`。
- `prd-llmgw/Program.cs`：`/gw/runtime-gates` 统计当前 commit 日志时排除 health probe。
- `prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs`：增加静态守卫，防止控制台日志库和 health probe 口径回退。
- `changelogs/2026-07-10_llmgw-smoke-health-probe.md`：新增 changelog 碎片。

## 测试
- [x] `python3 -m py_compile scripts/gw-smoke.py`
- [x] `GW_SMOKE_SELF_TEST=1 python3 scripts/gw-smoke.py`
- [x] `cd prd-api && dotnet build --no-restore` 无 CS error，只有既有 warning
- [x] `git diff --check`