### PR TITLE
ops(llmgw): 降低生产 smoke 探针成本

### DIFF
--- a/changelogs/2026-07-10_llmgw-low-cost-smoke.md
+++ b/changelogs/2026-07-10_llmgw-low-cost-smoke.md
@@ -1,0 +1,1 @@
+| ops | scripts | 降低 LLM Gateway 生产发布 smoke 的默认输出长度并支持探针超时配置 |

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -1738,7 +1738,10 @@ public class GatewayDataDomainGuardTests
         Assert.Contains("stream[chat]", script);
         Assert.Contains("\"/client-stream\"", script);
         Assert.Contains("client-stream[chat]", script);
-        Assert.Contains("\"Messages\": [{\"Role\": \"user\", \"Content\": \"ping, client stream reply OK\"}]", script);
+        Assert.Contains("GW_SMOKE_PROMPT", script);
+        Assert.Contains("GW_SMOKE_MAX_TOKENS", script);
+        Assert.Contains("GW_SMOKE_REQUEST_TIMEOUT_SECONDS", script);
+        Assert.Contains("\"Messages\": [{\"Role\": \"user\", \"Content\": SMOKE_PROMPT}]", script);
         Assert.Contains("GW_SMOKE_JSON_OUT", script);
         Assert.Contains("GW_SMOKE_REPORT_MD", script);
         Assert.Contains("\"verdict\": \"pass\" if passed == len(rows) else \"fail\"", script);

--- a/scripts/gw-smoke.py
+++ b/scripts/gw-smoke.py
@@ -31,6 +31,9 @@ ROUTE_POOL_ID = os.environ.get("GW_SMOKE_ROUTE_POOL_ID", "").strip()
 ROUTE_PINNED_PLATFORM_ID = os.environ.get("GW_SMOKE_ROUTE_PINNED_PLATFORM_ID", "").strip()
 ROUTE_PINNED_MODEL_ID = os.environ.get("GW_SMOKE_ROUTE_PINNED_MODEL_ID", "").strip()
 SELF_TEST = os.environ.get("GW_SMOKE_SELF_TEST", "").strip().lower() in {"1", "true", "yes", "on"}
+SMOKE_PROMPT = os.environ.get("GW_SMOKE_PROMPT", "Reply exactly OK. No explanation.").strip() or "Reply exactly OK. No explanation."
+SMOKE_MAX_TOKENS = int(os.environ.get("GW_SMOKE_MAX_TOKENS", "4"))
+SMOKE_REQUEST_TIMEOUT = int(os.environ.get("GW_SMOKE_REQUEST_TIMEOUT_SECONDS", os.environ.get("GW_TIMEOUT", "120")))
 
 # 每类 ModelType 抽 1 个代表入口（D1×D2 抽样）。真机存在性以 /gw/v1/pools 为准。
 # 默认只跑低成本 chat provider canary；intent/vision 需要通过 GW_SMOKE_MODEL_TYPES 显式打开。
@@ -327,7 +330,8 @@ def main():
     for accode, mtype in sample_codes:
         body = {
             "AppCallerCode": accode, "ModelType": mtype, "Stream": False,
-            "RequestBody": {"messages": [{"role": "user", "content": "ping, reply OK"}], "max_tokens": 16},
+            "TimeoutSeconds": SMOKE_REQUEST_TIMEOUT,
+            "RequestBody": {"messages": [{"role": "user", "content": SMOKE_PROMPT}], "max_tokens": SMOKE_MAX_TOKENS},
             "Context": {"UserId": "smoke-test", "IsHealthProbe": True},
         }
         code, raw = _req("POST", "/invoke", body)
@@ -345,7 +349,8 @@ def main():
             "AppCallerCode": "report-agent.generate::chat",
             "ModelType": "chat",
             "Stream": False,
-            "RequestBody": {"messages": [{"role": "user", "content": "ping, send compat reply OK"}], "max_tokens": 16},
+            "TimeoutSeconds": SMOKE_REQUEST_TIMEOUT,
+            "RequestBody": {"messages": [{"role": "user", "content": SMOKE_PROMPT}], "max_tokens": SMOKE_MAX_TOKENS},
             "Context": {"UserId": "smoke-test", "IsHealthProbe": True},
         }
         code, raw = _req("POST", "/send", send_body)
@@ -362,9 +367,10 @@ def main():
             "AppCallerCode": "report-agent.generate::chat",
             "ModelType": "chat",
             "Stream": True,
+            "TimeoutSeconds": SMOKE_REQUEST_TIMEOUT,
             "RequestBody": {
-                "messages": [{"role": "user", "content": "ping, stream reply OK"}],
-                "max_tokens": 16,
+                "messages": [{"role": "user", "content": SMOKE_PROMPT}],
+                "max_tokens": SMOKE_MAX_TOKENS,
                 "stream": True,
             },
             "Context": {"UserId": "smoke-test", "IsHealthProbe": True},
@@ -392,11 +398,11 @@ def main():
         client_stream_body = {
             "AppCallerCode": "report-agent.generate::chat",
             "ModelType": "chat",
-            "MaxTokens": 16,
+            "MaxTokens": SMOKE_MAX_TOKENS,
             "Temperature": 0.2,
             "IncludeThinking": False,
             "SystemPrompt": "Reply briefly.",
-            "Messages": [{"Role": "user", "Content": "ping, client stream reply OK"}],
+            "Messages": [{"Role": "user", "Content": SMOKE_PROMPT}],
             "EnablePromptCache": True,
             "Context": {"UserId": "smoke-test", "IsHealthProbe": True},
         }


### PR DESCRIPTION
## 摘要
生产 full-http gate 的 gw-smoke 在 report-agent chat 默认池上触发长思考，导致 /send 和 /stream 探针超过 120 秒。本 PR 将 smoke 探针改为短 prompt、短 max tokens，并支持 request timeout 环境变量，保持四个 GW 入口覆盖但避免发布验证反复消耗和超时。

## 改动 diff
- `scripts/gw-smoke.py`：新增 `GW_SMOKE_PROMPT`、`GW_SMOKE_MAX_TOKENS`、`GW_SMOKE_REQUEST_TIMEOUT_SECONDS`，并让 invoke/send/stream/client-stream 使用低成本探针参数。
- `prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs`：更新 guard 断言，确保低成本参数和四个入口覆盖仍存在。
- `changelogs/2026-07-10_llmgw-low-cost-smoke.md`：新增发布脚本变更记录。

## 测试
- [x] `GW_SMOKE_SELF_TEST=1 python3 scripts/gw-smoke.py`
- [x] `dotnet test prd-api/tests/PrdAgent.Tests/PrdAgent.Tests.csproj --no-restore --filter GatewayDataDomainGuardTests`
- [x] `cd prd-api && dotnet build --no-restore` 无 CS error，仅既有 warning
- [x] 生产 `https://map.ebcone.net/gw/v1` 低成本 smoke 7/7 通过

## 备注
- 不改业务模型池、不改 LLMGW_MODE、不切 full-http。