### PR TITLE
fix(llmgw): 从成功历史保留影子证据

### DIFF
--- a/changelogs/2026-07-11_llmgw-retained-shadow-ledger-history.md
+++ b/changelogs/2026-07-11_llmgw-retained-shadow-ledger-history.md
@@ -1,0 +1,2 @@
+| fix | prd-llmgw | 让 full-http 维护发布从全部有效成功台账中匹配最近干净 shadow 证据，避免当前成功记录覆盖前置迁移证据 |
+| test | prd-api | 补充 full-http 成功历史的 release gate 与协议 canary 守卫 |

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -701,8 +701,11 @@ public class GatewayDataDomainGuardTests
         var consoleProgram = ReadRepoFile("prd-llmgw/Program.cs");
 
         Assert.Contains("retainedShadowMatchesPreviousFullHttp", consoleProgram);
-        Assert.Contains("latestSuccessfulHttpFullCommit", consoleProgram);
+        Assert.Contains("ReadSuccessfulHttpFullRolloutCommits", consoleProgram);
+        Assert.Contains("successfulHttpFullCommits", consoleProgram);
         Assert.Contains("retainedShadowCandidates.FirstOrDefault", consoleProgram);
+        Assert.Contains("!ReadJsonBool(root, \"releaseGateRequired\")", consoleProgram);
+        Assert.Contains("!ReadJsonBool(root, \"protocolCanaryRequired\")", consoleProgram);
         Assert.Contains("configAuthorityLedgerEvidence.Ready", consoleProgram);
         Assert.Contains("httpTransportLogs == releaseLogTotal", consoleProgram);
         Assert.Contains("missingIngressProtocols.Count == 0", consoleProgram);

