### PR TITLE
fix(llmgw): 兼容网关模型配置元数据字段

### DIFF
--- a/changelogs/2026-07-10_llmgw-owned-config-extra-fields.md
+++ b/changelogs/2026-07-10_llmgw-owned-config-extra-fields.md
@@ -1,0 +1,1 @@
+| fix | prd-api | 修复 GW-owned 模型池和中继配置带元数据字段时反序列化失败，避免 video/ASR resolve 在 full-http gate 前返回 500 |

--- a/prd-api/src/PrdAgent.Core/Models/ModelExchange.cs
+++ b/prd-api/src/PrdAgent.Core/Models/ModelExchange.cs
@@ -1,4 +1,5 @@
 using PrdAgent.Core.Attributes;
+using MongoDB.Bson.Serialization.Attributes;
 
 namespace PrdAgent.Core.Models;
 
@@ -10,6 +11,7 @@ namespace PrdAgent.Core.Models;
 /// 一个 Exchange = 一个「虚拟平台」。Name 字段就是用户定义的平台展示名（如 "我的 Gemini"）。
 /// </summary>
 [AppOwnership(AppNames.Llm, AppNames.LlmDisplay, IsPrimary = true)]
+[BsonIgnoreExtraElements]
 public class ModelExchange
 {
     /// <summary>Exchange ID（也用作虚拟平台 ID）</summary>

--- a/prd-api/src/PrdAgent.Core/Models/ModelGroup.cs
+++ b/prd-api/src/PrdAgent.Core/Models/ModelGroup.cs
@@ -1,4 +1,5 @@
 using PrdAgent.Core.Attributes;
+using MongoDB.Bson.Serialization.Attributes;
 
 namespace PrdAgent.Core.Models;
 
@@ -6,6 +7,7 @@ namespace PrdAgent.Core.Models;
 /// 模型分组 - 按模型类型组织的模型列表
 /// </summary>
 [AppOwnership(AppNames.Llm, AppNames.LlmDisplay, IsPrimary = true)]
+[BsonIgnoreExtraElements]
 public class ModelGroup
 {
     /// <summary>分组ID（UUID，唯一标识）</summary>

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -35,6 +35,18 @@ public class GatewayDataDomainGuardTests
     }
 
     [Fact]
+    public void GatewayOwnedModelConfig_ModelsIgnoreExtraMetadataFields()
+    {
+        var modelGroup = ReadRepoFile("prd-api/src/PrdAgent.Core/Models/ModelGroup.cs");
+        var modelExchange = ReadRepoFile("prd-api/src/PrdAgent.Core/Models/ModelExchange.cs");
+
+        Assert.Contains("using MongoDB.Bson.Serialization.Attributes;", modelGroup);
+        Assert.Contains("[BsonIgnoreExtraElements]\npublic class ModelGroup", modelGroup);
+        Assert.Contains("using MongoDB.Bson.Serialization.Attributes;", modelExchange);
+        Assert.Contains("[BsonIgnoreExtraElements]\npublic class ModelExchange", modelExchange);
+    }
+
+    [Fact]
     public void ShadowReadEndpoints_UseGatewayDatabase()
     {
         var servingEndpoints = ReadRepoFile("prd-api/src/PrdAgent.LlmGateway/GatewayHttpEndpoints.cs");


### PR DESCRIPTION
## 摘要
修复 LLM Gateway full-http gate 发现的 resolver 兼容性问题：GW-owned `llmgw_model_pools` / `llmgw_model_exchanges` 会带 `SourceCollection` 等元数据，旧模型类反序列化时未忽略额外字段，导致 video/ASR resolve 返回 500。

## 改动 diff
- `prd-api/src/PrdAgent.Core/Models/ModelGroup.cs`：增加 `BsonIgnoreExtraElements`。
- `prd-api/src/PrdAgent.Core/Models/ModelExchange.cs`：增加 `BsonIgnoreExtraElements`。
- `prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs`：增加守卫测试，防止 GW-owned 元数据再次破坏 resolver。
- `changelogs/2026-07-10_llmgw-owned-config-extra-fields.md`：新增 changelog 碎片。

## 测试
- [x] `dotnet test prd-api/tests/PrdAgent.Tests/PrdAgent.Tests.csproj --no-restore --filter GatewayDataDomainGuardTests` 通过，39/39。
- [x] `cd prd-api && dotnet build --no-restore` 无 error CS；仅仓库已有 warning。

## 生产影响
- 修复 full-http 前置 gate 中 video/ASR resolve 500。
- 不修改模型池数据，不改运行模式。
- 合并后需要重新部署同 commit，再重跑 upstream readiness 和 http-full。