### PR TITLE
fix(deploy): 转发 GW 兼容协议入口

### DIFF
--- a/changelogs/2026-07-10_llmgw-compat-nginx-routes.md
+++ b/changelogs/2026-07-10_llmgw-compat-nginx-routes.md
@@ -1,0 +1,1 @@
+| fix | deploy | 将 OpenAI/Claude/Gemini 兼容协议入口转发到 llmgw-serve，避免正式环境被 nginx 静态站点返回 405 |

--- a/deploy/nginx/conf.d/branches/_standalone.conf
+++ b/deploy/nginx/conf.d/branches/_standalone.conf
@@ -60,6 +60,57 @@ server {
         proxy_read_timeout 3600s;
     }
 
+    # OpenAI-compatible / Claude-compatible / Gemini-compatible 入口同样属于 serving 网关。
+    # 这些路径不是 MAP 前端路由，必须在 SPA fallback 前转发到 llmgw-serve，
+    # 否则 nginx 会把 POST 当作静态站点请求并返回 405。
+    location ^~ /v1/ {
+        proxy_pass http://llmgw-serve:8091;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_connect_timeout 3s;
+        proxy_send_timeout 60s;
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 3600s;
+    }
+
+    location ^~ /v1beta/ {
+        proxy_pass http://llmgw-serve:8091;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_connect_timeout 3s;
+        proxy_send_timeout 60s;
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 3600s;
+    }
+
+    location ^~ /gemini/v1beta/ {
+        proxy_pass http://llmgw-serve:8091;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_connect_timeout 3s;
+        proxy_send_timeout 60s;
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 3600s;
+    }
+
     # /gw/* 反代到独立 LLM 网关服务 llmgw（端口 8090，观测控制台）
     # 网关同样有 SSE 流式输出，必须关闭缓冲 + 长读超时，否则流式响应会被 nginx 攒齐再吐
     location ^~ /gw/ {

--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -31,6 +31,56 @@ server {
     proxy_read_timeout 3600s;
   }
 
+  # OpenAI-compatible / Claude-compatible / Gemini-compatible 入口同样属于 serving 网关。
+  # 这些路径不是 MAP 前端路由，必须在 SPA fallback 前转发到 llmgw-serve。
+  location ^~ /v1/ {
+    proxy_pass http://llmgw-serve:8091;
+    proxy_http_version 1.1;
+
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    proxy_connect_timeout 3s;
+    proxy_send_timeout 60s;
+    proxy_buffering off;
+    proxy_cache off;
+    proxy_read_timeout 3600s;
+  }
+
+  location ^~ /v1beta/ {
+    proxy_pass http://llmgw-serve:8091;
+    proxy_http_version 1.1;
+
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    proxy_connect_timeout 3s;
+    proxy_send_timeout 60s;
+    proxy_buffering off;
+    proxy_cache off;
+    proxy_read_timeout 3600s;
+  }
+
+  location ^~ /gemini/v1beta/ {
+    proxy_pass http://llmgw-serve:8091;
+    proxy_http_version 1.1;
+
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    proxy_connect_timeout 3s;
+    proxy_send_timeout 60s;
+    proxy_buffering off;
+    proxy_cache off;
+    proxy_read_timeout 3600s;
+  }
+
   # /assets/ 目录下的所有文件（静态资源）
   # 优先级高于 SPA fallback，避免前端路由冲突
   location ^~ /assets/ {
@@ -52,5 +102,4 @@ server {
     try_files $uri /index.html;
   }
 }
-
 


### PR DESCRIPTION
## 摘要
修复正式 nginx 未将 OpenAI/Claude/Gemini 兼容协议入口转发到 llmgw-serve 的问题。此前 /v1/chat/completions、/v1/messages、/v1beta/models/* 会落到静态站点并返回 405，导致四协议 runtime canary 失败。

## 改动 diff
- `deploy/nginx/conf.d/branches/_standalone.conf`：新增 `/v1/`、`/v1beta/`、`/gemini/v1beta/` 到 llmgw-serve 的反代规则。
- `deploy/nginx/nginx.conf`：同步本地 nginx 配置语义。
- `changelogs/2026-07-10_llmgw-compat-nginx-routes.md`：新增 changelog 碎片。

## 测试
- [x] `git diff --check` 通过
- [x] `python3 scripts/llmgw-protocol-router-audit.py` 通过
- [x] nginx 临时 wrapper `nginx -t` 通过
- [ ] CI 通过
- [ ] 合并后发布生产并重跑 protocol canary
