### PR TITLE
fix(llmgw): 修复维护发布基线审计

### DIFF
--- a/changelogs/2026-07-12_llmgw-maintenance-baseline-audit.md
+++ b/changelogs/2026-07-12_llmgw-maintenance-baseline-audit.md
@@ -1,0 +1,1 @@
+| fix | scripts | 修复 full-http 维护发布错误使用新 schema 重审历史全阶段证据的问题 |

--- a/doc/plan.platform.llm-gateway-known-availability-closeout.md
+++ b/doc/plan.platform.llm-gateway-known-availability-closeout.md
@@ -36,6 +36,10 @@
 
 不新增第四个实现 PR。计划文档、测试和 changelog 分别随对应 PR 合并。
 
+### 3.1 发布阻塞修正
+
+三批实现 PR 合并后的首次生产发布发现：PR-A 的 `--maintenance-from-commit` 仍调用通用全迁移 audit，导致历史 `http-full success` 被今天新增的证据字段反向判定失败，维护发布事实上不可执行。允许增加一个仅含发布脚本和合同测试的纠错 PR，不得包含运行代码、模型调用、数据库或 UI 变更。纠错后的维护基线审计只验证：历史 `http-full success`、stage/release-gate 文件存在且 commit/mode/fallback 一致、shadow `critical/httpFail=0`、同 commit 无后续 rollback/failed；新 commit 的 health、协议、配置权威和 runtime gate 仍由维护发布重新验证。
+
 ## 4. PR-A 设计
 
 ### 4.1 两类发布

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -590,9 +590,8 @@ public class GatewayDataDomainGuardTests
         var ledger = ReadRepoFile("scripts/llmgw-rollout-ledger.py");
 
         Assert.Contains("--maintenance-from-commit", stage);
-        Assert.Contains("--target-stage http-full", stage);
-        Assert.Contains("--require-target-success", stage);
-        Assert.Contains("--min-observation-hours 0", stage);
+        Assert.Contains("llmgw-rollout-ledger.py maintenance-baseline", stage);
+        Assert.Contains("--json-out \"$maintenance_baseline_json\"", stage);
         Assert.Contains("maintenance evidence commit must differ from the new release commit", stage);
         Assert.Contains("--shadow-evidence-commit \"${maintenance_from_commit:-$commit}\"", stage);
         Assert.Contains("export LLMGW_GATE_SHADOW_RELEASE_COMMIT=\"$maintenance_from_commit\"", stage);
@@ -600,6 +599,9 @@ public class GatewayDataDomainGuardTests
         Assert.Contains("LLMGW_POST_DEPLOY_EXPECT_COMMIT=\"$expect_commit\"", deploy);
         Assert.Contains("shadowEvidenceCommit", ledger);
         Assert.Contains("args.shadow_evidence_commit or args.commit", ledger);
+        Assert.Contains("def maintenance_baseline(args: argparse.Namespace)", ledger);
+        Assert.Contains("maintenance baseline is stale because a later negative event exists", ledger);
+        Assert.Contains("maintenance baseline release gate has no shadow checks", ledger);
         Assert.Contains("deployment_receipt=", stage);
         Assert.Contains("LLM Gateway deploy-once: receipt exists", stage);
         Assert.Contains("LLMGW_VERIFY_ONLY=1", stage);

--- a/scripts/llmgw-prod-stage.sh
+++ b/scripts/llmgw-prod-stage.sh
@@ -386,6 +386,7 @@ config_authority_json="${evidence_prefix}.config-authority.json"
 config_authority_md="${evidence_prefix}.config-authority.md"
 stage_json="${evidence_prefix}.stage.json"
 stage_md="${evidence_prefix}.stage.md"
+maintenance_baseline_json="${evidence_prefix}.maintenance-baseline.json"
 
 case "$stage" in
   canary-asr|canary-video-asr|http-full)
