### PR TITLE
fix(llmgw): 放宽调用方目标路由策略校验

### DIFF
--- a/changelogs/2026-07-10_llmgw-appcaller-policy-modes.md
+++ b/changelogs/2026-07-10_llmgw-appcaller-policy-modes.md
@@ -1,0 +1,4 @@
+| fix | prd-llmgw | 修正 active appCaller 治理校验，允许 auto/pool/pinned 三种目标路由策略 |
+| fix | prd-llmgw | 修正 config-authority 自动绑池逻辑，保留 active appCaller 已配置的 auto/pool/pinned 策略 |
+| fix | prd-api | 修正 active appCaller 在 auto 策略下的运行态解析，使用绑定的 GW 模型池而不是 fail-close |
+| fix | prd-api | 修正 active appCaller 的 pinned 解析顺序，full-http 退场后只允许命中 GW-owned 平台和模型 |

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/ModelResolver.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/ModelResolver.cs
@@ -50,12 +50,6 @@ public class ModelResolver : IModelResolver
             .Find(a => a.AppCode == appCallerCode)
             .FirstOrDefaultAsync(ct);
 
-        var pinned = await TryResolvePinnedModelAsync(expectedModel, pinnedPlatformId, pinnedModelId, ct);
-        if (pinned != null)
-        {
-            return pinned;
-        }
-
         List<ModelGroup>? candidateGroups = null;
         var hasDedicatedBinding = false;
         string resolutionType = "NotFound";
@@ -63,6 +57,26 @@ public class ModelResolver : IModelResolver
         var gatewayRegistry = await TryGetActiveGatewayRegistryGroupsAsync(appCallerCode, modelType, ct);
         var activeGatewayAppCallerRequiresGwConfig =
             gatewayRegistry.ActiveAppCallerFound && DisableMapConfigFallbackForActiveAppCallers();
+        if (gatewayRegistry.Groups.Count == 0 && activeGatewayAppCallerRequiresGwConfig)
+        {
+            _logger.LogWarning(
+                "[ModelResolver] GW active appCaller 禁止 MAP fallback，但未命中有效 GW 模型池: AppCallerCode={Code}, ModelType={Type}, ModelPoolId={PoolId}, Reason={Reason}",
+                appCallerCode, modelType, gatewayRegistry.ModelPoolId ?? "(未绑定)", gatewayRegistry.BlockReason ?? "missing-gateway-pool");
+            return ModelResolutionResult.NotFound(expectedModel,
+                $"GW active appCaller 未绑定有效 GW 模型池，已禁止 MAP fallback: AppCallerCode={appCallerCode}, ModelType={modelType}");
+        }
+
+        var pinned = await TryResolvePinnedModelAsync(
+            expectedModel,
+            pinnedPlatformId,
+            pinnedModelId,
+            ct,
+            allowMapFallback: !activeGatewayAppCallerRequiresGwConfig);
+        if (pinned != null)
+        {
+            return pinned;
+        }
+
         if (gatewayRegistry.Groups.Count > 0)
         {
             candidateGroups = gatewayRegistry.Groups;
@@ -72,15 +86,6 @@ public class ModelResolver : IModelResolver
                 "[ModelResolver] 使用 GW appCaller active 模型池: AppCallerCode={Code}, PoolCount={Count}, PoolNames={Names}",
                 appCallerCode, candidateGroups.Count,
                 string.Join(", ", candidateGroups.Select(g => g.Name)));
-        }
-
-        if ((candidateGroups == null || candidateGroups.Count == 0) && activeGatewayAppCallerRequiresGwConfig)
-        {
-            _logger.LogWarning(
-                "[ModelResolver] GW active appCaller 禁止 MAP fallback，但未命中有效 GW 模型池: AppCallerCode={Code}, ModelType={Type}, ModelPoolId={PoolId}, Reason={Reason}",
-                appCallerCode, modelType, gatewayRegistry.ModelPoolId ?? "(未绑定)", gatewayRegistry.BlockReason ?? "missing-gateway-pool");
-            return ModelResolutionResult.NotFound(expectedModel,
-                $"GW active appCaller 未绑定有效 GW 模型池，已禁止 MAP fallback: AppCallerCode={appCallerCode}, ModelType={modelType}");
         }
 
         if ((candidateGroups == null || candidateGroups.Count == 0) && appCaller == null)
@@ -793,7 +798,8 @@ public class ModelResolver : IModelResolver
         string? expectedModel,
         string? pinnedPlatformId,
         string? pinnedModelId,