--- a/prd-llmgw/Program.cs
+++ b/prd-llmgw/Program.cs
@@ -1168,23 +1168,15 @@ app.MapGet("/gw/runtime-gates", async () =>
         ?? ".llmgw-release-evidence/rollout-ledger.jsonl";
     var configAuthorityLedgerEvidence = ReadLatestConfigAuthorityRolloutLedgerEvidence(ledgerPath, gitCommit);
     var httpFullLedgerEvidence = ReadLatestHttpFullRolloutLedgerEvidence(ledgerPath, gitCommit);
-    var latestSuccessfulHttpFullCommit = httpFullLedgerEvidence.Facts.TryGetValue("latestCommit", out var latestCommitFact)
-        ? latestCommitFact
-        : string.Empty;
-    var retainedShadowEvidence = retainedShadowCandidates.FirstOrDefault(candidate =>
-        string.Equals(candidate.AsNullableString("_id"), latestSuccessfulHttpFullCommit, StringComparison.OrdinalIgnoreCase));
+    var successfulHttpFullCommits = ReadSuccessfulHttpFullRolloutCommits(ledgerPath);
+    var retainedShadowEvidence = successfulHttpFullCommits
+        .Select(commit => retainedShadowCandidates.FirstOrDefault(candidate =>
+            string.Equals(candidate.AsNullableString("_id"), commit, StringComparison.OrdinalIgnoreCase)))
+        .FirstOrDefault(candidate => candidate is not null);
     var retainedShadowCommit = retainedShadowEvidence?.AsNullableString("_id") ?? string.Empty;
     var retainedShadowTotal = retainedShadowEvidence?.AsNullableLong("Total") ?? 0;
     var retainedShadowMatchesPreviousFullHttp = retainedShadowCommit.Length > 0
-        && string.Equals(retainedShadowCommit, latestSuccessfulHttpFullCommit, StringComparison.OrdinalIgnoreCase)
-        && httpFullLedgerEvidence.Facts.TryGetValue("releaseGateRequired", out var previousReleaseGateRequired)
-        && string.Equals(previousReleaseGateRequired, "true", StringComparison.OrdinalIgnoreCase)
-        && httpFullLedgerEvidence.Facts.TryGetValue("disableMapConfigFallbackForActiveAppCallers", out var previousDisableMapFallback)
-        && string.Equals(previousDisableMapFallback, "true", StringComparison.OrdinalIgnoreCase)
-        && httpFullLedgerEvidence.Facts.TryGetValue("protocolCanaryRequired", out var previousProtocolCanaryRequired)
-        && string.Equals(previousProtocolCanaryRequired, "true", StringComparison.OrdinalIgnoreCase)
-        && httpFullLedgerEvidence.Facts.TryGetValue("protocolCanaryJson", out var previousProtocolCanaryJson)
-        && string.Equals(previousProtocolCanaryJson, "true", StringComparison.OrdinalIgnoreCase);
+        && successfulHttpFullCommits.Contains(retainedShadowCommit, StringComparer.OrdinalIgnoreCase);
     var canRetainPreviousShadowEvidence = shadowTotal == 0
         && retainedShadowMatchesPreviousFullHttp
         && configAuthorityLedgerEvidence.Ready
@@ -5681,6 +5673,47 @@ static (bool Ready, string Detail, string Evidence, Dictionary<string, string> F
     facts["protocolCanaryJson"] = latestHasProtocolCanaryJson ? "true" : "false";
     facts["missing"] = string.Join(",", missing);
     return (ready, detail, evidence, facts);
+}
+
+static List<string> ReadSuccessfulHttpFullRolloutCommits(string path)
+{
+    var normalizedPath = string.IsNullOrWhiteSpace(path) ? ".llmgw-release-evidence/rollout-ledger.jsonl" : path.Trim();
+    if (!File.Exists(normalizedPath)) return new List<string>();
+
+    var commits = new List<string>();
+    foreach (var line in File.ReadLines(normalizedPath))
+    {
+        var raw = line.Trim();
+        if (raw.Length == 0) continue;
+        try
+        {
+            using var doc = JsonDocument.Parse(raw);
+            var root = doc.RootElement;
+            if (!string.Equals(ReadJsonString(root, "stage"), "http-full", StringComparison.OrdinalIgnoreCase)
+                || !string.Equals(ReadJsonString(root, "status"), "success", StringComparison.OrdinalIgnoreCase)
+                || !ReadJsonBool(root, "releaseGateRequired")
+                || !ReadJsonBool(root, "disableMapConfigFallbackForActiveAppCallers")
+                || string.IsNullOrWhiteSpace(ReadJsonString(root, "evidenceJson"))
+                || string.IsNullOrWhiteSpace(ReadJsonString(root, "releaseGateJson"))
+                || !ReadJsonBool(root, "protocolCanaryRequired")
+                || string.IsNullOrWhiteSpace(ReadJsonString(root, "protocolCanaryJson")))
+            {
+                continue;
+            }
+
+            var commit = NormalizeCommitFilter(ReadJsonString(root, "commit"));
+            if (commit is null) continue;
+            commits.RemoveAll(existing => string.Equals(existing, commit, StringComparison.OrdinalIgnoreCase));
+            commits.Add(commit);
+        }
+        catch (JsonException)
+        {
+            // A malformed historical line cannot become release evidence.
+        }
+    }
+
+    commits.Reverse();
+    return commits;
 }
 
 static (bool Ready, string Detail, string Evidence, Dictionary<string, string> Facts) ReadLatestConfigAuthorityRolloutLedgerEvidence(string path, string currentCommit)


### PR DESCRIPTION
## 摘要
修正维护发布成功台账写入后，最新提交覆盖前置迁移 shadow 证据而使 runtime gate 回到 waiting 的问题。仅从满足完整发布条件的 http-full success 历史中匹配最近干净 shadow。

## 改动 diff
- `prd-llmgw/Program.cs`：读取有效 full-http 成功提交历史，并与零 critical、零 httpFail shadow 精确匹配。
- `prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs`：增加成功历史过滤条件守卫。
- `changelogs/2026-07-11_llmgw-retained-shadow-ledger-history.md`：记录修复。

## 测试
- [x] `dotnet build --no-restore`，0 error
- [x] Gateway 测试 107/107
- [ ] CI 与自动审查
- [ ] 合并后生产 runtime gates 复核