### PR TITLE
fix(ops): 补齐网关维护发布证据交接

### DIFF
--- a/changelogs/2026-07-12_llmgw-maintenance-gate-handoff.md
+++ b/changelogs/2026-07-12_llmgw-maintenance-gate-handoff.md
@@ -1,0 +1,1 @@
+| fix | ops | 修复 LLM Gateway 维护发布未将已审计 shadow 基线传递给正式部署门的问题 |

--- a/doc/plan.platform.llm-gateway-known-availability-closeout.md
+++ b/doc/plan.platform.llm-gateway-known-availability-closeout.md
@@ -40,6 +40,8 @@
 
 三批实现 PR 合并后的首次生产发布发现：PR-A 的 `--maintenance-from-commit` 仍调用通用全迁移 audit，导致历史 `http-full success` 被今天新增的证据字段反向判定失败，维护发布事实上不可执行。允许增加一个仅含发布脚本和合同测试的纠错 PR，不得包含运行代码、模型调用、数据库或 UI 变更。纠错后的维护基线审计只验证：历史 `http-full success`、stage/release-gate 文件存在且 commit/mode/fallback 一致、shadow `critical/httpFail=0`、同 commit 无后续 rollback/failed；新 commit 的 health、协议、配置权威和 runtime gate 仍由维护发布重新验证。
 
+首次使用纠错后的维护基线时，正式机又在 `exec_dep.sh` 的重复 shadow 数量门被拦截：stage 已验证历史基线，但未把该通过结果交给部署层。第二个纠错 PR 只允许补齐证据交接：`exec_dep.sh` 必须校验 stage 生成的 baseline JSON 与基线 commit 完全一致；校验通过后只把重复 shadow 数量阈值降为 0，不得关闭配置权威、同 commit 镜像、health、serving probe、D 层 smoke、四协议 canary 或 runtime gates。stage evidence 继续记录继承的 `shadowEvidenceCommit`，使后续维护发布可以追溯完整证据链。
+
 ## 4. PR-A 设计
 
 ### 4.1 两类发布

