### PR TITLE
fix(ops): 注入正式环境 AI 访问密钥

### DIFF
--- a/changelogs/2026-07-12_map-ai-access-key-prod.md
+++ b/changelogs/2026-07-12_map-ai-access-key-prod.md
@@ -1,0 +1,1 @@
+| fix | ops | 将正式环境 AI_ACCESS_KEY 显式注入 MAP API 容器 |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,8 @@ services:
       # 生产环境：必须显式设置 JWT_SECRET（禁止使用仓库内默认值）
       - Jwt__Secret=${JWT_SECRET}
       - Jwt__Issuer=prdagent
+      # AI 自动化超级访问密钥；认证处理器只读取容器内 AI_ACCESS_KEY。
+      - AI_ACCESS_KEY=${AI_ACCESS_KEY:-}
       # 项目数据加密密钥：用于模型平台 API key 等持久化密文，必须独立于 JWT_SECRET。
       # 生产必须显式配置；旧密文迁移期用 API_KEY_CRYPTO_LEGACY_SECRETS 注入历史 JWT/旧密钥。
       - ApiKeyCrypto__Secret=${API_KEY_CRYPTO_SECRET:?must set API_KEY_CRYPTO_SECRET in production (platform API key encryption, shared by api and llmgw-serve)}

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -1629,6 +1629,7 @@ public class GatewayDataDomainGuardTests
         Assert.Contains("PRD_AGENT_COMPOSE_PROJECT_NAME", deploy);
         Assert.Contains("COMPOSE_PROJECT_NAME", deploy);
         Assert.Contains("PRD_AGENT_COMPOSE_PROJECT_NAME", stage);
+        Assert.Contains("AI_ACCESS_KEY=${AI_ACCESS_KEY:-}", compose);
         Assert.Contains("wait_for_llmgw_serving_readiness", deploy);
         Assert.Contains("llmgw-prod-topology-preflight.sh", deploy);
         Assert.Contains("LLMGW_SERVE_BASE_URL must be", topologyPreflight);


### PR DESCRIPTION
## 摘要
修复生产 compose 未将宿主机 `AI_ACCESS_KEY` 注入 MAP API 容器的问题。此前 `AiAccessKeyAuthenticationHandler` 在容器内始终读不到配置，所有 `X-AI-Access-Key` 请求都会在鉴权层返回 401。

## 改动 diff
- `docker-compose.yml`：为 API 显式注入可选 `AI_ACCESS_KEY`。
- `prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs`：增加生产 compose 合同。
- `changelogs/2026-07-12_map-ai-access-key-prod.md`：记录修复。

## 测试
- [x] `GatewayDataDomainGuardTests` 47/47
- [x] `git diff --check`
- [ ] GitHub CI / CDS / Bugbot
