### PR TITLE
fix(ops): 恢复正式环境根级健康检查

### DIFF
--- a/changelogs/2026-07-12_standalone-health-route.md
+++ b/changelogs/2026-07-12_standalone-health-route.md
@@ -1,0 +1,1 @@
+| fix | ops | 恢复正式环境 standalone nginx 的根级健康检查代理 |

--- a/deploy/nginx/conf.d/branches/_standalone.conf
+++ b/deploy/nginx/conf.d/branches/_standalone.conf
@@ -31,6 +31,18 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # 发布预检和外部探针使用根级 /health；必须在 SPA fallback 前交给 API。
+    location = /health {
+        proxy_pass http://api:8080/health;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 3s;
+        proxy_read_timeout 10s;
+    }
+
     # /api/* 反代到后端（后端路由为 /api/v1/...）
     location ^~ /api/ {
         proxy_pass http://api:8080;

--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -20,6 +20,18 @@ server {
   root /usr/share/nginx/html;
   index index.html;
 
+  # 发布预检和外部探针使用根级 /health；必须在 SPA fallback 前交给 API。
+  location = /health {
+    proxy_pass http://api:8080/health;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_connect_timeout 3s;
+    proxy_read_timeout 10s;
+  }
+
   # /api/* 反代到后端（后端路由为 /api/v1/...）
   location ^~ /api/ {
     proxy_pass http://api:8080;

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -1614,6 +1614,7 @@ public class GatewayDataDomainGuardTests
         var endpoint = ReadRepoFile("prd-api/src/PrdAgent.LlmGateway/GatewayHttpEndpoints.cs");
         var readiness = ReadRepoFile("prd-api/src/PrdAgent.LlmGateway/GatewayServingReadinessProbe.cs");
         var nginx = ReadRepoFile("deploy/nginx/conf.d/branches/_standalone.conf");
+        var imageNginx = ReadRepoFile("deploy/nginx/nginx.conf");
         var providerAudit = ReadRepoFile("scripts/llmgw-prod-provider-config-audit.py");
         var topologyPreflight = ReadRepoFile("scripts/llmgw-prod-topology-preflight.sh");
         var cdsServingStart = cdsCompose.LastIndexOf("\n  llmgw-serve:\n", StringComparison.Ordinal);
@@ -1633,6 +1634,10 @@ public class GatewayDataDomainGuardTests
         Assert.Contains("LLMGW_SERVE_BASE_URL must be", topologyPreflight);
         Assert.Contains("LLMGW_READINESS_ASSET_PROBE_KEY", topologyPreflight);
         Assert.Contains("LLMGW_READINESS_REQUIRE_ASSET_PROBE=true", topologyPreflight);
+        Assert.Contains("location = /health", nginx);
+        Assert.Contains("proxy_pass http://api:8080/health;", nginx);
+        Assert.Contains("location = /health", imageNginx);
+        Assert.Contains("proxy_pass http://api:8080/health;", imageNginx);
         Assert.Contains("[ \"$health\" != \"healthy\" ]", deploy);
         Assert.Contains("llmgw-serve-b:", compose);
         Assert.Contains("condition: service_healthy", compose);


### PR DESCRIPTION
## 摘要
修复正式环境 standalone nginx 缺少根级 `/health` 路由的问题。此前发布预检访问 `/health` 会落入 SPA fallback，并因静态目录权限产生 500，尽管 MAP API 业务接口实际可用。

## 改动 diff
- `deploy/nginx/conf.d/branches/_standalone.conf`：新增 `/health -> api:8080/health` 精确代理。
- `deploy/nginx/nginx.conf`：同步镜像内 nginx 配置，保持两条部署路径一致。
- `prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs`：增加双配置健康路由合同。
- `changelogs/2026-07-12_standalone-health-route.md`：记录修复。

## 测试
- [x] nginx 容器 `nginx -t` 通过
- [x] `GatewayDataDomainGuardTests` 47/47
- [x] `git diff --check`
- [ ] GitHub CI / CDS / Bugbot