--- a/exec_dep.sh
+++ b/exec_dep.sh
@@ -520,6 +520,34 @@ guard_llmgw_prod_stage_context_if_needed() {
   shadow_sample_compact="$(printf '%s' "$shadow_sample_raw" | xargs || true)"
   shadow_sample_allowlist_raw="$(llmgw_shadow_sample_allowlist_value)"
   shadow_sample_allowlist_compact="$(printf '%s' "$shadow_sample_allowlist_raw" | tr ',;\n\r' '    ' | xargs || true)"
+  maintenance_baseline_commit="$(printf '%s' "${LLMGW_MAINTENANCE_BASELINE_COMMIT:-}" | tr 'A-F' 'a-f' | xargs || true)"
+  maintenance_baseline_json="$(printf '%s' "${LLMGW_MAINTENANCE_BASELINE_JSON:-}" | xargs || true)"
+  maintenance_release=0
+  if [ -n "$maintenance_baseline_commit" ] || [ -n "$maintenance_baseline_json" ]; then
+    if ! printf '%s' "$maintenance_baseline_commit" | grep -Eq '^[0-9a-f]{40}$'; then
+      echo "ERROR: LLMGW_MAINTENANCE_BASELINE_COMMIT must be a complete 40-character commit." >&2
+      exit 1
+    fi
+    if [ -z "$maintenance_baseline_json" ] || [ ! -f "$maintenance_baseline_json" ]; then
+      echo "ERROR: maintenance release requires an existing LLMGW_MAINTENANCE_BASELINE_JSON." >&2
+      exit 1
+    fi
+    python3 - "$maintenance_baseline_json" "$maintenance_baseline_commit" <<'PY'
+import json
+import sys
+
+path, expected = sys.argv[1:3]
+with open(path, "r", encoding="utf-8") as handle:
+    report = json.load(handle)
+failures = report.get("failures") or []
+if report.get("verdict") != "pass" or str(report.get("commit") or "").lower() != expected or failures:
+    raise SystemExit("ERROR: maintenance baseline JSON is not a matching pass result")
+if str(report.get("stage") or "").lower() != "http-full" or not report.get("releaseGateJson"):
+    raise SystemExit("ERROR: maintenance baseline JSON is missing audited http-full evidence")
+PY
+    maintenance_release=1
+    echo "LLM Gateway maintenance release: audited baseline accepted commit=$maintenance_baseline_commit"
+  fi
   shadow_sample_enabled=0
   if [ "$mode" = "shadow" ]; then
     case "$shadow_sample_compact" in
@@ -968,7 +996,11 @@ run_llmgw_release_gate_if_needed() {
   LLMGW_POST_DEPLOY_GATE_KEY="$gate_key"
   LLMGW_POST_DEPLOY_EXPECT_COMMIT="$expect_commit"
 
-  args="--base $gate_base --min-total ${LLMGW_GATE_MIN_TOTAL:-30} --min-per-app ${LLMGW_GATE_MIN_PER_APP:-30}"
+  if [ "$maintenance_release" = "1" ]; then
+    args="--base $gate_base --min-total 0 --min-per-app 0"
+  else
+    args="--base $gate_base --min-total ${LLMGW_GATE_MIN_TOTAL:-30} --min-per-app ${LLMGW_GATE_MIN_PER_APP:-30}"
+  fi
   args="$args --since-hours ${LLMGW_GATE_SHADOW_SINCE_HOURS:-48}"
   gate_min_coverage_hours="${LLMGW_GATE_MIN_COVERAGE_HOURS:-}"
   if [ "$release_gate_required" = "1" ] && [ -z "$(printf '%s' "$gate_min_coverage_hours" | xargs || true)" ]; then
@@ -999,7 +1031,7 @@ run_llmgw_release_gate_if_needed() {
   IFS=',;'
   gate_app_callers_raw="${LLMGW_GATE_APP_CALLERS:-}"
   gate_app_callers_compact="$(printf '%s' "$gate_app_callers_raw" | tr ',;\n\r' '    ' | xargs || true)"
-  if [ "$mode" = "http" ] && [ -z "$gate_app_callers_compact" ]; then
+  if [ "$mode" = "http" ] && [ "$maintenance_release" != "1" ] && [ -z "$gate_app_callers_compact" ]; then
     gate_app_callers_raw="${LLMGW_GATE_FULL_HTTP_APP_CALLERS:-report-agent.generate::chat,prd-agent-desktop.chat.sendmessage::chat,prd-agent-desktop.preview-ask.section::chat,open-platform-agent.proxy::chat,open-api.proxy::chat,open-api.proxy::generation,prd-agent-web.model-lab.run::chat,prd-agent.arena.battle::chat,tutorial-email.generate::chat,visual-agent.image-gen.generate::generation,visual-agent.image.text2img::generation,visual-agent.image.img2img::generation,visual-agent.image.vision::generation,video-agent.videogen::video-gen,visual-agent.videogen::video-gen,document-store.subtitle::asr,transcript-agent.transcribe::asr,video-agent.v2d.transcribe::asr,video-agent.video-to-text::asr}"
     echo "LLM Gateway release gate: LLMGW_MODE=http 未设置 LLMGW_GATE_APP_CALLERS，默认要求核心入口逐个达标"
   fi
@@ -1021,7 +1053,7 @@ run_llmgw_release_gate_if_needed() {
   IFS=',;'
   required_kinds_raw="${LLMGW_GATE_REQUIRED_KINDS:-}"
   required_kinds_compact="$(printf '%s' "$required_kinds_raw" | tr ',;\n\r' '    ' | xargs || true)"
-  if [ "$mode" = "http" ] && [ -z "$required_kinds_compact" ]; then
+  if [ "$mode" = "http" ] && [ "$maintenance_release" != "1" ] && [ -z "$required_kinds_compact" ]; then
     full_http_kind_min="${LLMGW_GATE_FULL_HTTP_KIND_MIN:-${LLMGW_GATE_MIN_PER_APP:-30}}"
     required_kinds_raw="send:${full_http_kind_min},stream:${full_http_kind_min},raw:${full_http_kind_min}"
     echo "LLM Gateway release gate: LLMGW_MODE=http 未设置 LLMGW_GATE_REQUIRED_KINDS，默认要求 $required_kinds_raw"
@@ -1048,7 +1080,7 @@ run_llmgw_release_gate_if_needed() {
   done
   required_app_kinds_raw="${LLMGW_GATE_REQUIRED_APP_KINDS:-}"
   required_app_kinds_compact="$(printf '%s' "$required_app_kinds_raw" | tr ',;\n\r' '    ' | xargs || true)"
-  if [ "$mode" = "http" ] && [ -z "$required_app_kinds_compact" ]; then
+  if [ "$mode" = "http" ] && [ "$maintenance_release" != "1" ] && [ -z "$required_app_kinds_compact" ]; then
     full_http_app_kind_min="${LLMGW_GATE_FULL_HTTP_APP_KIND_MIN:-${LLMGW_GATE_FULL_HTTP_KIND_MIN:-${LLMGW_GATE_MIN_PER_APP:-30}}}"
     required_app_kinds_raw="${LLMGW_GATE_FULL_HTTP_APP_KINDS:-report-agent.generate::chat:send:${full_http_app_kind_min},prd-agent-desktop.chat.sendmessage::chat:stream:${full_http_app_kind_min},prd-agent-desktop.preview-ask.section::chat:stream:${full_http_app_kind_min},open-platform-agent.proxy::chat:stream:${full_http_app_kind_min},open-api.proxy::chat:send:${full_http_app_kind_min},open-api.proxy::generation:raw:${full_http_app_kind_min},prd-agent-web.model-lab.run::chat:stream:${full_http_app_kind_min},prd-agent.arena.battle::chat:stream:${full_http_app_kind_min},tutorial-email.generate::chat:send:${full_http_app_kind_min},visual-agent.image-gen.generate::generation:raw:${full_http_app_kind_min},visual-agent.image.text2img::generation:raw:${full_http_app_kind_min},visual-agent.image.img2img::generation:raw:${full_http_app_kind_min},visual-agent.image.vision::generation:raw:${full_http_app_kind_min},video-agent.videogen::video-gen:raw:${full_http_app_kind_min},visual-agent.videogen::video-gen:raw:${full_http_app_kind_min},document-store.subtitle::asr:raw:${full_http_app_kind_min},transcript-agent.transcribe::asr:raw:${full_http_app_kind_min},video-agent.v2d.transcribe::asr:raw:${full_http_app_kind_min},video-agent.video-to-text::asr:raw:${full_http_app_kind_min}}"
     echo "LLM Gateway release gate: LLMGW_MODE=http 未设置 LLMGW_GATE_REQUIRED_APP_KINDS，默认要求核心 send/stream/raw 入口逐个具备 app-kind 样本"

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -426,7 +426,7 @@ public class GatewayDataDomainGuardTests
         Assert.Contains("LLM Gateway release gate: LLMGW_MODE=http 未设置 LLMGW_GATE_APP_CALLERS，默认要求核心入口逐个达标", script);
         Assert.Contains("LLMGW_GATE_REQUIRED_KINDS", script);
         Assert.Contains("required_kinds_raw=\"${LLMGW_GATE_REQUIRED_KINDS:-}\"", script);
-        Assert.Contains("if [ \"$mode\" = \"http\" ] && [ -z \"$required_kinds_compact\" ]; then", script);
+        Assert.Contains("if [ \"$mode\" = \"http\" ] && [ \"$maintenance_release\" != \"1\" ] && [ -z \"$required_kinds_compact\" ]; then", script);
         Assert.Contains("full_http_kind_min=\"${LLMGW_GATE_FULL_HTTP_KIND_MIN:-${LLMGW_GATE_MIN_PER_APP:-30}}\"", script);
         Assert.Contains("required_kinds_raw=\"send:${full_http_kind_min},stream:${full_http_kind_min},raw:${full_http_kind_min}\"", script);
         Assert.Contains("LLMGW_GATE_CANARY_KIND_MIN", script);
@@ -595,13 +595,19 @@ public class GatewayDataDomainGuardTests
         Assert.Contains("maintenance evidence commit must differ from the new release commit", stage);
         Assert.Contains("--shadow-evidence-commit \"${maintenance_from_commit:-$commit}\"", stage);
         Assert.Contains("export LLMGW_GATE_SHADOW_RELEASE_COMMIT=\"$maintenance_from_commit\"", stage);
+        Assert.Contains("export LLMGW_MAINTENANCE_BASELINE_COMMIT=\"$maintenance_from_commit\"", stage);
+        Assert.Contains("export LLMGW_MAINTENANCE_BASELINE_JSON=\"$maintenance_baseline_json\"", stage);
         Assert.Contains("LLMGW_GATE_SHADOW_RELEASE_COMMIT:-$expect_commit", deploy);
+        Assert.Contains("LLM Gateway maintenance release: audited baseline accepted", deploy);
+        Assert.Contains("args=\"--base $gate_base --min-total 0 --min-per-app 0\"", deploy);
+        Assert.Contains("[ \"$maintenance_release\" != \"1\" ]", deploy);
         Assert.Contains("LLMGW_POST_DEPLOY_EXPECT_COMMIT=\"$expect_commit\"", deploy);
         Assert.Contains("shadowEvidenceCommit", ledger);
         Assert.Contains("args.shadow_evidence_commit or args.commit", ledger);
         Assert.Contains("def maintenance_baseline(args: argparse.Namespace)", ledger);
         Assert.Contains("maintenance baseline is stale because a later negative event exists", ledger);
         Assert.Contains("maintenance baseline release gate has no shadow checks", ledger);
+        Assert.Contains("shadow_evidence_commit = _normalize_commit(stage_evidence.get(\"shadowEvidenceCommit\")) or commit", ledger);
         Assert.Contains("deployment_receipt=", stage);
         Assert.Contains("LLM Gateway deploy-once: receipt exists", stage);
         Assert.Contains("LLMGW_VERIFY_ONLY=1", stage);

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -593,8 +593,9 @@ public class GatewayDataDomainGuardTests
         Assert.Contains("llmgw-rollout-ledger.py maintenance-baseline", stage);
         Assert.Contains("--json-out \"$maintenance_baseline_json\"", stage);
         Assert.Contains("maintenance evidence commit must differ from the new release commit", stage);
-        Assert.Contains("--shadow-evidence-commit \"${maintenance_from_commit:-$commit}\"", stage);
-        Assert.Contains("export LLMGW_GATE_SHADOW_RELEASE_COMMIT=\"$maintenance_from_commit\"", stage);
+        Assert.Contains("shadow_evidence_commit=\"$(python3 - \"$maintenance_baseline_json\"", stage);
+        Assert.Contains("--shadow-evidence-commit \"$shadow_evidence_commit\"", stage);
+        Assert.Contains("export LLMGW_GATE_SHADOW_RELEASE_COMMIT=\"$shadow_evidence_commit\"", stage);
         Assert.Contains("export LLMGW_MAINTENANCE_BASELINE_COMMIT=\"$maintenance_from_commit\"", stage);
         Assert.Contains("export LLMGW_MAINTENANCE_BASELINE_JSON=\"$maintenance_baseline_json\"", stage);
         Assert.Contains("LLMGW_GATE_SHADOW_RELEASE_COMMIT:-$expect_commit", deploy);

--- a/scripts/llmgw-prod-stage.sh
+++ b/scripts/llmgw-prod-stage.sh
@@ -1553,6 +1553,8 @@ if [ -n "$maintenance_from_commit" ]; then
   export LLMGW_GATE_SHADOW_RELEASE_COMMIT="$maintenance_from_commit"
   export LLMGW_SHADOW_COVERAGE_RELEASE_COMMIT="$maintenance_from_commit"
   export LLMGW_GATE_MIN_COVERAGE_HOURS="${LLMGW_GATE_MIN_COVERAGE_HOURS:-0}"
+  export LLMGW_MAINTENANCE_BASELINE_COMMIT="$maintenance_from_commit"
+  export LLMGW_MAINTENANCE_BASELINE_JSON="$maintenance_baseline_json"
 fi
 export PRD_AGENT_REQUIRE_FAST_INTENT="${PRD_AGENT_REQUIRE_FAST_INTENT:-1}"
 export LLMGW_GATE_JSON_OUT="${LLMGW_GATE_JSON_OUT:-$release_gate_json}"

--- a/scripts/llmgw-prod-stage.sh
+++ b/scripts/llmgw-prod-stage.sh
@@ -387,6 +387,7 @@ config_authority_md="${evidence_prefix}.config-authority.md"
 stage_json="${evidence_prefix}.stage.json"
 stage_md="${evidence_prefix}.stage.md"
 maintenance_baseline_json="${evidence_prefix}.maintenance-baseline.json"
+shadow_evidence_commit="$commit"
 
 case "$stage" in
   canary-asr|canary-video-asr|http-full)
@@ -695,6 +696,19 @@ validate_ledger_order() {
       --ledger "$ledger" \
       --commit "$maintenance_from_commit" \
       --json-out "$maintenance_baseline_json"
+    shadow_evidence_commit="$(python3 - "$maintenance_baseline_json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as handle:
+    report = json.load(handle)
+print(report.get("shadowEvidenceCommit") or report.get("commit") or "")
+PY
+)"
+    if ! printf '%s' "$shadow_evidence_commit" | grep -Eq '^[0-9a-f]{40}$'; then
+      echo "ERROR: maintenance baseline did not return a complete shadowEvidenceCommit." >&2
+      exit 1
+    fi
     echo "LLM Gateway maintenance release: inherited audited full-http evidence from commit=$maintenance_from_commit"
   elif [ "$allow_out_of_order" = "1" ]; then
     python3 scripts/llmgw-rollout-ledger.py validate \
@@ -733,7 +747,7 @@ append_ledger_entry() {
     --evidence-json "$stage_json" \
     --evidence-md "$stage_md" \
     --release-gate-json "$release_gate_json" \
-    --shadow-evidence-commit "${maintenance_from_commit:-$commit}" \
+    --shadow-evidence-commit "$shadow_evidence_commit" \
     --release-gate-required "${release_gate_required:-0}" \
     --prod-preflight-json "$prod_preflight_json" \
     --prod-health-preflight-json "$prod_health_preflight_json" \
@@ -1550,8 +1564,8 @@ export LLMGW_SERVE_KEY="${LLMGW_SERVE_KEY:-$gate_key}"
 export LLMGW_GATE_SHADOW_RELEASE_COMMIT="${LLMGW_GATE_SHADOW_RELEASE_COMMIT:-$commit}"
 export LLMGW_SHADOW_COVERAGE_RELEASE_COMMIT="${LLMGW_SHADOW_COVERAGE_RELEASE_COMMIT:-$commit}"
 if [ -n "$maintenance_from_commit" ]; then
-  export LLMGW_GATE_SHADOW_RELEASE_COMMIT="$maintenance_from_commit"
-  export LLMGW_SHADOW_COVERAGE_RELEASE_COMMIT="$maintenance_from_commit"
+  export LLMGW_GATE_SHADOW_RELEASE_COMMIT="$shadow_evidence_commit"
+  export LLMGW_SHADOW_COVERAGE_RELEASE_COMMIT="$shadow_evidence_commit"
   export LLMGW_GATE_MIN_COVERAGE_HOURS="${LLMGW_GATE_MIN_COVERAGE_HOURS:-0}"
   export LLMGW_MAINTENANCE_BASELINE_COMMIT="$maintenance_from_commit"
   export LLMGW_MAINTENANCE_BASELINE_JSON="$maintenance_baseline_json"
@@ -1658,7 +1672,7 @@ if [ "$execute" = "1" ]; then
     --disable-map-config-fallback-for-active-app-callers "$disable_map_fallback_for_active_app_callers" \
     --gate-base "$gate_base" \
     --release-gate-json "$release_gate_json" \
-    --shadow-evidence-commit "${maintenance_from_commit:-$commit}" \
+    --shadow-evidence-commit "$shadow_evidence_commit" \
     --release-gate-required "$release_gate_required" \
     --prod-preflight-json "$prod_preflight_json" \
     --prod-health-preflight-json "$prod_health_preflight_json" \

--- a/scripts/llmgw-rollout-ledger.py
+++ b/scripts/llmgw-rollout-ledger.py
@@ -1520,6 +1520,7 @@ def maintenance_baseline(args: argparse.Namespace) -> int:
     failures: list[str] = []
     stage_evidence: dict = {}
     release_gate: dict = {}
+    shadow_evidence_commit = commit
     if not target:
         failures.append(f"missing http-full success baseline for commit={commit}")
     else:
@@ -1536,12 +1537,13 @@ def maintenance_baseline(args: argparse.Namespace) -> int:
                 "noFailures": not (stage_evidence.get("failures") or []),
             }
             failures.extend(f"maintenance baseline stage evidence invalid: {name}" for name, ok in checks.items() if not ok)
+            shadow_evidence_commit = _normalize_commit(stage_evidence.get("shadowEvidenceCommit")) or commit
         except SystemExit as exc:
             failures.append(str(exc))
 
         try:
             release_gate = _require_pass_json(release_gate_path, "maintenance baseline release gate")
-            if _normalize_commit(release_gate.get("shadowReleaseCommit") or release_gate.get("expectedCommit")) != commit:
+            if _normalize_commit(release_gate.get("shadowReleaseCommit") or release_gate.get("expectedCommit")) != shadow_evidence_commit:
                 failures.append("maintenance baseline release gate commit mismatch")
             shadow_checks = release_gate.get("shadowChecks") or []
             if not isinstance(shadow_checks, list) or not shadow_checks:
@@ -1551,7 +1553,7 @@ def maintenance_baseline(args: argparse.Namespace) -> int:
                     if not isinstance(item, dict):
                         failures.append("maintenance baseline release gate contains an invalid shadow check")
                         continue
-                    if _normalize_commit(item.get("releaseCommit")) != commit:
+                    if _normalize_commit(item.get("releaseCommit")) != shadow_evidence_commit:
                         failures.append("maintenance baseline shadow check commit mismatch")
                     if int(item.get("critical") or 0) != 0 or int(item.get("httpFail") or 0) != 0 or item.get("ok") is not True:
                         failures.append(f"maintenance baseline shadow check is unsafe: {item.get('label') or 'unknown'}")
@@ -1573,6 +1575,7 @@ def maintenance_baseline(args: argparse.Namespace) -> int:
         "verdict": "fail" if failures else "pass",
         "ledger": args.ledger,
         "commit": commit,
+        "shadowEvidenceCommit": shadow_evidence_commit,
         "stage": "http-full",
         "recordedAt": str((target or {}).get("recordedAt") or ""),
         "evidenceJson": str((target or {}).get("evidenceJson") or ""),


### PR DESCRIPTION
## 摘要
修复 LLM Gateway 维护发布已审计历史基线未传递给 `exec_dep.sh`，导致正式发布重复要求已过保留期 shadow 样本的问题。维护模式只免除重复样本数量统计，新提交的配置权威、镜像一致性、health、serving probe、D 层 smoke、四协议 canary 与 runtime gates 仍全部执行。

## 改动 diff
- `scripts/llmgw-prod-stage.sh`：向部署层传递维护基线 commit 与审计 JSON。
- `exec_dep.sh`：严格校验维护基线后使用零阈值关联检查，不再重新要求每入口 30 条历史样本。
- `scripts/llmgw-rollout-ledger.py`：维护证据链支持继承 `shadowEvidenceCommit`。
- `prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs`：补充维护发布证据交接合同。
- `doc/plan.platform.llm-gateway-known-availability-closeout.md`、`changelogs/2026-07-12_llmgw-maintenance-gate-handoff.md`：记录发布阻塞修正。

## 测试
- [x] `sh -n exec_dep.sh`
- [x] `sh -n scripts/llmgw-prod-stage.sh`
- [x] `python3 -m py_compile scripts/llmgw-rollout-ledger.py`
- [x] `GatewayDataDomainGuardTests` 47/47
- [x] `dotnet build prd-api/PrdAgent.sln --no-restore` 通过，零错误
- [ ] GitHub CI / CDS / Bugbot
