### PR TITLE
fix(llmgw): 修正维护发布影子证据门禁

### DIFF
--- a/changelogs/2026-07-11_llmgw-maintenance-shadow-retention.md
+++ b/changelogs/2026-07-11_llmgw-maintenance-shadow-retention.md
@@ -1,0 +1,2 @@
+| fix | prd-llmgw | 修正 full-http 维护发布对同提交 shadow 证据的循环依赖，仅在当前运行态门全绿时保留最近成功迁移证据 |
+| test | prd-api | 新增维护发布 shadow 证据保留条件静态守卫 |

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -701,6 +701,8 @@ public class GatewayDataDomainGuardTests
         var consoleProgram = ReadRepoFile("prd-llmgw/Program.cs");
 
         Assert.Contains("retainedShadowMatchesPreviousFullHttp", consoleProgram);
+        Assert.Contains("latestSuccessfulHttpFullCommit", consoleProgram);
+        Assert.Contains("retainedShadowCandidates.FirstOrDefault", consoleProgram);
         Assert.Contains("configAuthorityLedgerEvidence.Ready", consoleProgram);
         Assert.Contains("httpTransportLogs == releaseLogTotal", consoleProgram);
         Assert.Contains("missingIngressProtocols.Count == 0", consoleProgram);

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -696,6 +696,21 @@ public class GatewayDataDomainGuardTests
     }
 
     [Fact]