@@ -690,12 +691,10 @@ validate_ledger_order() {
     exit 1
   fi
   if [ -n "$maintenance_from_commit" ]; then
-    python3 scripts/llmgw-rollout-ledger.py audit \
+    python3 scripts/llmgw-rollout-ledger.py maintenance-baseline \
       --ledger "$ledger" \
       --commit "$maintenance_from_commit" \
-      --target-stage http-full \
-      --require-target-success \
-      --min-observation-hours 0
+      --json-out "$maintenance_baseline_json"
     echo "LLM Gateway maintenance release: inherited audited full-http evidence from commit=$maintenance_from_commit"
   elif [ "$allow_out_of_order" = "1" ]; then
     python3 scripts/llmgw-rollout-ledger.py validate \

--- a/scripts/llmgw-rollout-ledger.py
+++ b/scripts/llmgw-rollout-ledger.py
@@ -1509,6 +1509,85 @@ def audit(args: argparse.Namespace) -> int:
     return 0
 
 
+def maintenance_baseline(args: argparse.Namespace) -> int:
+    commit = _normalize_commit(args.commit)
+    if len(commit) != 40 or any(ch not in "0123456789abcdef" for ch in commit):
+        print("ERROR: maintenance baseline requires a full 40-character commit", file=sys.stderr)
+        return 2
+
+    entries = _load(args.ledger)
+    target = _latest_success(entries, commit, "http-full")
+    failures: list[str] = []
+    stage_evidence: dict = {}
+    release_gate: dict = {}
+    if not target:
+        failures.append(f"missing http-full success baseline for commit={commit}")
+    else:
+        evidence_path = str(target.get("evidenceJson") or "")
+        release_gate_path = str(target.get("releaseGateJson") or "")
+        try:
+            stage_evidence = _require_pass_json(evidence_path, "maintenance baseline stage evidence")
+            checks = {
+                "stage": str(stage_evidence.get("stage") or "").lower() == "http-full",
+                "status": str(stage_evidence.get("status") or "").lower() == "success",
+                "commit": _normalize_commit(stage_evidence.get("commit")) == commit,
+                "mode": str(stage_evidence.get("mode") or "").lower() == "http",
+                "mapFallbackDisabled": _bool_flag(str(stage_evidence.get("disableMapConfigFallbackForActiveAppCallers") or "0")),
+                "noFailures": not (stage_evidence.get("failures") or []),
+            }
+            failures.extend(f"maintenance baseline stage evidence invalid: {name}" for name, ok in checks.items() if not ok)
+        except SystemExit as exc:
+            failures.append(str(exc))
+
+        try:
+            release_gate = _require_pass_json(release_gate_path, "maintenance baseline release gate")
+            if _normalize_commit(release_gate.get("shadowReleaseCommit") or release_gate.get("expectedCommit")) != commit:
+                failures.append("maintenance baseline release gate commit mismatch")
+            shadow_checks = release_gate.get("shadowChecks") or []
+            if not isinstance(shadow_checks, list) or not shadow_checks:
+                failures.append("maintenance baseline release gate has no shadow checks")
+            else:
+                for item in shadow_checks:
+                    if not isinstance(item, dict):
+                        failures.append("maintenance baseline release gate contains an invalid shadow check")
+                        continue
+                    if _normalize_commit(item.get("releaseCommit")) != commit:
+                        failures.append("maintenance baseline shadow check commit mismatch")
+                    if int(item.get("critical") or 0) != 0 or int(item.get("httpFail") or 0) != 0 or item.get("ok") is not True:
+                        failures.append(f"maintenance baseline shadow check is unsafe: {item.get('label') or 'unknown'}")
+        except (SystemExit, TypeError, ValueError) as exc:
+            failures.append(str(exc))
+
+        target_time = _parse_recorded_at(target.get("recordedAt"))
+        if not target_time:
+            failures.append("maintenance baseline http-full success has no valid recordedAt")
+        else:
+            for item in _entries_after(entries, commit, target_time, {"failed", "rollback"}):
+                failures.append(
+                    "maintenance baseline is stale because a later negative event exists. "
+                    f"stage={item.get('stage') or ''} status={item.get('status') or ''} recordedAt={item.get('recordedAt') or ''}"
+                )
+
+    report = {
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "verdict": "fail" if failures else "pass",
+        "ledger": args.ledger,
+        "commit": commit,
+        "stage": "http-full",
+        "recordedAt": str((target or {}).get("recordedAt") or ""),
+        "evidenceJson": str((target or {}).get("evidenceJson") or ""),
+        "releaseGateJson": str((target or {}).get("releaseGateJson") or ""),
+        "failures": failures,
+    }
+    _write_json(args.json_out, report)
+    if failures:
+        for failure in failures:
+            print(f"ERROR: {failure}", file=sys.stderr)
+        return 1
+    print(f"LLM Gateway maintenance baseline audit: PASS commit={commit}")
+    return 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="LLM Gateway rollout ledger")
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -1618,6 +1697,12 @@ def main() -> int:
     audit_parser.add_argument("--json-out", default="")
     audit_parser.add_argument("--report-md", default="")
     audit_parser.set_defaults(func=audit)
+
+    maintenance_parser = sub.add_parser("maintenance-baseline", help="audit a historical full-http maintenance baseline")
+    maintenance_parser.add_argument("--ledger", required=True)
+    maintenance_parser.add_argument("--commit", required=True)
+    maintenance_parser.add_argument("--json-out", default="")
+    maintenance_parser.set_defaults(func=maintenance_baseline)
 
     args = parser.parse_args()
     return int(args.func(args))


### PR DESCRIPTION
## 摘要
修复 `--maintenance-from-commit` 仍使用通用全迁移 audit 的发布阻塞。历史 full-http 基线改走专用兼容审计，新提交仍完整执行同 commit 的部署后检查。

## 改动 diff
- `scripts/llmgw-rollout-ledger.py`：新增 `maintenance-baseline`，校验历史 http-full success、stage/release-gate、shadow 零 critical/零 httpFail 和同 commit 后续负面事件。
- `scripts/llmgw-prod-stage.sh`：维护发布改用专用基线审计并保存 JSON 证据。
- `prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs`：锁定维护审计入口和安全条件。
- `doc/plan.platform.llm-gateway-known-availability-closeout.md`：记录发布阻塞纠错边界。
- `changelogs/2026-07-12_llmgw-maintenance-baseline-audit.md`：更新记录。

## 测试
- [x] Python 编译与 shell 语法检查
- [x] GatewayDataDomainGuardTests 47/47
- [x] 用生产现有 `7be287...` ledger 和历史证据只读验证 `maintenance-baseline` PASS
- [ ] CI、CDS 和机器人审查全绿后合并