-        CancellationToken ct)
+        CancellationToken ct,
+        bool allowMapFallback = true)
     {
         var platformId = pinnedPlatformId?.Trim();
         var modelId = pinnedModelId?.Trim();
@@ -808,7 +814,7 @@ public class ModelResolver : IModelResolver
                 "PinnedModel 调用必须同时提供 pinnedPlatformId 与 pinnedModelId");
         }
 
-        var platform = await FindGatewayOwnedOrMapPlatformAsync(platformId, enabledOnly: true, ct);
+        var platform = await FindGatewayOwnedOrMapPlatformAsync(platformId, enabledOnly: true, ct, allowMapFallback);
         if (platform == null)
         {
             return ModelResolutionResult.NotFound(
@@ -816,7 +822,7 @@ public class ModelResolver : IModelResolver
                 $"PinnedModel 平台不存在或未启用: {platformId}");
         }
 
-        var model = await FindGatewayOwnedOrMapModelAsync(platformId, modelId, ct);
+        var model = await FindGatewayOwnedOrMapModelAsync(platformId, modelId, ct, allowMapFallback);
         if (model == null)
         {
             return ModelResolutionResult.NotFound(
@@ -979,9 +985,6 @@ public class ModelResolver : IModelResolver
                     ? GatewayRegistryLookup.Empty()
                     : GatewayRegistryLookup.Blocked(record.ModelPoolId, "active-appcaller-missing-model-pool");
             }
-            if (string.Equals(record.ModelPolicy, "auto", StringComparison.OrdinalIgnoreCase))
-                return GatewayRegistryLookup.Blocked(record.ModelPoolId, "active-appcaller-auto-policy-without-gateway-pool");
-
             var group = await FindGatewayOwnedOrMapModelPoolAsync(
                 record.ModelPoolId,
                 modelType,

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -92,9 +92,14 @@ public class GatewayDataDomainGuardTests
         Assert.Contains("ObservedIngressProtocols = GetObservedIngressProtocols(d)", consoleProgram);
         Assert.Contains("fb.AnyEq(\"ObservedIngressProtocols\"", consoleProgram);
         Assert.Contains("active appCaller 必须绑定 llm_gateway.llmgw_model_pools", consoleProgram);
-        Assert.Contains("active appCaller 必须使用 modelPolicy=pool", consoleProgram);
-        Assert.Contains("normalized-to-gw-pool-policy", consoleProgram);
-        Assert.Contains(".Set(\"ModelPolicy\", \"pool\")", consoleProgram);
+        Assert.Contains("active appCaller 必须使用 modelPolicy=auto/pool/pinned", consoleProgram);
+        var modelResolver = ReadRepoFile("prd-api/src/PrdAgent.Infrastructure/LlmGateway/ModelResolver.cs");
+        Assert.DoesNotContain("active-appcaller-auto-policy-without-gateway-pool", modelResolver);
+        Assert.Contains("allowMapFallback: !activeGatewayAppCallerRequiresGwConfig", modelResolver);
+        Assert.Contains("FindGatewayOwnedOrMapPlatformAsync(platformId, enabledOnly: true, ct, allowMapFallback)", modelResolver);
+        Assert.Contains("normalized-to-supported-model-policy", consoleProgram);
+        Assert.Contains("IsSupportedAppCallerModelPolicy(currentModelPolicy)", consoleProgram);
+        Assert.Contains("路由策略保留或补齐为 {targetModelPolicy}", consoleProgram);
         Assert.Contains("HasUsableGatewayPoolMemberAsync", consoleProgram);
         Assert.Contains("m.AsNullableBool(\"Enabled\") ?? true", consoleProgram);
         Assert.Contains("string.Equals(m.AsNullableString(\"DisplayName\"), modelId, StringComparison.Ordinal)", consoleProgram);

--- a/prd-llmgw/Program.cs
+++ b/prd-llmgw/Program.cs
@@ -1667,6 +1667,11 @@ app.MapPost("/gw/config-authority/bind-active-app-callers", async (HttpContext h
         .Find(Builders<BsonDocument>.Filter.Eq("Status", "active"))
         .ToListAsync();
     var result = new BindActiveAppCallerPoolsResult();
+    static bool IsSupportedAppCallerModelPolicy(string? policy)
+    {
+        var normalized = (policy ?? string.Empty).Trim().ToLowerInvariant();
+        return normalized is "auto" or "pool" or "pinned";
+    }
 
     foreach (var appCaller in activeAppCallers)
     {
@@ -1690,7 +1695,7 @@ app.MapPost("/gw/config-authority/bind-active-app-callers", async (HttpContext h
                 continue;
             }
 
-            if (string.Equals(currentModelPolicy, "pool", StringComparison.OrdinalIgnoreCase))
+            if (IsSupportedAppCallerModelPolicy(currentModelPolicy))
             {
                 result.Skipped++;
                 continue;
@@ -1709,8 +1714,8 @@ app.MapPost("/gw/config-authority/bind-active-app-callers", async (HttpContext h
                     ObjectType = "appCaller",
                     Id = appCallerId,
                     Name = appCallerCode,
-                    Status = "normalized-to-gw-pool-policy",
-                    Detail = $"已保留现有 GW 模型池 {currentPoolId}，并将路由策略收敛为 pool。",
+                    Status = "normalized-to-supported-model-policy",
+                    Detail = $"已保留现有 GW 模型池 {currentPoolId}，并将缺失或非法路由策略补齐为 pool。",
                 });
             }
             else
@@ -1738,10 +1743,13 @@ app.MapPost("/gw/config-authority/bind-active-app-callers", async (HttpContext h
             continue;
         }
 
+        var targetModelPolicy = IsSupportedAppCallerModelPolicy(currentModelPolicy)
+            ? currentModelPolicy!.Trim().ToLowerInvariant()
+            : "pool";
         var updates = new List<UpdateDefinition<BsonDocument>>
         {
             Builders<BsonDocument>.Update.Set("ModelPoolId", defaultPool.Id),
-            Builders<BsonDocument>.Update.Set("ModelPolicy", "pool"),
+            Builders<BsonDocument>.Update.Set("ModelPolicy", targetModelPolicy),
             Builders<BsonDocument>.Update.Set("UpdatedAt", now),
         };
 
@@ -1757,7 +1765,7 @@ app.MapPost("/gw/config-authority/bind-active-app-callers", async (HttpContext h
                 Id = appCallerId,
                 Name = appCallerCode,
                 Status = "bound-to-gw-default-pool",
-                Detail = $"已绑定 requestType={requestType} 的 GW 默认池 {defaultPool.Name}，并将路由策略收敛为 pool。",
+                Detail = $"已绑定 requestType={requestType} 的 GW 默认池 {defaultPool.Name}，路由策略保留或补齐为 {targetModelPolicy}。",
             });
         }
         else
@@ -5047,9 +5055,10 @@ static async Task<string?> ValidateActiveGatewayAppCallerConfigAsync(
         return null;
     }
 
-    if (!string.Equals(modelPolicy, "pool", StringComparison.OrdinalIgnoreCase))
+    var normalizedModelPolicy = (modelPolicy ?? string.Empty).Trim().ToLowerInvariant();
+    if (normalizedModelPolicy is not ("auto" or "pool" or "pinned"))
     {
-        return "active appCaller 必须使用 modelPolicy=pool；请绑定 GW 模型池并使用 pool 策略。";
+        return "active appCaller 必须使用 modelPolicy=auto/pool/pinned；auto 使用调用方默认池，pool 使用指定池，pinned 保留精确模型意图。";
     }
 
     if (string.IsNullOrWhiteSpace(modelPoolId))


### PR DESCRIPTION
## 摘要
修正 LLM Gateway 调用方治理校验，让 active appCaller 支持目标架构里的 auto/pool/pinned 三种路由策略。这样普通调用方可以保持 auto 意图，ModelLab 可以保持 pinned 精确模型意图，不再被旧的 pool-only 规则卡住 runtime gate。

## 改动 diff
- `prd-llmgw/Program.cs`：active appCaller 校验从 pool-only 调整为 auto/pool/pinned，仍要求绑定有效 GW 模型池。
- `prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs`：同步守卫测试断言。
- `changelogs/2026-07-10_llmgw-appcaller-policy-modes.md`：新增 changelog 碎片。

## 测试
- [x] `dotnet build prd-llmgw/prd-llmgw.csproj --no-restore` 通过
- [x] `dotnet test prd-api/tests/PrdAgent.Tests/PrdAgent.Tests.csproj --no-restore --filter GatewayDataDomainGuardTests` 通过
- [x] `cd prd-api && dotnet build --no-restore 2>&1 | grep -E "error CS|warning CS" | head -30` 无 error CS，本次仅见存量 warning
- [ ] CDS 预览分支创建后补充深链