+    public void ConsoleRuntimeGate_MaintenanceReleaseRetainsOnlyQualifiedPriorShadowEvidence()
+    {
+        var consoleProgram = ReadRepoFile("prd-llmgw/Program.cs");
+
+        Assert.Contains("retainedShadowMatchesPreviousFullHttp", consoleProgram);
+        Assert.Contains("configAuthorityLedgerEvidence.Ready", consoleProgram);
+        Assert.Contains("httpTransportLogs == releaseLogTotal", consoleProgram);
+        Assert.Contains("missingIngressProtocols.Count == 0", consoleProgram);
+        Assert.Contains("protocolFailedLogs == 0", consoleProgram);
+        Assert.Contains("missingRuntimeCoverageAppCallers.Count == 0", consoleProgram);
+        Assert.Contains("canRetainPreviousShadowEvidence ? \"retained\" : \"waiting\"", consoleProgram);
+        Assert.Contains("首次切流必须跑当前 commit 的真实 appCaller shadow 样本", consoleProgram);
+    }
+
+    [Fact]
     public void ExecDep_ProvidesNoUnderscoreCompatibilityWrapper()
     {
         var wrapper = ReadRepoFile("execdep.sh");

--- a/prd-llmgw/Program.cs
+++ b/prd-llmgw/Program.cs
@@ -1056,10 +1056,10 @@ app.MapGet("/gw/runtime-gates", async () =>
     var shadowTotal = runtimeCommit is null ? 0 : await shadows.CountDocumentsAsync(shadowFilter);
     var shadowCritical = runtimeCommit is null ? 0 : await shadows.CountDocumentsAsync(Builders<BsonDocument>.Filter.And(shadowFilter, Builders<BsonDocument>.Filter.Eq("HasCritical", true)));
     var shadowHttpFail = runtimeCommit is null ? 0 : await shadows.CountDocumentsAsync(Builders<BsonDocument>.Filter.And(shadowFilter, Builders<BsonDocument>.Filter.Eq("HttpOk", false)));
-    BsonDocument? retainedShadowEvidence = null;
+    var retainedShadowCandidates = new List<BsonDocument>();
     if (runtimeCommit is not null && shadowTotal == 0)
     {
-        retainedShadowEvidence = await shadows.Aggregate()
+        retainedShadowCandidates = await shadows.Aggregate()
             .Match(Builders<BsonDocument>.Filter.And(
                 Builders<BsonDocument>.Filter.Ne("ReleaseCommit", runtimeCommit),
                 Builders<BsonDocument>.Filter.Exists("ReleaseCommit", true),
@@ -1088,10 +1088,8 @@ app.MapGet("/gw/runtime-gates", async () =>
                 Builders<BsonDocument>.Filter.Eq("Critical", 0),
                 Builders<BsonDocument>.Filter.Eq("HttpFail", 0)))
             .Sort(new BsonDocument("LastComparedAt", -1))
-            .FirstOrDefaultAsync();
+            .ToListAsync();
     }
-    var retainedShadowCommit = retainedShadowEvidence?.AsNullableString("_id") ?? string.Empty;
-    var retainedShadowTotal = retainedShadowEvidence?.AsNullableLong("Total") ?? 0;
     var logReleaseFilter = runtimeCommit is null
         ? FilterDefinition<BsonDocument>.Empty
         : Builders<BsonDocument>.Filter.And(
@@ -1170,9 +1168,15 @@ app.MapGet("/gw/runtime-gates", async () =>
         ?? ".llmgw-release-evidence/rollout-ledger.jsonl";
     var configAuthorityLedgerEvidence = ReadLatestConfigAuthorityRolloutLedgerEvidence(ledgerPath, gitCommit);
     var httpFullLedgerEvidence = ReadLatestHttpFullRolloutLedgerEvidence(ledgerPath, gitCommit);
+    var latestSuccessfulHttpFullCommit = httpFullLedgerEvidence.Facts.TryGetValue("latestCommit", out var latestCommitFact)
+        ? latestCommitFact
+        : string.Empty;
+    var retainedShadowEvidence = retainedShadowCandidates.FirstOrDefault(candidate =>
+        string.Equals(candidate.AsNullableString("_id"), latestSuccessfulHttpFullCommit, StringComparison.OrdinalIgnoreCase));
+    var retainedShadowCommit = retainedShadowEvidence?.AsNullableString("_id") ?? string.Empty;
+    var retainedShadowTotal = retainedShadowEvidence?.AsNullableLong("Total") ?? 0;
     var retainedShadowMatchesPreviousFullHttp = retainedShadowCommit.Length > 0
-        && httpFullLedgerEvidence.Facts.TryGetValue("latestCommit", out var latestHttpFullCommit)
-        && string.Equals(retainedShadowCommit, latestHttpFullCommit, StringComparison.OrdinalIgnoreCase)
+        && string.Equals(retainedShadowCommit, latestSuccessfulHttpFullCommit, StringComparison.OrdinalIgnoreCase)
         && httpFullLedgerEvidence.Facts.TryGetValue("releaseGateRequired", out var previousReleaseGateRequired)
         && string.Equals(previousReleaseGateRequired, "true", StringComparison.OrdinalIgnoreCase)
         && httpFullLedgerEvidence.Facts.TryGetValue("disableMapConfigFallbackForActiveAppCallers", out var previousDisableMapFallback)

--- a/prd-llmgw/Program.cs
+++ b/prd-llmgw/Program.cs
@@ -1056,6 +1056,42 @@ app.MapGet("/gw/runtime-gates", async () =>
     var shadowTotal = runtimeCommit is null ? 0 : await shadows.CountDocumentsAsync(shadowFilter);
     var shadowCritical = runtimeCommit is null ? 0 : await shadows.CountDocumentsAsync(Builders<BsonDocument>.Filter.And(shadowFilter, Builders<BsonDocument>.Filter.Eq("HasCritical", true)));
     var shadowHttpFail = runtimeCommit is null ? 0 : await shadows.CountDocumentsAsync(Builders<BsonDocument>.Filter.And(shadowFilter, Builders<BsonDocument>.Filter.Eq("HttpOk", false)));
+    BsonDocument? retainedShadowEvidence = null;
+    if (runtimeCommit is not null && shadowTotal == 0)
+    {
+        retainedShadowEvidence = await shadows.Aggregate()
+            .Match(Builders<BsonDocument>.Filter.And(
+                Builders<BsonDocument>.Filter.Ne("ReleaseCommit", runtimeCommit),
+                Builders<BsonDocument>.Filter.Exists("ReleaseCommit", true),
+                Builders<BsonDocument>.Filter.Ne("ReleaseCommit", BsonNull.Value),
+                Builders<BsonDocument>.Filter.Ne("ReleaseCommit", string.Empty)))
+            .Group(new BsonDocument
+            {
+                { "_id", "$ReleaseCommit" },
+                { "Total", new BsonDocument("$sum", 1) },
+                { "Critical", new BsonDocument("$sum", new BsonDocument("$cond", new BsonArray
+                    {
+                        new BsonDocument("$eq", new BsonArray { "$HasCritical", true }),
+                        1,
+                        0,
+                    })) },
+                { "HttpFail", new BsonDocument("$sum", new BsonDocument("$cond", new BsonArray
+                    {
+                        new BsonDocument("$eq", new BsonArray { "$HttpOk", false }),
+                        1,
+                        0,
+                    })) },
+                { "LastComparedAt", new BsonDocument("$max", "$ComparedAt") },
+            })
+            .Match(Builders<BsonDocument>.Filter.And(
+                Builders<BsonDocument>.Filter.Gt("Total", 0),
+                Builders<BsonDocument>.Filter.Eq("Critical", 0),
+                Builders<BsonDocument>.Filter.Eq("HttpFail", 0)))
+            .Sort(new BsonDocument("LastComparedAt", -1))
+            .FirstOrDefaultAsync();
+    }
+    var retainedShadowCommit = retainedShadowEvidence?.AsNullableString("_id") ?? string.Empty;
+    var retainedShadowTotal = retainedShadowEvidence?.AsNullableLong("Total") ?? 0;
     var logReleaseFilter = runtimeCommit is null
         ? FilterDefinition<BsonDocument>.Empty
         : Builders<BsonDocument>.Filter.And(
@@ -1134,6 +1170,26 @@ app.MapGet("/gw/runtime-gates", async () =>
         ?? ".llmgw-release-evidence/rollout-ledger.jsonl";
     var configAuthorityLedgerEvidence = ReadLatestConfigAuthorityRolloutLedgerEvidence(ledgerPath, gitCommit);
     var httpFullLedgerEvidence = ReadLatestHttpFullRolloutLedgerEvidence(ledgerPath, gitCommit);
+    var retainedShadowMatchesPreviousFullHttp = retainedShadowCommit.Length > 0
+        && httpFullLedgerEvidence.Facts.TryGetValue("latestCommit", out var latestHttpFullCommit)
+        && string.Equals(retainedShadowCommit, latestHttpFullCommit, StringComparison.OrdinalIgnoreCase)
+        && httpFullLedgerEvidence.Facts.TryGetValue("releaseGateRequired", out var previousReleaseGateRequired)
+        && string.Equals(previousReleaseGateRequired, "true", StringComparison.OrdinalIgnoreCase)
+        && httpFullLedgerEvidence.Facts.TryGetValue("disableMapConfigFallbackForActiveAppCallers", out var previousDisableMapFallback)
+        && string.Equals(previousDisableMapFallback, "true", StringComparison.OrdinalIgnoreCase)
+        && httpFullLedgerEvidence.Facts.TryGetValue("protocolCanaryRequired", out var previousProtocolCanaryRequired)
+        && string.Equals(previousProtocolCanaryRequired, "true", StringComparison.OrdinalIgnoreCase)
+        && httpFullLedgerEvidence.Facts.TryGetValue("protocolCanaryJson", out var previousProtocolCanaryJson)
+        && string.Equals(previousProtocolCanaryJson, "true", StringComparison.OrdinalIgnoreCase);
+    var canRetainPreviousShadowEvidence = shadowTotal == 0
+        && retainedShadowMatchesPreviousFullHttp
+        && configAuthorityLedgerEvidence.Ready
+        && releaseLogTotal > 0
+        && httpTransportLogs == releaseLogTotal
+        && droppedParameterLogs == 0
+        && missingIngressProtocols.Count == 0
+        && protocolFailedLogs == 0
+        && missingRuntimeCoverageAppCallers.Count == 0;
     var activeAppCallerMapFallbackCutoverPrerequisitesReady =
         mapFallbackObjectsRemaining == 0
         && activeMissingGatewayPool == 0
@@ -1516,21 +1572,34 @@ app.MapGet("/gw/runtime-gates", async () =>
     AddGate(
         "shadow_runtime_evidence",
         "shadow/http 运行证据",
-        shadowTotal == 0 ? "waiting" : shadowCritical == 0 && shadowHttpFail == 0 ? "pass" : "blocked",
-        shadowTotal == 0 || shadowCritical > 0 || shadowHttpFail > 0,
+        shadowTotal > 0
+            ? shadowCritical == 0 && shadowHttpFail == 0 ? "pass" : "blocked"
+            : canRetainPreviousShadowEvidence ? "retained" : "waiting",
+        shadowTotal > 0
+            ? shadowCritical > 0 || shadowHttpFail > 0
+            : !canRetainPreviousShadowEvidence,
         runtimeCommit is null
             ? "当前进程缺少 GIT_COMMIT，不能证明 shadow 样本属于本次发布版本。"
-            : shadowTotal == 0
-            ? "尚未看到 shadow comparison 样本，不能证明 http 路径等价。"
-            : $"当前 commit 的 shadow 样本 {shadowTotal} 条，critical={shadowCritical}，httpFail={shadowHttpFail}。",
-        $"/gw/shadow-comparisons releaseCommit={runtimeCommit ?? "empty"}; total={shadowTotal}; critical={shadowCritical}; httpFail={shadowHttpFail}",
-        shadowTotal == 0 ? "先跑当前 commit 的真实 appCaller shadow 样本；resolve-only route matrix 只能证明解析链路，不替代 shadow comparison。" : shadowCritical == 0 && shadowHttpFail == 0 ? "保留同 commit 证据并进入灰度 gate。" : "先归因当前 commit 的 critical/httpFail，再补测试。",
+            : shadowTotal > 0
+            ? $"当前 commit 的 shadow 样本 {shadowTotal} 条，critical={shadowCritical}，httpFail={shadowHttpFail}。"
+            : canRetainPreviousShadowEvidence
+            ? $"当前 commit 已完成 HTTP-only transport、四协议、active appCaller 和配置权威证据；保留最近 full-http 提交 {retainedShadowCommit} 的 {retainedShadowTotal} 条零 critical/零 httpFail shadow 迁移证据。"
+            : "尚未看到当前 commit 的 shadow comparison，且不满足 full-http 维护发布的历史证据保留条件。",
+        $"/gw/shadow-comparisons releaseCommit={runtimeCommit ?? "empty"}; total={shadowTotal}; critical={shadowCritical}; httpFail={shadowHttpFail}; retainedCommit={retainedShadowCommit}; retainedTotal={retainedShadowTotal}; retainedEligible={canRetainPreviousShadowEvidence}",
+        shadowTotal > 0
+            ? shadowCritical == 0 && shadowHttpFail == 0 ? "保留同 commit 证据并进入灰度 gate。" : "先归因当前 commit 的 critical/httpFail，再补测试。"
+            : canRetainPreviousShadowEvidence
+            ? "保留历史迁移证据；当前提交继续依赖 HTTP-only transport、四协议和 active appCaller 运行证据。"
+            : "首次切流必须跑当前 commit 的真实 appCaller shadow 样本；维护发布则先补齐当前 commit 的 HTTP-only transport、四协议、active appCaller 和配置权威证据。",
         new Dictionary<string, string>
         {
             ["releaseCommit"] = runtimeCommit ?? "",
             ["total"] = shadowTotal.ToString(System.Globalization.CultureInfo.InvariantCulture),
             ["critical"] = shadowCritical.ToString(System.Globalization.CultureInfo.InvariantCulture),
             ["httpFail"] = shadowHttpFail.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            ["retainedCommit"] = retainedShadowCommit,
+            ["retainedTotal"] = retainedShadowTotal.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            ["retainedEligible"] = canRetainPreviousShadowEvidence ? "true" : "false",
         });
 
     var ledgerEvidence = httpFullLedgerEvidence;


### PR DESCRIPTION
## 摘要
修正生产已经 full-http 后，维护升级仍强制当前提交先产生 shadow 样本形成的循环依赖。仅在当前提交运行态证据全部通过且历史 shadow 来自最近成功 full-http 提交时，允许将迁移证据标记为 retained。

## 改动 diff
- `prd-llmgw/Program.cs`：增加受约束的历史 shadow 证据保留判定，首次切流仍要求同提交 shadow。
- `prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs`：增加保留条件静态守卫。
- `changelogs/2026-07-11_llmgw-maintenance-shadow-retention.md`：记录修复与测试。

## 测试
- [x] `dotnet build --no-restore`，0 error
- [x] Gateway 静态测试 107/107
- [x] readiness audit 40/40
- [x] protocol router audit 10/10
- [ ] CI 与 Bugbot 审查
- [ ] 合并后生产同提交验证