### PR TITLE
feat(llmgw): 建立租户隔离与角色权限基座

### DIFF
--- a/changelogs/2026-07-12_llmgw-tenant-rbac.md
+++ b/changelogs/2026-07-12_llmgw-tenant-rbac.md
@@ -7,3 +7,4 @@
 | security | prd-api | multipart 清理仅在引用归属确认后执行，并只使用服务端已验证 TenantId |
 | security | prd-api | inline multipart 文件绕过引用 rehydrate 时禁止清理未经 manifest 验证的 RefKey |
 | fix | prd-api | LLM 日志缺省租户跟随 LlmGateway InternalTenantId 配置，避免落入硬编码租户 |
+| fix | prd-api | shadow 证据、provider 并发和 legacy key 的缺省租户统一跟随 InternalTenantId 配置 |

--- a/changelogs/2026-07-12_llmgw-tenant-rbac.md
+++ b/changelogs/2026-07-12_llmgw-tenant-rbac.md
@@ -4,3 +4,4 @@
 | test | prd-api | 新增 service key、请求幂等、取消注册和 provider 并发的跨租户隔离测试 |
 | fix | prd-api | 生命周期保留任务覆盖全部租户的日志脱敏、对象清理和逐租户审计记录 |
 | security | prd-api | 外部租户模型池预览禁止回退 MAP，multipart 引用按租户 manifest 校验后再下载 |
+| security | prd-api | multipart 清理仅在引用归属确认后执行，并只使用服务端已验证 TenantId |

--- a/changelogs/2026-07-12_llmgw-tenant-rbac.md
+++ b/changelogs/2026-07-12_llmgw-tenant-rbac.md
@@ -5,3 +5,4 @@
 | fix | prd-api | 生命周期保留任务覆盖全部租户的日志脱敏、对象清理和逐租户审计记录 |
 | security | prd-api | 外部租户模型池预览禁止回退 MAP，multipart 引用按租户 manifest 校验后再下载 |
 | security | prd-api | multipart 清理仅在引用归属确认后执行，并只使用服务端已验证 TenantId |
+| security | prd-api | inline multipart 文件绕过引用 rehydrate 时禁止清理未经 manifest 验证的 RefKey |

--- a/changelogs/2026-07-12_llmgw-tenant-rbac.md
+++ b/changelogs/2026-07-12_llmgw-tenant-rbac.md
@@ -8,3 +8,5 @@
 | security | prd-api | inline multipart 文件绕过引用 rehydrate 时禁止清理未经 manifest 验证的 RefKey |
 | fix | prd-api | LLM 日志缺省租户跟随 LlmGateway InternalTenantId 配置，避免落入硬编码租户 |
 | fix | prd-api | shadow 证据、provider 并发和 legacy key 的缺省租户统一跟随 InternalTenantId 配置 |
+| fix | prd-api | raw 幂等指纹计算前覆盖服务端已验证 tenant/team，忽略客户端自报租户字段 |
+| fix | prd-api | raw 幂等指纹容忍反序列化后的空 inline 文件内容，避免混合 multipart 请求异常 |

--- a/changelogs/2026-07-12_llmgw-tenant-rbac.md
+++ b/changelogs/2026-07-12_llmgw-tenant-rbac.md
@@ -10,3 +10,4 @@
 | fix | prd-api | shadow 证据、provider 并发和 legacy key 的缺省租户统一跟随 InternalTenantId 配置 |
 | fix | prd-api | raw 幂等指纹计算前覆盖服务端已验证 tenant/team，忽略客户端自报租户字段 |
 | fix | prd-api | raw 幂等指纹容忍反序列化后的空 inline 文件内容，避免混合 multipart 请求异常 |
+| fix | prd-llmgw | 团队重命名遇同租户重名时返回 TEAM_CONFLICT 409，不再泄漏 Mongo 500 |

--- a/changelogs/2026-07-12_llmgw-tenant-rbac.md
+++ b/changelogs/2026-07-12_llmgw-tenant-rbac.md
@@ -3,3 +3,4 @@
 | security | prd-llmgw | 服务 key、日志、审计、路由配置和组织资源按服务端租户上下文隔离 |
 | test | prd-api | 新增 service key、请求幂等、取消注册和 provider 并发的跨租户隔离测试 |
 | fix | prd-api | 生命周期保留任务覆盖全部租户的日志脱敏、对象清理和逐租户审计记录 |
+| security | prd-api | 外部租户模型池预览禁止回退 MAP，multipart 引用按租户 manifest 校验后再下载 |

--- a/changelogs/2026-07-12_llmgw-tenant-rbac.md
+++ b/changelogs/2026-07-12_llmgw-tenant-rbac.md
@@ -1,0 +1,4 @@
+| feat | prd-api | LLM Gateway 运行时增加租户解析、tenant-first 数据隔离及跨租户预算、幂等、取消和并发治理 |
+| feat | prd-llmgw | 新增租户、团队、成员、角色权限、租户切换与 tenant-scoped 控制台 API |
+| security | prd-llmgw | 服务 key、日志、审计、路由配置和组织资源按服务端租户上下文隔离 |
+| test | prd-api | 新增 service key、请求幂等、取消注册和 provider 并发的跨租户隔离测试 |

--- a/changelogs/2026-07-12_llmgw-tenant-rbac.md
+++ b/changelogs/2026-07-12_llmgw-tenant-rbac.md
@@ -2,3 +2,4 @@
 | feat | prd-llmgw | 新增租户、团队、成员、角色权限、租户切换与 tenant-scoped 控制台 API |
 | security | prd-llmgw | 服务 key、日志、审计、路由配置和组织资源按服务端租户上下文隔离 |
 | test | prd-api | 新增 service key、请求幂等、取消注册和 provider 并发的跨租户隔离测试 |
+| fix | prd-api | 生命周期保留任务覆盖全部租户的日志脱敏、对象清理和逐租户审计记录 |

--- a/changelogs/2026-07-12_llmgw-tenant-rbac.md
+++ b/changelogs/2026-07-12_llmgw-tenant-rbac.md
@@ -6,3 +6,4 @@
 | security | prd-api | 外部租户模型池预览禁止回退 MAP，multipart 引用按租户 manifest 校验后再下载 |
 | security | prd-api | multipart 清理仅在引用归属确认后执行，并只使用服务端已验证 TenantId |
 | security | prd-api | inline multipart 文件绕过引用 rehydrate 时禁止清理未经 manifest 验证的 RefKey |
+| fix | prd-api | LLM 日志缺省租户跟随 LlmGateway InternalTenantId 配置，避免落入硬编码租户 |

--- a/changelogs/2026-07-12_llmgw-tenant-rbac.md
+++ b/changelogs/2026-07-12_llmgw-tenant-rbac.md
@@ -11,3 +11,4 @@
 | fix | prd-api | raw 幂等指纹计算前覆盖服务端已验证 tenant/team，忽略客户端自报租户字段 |
 | fix | prd-api | raw 幂等指纹容忍反序列化后的空 inline 文件内容，避免混合 multipart 请求异常 |
 | fix | prd-llmgw | 团队重命名遇同租户重名时返回 TEAM_CONFLICT 409，不再泄漏 Mongo 500 |
+| fix | prd-llmgw | service key 写操作使用独立 RBAC 权限，developer 可自助管理 key 但不可写路由配置 |

--- a/doc/plan.platform.llm-gateway-external-platform.md
+++ b/doc/plan.platform.llm-gateway-external-platform.md
@@ -1,6 +1,6 @@
 # LLM Gateway 外部平台化与控制台体验收口 · 计划
 
-> **版本**：v1.0 | **日期**：2026-07-12 | **状态**：规划中
+> **版本**：v1.1 | **日期**：2026-07-12 | **状态**：开发中
 
 ## 1. 目标
 
@@ -13,6 +13,29 @@
 3. 网页版快速接入教程和四协议示例。
 4. appCaller 级提示词前缀/后缀与版本化治理。
 5. 面向普通使用者的控制台信息架构、图表和金额可信度。
+
+## 1.1 执行目标与推进合同
+
+本文件是本任务唯一计划和进度 SSOT，不再创建第二份并行计划。执行目标是按 PR-1 至 PR-5 依次完成外部平台化；每个 PR 必须独立评审、验证、发布和验收，前一个 PR 未完成时不得提前混入后一个 PR 的功能。
+
+| PR | 当前状态 | 分支 | 独立完成门 |
+|---|---|---|---|
+| PR-1 | 本地验收完成，等待 CI/Bugbot/CDS | `codex/llmgw-tenant-rbac` | tenant/team/user/membership/RBAC、服务端租户解析、全租户数据隔离与跨租户拒绝测试 |
+| PR-2 | 待开始 | 待 PR-1 完成后创建 | tenant-scoped service key、自助接入、四协议 Quickstart；四协议各一次真实请求，其余假上游 |
+| PR-3 | 待开始 | 待 PR-2 完成后创建 | PromptPolicy 版本、预览、审计及 chat/vision 注入合同 |
+| PR-4 | 待开始 | 待 PR-3 完成后创建 | 控制台 IA、左侧导航、首页、Activity 图表与金额可信度，多视口双主题验收 |
+| PR-5 | 待开始 | 待 PR-4 完成后创建 | 跨租户安全、四协议、完整接入流程和迁移收口验收 |
+
+每个 PR 的固定流程：从最新 `main` 建独立分支 → 实现有限范围 → 本地静态、单元与行为测试 → 中文 commit → push → 创建独立 PR → 等待 CI、Bugbot、CDS → 直连预览域名验收 → 修复所有阻塞项 → 合并后再开始下一 PR。
+
+PR-1 本地证据（2026-07-12）：`prd-api`、`PrdAgent.Api.Tests`、`prd-llmgw` 编译通过；.NET 8 容器连接临时 Mongo 实跑 Gateway 相关 101 项测试，0 失败；真实 `prd-llmgw` HTTP 流程验证 tenant B 对 tenant A 的 team/key 列表泄漏为 0，跨租户资源写入返回 404，viewer 对审计和组织写入返回 403，无 membership 的租户切换返回 403，membership 版本变化后旧 token 返回 401。PR-1 尚未完成的门仅为远端 CI、Bugbot、CDS 和预览环境验收。
+
+执行期间保持以下边界：
+
+- 不重做 full-http、模型迁移、模型池、配置权威或发布 gate。
+- 不在相邻 PR 之间夹带实现；为后续 PR 预留的 DTO、路由或页面必须等对应 PR 再增加。
+- 不批量调用付费模型；每类真实协议最多一次，其余使用假上游和固定数据。
+- 所有进度以本节状态表、GitHub PR 证据和 CDS 验收结果为准，不用聊天文字替代落盘状态。
 
 ## 2. 当前事实
 
@@ -158,6 +181,17 @@ Tenant
 - 对标的是信息层级、首次接入路径、错误解释和治理能力，不做像素级抄袭，不复制品牌、文案和受版权保护的视觉资产。
 - 先用浏览器记录当前 GW 在桌面和移动端的真实问题，再改布局；不得仅凭源码想象页面。
 - 模型池核心调度本轮不改，除非发现阻断租户隔离的安全问题。
+
+### 8.1 OpenRouter 登录态页面借鉴结论
+
+2026-07-12 已在用户授权的登录态浏览器中只读核对 OpenRouter 的 Workspace、Logs、Activity 和 Models 页面。后续实现只借鉴信息结构与交互原则：
+
+- 顶部只承载品牌、全局搜索、产品级入口、组织/个人上下文和用户菜单；Workspace 与 Account 的管理入口进入左侧分组。
+- Workspace 范围集中放 API Keys、Routing、Guardrails、Observability 和 Settings；Account 范围集中放 Activity、Logs、Credits、Management Keys、Privacy 和 Preferences。
+- Logs 先给日期、复合筛选、请求趋势和请求表，再把 model、provider、appCaller、输入、输出、cost、usage type、speed、finish reason、client user id、API key 作为可配置列；GW 不复制字段命名，但保留同等可定位性。
+- Activity 分 Overview、Trends、Explore、Guardrails；首页指标优先为 spend、requests、token volume、cache hit rate，并提供 Top API Keys、Top Apps、Usage by model、Usage type、Request volume、Token breakdown 和 Prompt caching 的下钻。
+- 无数据必须明确显示“无数据/未知”，缓存命中率等不可计算指标显示占位状态；不得用 0 伪装未知值。金额仍遵守本计划的 actual/estimated/unknown、币种和价格覆盖率规则。
+- Models 的模态、上下文、价格、支持参数、provider、作者、数据保留和区域筛选可作为 PR-4 信息密度参考；本轮不复制其视觉资产，也不重做现有 GW 模型池和 provider router。
 
 ## 9. 验收
 

--- a/doc/plan.platform.llm-gateway-external-platform.md
+++ b/doc/plan.platform.llm-gateway-external-platform.md
@@ -1,6 +1,6 @@
 # LLM Gateway 外部平台化与控制台体验收口 · 计划
 
-> **版本**：v1.1 | **日期**：2026-07-12 | **状态**：开发中
+> **版本**：v1.2 | **日期**：2026-07-12 | **状态**：开发中
 
 ## 1. 目标
 
@@ -20,7 +20,7 @@
 
 | PR | 当前状态 | 分支 | 独立完成门 |
 |---|---|---|---|
-| PR-1 | 本地验收完成，等待 CI/Bugbot/CDS | `codex/llmgw-tenant-rbac` | tenant/team/user/membership/RBAC、服务端租户解析、全租户数据隔离与跨租户拒绝测试 |
+| PR-1 | CI、CDS、预览验收通过，等待 Codex Review；Bugbot 被仓库设置禁用 | `codex/llmgw-tenant-rbac` / [PR #1085](https://github.com/inernoro/prd_agent/pull/1085) | tenant/team/user/membership/RBAC、服务端租户解析、全租户数据隔离与跨租户拒绝测试 |
 | PR-2 | 待开始 | 待 PR-1 完成后创建 | tenant-scoped service key、自助接入、四协议 Quickstart；四协议各一次真实请求，其余假上游 |
 | PR-3 | 待开始 | 待 PR-2 完成后创建 | PromptPolicy 版本、预览、审计及 chat/vision 注入合同 |
 | PR-4 | 待开始 | 待 PR-3 完成后创建 | 控制台 IA、左侧导航、首页、Activity 图表与金额可信度，多视口双主题验收 |
@@ -28,7 +28,7 @@
 
 每个 PR 的固定流程：从最新 `main` 建独立分支 → 实现有限范围 → 本地静态、单元与行为测试 → 中文 commit → push → 创建独立 PR → 等待 CI、Bugbot、CDS → 直连预览域名验收 → 修复所有阻塞项 → 合并后再开始下一 PR。
 
-PR-1 本地证据（2026-07-12）：`prd-api`、`PrdAgent.Api.Tests`、`prd-llmgw` 编译通过；.NET 8 容器连接临时 Mongo 实跑 Gateway 相关 101 项测试，0 失败；真实 `prd-llmgw` HTTP 流程验证 tenant B 对 tenant A 的 team/key 列表泄漏为 0，跨租户资源写入返回 404，viewer 对审计和组织写入返回 403，无 membership 的租户切换返回 403，membership 版本变化后旧 token 返回 401。PR-1 尚未完成的门仅为远端 CI、Bugbot、CDS 和预览环境验收。
+PR-1 证据（2026-07-12）：`prd-api`、`PrdAgent.Api.Tests`、`prd-llmgw` 编译通过；.NET 8 容器连接临时 Mongo 实跑 Gateway 相关 101 项测试，0 失败；真实 `prd-llmgw` HTTP 流程验证 tenant B 对 tenant A 的 team/key 列表泄漏为 0，跨租户资源写入返回 404，viewer 对审计和组织写入返回 403，无 membership 的租户切换返回 403，membership 版本变化后旧 token 返回 401。针对旧版 provider 并发槽位 `_id` 的迁移兼容又增加 4 项真实 Mongo 测试并全部通过。GitHub Server Build & Test、四个相关镜像、CDS Deploy 已在实现提交 `071209eda` 上通过，CDS 五个服务均运行且 commit SHA 一致；控制台预览可直接访问。当前尚未完成的门为最终 Codex Review，以及被 Cursor 明确报告“Bugbot is disabled for this repository”的 Bugbot 外部门禁；未解除或明确豁免前不合并 PR-1、不启动 PR-2。
 
 执行期间保持以下边界：
 

--- a/prd-api/src/PrdAgent.Api/Program.cs
+++ b/prd-api/src/PrdAgent.Api/Program.cs
@@ -251,7 +251,8 @@ else if (isShadow || httpAllowlist.Count > 0)
                 sp.GetRequiredService<ILogger<PrdAgent.Infrastructure.LlmGateway.LlmGateway>>(),
                 sp.GetService<PrdAgent.Core.Interfaces.ILlmRequestLogWriter>(),
                 sp.GetService<PrdAgent.Core.Interfaces.ILLMRequestContextAccessor>(),
-                sp.GetService<PrdAgent.Infrastructure.ModelPool.IPoolFailoverNotifier>()),
+                sp.GetService<PrdAgent.Infrastructure.ModelPool.IPoolFailoverNotifier>(),
+                configuration: sp.GetRequiredService<IConfiguration>()),
             http: new PrdAgent.Infrastructure.LlmGateway.HttpLlmGatewayClient(
                 sp.GetRequiredService<IHttpClientFactory>(),
                 sp.GetRequiredService<IConfiguration>(),
@@ -265,7 +266,8 @@ else if (isShadow || httpAllowlist.Count > 0)
             ctx: sp.GetService<PrdAgent.Core.Interfaces.ILLMRequestContextAccessor>(),
             httpAllowlist: httpAllowlist,
             fullSampleAllowlist: shadowFullSampleAllowlist,
-            releaseCommit: FirstEnv("GIT_COMMIT", "COMMIT_SHA", "GITHUB_SHA", "SOURCE_VERSION", "CDS_COMMIT_SHA")));
+            releaseCommit: FirstEnv("GIT_COMMIT", "COMMIT_SHA", "GITHUB_SHA", "SOURCE_VERSION", "CDS_COMMIT_SHA"),
+            configuration: sp.GetRequiredService<IConfiguration>()));
 }
 else
 {

--- a/prd-api/src/PrdAgent.Core/Interfaces/ILLMRequestContextAccessor.cs
+++ b/prd-api/src/PrdAgent.Core/Interfaces/ILLMRequestContextAccessor.cs
@@ -36,7 +36,10 @@ public record LlmRequestContext(
     /// <summary>
     /// MAP 业务运行 ID。用于把 GW 请求日志反查到 chat/image/video/asr 等业务 run。
     /// </summary>
-    string? RunId = null);
+    string? RunId = null,
+    /// <summary>由服务端会话或 service key 解析，禁止相信请求自报值。</summary>
+    string? TenantId = null,
+    string? TeamId = null);
 
 public interface ILLMRequestContextAccessor
 {

--- a/prd-api/src/PrdAgent.Core/Interfaces/ILlmRequestLogWriter.cs
+++ b/prd-api/src/PrdAgent.Core/Interfaces/ILlmRequestLogWriter.cs
@@ -79,7 +79,9 @@ public record LlmLogStart(
     /// <summary>产生本条请求日志的发布 commit；为空时写入器从 GIT_COMMIT 兜底。</summary>
     string? ReleaseCommit = null,
     /// <summary>MAP 业务运行 ID，用于把 GW 请求日志反查到业务 run。</summary>
-    string? RunId = null);
+    string? RunId = null,
+    string? TenantId = null,
+    string? TeamId = null);
 
 public record LlmLogDone(
     int? StatusCode,

--- a/prd-api/src/PrdAgent.Core/Models/LlmRequestLog.cs
+++ b/prd-api/src/PrdAgent.Core/Models/LlmRequestLog.cs
@@ -28,6 +28,10 @@ public class LlmRequestLog
 {
     public string Id { get; set; } = Guid.NewGuid().ToString();
 
+    /// <summary>服务端解析的租户边界；所有查询和费用聚合必须以此为首要过滤条件。</summary>
+    public string TenantId { get; set; } = string.Empty;
+    public string? TeamId { get; set; }
+
     // 关联/定位
     public string RequestId { get; set; } = string.Empty;
     /// <summary>

--- a/prd-api/src/PrdAgent.Core/Models/LlmShadowComparison.cs
+++ b/prd-api/src/PrdAgent.Core/Models/LlmShadowComparison.cs
@@ -17,6 +17,9 @@ public class LlmShadowComparison
     /// <summary>主键（Guid）</summary>
     public string Id { get; set; } = Guid.NewGuid().ToString("N");
 
+    public string TenantId { get; set; } = string.Empty;
+    public string? TeamId { get; set; }
+
     /// <summary>比对种类：resolve（仅解析，免费）/ send（完整非流式）/ stream（流式解析）/ raw（图片/ASR/视频原始代理）/ pools（模型池列表）</summary>
     public string Kind { get; set; } = "resolve";
 

--- a/prd-api/src/PrdAgent.Infrastructure/Database/LlmGatewayDatabaseInitializer.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Database/LlmGatewayDatabaseInitializer.cs
@@ -31,6 +31,8 @@ public sealed class LlmGatewayDatabaseInitializer : IHostedService
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
+        await BackfillInternalTenantAsync(cancellationToken);
+        await BackfillServiceKeyDirectoryAsync(cancellationToken);
         var callers = _data.Database.GetCollection<GatewayAppCallerRecord>(AppCallerCollectionName);
         await ConsolidateDuplicateAppCallersAsync(callers, cancellationToken);
         await EnsureBudgetConfigurationIntegrityAsync(callers, cancellationToken);
@@ -39,27 +41,106 @@ public sealed class LlmGatewayDatabaseInitializer : IHostedService
         {
             new CreateIndexModel<GatewayAppCallerRecord>(
                 Builders<GatewayAppCallerRecord>.IndexKeys
+                    .Ascending(x => x.TenantId)
                     .Ascending(x => x.AppCallerCode)
                     .Ascending(x => x.RequestType),
                 new CreateIndexOptions
                 {
-                    Name = "uniq_llmgw_app_callers_code_request_type",
+                    Name = "uniq_llmgw_app_callers_tenant_code_request_type",
                     Unique = true,
                     Collation = GatewayAppCallerIdentity.Collation,
                 }),
             new CreateIndexModel<GatewayAppCallerRecord>(
                 Builders<GatewayAppCallerRecord>.IndexKeys
+                    .Ascending(x => x.TenantId)
                     .Ascending(x => x.Status)
                     .Ascending(x => x.RequestType)
                     .Descending(x => x.LastSeenAt),
-                new CreateIndexOptions { Name = "idx_llmgw_app_callers_status_type_seen" }),
+                new CreateIndexOptions { Name = "idx_llmgw_app_callers_tenant_status_type_seen" }),
         };
         await callers.Indexes.CreateManyAsync(indexes, cancellationToken);
+        await DropIndexIfPresentAsync(callers, "uniq_llmgw_app_callers_code_request_type", cancellationToken);
+        await DropIndexIfPresentAsync(callers, "idx_llmgw_app_callers_status_type_seen", cancellationToken);
         await EnsureGovernanceIndexesAsync(cancellationToken);
         _logger.LogInformation("[LlmGatewayData] appCaller、日志与治理索引已就绪");
     }
 
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    private async Task BackfillInternalTenantAsync(CancellationToken ct)
+    {
+        var configured = _configuration["LlmGateway:InternalTenantId"]?.Trim();
+        var tenantId = string.IsNullOrWhiteSpace(configured)
+            ? GatewayTenantDefaults.InternalTenantId
+            : configured;
+        var collections = new[]
+        {
+            "llmgw_app_callers",
+            "llmgw_model_pools",
+            "llmgw_platforms",
+            "llmgw_models",
+            "llmgw_model_exchanges",
+            "llmgw_service_keys",
+            "llmrequestlogs",
+            "llmshadow_comparisons",
+            "llmgw_operation_audits",
+            "llmgw_login_audits",
+            "llmgw_lifecycle_runs",
+            "llmgw_app_caller_rate_windows",
+            "llmgw_budget_months",
+            "llmgw_budget_reservations",
+            "llmgw_request_executions",
+            "llmgw_multipart_objects",
+            "llmgw_provider_concurrency_slots",
+            "llmgw_runtime_settings",
+            "llmgw_asset_registry",
+        };
+
+        var missingTenant = Builders<BsonDocument>.Filter.Or(
+            Builders<BsonDocument>.Filter.Exists("TenantId", false),
+            Builders<BsonDocument>.Filter.Eq("TenantId", ""),
+            Builders<BsonDocument>.Filter.Eq("TenantId", BsonNull.Value));
+        foreach (var collectionName in collections)
+        {
+            var collection = _data.Database.GetCollection<BsonDocument>(collectionName);
+            await collection.UpdateManyAsync(
+                missingTenant,
+                Builders<BsonDocument>.Update.Set("TenantId", tenantId),
+                cancellationToken: ct);
+        }
+    }
+
+    private static async Task DropIndexIfPresentAsync<T>(
+        IMongoCollection<T> collection,
+        string indexName,
+        CancellationToken ct)
+    {
+        var indexes = await (await collection.Indexes.ListAsync(ct)).ToListAsync(ct);
+        if (indexes.Any(x => x.GetValue("name", "").AsString == indexName))
+            await collection.Indexes.DropOneAsync(indexName, ct);
+    }
+
+    private async Task BackfillServiceKeyDirectoryAsync(CancellationToken ct)
+    {
+        var keys = _data.Database.GetCollection<GatewayServiceKeyRecord>("llmgw_service_keys");
+        var directory = _data.Database.GetCollection<GatewayServiceKeyDirectoryRecord>("llmgw_service_key_directory");
+        var records = await keys.Find(x => x.TenantId != "" && x.KeyHash != "").ToListAsync(ct);
+        foreach (var key in records)
+        {
+            await directory.ReplaceOneAsync(
+                x => x.KeyHash == key.KeyHash,
+                new GatewayServiceKeyDirectoryRecord
+                {
+                    Id = key.Id,
+                    KeyHash = key.KeyHash,
+                    TenantId = key.TenantId,
+                    ServiceKeyId = key.Id,
+                    CreatedAt = key.CreatedAt,
+                },
+                new ReplaceOptions { IsUpsert = true },
+                ct);
+        }
+    }
 
     private async Task EnsureGovernanceIndexesAsync(CancellationToken ct)
     {
@@ -68,22 +149,25 @@ public sealed class LlmGatewayDatabaseInitializer : IHostedService
         {
             new CreateIndexModel<BsonDocument>(
                 Builders<BsonDocument>.IndexKeys
+                    .Ascending("TenantId")
                     .Descending("StartedAt")
                     .Ascending("AppCallerCode")
                     .Ascending("RequestType")
                     .Ascending("GatewayTransport"),
-                new CreateIndexOptions { Name = "idx_llmgw_logs_time_caller_type_transport" }),
+                new CreateIndexOptions { Name = "idx_llmgw_logs_tenant_time_caller_type_transport" }),
             new CreateIndexModel<BsonDocument>(
                 Builders<BsonDocument>.IndexKeys
+                    .Ascending("TenantId")
                     .Ascending("ReleaseCommit")
                     .Ascending("AppCallerCode")
                     .Descending("StartedAt"),
-                new CreateIndexOptions { Name = "idx_llmgw_logs_release_caller_time" }),
+                new CreateIndexOptions { Name = "idx_llmgw_logs_tenant_release_caller_time" }),
             new CreateIndexModel<BsonDocument>(
                 Builders<BsonDocument>.IndexKeys
+                    .Ascending("TenantId")
                     .Ascending("RequestId")
                     .Descending("StartedAt"),
-                new CreateIndexOptions { Name = "idx_llmgw_logs_request_time" }),
+                new CreateIndexOptions { Name = "idx_llmgw_logs_tenant_request_time" }),
         }, cancellationToken: ct);
 
         var shadows = _data.Database.GetCollection<BsonDocument>("llmshadow_comparisons");
@@ -91,110 +175,166 @@ public sealed class LlmGatewayDatabaseInitializer : IHostedService
         {
             new CreateIndexModel<BsonDocument>(
                 Builders<BsonDocument>.IndexKeys
+                    .Ascending("TenantId")
                     .Ascending("ReleaseCommit")
                     .Ascending("AppCallerCode")
                     .Ascending("Kind")
                     .Descending("ComparedAt"),
-                new CreateIndexOptions { Name = "idx_llmgw_shadow_release_caller_kind_time" }),
+                new CreateIndexOptions { Name = "idx_llmgw_shadow_tenant_release_caller_kind_time" }),
             new CreateIndexModel<BsonDocument>(
                 Builders<BsonDocument>.IndexKeys
+                    .Ascending("TenantId")
                     .Ascending("HasCritical")
                     .Ascending("HttpOk")
                     .Descending("ComparedAt"),
-                new CreateIndexOptions { Name = "idx_llmgw_shadow_failure_time" }),
+                new CreateIndexOptions { Name = "idx_llmgw_shadow_tenant_failure_time" }),
         }, cancellationToken: ct);
 
         await CreateBsonIndexesAsync("llmgw_operation_audits", new[]
         {
             new CreateIndexModel<BsonDocument>(
-                Builders<BsonDocument>.IndexKeys.Descending("CreatedAt").Ascending("Action"),
-                new CreateIndexOptions { Name = "idx_llmgw_audit_time_action" }),
+                Builders<BsonDocument>.IndexKeys.Ascending("TenantId").Descending("CreatedAt").Ascending("Action"),
+                new CreateIndexOptions { Name = "idx_llmgw_audit_tenant_time_action" }),
         }, ct);
         await CreateBsonIndexesAsync("llmgw_login_audits", new[]
         {
             new CreateIndexModel<BsonDocument>(
-                Builders<BsonDocument>.IndexKeys.Descending("CreatedAt").Ascending("Success"),
-                new CreateIndexOptions { Name = "idx_llmgw_login_audit_time_success" }),
+                Builders<BsonDocument>.IndexKeys.Ascending("TenantId").Descending("CreatedAt").Ascending("Success"),
+                new CreateIndexOptions { Name = "idx_llmgw_login_audit_tenant_time_success" }),
         }, ct);
         await CreateBsonIndexesAsync("llmgw_lifecycle_runs", new[]
         {
             new CreateIndexModel<BsonDocument>(
-                Builders<BsonDocument>.IndexKeys.Descending("StartedAt"),
-                new CreateIndexOptions { Name = "idx_llmgw_lifecycle_started" }),
+                Builders<BsonDocument>.IndexKeys.Ascending("TenantId").Descending("StartedAt"),
+                new CreateIndexOptions { Name = "idx_llmgw_lifecycle_tenant_started" }),
         }, ct);
+        await DropIndexIfPresentAsync(_data.Database.GetCollection<BsonDocument>("llmgw_lifecycle_runs"), "idx_llmgw_lifecycle_started", ct);
         await CreateBsonIndexesAsync("llmgw_app_caller_rate_windows", new[]
         {
             new CreateIndexModel<BsonDocument>(
+                Builders<BsonDocument>.IndexKeys
+                    .Ascending("TenantId")
+                    .Ascending("AppCallerCode")
+                    .Ascending("RequestType")
+                    .Ascending("WindowStart"),
+                new CreateIndexOptions { Name = "idx_llmgw_rate_window_tenant_caller_type_time" }),
+            new CreateIndexModel<BsonDocument>(
                 Builders<BsonDocument>.IndexKeys.Ascending("ExpiresAt"),
                 new CreateIndexOptions { Name = "ttl_llmgw_rate_windows", ExpireAfter = TimeSpan.Zero }),
+        }, ct);
+        await CreateBsonIndexesAsync("llmgw_model_pools", new[]
+        {
+            new CreateIndexModel<BsonDocument>(
+                Builders<BsonDocument>.IndexKeys.Ascending("TenantId").Ascending("ModelType").Ascending("IsDefaultForType").Ascending("Priority"),
+                new CreateIndexOptions { Name = "idx_llmgw_pool_tenant_type_default_priority" }),
+        }, ct);
+        await CreateBsonIndexesAsync("llmgw_platforms", new[]
+        {
+            new CreateIndexModel<BsonDocument>(
+                Builders<BsonDocument>.IndexKeys.Ascending("TenantId").Ascending("Enabled").Ascending("Name"),
+                new CreateIndexOptions { Name = "idx_llmgw_platform_tenant_enabled_name" }),
+        }, ct);
+        await CreateBsonIndexesAsync("llmgw_models", new[]
+        {
+            new CreateIndexModel<BsonDocument>(
+                Builders<BsonDocument>.IndexKeys.Ascending("TenantId").Ascending("PlatformId").Ascending("Enabled").Ascending("Priority"),
+                new CreateIndexOptions { Name = "idx_llmgw_model_tenant_platform_enabled_priority" }),
+        }, ct);
+        await CreateBsonIndexesAsync("llmgw_model_exchanges", new[]
+        {
+            new CreateIndexModel<BsonDocument>(
+                Builders<BsonDocument>.IndexKeys.Ascending("TenantId").Ascending("Enabled").Ascending("Name"),
+                new CreateIndexOptions { Name = "idx_llmgw_exchange_tenant_enabled_name" }),
         }, ct);
 
         var budgets = _data.Database.GetCollection<GatewayBudgetMonthRecord>("llmgw_budget_months");
         await budgets.Indexes.CreateOneAsync(new CreateIndexModel<GatewayBudgetMonthRecord>(
             Builders<GatewayBudgetMonthRecord>.IndexKeys
+                .Ascending(x => x.TenantId)
                 .Ascending(x => x.AppCallerCode)
                 .Ascending(x => x.RequestType)
                 .Ascending(x => x.MonthStart),
-            new CreateIndexOptions { Name = "uniq_llmgw_budget_month", Unique = true }), cancellationToken: ct);
+            new CreateIndexOptions { Name = "uniq_llmgw_budget_tenant_month", Unique = true }), cancellationToken: ct);
+        await DropIndexIfPresentAsync(budgets, "uniq_llmgw_budget_month", ct);
 
         var reservations = _data.Database.GetCollection<GatewayBudgetReservationRecord>("llmgw_budget_reservations");
         await reservations.Indexes.CreateManyAsync(new[]
         {
             new CreateIndexModel<GatewayBudgetReservationRecord>(
                 Builders<GatewayBudgetReservationRecord>.IndexKeys
+                    .Ascending(x => x.TenantId)
                     .Ascending(x => x.AppCallerCode)
                     .Ascending(x => x.RequestType)
                     .Ascending(x => x.RequestId),
-                new CreateIndexOptions { Name = "uniq_llmgw_budget_reservation_request", Unique = true }),
+                new CreateIndexOptions { Name = "uniq_llmgw_budget_tenant_reservation_request", Unique = true }),
             new CreateIndexModel<GatewayBudgetReservationRecord>(
                 Builders<GatewayBudgetReservationRecord>.IndexKeys
+                    .Ascending(x => x.TenantId)
                     .Ascending(x => x.Status)
                     .Ascending(x => x.ExpiresAt),
-                new CreateIndexOptions { Name = "idx_llmgw_budget_reservation_status_expiry" }),
+                new CreateIndexOptions { Name = "idx_llmgw_budget_tenant_reservation_status_expiry" }),
         }, cancellationToken: ct);
+        await DropIndexIfPresentAsync(reservations, "uniq_llmgw_budget_reservation_request", ct);
 
         var executions = _data.Database.GetCollection<GatewayRequestExecutionRecord>("llmgw_request_executions");
         await executions.Indexes.CreateManyAsync(new[]
         {
             new CreateIndexModel<GatewayRequestExecutionRecord>(
                 Builders<GatewayRequestExecutionRecord>.IndexKeys
+                    .Ascending(x => x.TenantId)
                     .Ascending(x => x.AppCallerCode)
                     .Ascending(x => x.RequestId)
                     .Ascending(x => x.Operation),
-                new CreateIndexOptions { Name = "uniq_llmgw_execution_request", Unique = true }),
+                new CreateIndexOptions { Name = "uniq_llmgw_execution_tenant_request", Unique = true }),
             new CreateIndexModel<GatewayRequestExecutionRecord>(
                 Builders<GatewayRequestExecutionRecord>.IndexKeys.Ascending(x => x.ExpiresAt),
                 new CreateIndexOptions { Name = "ttl_llmgw_request_executions", ExpireAfter = TimeSpan.Zero }),
         }, cancellationToken: ct);
+        await DropIndexIfPresentAsync(executions, "uniq_llmgw_execution_request", ct);
 
         var serviceKeys = _data.Database.GetCollection<GatewayServiceKeyRecord>("llmgw_service_keys");
-        await serviceKeys.Indexes.CreateOneAsync(new CreateIndexModel<GatewayServiceKeyRecord>(
-            Builders<GatewayServiceKeyRecord>.IndexKeys.Ascending(x => x.KeyHash),
-            new CreateIndexOptions { Name = "uniq_llmgw_service_key_hash", Unique = true }), cancellationToken: ct);
+        await serviceKeys.Indexes.CreateManyAsync(new[]
+        {
+            new CreateIndexModel<GatewayServiceKeyRecord>(
+                Builders<GatewayServiceKeyRecord>.IndexKeys.Ascending(x => x.TenantId).Ascending(x => x.KeyHash),
+                new CreateIndexOptions { Name = "uniq_llmgw_service_key_tenant_hash", Unique = true }),
+            new CreateIndexModel<GatewayServiceKeyRecord>(
+                Builders<GatewayServiceKeyRecord>.IndexKeys.Ascending(x => x.TenantId).Descending(x => x.CreatedAt),
+                new CreateIndexOptions { Name = "idx_llmgw_service_key_tenant_created" }),
+        }, cancellationToken: ct);
+        await DropIndexIfPresentAsync(serviceKeys, "uniq_llmgw_service_key_hash", ct);
+        var serviceKeyDirectory = _data.Database.GetCollection<GatewayServiceKeyDirectoryRecord>("llmgw_service_key_directory");
+        await serviceKeyDirectory.Indexes.CreateOneAsync(new CreateIndexModel<GatewayServiceKeyDirectoryRecord>(
+            Builders<GatewayServiceKeyDirectoryRecord>.IndexKeys.Ascending(x => x.KeyHash),
+            new CreateIndexOptions { Name = "uniq_llmgw_service_key_directory_hash", Unique = true }), cancellationToken: ct);
 
         var multipart = _data.Database.GetCollection<GatewayMultipartObjectRecord>("llmgw_multipart_objects");
         await multipart.Indexes.CreateManyAsync(new[]
         {
             new CreateIndexModel<GatewayMultipartObjectRecord>(
-                Builders<GatewayMultipartObjectRecord>.IndexKeys.Ascending(x => x.RefKey),
-                new CreateIndexOptions { Name = "uniq_llmgw_multipart_ref", Unique = true }),
+                Builders<GatewayMultipartObjectRecord>.IndexKeys.Ascending(x => x.TenantId).Ascending(x => x.RefKey),
+                new CreateIndexOptions { Name = "uniq_llmgw_multipart_tenant_ref", Unique = true }),
             new CreateIndexModel<GatewayMultipartObjectRecord>(
-                Builders<GatewayMultipartObjectRecord>.IndexKeys.Ascending(x => x.Status).Ascending(x => x.ExpiresAt),
-                new CreateIndexOptions { Name = "idx_llmgw_multipart_status_expiry" }),
+                Builders<GatewayMultipartObjectRecord>.IndexKeys.Ascending(x => x.TenantId).Ascending(x => x.Status).Ascending(x => x.ExpiresAt),
+                new CreateIndexOptions { Name = "idx_llmgw_multipart_tenant_status_expiry" }),
         }, cancellationToken: ct);
+        await DropIndexIfPresentAsync(multipart, "uniq_llmgw_multipart_ref", ct);
+        await DropIndexIfPresentAsync(multipart, "idx_llmgw_multipart_status_expiry", ct);
 
         var concurrencySlots = _data.Database.GetCollection<GatewayProviderConcurrencySlotRecord>("llmgw_provider_concurrency_slots");
         await concurrencySlots.Indexes.CreateManyAsync(new[]
         {
             new CreateIndexModel<GatewayProviderConcurrencySlotRecord>(
                 Builders<GatewayProviderConcurrencySlotRecord>.IndexKeys
+                    .Ascending(x => x.TenantId)
                     .Ascending(x => x.ResourceKey)
                     .Ascending(x => x.Slot),
-                new CreateIndexOptions { Name = "uniq_llmgw_provider_concurrency_slot", Unique = true }),
+                new CreateIndexOptions { Name = "uniq_llmgw_provider_tenant_concurrency_slot", Unique = true }),
             new CreateIndexModel<GatewayProviderConcurrencySlotRecord>(
                 Builders<GatewayProviderConcurrencySlotRecord>.IndexKeys.Ascending(x => x.ExpiresAt),
                 new CreateIndexOptions { Name = "ttl_llmgw_provider_concurrency_slot", ExpireAfter = TimeSpan.Zero }),
         }, cancellationToken: ct);
+        await DropIndexIfPresentAsync(concurrencySlots, "uniq_llmgw_provider_concurrency_slot", ct);
 
         _logger.LogInformation("[LlmGatewayData] 非破坏性治理索引已就绪；TTL 索引由 lifecycle worker 在持久化 dry-run 后启用");
     }
@@ -303,8 +443,8 @@ public sealed class LlmGatewayDatabaseInitializer : IHostedService
         var duplicateGroups = records
             .Where(x => !string.IsNullOrWhiteSpace(x.AppCallerCode) && !string.IsNullOrWhiteSpace(x.RequestType))
             .GroupBy(
-                x => (x.AppCallerCode.Trim(), x.RequestType.Trim()),
-                StringTupleComparer.OrdinalIgnoreCase)
+                x => (x.TenantId, x.AppCallerCode.Trim(), x.RequestType.Trim()),
+                TenantAppCallerTupleComparer.OrdinalIgnoreCase)
             .Where(x => x.Count() > 1)
             .ToList();
 
@@ -328,8 +468,8 @@ public sealed class LlmGatewayDatabaseInitializer : IHostedService
                 .ToList();
 
             var update = Builders<GatewayAppCallerRecord>.Update
-                .Set(x => x.AppCallerCode, group.Key.Item1)
-                .Set(x => x.RequestType, group.Key.Item2)
+                .Set(x => x.AppCallerCode, group.Key.Item2)
+                .Set(x => x.RequestType, group.Key.Item3)
                 .Set(x => x.ObservedIngressProtocols, protocols)
                 .Set(x => x.TotalSeen, ordered.Sum(x => Math.Max(0, x.TotalSeen)))
                 .Set(x => x.FirstSeenAt, ordered.Min(x => x.FirstSeenAt))
@@ -345,8 +485,9 @@ public sealed class LlmGatewayDatabaseInitializer : IHostedService
                 var archiveDocument = new BsonDocument
                 {
                     { "_id", duplicate.Id },
-                    { "AppCallerCode", group.Key.Item1 },
-                    { "RequestType", group.Key.Item2 },
+                    { "TenantId", group.Key.Item1 },
+                    { "AppCallerCode", group.Key.Item2 },
+                    { "RequestType", group.Key.Item3 },
                     { "SurvivorId", survivor.Id },
                     { "ArchivedAt", DateTime.UtcNow },
                     { "Reason", "duplicate-before-unique-index" },
@@ -359,17 +500,18 @@ public sealed class LlmGatewayDatabaseInitializer : IHostedService
                     ct);
             }
 
-            await callers.UpdateOneAsync(x => x.Id == survivor.Id, update, cancellationToken: ct);
-            var deleteResult = await callers.DeleteManyAsync(x => duplicateIds.Contains(x.Id), ct);
+            await callers.UpdateOneAsync(x => x.TenantId == group.Key.Item1 && x.Id == survivor.Id, update, cancellationToken: ct);
+            var deleteResult = await callers.DeleteManyAsync(x => x.TenantId == group.Key.Item1 && duplicateIds.Contains(x.Id), ct);
 
             var audits = _data.Database.GetCollection<BsonDocument>(OperationAuditCollectionName);
             await audits.InsertOneAsync(new BsonDocument
             {
                 { "_id", Guid.NewGuid().ToString("N") },
+                { "TenantId", group.Key.Item1 },
                 { "Action", "app_caller.deduplicate" },
                 { "TargetType", "llmgw_app_caller" },
                 { "TargetId", survivor.Id },
-                { "TargetName", $"{group.Key.Item1}::{group.Key.Item2}" },
+                { "TargetName", $"{group.Key.Item2}::{group.Key.Item3}" },
                 { "ActorUserId", BsonNull.Value },
                 { "ActorUsername", "system" },
                 { "Success", true },
@@ -387,24 +529,26 @@ public sealed class LlmGatewayDatabaseInitializer : IHostedService
             }, cancellationToken: ct);
             _logger.LogWarning(
                 "[LlmGatewayData] 合并重复 appCaller: Code={Code}, RequestType={RequestType}, Survivor={Survivor}, Removed={Removed}",
-                group.Key.Item1,
                 group.Key.Item2,
+                group.Key.Item3,
                 survivor.Id,
                 deleteResult.DeletedCount);
         }
     }
 
-    private sealed class StringTupleComparer : IEqualityComparer<(string, string)>
+    private sealed class TenantAppCallerTupleComparer : IEqualityComparer<(string, string, string)>
     {
-        public static StringTupleComparer OrdinalIgnoreCase { get; } = new();
+        public static TenantAppCallerTupleComparer OrdinalIgnoreCase { get; } = new();
 
-        public bool Equals((string, string) x, (string, string) y)
+        public bool Equals((string, string, string) x, (string, string, string) y)
             => string.Equals(x.Item1, y.Item1, StringComparison.OrdinalIgnoreCase)
-               && string.Equals(x.Item2, y.Item2, StringComparison.OrdinalIgnoreCase);
+               && string.Equals(x.Item2, y.Item2, StringComparison.OrdinalIgnoreCase)
+               && string.Equals(x.Item3, y.Item3, StringComparison.OrdinalIgnoreCase);
 
-        public int GetHashCode((string, string) obj)
+        public int GetHashCode((string, string, string) obj)
             => HashCode.Combine(
                 StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Item1),
-                StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Item2));
+                StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Item2),
+                StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Item3));
     }
 }

--- a/prd-api/src/PrdAgent.Infrastructure/LLM/LlmRequestLogWriter.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LLM/LlmRequestLogWriter.cs
@@ -6,6 +6,7 @@ using MongoDB.Driver;
 using PrdAgent.Core.Interfaces;
 using PrdAgent.Core.Models;
 using PrdAgent.Infrastructure.Database;
+using PrdAgent.Infrastructure.LlmGateway;
 using PrdAgent.Infrastructure.Services.AssetStorage;
 
 namespace PrdAgent.Infrastructure.LLM;
@@ -51,7 +52,7 @@ public class LlmRequestLogWriter : ILlmRequestLogWriter
             var log = new LlmRequestLog
             {
                 Id = Guid.NewGuid().ToString(),
-                TenantId = start.TenantId ?? string.Empty,
+                TenantId = ResolveTenantId(start.TenantId),
                 TeamId = start.TeamId,
                 RequestId = start.RequestId,
                 ReleaseCommit = releaseCommit,
@@ -152,7 +153,7 @@ public class LlmRequestLogWriter : ILlmRequestLogWriter
                 var fallbackLog = new LlmRequestLog
                 {
                     Id = Guid.NewGuid().ToString(),
-                    TenantId = start.TenantId ?? string.Empty,
+                    TenantId = ResolveTenantId(start.TenantId),
                     TeamId = start.TeamId,
                     RequestId = start.RequestId,
                     ReleaseCommit = releaseCommit,
@@ -191,6 +192,11 @@ public class LlmRequestLogWriter : ILlmRequestLogWriter
             }
         }
     }
+
+    private static string ResolveTenantId(string? tenantId)
+        => string.IsNullOrWhiteSpace(tenantId)
+            ? GatewayTenantDefaults.InternalTenantId
+            : tenantId.Trim();
 
     public void MarkFirstByte(string logId, DateTime at)
     {

--- a/prd-api/src/PrdAgent.Infrastructure/LLM/LlmRequestLogWriter.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LLM/LlmRequestLogWriter.cs
@@ -51,6 +51,8 @@ public class LlmRequestLogWriter : ILlmRequestLogWriter
             var log = new LlmRequestLog
             {
                 Id = Guid.NewGuid().ToString(),
+                TenantId = start.TenantId ?? string.Empty,
+                TeamId = start.TeamId,
                 RequestId = start.RequestId,
                 ReleaseCommit = releaseCommit,
                 GroupId = start.GroupId,
@@ -150,6 +152,8 @@ public class LlmRequestLogWriter : ILlmRequestLogWriter
                 var fallbackLog = new LlmRequestLog
                 {
                     Id = Guid.NewGuid().ToString(),
+                    TenantId = start.TenantId ?? string.Empty,
+                    TeamId = start.TeamId,
                     RequestId = start.RequestId,
                     ReleaseCommit = releaseCommit,
                     GroupId = start.GroupId,

--- a/prd-api/src/PrdAgent.Infrastructure/LLM/LlmRequestLogWriter.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LLM/LlmRequestLogWriter.cs
@@ -1,6 +1,7 @@
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 using PrdAgent.Core.Interfaces;
@@ -19,16 +20,26 @@ public class LlmRequestLogWriter : ILlmRequestLogWriter
     private readonly ILogger<LlmRequestLogWriter> _logger;
     private readonly IAppSettingsService _settingsService;
     private readonly IAssetStorage _assetStorage;
+    private readonly string _internalTenantId;
 
     /// <summary>JSON 中字符串值超过此长度时，上传 COS 存储引用</summary>
     private const int CosTextThreshold = 1024;
 
-    public LlmRequestLogWriter(MongoDbContext db, ILogger<LlmRequestLogWriter> logger, LlmRequestLogBackground _, IAppSettingsService settingsService, IAssetStorage assetStorage)
+    public LlmRequestLogWriter(
+        MongoDbContext db,
+        ILogger<LlmRequestLogWriter> logger,
+        LlmRequestLogBackground _,
+        IAppSettingsService settingsService,
+        IAssetStorage assetStorage,
+        IConfiguration configuration)
     {
         _db = db;
         _logger = logger;
         _settingsService = settingsService;
         _assetStorage = assetStorage;
+        _internalTenantId = configuration["LlmGateway:InternalTenantId"]?.Trim() is { Length: > 0 } tenantId
+            ? tenantId
+            : GatewayTenantDefaults.InternalTenantId;
     }
 
     public async Task<string?> StartAsync(LlmLogStart start, CancellationToken ct = default)
@@ -193,9 +204,9 @@ public class LlmRequestLogWriter : ILlmRequestLogWriter
         }
     }
 
-    private static string ResolveTenantId(string? tenantId)
+    private string ResolveTenantId(string? tenantId)
         => string.IsNullOrWhiteSpace(tenantId)
-            ? GatewayTenantDefaults.InternalTenantId
+            ? _internalTenantId
             : tenantId.Trim();
 
     public void MarkFirstByte(string logId, DateTime at)

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/GatewayGovernanceRecords.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/GatewayGovernanceRecords.cs
@@ -7,6 +7,8 @@ namespace PrdAgent.Infrastructure.LlmGateway;
 public sealed class GatewayServiceKeyRecord
 {
     public string Id { get; set; } = Guid.NewGuid().ToString("N");
+    public string TenantId { get; set; } = string.Empty;
+    public string? TeamId { get; set; }
     public string Name { get; set; } = string.Empty;
     public string KeyHash { get; set; } = string.Empty;
     public bool Enabled { get; set; } = true;
@@ -21,9 +23,20 @@ public sealed class GatewayServiceKeyRecord
 }
 
 [BsonIgnoreExtraElements]
+public sealed class GatewayServiceKeyDirectoryRecord
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString("N");
+    public string KeyHash { get; set; } = string.Empty;
+    public string TenantId { get; set; } = string.Empty;
+    public string ServiceKeyId { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}
+
+[BsonIgnoreExtraElements]
 public sealed class GatewayBudgetMonthRecord
 {
     public string Id { get; set; } = Guid.NewGuid().ToString("N");
+    public string TenantId { get; set; } = string.Empty;
     public string AppCallerCode { get; set; } = string.Empty;
     public string RequestType { get; set; } = string.Empty;
     public DateTime MonthStart { get; set; }
@@ -37,6 +50,7 @@ public sealed class GatewayBudgetMonthRecord
 public sealed class GatewayBudgetReservationRecord
 {
     public string Id { get; set; } = Guid.NewGuid().ToString("N");
+    public string TenantId { get; set; } = string.Empty;
     public string AppCallerCode { get; set; } = string.Empty;
     public string RequestType { get; set; } = string.Empty;
     public string RequestId { get; set; } = string.Empty;
@@ -54,6 +68,7 @@ public sealed class GatewayBudgetReservationRecord
 public sealed class GatewayRequestExecutionRecord
 {
     public string Id { get; set; } = Guid.NewGuid().ToString("N");
+    public string TenantId { get; set; } = string.Empty;
     public string AppCallerCode { get; set; } = string.Empty;
     public string RequestId { get; set; } = string.Empty;
     public string Operation { get; set; } = string.Empty;
@@ -70,6 +85,7 @@ public sealed class GatewayRequestExecutionRecord
 public sealed class GatewayMultipartObjectRecord
 {
     public string Id { get; set; } = Guid.NewGuid().ToString("N");
+    public string TenantId { get; set; } = string.Empty;
     public string RequestId { get; set; } = string.Empty;
     public string RefKey { get; set; } = string.Empty;
     public string Sha256 { get; set; } = string.Empty;
@@ -86,6 +102,7 @@ public sealed class GatewayMultipartObjectRecord
 public sealed class GatewayLifecycleRunRecord
 {
     public string Id { get; set; } = Guid.NewGuid().ToString("N");
+    public string TenantId { get; set; } = string.Empty;
     public string Mode { get; set; } = "dry-run";
     public string Status { get; set; } = "running";
     public DateTime StartedAt { get; set; } = DateTime.UtcNow;
@@ -114,6 +131,7 @@ public sealed class GatewayLifecycleRunRecord
 public sealed class GatewayProviderConcurrencySlotRecord
 {
     public string Id { get; set; } = string.Empty;
+    public string TenantId { get; set; } = string.Empty;
     public string ResourceKey { get; set; } = string.Empty;
     public int Slot { get; set; }
     public string LeaseId { get; set; } = string.Empty;

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/GatewayLLMClient.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/GatewayLLMClient.cs
@@ -112,6 +112,8 @@ public class GatewayLLMClient : ILLMClient
             TimeoutSeconds = 120,
             Context = new GatewayRequestContext
             {
+                TenantId = scopeCtx?.TenantId,
+                TeamId = scopeCtx?.TeamId,
                 RequestId = scopeCtx?.RequestId,
                 SessionId = scopeCtx?.SessionId,
                 GroupId = scopeCtx?.GroupId,

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/GatewayProviderConcurrencyCoordinator.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/GatewayProviderConcurrencyCoordinator.cs
@@ -37,6 +37,7 @@ public sealed class GatewayProviderConcurrencyCoordinator
     }
 
     public async Task<GatewayProviderConcurrencyAdmission> AcquireAsync(
+        string tenantId,
         ModelResolutionResult resolution,
         int timeoutSeconds,
         CancellationToken ct)
@@ -59,10 +60,10 @@ public sealed class GatewayProviderConcurrencyCoordinator
         var acquired = new List<string>(limits.Count);
         foreach (var (resourceKey, limit) in limits)
         {
-            var slotId = await TryAcquireSlotAsync(resourceKey, Math.Clamp(limit, 1, 10000), leaseId, expiresAt, ct);
+            var slotId = await TryAcquireSlotAsync(tenantId, resourceKey, Math.Clamp(limit, 1, 10000), leaseId, expiresAt, ct);
             if (slotId is null)
             {
-                await ReleaseAsync(leaseId, acquired, CancellationToken.None);
+                await ReleaseAsync(tenantId, leaseId, acquired, CancellationToken.None);
                 _logger.LogWarning(
                     "[GatewayConcurrency] provider concurrency exhausted resource={ResourceKey} limit={Limit} platform={Platform} model={Model}",
                     resourceKey,
@@ -75,10 +76,11 @@ public sealed class GatewayProviderConcurrencyCoordinator
         }
 
         return GatewayProviderConcurrencyAdmission.Allow(
-            new GatewayProviderConcurrencyLease(this, leaseId, acquired));
+            new GatewayProviderConcurrencyLease(this, tenantId, leaseId, acquired));
     }
 
     private async Task<string?> TryAcquireSlotAsync(
+        string tenantId,
         string resourceKey,
         int limit,
         string leaseId,
@@ -89,8 +91,9 @@ public sealed class GatewayProviderConcurrencyCoordinator
         var collection = _data.Database.GetCollection<GatewayProviderConcurrencySlotRecord>(CollectionName);
         for (var slot = 0; slot < limit; slot++)
         {
-            var slotId = $"{Sha256Hex(resourceKey)}:{slot}";
-            var filter = Builders<GatewayProviderConcurrencySlotRecord>.Filter.Eq(x => x.Id, slotId)
+            var slotId = $"{Sha256Hex(tenantId)}:{Sha256Hex(resourceKey)}:{slot}";
+            var filter = Builders<GatewayProviderConcurrencySlotRecord>.Filter.Eq(x => x.TenantId, tenantId)
+                         & Builders<GatewayProviderConcurrencySlotRecord>.Filter.Eq(x => x.Id, slotId)
                          & (Builders<GatewayProviderConcurrencySlotRecord>.Filter.Lte(x => x.ExpiresAt, now)
                             | Builders<GatewayProviderConcurrencySlotRecord>.Filter.Eq(x => x.LeaseId, string.Empty));
             try
@@ -99,6 +102,7 @@ public sealed class GatewayProviderConcurrencyCoordinator
                     filter,
                     Builders<GatewayProviderConcurrencySlotRecord>.Update
                         .SetOnInsert(x => x.Id, slotId)
+                        .SetOnInsert(x => x.TenantId, tenantId)
                         .SetOnInsert(x => x.ResourceKey, resourceKey)
                         .SetOnInsert(x => x.Slot, slot)
                         .Set(x => x.LeaseId, leaseId)
@@ -127,21 +131,22 @@ public sealed class GatewayProviderConcurrencyCoordinator
         return null;
     }
 
-    internal async Task ReleaseAsync(string leaseId, IReadOnlyCollection<string> slotIds, CancellationToken ct)
+    internal async Task ReleaseAsync(string tenantId, string leaseId, IReadOnlyCollection<string> slotIds, CancellationToken ct)
     {
         if (slotIds.Count == 0) return;
         var collection = _data.Database.GetCollection<GatewayProviderConcurrencySlotRecord>(CollectionName);
         await collection.DeleteManyAsync(
-            Builders<GatewayProviderConcurrencySlotRecord>.Filter.In(x => x.Id, slotIds)
+            Builders<GatewayProviderConcurrencySlotRecord>.Filter.Eq(x => x.TenantId, tenantId)
+            & Builders<GatewayProviderConcurrencySlotRecord>.Filter.In(x => x.Id, slotIds)
             & Builders<GatewayProviderConcurrencySlotRecord>.Filter.Eq(x => x.LeaseId, leaseId),
             ct);
     }
 
-    internal async Task ReleaseSafelyAsync(string leaseId, IReadOnlyCollection<string> slotIds)
+    internal async Task ReleaseSafelyAsync(string tenantId, string leaseId, IReadOnlyCollection<string> slotIds)
     {
         try
         {
-            await ReleaseAsync(leaseId, slotIds, CancellationToken.None);
+            await ReleaseAsync(tenantId, leaseId, slotIds, CancellationToken.None);
         }
         catch (Exception ex)
         {
@@ -159,16 +164,19 @@ public sealed class GatewayProviderConcurrencyCoordinator
 public sealed class GatewayProviderConcurrencyLease : IAsyncDisposable
 {
     private readonly GatewayProviderConcurrencyCoordinator _owner;
+    private readonly string _tenantId;
     private readonly string _leaseId;
     private readonly IReadOnlyCollection<string> _slotIds;
     private int _released;
 
     internal GatewayProviderConcurrencyLease(
         GatewayProviderConcurrencyCoordinator owner,
+        string tenantId,
         string leaseId,
         IReadOnlyCollection<string> slotIds)
     {
         _owner = owner;
+        _tenantId = tenantId;
         _leaseId = leaseId;
         _slotIds = slotIds;
     }
@@ -176,6 +184,6 @@ public sealed class GatewayProviderConcurrencyLease : IAsyncDisposable
     public async ValueTask DisposeAsync()
     {
         if (Interlocked.Exchange(ref _released, 1) != 0) return;
-        await _owner.ReleaseSafelyAsync(_leaseId, _slotIds);
+        await _owner.ReleaseSafelyAsync(_tenantId, _leaseId, _slotIds);
     }
 }

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/GatewayProviderConcurrencyCoordinator.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/GatewayProviderConcurrencyCoordinator.cs
@@ -93,7 +93,8 @@ public sealed class GatewayProviderConcurrencyCoordinator
         {
             var slotId = $"{Sha256Hex(tenantId)}:{Sha256Hex(resourceKey)}:{slot}";
             var filter = Builders<GatewayProviderConcurrencySlotRecord>.Filter.Eq(x => x.TenantId, tenantId)
-                         & Builders<GatewayProviderConcurrencySlotRecord>.Filter.Eq(x => x.Id, slotId)
+                         & Builders<GatewayProviderConcurrencySlotRecord>.Filter.Eq(x => x.ResourceKey, resourceKey)
+                         & Builders<GatewayProviderConcurrencySlotRecord>.Filter.Eq(x => x.Slot, slot)
                          & (Builders<GatewayProviderConcurrencySlotRecord>.Filter.Lte(x => x.ExpiresAt, now)
                             | Builders<GatewayProviderConcurrencySlotRecord>.Filter.Eq(x => x.LeaseId, string.Empty));
             try
@@ -116,7 +117,7 @@ public sealed class GatewayProviderConcurrencyCoordinator
                     },
                     ct);
                 if (acquired?.LeaseId == leaseId)
-                    return slotId;
+                    return acquired.Id;
             }
             catch (MongoWriteException ex) when (ex.WriteError?.Category == ServerErrorCategory.DuplicateKey)
             {

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/GatewayRequest.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/GatewayRequest.cs
@@ -162,6 +162,13 @@ public class GatewayRequest
 public class GatewayRequestContext
 {
     /// <summary>
+    /// 仅由 serving 的已验证会话或 service key 上下文写入。入口适配器不得信任请求自报值。
+    /// </summary>
+    public string? TenantId { get; set; }
+
+    public string? TeamId { get; set; }
+
+    /// <summary>
     /// 请求 ID（用于关联日志）
     /// </summary>
     public string? RequestId { get; init; }
@@ -277,6 +284,8 @@ public class GatewayRequestContext
     public static GatewayRequestContext WithTransport(GatewayRequestContext? source, string transport)
         => new()
         {
+            TenantId = source?.TenantId,
+            TeamId = source?.TeamId,
             RequestId = source?.RequestId,
             SessionId = source?.SessionId,
             RunId = source?.RunId,
@@ -321,7 +330,7 @@ public sealed class GatewayIngressRequest
     public string? PinnedModelId { get; init; }
     public JsonObject RequestBody { get; init; } = new();
     public List<string> DroppedParameters { get; init; } = new();
-    public GatewayRequestContext? Context { get; init; }
+    public GatewayRequestContext? Context { get; set; }
 
     public GatewayRequest ToGatewayRequest(bool stream, int timeoutSeconds = 600, bool includeThinking = true)
     {
@@ -374,6 +383,8 @@ public sealed class GatewayIngressRequest
 public sealed class GatewayAppCallerRecord
 {
     public string Id { get; set; } = Guid.NewGuid().ToString("N");
+    public string TenantId { get; set; } = string.Empty;
+    public string? TeamId { get; set; }
     public string AppCallerCode { get; set; } = string.Empty;
     public string RequestType { get; set; } = string.Empty;
     public string SourceSystem { get; set; } = "external";

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/GatewayRequest.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/GatewayRequest.cs
@@ -350,6 +350,8 @@ public sealed class GatewayIngressRequest
             TimeoutSeconds = timeoutSeconds,
             Context = new GatewayRequestContext
             {
+                TenantId = Context?.TenantId,
+                TeamId = Context?.TeamId,
                 RequestId = Context?.RequestId ?? RequestId,
                 SessionId = Context?.SessionId,
                 RunId = Context?.RunId,

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/GatewayTenantDefaults.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/GatewayTenantDefaults.cs
@@ -1,0 +1,8 @@
+namespace PrdAgent.Infrastructure.LlmGateway;
+
+public static class GatewayTenantDefaults
+{
+    public const string InternalTenantId = "tenant_map_internal";
+    public const string InternalTenantName = "MAP Internal";
+    public const string InternalTenantSlug = "map-internal";
+}

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/HttpLlmClient.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/HttpLlmClient.cs
@@ -89,6 +89,8 @@ public sealed class HttpLlmClient : PrdAgent.Core.Interfaces.ILLMClient
         var current = _ctxAccessor?.Current;
         var context = new GatewayRequestContext
         {
+            TenantId = current?.TenantId,
+            TeamId = current?.TeamId,
             RequestId = current?.RequestId ?? Guid.NewGuid().ToString("N"),
             GroupId = current?.GroupId,
             RunId = current?.RunId,

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/HttpLlmGatewayClient.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/HttpLlmGatewayClient.cs
@@ -37,6 +37,7 @@ public sealed class HttpLlmGatewayClient
     private readonly string _baseUrl;
     private readonly string _gatewayKey;
     private readonly int _failedMultipartHours;
+    private readonly string _internalTenantId;
 
     /// <summary>
     /// 与 serving 端一致的序列化口径：PascalCase + 不写 null 字段。
@@ -67,6 +68,9 @@ public sealed class HttpLlmGatewayClient
         // 直接 401 响亮失败，而非用可预测的共享密钥静默通过、削弱本 PR 新增的密钥门（Cursor Bugbot）。
         _gatewayKey = config["LlmGwServe:ApiKey"] ?? string.Empty;
         _failedMultipartHours = Math.Max(1, config.GetValue("LlmGateway:Retention:FailedMultipartHours", 72));
+        _internalTenantId = config["LlmGateway:InternalTenantId"]?.Trim() is { Length: > 0 } tenantId
+            ? tenantId
+            : GatewayTenantDefaults.InternalTenantId;
     }
 
     private HttpClient CreateHttp(bool infiniteTimeout)
@@ -244,6 +248,7 @@ public sealed class HttpLlmGatewayClient
                     request.MultipartFiles!,
                     _assetStorage,
                     _gatewayData,
+                    string.IsNullOrWhiteSpace(request.Context?.TenantId) ? _internalTenantId : request.Context.TenantId,
                     request.Context?.RequestId ?? Guid.NewGuid().ToString("N"),
                     _failedMultipartHours,
                     ct);
@@ -336,6 +341,7 @@ public sealed class HttpLlmGatewayClient
         Dictionary<string, (string FileName, byte[] Content, string MimeType)> files,
         IAssetStorage storage,
         LlmGatewayDataContext? gatewayData,
+        string tenantId,
         string requestId,
         int failedMultipartHours,
         CancellationToken ct)
@@ -368,9 +374,10 @@ public sealed class HttpLlmGatewayClient
                 {
                     await gatewayData.Database.GetCollection<GatewayMultipartObjectRecord>("llmgw_multipart_objects")
                         .ReplaceOneAsync(
-                            x => x.RefKey == key,
+                            x => x.TenantId == tenantId && x.RefKey == key,
                             new GatewayMultipartObjectRecord
                             {
+                                TenantId = tenantId,
                                 RequestId = requestId,
                                 RefKey = key,
                                 Sha256 = sha256,

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/LlmGateway.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/LlmGateway.cs
@@ -318,7 +318,7 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
                     continue;
                 }
 
-                var concurrency = await AcquireProviderConcurrencyAsync(activeResolution, request.TimeoutSeconds, ct);
+                var concurrency = await AcquireProviderConcurrencyAsync(request.Context?.TenantId, activeResolution, request.TimeoutSeconds, ct);
                 if (!concurrency.Allowed)
                 {
                     const string message = "上游平台或模型已达到最大并发";
@@ -558,7 +558,7 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
                     continue;
                 }
 
-                var concurrency = await AcquireProviderConcurrencyAsync(resolution, request.TimeoutSeconds, ct);
+                var concurrency = await AcquireProviderConcurrencyAsync(request.Context?.TenantId, resolution, request.TimeoutSeconds, ct);
                 if (!concurrency.Allowed)
                 {
                     terminalError = "上游平台或模型已达到最大并发";
@@ -929,12 +929,17 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
     }
 
     private Task<GatewayProviderConcurrencyAdmission> AcquireProviderConcurrencyAsync(
+        string? tenantId,
         ModelResolutionResult resolution,
         int timeoutSeconds,
         CancellationToken ct)
         => _concurrencyCoordinator is null
             ? Task.FromResult(GatewayProviderConcurrencyAdmission.Allow())
-            : _concurrencyCoordinator.AcquireAsync(resolution, timeoutSeconds, ct);
+            : _concurrencyCoordinator.AcquireAsync(
+                string.IsNullOrWhiteSpace(tenantId) ? GatewayTenantDefaults.InternalTenantId : tenantId,
+                resolution,
+                timeoutSeconds,
+                ct);
 
     /// <inheritdoc />
     public async Task<GatewayRawResponse> SendRawWithResolutionAsync(
@@ -1306,7 +1311,7 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
         try
         {
             var gatewayResolution = resolution.ToGatewayResolution();
-            var concurrency = await AcquireProviderConcurrencyAsync(resolution, request.TimeoutSeconds, ct);
+            var concurrency = await AcquireProviderConcurrencyAsync(request.Context?.TenantId, resolution, request.TimeoutSeconds, ct);
             if (!concurrency.Allowed)
             {
                 return GatewayRawResponse.Fail(
@@ -1642,7 +1647,7 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
                     await providerLease.DisposeAsync();
                     providerLease = null;
                 }
-                var retryConcurrency = await AcquireProviderConcurrencyAsync(resolution, request.TimeoutSeconds, ct);
+                var retryConcurrency = await AcquireProviderConcurrencyAsync(request.Context?.TenantId, resolution, request.TimeoutSeconds, ct);
                 if (!retryConcurrency.Allowed)
                 {
                     var dur = (long)(DateTime.UtcNow - startedAt).TotalMilliseconds;
@@ -3106,6 +3111,8 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
                     OutputPricePerMillion: resolution.OutputPricePerMillion,
                     PricePerCall: resolution.PricePerCall,
                     PriceCurrency: resolution.PriceCurrency,
+                    TenantId: request.Context?.TenantId,
+                    TeamId: request.Context?.TeamId,
                     // S2：默认进程内网关路径。若 serving 端处理来自 MAP 的跨进程请求，
                     // MAP 侧 HttpLlmGatewayClient 已把 Context.GatewayTransport 置为 "http" 过线，此处尊重之。
                     GatewayTransport: request.Context?.GatewayTransport ?? GatewayTransports.Inproc),
@@ -3474,6 +3481,8 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
                     OutputPricePerMillion: resolution.OutputPricePerMillion,
                     PricePerCall: resolution.PricePerCall,
                     PriceCurrency: resolution.PriceCurrency,
+                    TenantId: request.Context?.TenantId,
+                    TeamId: request.Context?.TeamId,
                     // S2：默认进程内网关 raw 路径（生图/视频等）。serving 端处理跨进程请求时，
                     // MAP 侧已把 Context.GatewayTransport 置为 "http"，此处尊重之。
                     GatewayTransport: request.Context?.GatewayTransport ?? GatewayTransports.Inproc),

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/LlmGateway.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/LlmGateway.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using PrdAgent.Core.Interfaces;
@@ -26,6 +27,7 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
     private readonly ModelPool.IPoolFailoverNotifier? _failoverNotifier;
     private readonly IDoubaoStreamAsrExecutor _doubaoStreamAsr;
     private readonly GatewayProviderConcurrencyCoordinator? _concurrencyCoordinator;
+    private readonly string _internalTenantId;
     private readonly Dictionary<string, IGatewayAdapter> _adapters = new(StringComparer.OrdinalIgnoreCase);
     private readonly ExchangeTransformerRegistry _transformerRegistry = new();
     private static readonly HashSet<string> StrictParameterCapabilityKeys = new(StringComparer.OrdinalIgnoreCase)
@@ -54,7 +56,8 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
         ILLMRequestContextAccessor? contextAccessor = null,
         ModelPool.IPoolFailoverNotifier? failoverNotifier = null,
         IDoubaoStreamAsrExecutor? doubaoStreamAsr = null,
-        GatewayProviderConcurrencyCoordinator? concurrencyCoordinator = null)
+        GatewayProviderConcurrencyCoordinator? concurrencyCoordinator = null,
+        IConfiguration? configuration = null)
     {
         _modelResolver = modelResolver;
         _httpClientFactory = httpClientFactory;
@@ -63,6 +66,9 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
         _contextAccessor = contextAccessor;
         _failoverNotifier = failoverNotifier;
         _concurrencyCoordinator = concurrencyCoordinator;
+        _internalTenantId = configuration?["LlmGateway:InternalTenantId"]?.Trim() is { Length: > 0 } tenantId
+            ? tenantId
+            : GatewayTenantDefaults.InternalTenantId;
         _doubaoStreamAsr = doubaoStreamAsr
             ?? new DoubaoStreamAsrService(NullLogger<DoubaoStreamAsrService>.Instance);
 
@@ -936,7 +942,7 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
         => _concurrencyCoordinator is null
             ? Task.FromResult(GatewayProviderConcurrencyAdmission.Allow())
             : _concurrencyCoordinator.AcquireAsync(
-                string.IsNullOrWhiteSpace(tenantId) ? GatewayTenantDefaults.InternalTenantId : tenantId,
+                string.IsNullOrWhiteSpace(tenantId) ? _internalTenantId : tenantId,
                 resolution,
                 timeoutSeconds,
                 ct);

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/LlmGateway.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/LlmGateway.cs
@@ -1071,6 +1071,8 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
             },
             Context = new GatewayRequestContext
             {
+                TenantId = sourceContext?.TenantId,
+                TeamId = sourceContext?.TeamId,
                 RequestId = string.IsNullOrWhiteSpace(request.RequestId)
                     ? Guid.NewGuid().ToString("N")
                     : request.RequestId.Trim(),

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/ModelResolver.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/ModelResolver.cs
@@ -539,6 +539,8 @@ public class ModelResolver : IModelResolver
         }
         if (result.Count > 0)
             return result;
+        if (!string.Equals(CurrentTenantId, _internalTenantId, StringComparison.Ordinal))
+            return result;
         if (DisableMapConfigFallbackForRegisteredAppCallers())
             return result;
 

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/ModelResolver.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/ModelResolver.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 using PrdAgent.Core.Models;
+using PrdAgent.Core.Interfaces;
 using PrdAgent.Infrastructure.Database;
 using PrdAgent.Infrastructure.Security;
 
@@ -16,17 +17,24 @@ public class ModelResolver : IModelResolver
     private readonly LlmGatewayDataContext? _gatewayDb;
     private readonly IConfiguration _config;
     private readonly ILogger<ModelResolver> _logger;
+    private readonly ILLMRequestContextAccessor? _requestContext;
+    private readonly string _internalTenantId;
 
     public ModelResolver(
         MongoDbContext db,
         IConfiguration config,
         ILogger<ModelResolver> logger,
-        LlmGatewayDataContext? gatewayDb = null)
+        LlmGatewayDataContext? gatewayDb = null,
+        ILLMRequestContextAccessor? requestContext = null)
     {
         _db = db;
         _gatewayDb = gatewayDb;
         _config = config;
         _logger = logger;
+        _requestContext = requestContext;
+        _internalTenantId = config["LlmGateway:InternalTenantId"]?.Trim() is { Length: > 0 } tenantId
+            ? tenantId
+            : GatewayTenantDefaults.InternalTenantId;
     }
 
     /// <inheritdoc />
@@ -49,7 +57,8 @@ public class ModelResolver : IModelResolver
         var hasDedicatedBinding = false;
         string resolutionType = "NotFound";
 
-        var gatewayConfigRequired = DisableMapConfigFallbackForRegisteredAppCallers();
+        var gatewayConfigRequired = !string.Equals(CurrentTenantId, _internalTenantId, StringComparison.Ordinal)
+                                    || DisableMapConfigFallbackForRegisteredAppCallers();
         var gatewayRegistry = await TryGetGatewayRegistryGroupsAsync(appCallerCode, modelType, ct);
         if (gatewayRegistry.TrafficRejected)
         {
@@ -994,8 +1003,10 @@ public class ModelResolver : IModelResolver
         {
             var records = _gatewayDb.Context.Database.GetCollection<GatewayAppCallerRecord>("llmgw_app_callers");
             var record = await records
-                .Find(x => x.AppCallerCode == appCallerCode
-                           && x.RequestType == modelType,
+                .Find(Builders<GatewayAppCallerRecord>.Filter.And(
+                    Builders<GatewayAppCallerRecord>.Filter.Eq(x => x.TenantId, CurrentTenantId),
+                    Builders<GatewayAppCallerRecord>.Filter.Eq(x => x.AppCallerCode, appCallerCode),
+                    Builders<GatewayAppCallerRecord>.Filter.Eq(x => x.RequestType, modelType)),
                     new FindOptions { Collation = GatewayAppCallerIdentity.Collation })
                 .SortByDescending(x => x.UpdatedAt)
                 .FirstOrDefaultAsync(ct);
@@ -1058,7 +1069,10 @@ public class ModelResolver : IModelResolver
 
         var gatewayPools = _gatewayDb.Context.Database.GetCollection<ModelGroup>("llmgw_model_pools");
         return await gatewayPools
-            .Find(g => g.ModelType == modelType && g.IsDefaultForType)
+            .Find(Builders<ModelGroup>.Filter.And(
+                Builders<ModelGroup>.Filter.Eq("TenantId", CurrentTenantId),
+                Builders<ModelGroup>.Filter.Eq(g => g.ModelType, modelType),
+                Builders<ModelGroup>.Filter.Eq(g => g.IsDefaultForType, true)))
             .SortBy(g => g.Priority)
             .ToListAsync(ct);
     }
@@ -1073,7 +1087,10 @@ public class ModelResolver : IModelResolver
         {
             var gatewayPools = _gatewayDb.Context.Database.GetCollection<ModelGroup>("llmgw_model_pools");
             var gatewayPool = await gatewayPools
-                .Find(g => g.Id == modelPoolId && g.ModelType == modelType)
+                .Find(Builders<ModelGroup>.Filter.And(
+                    Builders<ModelGroup>.Filter.Eq("TenantId", CurrentTenantId),
+                    Builders<ModelGroup>.Filter.Eq(g => g.Id, modelPoolId),
+                    Builders<ModelGroup>.Filter.Eq(g => g.ModelType, modelType)))
                 .FirstOrDefaultAsync(ct);
             if (gatewayPool is not null)
             {
@@ -1105,7 +1122,10 @@ public class ModelResolver : IModelResolver
         {
             var gatewayPlatforms = _gatewayDb.Context.Database.GetCollection<LLMPlatform>("llmgw_platforms");
             var gatewayPlatform = await gatewayPlatforms
-                .Find(p => p.Id == platformId && (!enabledOnly || p.Enabled))
+                .Find(Builders<LLMPlatform>.Filter.And(
+                    Builders<LLMPlatform>.Filter.Eq("TenantId", CurrentTenantId),
+                    Builders<LLMPlatform>.Filter.Eq(p => p.Id, platformId),
+                    enabledOnly ? Builders<LLMPlatform>.Filter.Eq(p => p.Enabled, true) : Builders<LLMPlatform>.Filter.Empty))
                 .FirstOrDefaultAsync(ct);
             if (gatewayPlatform is not null)
             {
@@ -1134,9 +1154,13 @@ public class ModelResolver : IModelResolver
         {
             var gatewayModels = _gatewayDb.Context.Database.GetCollection<LLMModel>("llmgw_models");
             var gatewayModel = await gatewayModels
-                .Find(m => m.Enabled
-                    && m.PlatformId == platformId
-                    && (m.ModelName == modelId || m.Id == modelId))
+                .Find(Builders<LLMModel>.Filter.And(
+                    Builders<LLMModel>.Filter.Eq("TenantId", CurrentTenantId),
+                    Builders<LLMModel>.Filter.Eq(m => m.Enabled, true),
+                    Builders<LLMModel>.Filter.Eq(m => m.PlatformId, platformId),
+                    Builders<LLMModel>.Filter.Or(
+                        Builders<LLMModel>.Filter.Eq(m => m.ModelName, modelId),
+                        Builders<LLMModel>.Filter.Eq(m => m.Id, modelId))))
                 .FirstOrDefaultAsync(ct);
             if (gatewayModel is not null)
             {
@@ -1207,7 +1231,9 @@ public class ModelResolver : IModelResolver
             return null;
 
         var gatewayExchanges = _gatewayDb.Context.Database.GetCollection<ModelExchange>("llmgw_model_exchanges");
-        var exchange = await gatewayExchanges.Find(filter).FirstOrDefaultAsync(ct);
+        var exchange = await gatewayExchanges.Find(Builders<ModelExchange>.Filter.And(
+            Builders<ModelExchange>.Filter.Eq("TenantId", CurrentTenantId),
+            filter)).FirstOrDefaultAsync(ct);
         if (exchange is not null)
         {
             _logger.LogDebug(
@@ -1216,6 +1242,9 @@ public class ModelResolver : IModelResolver
         }
         return exchange;
     }
+
+    private string CurrentTenantId
+        => _requestContext?.Current?.TenantId is { Length: > 0 } tenantId ? tenantId : _internalTenantId;
 
     private async Task<AvailableModelPool> MapToAvailablePoolAsync(
         ModelGroup group,

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/ShadowLlmGateway.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/ShadowLlmGateway.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using PrdAgent.Core.Interfaces;
 using PrdAgent.Core.Models;
@@ -35,6 +36,7 @@ public sealed class ShadowLlmGateway : ILlmGateway, CoreGateway.ILlmGateway
     private readonly IReadOnlySet<string> _httpAllowlist;
     private readonly IReadOnlySet<string> _fullSampleAllowlist;
     private readonly string? _releaseCommit;
+    private readonly string _internalTenantId;
 
     public ShadowLlmGateway(
         ILlmGateway inproc,
@@ -45,7 +47,8 @@ public sealed class ShadowLlmGateway : ILlmGateway, CoreGateway.ILlmGateway
         ILLMRequestContextAccessor? ctx = null,
         IReadOnlySet<string>? httpAllowlist = null,
         IReadOnlySet<string>? fullSampleAllowlist = null,
-        string? releaseCommit = null)
+        string? releaseCommit = null,
+        IConfiguration? configuration = null)
     {
         _inproc = inproc;
         _http = http;
@@ -56,6 +59,9 @@ public sealed class ShadowLlmGateway : ILlmGateway, CoreGateway.ILlmGateway
         _httpAllowlist = httpAllowlist ?? new HashSet<string>();
         _fullSampleAllowlist = fullSampleAllowlist ?? new HashSet<string>();
         _releaseCommit = NormalizeCommit(releaseCommit);
+        _internalTenantId = configuration?["LlmGateway:InternalTenantId"]?.Trim() is { Length: > 0 } tenantId
+            ? tenantId
+            : GatewayTenantDefaults.InternalTenantId;
     }
 
     /// <summary>该 appCallerCode 是否已灰度翻 http（白名单命中 → http 权威）。</summary>
@@ -201,7 +207,7 @@ public sealed class ShadowLlmGateway : ILlmGateway, CoreGateway.ILlmGateway
     {
         if (_writer == null) return;
         var requestId = _ctx?.Current?.RequestId;
-        var tenantId = _ctx?.Current?.TenantId ?? GatewayTenantDefaults.InternalTenantId;
+        var tenantId = _ctx?.Current?.TenantId ?? _internalTenantId;
         SafeRun(async () =>
         {
             var sw = Stopwatch.StartNew();
@@ -219,7 +225,7 @@ public sealed class ShadowLlmGateway : ILlmGateway, CoreGateway.ILlmGateway
     {
         if (_writer == null) return;
         var requestId = _ctx?.Current?.RequestId;
-        var tenantId = request.Context?.TenantId ?? _ctx?.Current?.TenantId ?? GatewayTenantDefaults.InternalTenantId;
+        var tenantId = request.Context?.TenantId ?? _ctx?.Current?.TenantId ?? _internalTenantId;
         // 构造**私有副本**用于 http 全量比对，绝不改调用方仍持有的 request.RequestBody：
         //   - inproc 已把 body["model"] 改写为其选中模型；这里在副本上把 model 恢复成原始有效期望模型
         //     （有则写回、无则移除），让 http 独立解析（与 resolve 探针同根，评审 P2）。
@@ -285,7 +291,7 @@ public sealed class ShadowLlmGateway : ILlmGateway, CoreGateway.ILlmGateway
     {
         if (_writer == null) return;
         var requestId = _ctx?.Current?.RequestId;
-        var tenantId = request.Context?.TenantId ?? _ctx?.Current?.TenantId ?? GatewayTenantDefaults.InternalTenantId;
+        var tenantId = request.Context?.TenantId ?? _ctx?.Current?.TenantId ?? _internalTenantId;
         var shadowReq = CloneRawRequest(request);
         SafeRun(async () =>
         {
@@ -370,7 +376,7 @@ public sealed class ShadowLlmGateway : ILlmGateway, CoreGateway.ILlmGateway
     {
         if (_writer == null) return;
         var requestId = _ctx?.Current?.RequestId;
-        var tenantId = _ctx?.Current?.TenantId ?? GatewayTenantDefaults.InternalTenantId;
+        var tenantId = _ctx?.Current?.TenantId ?? _internalTenantId;
         SafeRun(async () =>
         {
             var sw = Stopwatch.StartNew();

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/ShadowLlmGateway.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/ShadowLlmGateway.cs
@@ -201,6 +201,7 @@ public sealed class ShadowLlmGateway : ILlmGateway, CoreGateway.ILlmGateway
     {
         if (_writer == null) return;
         var requestId = _ctx?.Current?.RequestId;
+        var tenantId = _ctx?.Current?.TenantId ?? GatewayTenantDefaults.InternalTenantId;
         SafeRun(async () =>
         {
             var sw = Stopwatch.StartNew();
@@ -209,7 +210,7 @@ public sealed class ShadowLlmGateway : ILlmGateway, CoreGateway.ILlmGateway
             try { httpResolution = await _http.ResolveModelAsync(appCallerCode, modelType, expectedModel, pinnedPlatformId, pinnedModelId, CancellationToken.None); }
             catch (Exception ex) { httpErr = ex.Message; }
             sw.Stop();
-            var cmp = BuildResolveComparison(kind, requestId, appCallerCode, modelType, inprocResolution, httpResolution, httpErr, sw.ElapsedMilliseconds, _releaseCommit);
+            var cmp = BuildResolveComparison(tenantId, kind, requestId, appCallerCode, modelType, inprocResolution, httpResolution, httpErr, sw.ElapsedMilliseconds, _releaseCommit);
             await _writer!.RecordAsync(cmp, CancellationToken.None);
         });
     }
@@ -218,6 +219,7 @@ public sealed class ShadowLlmGateway : ILlmGateway, CoreGateway.ILlmGateway
     {
         if (_writer == null) return;
         var requestId = _ctx?.Current?.RequestId;
+        var tenantId = request.Context?.TenantId ?? _ctx?.Current?.TenantId ?? GatewayTenantDefaults.InternalTenantId;
         // 构造**私有副本**用于 http 全量比对，绝不改调用方仍持有的 request.RequestBody：
         //   - inproc 已把 body["model"] 改写为其选中模型；这里在副本上把 model 恢复成原始有效期望模型
         //     （有则写回、无则移除），让 http 独立解析（与 resolve 探针同根，评审 P2）。
@@ -251,7 +253,7 @@ public sealed class ShadowLlmGateway : ILlmGateway, CoreGateway.ILlmGateway
             try { http = await _http.SendAsync(shadowReq, CancellationToken.None); }
             catch (Exception ex) { httpErr = ex.Message; }
             sw.Stop();
-            var cmp = BuildResolveComparison("send", requestId, request.AppCallerCode, request.ModelType,
+            var cmp = BuildResolveComparison(tenantId, "send", requestId, request.AppCallerCode, request.ModelType,
                 inproc.Resolution, http?.Resolution, httpErr, sw.ElapsedMilliseconds, _releaseCommit);
             if (http != null)
             {
@@ -283,6 +285,7 @@ public sealed class ShadowLlmGateway : ILlmGateway, CoreGateway.ILlmGateway
     {
         if (_writer == null) return;
         var requestId = _ctx?.Current?.RequestId;
+        var tenantId = request.Context?.TenantId ?? _ctx?.Current?.TenantId ?? GatewayTenantDefaults.InternalTenantId;
         var shadowReq = CloneRawRequest(request);
         SafeRun(async () =>
         {
@@ -299,6 +302,7 @@ public sealed class ShadowLlmGateway : ILlmGateway, CoreGateway.ILlmGateway
             sw.Stop();
 
             var cmp = BuildResolveComparison(
+                tenantId,
                 "raw",
                 requestId,
                 request.AppCallerCode,
@@ -366,6 +370,7 @@ public sealed class ShadowLlmGateway : ILlmGateway, CoreGateway.ILlmGateway
     {
         if (_writer == null) return;
         var requestId = _ctx?.Current?.RequestId;
+        var tenantId = _ctx?.Current?.TenantId ?? GatewayTenantDefaults.InternalTenantId;
         SafeRun(async () =>
         {
             var sw = Stopwatch.StartNew();
@@ -376,6 +381,7 @@ public sealed class ShadowLlmGateway : ILlmGateway, CoreGateway.ILlmGateway
             sw.Stop();
             var cmp = new LlmShadowComparison
             {
+                TenantId = tenantId,
                 Kind = "pools", RequestId = requestId, AppCallerCode = appCallerCode, ModelType = modelType,
                 ReleaseCommit = _releaseCommit,
                 ShadowDurationMs = sw.ElapsedMilliseconds, HttpOk = httpErr == null && http != null, HttpError = httpErr,
@@ -407,12 +413,13 @@ public sealed class ShadowLlmGateway : ILlmGateway, CoreGateway.ILlmGateway
     };
 
     private static LlmShadowComparison BuildResolveComparison(
-        string kind, string? requestId, string appCallerCode, string modelType,
+        string tenantId, string kind, string? requestId, string appCallerCode, string modelType,
         GatewayModelResolution? inproc, GatewayModelResolution? http, string? httpErr, long ms,
         string? releaseCommit)
     {
         var cmp = new LlmShadowComparison
         {
+            TenantId = tenantId,
             Kind = kind, RequestId = requestId, AppCallerCode = appCallerCode, ModelType = modelType,
             ReleaseCommit = releaseCommit,
             ShadowDurationMs = ms, HttpOk = httpErr == null && http != null, HttpError = httpErr,

--- a/prd-api/src/PrdAgent.LlmGateway/GatewayHttpEndpoints.cs
+++ b/prd-api/src/PrdAgent.LlmGateway/GatewayHttpEndpoints.cs
@@ -908,7 +908,14 @@ public static class GatewayHttpEndpoints
             {
                 cancellation = services.GetService<GatewayCancellationRegistry>()?.Register(GetVerifiedTenantId(http), ingress.AppCallerCode, ingress.RequestId);
                 var token = cancellation?.Token ?? CancellationToken.None;
-                var rehydrated = await RehydrateMultipartFileRefsAsync(request, services.GetService<IAssetStorage>(), token);
+                var authorization = http.Items["llmgw.key.authorization"] as GatewayKeyAuthorization;
+                var rehydrated = await RehydrateMultipartFileRefsAsync(
+                    request,
+                    services.GetService<IAssetStorage>(),
+                    services.GetService<LlmGatewayDataContext>(),
+                    GetVerifiedTenantId(http),
+                    requireTenantManifest: authorization is { LegacySharedKey: false },
+                    token);
                 if (!rehydrated.Success)
                 {
                     if (executionStore is not null && execution is not null)
@@ -4298,6 +4305,9 @@ public static class GatewayHttpEndpoints
     private static async Task<RehydrateResult> RehydrateMultipartFileRefsAsync(
         GatewayRawRequest request,
         IAssetStorage? storage,
+        LlmGatewayDataContext? data,
+        string tenantId,
+        bool requireTenantManifest,
         CancellationToken ct)
     {
         if (!request.IsMultipart
@@ -4314,12 +4324,39 @@ public static class GatewayHttpEndpoints
                 "serving 未注册 IAssetStorage，无法按 MultipartFileRefs rehydrate 文件。");
         }
 
+        var manifests = data?.Database.GetCollection<GatewayMultipartObjectRecord>("llmgw_multipart_objects");
+        if (requireTenantManifest && manifests is null)
+        {
+            return RehydrateResult.Fail(
+                "MULTIPART_MANIFEST_UNAVAILABLE",
+                "serving 未注册 multipart manifest 数据源，拒绝处理 tenant-scoped 文件引用。",
+                503);
+        }
+
         var files = new Dictionary<string, (string FileName, byte[] Content, string MimeType)>(StringComparer.Ordinal);
         foreach (var (fieldName, fileRef) in request.MultipartFileRefs)
         {
             if (string.IsNullOrWhiteSpace(fileRef.RefKey))
             {
                 return RehydrateResult.Fail("MULTIPART_REF_INVALID", $"multipart 字段 {fieldName} 缺少 RefKey。", 400);
+            }
+
+            GatewayMultipartObjectRecord? manifest = null;
+            if (manifests is not null)
+            {
+                manifest = await manifests.Find(x =>
+                        x.TenantId == tenantId
+                        && x.RefKey == fileRef.RefKey
+                        && x.Status != "deleted"
+                        && x.ExpiresAt > DateTime.UtcNow)
+                    .FirstOrDefaultAsync(ct);
+                if (manifest is null)
+                {
+                    return RehydrateResult.Fail(
+                        "MULTIPART_REF_NOT_FOUND",
+                        $"multipart 字段 {fieldName} 引用的对象不存在。",
+                        404);
+                }
             }
 
             var bytes = await storage.TryDownloadBytesAsync(fileRef.RefKey, ct);
@@ -4337,6 +4374,16 @@ public static class GatewayHttpEndpoints
             }
 
             var actualSha = Sha256Hex(bytes);
+            if (manifest is not null
+                && ((manifest.SizeBytes > 0 && bytes.LongLength != manifest.SizeBytes)
+                    || (!string.IsNullOrWhiteSpace(manifest.Sha256)
+                        && !string.Equals(actualSha, manifest.Sha256, StringComparison.OrdinalIgnoreCase))))
+            {
+                return RehydrateResult.Fail(
+                    "MULTIPART_MANIFEST_MISMATCH",
+                    $"multipart 字段 {fieldName} 与 tenant manifest 不一致。",
+                    400);
+            }
             if (!string.IsNullOrWhiteSpace(fileRef.Sha256)
                 && !string.Equals(actualSha, fileRef.Sha256, StringComparison.OrdinalIgnoreCase))
             {

--- a/prd-api/src/PrdAgent.LlmGateway/GatewayHttpEndpoints.cs
+++ b/prd-api/src/PrdAgent.LlmGateway/GatewayHttpEndpoints.cs
@@ -4064,8 +4064,8 @@ public static class GatewayHttpEndpoints
             IncludeThinking = request.IncludeThinking,
             Context = new GatewayRequestContext
             {
-                TenantId = source?.TenantId,
-                TeamId = source?.TeamId,
+                TenantId = ingress.Context?.TenantId,
+                TeamId = ingress.Context?.TeamId,
                 RequestId = source?.RequestId ?? ingress.RequestId,
                 SessionId = source?.SessionId,
                 RunId = source?.RunId,
@@ -4113,8 +4113,8 @@ public static class GatewayHttpEndpoints
             ExpectBinaryResponse = request.ExpectBinaryResponse,
             Context = new GatewayRequestContext
             {
-                TenantId = source?.TenantId,
-                TeamId = source?.TeamId,
+                TenantId = ingress.Context?.TenantId,
+                TeamId = ingress.Context?.TeamId,
                 RequestId = source?.RequestId ?? ingress.RequestId,
                 SessionId = source?.SessionId,
                 RunId = source?.RunId,

--- a/prd-api/src/PrdAgent.LlmGateway/GatewayHttpEndpoints.cs
+++ b/prd-api/src/PrdAgent.LlmGateway/GatewayHttpEndpoints.cs
@@ -867,6 +867,7 @@ public static class GatewayHttpEndpoints
             [Microsoft.AspNetCore.Mvc.FromServices] IServiceProvider services) =>
         {
             var ingress = ToIngress(request, "gw-native", "map");
+            request = ApplyVerifiedRawRequestContext(http, request, ingress);
             var executionStore = services.GetService<GatewayRequestExecutionStore>();
             GatewayExecutionBeginResult? execution = null;
             if (executionStore is not null)
@@ -2856,6 +2857,7 @@ public static class GatewayHttpEndpoints
         string requestId,
         string operation)
     {
+        request = ApplyVerifiedRawRequestContext(http, request, ingress);
         var store = services.GetService<GatewayRequestExecutionStore>();
         GatewayExecutionBeginResult? execution = null;
         if (store is not null)
@@ -4183,6 +4185,17 @@ public static class GatewayHttpEndpoints
                 IsHealthProbe = source?.IsHealthProbe,
             },
         };
+    }
+
+    private static GatewayRawRequest ApplyVerifiedRawRequestContext(
+        HttpContext http,
+        GatewayRawRequest request,
+        GatewayIngressRequest ingress)
+    {
+        ingress.Context ??= new GatewayRequestContext { RequestId = ingress.RequestId };
+        ingress.Context.TenantId = GetVerifiedTenantId(http);
+        ingress.Context.TeamId = GetVerifiedTeamId(http);
+        return ApplyIngressRouting(request, ingress);
     }
 
     private static GatewayIngressRequest ToIngress(GatewayRawRequest request, string ingressProtocol, string sourceSystem)

--- a/prd-api/src/PrdAgent.LlmGateway/GatewayHttpEndpoints.cs
+++ b/prd-api/src/PrdAgent.LlmGateway/GatewayHttpEndpoints.cs
@@ -3361,6 +3361,8 @@ public static class GatewayHttpEndpoints
             TimeoutSeconds = 600,
             Context = new GatewayRequestContext
             {
+                TenantId = ingress.Context?.TenantId,
+                TeamId = ingress.Context?.TeamId,
                 RequestId = ingress.Context?.RequestId ?? ingress.RequestId,
                 SessionId = ingress.Context?.SessionId,
                 RunId = ingress.Context?.RunId,
@@ -4062,6 +4064,8 @@ public static class GatewayHttpEndpoints
             IncludeThinking = request.IncludeThinking,
             Context = new GatewayRequestContext
             {
+                TenantId = source?.TenantId,
+                TeamId = source?.TeamId,
                 RequestId = source?.RequestId ?? ingress.RequestId,
                 SessionId = source?.SessionId,
                 RunId = source?.RunId,
@@ -4109,6 +4113,8 @@ public static class GatewayHttpEndpoints
             ExpectBinaryResponse = request.ExpectBinaryResponse,
             Context = new GatewayRequestContext
             {
+                TenantId = source?.TenantId,
+                TeamId = source?.TeamId,
                 RequestId = source?.RequestId ?? ingress.RequestId,
                 SessionId = source?.SessionId,
                 RunId = source?.RunId,

--- a/prd-api/src/PrdAgent.LlmGateway/GatewayHttpEndpoints.cs
+++ b/prd-api/src/PrdAgent.LlmGateway/GatewayHttpEndpoints.cs
@@ -668,8 +668,10 @@ public static class GatewayHttpEndpoints
 
         // 预解析模型调度结果（不发送请求）。
         app.MapPost("/gw/v1/resolve", async (
+            HttpContext http,
             ResolveRequestDto body,
             PrdAgent.Infrastructure.LlmGateway.ILlmGateway gateway,
+            ILLMRequestContextAccessor accessor,
             [Microsoft.AspNetCore.Mvc.FromServices] IServiceProvider services) =>
         {
             var resolveModelPolicy = NormalizeModelPolicy(body.ModelPolicy)
@@ -679,7 +681,7 @@ public static class GatewayHttpEndpoints
                                          && !string.IsNullOrWhiteSpace(resolveModelPoolId)
                 ? resolveModelPoolId
                 : body.ExpectedModel;
-            await RecordDiscoveredAppCallerAsync(services, new GatewayIngressRequest
+            var ingress = new GatewayIngressRequest
             {
                 RequestId = Guid.NewGuid().ToString("N"),
                 SourceSystem = "map",
@@ -694,7 +696,15 @@ public static class GatewayHttpEndpoints
                 ExpectedModel = effectiveExpectedModel,
                 PinnedPlatformId = body.PinnedPlatformId,
                 PinnedModelId = body.PinnedModelId,
-            }, CancellationToken.None);
+                Context = new GatewayRequestContext
+                {
+                    TenantId = GetVerifiedTenantId(http),
+                    TeamId = GetVerifiedTeamId(http),
+                    GatewayTransport = GatewayTransports.Http,
+                },
+            };
+            await RecordDiscoveredAppCallerAsync(services, ingress, CancellationToken.None);
+            using var _ = OpenContextScope(accessor, ingress.Context, body.ModelType, body.AppCallerCode);
             var resolution = await gateway.ResolveModelAsync(
                 body.AppCallerCode, body.ModelType, effectiveExpectedModel, body.PinnedPlatformId, body.PinnedModelId, CancellationToken.None);
             return Results.Json(resolution, jsonOpts);
@@ -1027,10 +1037,18 @@ public static class GatewayHttpEndpoints
 
         // 可用模型池列表。
         app.MapGet("/gw/v1/pools", async (
+            HttpContext http,
             string appCallerCode,
             string modelType,
-            PrdAgent.Infrastructure.LlmGateway.ILlmGateway gateway) =>
+            PrdAgent.Infrastructure.LlmGateway.ILlmGateway gateway,
+            ILLMRequestContextAccessor accessor) =>
         {
+            using var _ = OpenContextScope(accessor, new GatewayRequestContext
+            {
+                TenantId = GetVerifiedTenantId(http),
+                TeamId = GetVerifiedTeamId(http),
+                GatewayTransport = GatewayTransports.Http,
+            }, modelType, appCallerCode);
             var pools = await gateway.GetAvailablePoolsAsync(appCallerCode, modelType, CancellationToken.None);
             return Results.Json(pools, jsonOpts);
         });
@@ -1221,6 +1239,11 @@ public static class GatewayHttpEndpoints
         => context.Items["llmgw.key.authorization"] is GatewayKeyAuthorization { TenantId.Length: > 0 } authorization
             ? authorization.TenantId
             : throw new UnauthorizedAccessException("verified tenant context is unavailable");
+
+    private static string? GetVerifiedTeamId(HttpContext context)
+        => context.Items["llmgw.key.authorization"] is GatewayKeyAuthorization authorization
+            ? authorization.TeamId
+            : null;
 
     private static string ResolveIngressProtocol(string path)
     {

--- a/prd-api/src/PrdAgent.LlmGateway/GatewayHttpEndpoints.cs
+++ b/prd-api/src/PrdAgent.LlmGateway/GatewayHttpEndpoints.cs
@@ -333,11 +333,11 @@ public static class GatewayHttpEndpoints
                 return;
 
             var rawRequest = ToOpenAiImageRawRequest(ingress);
-            using var _ = OpenContextScope(accessor, rawRequest.Context, rawRequest.ModelType, rawRequest.AppCallerCode);
             await ExecuteRawWithIdempotencyAsync(
                 http,
                 services,
                 gateway,
+                accessor,
                 ingress,
                 rawRequest,
                 requestId,
@@ -404,11 +404,11 @@ public static class GatewayHttpEndpoints
                 "/v1/images/edits",
                 multipartFields,
                 parsed.MultipartFiles);
-            using var _ = OpenContextScope(accessor, rawRequest.Context, rawRequest.ModelType, rawRequest.AppCallerCode);
             await ExecuteRawWithIdempotencyAsync(
                 http,
                 services,
                 gateway,
+                accessor,
                 ingress,
                 rawRequest,
                 requestId,
@@ -1073,7 +1073,7 @@ public static class GatewayHttpEndpoints
             http.Response.Headers.ContentType = "text/event-stream";
             http.Response.Headers.CacheControl = "no-cache";
             http.Response.Headers["X-Accel-Buffering"] = "no";
-            using var _ = OpenContextScope(accessor, body.Context, body.ModelType, body.AppCallerCode);
+            using var _ = OpenContextScope(accessor, ingress.Context, body.ModelType, body.AppCallerCode);
             var clientExpectedModel = string.Equals(NormalizeModelPolicy(body.Context?.ModelPolicy), "pool", StringComparison.OrdinalIgnoreCase)
                                       && !string.IsNullOrWhiteSpace(body.Context?.ModelPoolId)
                 ? body.Context.ModelPoolId
@@ -2809,6 +2809,7 @@ public static class GatewayHttpEndpoints
         HttpContext http,
         IServiceProvider services,
         PrdAgent.Infrastructure.LlmGateway.ILlmGateway gateway,
+        ILLMRequestContextAccessor accessor,
         GatewayIngressRequest ingress,
         GatewayRawRequest request,
         string requestId,
@@ -2856,6 +2857,7 @@ public static class GatewayHttpEndpoints
         }
 
         request = ApplyIngressRouting(request, ingress);
+        using var _ = OpenContextScope(accessor, request.Context, request.ModelType, request.AppCallerCode);
 
         await RunWithRequestCancellationAsync(http, services, ingress.AppCallerCode, requestId, async ct =>
         {

--- a/prd-api/src/PrdAgent.LlmGateway/GatewayHttpEndpoints.cs
+++ b/prd-api/src/PrdAgent.LlmGateway/GatewayHttpEndpoints.cs
@@ -2855,6 +2855,8 @@ public static class GatewayHttpEndpoints
             return;
         }
 
+        request = ApplyIngressRouting(request, ingress);
+
         await RunWithRequestCancellationAsync(http, services, ingress.AppCallerCode, requestId, async ct =>
         {
             try

--- a/prd-api/src/PrdAgent.LlmGateway/GatewayHttpEndpoints.cs
+++ b/prd-api/src/PrdAgent.LlmGateway/GatewayHttpEndpoints.cs
@@ -42,6 +42,10 @@ public static class GatewayHttpEndpoints
         string gatewayApiKey,
         string gitCommit)
     {
+        var configuredInternalTenantId = app.Configuration["LlmGateway:InternalTenantId"]?.Trim();
+        var internalTenantId = string.IsNullOrWhiteSpace(configuredInternalTenantId)
+            ? GatewayTenantDefaults.InternalTenantId
+            : configuredInternalTenantId;
         // 服务密钥门（内部 M2M，不走 JWT）：
         // - /gw/v1/* 除 healthz 外必须带 key，readyz 也不能公网匿名读取依赖状态。
         // - 迁移期共享 key 只服务 MAP；新接入方使用 llmgw_service_keys 的 scoped key。
@@ -85,7 +89,7 @@ public static class GatewayHttpEndpoints
                         StatusCodes.Status401Unauthorized,
                         "GATEWAY_KEY_INVALID",
                         "gateway key rejected",
-                        TenantId: GatewayTenantDefaults.InternalTenantId,
+                        TenantId: internalTenantId,
                         LegacySharedKey: true)
                     : await authorizer.AuthorizeAsync(
                         providedKey ?? string.Empty,

--- a/prd-api/src/PrdAgent.LlmGateway/GatewayHttpEndpoints.cs
+++ b/prd-api/src/PrdAgent.LlmGateway/GatewayHttpEndpoints.cs
@@ -84,7 +84,9 @@ public static class GatewayHttpEndpoints
                         HasGatewayKey(context, gatewayApiKey),
                         StatusCodes.Status401Unauthorized,
                         "GATEWAY_KEY_INVALID",
-                        "gateway key rejected")
+                        "gateway key rejected",
+                        TenantId: GatewayTenantDefaults.InternalTenantId,
+                        LegacySharedKey: true)
                     : await authorizer.AuthorizeAsync(
                         providedKey ?? string.Empty,
                         gatewayApiKey,
@@ -265,7 +267,7 @@ public static class GatewayHttpEndpoints
             if (await TryRejectStrictDroppedParametersAsync(http, ingress))
                 return;
 
-            var governance = await RecordAndCheckAppCallerGovernanceAsync(services, ingress, CancellationToken.None);
+            var governance = await RecordAndCheckAppCallerGovernanceAsync(http, services, ingress, CancellationToken.None);
             if (await TryWriteGovernanceErrorAsync(http, governance)) return;
             var gatewayRequest = ingress.ToGatewayRequest(stream);
             using var _ = OpenContextScope(accessor, gatewayRequest.Context, gatewayRequest.ModelType, gatewayRequest.AppCallerCode);
@@ -482,7 +484,7 @@ public static class GatewayHttpEndpoints
             if (await TryRejectStrictDroppedParametersAsync(http, ingress))
                 return;
 
-            var governance = await RecordAndCheckAppCallerGovernanceAsync(services, ingress, CancellationToken.None);
+            var governance = await RecordAndCheckAppCallerGovernanceAsync(http, services, ingress, CancellationToken.None);
             if (await TryWriteGovernanceErrorAsync(http, governance)) return;
             var gatewayRequest = ingress.ToGatewayRequest(stream);
             using var _ = OpenContextScope(accessor, gatewayRequest.Context, gatewayRequest.ModelType, gatewayRequest.AppCallerCode);
@@ -554,7 +556,7 @@ public static class GatewayHttpEndpoints
             if (await TryRejectStrictDroppedParametersAsync(http, ingress))
                 return;
 
-            var governance = await RecordAndCheckAppCallerGovernanceAsync(services, ingress, CancellationToken.None);
+            var governance = await RecordAndCheckAppCallerGovernanceAsync(http, services, ingress, CancellationToken.None);
             if (await TryWriteGovernanceErrorAsync(http, governance)) return;
             var gatewayRequest = ingress.ToGatewayRequest(stream);
             using var _ = OpenContextScope(accessor, gatewayRequest.Context, gatewayRequest.ModelType, gatewayRequest.AppCallerCode);
@@ -655,7 +657,7 @@ public static class GatewayHttpEndpoints
             if (await TryRejectStrictDroppedParametersAsync(http, ingress))
                 return;
 
-            var governance = await RecordAndCheckAppCallerGovernanceAsync(services, ingress, CancellationToken.None);
+            var governance = await RecordAndCheckAppCallerGovernanceAsync(http, services, ingress, CancellationToken.None);
             if (await TryWriteGovernanceErrorAsync(http, governance)) return;
             var gatewayRequest = ingress.ToGatewayRequest(stream);
             using var _ = OpenContextScope(accessor, gatewayRequest.Context, gatewayRequest.ModelType, gatewayRequest.AppCallerCode);
@@ -706,7 +708,7 @@ public static class GatewayHttpEndpoints
             [Microsoft.AspNetCore.Mvc.FromServices] IServiceProvider services)
         {
             var ingress = ToIngress(request, "gw-native", "map");
-            var governance = await RecordAndCheckAppCallerGovernanceAsync(services, ingress, CancellationToken.None);
+            var governance = await RecordAndCheckAppCallerGovernanceAsync(http, services, ingress, CancellationToken.None);
             var governanceResult = GovernanceResult(http, governance, jsonOpts);
             if (governanceResult is not null) return governanceResult;
             var routedRequest = ApplyIngressRouting(request, ingress, stream: false);
@@ -714,7 +716,7 @@ public static class GatewayHttpEndpoints
             GatewayCancellationLease? cancellation = null;
             try
             {
-                cancellation = services.GetService<GatewayCancellationRegistry>()?.Register(ingress.AppCallerCode, ingress.RequestId);
+                cancellation = services.GetService<GatewayCancellationRegistry>()?.Register(GetVerifiedTenantId(http), ingress.AppCallerCode, ingress.RequestId);
                 var response = await gateway.SendAsync(routedRequest, cancellation?.Token ?? CancellationToken.None);
                 return GatewayResponseResult(response, jsonOpts);
             }
@@ -744,7 +746,7 @@ public static class GatewayHttpEndpoints
                     error = new { code = "GATEWAY_REQUEST_CANCEL_INVALID", message = "X-Gateway-App-Caller 为必填" },
                 }, jsonOpts, statusCode: 400);
             }
-            var cancelled = cancellations.Cancel(appCallerCode, requestId);
+            var cancelled = cancellations.Cancel(GetVerifiedTenantId(http), appCallerCode, requestId);
             return Results.Json(new
             {
                 requestId,
@@ -767,7 +769,7 @@ public static class GatewayHttpEndpoints
                 }, jsonOpts, statusCode: 400);
             }
 
-            var execution = await executions.GetAsync(appCallerCode, requestId, operation.Trim(), CancellationToken.None);
+            var execution = await executions.GetAsync(GetVerifiedTenantId(http), appCallerCode, requestId, operation.Trim(), CancellationToken.None);
             if (execution is null)
             {
                 return Results.Json(new
@@ -802,7 +804,7 @@ public static class GatewayHttpEndpoints
             [Microsoft.AspNetCore.Mvc.FromServices] IServiceProvider services) =>
         {
             var ingress = ToIngress(request, "gw-native", "map");
-            var governance = await RecordAndCheckAppCallerGovernanceAsync(services, ingress, CancellationToken.None);
+            var governance = await RecordAndCheckAppCallerGovernanceAsync(http, services, ingress, CancellationToken.None);
             if (await TryWriteGovernanceErrorAsync(http, governance)) return;
 
             http.Response.Headers.ContentType = "text/event-stream";
@@ -814,7 +816,7 @@ public static class GatewayHttpEndpoints
             GatewayCancellationLease? cancellation = null;
             try
             {
-                cancellation = services.GetService<GatewayCancellationRegistry>()?.Register(ingress.AppCallerCode, ingress.RequestId);
+                cancellation = services.GetService<GatewayCancellationRegistry>()?.Register(GetVerifiedTenantId(http), ingress.AppCallerCode, ingress.RequestId);
                 await foreach (var chunk in gateway.StreamAsync(routedRequest, cancellation?.Token ?? CancellationToken.None))
                 {
                     var data = "data: " + JsonSerializer.Serialize(chunk, jsonOpts) + "\n\n";
@@ -856,6 +858,7 @@ public static class GatewayHttpEndpoints
             if (executionStore is not null)
             {
                 execution = await executionStore.BeginAsync(
+                    GetVerifiedTenantId(http),
                     ingress.AppCallerCode,
                     ingress.RequestId,
                     "raw-submit",
@@ -880,12 +883,12 @@ public static class GatewayHttpEndpoints
                 }
             }
 
-            var governance = await RecordAndCheckAppCallerGovernanceAsync(services, ingress, CancellationToken.None);
+            var governance = await RecordAndCheckAppCallerGovernanceAsync(http, services, ingress, CancellationToken.None);
             var governanceResult = GovernanceResult(http, governance, jsonOpts);
             if (governanceResult is not null)
             {
                 if (executionStore is not null && execution is not null)
-                    await executionStore.FailAsync(execution.ExecutionId, GovernanceErrorCode(governance), CancellationToken.None);
+                    await executionStore.FailAsync(GetVerifiedTenantId(http), execution.ExecutionId, GovernanceErrorCode(governance), CancellationToken.None);
                 return governanceResult;
             }
 
@@ -893,13 +896,13 @@ public static class GatewayHttpEndpoints
             var multipartRequestSucceeded = false;
             try
             {
-                cancellation = services.GetService<GatewayCancellationRegistry>()?.Register(ingress.AppCallerCode, ingress.RequestId);
+                cancellation = services.GetService<GatewayCancellationRegistry>()?.Register(GetVerifiedTenantId(http), ingress.AppCallerCode, ingress.RequestId);
                 var token = cancellation?.Token ?? CancellationToken.None;
                 var rehydrated = await RehydrateMultipartFileRefsAsync(request, services.GetService<IAssetStorage>(), token);
                 if (!rehydrated.Success)
                 {
                     if (executionStore is not null && execution is not null)
-                        await executionStore.FailAsync(execution.ExecutionId, rehydrated.Error?.ErrorCode ?? "MULTIPART_REHYDRATE_FAILED", CancellationToken.None);
+                        await executionStore.FailAsync(GetVerifiedTenantId(http), execution.ExecutionId, rehydrated.Error?.ErrorCode ?? "MULTIPART_REHYDRATE_FAILED", CancellationToken.None);
                     return JsonContentResult(rehydrated.Error!, jsonOpts);
                 }
 
@@ -918,25 +921,25 @@ public static class GatewayHttpEndpoints
                 if (executionStore is not null && execution is not null)
                 {
                     if (raw.Success)
-                        await executionStore.CompleteAsync(execution.ExecutionId, JsonSerializer.Serialize(raw, jsonOpts), CancellationToken.None);
+                        await executionStore.CompleteAsync(GetVerifiedTenantId(http), execution.ExecutionId, JsonSerializer.Serialize(raw, jsonOpts), CancellationToken.None);
                     else if (raw.StatusCode >= 500)
-                        await executionStore.UnknownAsync(execution.ExecutionId, raw.ErrorCode ?? "UPSTREAM_OUTCOME_UNKNOWN", CancellationToken.None);
+                        await executionStore.UnknownAsync(GetVerifiedTenantId(http), execution.ExecutionId, raw.ErrorCode ?? "UPSTREAM_OUTCOME_UNKNOWN", CancellationToken.None);
                     else
-                        await executionStore.FailAsync(execution.ExecutionId, raw.ErrorCode ?? "RAW_REQUEST_FAILED", CancellationToken.None);
+                        await executionStore.FailAsync(GetVerifiedTenantId(http), execution.ExecutionId, raw.ErrorCode ?? "RAW_REQUEST_FAILED", CancellationToken.None);
                 }
                 return JsonContentResult(raw, jsonOpts);
             }
             catch (OperationCanceledException)
             {
                 if (executionStore is not null && execution is not null)
-                    await executionStore.UnknownAsync(execution.ExecutionId, "GATEWAY_REQUEST_CANCELLED_OUTCOME_UNKNOWN", CancellationToken.None);
+                    await executionStore.UnknownAsync(GetVerifiedTenantId(http), execution.ExecutionId, "GATEWAY_REQUEST_CANCELLED_OUTCOME_UNKNOWN", CancellationToken.None);
                 http.Items[GatewayBudgetCoordinator.HttpContextOutcomeUnknownKey] = true;
                 return Results.Json(GatewayRawResponse.Fail("GATEWAY_REQUEST_CANCELLED", "请求已取消；上游结果状态未知，禁止自动重试", 409), jsonOpts, statusCode: 409);
             }
             catch
             {
                 if (executionStore is not null && execution is not null)
-                    await executionStore.UnknownAsync(execution.ExecutionId, "UPSTREAM_OUTCOME_UNKNOWN", CancellationToken.None);
+                    await executionStore.UnknownAsync(GetVerifiedTenantId(http), execution.ExecutionId, "UPSTREAM_OUTCOME_UNKNOWN", CancellationToken.None);
                 throw;
             }
             finally
@@ -1001,14 +1004,14 @@ public static class GatewayHttpEndpoints
                 ParameterPolicy = "default-drop",
                 Context = profileContext,
             };
-            var governance = await RecordAndCheckAppCallerGovernanceAsync(services, ingress, CancellationToken.None);
+            var governance = await RecordAndCheckAppCallerGovernanceAsync(http, services, ingress, CancellationToken.None);
             var governanceResult = GovernanceResult(http, governance, jsonOpts);
             if (governanceResult is not null) return governanceResult;
 
             GatewayCancellationLease? cancellation = null;
             try
             {
-                cancellation = services.GetService<GatewayCancellationRegistry>()?.Register(profileRequest.AppCallerCode, requestId);
+                cancellation = services.GetService<GatewayCancellationRegistry>()?.Register(GetVerifiedTenantId(http), profileRequest.AppCallerCode, requestId);
                 var raw = await gateway.TestUpstreamProfileAsync(profileRequest, cancellation?.Token ?? CancellationToken.None);
                 return JsonContentResult(raw, jsonOpts);
             }
@@ -1064,7 +1067,7 @@ public static class GatewayHttpEndpoints
                 PinnedModelId = body.PinnedModelId,
                 Context = body.Context,
             };
-            var governance = await RecordAndCheckAppCallerGovernanceAsync(services, ingress, CancellationToken.None);
+            var governance = await RecordAndCheckAppCallerGovernanceAsync(http, services, ingress, CancellationToken.None);
             if (await TryWriteGovernanceErrorAsync(http, governance)) return;
 
             http.Response.Headers.ContentType = "text/event-stream";
@@ -1088,7 +1091,7 @@ public static class GatewayHttpEndpoints
             GatewayCancellationLease? cancellation = null;
             try
             {
-                cancellation = services.GetService<GatewayCancellationRegistry>()?.Register(ingress.AppCallerCode, ingress.RequestId);
+                cancellation = services.GetService<GatewayCancellationRegistry>()?.Register(GetVerifiedTenantId(http), ingress.AppCallerCode, ingress.RequestId);
                 await foreach (var chunk in client.StreamGenerateAsync(
                                    body.SystemPrompt,
                                    body.Messages,
@@ -1128,6 +1131,7 @@ public static class GatewayHttpEndpoints
             // InvalidOperationException（"Body was inferred but the method does not allow inferred body
             // parameters"），进而拖垮整张路由表（含 healthz / 全部 /gw/v1/*）。见 GatewayKeyGateContractTests。
             [Microsoft.AspNetCore.Mvc.FromServices] IServiceProvider services,
+            HttpContext http,
             int? limit,
             int? failureLimit,
             string? appCallerCode,
@@ -1139,7 +1143,10 @@ public static class GatewayHttpEndpoints
             var db = services.GetService<LlmGatewayDataContext>()?.Context
                 ?? services.GetRequiredService<MongoDbContext>();
             var col = db.LlmShadowComparisons;
-            var filters = new List<FilterDefinition<LlmShadowComparison>>();
+            var filters = new List<FilterDefinition<LlmShadowComparison>>
+            {
+                Builders<LlmShadowComparison>.Filter.Eq(x => x.TenantId, GetVerifiedTenantId(http)),
+            };
             if (!string.IsNullOrWhiteSpace(appCallerCode))
                 filters.Add(Builders<LlmShadowComparison>.Filter.Eq(x => x.AppCallerCode, appCallerCode.Trim()));
             if (!string.IsNullOrWhiteSpace(kind))
@@ -1150,9 +1157,7 @@ public static class GatewayHttpEndpoints
             var since = sinceHours is > 0 ? DateTime.UtcNow.AddHours(-sinceHours.Value) : (DateTime?)null;
             if (since is not null)
                 filters.Add(Builders<LlmShadowComparison>.Filter.Gte(x => x.ComparedAt, since.Value));
-            var filter = filters.Count == 0
-                ? FilterDefinition<LlmShadowComparison>.Empty
-                : Builders<LlmShadowComparison>.Filter.And(filters);
+            var filter = Builders<LlmShadowComparison>.Filter.And(filters);
 
             var total = await col.CountDocumentsAsync(filter);
             var allMatch = await col.CountDocumentsAsync(filter & Builders<LlmShadowComparison>.Filter.Eq(x => x.AllMatch, true));
@@ -1211,6 +1216,11 @@ public static class GatewayHttpEndpoints
             ? auth["Bearer ".Length..].Trim()
             : null;
     }
+
+    private static string GetVerifiedTenantId(HttpContext context)
+        => context.Items["llmgw.key.authorization"] is GatewayKeyAuthorization { TenantId.Length: > 0 } authorization
+            ? authorization.TenantId
+            : throw new UnauthorizedAccessException("verified tenant context is unavailable");
 
     private static string ResolveIngressProtocol(string path)
     {
@@ -1847,16 +1857,24 @@ public static class GatewayHttpEndpoints
     ];
 
     private static async Task<AppCallerGovernanceDecision> RecordAndCheckAppCallerGovernanceAsync(
+        HttpContext http,
         IServiceProvider services,
         GatewayIngressRequest ingress,
         CancellationToken ct)
     {
+        var authorization = http.Items["llmgw.key.authorization"] as GatewayKeyAuthorization;
+        if (authorization is null || string.IsNullOrWhiteSpace(authorization.TenantId))
+            return AppCallerGovernanceDecision.RejectTenantUnavailable(ingress.AppCallerCode, ingress.RequestType);
+        ingress.Context ??= new GatewayRequestContext { RequestId = ingress.RequestId };
+        ingress.Context.TenantId = authorization.TenantId;
+        ingress.Context.TeamId = authorization.TeamId;
         await RecordDiscoveredAppCallerAsync(services, ingress, ct);
-        return await CheckAppCallerGovernanceAsync(services, ingress.AppCallerCode, ingress.RequestType, ingress.RequestId, ct);
+        return await CheckAppCallerGovernanceAsync(services, authorization.TenantId, ingress.AppCallerCode, ingress.RequestType, ingress.RequestId, ct);
     }
 
     private static async Task<AppCallerGovernanceDecision> CheckAppCallerGovernanceAsync(
         IServiceProvider services,
+        string tenantId,
         string appCallerCode,
         string requestType,
         string requestId,
@@ -1876,6 +1894,7 @@ public static class GatewayHttpEndpoints
             var normalizedAppCallerCode = GatewayAppCallerIdentity.NormalizePart(appCallerCode);
             var normalizedRequestType = GatewayAppCallerIdentity.NormalizePart(requestType);
             caller = await callers.Find(Builders<GatewayAppCallerRecord>.Filter.And(
+                    Builders<GatewayAppCallerRecord>.Filter.Eq(x => x.TenantId, tenantId),
                     Builders<GatewayAppCallerRecord>.Filter.Eq(x => x.AppCallerCode, normalizedAppCallerCode),
                     Builders<GatewayAppCallerRecord>.Filter.Eq(x => x.RequestType, normalizedRequestType)),
                     new FindOptions { Collation = GatewayAppCallerIdentity.Collation })
@@ -1902,12 +1921,14 @@ public static class GatewayHttpEndpoints
             var windowStart = new DateTime(now.Year, now.Month, now.Day, now.Hour, now.Minute, 0, DateTimeKind.Utc);
             var windows = gatewayData.Database.GetCollection<BsonDocument>("llmgw_app_caller_rate_windows");
             var windowFilter = Builders<BsonDocument>.Filter.And(
+                Builders<BsonDocument>.Filter.Eq("TenantId", tenantId),
                 Builders<BsonDocument>.Filter.Eq("AppCallerCode", normalizedAppCallerCode),
                 Builders<BsonDocument>.Filter.Eq("RequestType", normalizedRequestType),
                 Builders<BsonDocument>.Filter.Eq("WindowStart", windowStart));
             var updated = await windows.FindOneAndUpdateAsync(
                 windowFilter,
                 Builders<BsonDocument>.Update
+                    .SetOnInsert("TenantId", tenantId)
                     .SetOnInsert("AppCallerCode", normalizedAppCallerCode)
                     .SetOnInsert("RequestType", normalizedRequestType)
                     .SetOnInsert("WindowStart", windowStart)
@@ -2750,7 +2771,7 @@ public static class GatewayHttpEndpoints
         GatewayCancellationLease? lease = null;
         try
         {
-            lease = services.GetService<GatewayCancellationRegistry>()?.Register(appCallerCode, requestId);
+            lease = services.GetService<GatewayCancellationRegistry>()?.Register(GetVerifiedTenantId(http), appCallerCode, requestId);
             await action(lease?.Token ?? CancellationToken.None);
         }
         catch (InvalidOperationException) when (lease is null)
@@ -2798,6 +2819,7 @@ public static class GatewayHttpEndpoints
         if (store is not null)
         {
             execution = await store.BeginAsync(
+                GetVerifiedTenantId(http),
                 request.AppCallerCode,
                 requestId,
                 operation,
@@ -2825,11 +2847,11 @@ public static class GatewayHttpEndpoints
             }
         }
 
-        var governance = await RecordAndCheckAppCallerGovernanceAsync(services, ingress, CancellationToken.None);
+        var governance = await RecordAndCheckAppCallerGovernanceAsync(http, services, ingress, CancellationToken.None);
         if (await TryWriteGovernanceErrorAsync(http, governance))
         {
             if (store is not null && execution is not null)
-                await store.FailAsync(execution.ExecutionId, GovernanceErrorCode(governance), CancellationToken.None);
+                await store.FailAsync(GetVerifiedTenantId(http), execution.ExecutionId, GovernanceErrorCode(governance), CancellationToken.None);
             return;
         }
 
@@ -2848,24 +2870,24 @@ public static class GatewayHttpEndpoints
                 if (store is not null && execution is not null)
                 {
                     if (raw.Success)
-                        await store.CompleteAsync(execution.ExecutionId, JsonSerializer.Serialize(raw), CancellationToken.None);
+                        await store.CompleteAsync(GetVerifiedTenantId(http), execution.ExecutionId, JsonSerializer.Serialize(raw), CancellationToken.None);
                     else if (raw.StatusCode >= 500)
-                        await store.UnknownAsync(execution.ExecutionId, raw.ErrorCode ?? "UPSTREAM_OUTCOME_UNKNOWN", CancellationToken.None);
+                        await store.UnknownAsync(GetVerifiedTenantId(http), execution.ExecutionId, raw.ErrorCode ?? "UPSTREAM_OUTCOME_UNKNOWN", CancellationToken.None);
                     else
-                        await store.FailAsync(execution.ExecutionId, raw.ErrorCode ?? "RAW_REQUEST_FAILED", CancellationToken.None);
+                        await store.FailAsync(GetVerifiedTenantId(http), execution.ExecutionId, raw.ErrorCode ?? "RAW_REQUEST_FAILED", CancellationToken.None);
                 }
                 await WriteOpenAiRawCompatAsync(http, raw);
             }
             catch (OperationCanceledException)
             {
                 if (store is not null && execution is not null)
-                    await store.UnknownAsync(execution.ExecutionId, "GATEWAY_REQUEST_CANCELLED_OUTCOME_UNKNOWN", CancellationToken.None);
+                    await store.UnknownAsync(GetVerifiedTenantId(http), execution.ExecutionId, "GATEWAY_REQUEST_CANCELLED_OUTCOME_UNKNOWN", CancellationToken.None);
                 throw;
             }
             catch
             {
                 if (store is not null && execution is not null)
-                    await store.UnknownAsync(execution.ExecutionId, "UPSTREAM_OUTCOME_UNKNOWN", CancellationToken.None);
+                    await store.UnknownAsync(GetVerifiedTenantId(http), execution.ExecutionId, "UPSTREAM_OUTCOME_UNKNOWN", CancellationToken.None);
                 throw;
             }
         });
@@ -3988,7 +4010,9 @@ public static class GatewayHttpEndpoints
             // S2：MAP 侧 http 模式已把传输标记随 body.Context 过线，透传进作用域，
             // 供 serving 端直连客户端（若有）读取；网关日志由 LlmGateway 直接读 request.Context 标注。
             GatewayTransport: ctx?.GatewayTransport,
-            IsHealthProbe: ctx?.IsHealthProbe));
+            IsHealthProbe: ctx?.IsHealthProbe,
+            TenantId: ctx?.TenantId,
+            TeamId: ctx?.TeamId));
     }
 
     private static GatewayIngressRequest ToIngress(GatewayRequest request, string ingressProtocol, string sourceSystem)
@@ -4162,13 +4186,18 @@ public static class GatewayHttpEndpoints
         var requestId = NormalizeOptionalTraceId(ingress.Context?.RequestId) ?? NormalizeOptionalTraceId(ingress.RequestId);
         var sessionId = NormalizeOptionalTraceId(ingress.Context?.SessionId);
         var runId = NormalizeOptionalTraceId(ingress.Context?.RunId);
+        var tenantId = ingress.Context?.TenantId;
+        if (string.IsNullOrWhiteSpace(tenantId)) return;
         var filter = Builders<GatewayAppCallerRecord>.Filter.And(
+            Builders<GatewayAppCallerRecord>.Filter.Eq(x => x.TenantId, tenantId),
             Builders<GatewayAppCallerRecord>.Filter.Eq(x => x.AppCallerCode, appCallerCode),
             Builders<GatewayAppCallerRecord>.Filter.Eq(x => x.RequestType, requestType));
         var updates = new List<UpdateDefinition<GatewayAppCallerRecord>>
         {
             Builders<GatewayAppCallerRecord>.Update
             .SetOnInsert(x => x.Id, Guid.NewGuid().ToString("N"))
+            .SetOnInsert(x => x.TenantId, tenantId)
+            .SetOnInsert(x => x.TeamId, ingress.Context?.TeamId)
             .SetOnInsert(x => x.AppCallerCode, appCallerCode)
             .SetOnInsert(x => x.RequestType, requestType)
             .SetOnInsert(x => x.Status, "discovered")
@@ -4325,6 +4354,8 @@ public static class GatewayHttpEndpoints
     {
         if (storage == null || request.MultipartFileRefs is not { Count: > 0 }) return;
         var manifests = data?.Database.GetCollection<GatewayMultipartObjectRecord>("llmgw_multipart_objects");
+        var tenantId = request.Context?.TenantId;
+        if (string.IsNullOrWhiteSpace(tenantId)) return;
         foreach (var fileRef in request.MultipartFileRefs.Values)
         {
             if (string.IsNullOrWhiteSpace(fileRef.RefKey)) continue;
@@ -4334,7 +4365,7 @@ public static class GatewayHttpEndpoints
                 if (manifests is not null)
                 {
                     await manifests.UpdateOneAsync(
-                        x => x.RefKey == fileRef.RefKey,
+                        x => x.TenantId == tenantId && x.RefKey == fileRef.RefKey,
                         Builders<GatewayMultipartObjectRecord>.Update
                             .Set(x => x.Status, "deleted")
                             .Set(x => x.DeletedAt, DateTime.UtcNow)
@@ -4350,7 +4381,7 @@ public static class GatewayHttpEndpoints
                         ? Math.Max(1, configuration?.GetValue("LlmGateway:Retention:SuccessfulMultipartHours", 24) ?? 24)
                         : Math.Max(1, configuration?.GetValue("LlmGateway:Retention:FailedMultipartHours", 72) ?? 72);
                     await manifests.UpdateOneAsync(
-                        x => x.RefKey == fileRef.RefKey,
+                        x => x.TenantId == tenantId && x.RefKey == fileRef.RefKey,
                         Builders<GatewayMultipartObjectRecord>.Update
                             .Set(x => x.Status, "cleanup-pending")
                             .Set(x => x.Detail, ex.GetType().Name)
@@ -4470,6 +4501,12 @@ public static class GatewayHttpEndpoints
                 AppCallerStatusDecision.Allow(appCallerCode, requestType, "unknown"),
                 AppCallerRateLimitDecision.Allow(appCallerCode, requestType),
                 AppCallerBudgetDecision.Reject(appCallerCode, requestType, 0, 0, DateTime.UtcNow, "APP_CALLER_BUDGET_GOVERNANCE_UNAVAILABLE"));
+
+        public static AppCallerGovernanceDecision RejectTenantUnavailable(string appCallerCode, string requestType)
+            => new(
+                AppCallerStatusDecision.Allow(appCallerCode, requestType, "unknown"),
+                AppCallerRateLimitDecision.Allow(appCallerCode, requestType),
+                AppCallerBudgetDecision.Reject(appCallerCode, requestType, 0, 0, DateTime.UtcNow, "TENANT_CONTEXT_UNAVAILABLE"));
     }
 }
 

--- a/prd-api/src/PrdAgent.LlmGateway/GatewayHttpEndpoints.cs
+++ b/prd-api/src/PrdAgent.LlmGateway/GatewayHttpEndpoints.cs
@@ -904,16 +904,18 @@ public static class GatewayHttpEndpoints
 
             GatewayCancellationLease? cancellation = null;
             var multipartRequestSucceeded = false;
+            var multipartOwnershipEstablished = false;
+            var verifiedTenantId = GetVerifiedTenantId(http);
             try
             {
-                cancellation = services.GetService<GatewayCancellationRegistry>()?.Register(GetVerifiedTenantId(http), ingress.AppCallerCode, ingress.RequestId);
+                cancellation = services.GetService<GatewayCancellationRegistry>()?.Register(verifiedTenantId, ingress.AppCallerCode, ingress.RequestId);
                 var token = cancellation?.Token ?? CancellationToken.None;
                 var authorization = http.Items["llmgw.key.authorization"] as GatewayKeyAuthorization;
                 var rehydrated = await RehydrateMultipartFileRefsAsync(
                     request,
                     services.GetService<IAssetStorage>(),
                     services.GetService<LlmGatewayDataContext>(),
-                    GetVerifiedTenantId(http),
+                    verifiedTenantId,
                     requireTenantManifest: authorization is { LegacySharedKey: false },
                     token);
                 if (!rehydrated.Success)
@@ -923,6 +925,7 @@ public static class GatewayHttpEndpoints
                     return JsonContentResult(rehydrated.Error!, jsonOpts);
                 }
 
+                multipartOwnershipEstablished = true;
                 request = rehydrated.Request ?? request;
                 var routedRequest = ApplyIngressRouting(request, ingress);
                 using var _ = OpenContextScope(accessor, routedRequest.Context, routedRequest.ModelType, routedRequest.AppCallerCode);
@@ -962,12 +965,16 @@ public static class GatewayHttpEndpoints
             finally
             {
                 cancellation?.Dispose();
-                await CleanupMultipartRefsAsync(
-                    request,
-                    services.GetService<IAssetStorage>(),
-                    services.GetService<LlmGatewayDataContext>(),
-                    services.GetService<IConfiguration>(),
-                    multipartRequestSucceeded);
+                if (multipartOwnershipEstablished)
+                {
+                    await CleanupMultipartRefsAsync(
+                        request,
+                        services.GetService<IAssetStorage>(),
+                        services.GetService<LlmGatewayDataContext>(),
+                        services.GetService<IConfiguration>(),
+                        verifiedTenantId,
+                        multipartRequestSucceeded);
+                }
             }
         });
 
@@ -4430,11 +4437,11 @@ public static class GatewayHttpEndpoints
         IAssetStorage? storage,
         LlmGatewayDataContext? data,
         IConfiguration? configuration,
+        string tenantId,
         bool requestSucceeded)
     {
         if (storage == null || request.MultipartFileRefs is not { Count: > 0 }) return;
         var manifests = data?.Database.GetCollection<GatewayMultipartObjectRecord>("llmgw_multipart_objects");
-        var tenantId = request.Context?.TenantId;
         if (string.IsNullOrWhiteSpace(tenantId)) return;
         foreach (var fileRef in request.MultipartFileRefs.Values)
         {

--- a/prd-api/src/PrdAgent.LlmGateway/GatewayHttpEndpoints.cs
+++ b/prd-api/src/PrdAgent.LlmGateway/GatewayHttpEndpoints.cs
@@ -925,7 +925,7 @@ public static class GatewayHttpEndpoints
                     return JsonContentResult(rehydrated.Error!, jsonOpts);
                 }
 
-                multipartOwnershipEstablished = true;
+                multipartOwnershipEstablished = rehydrated.MultipartRefOwnershipEstablished;
                 request = rehydrated.Request ?? request;
                 var routedRequest = ApplyIngressRouting(request, ingress);
                 using var _ = OpenContextScope(accessor, routedRequest.Context, routedRequest.ModelType, routedRequest.AppCallerCode);
@@ -4321,7 +4321,7 @@ public static class GatewayHttpEndpoints
             || request.MultipartFileRefs is not { Count: > 0 }
             || request.MultipartFiles is { Count: > 0 })
         {
-            return RehydrateResult.Ok(request);
+            return RehydrateResult.Ok(request, multipartRefOwnershipEstablished: false);
         }
 
         if (storage == null)
@@ -4429,7 +4429,7 @@ public static class GatewayHttpEndpoints
             Context = request.Context,
         };
 
-        return RehydrateResult.Ok(hydrated);
+        return RehydrateResult.Ok(hydrated, multipartRefOwnershipEstablished: manifests is not null);
     }
 
     private static async Task CleanupMultipartRefsAsync(
@@ -4489,12 +4489,14 @@ public static class GatewayHttpEndpoints
     private sealed record RehydrateResult(
         bool Success,
         GatewayRawRequest? Request,
-        GatewayRawResponse? Error)
+        GatewayRawResponse? Error,
+        bool MultipartRefOwnershipEstablished)
     {
-        public static RehydrateResult Ok(GatewayRawRequest request) => new(true, request, null);
+        public static RehydrateResult Ok(GatewayRawRequest request, bool multipartRefOwnershipEstablished)
+            => new(true, request, null, multipartRefOwnershipEstablished);
 
         public static RehydrateResult Fail(string code, string message, int statusCode = 500)
-            => new(false, null, GatewayRawResponse.Fail(code, message, statusCode));
+            => new(false, null, GatewayRawResponse.Fail(code, message, statusCode), false);
     }
 
     private sealed record GatewayAuthorizationInputs(

--- a/prd-api/src/PrdAgent.LlmGateway/GatewayRuntimeGovernance.cs
+++ b/prd-api/src/PrdAgent.LlmGateway/GatewayRuntimeGovernance.cs
@@ -854,23 +854,36 @@ public sealed class GatewayDataLifecycleWorker : BackgroundService
     private async Task<List<string>> ResolveLifecycleTenantIdsAsync(string internalTenantId, CancellationToken ct)
     {
         var tenantIds = new HashSet<string>(StringComparer.Ordinal) { internalTenantId };
-        var tenantCollections = new[]
+        var tenantSources = new (string CollectionName, string FieldName)[]
         {
-            "llmgw_tenants",
-            "llmrequestlogs",
-            "llmshadow_comparisons",
-            "llmgw_operation_audits",
-            "llmgw_login_audits",
-            "llmgw_lifecycle_runs",
-            "llmgw_multipart_objects",
+            ("llmgw_tenants", "_id"),
+            ("llmgw_app_callers", "TenantId"),
+            ("llmgw_model_pools", "TenantId"),
+            ("llmgw_platforms", "TenantId"),
+            ("llmgw_models", "TenantId"),
+            ("llmgw_model_exchanges", "TenantId"),
+            ("llmgw_service_keys", "TenantId"),
+            ("llmrequestlogs", "TenantId"),
+            ("llmshadow_comparisons", "TenantId"),
+            ("llmgw_operation_audits", "TenantId"),
+            ("llmgw_login_audits", "TenantId"),
+            ("llmgw_lifecycle_runs", "TenantId"),
+            ("llmgw_app_caller_rate_windows", "TenantId"),
+            ("llmgw_budget_months", "TenantId"),
+            ("llmgw_budget_reservations", "TenantId"),
+            ("llmgw_request_executions", "TenantId"),
+            ("llmgw_multipart_objects", "TenantId"),
+            ("llmgw_provider_concurrency_slots", "TenantId"),
+            ("llmgw_runtime_settings", "TenantId"),
+            ("llmgw_asset_registry", "TenantId"),
         };
-        var validTenant = Builders<MongoDB.Bson.BsonDocument>.Filter.And(
-            Builders<MongoDB.Bson.BsonDocument>.Filter.Type("TenantId", MongoDB.Bson.BsonType.String),
-            Builders<MongoDB.Bson.BsonDocument>.Filter.Ne("TenantId", ""));
-        foreach (var collectionName in tenantCollections)
+        foreach (var (collectionName, fieldName) in tenantSources)
         {
+            var validTenant = Builders<MongoDB.Bson.BsonDocument>.Filter.And(
+                Builders<MongoDB.Bson.BsonDocument>.Filter.Type(fieldName, MongoDB.Bson.BsonType.String),
+                Builders<MongoDB.Bson.BsonDocument>.Filter.Ne(fieldName, ""));
             var values = await _data.Database.GetCollection<MongoDB.Bson.BsonDocument>(collectionName)
-                .Distinct<string>("TenantId", validTenant)
+                .Distinct<string>(fieldName, validTenant)
                 .ToListAsync(ct);
             foreach (var value in values.Where(x => !string.IsNullOrWhiteSpace(x)))
                 tenantIds.Add(value.Trim());

--- a/prd-api/src/PrdAgent.LlmGateway/GatewayRuntimeGovernance.cs
+++ b/prd-api/src/PrdAgent.LlmGateway/GatewayRuntimeGovernance.cs
@@ -19,6 +19,8 @@ public sealed record GatewayKeyAuthorization(
     string ErrorCode,
     string Detail,
     string? KeyId = null,
+    string? TenantId = null,
+    string? TeamId = null,
     bool LegacySharedKey = false);
 
 public interface IGatewayScopedKeyAuthorizer
@@ -36,8 +38,15 @@ public interface IGatewayScopedKeyAuthorizer
 public sealed class GatewayScopedKeyAuthorizer : IGatewayScopedKeyAuthorizer
 {
     private readonly LlmGatewayDataContext _data;
+    private readonly string _internalTenantId;
 
-    public GatewayScopedKeyAuthorizer(LlmGatewayDataContext data) => _data = data;
+    public GatewayScopedKeyAuthorizer(LlmGatewayDataContext data, IConfiguration? configuration = null)
+    {
+        _data = data;
+        _internalTenantId = configuration?["LlmGateway:InternalTenantId"]?.Trim() is { Length: > 0 } configured
+            ? configured
+            : "tenant_map_internal";
+    }
 
     public async Task<GatewayKeyAuthorization> AuthorizeAsync(
         string providedKey,
@@ -52,12 +61,26 @@ public sealed class GatewayScopedKeyAuthorizer : IGatewayScopedKeyAuthorizer
             return new(false, false, 401, "GATEWAY_KEY_REQUIRED", "missing gateway key");
 
         if (FixedTimeEquals(providedKey, legacySharedKey))
-            return new(true, true, 200, string.Empty, "legacy MAP shared key", LegacySharedKey: true);
+            return new(
+                true,
+                true,
+                200,
+                string.Empty,
+                "legacy MAP shared key",
+                TenantId: _internalTenantId,
+                LegacySharedKey: true);
 
         var hash = Sha256Hex(providedKey);
         var keys = _data.Database.GetCollection<GatewayServiceKeyRecord>("llmgw_service_keys");
-        var record = await keys.Find(x => x.KeyHash == hash).FirstOrDefaultAsync(ct);
-        if (record == null || !record.Enabled || record.ExpiresAt is not null && record.ExpiresAt <= DateTime.UtcNow)
+        var directory = _data.Database.GetCollection<GatewayServiceKeyDirectoryRecord>("llmgw_service_key_directory");
+        var locator = await directory.Find(x => x.KeyHash == hash).FirstOrDefaultAsync(ct);
+        var record = locator is null
+            ? null
+            : await keys.Find(x => x.TenantId == locator.TenantId && x.Id == locator.ServiceKeyId && x.KeyHash == hash).FirstOrDefaultAsync(ct);
+        if (record == null
+            || string.IsNullOrWhiteSpace(record.TenantId)
+            || !record.Enabled
+            || record.ExpiresAt is not null && record.ExpiresAt <= DateTime.UtcNow)
             return new(false, false, 401, "GATEWAY_KEY_INVALID", "invalid or expired gateway key");
 
         if (!Matches(record.SourceSystem, sourceSystem)
@@ -69,6 +92,8 @@ public sealed class GatewayScopedKeyAuthorizer : IGatewayScopedKeyAuthorizer
                 new MongoDB.Bson.BsonDocument
                 {
                     { "_id", Guid.NewGuid().ToString("N") },
+                    { "TenantId", record.TenantId },
+                    { "TeamId", string.IsNullOrWhiteSpace(record.TeamId) ? MongoDB.Bson.BsonNull.Value : record.TeamId },
                     { "Action", "service_key.scope_denied" },
                     { "TargetType", "llmgw_service_key" },
                     { "TargetId", record.Id },
@@ -85,14 +110,24 @@ public sealed class GatewayScopedKeyAuthorizer : IGatewayScopedKeyAuthorizer
                     },
                     { "CreatedAt", DateTime.UtcNow },
                 }, cancellationToken: ct);
-            return new(false, true, 403, "GATEWAY_KEY_SCOPE_DENIED", "gateway key scope does not allow this request", record.Id);
+            return new(
+                false,
+                true,
+                403,
+                "GATEWAY_KEY_SCOPE_DENIED",
+                "gateway key scope does not allow this request",
+                record.Id,
+                record.TenantId,
+                record.TeamId);
         }
 
         _ = keys.UpdateOneAsync(
-            Builders<GatewayServiceKeyRecord>.Filter.Eq(x => x.Id, record.Id),
+            Builders<GatewayServiceKeyRecord>.Filter.And(
+                Builders<GatewayServiceKeyRecord>.Filter.Eq(x => x.TenantId, record.TenantId),
+                Builders<GatewayServiceKeyRecord>.Filter.Eq(x => x.Id, record.Id)),
             Builders<GatewayServiceKeyRecord>.Update.Set(x => x.LastUsedAt, DateTime.UtcNow),
             cancellationToken: CancellationToken.None);
-        return new(true, true, 200, string.Empty, "scoped key", record.Id);
+        return new(true, true, 200, string.Empty, "scoped key", record.Id, record.TenantId, record.TeamId);
     }
 
     public static string Sha256Hex(string value)
@@ -117,7 +152,7 @@ public sealed class GatewayScopedKeyAuthorizer : IGatewayScopedKeyAuthorizer
     }
 }
 
-public sealed record GatewayBudgetLease(string ReservationId, decimal ReservedUsd);
+public sealed record GatewayBudgetLease(string TenantId, string ReservationId, decimal ReservedUsd);
 
 public sealed record GatewayBudgetAdmission(
     bool Allowed,
@@ -167,6 +202,7 @@ public sealed class GatewayBudgetCoordinator
         var reservations = _data.Database.GetCollection<GatewayBudgetReservationRecord>("llmgw_budget_reservations");
         var reservation = new GatewayBudgetReservationRecord
         {
+            TenantId = caller.TenantId,
             AppCallerCode = caller.AppCallerCode,
             RequestType = caller.RequestType,
             RequestId = requestId,
@@ -184,7 +220,8 @@ public sealed class GatewayBudgetCoordinator
         catch (MongoWriteException ex) when (ex.WriteError?.Category == ServerErrorCategory.DuplicateKey)
         {
             var existing = await reservations.Find(x =>
-                    x.AppCallerCode == caller.AppCallerCode
+                    x.TenantId == caller.TenantId
+                    && x.AppCallerCode == caller.AppCallerCode
                     && x.RequestType == caller.RequestType
                     && x.RequestId == requestId)
                 .FirstOrDefaultAsync(ct);
@@ -196,6 +233,7 @@ public sealed class GatewayBudgetCoordinator
 
         var months = _data.Database.GetCollection<GatewayBudgetMonthRecord>("llmgw_budget_months");
         var identity = Builders<GatewayBudgetMonthRecord>.Filter.And(
+            Builders<GatewayBudgetMonthRecord>.Filter.Eq(x => x.TenantId, caller.TenantId),
             Builders<GatewayBudgetMonthRecord>.Filter.Eq(x => x.AppCallerCode, caller.AppCallerCode),
             Builders<GatewayBudgetMonthRecord>.Filter.Eq(x => x.RequestType, caller.RequestType),
             Builders<GatewayBudgetMonthRecord>.Filter.Eq(x => x.MonthStart, monthStart));
@@ -227,6 +265,7 @@ public sealed class GatewayBudgetCoordinator
                 identity,
                 Builders<GatewayBudgetMonthRecord>.Update
                     .SetOnInsert(x => x.Id, Guid.NewGuid().ToString("N"))
+                    .SetOnInsert(x => x.TenantId, caller.TenantId)
                     .SetOnInsert(x => x.AppCallerCode, caller.AppCallerCode)
                     .SetOnInsert(x => x.RequestType, caller.RequestType)
                     .SetOnInsert(x => x.MonthStart, monthStart)
@@ -248,7 +287,7 @@ public sealed class GatewayBudgetCoordinator
         if (updated == null)
         {
             await reservations.UpdateOneAsync(
-                x => x.Id == reservation.Id && x.Status == "pending",
+                x => x.TenantId == caller.TenantId && x.Id == reservation.Id && x.Status == "pending",
                 Builders<GatewayBudgetReservationRecord>.Update
                     .Set(x => x.Status, "rejected")
                     .Set(x => x.Detail, "monthly-budget-exceeded")
@@ -259,12 +298,12 @@ public sealed class GatewayBudgetCoordinator
         }
 
         await reservations.UpdateOneAsync(
-            x => x.Id == reservation.Id && x.Status == "pending",
+            x => x.TenantId == caller.TenantId && x.Id == reservation.Id && x.Status == "pending",
             Builders<GatewayBudgetReservationRecord>.Update
                 .Set(x => x.Status, "reserved")
                 .Set(x => x.UpdatedAt, DateTime.UtcNow),
             cancellationToken: ct);
-        return GatewayBudgetAdmission.Allow(budget, updated.ReservedUsd + updated.SpentUsd, new GatewayBudgetLease(reservation.Id, amount));
+        return GatewayBudgetAdmission.Allow(budget, updated.ReservedUsd + updated.SpentUsd, new GatewayBudgetLease(caller.TenantId, reservation.Id, amount));
     }
 
     public async Task FinalizeAsync(
@@ -277,17 +316,17 @@ public sealed class GatewayBudgetCoordinator
         {
             if (outcomeUnknown || pipelineThrew || responseStatusCode >= 500)
             {
-                await SetReservationStatusAsync(lease.ReservationId, "unknown", "upstream-outcome-unknown", adjustMonth: false, settle: false, CancellationToken.None);
+                await SetReservationStatusAsync(lease.TenantId, lease.ReservationId, "unknown", "upstream-outcome-unknown", adjustMonth: false, settle: false, CancellationToken.None);
                 return;
             }
 
             if (responseStatusCode >= 400)
             {
-                await SetReservationStatusAsync(lease.ReservationId, "released", "request-rejected-before-success", adjustMonth: true, settle: false, CancellationToken.None);
+                await SetReservationStatusAsync(lease.TenantId, lease.ReservationId, "released", "request-rejected-before-success", adjustMonth: true, settle: false, CancellationToken.None);
                 return;
             }
 
-            await SetReservationStatusAsync(lease.ReservationId, "settled", "conservative-reservation-settlement", adjustMonth: true, settle: true, CancellationToken.None);
+            await SetReservationStatusAsync(lease.TenantId, lease.ReservationId, "settled", "conservative-reservation-settlement", adjustMonth: true, settle: true, CancellationToken.None);
         }
         catch (Exception ex)
         {
@@ -298,25 +337,34 @@ public sealed class GatewayBudgetCoordinator
     public async Task ReleaseExpiredAsync(CancellationToken ct)
     {
         var reservations = _data.Database.GetCollection<GatewayBudgetReservationRecord>("llmgw_budget_reservations");
-        var expired = await reservations.Find(x =>
-                (x.Status == "pending" || x.Status == "reserved" || x.Status == "unknown")
-                && x.ExpiresAt <= DateTime.UtcNow)
-            .Limit(500)
-            .ToListAsync(ct);
-        foreach (var item in expired)
+        var tenantIds = await reservations.Distinct<string>(
+            "TenantId",
+            Builders<GatewayBudgetReservationRecord>.Filter.Ne(x => x.TenantId, "")).ToListAsync(ct);
+        foreach (var tenantId in tenantIds)
         {
-            var outcomeUnknown = item.Status == "unknown";
-            await SetReservationStatusAsync(
-                item.Id,
-                outcomeUnknown ? "settled-unknown-expired" : "released-expired",
-                outcomeUnknown ? "unknown-outcome-conservative-settlement" : "reservation-expired",
-                adjustMonth: item.Status != "pending",
-                settle: outcomeUnknown,
-                ct);
+            var expired = await reservations.Find(x =>
+                    x.TenantId == tenantId
+                    && (x.Status == "pending" || x.Status == "reserved" || x.Status == "unknown")
+                    && x.ExpiresAt <= DateTime.UtcNow)
+                .Limit(500)
+                .ToListAsync(ct);
+            foreach (var item in expired)
+            {
+                var outcomeUnknown = item.Status == "unknown";
+                await SetReservationStatusAsync(
+                    tenantId,
+                    item.Id,
+                    outcomeUnknown ? "settled-unknown-expired" : "released-expired",
+                    outcomeUnknown ? "unknown-outcome-conservative-settlement" : "reservation-expired",
+                    adjustMonth: item.Status != "pending",
+                    settle: outcomeUnknown,
+                    ct);
+            }
         }
     }
 
     private async Task SetReservationStatusAsync(
+        string tenantId,
         string reservationId,
         string targetStatus,
         string detail,
@@ -327,6 +375,7 @@ public sealed class GatewayBudgetCoordinator
         var reservations = _data.Database.GetCollection<GatewayBudgetReservationRecord>("llmgw_budget_reservations");
         var current = await reservations.FindOneAndUpdateAsync(
             Builders<GatewayBudgetReservationRecord>.Filter.And(
+                Builders<GatewayBudgetReservationRecord>.Filter.Eq(x => x.TenantId, tenantId),
                 Builders<GatewayBudgetReservationRecord>.Filter.Eq(x => x.Id, reservationId),
                 Builders<GatewayBudgetReservationRecord>.Filter.In(x => x.Status, new[] { "pending", "reserved", "unknown" })),
             Builders<GatewayBudgetReservationRecord>.Update
@@ -340,7 +389,7 @@ public sealed class GatewayBudgetCoordinator
         if (settle)
         {
             await reservations.UpdateOneAsync(
-                x => x.Id == current.Id,
+                x => x.TenantId == current.TenantId && x.Id == current.Id,
                 Builders<GatewayBudgetReservationRecord>.Update.Set(x => x.SettledUsd, current.ReservedUsd),
                 cancellationToken: ct);
         }
@@ -351,7 +400,8 @@ public sealed class GatewayBudgetCoordinator
             .Set(x => x.UpdatedAt, DateTime.UtcNow);
         if (settle) update = update.Inc(x => x.SpentUsd, current.ReservedUsd);
         await months.UpdateOneAsync(x =>
-            x.AppCallerCode == current.AppCallerCode
+            x.TenantId == current.TenantId
+            && x.AppCallerCode == current.AppCallerCode
             && x.RequestType == current.RequestType
             && x.MonthStart == current.MonthStart, update, cancellationToken: ct);
     }
@@ -388,6 +438,7 @@ public sealed class GatewayRequestExecutionStore
     }
 
     public async Task<GatewayExecutionBeginResult> BeginAsync(
+        string tenantId,
         string appCallerCode,
         string requestId,
         string operation,
@@ -397,6 +448,7 @@ public sealed class GatewayRequestExecutionStore
         var records = _data.Database.GetCollection<GatewayRequestExecutionRecord>("llmgw_request_executions");
         var record = new GatewayRequestExecutionRecord
         {
+            TenantId = tenantId,
             AppCallerCode = appCallerCode,
             RequestId = requestId,
             Operation = operation,
@@ -411,7 +463,8 @@ public sealed class GatewayRequestExecutionStore
         catch (MongoWriteException ex) when (ex.WriteError?.Category == ServerErrorCategory.DuplicateKey)
         {
             var existing = await records.Find(x =>
-                    x.AppCallerCode == appCallerCode
+                    x.TenantId == tenantId
+                    && x.AppCallerCode == appCallerCode
                     && x.RequestId == requestId
                     && x.Operation == operation)
                 .FirstAsync(ct);
@@ -429,16 +482,16 @@ public sealed class GatewayRequestExecutionStore
         }
     }
 
-    public async Task CompleteAsync(string executionId, string responseJson, CancellationToken ct)
+    public async Task CompleteAsync(string tenantId, string executionId, string responseJson, CancellationToken ct)
     {
         var responseTooLarge = Encoding.UTF8.GetByteCount(responseJson) > MaxReplayResponseBytes;
 
         try
         {
             if (responseTooLarge)
-                await MarkReplayUnavailableAsync(executionId, "GATEWAY_REPLAY_RESPONSE_TOO_LARGE", ct);
+                await MarkReplayUnavailableAsync(tenantId, executionId, "GATEWAY_REPLAY_RESPONSE_TOO_LARGE", ct);
             else
-                await UpdateAsync(executionId, "completed", responseJson, null, ct);
+                await UpdateAsync(tenantId, executionId, "completed", responseJson, null, ct);
         }
         catch (MongoException ex)
         {
@@ -449,7 +502,7 @@ public sealed class GatewayRequestExecutionStore
             {
                 try
                 {
-                    await MarkReplayUnavailableAsync(executionId, "GATEWAY_REPLAY_SNAPSHOT_UNAVAILABLE", CancellationToken.None);
+                    await MarkReplayUnavailableAsync(tenantId, executionId, "GATEWAY_REPLAY_SNAPSHOT_UNAVAILABLE", CancellationToken.None);
                 }
                 catch (Exception fallbackEx)
                 {
@@ -459,13 +512,14 @@ public sealed class GatewayRequestExecutionStore
         }
     }
 
-    public Task UnknownAsync(string executionId, string errorCode, CancellationToken ct)
-        => UpdateAsync(executionId, "unknown", null, errorCode, ct);
+    public Task UnknownAsync(string tenantId, string executionId, string errorCode, CancellationToken ct)
+        => UpdateAsync(tenantId, executionId, "unknown", null, errorCode, ct);
 
-    public Task FailAsync(string executionId, string errorCode, CancellationToken ct)
-        => UpdateAsync(executionId, "failed", null, errorCode, ct);
+    public Task FailAsync(string tenantId, string executionId, string errorCode, CancellationToken ct)
+        => UpdateAsync(tenantId, executionId, "failed", null, errorCode, ct);
 
     public async Task<GatewayRequestExecutionRecord?> GetAsync(
+        string tenantId,
         string appCallerCode,
         string requestId,
         string operation,
@@ -473,18 +527,19 @@ public sealed class GatewayRequestExecutionStore
     {
         GatewayRequestExecutionRecord? record = await _data.Database
             .GetCollection<GatewayRequestExecutionRecord>("llmgw_request_executions")
-            .Find(x => x.AppCallerCode == appCallerCode
+            .Find(x => x.TenantId == tenantId
+                       && x.AppCallerCode == appCallerCode
                        && x.RequestId == requestId
                        && x.Operation == operation)
             .FirstOrDefaultAsync(ct);
         return record;
     }
 
-    private async Task UpdateAsync(string id, string status, string? responseJson, string? errorCode, CancellationToken ct)
+    private async Task UpdateAsync(string tenantId, string id, string status, string? responseJson, string? errorCode, CancellationToken ct)
     {
         var records = _data.Database.GetCollection<GatewayRequestExecutionRecord>("llmgw_request_executions");
         await records.UpdateOneAsync(
-            x => x.Id == id && x.Status == "running",
+            x => x.TenantId == tenantId && x.Id == id && x.Status == "running",
             Builders<GatewayRequestExecutionRecord>.Update
                 .Set(x => x.Status, status)
                 .Set(x => x.ResponseJson, responseJson)
@@ -493,8 +548,8 @@ public sealed class GatewayRequestExecutionStore
             cancellationToken: ct);
     }
 
-    private Task MarkReplayUnavailableAsync(string executionId, string errorCode, CancellationToken ct)
-        => UpdateAsync(executionId, "completed-unreplayable", null, errorCode, ct);
+    private Task MarkReplayUnavailableAsync(string tenantId, string executionId, string errorCode, CancellationToken ct)
+        => UpdateAsync(tenantId, executionId, "completed-unreplayable", null, errorCode, ct);
 
     public static string Fingerprint(GatewayRawRequest request)
     {
@@ -552,9 +607,9 @@ public sealed class GatewayCancellationRegistry
 {
     private readonly ConcurrentDictionary<GatewayCancellationKey, CancellationTokenSource> _requests = new();
 
-    public GatewayCancellationLease Register(string appCallerCode, string requestId)
+    public GatewayCancellationLease Register(string tenantId, string appCallerCode, string requestId)
     {
-        var key = GatewayCancellationKey.Create(appCallerCode, requestId);
+        var key = GatewayCancellationKey.Create(tenantId, appCallerCode, requestId);
         var cts = new CancellationTokenSource();
         if (!_requests.TryAdd(key, cts))
         {
@@ -564,9 +619,9 @@ public sealed class GatewayCancellationRegistry
         return new GatewayCancellationLease(this, key, cts);
     }
 
-    public bool Cancel(string appCallerCode, string requestId)
+    public bool Cancel(string tenantId, string appCallerCode, string requestId)
     {
-        var key = GatewayCancellationKey.Create(appCallerCode, requestId);
+        var key = GatewayCancellationKey.Create(tenantId, appCallerCode, requestId);
         return _requests.TryGetValue(key, out var cts) && Cancel(cts);
     }
 
@@ -584,15 +639,17 @@ public sealed class GatewayCancellationRegistry
     }
 }
 
-public readonly record struct GatewayCancellationKey(string AppCallerCode, string RequestId)
+public readonly record struct GatewayCancellationKey(string TenantId, string AppCallerCode, string RequestId)
 {
-    public static GatewayCancellationKey Create(string appCallerCode, string requestId)
+    public static GatewayCancellationKey Create(string tenantId, string appCallerCode, string requestId)
     {
+        if (string.IsNullOrWhiteSpace(tenantId))
+            throw new ArgumentException("tenantId is required", nameof(tenantId));
         if (string.IsNullOrWhiteSpace(appCallerCode))
             throw new ArgumentException("appCallerCode is required", nameof(appCallerCode));
         if (string.IsNullOrWhiteSpace(requestId))
             throw new ArgumentException("requestId is required", nameof(requestId));
-        return new(appCallerCode.Trim().ToLowerInvariant(), requestId.Trim());
+        return new(tenantId.Trim(), appCallerCode.Trim().ToLowerInvariant(), requestId.Trim());
     }
 }
 
@@ -656,6 +713,9 @@ public sealed class GatewayDataLifecycleWorker : BackgroundService
 
     private async Task RunOnceAsync(CancellationToken ct)
     {
+        var tenantId = _configuration["LlmGateway:InternalTenantId"]?.Trim() is { Length: > 0 } configuredTenantId
+            ? configuredTenantId
+            : GatewayTenantDefaults.InternalTenantId;
         var now = DateTime.UtcNow;
         var apply = _configuration.GetValue("LlmGateway:Retention:ApplyChanges", false);
         var sensitiveDays = Math.Max(1, _configuration.GetValue("LlmGateway:Retention:SensitiveBodyDays", 7));
@@ -663,7 +723,8 @@ public sealed class GatewayDataLifecycleWorker : BackgroundService
         var shadowDays = Math.Max(1, _configuration.GetValue("LlmGateway:Retention:ShadowDays", 30));
         var auditDays = Math.Max(1, _configuration.GetValue("LlmGateway:Retention:AuditDays", 180));
         var logs = _data.Database.GetCollection<MongoDB.Bson.BsonDocument>("llmrequestlogs");
-        var sensitiveFilter = Builders<MongoDB.Bson.BsonDocument>.Filter.Lt("StartedAt", now.AddDays(-sensitiveDays))
+        var sensitiveFilter = Builders<MongoDB.Bson.BsonDocument>.Filter.Eq("TenantId", tenantId)
+                              & Builders<MongoDB.Bson.BsonDocument>.Filter.Lt("StartedAt", now.AddDays(-sensitiveDays))
                               & Builders<MongoDB.Bson.BsonDocument>.Filter.Or(
                                   Builders<MongoDB.Bson.BsonDocument>.Filter.Ne("RequestBodyRedacted", ""),
                                   Builders<MongoDB.Bson.BsonDocument>.Filter.Exists("QuestionText", true),
@@ -671,7 +732,8 @@ public sealed class GatewayDataLifecycleWorker : BackgroundService
                                   Builders<MongoDB.Bson.BsonDocument>.Filter.Exists("ThinkingText", true));
         var sensitiveCount = await logs.CountDocumentsAsync(sensitiveFilter, cancellationToken: ct);
         var multipart = _data.Database.GetCollection<GatewayMultipartObjectRecord>("llmgw_multipart_objects");
-        var expiredFilter = Builders<GatewayMultipartObjectRecord>.Filter.Ne(x => x.Status, "deleted")
+        var expiredFilter = Builders<GatewayMultipartObjectRecord>.Filter.Eq(x => x.TenantId, tenantId)
+                            & Builders<GatewayMultipartObjectRecord>.Filter.Ne(x => x.Status, "deleted")
                             & Builders<GatewayMultipartObjectRecord>.Filter.Lte(x => x.ExpiresAt, now);
         var expiredMultipartCount = await multipart.CountDocumentsAsync(expiredFilter, cancellationToken: ct);
         var expired = await multipart.Find(expiredFilter).SortBy(x => x.ExpiresAt).Limit(200).ToListAsync(ct);
@@ -679,21 +741,22 @@ public sealed class GatewayDataLifecycleWorker : BackgroundService
         var lifecycle = _data.Database.GetCollection<GatewayLifecycleRunRecord>("llmgw_lifecycle_runs");
         var run = new GatewayLifecycleRunRecord
         {
+            TenantId = tenantId,
             Mode = apply ? "apply" : "dry-run",
             Status = "dry-run-complete",
             StartedAt = now,
             DryRunCompletedAt = DateTime.UtcNow,
             SensitiveLogs = sensitiveCount,
-            ExpiredRequestLogs = await CountExpiredAsync("llmrequestlogs", "StartedAt", now.AddDays(-requestLogDays), ct),
-            ExpiredShadowComparisons = await CountExpiredAsync("llmshadow_comparisons", "ComparedAt", now.AddDays(-shadowDays), ct),
-            ExpiredOperationAudits = await CountExpiredAsync("llmgw_operation_audits", "CreatedAt", now.AddDays(-auditDays), ct),
-            ExpiredLoginAudits = await CountExpiredAsync("llmgw_login_audits", "CreatedAt", now.AddDays(-auditDays), ct),
+            ExpiredRequestLogs = await CountExpiredAsync(tenantId, "llmrequestlogs", "StartedAt", now.AddDays(-requestLogDays), ct),
+            ExpiredShadowComparisons = await CountExpiredAsync(tenantId, "llmshadow_comparisons", "ComparedAt", now.AddDays(-shadowDays), ct),
+            ExpiredOperationAudits = await CountExpiredAsync(tenantId, "llmgw_operation_audits", "CreatedAt", now.AddDays(-auditDays), ct),
+            ExpiredLoginAudits = await CountExpiredAsync(tenantId, "llmgw_login_audits", "CreatedAt", now.AddDays(-auditDays), ct),
             ExpiredMultipartObjects = expiredMultipartCount,
-            OldestExpiredRequestLogAt = await OldestAsync("llmrequestlogs", "StartedAt", Builders<MongoDB.Bson.BsonDocument>.Filter.Lt("StartedAt", now.AddDays(-requestLogDays)), ct),
-            OldestSensitiveLogAt = await OldestAsync("llmrequestlogs", "StartedAt", sensitiveFilter, ct),
-            OldestExpiredShadowAt = await OldestAsync("llmshadow_comparisons", "ComparedAt", Builders<MongoDB.Bson.BsonDocument>.Filter.Lt("ComparedAt", now.AddDays(-shadowDays)), ct),
-            OldestExpiredOperationAuditAt = await OldestAsync("llmgw_operation_audits", "CreatedAt", Builders<MongoDB.Bson.BsonDocument>.Filter.Lt("CreatedAt", now.AddDays(-auditDays)), ct),
-            OldestExpiredLoginAuditAt = await OldestAsync("llmgw_login_audits", "CreatedAt", Builders<MongoDB.Bson.BsonDocument>.Filter.Lt("CreatedAt", now.AddDays(-auditDays)), ct),
+            OldestExpiredRequestLogAt = await OldestAsync(tenantId, "llmrequestlogs", "StartedAt", Builders<MongoDB.Bson.BsonDocument>.Filter.Lt("StartedAt", now.AddDays(-requestLogDays)), ct),
+            OldestSensitiveLogAt = await OldestAsync(tenantId, "llmrequestlogs", "StartedAt", sensitiveFilter, ct),
+            OldestExpiredShadowAt = await OldestAsync(tenantId, "llmshadow_comparisons", "ComparedAt", Builders<MongoDB.Bson.BsonDocument>.Filter.Lt("ComparedAt", now.AddDays(-shadowDays)), ct),
+            OldestExpiredOperationAuditAt = await OldestAsync(tenantId, "llmgw_operation_audits", "CreatedAt", Builders<MongoDB.Bson.BsonDocument>.Filter.Lt("CreatedAt", now.AddDays(-auditDays)), ct),
+            OldestExpiredLoginAuditAt = await OldestAsync(tenantId, "llmgw_login_audits", "CreatedAt", Builders<MongoDB.Bson.BsonDocument>.Filter.Lt("CreatedAt", now.AddDays(-auditDays)), ct),
             OldestExpiredMultipartAt = expired.FirstOrDefault()?.ExpiresAt,
             RetentionIndexesReady = indexStatus.Count == 0,
             MissingRetentionIndexes = indexStatus.ToArray(),
@@ -708,7 +771,7 @@ public sealed class GatewayDataLifecycleWorker : BackgroundService
         {
             await _databaseInitializer.EnsureRetentionTtlIndexesAsync(ct);
             indexStatus = await ReadRetentionIndexStatusAsync(ct);
-            await lifecycle.UpdateOneAsync(x => x.Id == run.Id,
+            await lifecycle.UpdateOneAsync(x => x.TenantId == tenantId && x.Id == run.Id,
                 Builders<GatewayLifecycleRunRecord>.Update
                     .Set(x => x.RetentionIndexesReady, indexStatus.Count == 0)
                     .Set(x => x.MissingRetentionIndexes, indexStatus.ToArray()),
@@ -734,7 +797,7 @@ public sealed class GatewayDataLifecycleWorker : BackgroundService
                 try
                 {
                     await _storage.DeleteByKeyAsync(item.RefKey, ct);
-                    await multipart.UpdateOneAsync(x => x.Id == item.Id,
+                    await multipart.UpdateOneAsync(x => x.TenantId == tenantId && x.Id == item.Id,
                         Builders<GatewayMultipartObjectRecord>.Update
                             .Set(x => x.Status, "deleted")
                             .Set(x => x.DeletedAt, DateTime.UtcNow)
@@ -747,7 +810,7 @@ public sealed class GatewayDataLifecycleWorker : BackgroundService
                 }
             }
 
-            await lifecycle.UpdateOneAsync(x => x.Id == run.Id,
+            await lifecycle.UpdateOneAsync(x => x.TenantId == tenantId && x.Id == run.Id,
                 Builders<GatewayLifecycleRunRecord>.Update
                     .Set(x => x.Status, "applied")
                     .Set(x => x.RedactedSensitiveLogs, redacted)
@@ -765,21 +828,26 @@ public sealed class GatewayDataLifecycleWorker : BackgroundService
             run.Id);
     }
 
-    private async Task<long> CountExpiredAsync(string collectionName, string field, DateTime cutoff, CancellationToken ct)
+    private async Task<long> CountExpiredAsync(string tenantId, string collectionName, string field, DateTime cutoff, CancellationToken ct)
     {
         var collection = _data.Database.GetCollection<MongoDB.Bson.BsonDocument>(collectionName);
         return await collection.CountDocumentsAsync(
-            Builders<MongoDB.Bson.BsonDocument>.Filter.Lt(field, cutoff), cancellationToken: ct);
+            Builders<MongoDB.Bson.BsonDocument>.Filter.And(
+                Builders<MongoDB.Bson.BsonDocument>.Filter.Eq("TenantId", tenantId),
+                Builders<MongoDB.Bson.BsonDocument>.Filter.Lt(field, cutoff)), cancellationToken: ct);
     }
 
     private async Task<DateTime?> OldestAsync(
+        string tenantId,
         string collectionName,
         string field,
         FilterDefinition<MongoDB.Bson.BsonDocument> filter,
         CancellationToken ct)
     {
         var document = await _data.Database.GetCollection<MongoDB.Bson.BsonDocument>(collectionName)
-            .Find(filter)
+            .Find(Builders<MongoDB.Bson.BsonDocument>.Filter.And(
+                Builders<MongoDB.Bson.BsonDocument>.Filter.Eq("TenantId", tenantId),
+                filter))
             .Sort(Builders<MongoDB.Bson.BsonDocument>.Sort.Ascending(field))
             .Project(Builders<MongoDB.Bson.BsonDocument>.Projection.Include(field).Exclude("_id"))
             .FirstOrDefaultAsync(ct);

--- a/prd-api/src/PrdAgent.LlmGateway/GatewayRuntimeGovernance.cs
+++ b/prd-api/src/PrdAgent.LlmGateway/GatewayRuntimeGovernance.cs
@@ -555,13 +555,17 @@ public sealed class GatewayRequestExecutionStore
     {
         var multipartFiles = request.MultipartFiles?
             .OrderBy(x => x.Key, StringComparer.Ordinal)
-            .Select(x => new
+            .Select(x =>
             {
-                FieldName = x.Key,
-                x.Value.FileName,
-                x.Value.MimeType,
-                SizeBytes = x.Value.Content.LongLength,
-                Sha256 = Convert.ToHexString(SHA256.HashData(x.Value.Content)).ToLowerInvariant(),
+                var content = x.Value.Content ?? Array.Empty<byte>();
+                return new
+                {
+                    FieldName = x.Key,
+                    x.Value.FileName,
+                    x.Value.MimeType,
+                    SizeBytes = content.LongLength,
+                    Sha256 = Convert.ToHexString(SHA256.HashData(content)).ToLowerInvariant(),
+                };
             })
             .ToArray();
         var multipartRefs = request.MultipartFileRefs?

--- a/prd-api/src/PrdAgent.LlmGateway/GatewayRuntimeGovernance.cs
+++ b/prd-api/src/PrdAgent.LlmGateway/GatewayRuntimeGovernance.cs
@@ -713,7 +713,7 @@ public sealed class GatewayDataLifecycleWorker : BackgroundService
 
     private async Task RunOnceAsync(CancellationToken ct)
     {
-        var tenantId = _configuration["LlmGateway:InternalTenantId"]?.Trim() is { Length: > 0 } configuredTenantId
+        var internalTenantId = _configuration["LlmGateway:InternalTenantId"]?.Trim() is { Length: > 0 } configuredTenantId
             ? configuredTenantId
             : GatewayTenantDefaults.InternalTenantId;
         var now = DateTime.UtcNow;
@@ -723,45 +723,58 @@ public sealed class GatewayDataLifecycleWorker : BackgroundService
         var shadowDays = Math.Max(1, _configuration.GetValue("LlmGateway:Retention:ShadowDays", 30));
         var auditDays = Math.Max(1, _configuration.GetValue("LlmGateway:Retention:AuditDays", 180));
         var logs = _data.Database.GetCollection<MongoDB.Bson.BsonDocument>("llmrequestlogs");
-        var sensitiveFilter = Builders<MongoDB.Bson.BsonDocument>.Filter.Eq("TenantId", tenantId)
-                              & Builders<MongoDB.Bson.BsonDocument>.Filter.Lt("StartedAt", now.AddDays(-sensitiveDays))
-                              & Builders<MongoDB.Bson.BsonDocument>.Filter.Or(
-                                  Builders<MongoDB.Bson.BsonDocument>.Filter.Ne("RequestBodyRedacted", ""),
-                                  Builders<MongoDB.Bson.BsonDocument>.Filter.Exists("QuestionText", true),
-                                  Builders<MongoDB.Bson.BsonDocument>.Filter.Exists("AnswerText", true),
-                                  Builders<MongoDB.Bson.BsonDocument>.Filter.Exists("ThinkingText", true));
-        var sensitiveCount = await logs.CountDocumentsAsync(sensitiveFilter, cancellationToken: ct);
         var multipart = _data.Database.GetCollection<GatewayMultipartObjectRecord>("llmgw_multipart_objects");
-        var expiredFilter = Builders<GatewayMultipartObjectRecord>.Filter.Eq(x => x.TenantId, tenantId)
-                            & Builders<GatewayMultipartObjectRecord>.Filter.Ne(x => x.Status, "deleted")
-                            & Builders<GatewayMultipartObjectRecord>.Filter.Lte(x => x.ExpiresAt, now);
-        var expiredMultipartCount = await multipart.CountDocumentsAsync(expiredFilter, cancellationToken: ct);
-        var expired = await multipart.Find(expiredFilter).SortBy(x => x.ExpiresAt).Limit(200).ToListAsync(ct);
         var indexStatus = await ReadRetentionIndexStatusAsync(ct);
         var lifecycle = _data.Database.GetCollection<GatewayLifecycleRunRecord>("llmgw_lifecycle_runs");
-        var run = new GatewayLifecycleRunRecord
+        var tenantIds = await ResolveLifecycleTenantIdsAsync(internalTenantId, ct);
+        var passes = new List<(
+            string TenantId,
+            FilterDefinition<MongoDB.Bson.BsonDocument> SensitiveFilter,
+            long SensitiveCount,
+            IReadOnlyList<GatewayMultipartObjectRecord> ExpiredMultipart,
+            long ExpiredMultipartCount,
+            GatewayLifecycleRunRecord Run)>(tenantIds.Count);
+
+        foreach (var tenantId in tenantIds)
         {
-            TenantId = tenantId,
-            Mode = apply ? "apply" : "dry-run",
-            Status = "dry-run-complete",
-            StartedAt = now,
-            DryRunCompletedAt = DateTime.UtcNow,
-            SensitiveLogs = sensitiveCount,
-            ExpiredRequestLogs = await CountExpiredAsync(tenantId, "llmrequestlogs", "StartedAt", now.AddDays(-requestLogDays), ct),
-            ExpiredShadowComparisons = await CountExpiredAsync(tenantId, "llmshadow_comparisons", "ComparedAt", now.AddDays(-shadowDays), ct),
-            ExpiredOperationAudits = await CountExpiredAsync(tenantId, "llmgw_operation_audits", "CreatedAt", now.AddDays(-auditDays), ct),
-            ExpiredLoginAudits = await CountExpiredAsync(tenantId, "llmgw_login_audits", "CreatedAt", now.AddDays(-auditDays), ct),
-            ExpiredMultipartObjects = expiredMultipartCount,
-            OldestExpiredRequestLogAt = await OldestAsync(tenantId, "llmrequestlogs", "StartedAt", Builders<MongoDB.Bson.BsonDocument>.Filter.Lt("StartedAt", now.AddDays(-requestLogDays)), ct),
-            OldestSensitiveLogAt = await OldestAsync(tenantId, "llmrequestlogs", "StartedAt", sensitiveFilter, ct),
-            OldestExpiredShadowAt = await OldestAsync(tenantId, "llmshadow_comparisons", "ComparedAt", Builders<MongoDB.Bson.BsonDocument>.Filter.Lt("ComparedAt", now.AddDays(-shadowDays)), ct),
-            OldestExpiredOperationAuditAt = await OldestAsync(tenantId, "llmgw_operation_audits", "CreatedAt", Builders<MongoDB.Bson.BsonDocument>.Filter.Lt("CreatedAt", now.AddDays(-auditDays)), ct),
-            OldestExpiredLoginAuditAt = await OldestAsync(tenantId, "llmgw_login_audits", "CreatedAt", Builders<MongoDB.Bson.BsonDocument>.Filter.Lt("CreatedAt", now.AddDays(-auditDays)), ct),
-            OldestExpiredMultipartAt = expired.FirstOrDefault()?.ExpiresAt,
-            RetentionIndexesReady = indexStatus.Count == 0,
-            MissingRetentionIndexes = indexStatus.ToArray(),
-        };
-        await lifecycle.InsertOneAsync(run, cancellationToken: ct);
+            var sensitiveFilter = Builders<MongoDB.Bson.BsonDocument>.Filter.Eq("TenantId", tenantId)
+                                  & Builders<MongoDB.Bson.BsonDocument>.Filter.Lt("StartedAt", now.AddDays(-sensitiveDays))
+                                  & Builders<MongoDB.Bson.BsonDocument>.Filter.Or(
+                                      Builders<MongoDB.Bson.BsonDocument>.Filter.Ne("RequestBodyRedacted", ""),
+                                      Builders<MongoDB.Bson.BsonDocument>.Filter.Exists("QuestionText", true),
+                                      Builders<MongoDB.Bson.BsonDocument>.Filter.Exists("AnswerText", true),
+                                      Builders<MongoDB.Bson.BsonDocument>.Filter.Exists("ThinkingText", true));
+            var sensitiveCount = await logs.CountDocumentsAsync(sensitiveFilter, cancellationToken: ct);
+            var expiredFilter = Builders<GatewayMultipartObjectRecord>.Filter.Eq(x => x.TenantId, tenantId)
+                                & Builders<GatewayMultipartObjectRecord>.Filter.Ne(x => x.Status, "deleted")
+                                & Builders<GatewayMultipartObjectRecord>.Filter.Lte(x => x.ExpiresAt, now);
+            var expiredMultipartCount = await multipart.CountDocumentsAsync(expiredFilter, cancellationToken: ct);
+            var expired = await multipart.Find(expiredFilter).SortBy(x => x.ExpiresAt).Limit(200).ToListAsync(ct);
+            var run = new GatewayLifecycleRunRecord
+            {
+                TenantId = tenantId,
+                Mode = apply ? "apply" : "dry-run",
+                Status = "dry-run-complete",
+                StartedAt = now,
+                DryRunCompletedAt = DateTime.UtcNow,
+                SensitiveLogs = sensitiveCount,
+                ExpiredRequestLogs = await CountExpiredAsync(tenantId, "llmrequestlogs", "StartedAt", now.AddDays(-requestLogDays), ct),
+                ExpiredShadowComparisons = await CountExpiredAsync(tenantId, "llmshadow_comparisons", "ComparedAt", now.AddDays(-shadowDays), ct),
+                ExpiredOperationAudits = await CountExpiredAsync(tenantId, "llmgw_operation_audits", "CreatedAt", now.AddDays(-auditDays), ct),
+                ExpiredLoginAudits = await CountExpiredAsync(tenantId, "llmgw_login_audits", "CreatedAt", now.AddDays(-auditDays), ct),
+                ExpiredMultipartObjects = expiredMultipartCount,
+                OldestExpiredRequestLogAt = await OldestAsync(tenantId, "llmrequestlogs", "StartedAt", Builders<MongoDB.Bson.BsonDocument>.Filter.Lt("StartedAt", now.AddDays(-requestLogDays)), ct),
+                OldestSensitiveLogAt = await OldestAsync(tenantId, "llmrequestlogs", "StartedAt", sensitiveFilter, ct),
+                OldestExpiredShadowAt = await OldestAsync(tenantId, "llmshadow_comparisons", "ComparedAt", Builders<MongoDB.Bson.BsonDocument>.Filter.Lt("ComparedAt", now.AddDays(-shadowDays)), ct),
+                OldestExpiredOperationAuditAt = await OldestAsync(tenantId, "llmgw_operation_audits", "CreatedAt", Builders<MongoDB.Bson.BsonDocument>.Filter.Lt("CreatedAt", now.AddDays(-auditDays)), ct),
+                OldestExpiredLoginAuditAt = await OldestAsync(tenantId, "llmgw_login_audits", "CreatedAt", Builders<MongoDB.Bson.BsonDocument>.Filter.Lt("CreatedAt", now.AddDays(-auditDays)), ct),
+                OldestExpiredMultipartAt = expired.FirstOrDefault()?.ExpiresAt,
+                RetentionIndexesReady = indexStatus.Count == 0,
+                MissingRetentionIndexes = indexStatus.ToArray(),
+            };
+            await lifecycle.InsertOneAsync(run, cancellationToken: ct);
+            passes.Add((tenantId, sensitiveFilter, sensitiveCount, expired, expiredMultipartCount, run));
+        }
 
         // Budget reservation expiry is runtime accounting, not data retention. It must run
         // even while destructive retention remains in dry-run mode.
@@ -771,61 +784,98 @@ public sealed class GatewayDataLifecycleWorker : BackgroundService
         {
             await _databaseInitializer.EnsureRetentionTtlIndexesAsync(ct);
             indexStatus = await ReadRetentionIndexStatusAsync(ct);
-            await lifecycle.UpdateOneAsync(x => x.TenantId == tenantId && x.Id == run.Id,
-                Builders<GatewayLifecycleRunRecord>.Update
-                    .Set(x => x.RetentionIndexesReady, indexStatus.Count == 0)
-                    .Set(x => x.MissingRetentionIndexes, indexStatus.ToArray()),
-                cancellationToken: ct);
+            foreach (var pass in passes)
+            {
+                await lifecycle.UpdateOneAsync(x => x.TenantId == pass.TenantId && x.Id == pass.Run.Id,
+                    Builders<GatewayLifecycleRunRecord>.Update
+                        .Set(x => x.RetentionIndexesReady, indexStatus.Count == 0)
+                        .Set(x => x.MissingRetentionIndexes, indexStatus.ToArray()),
+                    cancellationToken: ct);
+            }
         }
 
         if (apply)
         {
-            var redacted = sensitiveCount > 0
-                ? (await logs.UpdateManyAsync(sensitiveFilter,
-                    Builders<MongoDB.Bson.BsonDocument>.Update
-                        .Set("RequestBodyRedacted", "[retention-redacted]")
-                        .Unset("QuestionText")
-                        .Unset("AnswerText")
-                        .Unset("ThinkingText")
-                        .Unset("SystemPromptText")
-                        .Unset("ResponseToolCalls"),
-                    cancellationToken: ct)).ModifiedCount
-                : 0;
-            long deleted = 0;
-            foreach (var item in expired)
+            foreach (var pass in passes)
             {
-                try
+                var redacted = pass.SensitiveCount > 0
+                    ? (await logs.UpdateManyAsync(pass.SensitiveFilter,
+                        Builders<MongoDB.Bson.BsonDocument>.Update
+                            .Set("RequestBodyRedacted", "[retention-redacted]")
+                            .Unset("QuestionText")
+                            .Unset("AnswerText")
+                            .Unset("ThinkingText")
+                            .Unset("SystemPromptText")
+                            .Unset("ResponseToolCalls"),
+                        cancellationToken: ct)).ModifiedCount
+                    : 0;
+                long deleted = 0;
+                foreach (var item in pass.ExpiredMultipart)
                 {
-                    await _storage.DeleteByKeyAsync(item.RefKey, ct);
-                    await multipart.UpdateOneAsync(x => x.TenantId == tenantId && x.Id == item.Id,
-                        Builders<GatewayMultipartObjectRecord>.Update
-                            .Set(x => x.Status, "deleted")
-                            .Set(x => x.DeletedAt, DateTime.UtcNow)
-                            .Set(x => x.UpdatedAt, DateTime.UtcNow), cancellationToken: ct);
-                    deleted++;
+                    try
+                    {
+                        await _storage.DeleteByKeyAsync(item.RefKey, ct);
+                        await multipart.UpdateOneAsync(x => x.TenantId == pass.TenantId && x.Id == item.Id,
+                            Builders<GatewayMultipartObjectRecord>.Update
+                                .Set(x => x.Status, "deleted")
+                                .Set(x => x.DeletedAt, DateTime.UtcNow)
+                                .Set(x => x.UpdatedAt, DateTime.UtcNow), cancellationToken: ct);
+                        deleted++;
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex,
+                            "[GatewayLifecycle] multipart cleanup failed tenant={TenantId} ref={RefKey}",
+                            pass.TenantId,
+                            item.RefKey);
+                    }
                 }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex, "[GatewayLifecycle] multipart cleanup failed ref={RefKey}", item.RefKey);
-                }
-            }
 
-            await lifecycle.UpdateOneAsync(x => x.TenantId == tenantId && x.Id == run.Id,
-                Builders<GatewayLifecycleRunRecord>.Update
-                    .Set(x => x.Status, "applied")
-                    .Set(x => x.RedactedSensitiveLogs, redacted)
-                    .Set(x => x.DeletedMultipartObjects, deleted)
-                    .Set(x => x.CompletedAt, DateTime.UtcNow),
-                cancellationToken: ct);
+                await lifecycle.UpdateOneAsync(x => x.TenantId == pass.TenantId && x.Id == pass.Run.Id,
+                    Builders<GatewayLifecycleRunRecord>.Update
+                        .Set(x => x.Status, "applied")
+                        .Set(x => x.RedactedSensitiveLogs, redacted)
+                        .Set(x => x.DeletedMultipartObjects, deleted)
+                        .Set(x => x.CompletedAt, DateTime.UtcNow),
+                    cancellationToken: ct);
+            }
         }
 
         _logger.LogInformation(
-            "[GatewayLifecycle] mode={Mode} sensitiveLogs={SensitiveLogs} expiredMultipart={ExpiredMultipart} indexesReady={IndexesReady} runId={RunId}",
+            "[GatewayLifecycle] mode={Mode} tenants={TenantCount} sensitiveLogs={SensitiveLogs} expiredMultipart={ExpiredMultipart} indexesReady={IndexesReady} runIds={RunIds}",
             apply ? "apply" : "dry-run",
-            sensitiveCount,
-            expiredMultipartCount,
+            passes.Count,
+            passes.Sum(x => x.SensitiveCount),
+            passes.Sum(x => x.ExpiredMultipartCount),
             indexStatus.Count == 0,
-            run.Id);
+            string.Join(',', passes.Select(x => x.Run.Id)));
+    }
+
+    private async Task<List<string>> ResolveLifecycleTenantIdsAsync(string internalTenantId, CancellationToken ct)
+    {
+        var tenantIds = new HashSet<string>(StringComparer.Ordinal) { internalTenantId };
+        var tenantCollections = new[]
+        {
+            "llmgw_tenants",
+            "llmrequestlogs",
+            "llmshadow_comparisons",
+            "llmgw_operation_audits",
+            "llmgw_login_audits",
+            "llmgw_lifecycle_runs",
+            "llmgw_multipart_objects",
+        };
+        var validTenant = Builders<MongoDB.Bson.BsonDocument>.Filter.And(
+            Builders<MongoDB.Bson.BsonDocument>.Filter.Type("TenantId", MongoDB.Bson.BsonType.String),
+            Builders<MongoDB.Bson.BsonDocument>.Filter.Ne("TenantId", ""));
+        foreach (var collectionName in tenantCollections)
+        {
+            var values = await _data.Database.GetCollection<MongoDB.Bson.BsonDocument>(collectionName)
+                .Distinct<string>("TenantId", validTenant)
+                .ToListAsync(ct);
+            foreach (var value in values.Where(x => !string.IsNullOrWhiteSpace(x)))
+                tenantIds.Add(value.Trim());
+        }
+        return tenantIds.OrderBy(x => x, StringComparer.Ordinal).ToList();
     }
 
     private async Task<long> CountExpiredAsync(string tenantId, string collectionName, string field, DateTime cutoff, CancellationToken ct)

--- a/prd-api/src/PrdAgent.LlmGateway/Program.cs
+++ b/prd-api/src/PrdAgent.LlmGateway/Program.cs
@@ -55,7 +55,8 @@ builder.Services.AddSingleton<ILlmRequestLogWriter>(sp =>
         sp.GetRequiredService<ILogger<LlmRequestLogWriter>>(),
         sp.GetRequiredService<LlmRequestLogBackground>(),
         sp.GetRequiredService<PrdAgent.Core.Interfaces.IAppSettingsService>(),
-        sp.GetRequiredService<IAssetStorage>()));
+        sp.GetRequiredService<IAssetStorage>(),
+        sp.GetRequiredService<IConfiguration>()));
 builder.Services.AddSingleton<ILlmShadowComparisonWriter>(sp =>
     new LlmShadowComparisonWriter(
         sp.GetRequiredService<LlmGatewayDataContext>().Context,

--- a/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayKeyGateContractTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayKeyGateContractTests.cs
@@ -1076,7 +1076,8 @@ public class GatewayKeyGateContractTests
     public async Task OpenAiImagesCompatibleEndpoint_AcceptsBearerGatewayKey()
     {
         var gateway = new EchoingGateway();
-        await using var app = BuildHostWithGateway(gateway);
+        var authorizer = new CapturingScopedKeyAuthorizer(_ => true);
+        await using var app = BuildHostWithGateway(gateway, keyAuthorizer: authorizer);
         await app.StartAsync();
         try
         {
@@ -1091,7 +1092,8 @@ public class GatewayKeyGateContractTests
                     background = "transparent",
                 }),
             };
-            req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GatewayKey);
+            req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", "scoped-test-key");
+            req.Headers.Add("X-Gateway-Source", "external");
 
             var resp = await client.SendAsync(req);
             var body = await resp.Content.ReadAsStringAsync();
@@ -1103,6 +1105,7 @@ public class GatewayKeyGateContractTests
             gateway.LastRawRequest.ModelType.ShouldBe("generation");
             gateway.LastRawRequest.ExpectedModel.ShouldBe("image-picked");
             gateway.LastRawRequest.Context.ShouldNotBeNull();
+            gateway.LastRawRequest.Context!.TenantId.ShouldBe("tenant-test");
             var dropped = gateway.LastRawRequest.Context!.DroppedParameters;
             dropped.ShouldNotBeNull();
             dropped!.ShouldContain("background");

--- a/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayKeyGateContractTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayKeyGateContractTests.cs
@@ -221,7 +221,7 @@ public class GatewayKeyGateContractTests
         try
         {
             var registry = app.Services.GetRequiredService<GatewayCancellationRegistry>();
-            using var lease = registry.Register("demo.app::chat", "cancel-me");
+            using var lease = registry.Register(GatewayTenantDefaults.InternalTenantId, "demo.app::chat", "cancel-me");
             var request = new HttpRequestMessage(HttpMethod.Post, "/gw/v1/requests/cancel-me/cancel");
             request.Headers.Add("X-Gateway-Key", GatewayKey);
             request.Headers.Add("X-Gateway-App-Caller", "demo.app::chat");
@@ -245,7 +245,7 @@ public class GatewayKeyGateContractTests
         try
         {
             var registry = app.Services.GetRequiredService<GatewayCancellationRegistry>();
-            using var lease = registry.Register("caller-b::chat", "shared-request-id");
+            using var lease = registry.Register(GatewayTenantDefaults.InternalTenantId, "caller-b::chat", "shared-request-id");
             var request = new HttpRequestMessage(HttpMethod.Post, "/gw/v1/requests/shared-request-id/cancel");
             request.Headers.Add("X-Gateway-Key", GatewayKey);
             request.Headers.Add("X-Gateway-App-Caller", "caller-a::chat");
@@ -2193,7 +2193,8 @@ public class GatewayKeyGateContractTests
                 allowed ? 200 : 403,
                 allowed ? string.Empty : "GATEWAY_KEY_SCOPE_DENIED",
                 allowed ? "allowed" : "scope denied",
-                "capturing-key"));
+                "capturing-key",
+                "tenant-test"));
         }
     }
 

--- a/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayKeyGateContractTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayKeyGateContractTests.cs
@@ -1151,6 +1151,45 @@ public class GatewayKeyGateContractTests
     }
 
     [Fact]
+    public async Task ResolveAndPools_UseVerifiedScopedKeyTenant()
+    {
+        var contextAccessor = new PrdAgent.Core.Services.LLMRequestContextAccessor();
+        var gateway = new EchoingGateway(contextAccessor);
+        var authorizer = new CapturingScopedKeyAuthorizer(_ => true);
+        await using var app = BuildHostWithGateway(gateway, keyAuthorizer: authorizer, contextAccessor: contextAccessor);
+        await app.StartAsync();
+        try
+        {
+            var resolve = new HttpRequestMessage(HttpMethod.Post, "/gw/v1/resolve")
+            {
+                Content = JsonContent.Create(new
+                {
+                    AppCallerCode = "external.resolve::chat",
+                    ModelType = "chat",
+                }),
+            };
+            resolve.Headers.Add("X-Gateway-Key", "scoped-test-key");
+            var resolveResponse = await app.GetTestClient().SendAsync(resolve);
+
+            resolveResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+            gateway.LastResolveTenantId.ShouldBe("tenant-test");
+
+            var pools = new HttpRequestMessage(
+                HttpMethod.Get,
+                "/gw/v1/pools?appCallerCode=external.resolve%3A%3Achat&modelType=chat");
+            pools.Headers.Add("X-Gateway-Key", "scoped-test-key");
+            var poolsResponse = await app.GetTestClient().SendAsync(pools);
+
+            poolsResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+            gateway.LastPoolsTenantId.ShouldBe("tenant-test");
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    [Fact]
     public async Task OpenAiImagesCompatibleEndpoint_PreservesPinnedTargetProviderMetadata()
     {
         var gateway = new EchoingGateway();
@@ -2352,6 +2391,7 @@ public class GatewayKeyGateContractTests
         public GatewayRawRequest? LastRawRequest { get; private set; }
         public string? LastResolveTenantId { get; private set; }
         public string? LastCreateClientTenantId { get; private set; }
+        public string? LastPoolsTenantId { get; private set; }
         public string? LastResolveExpectedModel { get; private set; }
         public string? LastResolvePinnedPlatformId { get; private set; }
         public string? LastResolvePinnedModelId { get; private set; }
@@ -2477,7 +2517,11 @@ public class GatewayKeyGateContractTests
             return Task.FromResult(Resolve(expectedModel));
         }
 
-        public Task<List<AvailableModelPool>> GetAvailablePoolsAsync(string appCallerCode, string modelType, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<List<AvailableModelPool>> GetAvailablePoolsAsync(string appCallerCode, string modelType, CancellationToken ct = default)
+        {
+            LastPoolsTenantId = _contextAccessor?.Current?.TenantId;
+            return Task.FromResult(new List<AvailableModelPool>());
+        }
 
         public ILLMClient CreateClient(string appCallerCode, string modelType, int maxTokens = 4096, double temperature = 0.2, bool includeThinking = false, string? expectedModel = null, string? pinnedPlatformId = null, string? pinnedModelId = null)
         {

--- a/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayKeyGateContractTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayKeyGateContractTests.cs
@@ -435,7 +435,6 @@ public class GatewayKeyGateContractTests
                 }),
             };
             request.Headers.Add("X-Gateway-Key", "scoped-test-key");
-            request.Headers.Add("X-Gateway-Source", "external");
 
             var response = await app.GetTestClient().SendAsync(request);
 
@@ -1075,9 +1074,10 @@ public class GatewayKeyGateContractTests
     [Fact]
     public async Task OpenAiImagesCompatibleEndpoint_AcceptsBearerGatewayKey()
     {
-        var gateway = new EchoingGateway();
+        var contextAccessor = new PrdAgent.Core.Services.LLMRequestContextAccessor();
+        var gateway = new EchoingGateway(contextAccessor);
         var authorizer = new CapturingScopedKeyAuthorizer(_ => true);
-        await using var app = BuildHostWithGateway(gateway, keyAuthorizer: authorizer);
+        await using var app = BuildHostWithGateway(gateway, keyAuthorizer: authorizer, contextAccessor: contextAccessor);
         await app.StartAsync();
         try
         {
@@ -1106,9 +1106,43 @@ public class GatewayKeyGateContractTests
             gateway.LastRawRequest.ExpectedModel.ShouldBe("image-picked");
             gateway.LastRawRequest.Context.ShouldNotBeNull();
             gateway.LastRawRequest.Context!.TenantId.ShouldBe("tenant-test");
+            gateway.LastResolveTenantId.ShouldBe("tenant-test");
             var dropped = gateway.LastRawRequest.Context!.DroppedParameters;
             dropped.ShouldNotBeNull();
             dropped!.ShouldContain("background");
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    [Fact]
+    public async Task ClientStream_UsesGovernedTenantWhenBodyContextIsMissing()
+    {
+        var contextAccessor = new PrdAgent.Core.Services.LLMRequestContextAccessor();
+        var gateway = new EchoingGateway(contextAccessor);
+        var authorizer = new CapturingScopedKeyAuthorizer(_ => true);
+        await using var app = BuildHostWithGateway(gateway, keyAuthorizer: authorizer, contextAccessor: contextAccessor);
+        await app.StartAsync();
+        try
+        {
+            var request = new HttpRequestMessage(HttpMethod.Post, "/gw/v1/client-stream")
+            {
+                Content = JsonContent.Create(new
+                {
+                    AppCallerCode = "external.client-stream::chat",
+                    ModelType = "chat",
+                    SystemPrompt = string.Empty,
+                    Messages = Array.Empty<object>(),
+                }),
+            };
+            request.Headers.Add("X-Gateway-Key", "scoped-test-key");
+
+            var response = await app.GetTestClient().SendAsync(request);
+
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+            gateway.LastCreateClientTenantId.ShouldBe("tenant-test");
         }
         finally
         {
@@ -2133,14 +2167,16 @@ public class GatewayKeyGateContractTests
     private static WebApplication BuildHostWithGateway(
         PrdAgent.Infrastructure.LlmGateway.ILlmGateway gateway,
         IGatewayServingReadinessProbe? readinessProbe = null,
-        IGatewayScopedKeyAuthorizer? keyAuthorizer = null)
+        IGatewayScopedKeyAuthorizer? keyAuthorizer = null,
+        ILLMRequestContextAccessor? contextAccessor = null)
     {
         var builder = WebApplication.CreateBuilder();
         builder.Logging.ClearProviders();
         builder.WebHost.UseTestServer();
         builder.Services.ConfigureHttpJsonOptions(o => o.SerializerOptions.PropertyNamingPolicy = null);
         builder.Services.AddSingleton(gateway);
-        builder.Services.AddSingleton<ILLMRequestContextAccessor, PrdAgent.Core.Services.LLMRequestContextAccessor>();
+        builder.Services.AddSingleton<ILLMRequestContextAccessor>(
+            contextAccessor ?? new PrdAgent.Core.Services.LLMRequestContextAccessor());
         builder.Services.AddSingleton<GatewayCancellationRegistry>();
         if (readinessProbe != null)
             builder.Services.AddSingleton(readinessProbe);
@@ -2308,8 +2344,14 @@ public class GatewayKeyGateContractTests
 
     private sealed class EchoingGateway : PrdAgent.Infrastructure.LlmGateway.ILlmGateway
     {
+        private readonly ILLMRequestContextAccessor? _contextAccessor;
+
+        public EchoingGateway(ILLMRequestContextAccessor? contextAccessor = null) => _contextAccessor = contextAccessor;
+
         public GatewayRequest? LastRequest { get; private set; }
         public GatewayRawRequest? LastRawRequest { get; private set; }
+        public string? LastResolveTenantId { get; private set; }
+        public string? LastCreateClientTenantId { get; private set; }
         public string? LastResolveExpectedModel { get; private set; }
         public string? LastResolvePinnedPlatformId { get; private set; }
         public string? LastResolvePinnedModelId { get; private set; }
@@ -2428,6 +2470,7 @@ public class GatewayKeyGateContractTests
 
         public Task<GatewayModelResolution> ResolveModelAsync(string appCallerCode, string modelType, string? expectedModel = null, string? pinnedPlatformId = null, string? pinnedModelId = null, CancellationToken ct = default)
         {
+            LastResolveTenantId = _contextAccessor?.Current?.TenantId;
             LastResolveExpectedModel = expectedModel;
             LastResolvePinnedPlatformId = pinnedPlatformId;
             LastResolvePinnedModelId = pinnedModelId;
@@ -2436,6 +2479,31 @@ public class GatewayKeyGateContractTests
 
         public Task<List<AvailableModelPool>> GetAvailablePoolsAsync(string appCallerCode, string modelType, CancellationToken ct = default) => throw new NotSupportedException();
 
-        public ILLMClient CreateClient(string appCallerCode, string modelType, int maxTokens = 4096, double temperature = 0.2, bool includeThinking = false, string? expectedModel = null, string? pinnedPlatformId = null, string? pinnedModelId = null) => throw new NotSupportedException();
+        public ILLMClient CreateClient(string appCallerCode, string modelType, int maxTokens = 4096, double temperature = 0.2, bool includeThinking = false, string? expectedModel = null, string? pinnedPlatformId = null, string? pinnedModelId = null)
+        {
+            LastCreateClientTenantId = _contextAccessor?.Current?.TenantId;
+            return new EchoingLlmClient();
+        }
+
+        private sealed class EchoingLlmClient : ILLMClient
+        {
+            public string Provider => "test";
+
+            public IAsyncEnumerable<LLMStreamChunk> StreamGenerateAsync(
+                string systemPrompt,
+                List<LLMMessage> messages,
+                CancellationToken cancellationToken = default)
+                => StreamGenerateAsync(systemPrompt, messages, false, cancellationToken);
+
+            public async IAsyncEnumerable<LLMStreamChunk> StreamGenerateAsync(
+                string systemPrompt,
+                List<LLMMessage> messages,
+                bool enablePromptCache,
+                [EnumeratorCancellation] CancellationToken cancellationToken = default)
+            {
+                await Task.Yield();
+                yield return new LLMStreamChunk { Type = "done" };
+            }
+        }
     }
 }

--- a/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayMultipartHttpTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayMultipartHttpTests.cs
@@ -247,6 +247,75 @@ public class GatewayMultipartHttpTests
     }
 
     [Fact]
+    public async Task ScopedRawEndpoint_DoesNotCleanupUnverifiedRefsWhenInlineFilesBypassRehydration()
+    {
+        var testDatabase = await TryCreateDatabaseAsync();
+        if (testDatabase is null) return;
+        await using var scope = testDatabase;
+        var victimBytes = Encoding.UTF8.GetBytes("tenant-b-secret-image");
+        var inlineBytes = Encoding.UTF8.GetBytes("tenant-a-inline-image");
+        const string key = "llmgw/multipart/tenant-b/mixed-image.png";
+        var storage = new MemoryAssetStorage();
+        await storage.UploadToKeyAsync(key, victimBytes, "image/png", CancellationToken.None);
+        await scope.Context.Database.GetCollection<GatewayMultipartObjectRecord>("llmgw_multipart_objects")
+            .InsertOneAsync(new GatewayMultipartObjectRecord
+            {
+                TenantId = "tenant-b",
+                RefKey = key,
+                Sha256 = Sha256Hex(victimBytes),
+                SizeBytes = victimBytes.LongLength,
+                Status = "uploaded",
+            });
+
+        await using var app = BuildHost(
+            storage,
+            new CapturingGateway(),
+            scope.Context,
+            new StaticTenantKeyAuthorizer("tenant-a"));
+        await app.StartAsync();
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Post, "/gw/v1/raw")
+            {
+                Content = JsonContent.Create(new GatewayRawRequest
+                {
+                    AppCallerCode = "tenant-a.app::vision",
+                    ModelType = "vision",
+                    IsMultipart = true,
+                    Context = new GatewayRequestContext { TenantId = "tenant-b" },
+                    MultipartFiles = new Dictionary<string, (string FileName, byte[] Content, string MimeType)>
+                    {
+                        ["inline"] = ("inline.png", inlineBytes, "image/png"),
+                    },
+                    MultipartFileRefs = new Dictionary<string, MultipartFileRef>
+                    {
+                        ["victim"] = new()
+                        {
+                            RefKey = key,
+                            FileName = "mixed-image.png",
+                            MimeType = "image/png",
+                            SizeBytes = victimBytes.LongLength,
+                            Sha256 = Sha256Hex(victimBytes),
+                        },
+                    },
+                }, options: PascalJson),
+            };
+            request.Headers.Add("X-Gateway-Key", "tenant-a-scoped-key");
+
+            var response = await app.GetTestClient().SendAsync(request);
+
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+            storage.DownloadCount.ShouldBe(0);
+            storage.DeleteCount.ShouldBe(0);
+            (await storage.ExistsAsync(key, CancellationToken.None)).ShouldBeTrue();
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    [Fact]
     public async Task RawEndpoint_RejectsMultipartRefHashMismatch()
     {
         var bytes = Encoding.UTF8.GetBytes("real-bytes");

--- a/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayMultipartHttpTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayMultipartHttpTests.cs
@@ -192,6 +192,7 @@ public class GatewayMultipartHttpTests
                         AppCallerCode = "tenant-a.app::vision",
                         ModelType = "vision",
                         IsMultipart = true,
+                        Context = new GatewayRequestContext { TenantId = "tenant-b" },
                         MultipartFileRefs = new Dictionary<string, MultipartFileRef>
                         {
                             ["image"] = new()
@@ -219,6 +220,7 @@ public class GatewayMultipartHttpTests
             raw.ShouldNotBeNull();
             raw!.ErrorCode.ShouldBe("MULTIPART_REF_NOT_FOUND");
             storage.DownloadCount.ShouldBe(0);
+            storage.DeleteCount.ShouldBe(0);
             gateway.CapturedRaw.ShouldBeNull();
 
             await scope.Context.Database.GetCollection<GatewayMultipartObjectRecord>("llmgw_multipart_objects")
@@ -235,6 +237,7 @@ public class GatewayMultipartHttpTests
 
             ownTenantResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
             storage.DownloadCount.ShouldBe(1);
+            storage.DeleteCount.ShouldBe(1);
             gateway.CapturedRaw.ShouldNotBeNull();
         }
         finally
@@ -379,6 +382,7 @@ public class GatewayMultipartHttpTests
     {
         private readonly Dictionary<string, (byte[] Bytes, string? ContentType)> _objects = new(StringComparer.Ordinal);
         public int DownloadCount { get; private set; }
+        public int DeleteCount { get; private set; }
 
         public Task<StoredAsset> SaveAsync(byte[] bytes, string mime, CancellationToken ct, string? domain = null, string? type = null, string? fileName = null, string? extensionHint = null)
         {
@@ -416,6 +420,7 @@ public class GatewayMultipartHttpTests
 
         public Task DeleteByKeyAsync(string key, CancellationToken ct)
         {
+            DeleteCount++;
             _objects.Remove(key);
             return Task.CompletedTask;
         }

--- a/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayMultipartHttpTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayMultipartHttpTests.cs
@@ -316,6 +316,89 @@ public class GatewayMultipartHttpTests
     }
 
     [Fact]
+    public async Task ScopedRawEndpoint_IdempotencyIgnoresClientReportedTenantContext()
+    {
+        var testDatabase = await TryCreateDatabaseAsync();
+        if (testDatabase is null) return;
+        await using var scope = testDatabase;
+        await scope.Context.Database.GetCollection<GatewayRequestExecutionRecord>("llmgw_request_executions")
+            .Indexes.CreateOneAsync(new CreateIndexModel<GatewayRequestExecutionRecord>(
+                Builders<GatewayRequestExecutionRecord>.IndexKeys
+                    .Ascending(x => x.TenantId)
+                    .Ascending(x => x.AppCallerCode)
+                    .Ascending(x => x.RequestId)
+                    .Ascending(x => x.Operation),
+                new CreateIndexOptions { Unique = true }));
+        var bytes = Encoding.UTF8.GetBytes("tenant-a-owned-image");
+        const string key = "llmgw/multipart/tenant-a/idempotent-image.png";
+        var storage = new MemoryAssetStorage();
+        await storage.UploadToKeyAsync(key, bytes, "image/png", CancellationToken.None);
+        await scope.Context.Database.GetCollection<GatewayMultipartObjectRecord>("llmgw_multipart_objects")
+            .InsertOneAsync(new GatewayMultipartObjectRecord
+            {
+                TenantId = "tenant-a",
+                RefKey = key,
+                Sha256 = Sha256Hex(bytes),
+                SizeBytes = bytes.LongLength,
+                Status = "uploaded",
+            });
+
+        await using var app = BuildHost(
+            storage,
+            new CapturingGateway(),
+            scope.Context,
+            new StaticTenantKeyAuthorizer("tenant-a"));
+        await app.StartAsync();
+        try
+        {
+            HttpRequestMessage CreateRequest(string clientTenantId)
+            {
+                var request = new HttpRequestMessage(HttpMethod.Post, "/gw/v1/raw")
+                {
+                    Content = JsonContent.Create(new GatewayRawRequest
+                    {
+                        AppCallerCode = "tenant-a.app::vision",
+                        ModelType = "vision",
+                        IsMultipart = true,
+                        Context = new GatewayRequestContext
+                        {
+                            TenantId = clientTenantId,
+                            RequestId = "stable-idempotency-request",
+                        },
+                        MultipartFileRefs = new Dictionary<string, MultipartFileRef>
+                        {
+                            ["image"] = new()
+                            {
+                                RefKey = key,
+                                FileName = "image.png",
+                                MimeType = "image/png",
+                                SizeBytes = bytes.LongLength,
+                                Sha256 = Sha256Hex(bytes),
+                            },
+                        },
+                    }, options: PascalJson),
+                };
+                request.Headers.Add("X-Gateway-Key", "tenant-a-scoped-key");
+                return request;
+            }
+
+            using var firstRequest = CreateRequest("tenant-a");
+            var first = await app.GetTestClient().SendAsync(firstRequest);
+            using var retryRequest = CreateRequest("tenant-b-client-spoof");
+            var retry = await app.GetTestClient().SendAsync(retryRequest);
+
+            first.StatusCode.ShouldBe(HttpStatusCode.OK);
+            retry.StatusCode.ShouldBe(HttpStatusCode.OK);
+            storage.DownloadCount.ShouldBe(1);
+            storage.DeleteCount.ShouldBe(1);
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    [Fact]
     public async Task RawEndpoint_RejectsMultipartRefHashMismatch()
     {
         var bytes = Encoding.UTF8.GetBytes("real-bytes");
@@ -379,7 +462,11 @@ public class GatewayMultipartHttpTests
         builder.Services.AddSingleton<IAssetStorage>(storage);
         builder.Services.AddSingleton<PrdAgent.Infrastructure.LlmGateway.ILlmGateway>(gateway);
         builder.Services.AddSingleton<ILLMRequestContextAccessor, PrdAgent.Core.Services.LLMRequestContextAccessor>();
-        if (data is not null) builder.Services.AddSingleton(data);
+        if (data is not null)
+        {
+            builder.Services.AddSingleton(data);
+            builder.Services.AddSingleton(new GatewayRequestExecutionStore(data));
+        }
         if (keyAuthorizer is not null) builder.Services.AddSingleton(keyAuthorizer);
 
         var app = builder.Build();

--- a/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayMultipartHttpTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayMultipartHttpTests.cs
@@ -12,7 +12,10 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using MongoDB.Bson;
+using MongoDB.Driver;
 using PrdAgent.Core.Interfaces;
+using PrdAgent.Infrastructure.Database;
 using PrdAgent.Infrastructure.LlmGateway;
 using PrdAgent.Infrastructure.Services.AssetStorage;
 using PrdAgent.LlmGatewayHost;
@@ -152,6 +155,95 @@ public class GatewayMultipartHttpTests
     }
 
     [Fact]
+    public async Task ScopedRawEndpoint_RejectsMultipartRefOwnedByAnotherTenantBeforeDownload()
+    {
+        var testDatabase = await TryCreateDatabaseAsync();
+        if (testDatabase is null) return;
+        await using var scope = testDatabase;
+        var bytes = Encoding.UTF8.GetBytes("tenant-b-secret-image");
+        const string key = "llmgw/multipart/tenant-b/image.png";
+        var storage = new MemoryAssetStorage();
+        await storage.UploadToKeyAsync(key, bytes, "image/png", CancellationToken.None);
+        await scope.Context.Database.GetCollection<GatewayMultipartObjectRecord>("llmgw_multipart_objects")
+            .InsertOneAsync(new GatewayMultipartObjectRecord
+            {
+                TenantId = "tenant-b",
+                RefKey = key,
+                Sha256 = Sha256Hex(bytes),
+                SizeBytes = bytes.LongLength,
+                Status = "uploaded",
+            });
+        var gateway = new CapturingGateway();
+
+        await using var app = BuildHost(
+            storage,
+            gateway,
+            scope.Context,
+            new StaticTenantKeyAuthorizer("tenant-a"));
+        await app.StartAsync();
+        try
+        {
+            HttpRequestMessage CreateRequest()
+            {
+                var request = new HttpRequestMessage(HttpMethod.Post, "/gw/v1/raw")
+                {
+                    Content = JsonContent.Create(new GatewayRawRequest
+                    {
+                        AppCallerCode = "tenant-a.app::vision",
+                        ModelType = "vision",
+                        IsMultipart = true,
+                        MultipartFileRefs = new Dictionary<string, MultipartFileRef>
+                        {
+                            ["image"] = new()
+                            {
+                                RefKey = key,
+                                FileName = "image.png",
+                                MimeType = "image/png",
+                                SizeBytes = bytes.LongLength,
+                                Sha256 = Sha256Hex(bytes),
+                            },
+                        },
+                    }, options: PascalJson),
+                };
+                request.Headers.Add("X-Gateway-Key", "tenant-a-scoped-key");
+                return request;
+            }
+
+            using var crossTenantRequest = CreateRequest();
+            var response = await app.GetTestClient().SendAsync(crossTenantRequest);
+            var raw = JsonSerializer.Deserialize<GatewayRawResponse>(
+                await response.Content.ReadAsStringAsync(),
+                PascalJson);
+
+            response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+            raw.ShouldNotBeNull();
+            raw!.ErrorCode.ShouldBe("MULTIPART_REF_NOT_FOUND");
+            storage.DownloadCount.ShouldBe(0);
+            gateway.CapturedRaw.ShouldBeNull();
+
+            await scope.Context.Database.GetCollection<GatewayMultipartObjectRecord>("llmgw_multipart_objects")
+                .InsertOneAsync(new GatewayMultipartObjectRecord
+                {
+                    TenantId = "tenant-a",
+                    RefKey = key,
+                    Sha256 = Sha256Hex(bytes),
+                    SizeBytes = bytes.LongLength,
+                    Status = "uploaded",
+                });
+            using var ownTenantRequest = CreateRequest();
+            var ownTenantResponse = await app.GetTestClient().SendAsync(ownTenantRequest);
+
+            ownTenantResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+            storage.DownloadCount.ShouldBe(1);
+            gateway.CapturedRaw.ShouldNotBeNull();
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    [Fact]
     public async Task RawEndpoint_RejectsMultipartRefHashMismatch()
     {
         var bytes = Encoding.UTF8.GetBytes("real-bytes");
@@ -202,7 +294,11 @@ public class GatewayMultipartHttpTests
         }
     }
 
-    private static WebApplication BuildHost(MemoryAssetStorage storage, CapturingGateway gateway)
+    private static WebApplication BuildHost(
+        MemoryAssetStorage storage,
+        CapturingGateway gateway,
+        LlmGatewayDataContext? data = null,
+        IGatewayScopedKeyAuthorizer? keyAuthorizer = null)
     {
         var builder = WebApplication.CreateBuilder();
         builder.Logging.ClearProviders();
@@ -211,6 +307,8 @@ public class GatewayMultipartHttpTests
         builder.Services.AddSingleton<IAssetStorage>(storage);
         builder.Services.AddSingleton<PrdAgent.Infrastructure.LlmGateway.ILlmGateway>(gateway);
         builder.Services.AddSingleton<ILLMRequestContextAccessor, PrdAgent.Core.Services.LLMRequestContextAccessor>();
+        if (data is not null) builder.Services.AddSingleton(data);
+        if (keyAuthorizer is not null) builder.Services.AddSingleton(keyAuthorizer);
 
         var app = builder.Build();
         app.MapGatewayServingEndpoints(PascalJson, GatewayKey, "multipart-http-test");
@@ -228,6 +326,28 @@ public class GatewayMultipartHttpTests
     {
         using var sha = SHA256.Create();
         return Convert.ToHexString(sha.ComputeHash(bytes)).ToLowerInvariant();
+    }
+
+    private static async Task<TestDatabase?> TryCreateDatabaseAsync()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("MONGODB_TEST_CONNECTION")
+                               ?? "mongodb://localhost:27017";
+        var settings = MongoClientSettings.FromConnectionString(connectionString);
+        settings.ServerSelectionTimeout = TimeSpan.FromSeconds(2);
+        var client = new MongoClient(settings);
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+            await client.GetDatabase("admin").RunCommandAsync<BsonDocument>(
+                new BsonDocument("ping", 1),
+                cancellationToken: cts.Token);
+            var databaseName = $"llmgw_multipart_tenant_test_{Guid.NewGuid():N}";
+            return new TestDatabase(client, databaseName, new LlmGatewayDataContext(connectionString, databaseName));
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     private sealed class CapturingHandler : HttpMessageHandler
@@ -258,6 +378,7 @@ public class GatewayMultipartHttpTests
     private sealed class MemoryAssetStorage : IAssetStorage
     {
         private readonly Dictionary<string, (byte[] Bytes, string? ContentType)> _objects = new(StringComparer.Ordinal);
+        public int DownloadCount { get; private set; }
 
         public Task<StoredAsset> SaveAsync(byte[] bytes, string mime, CancellationToken ct, string? domain = null, string? type = null, string? fileName = null, string? extensionHint = null)
         {
@@ -277,7 +398,10 @@ public class GatewayMultipartHttpTests
             => null;
 
         public Task<byte[]?> TryDownloadBytesAsync(string key, CancellationToken ct)
-            => Task.FromResult(_objects.TryGetValue(key, out var value) ? value.Bytes : null);
+        {
+            DownloadCount++;
+            return Task.FromResult(_objects.TryGetValue(key, out var value) ? value.Bytes : null);
+        }
 
         public Task<bool> ExistsAsync(string key, CancellationToken ct)
             => Task.FromResult(_objects.ContainsKey(key));
@@ -351,5 +475,46 @@ public class GatewayMultipartHttpTests
             ActualPlatformId = "platform",
             Protocol = "openai",
         };
+    }
+
+    private sealed class StaticTenantKeyAuthorizer : IGatewayScopedKeyAuthorizer
+    {
+        private readonly string _tenantId;
+
+        public StaticTenantKeyAuthorizer(string tenantId) => _tenantId = tenantId;
+
+        public Task<GatewayKeyAuthorization> AuthorizeAsync(
+            string providedKey,
+            string legacySharedKey,
+            string sourceSystem,
+            string appCallerCode,
+            string ingressProtocol,
+            string requiredScope,
+            CancellationToken ct)
+            => Task.FromResult(new GatewayKeyAuthorization(
+                true,
+                true,
+                200,
+                string.Empty,
+                "allowed",
+                "tenant-key",
+                _tenantId));
+    }
+
+    private sealed class TestDatabase : IAsyncDisposable
+    {
+        private readonly MongoClient _client;
+        private readonly string _databaseName;
+
+        public TestDatabase(MongoClient client, string databaseName, LlmGatewayDataContext context)
+        {
+            _client = client;
+            _databaseName = databaseName;
+            Context = context;
+        }
+
+        public LlmGatewayDataContext Context { get; }
+
+        public async ValueTask DisposeAsync() => await _client.DropDatabaseAsync(_databaseName);
     }
 }

--- a/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayProviderConcurrencyCoordinatorTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayProviderConcurrencyCoordinatorTests.cs
@@ -80,6 +80,50 @@ public sealed class GatewayProviderConcurrencyCoordinatorTests
         if (tenantB.Lease is not null) await tenantB.Lease.DisposeAsync();
     }
 
+    [Fact]
+    public async Task BackfilledLegacySlotId_IsAcquiredAndReleasedWithoutDuplicateInsert()
+    {
+        var testDatabase = await TryCreateDatabaseAsync();
+        if (testDatabase is null) return;
+        await using var scope = testDatabase;
+        var slots = scope.Context.Database.GetCollection<GatewayProviderConcurrencySlotRecord>(
+            "llmgw_provider_concurrency_slots");
+        await slots.Indexes.CreateOneAsync(new CreateIndexModel<GatewayProviderConcurrencySlotRecord>(
+            Builders<GatewayProviderConcurrencySlotRecord>.IndexKeys
+                .Ascending(x => x.TenantId)
+                .Ascending(x => x.ResourceKey)
+                .Ascending(x => x.Slot),
+            new CreateIndexOptions { Unique = true }));
+        await slots.InsertOneAsync(new GatewayProviderConcurrencySlotRecord
+        {
+            Id = "legacy-resource-hash:0",
+            TenantId = "tenant-a",
+            ResourceKey = "platform:legacy-platform",
+            Slot = 0,
+            ExpiresAt = DateTime.UtcNow.AddMinutes(-1),
+        });
+        var coordinator = new GatewayProviderConcurrencyCoordinator(
+            scope.Context,
+            NullLogger<GatewayProviderConcurrencyCoordinator>.Instance);
+
+        var admission = await coordinator.AcquireAsync(
+            "tenant-a",
+            Resolution("legacy-platform", "legacy-model", platformLimit: 1, modelLimit: 0),
+            30,
+            CancellationToken.None);
+
+        admission.Allowed.ShouldBeTrue();
+        var records = await slots.Find(FilterDefinition<GatewayProviderConcurrencySlotRecord>.Empty).ToListAsync();
+        records.Count.ShouldBe(1);
+        records[0].Id.ShouldBe("legacy-resource-hash:0");
+        records[0].LeaseId.ShouldNotBeEmpty();
+
+        admission.Lease.ShouldNotBeNull();
+        await admission.Lease.DisposeAsync();
+        var remaining = await slots.CountDocumentsAsync(FilterDefinition<GatewayProviderConcurrencySlotRecord>.Empty);
+        remaining.ShouldBe(0);
+    }
+
     private static ModelResolutionResult Resolution(string platform, string model, int platformLimit, int modelLimit)
         => new()
         {

--- a/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayProviderConcurrencyCoordinatorTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayProviderConcurrencyCoordinatorTests.cs
@@ -25,7 +25,7 @@ public sealed class GatewayProviderConcurrencyCoordinatorTests
         var resolution = Resolution("platform-a", "model-a", platformLimit: 1, modelLimit: 5);
 
         var admissions = await Task.WhenAll(coordinators.Select(x =>
-            x.AcquireAsync(resolution, timeoutSeconds: 30, CancellationToken.None)));
+            x.AcquireAsync("tenant-a", resolution, timeoutSeconds: 30, CancellationToken.None)));
 
         admissions.Count(x => x.Allowed).ShouldBe(1);
         admissions.Count(x => !x.Allowed && x.ErrorCode == "PROVIDER_CONCURRENCY_EXHAUSTED").ShouldBe(7);
@@ -34,7 +34,7 @@ public sealed class GatewayProviderConcurrencyCoordinatorTests
         winner.ShouldNotBeNull();
         await winner.DisposeAsync();
 
-        var afterRelease = await coordinators[1].AcquireAsync(resolution, 30, CancellationToken.None);
+        var afterRelease = await coordinators[1].AcquireAsync("tenant-a", resolution, 30, CancellationToken.None);
         afterRelease.Allowed.ShouldBeTrue();
         if (afterRelease.Lease is not null) await afterRelease.Lease.DisposeAsync();
     }
@@ -53,12 +53,31 @@ public sealed class GatewayProviderConcurrencyCoordinatorTests
             scope.Context,
             NullLogger<GatewayProviderConcurrencyCoordinator>.Instance);
 
-        var modelA = await first.AcquireAsync(Resolution("platform-a", "model-a", 1, 1), 30, CancellationToken.None);
-        var modelB = await second.AcquireAsync(Resolution("platform-a", "model-b", 1, 1), 30, CancellationToken.None);
+        var modelA = await first.AcquireAsync("tenant-a", Resolution("platform-a", "model-a", 1, 1), 30, CancellationToken.None);
+        var modelB = await second.AcquireAsync("tenant-a", Resolution("platform-a", "model-b", 1, 1), 30, CancellationToken.None);
 
         modelA.Allowed.ShouldBeTrue();
         modelB.Allowed.ShouldBeFalse();
         if (modelA.Lease is not null) await modelA.Lease.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task SameProviderLimits_AreIndependentAcrossTenants()
+    {
+        var testDatabase = await TryCreateDatabaseAsync();
+        if (testDatabase is null) return;
+        await using var scope = testDatabase;
+        var first = new GatewayProviderConcurrencyCoordinator(scope.Context, NullLogger<GatewayProviderConcurrencyCoordinator>.Instance);
+        var second = new GatewayProviderConcurrencyCoordinator(scope.Context, NullLogger<GatewayProviderConcurrencyCoordinator>.Instance);
+        var resolution = Resolution("shared-platform", "shared-model", 1, 1);
+
+        var tenantA = await first.AcquireAsync("tenant-a", resolution, 30, CancellationToken.None);
+        var tenantB = await second.AcquireAsync("tenant-b", resolution, 30, CancellationToken.None);
+
+        tenantA.Allowed.ShouldBeTrue();
+        tenantB.Allowed.ShouldBeTrue();
+        if (tenantA.Lease is not null) await tenantA.Lease.DisposeAsync();
+        if (tenantB.Lease is not null) await tenantB.Lease.DisposeAsync();
     }
 
     private static ModelResolutionResult Resolution(string platform, string model, int platformLimit, int modelLimit)

--- a/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayRuntimeGovernanceTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayRuntimeGovernanceTests.cs
@@ -1,8 +1,11 @@
+using System.Reflection;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using PrdAgent.Infrastructure.Database;
 using PrdAgent.Infrastructure.LlmGateway;
+using PrdAgent.Infrastructure.Services.AssetStorage;
 using PrdAgent.LlmGatewayHost;
 using Shouldly;
 using Xunit;
@@ -362,6 +365,93 @@ public sealed class GatewayRuntimeGovernanceTests
     }
 
     [Fact]
+    public async Task LifecycleApply_RedactsAndDeletesExpiredDataForEveryTenant()
+    {
+        var testDatabase = await TryCreateDatabaseAsync();
+        if (testDatabase is null) return;
+        await using var scope = testDatabase;
+        var now = DateTime.UtcNow;
+        var logs = scope.Context.Database.GetCollection<BsonDocument>("llmrequestlogs");
+        await logs.InsertManyAsync(new[]
+        {
+            new BsonDocument
+            {
+                { "_id", "log-a" },
+                { "TenantId", "tenant-a" },
+                { "StartedAt", now.AddDays(-10) },
+                { "QuestionText", "tenant-a-secret" },
+            },
+            new BsonDocument
+            {
+                { "_id", "log-b" },
+                { "TenantId", "tenant-b" },
+                { "StartedAt", now.AddDays(-10) },
+                { "QuestionText", "tenant-b-secret" },
+            },
+        });
+        var multipart = scope.Context.Database.GetCollection<GatewayMultipartObjectRecord>("llmgw_multipart_objects");
+        await multipart.InsertManyAsync(new[]
+        {
+            new GatewayMultipartObjectRecord
+            {
+                TenantId = "tenant-a",
+                RefKey = "tenant-a/expired.bin",
+                Status = "stored",
+                ExpiresAt = now.AddMinutes(-1),
+            },
+            new GatewayMultipartObjectRecord
+            {
+                TenantId = "tenant-b",
+                RefKey = "tenant-b/expired.bin",
+                Status = "stored",
+                ExpiresAt = now.AddMinutes(-1),
+            },
+        });
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["LlmGateway:InternalTenantId"] = "tenant-internal",
+            ["LlmGateway:Retention:ApplyChanges"] = "true",
+            ["LlmGateway:Retention:EnableTtlIndexes"] = "false",
+            ["LlmGateway:Retention:SensitiveBodyDays"] = "1",
+        }).Build();
+        var storage = new RecordingAssetStorage();
+        var worker = new GatewayDataLifecycleWorker(
+            scope.Context,
+            storage,
+            new GatewayBudgetCoordinator(scope.Context, NullLogger<GatewayBudgetCoordinator>.Instance),
+            new LlmGatewayDatabaseInitializer(
+                scope.Context,
+                configuration,
+                NullLogger<LlmGatewayDatabaseInitializer>.Instance),
+            configuration,
+            NullLogger<GatewayDataLifecycleWorker>.Instance);
+        var runOnce = typeof(GatewayDataLifecycleWorker).GetMethod(
+            "RunOnceAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        runOnce.ShouldNotBeNull();
+
+        await (Task)runOnce.Invoke(worker, new object[] { CancellationToken.None })!;
+
+        var updatedLogs = await logs.Find(_ => true).ToListAsync();
+        updatedLogs.Count.ShouldBe(2);
+        updatedLogs.ShouldAllBe(x => x["RequestBodyRedacted"].AsString == "[retention-redacted]");
+        updatedLogs.ShouldAllBe(x => !x.Contains("QuestionText"));
+        var updatedMultipart = await multipart.Find(_ => true).ToListAsync();
+        updatedMultipart.ShouldAllBe(x => x.Status == "deleted");
+        storage.DeletedKeys.OrderBy(x => x).ShouldBe(new[]
+        {
+            "tenant-a/expired.bin",
+            "tenant-b/expired.bin",
+        });
+        var tenantRuns = await scope.Context.Database.GetCollection<GatewayLifecycleRunRecord>("llmgw_lifecycle_runs")
+            .Find(x => x.TenantId == "tenant-a" || x.TenantId == "tenant-b")
+            .ToListAsync();
+        tenantRuns.Count.ShouldBe(2);
+        tenantRuns.ShouldAllBe(x => x.Status == "applied");
+        tenantRuns.ShouldAllBe(x => x.RedactedSensitiveLogs == 1 && x.DeletedMultipartObjects == 1);
+    }
+
+    [Fact]
     public async Task ScopedKey_RejectsCrossAppCallerAndWritesAudit()
     {
         var testDatabase = await TryCreateDatabaseAsync();
@@ -542,6 +632,42 @@ public sealed class GatewayRuntimeGovernanceTests
                 TenantId = record.TenantId,
                 ServiceKeyId = record.Id,
             });
+    }
+
+    private sealed class RecordingAssetStorage : IAssetStorage
+    {
+        public List<string> DeletedKeys { get; } = [];
+
+        public Task<StoredAsset> SaveAsync(byte[] bytes, string mime, CancellationToken ct, string? domain = null, string? type = null, string? fileName = null, string? extensionHint = null)
+            => throw new NotSupportedException();
+
+        public Task<(byte[] bytes, string mime)?> TryReadByShaAsync(string sha256, CancellationToken ct, string? domain = null, string? type = null)
+            => throw new NotSupportedException();
+
+        public Task DeleteByShaAsync(string sha256, CancellationToken ct, string? domain = null, string? type = null)
+            => throw new NotSupportedException();
+
+        public string? TryBuildUrlBySha(string sha256, string mime, string? domain = null, string? type = null)
+            => throw new NotSupportedException();
+
+        public Task<byte[]?> TryDownloadBytesAsync(string key, CancellationToken ct)
+            => throw new NotSupportedException();
+
+        public Task<bool> ExistsAsync(string key, CancellationToken ct)
+            => throw new NotSupportedException();
+
+        public Task UploadToKeyAsync(string key, byte[] bytes, string? contentType, CancellationToken ct, string? cacheControl = null)
+            => throw new NotSupportedException();
+
+        public string BuildUrlForKey(string key) => throw new NotSupportedException();
+
+        public Task DeleteByKeyAsync(string key, CancellationToken ct)
+        {
+            DeletedKeys.Add(key);
+            return Task.CompletedTask;
+        }
+
+        public string BuildSiteKey(string siteId, string filePath) => throw new NotSupportedException();
     }
 
     private sealed class TestDatabase : IAsyncDisposable

--- a/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayRuntimeGovernanceTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayRuntimeGovernanceTests.cs
@@ -407,6 +407,15 @@ public sealed class GatewayRuntimeGovernanceTests
                 ExpiresAt = now.AddMinutes(-1),
             },
         });
+        await scope.Context.Database.GetCollection<BsonDocument>("llmgw_tenants").InsertOneAsync(
+            new BsonDocument { { "_id", "tenant-c" }, { "Name", "Tenant C" } });
+        await scope.Context.Database.GetCollection<BsonDocument>("llmgw_request_executions").InsertOneAsync(
+            new BsonDocument
+            {
+                { "_id", "execution-d" },
+                { "TenantId", "tenant-d" },
+                { "ExpiresAt", now.AddHours(1) },
+            });
         var configuration = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["LlmGateway:InternalTenantId"] = "tenant-internal",
@@ -449,6 +458,11 @@ public sealed class GatewayRuntimeGovernanceTests
         tenantRuns.Count.ShouldBe(2);
         tenantRuns.ShouldAllBe(x => x.Status == "applied");
         tenantRuns.ShouldAllBe(x => x.RedactedSensitiveLogs == 1 && x.DeletedMultipartObjects == 1);
+        var discoveredTenantIds = await scope.Context.Database.GetCollection<GatewayLifecycleRunRecord>("llmgw_lifecycle_runs")
+            .Distinct<string>("TenantId", FilterDefinition<GatewayLifecycleRunRecord>.Empty)
+            .ToListAsync();
+        discoveredTenantIds.ShouldContain("tenant-c");
+        discoveredTenantIds.ShouldContain("tenant-d");
     }
 
     [Fact]

--- a/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayRuntimeGovernanceTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayRuntimeGovernanceTests.cs
@@ -21,6 +21,7 @@ public sealed class GatewayRuntimeGovernanceTests
 
         var caller = new GatewayAppCallerRecord
         {
+            TenantId = "tenant-a",
             AppCallerCode = "budget-test",
             RequestType = "chat",
             MonthlyBudgetUsd = 1m,
@@ -58,6 +59,7 @@ public sealed class GatewayRuntimeGovernanceTests
 
         var caller = new GatewayAppCallerRecord
         {
+            TenantId = "tenant-a",
             AppCallerCode = "budget-month-create-race",
             RequestType = "chat",
             MonthlyBudgetUsd = 1m,
@@ -89,6 +91,7 @@ public sealed class GatewayRuntimeGovernanceTests
         var coordinator = new GatewayBudgetCoordinator(scope.Context, NullLogger<GatewayBudgetCoordinator>.Instance);
         var admission = await coordinator.ReserveAsync(new GatewayAppCallerRecord
         {
+            TenantId = "tenant-a",
             AppCallerCode = "client-failure-test",
             RequestType = "chat",
             MonthlyBudgetUsd = 1m,
@@ -116,6 +119,7 @@ public sealed class GatewayRuntimeGovernanceTests
         var coordinator = new GatewayBudgetCoordinator(scope.Context, NullLogger<GatewayBudgetCoordinator>.Instance);
         var admission = await coordinator.ReserveAsync(new GatewayAppCallerRecord
         {
+            TenantId = "tenant-a",
             AppCallerCode = "server-failure-test",
             RequestType = "image-gen",
             MonthlyBudgetUsd = 1m,
@@ -147,6 +151,7 @@ public sealed class GatewayRuntimeGovernanceTests
         var coordinator = new GatewayBudgetCoordinator(scope.Context, NullLogger<GatewayBudgetCoordinator>.Instance);
         var admission = await coordinator.ReserveAsync(new GatewayAppCallerRecord
         {
+            TenantId = "tenant-a",
             AppCallerCode = "cancelled-unknown-test",
             RequestType = "image-gen",
             MonthlyBudgetUsd = 1m,
@@ -185,6 +190,7 @@ public sealed class GatewayRuntimeGovernanceTests
             .Select(_ => new GatewayRequestExecutionStore(scope.Context))
             .ToArray();
         var begins = await Task.WhenAll(stores.Select(store => store.BeginAsync(
+            "tenant-a",
             "idempotency-test",
             "same-request-id",
             "raw:/v1/images/generations",
@@ -194,8 +200,9 @@ public sealed class GatewayRuntimeGovernanceTests
         begins.Count(x => x.State == GatewayExecutionBeginState.Started).ShouldBe(1);
         begins.Count(x => x.State == GatewayExecutionBeginState.Running).ShouldBe(7);
         var owner = begins.Single(x => x.State == GatewayExecutionBeginState.Started);
-        await stores[0].UnknownAsync(owner.ExecutionId, "UPSTREAM_OUTCOME_UNKNOWN", CancellationToken.None);
+        await stores[0].UnknownAsync("tenant-a", owner.ExecutionId, "UPSTREAM_OUTCOME_UNKNOWN", CancellationToken.None);
         var status = await stores[1].GetAsync(
+            "tenant-a",
             "idempotency-test",
             "same-request-id",
             "raw:/v1/images/generations",
@@ -235,6 +242,7 @@ public sealed class GatewayRuntimeGovernanceTests
         await scope.CreateGovernanceIndexesAsync();
         var store = new GatewayRequestExecutionStore(scope.Context);
         var begin = await store.BeginAsync(
+            "tenant-a",
             "large-replay-test",
             "large-response-request",
             "openai-images-generation",
@@ -243,9 +251,10 @@ public sealed class GatewayRuntimeGovernanceTests
         begin.State.ShouldBe(GatewayExecutionBeginState.Started);
 
         var oversized = new string('x', GatewayRequestExecutionStore.MaxReplayResponseBytes + 1);
-        await store.CompleteAsync(begin.ExecutionId, oversized, CancellationToken.None);
+        await store.CompleteAsync("tenant-a", begin.ExecutionId, oversized, CancellationToken.None);
 
         var replay = await store.BeginAsync(
+            "tenant-a",
             "large-replay-test",
             "large-response-request",
             "openai-images-generation",
@@ -253,6 +262,7 @@ public sealed class GatewayRuntimeGovernanceTests
             CancellationToken.None);
         replay.State.ShouldBe(GatewayExecutionBeginState.ReplayUnavailable);
         var stored = await store.GetAsync(
+            "tenant-a",
             "large-replay-test",
             "large-response-request",
             "openai-images-generation",
@@ -274,6 +284,7 @@ public sealed class GatewayRuntimeGovernanceTests
         var monthStart = new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1, 0, 0, 0, DateTimeKind.Utc);
         await scope.Context.Database.GetCollection<GatewayBudgetMonthRecord>("llmgw_budget_months").InsertOneAsync(new GatewayBudgetMonthRecord
         {
+            TenantId = "tenant-a",
             AppCallerCode = "pending-test",
             RequestType = "chat",
             MonthStart = monthStart,
@@ -283,6 +294,7 @@ public sealed class GatewayRuntimeGovernanceTests
         });
         await scope.Context.Database.GetCollection<GatewayBudgetReservationRecord>("llmgw_budget_reservations").InsertOneAsync(new GatewayBudgetReservationRecord
         {
+            TenantId = "tenant-a",
             AppCallerCode = "pending-test",
             RequestType = "chat",
             RequestId = "pending-request",
@@ -312,6 +324,7 @@ public sealed class GatewayRuntimeGovernanceTests
         var monthStart = new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1, 0, 0, 0, DateTimeKind.Utc);
         await scope.Context.Database.GetCollection<GatewayBudgetMonthRecord>("llmgw_budget_months").InsertOneAsync(new GatewayBudgetMonthRecord
         {
+            TenantId = "tenant-a",
             AppCallerCode = "unknown-test",
             RequestType = "image-gen",
             MonthStart = monthStart,
@@ -321,6 +334,7 @@ public sealed class GatewayRuntimeGovernanceTests
         });
         var reservation = new GatewayBudgetReservationRecord
         {
+            TenantId = "tenant-a",
             AppCallerCode = "unknown-test",
             RequestType = "image-gen",
             RequestId = "unknown-request",
@@ -357,6 +371,7 @@ public sealed class GatewayRuntimeGovernanceTests
         const string key = "llmgw_test_scoped_key";
         var keyRecord = new GatewayServiceKeyRecord
         {
+            TenantId = "tenant-a",
             Name = "test-key",
             KeyHash = GatewayScopedKeyAuthorizer.Sha256Hex(key),
             SourceSystem = "external-system",
@@ -364,8 +379,7 @@ public sealed class GatewayRuntimeGovernanceTests
             IngressProtocols = ["openai-compatible"],
             Scopes = ["chat"],
         };
-        await scope.Context.Database.GetCollection<GatewayServiceKeyRecord>("llmgw_service_keys")
-            .InsertOneAsync(keyRecord);
+        await InsertServiceKeyAsync(scope.Context, keyRecord);
         var authorizer = new GatewayScopedKeyAuthorizer(scope.Context);
 
         var allowed = await authorizer.AuthorizeAsync(
@@ -386,6 +400,7 @@ public sealed class GatewayRuntimeGovernanceTests
             CancellationToken.None);
 
         allowed.Allowed.ShouldBeTrue();
+        allowed.TenantId.ShouldBe("tenant-a");
         denied.Allowed.ShouldBeFalse();
         denied.Authenticated.ShouldBeTrue();
         denied.StatusCode.ShouldBe(403);
@@ -393,6 +408,37 @@ public sealed class GatewayRuntimeGovernanceTests
             .GetCollection<BsonDocument>("llmgw_operation_audits")
             .CountDocumentsAsync(Builders<BsonDocument>.Filter.Eq("Action", "service_key.scope_denied"));
         auditCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task RequestExecution_SameIdentityIsIsolatedByTenant()
+    {
+        var testDatabase = await TryCreateDatabaseAsync();
+        if (testDatabase is null) return;
+        await using var scope = testDatabase;
+        var store = new GatewayRequestExecutionStore(scope.Context);
+
+        var tenantA = await store.BeginAsync("tenant-a", "shared-caller", "shared-request", "raw-submit", "fingerprint-a", CancellationToken.None);
+        var tenantB = await store.BeginAsync("tenant-b", "shared-caller", "shared-request", "raw-submit", "fingerprint-b", CancellationToken.None);
+
+        tenantA.State.ShouldBe(GatewayExecutionBeginState.Started);
+        tenantB.State.ShouldBe(GatewayExecutionBeginState.Started);
+        (await store.GetAsync("tenant-a", "shared-caller", "shared-request", "raw-submit", CancellationToken.None))!.Fingerprint.ShouldBe("fingerprint-a");
+        (await store.GetAsync("tenant-b", "shared-caller", "shared-request", "raw-submit", CancellationToken.None))!.Fingerprint.ShouldBe("fingerprint-b");
+        (await store.GetAsync("tenant-c", "shared-caller", "shared-request", "raw-submit", CancellationToken.None)).ShouldBeNull();
+    }
+
+    [Fact]
+    public void CancellationRegistry_SameRequestIdentityIsIsolatedByTenant()
+    {
+        var registry = new GatewayCancellationRegistry();
+        using var tenantA = registry.Register("tenant-a", "shared-caller", "shared-request");
+        using var tenantB = registry.Register("tenant-b", "shared-caller", "shared-request");
+
+        registry.Cancel("tenant-a", "shared-caller", "shared-request").ShouldBeTrue();
+        tenantA.Token.IsCancellationRequested.ShouldBeTrue();
+        tenantB.Token.IsCancellationRequested.ShouldBeFalse();
+        registry.Cancel("tenant-c", "shared-caller", "shared-request").ShouldBeFalse();
     }
 
     [Fact]
@@ -405,6 +451,7 @@ public sealed class GatewayRuntimeGovernanceTests
         const string key = "llmgw_test_empty_binding_key";
         var keyRecord = new GatewayServiceKeyRecord
         {
+            TenantId = "tenant-a",
             Name = "empty-binding-key",
             KeyHash = GatewayScopedKeyAuthorizer.Sha256Hex(key),
             SourceSystem = "*",
@@ -412,8 +459,7 @@ public sealed class GatewayRuntimeGovernanceTests
             IngressProtocols = [],
             Scopes = [],
         };
-        await scope.Context.Database.GetCollection<GatewayServiceKeyRecord>("llmgw_service_keys")
-            .InsertOneAsync(keyRecord);
+        await InsertServiceKeyAsync(scope.Context, keyRecord);
         var authorizer = new GatewayScopedKeyAuthorizer(scope.Context);
 
         var denied = await authorizer.AuthorizeAsync(
@@ -438,9 +484,9 @@ public sealed class GatewayRuntimeGovernanceTests
         await using var scope = testDatabase;
 
         const string key = "llmgw_test_invoke_only_key";
-        await scope.Context.Database.GetCollection<GatewayServiceKeyRecord>("llmgw_service_keys")
-            .InsertOneAsync(new GatewayServiceKeyRecord
+        await InsertServiceKeyAsync(scope.Context, new GatewayServiceKeyRecord
             {
+                TenantId = "tenant-a",
                 Name = "invoke-only",
                 KeyHash = GatewayScopedKeyAuthorizer.Sha256Hex(key),
                 SourceSystem = "external",
@@ -484,6 +530,18 @@ public sealed class GatewayRuntimeGovernanceTests
         {
             return null;
         }
+    }
+
+    private static async Task InsertServiceKeyAsync(LlmGatewayDataContext context, GatewayServiceKeyRecord record)
+    {
+        await context.Database.GetCollection<GatewayServiceKeyRecord>("llmgw_service_keys").InsertOneAsync(record);
+        await context.Database.GetCollection<GatewayServiceKeyDirectoryRecord>("llmgw_service_key_directory")
+            .InsertOneAsync(new GatewayServiceKeyDirectoryRecord
+            {
+                KeyHash = record.KeyHash,
+                TenantId = record.TenantId,
+                ServiceKeyId = record.Id,
+            });
     }
 
     private sealed class TestDatabase : IAsyncDisposable

--- a/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewaySerializationSecurityTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewaySerializationSecurityTests.cs
@@ -14,6 +14,30 @@ namespace PrdAgent.Api.Tests.Gateway;
 public class GatewaySerializationSecurityTests
 {
     [Fact]
+    public void GatewayIngressRequest_ToGatewayRequest_PreservesVerifiedTenantContext()
+    {
+        var ingress = new GatewayIngressRequest
+        {
+            RequestId = "request-1",
+            IngressProtocol = "openai-compatible",
+            AppCallerCode = "external.chat",
+            RequestType = "chat",
+            Context = new GatewayRequestContext
+            {
+                TenantId = "tenant-a",
+                TeamId = "team-a",
+                RequestId = "request-1",
+            },
+        };
+
+        var request = ingress.ToGatewayRequest(stream: false);
+
+        request.Context.ShouldNotBeNull();
+        request.Context.TenantId.ShouldBe("tenant-a");
+        request.Context.TeamId.ShouldBe("team-a");
+    }
+
+    [Fact]
     public void GatewayModelResolution_Serialized_MustNotLeakApiKey()
     {
         const string secret = "SECRET-must-not-cross";

--- a/prd-api/tests/PrdAgent.Api.Tests/Gateway/ShadowLlmGatewayTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Gateway/ShadowLlmGatewayTests.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using PrdAgent.Core.Interfaces;
 using PrdAgent.Core.Models;
@@ -108,6 +109,29 @@ public class ShadowLlmGatewayTests
 
         var cmp = await writer.WaitForRecordAsync();
         cmp.ReleaseCommit.ShouldBe("abcdef1234");
+    }
+
+    [Fact]
+    public async Task ShadowComparison_UsesConfiguredInternalTenantWithoutContextScope()
+    {
+        var writer = new CapturingWriter();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["LlmGateway:InternalTenantId"] = "tenant-configured-internal",
+            })
+            .Build();
+        var shadow = new ShadowLlmGateway(
+            new FakeGateway(Res("m1", "openai", "openai")),
+            new FakeGateway(Res("m1", "openai", "openai")),
+            NullLogger<ShadowLlmGateway>.Instance,
+            writer,
+            configuration: configuration);
+
+        await shadow.ResolveModelAsync("demo.app::chat", "chat");
+
+        var comparison = await writer.WaitForRecordAsync();
+        comparison.TenantId.ShouldBe("tenant-configured-internal");
     }
 
     // ② stream：inproc chunk 原样透传给 caller；流末做一次 resolve 比对（chat 主链路覆盖）

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -2281,6 +2281,28 @@ public class GatewayDataDomainGuardTests
     }
 
     [Fact]
+    public void ConsoleDefaultPoolSwitch_ClearsOnlyCurrentTenantGatewayPools()
+    {
+        var console = ReadRepoFile("prd-llmgw/Program.cs");
+        var endpointStart = console.IndexOf(
+            "app.MapPut(\"/gw/pools/{id}/default\"",
+            StringComparison.Ordinal);
+        var endpointEnd = console.IndexOf(
+            "app.MapPut(\"/gw/pools/{id}/claim\"",
+            endpointStart,
+            StringComparison.Ordinal);
+        Assert.True(endpointStart >= 0, "找不到默认模型池切换端点");
+        Assert.True(endpointEnd > endpointStart, "默认模型池切换端点边界无效");
+        var endpoint = console[endpointStart..endpointEnd];
+
+        Assert.Contains(
+            "targetAuthority == \"llm_gateway\" ? TenantAccess.Filter(http, others) : others",
+            endpoint);
+        Assert.Contains("targetPools.UpdateManyAsync(scopedOthers", endpoint);
+        Assert.DoesNotContain("targetPools.UpdateManyAsync(others", endpoint);
+    }
+
+    [Fact]
     public void ModelLabAndArena_PinSelectedModelThroughGateway()
     {
         var modelLab = ReadRepoFile("prd-api/src/PrdAgent.Api/Controllers/Api/ModelLabController.cs");

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -341,6 +341,23 @@ public class GatewayDataDomainGuardTests
     }
 
     [Fact]
+    public void ServiceKeyWrites_HaveDedicatedDeveloperPermissionWithoutConfigWrite()
+    {
+        var access = ReadRepoFile("prd-llmgw/Auth/TenantAccessContext.cs");
+        var consoleProgram = ReadRepoFile("prd-llmgw/Program.cs");
+        var createStart = consoleProgram.IndexOf("app.MapPost(\"/gw/service-keys\"", StringComparison.Ordinal);
+        var deleteStart = consoleProgram.IndexOf("app.MapDelete(\"/gw/service-keys/{id}\"", createStart, StringComparison.Ordinal);
+        var shadowStart = consoleProgram.IndexOf("// 影子比对", deleteStart, StringComparison.Ordinal);
+
+        Assert.Contains("public const string ServiceKeyWrite = \"service-key:write\"", access);
+        Assert.Contains("LlmGwTenantRoles.Developer => permission is LogsRead or RequestBodyRead or UsageRead or ServiceKeyWrite", access);
+        Assert.DoesNotContain("LlmGwTenantRoles.Developer => permission is LogsRead or RequestBodyRead or UsageRead or ConfigWrite", access);
+        Assert.Contains("options.AddPolicy(\"ServiceKeyWrite\"", consoleProgram);
+        Assert.Contains("RequireAuthorization(\"ServiceKeyWrite\")", consoleProgram[createStart..deleteStart]);
+        Assert.Contains("RequireAuthorization(\"ServiceKeyWrite\")", consoleProgram[deleteStart..shadowStart]);
+    }
+
+    [Fact]
     public void Compose_DeclaresGatewayDatabaseName_ForApiAndServing()
     {
         var dockerCompose = ReadRepoFile("docker-compose.yml");

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -283,6 +283,8 @@ public class GatewayDataDomainGuardTests
             endpoints.Split("TeamId = ingress.Context?.TeamId", StringSplitOptions.None).Length - 1 >= 2,
             "native 与 raw 路由重建都必须使用 service key 校验后写入的 ingress team");
         Assert.Contains("TenantId = ResolveTenantId(start.TenantId)", logWriter);
+        Assert.Contains("configuration[\"LlmGateway:InternalTenantId\"]", logWriter);
+        Assert.Contains("? _internalTenantId", logWriter);
         Assert.Contains("GatewayTenantDefaults.InternalTenantId", logWriter);
         Assert.DoesNotContain("TenantId = start.TenantId ?? string.Empty", logWriter);
     }

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -2244,6 +2244,43 @@ public class GatewayDataDomainGuardTests
     }
 
     [Fact]
+    public void ConsoleOnlyStartup_BackfillsLegacyGatewayDocumentsBeforeTenantFiltering()
+    {
+        var console = ReadRepoFile("prd-llmgw/Program.cs");
+        var backfillCall = console.IndexOf(
+            "await BackfillInternalTenantAsync(gatewayDatabase, internalTenantId, CancellationToken.None);",
+            StringComparison.Ordinal);
+        var firstTenantFilteredEndpoint = console.IndexOf(
+            "lifecycleRuns.Find(TenantAccess.Filter(http))",
+            StringComparison.Ordinal);
+
+        Assert.True(backfillCall >= 0, "console-only 启动必须执行 internal tenant 历史回填");
+        Assert.True(
+            firstTenantFilteredEndpoint > backfillCall,
+            "TenantAccess.Filter 生效前必须完成历史 TenantId 回填");
+        foreach (var collection in new[]
+                 {
+                     "llmrequestlogs",
+                     "llmshadow_comparisons",
+                     "llmgw_operation_audits",
+                     "llmgw_login_audits",
+                     "llmgw_lifecycle_runs",
+                     "llmgw_app_callers",
+                     "llmgw_model_pools",
+                     "llmgw_platforms",
+                     "llmgw_models",
+                     "llmgw_model_exchanges",
+                     "llmgw_service_keys",
+                 })
+        {
+            Assert.Contains($"\"{collection}\"", console);
+        }
+        Assert.Contains("Filter.Exists(\"TenantId\", false)", console);
+        Assert.Contains("Filter.Eq(\"TenantId\", BsonNull.Value)", console);
+        Assert.Contains("Update.Set(\"TenantId\", tenantId)", console);
+    }
+
+    [Fact]
     public void ModelLabAndArena_PinSelectedModelThroughGateway()
     {
         var modelLab = ReadRepoFile("prd-api/src/PrdAgent.Api/Controllers/Api/ModelLabController.cs");

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -307,6 +307,26 @@ public class GatewayDataDomainGuardTests
     }
 
     [Fact]
+    public void RawIdempotency_NormalizesVerifiedTenantContextBeforeFingerprinting()
+    {
+        var endpoints = ReadRepoFile("prd-api/src/PrdAgent.LlmGateway/GatewayHttpEndpoints.cs");
+        var nativeStart = endpoints.IndexOf("app.MapPost(\"/gw/v1/raw\"", StringComparison.Ordinal);
+        var compatStart = endpoints.IndexOf("private static async Task ExecuteRawWithIdempotencyAsync", StringComparison.Ordinal);
+
+        Assert.True(nativeStart >= 0 && compatStart > nativeStart, "找不到 raw 幂等入口");
+        Assert.True(
+            endpoints.IndexOf("request = ApplyVerifiedRawRequestContext(http, request, ingress);", nativeStart, StringComparison.Ordinal)
+            < endpoints.IndexOf("GatewayRequestExecutionStore.Fingerprint(request)", nativeStart, StringComparison.Ordinal),
+            "native raw 必须在 fingerprint 前覆盖服务端 tenant/team");
+        Assert.True(
+            endpoints.IndexOf("request = ApplyVerifiedRawRequestContext(http, request, ingress);", compatStart, StringComparison.Ordinal)
+            < endpoints.IndexOf("GatewayRequestExecutionStore.Fingerprint(request)", compatStart, StringComparison.Ordinal),
+            "兼容 raw 必须在 fingerprint 前覆盖服务端 tenant/team");
+        Assert.Contains("ingress.Context.TenantId = GetVerifiedTenantId(http)", endpoints);
+        Assert.Contains("ingress.Context.TeamId = GetVerifiedTeamId(http)", endpoints);
+    }
+
+    [Fact]
     public void Compose_DeclaresGatewayDatabaseName_ForApiAndServing()
     {
         var dockerCompose = ReadRepoFile("docker-compose.yml");

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -327,6 +327,20 @@ public class GatewayDataDomainGuardTests
     }
 
     [Fact]
+    public void TeamRename_MapsTenantScopedUniqueNameCollisionToConflict()
+    {
+        var consoleProgram = ReadRepoFile("prd-llmgw/Program.cs");
+        var updateStart = consoleProgram.IndexOf("app.MapPut(\"/gw/teams/{id}\"", StringComparison.Ordinal);
+        var memberStart = consoleProgram.IndexOf("app.MapPost(\"/gw/members\"", updateStart, StringComparison.Ordinal);
+        var updateBlock = consoleProgram[updateStart..memberStart];
+
+        Assert.Contains("x.Id == id && x.TenantId == access.TenantId", updateBlock);
+        Assert.Contains("ServerErrorCategory.DuplicateKey", updateBlock);
+        Assert.Contains("Fail(\"TEAM_CONFLICT\", \"当前租户已存在同名团队\")", updateBlock);
+        Assert.Contains("jsonOptions, 409", updateBlock);
+    }
+
+    [Fact]
     public void Compose_DeclaresGatewayDatabaseName_ForApiAndServing()
     {
         var dockerCompose = ReadRepoFile("docker-compose.yml");

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -259,7 +259,10 @@ public class GatewayDataDomainGuardTests
         Assert.Contains("action: \"admin.force_reset_bootstrap\"", consoleProgram);
         Assert.Contains("action: \"admin.bootstrap\"", consoleProgram);
         Assert.Contains("action: \"admin.reactivate\"", consoleProgram);
-        Assert.Contains("action: \"admin.deactivate_legacy_users\"", consoleProgram);
+        Assert.Contains("\"team.create\"", consoleProgram);
+        Assert.Contains("\"membership.create\"", consoleProgram);
+        Assert.Contains("\"membership.update\"", consoleProgram);
+        Assert.DoesNotContain("action: \"admin.deactivate_legacy_users\"", consoleProgram);
         Assert.Contains("Console.Error.WriteLine($\"[LlmGw] operation audit write failed:", consoleProgram);
         Assert.Contains("Console.Error.WriteLine($\"[LlmGw] system operation audit write failed:", consoleProgram);
         Assert.DoesNotContain("mapDatabase.GetCollection<BsonDocument>(\"llmgw_operation_audits\")", consoleProgram);
@@ -2256,7 +2259,7 @@ public class GatewayDataDomainGuardTests
         var httpClient = ReadRepoFile("prd-api/src/PrdAgent.Infrastructure/LlmGateway/HttpLlmGatewayClient.cs");
         var stage = ReadRepoFile("scripts/llmgw-prod-stage.sh");
 
-        Assert.Contains("idx_llmgw_logs_time_caller_type_transport", initializer);
+        Assert.Contains("idx_llmgw_logs_tenant_time_caller_type_transport", initializer);
         Assert.Contains("ttl_llmgw_logs_started", initializer);
         Assert.Contains("uniq_llmgw_budget_month", initializer);
         Assert.Contains("uniq_llmgw_execution_request", initializer);

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -290,6 +290,23 @@ public class GatewayDataDomainGuardTests
     }
 
     [Fact]
+    public void InternalTenantFallbacks_UseConfigurationAcrossLogsShadowConcurrencyAndLegacyKeys()
+    {
+        var apiProgram = ReadRepoFile("prd-api/src/PrdAgent.Api/Program.cs");
+        var shadow = ReadRepoFile("prd-api/src/PrdAgent.Infrastructure/LlmGateway/ShadowLlmGateway.cs");
+        var gateway = ReadRepoFile("prd-api/src/PrdAgent.Infrastructure/LlmGateway/LlmGateway.cs");
+        var endpoints = ReadRepoFile("prd-api/src/PrdAgent.LlmGateway/GatewayHttpEndpoints.cs");
+
+        Assert.Contains("configuration?[\"LlmGateway:InternalTenantId\"]", shadow);
+        Assert.DoesNotContain("?? GatewayTenantDefaults.InternalTenantId", shadow);
+        Assert.Contains("configuration?[\"LlmGateway:InternalTenantId\"]", gateway);
+        Assert.Contains("string.IsNullOrWhiteSpace(tenantId) ? _internalTenantId : tenantId", gateway);
+        Assert.Contains("app.Configuration[\"LlmGateway:InternalTenantId\"]", endpoints);
+        Assert.Contains("TenantId: internalTenantId", endpoints);
+        Assert.Contains("configuration: sp.GetRequiredService<IConfiguration>()", apiProgram);
+    }
+
+    [Fact]
     public void Compose_DeclaresGatewayDatabaseName_ForApiAndServing()
     {
         var dockerCompose = ReadRepoFile("docker-compose.yml");

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -2124,6 +2124,23 @@ public class GatewayDataDomainGuardTests
     }
 
     [Fact]
+    public void ModelResolver_AvailablePoolsFailClosedBeforeMapFallbackForExternalTenants()
+    {
+        var resolver = ReadRepoFile("prd-api/src/PrdAgent.Infrastructure/LlmGateway/ModelResolver.cs");
+        var methodStart = resolver.IndexOf("public async Task<List<AvailableModelPool>> GetAvailablePoolsAsync", StringComparison.Ordinal);
+        var mapFallback = resolver.IndexOf("var appCaller = await _db.LLMAppCallers", methodStart, StringComparison.Ordinal);
+        var externalTenantGuard = resolver.IndexOf(
+            "if (!string.Equals(CurrentTenantId, _internalTenantId, StringComparison.Ordinal))",
+            methodStart,
+            StringComparison.Ordinal);
+
+        Assert.True(methodStart >= 0 && mapFallback > methodStart, "找不到 available-pools MAP fallback");
+        Assert.True(
+            externalTenantGuard > methodStart && externalTenantGuard < mapFallback,
+            "外部租户必须在读取 MAP LLMAppCallers/ModelGroups 前 fail closed");
+    }
+
+    [Fact]
     public void ImageGenRunWorker_DoesNotSilentlyDowngradeReferenceImageRunsToText2Img()
     {
         var worker = ReadRepoFile("prd-api/src/PrdAgent.Api/Services/ImageGenRunWorker.cs");

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -269,6 +269,25 @@ public class GatewayDataDomainGuardTests
     }
 
     [Fact]
+    public void TenantBoundaryPropagation_PreservesVerifiedTenantAndInternalLogFallback()
+    {
+        var consoleProgram = ReadRepoFile("prd-llmgw/Program.cs");
+        var endpoints = ReadRepoFile("prd-api/src/PrdAgent.LlmGateway/GatewayHttpEndpoints.cs");
+        var logWriter = ReadRepoFile("prd-api/src/PrdAgent.Infrastructure/LLM/LlmRequestLogWriter.cs");
+
+        Assert.Contains("GetMetadata<IAllowAnonymous>()", consoleProgram);
+        Assert.True(
+            endpoints.Split("TenantId = ingress.Context?.TenantId", StringSplitOptions.None).Length - 1 >= 2,
+            "native 与 raw 路由重建都必须使用 service key 校验后写入的 ingress tenant");
+        Assert.True(
+            endpoints.Split("TeamId = ingress.Context?.TeamId", StringSplitOptions.None).Length - 1 >= 2,
+            "native 与 raw 路由重建都必须使用 service key 校验后写入的 ingress team");
+        Assert.Contains("TenantId = ResolveTenantId(start.TenantId)", logWriter);
+        Assert.Contains("GatewayTenantDefaults.InternalTenantId", logWriter);
+        Assert.DoesNotContain("TenantId = start.TenantId ?? string.Empty", logWriter);
+    }
+
+    [Fact]
     public void Compose_DeclaresGatewayDatabaseName_ForApiAndServing()
     {
         var dockerCompose = ReadRepoFile("docker-compose.yml");

--- a/prd-llmgw/Auth/GwJwt.cs
+++ b/prd-llmgw/Auth/GwJwt.cs
@@ -26,7 +26,10 @@ public sealed class GwJwt
     public SymmetricSecurityKey SigningKey => new(_key);
 
     /// <summary>签发 token，返回 (token, 过期时间 UTC)。</summary>
-    public (string Token, DateTime ExpiresAt) Issue(LlmGwUser user)
+    public (string Token, DateTime ExpiresAt) Issue(
+        LlmGwUser user,
+        LlmGwTenant? tenant = null,
+        LlmGwMembership? membership = null)
     {
         var now = DateTime.UtcNow;
         var expires = now.Add(Lifetime);
@@ -43,6 +46,14 @@ public sealed class GwJwt
         if (user.MustChangePassword)
         {
             claims.Add(new Claim("mcp", "1"));
+        }
+
+        if (tenant is not null && membership is not null)
+        {
+            claims.Add(new Claim(TenantAccess.TenantClaim, tenant.Id));
+            claims.Add(new Claim(TenantAccess.RoleClaim, membership.Role));
+            claims.Add(new Claim(TenantAccess.MembershipClaim, membership.Id));
+            claims.Add(new Claim(TenantAccess.MembershipVersionClaim, membership.Version.ToString()));
         }
 
         var creds = new SigningCredentials(SigningKey, SecurityAlgorithms.HmacSha256);

--- a/prd-llmgw/Auth/TenantAccessContext.cs
+++ b/prd-llmgw/Auth/TenantAccessContext.cs
@@ -22,14 +22,15 @@ public static class LlmGwPermissions
     public const string UsageRead = "usage:read";
     public const string AuditRead = "audit:read";
     public const string ConfigWrite = "config:write";
+    public const string ServiceKeyWrite = "service-key:write";
     public const string OrganizationWrite = "organization:write";
     public const string TenantOwner = "tenant:owner";
 
     public static bool Allows(string role, string permission) => role switch
     {
         LlmGwTenantRoles.Owner => true,
-        LlmGwTenantRoles.Admin => permission is LogsRead or RequestBodyRead or UsageRead or AuditRead or ConfigWrite or OrganizationWrite,
-        LlmGwTenantRoles.Developer => permission is LogsRead or RequestBodyRead or UsageRead,
+        LlmGwTenantRoles.Admin => permission is LogsRead or RequestBodyRead or UsageRead or AuditRead or ConfigWrite or ServiceKeyWrite or OrganizationWrite,
+        LlmGwTenantRoles.Developer => permission is LogsRead or RequestBodyRead or UsageRead or ServiceKeyWrite,
         LlmGwTenantRoles.Viewer => permission is LogsRead or RequestBodyRead or UsageRead,
         LlmGwTenantRoles.Billing => permission is UsageRead,
         _ => false,

--- a/prd-llmgw/Auth/TenantAccessContext.cs
+++ b/prd-llmgw/Auth/TenantAccessContext.cs
@@ -1,0 +1,112 @@
+using System.Security.Claims;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using PrdAgent.LlmGw.Models;
+
+namespace PrdAgent.LlmGw.Auth;
+
+public sealed record TenantAccessContext(
+    string TenantId,
+    string TenantName,
+    string UserId,
+    string Username,
+    string MembershipId,
+    long MembershipVersion,
+    string Role,
+    IReadOnlyList<string> TeamIds);
+
+public static class LlmGwPermissions
+{
+    public const string LogsRead = "logs:read";
+    public const string RequestBodyRead = "request-body:read";
+    public const string UsageRead = "usage:read";
+    public const string AuditRead = "audit:read";
+    public const string ConfigWrite = "config:write";
+    public const string OrganizationWrite = "organization:write";
+    public const string TenantOwner = "tenant:owner";
+
+    public static bool Allows(string role, string permission) => role switch
+    {
+        LlmGwTenantRoles.Owner => true,
+        LlmGwTenantRoles.Admin => permission is LogsRead or RequestBodyRead or UsageRead or AuditRead or ConfigWrite or OrganizationWrite,
+        LlmGwTenantRoles.Developer => permission is LogsRead or RequestBodyRead or UsageRead,
+        LlmGwTenantRoles.Viewer => permission is LogsRead or RequestBodyRead or UsageRead,
+        LlmGwTenantRoles.Billing => permission is UsageRead,
+        _ => false,
+    };
+}
+
+public static class TenantAccess
+{
+    public const string ItemKey = "llmgw.tenant.access";
+    public const string TenantClaim = "tenant_id";
+    public const string RoleClaim = "tenant_role";
+    public const string MembershipClaim = "membership_id";
+    public const string MembershipVersionClaim = "membership_version";
+
+    public static TenantAccessContext GetRequired(HttpContext http)
+        => http.Items.TryGetValue(ItemKey, out var value) && value is TenantAccessContext context
+            ? context
+            : throw new UnauthorizedAccessException("tenant context is not available");
+
+    public static FilterDefinition<BsonDocument> Filter(HttpContext http)
+        => Builders<BsonDocument>.Filter.Eq("TenantId", GetRequired(http).TenantId);
+
+    public static FilterDefinition<BsonDocument> Filter(HttpContext http, FilterDefinition<BsonDocument> filter)
+        => Builders<BsonDocument>.Filter.And(Filter(http), filter);
+
+    public static FilterDefinition<T> Filter<T>(HttpContext http, FilterDefinition<T> filter)
+        => Builders<T>.Filter.And(
+            Builders<T>.Filter.Eq("TenantId", GetRequired(http).TenantId),
+            filter);
+
+    public static bool HasPermission(ClaimsPrincipal user, string permission)
+    {
+        var role = user.FindFirst(RoleClaim)?.Value ?? string.Empty;
+        return LlmGwPermissions.Allows(role, permission);
+    }
+
+    public static async Task<TenantAccessContext?> ResolveAsync(
+        HttpContext http,
+        IMongoCollection<LlmGwMembership> memberships,
+        IMongoCollection<LlmGwTenant> tenants,
+        CancellationToken ct)
+    {
+        var userId = http.User.FindFirst(ClaimTypes.NameIdentifier)?.Value
+            ?? http.User.FindFirst("sub")?.Value;
+        var username = http.User.FindFirst(ClaimTypes.Name)?.Value;
+        var tenantId = http.User.FindFirst(TenantClaim)?.Value;
+        var membershipId = http.User.FindFirst(MembershipClaim)?.Value;
+        var versionText = http.User.FindFirst(MembershipVersionClaim)?.Value;
+        if (string.IsNullOrWhiteSpace(userId)
+            || string.IsNullOrWhiteSpace(username)
+            || string.IsNullOrWhiteSpace(tenantId)
+            || string.IsNullOrWhiteSpace(membershipId)
+            || !long.TryParse(versionText, out var membershipVersion))
+            return null;
+
+        var membership = await memberships.Find(x =>
+                x.Id == membershipId
+                && x.TenantId == tenantId
+                && x.UserId == userId
+                && x.Status == "active")
+            .FirstOrDefaultAsync(ct);
+        if (membership is null
+            || membership.Version != membershipVersion
+            || !LlmGwTenantRoles.All.Contains(membership.Role))
+            return null;
+
+        var tenant = await tenants.Find(x => x.Id == tenantId && x.Status == "active").FirstOrDefaultAsync(ct);
+        if (tenant is null) return null;
+
+        return new TenantAccessContext(
+            tenant.Id,
+            tenant.Name,
+            userId,
+            username,
+            membership.Id,
+            membership.Version,
+            membership.Role,
+            membership.TeamIds);
+    }
+}

--- a/prd-llmgw/Models/Dtos.cs
+++ b/prd-llmgw/Models/Dtos.cs
@@ -35,6 +35,20 @@ public sealed class LoginResultDto
 
     /// <summary>首登强制改密：为 true 时前端须跳「设置新口令」页，改密成功前不放行日志页。</summary>
     public bool MustChangePassword { get; init; }
+    public TenantSessionDto? Tenant { get; init; }
+}
+
+public sealed class TenantSessionDto
+{
+    public string Id { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public string Role { get; init; } = string.Empty;
+    public List<string> TeamIds { get; init; } = new();
+}
+
+public sealed class SwitchTenantRequestDto
+{
+    public string? TenantId { get; set; }
 }
 
 // ── 改密 ──
@@ -51,6 +65,7 @@ public sealed class ChangePasswordResultDto
     public string? Username { get; init; }
     public string? DisplayName { get; init; }
     public string? ExpiresAt { get; init; }
+    public TenantSessionDto? Tenant { get; init; }
 }
 
 // ── 日志列表 ──
@@ -844,4 +859,37 @@ public sealed class ServiceKeyItem
     public string? ExpiresAt { get; set; }
     public string? LastUsedAt { get; set; }
     public string? CreatedAt { get; set; }
+}
+
+public sealed class CreateTenantRequest
+{
+    public string? Name { get; set; }
+    public string? Slug { get; set; }
+}
+
+public sealed class CreateTeamRequest
+{
+    public string? Name { get; set; }
+}
+
+public sealed class UpdateTeamRequest
+{
+    public string? Name { get; set; }
+    public string? Status { get; set; }
+}
+
+public sealed class CreateMemberRequest
+{
+    public string? Username { get; set; }
+    public string? DisplayName { get; set; }
+    public string? InitialPassword { get; set; }
+    public string? Role { get; set; }
+    public List<string>? TeamIds { get; set; }
+}
+
+public sealed class UpdateMemberRequest
+{
+    public string? Role { get; set; }
+    public string? Status { get; set; }
+    public List<string>? TeamIds { get; set; }
 }

--- a/prd-llmgw/Models/LlmGwLoginAudit.cs
+++ b/prd-llmgw/Models/LlmGwLoginAudit.cs
@@ -8,8 +8,9 @@ namespace PrdAgent.LlmGw.Models;
 [BsonIgnoreExtraElements]
 public class LlmGwLoginAudit
 {
-    [BsonId]
     public string Id { get; set; } = Guid.NewGuid().ToString("N");
+
+    public string TenantId { get; set; } = string.Empty;
 
     public string Username { get; set; } = string.Empty;
 

--- a/prd-llmgw/Models/LlmGwTenantModels.cs
+++ b/prd-llmgw/Models/LlmGwTenantModels.cs
@@ -1,0 +1,61 @@
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace PrdAgent.LlmGw.Models;
+
+public static class LlmGwTenantRoles
+{
+    public const string Owner = "owner";
+    public const string Admin = "admin";
+    public const string Developer = "developer";
+    public const string Viewer = "viewer";
+    public const string Billing = "billing";
+
+    public static readonly HashSet<string> All = new(StringComparer.OrdinalIgnoreCase)
+    {
+        Owner,
+        Admin,
+        Developer,
+        Viewer,
+        Billing,
+    };
+}
+
+[BsonIgnoreExtraElements]
+public sealed class LlmGwTenant
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString("N");
+    public string Name { get; set; } = string.Empty;
+    public string NormalizedName { get; set; } = string.Empty;
+    public string Slug { get; set; } = string.Empty;
+    public string NormalizedSlug { get; set; } = string.Empty;
+    public string Status { get; set; } = "active";
+    public bool IsInternal { get; set; }
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}
+
+[BsonIgnoreExtraElements]
+public sealed class LlmGwTeam
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString("N");
+    public string TenantId { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string NormalizedName { get; set; } = string.Empty;
+    public string Status { get; set; } = "active";
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}
+
+[BsonIgnoreExtraElements]
+public sealed class LlmGwMembership
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString("N");
+    public string TenantId { get; set; } = string.Empty;
+    public string UserId { get; set; } = string.Empty;
+    public string Role { get; set; } = LlmGwTenantRoles.Viewer;
+    public List<string> TeamIds { get; set; } = new();
+    public string Status { get; set; } = "active";
+    public long Version { get; set; } = 1;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/prd-llmgw/Models/LlmGwUser.cs
+++ b/prd-llmgw/Models/LlmGwUser.cs
@@ -9,7 +9,6 @@ namespace PrdAgent.LlmGw.Models;
 [BsonIgnoreExtraElements]
 public class LlmGwUser
 {
-    [BsonId]
     public string Id { get; set; } = Guid.NewGuid().ToString("N");
 
     public string Username { get; set; } = string.Empty;
@@ -35,6 +34,14 @@ public class LlmGwUser
     public bool PasswordChangedByUser { get; set; }
 
     public string[] Scopes { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// 服务端维护的租户目录，只用于登录后定位候选 membership；权限权威仍是
+    /// llmgw_memberships，客户端不能写入或覆盖该列表。
+    /// </summary>
+    public List<string> TenantIds { get; set; } = new();
+
+    public string? DefaultTenantId { get; set; }
 
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 

--- a/prd-llmgw/Program.cs
+++ b/prd-llmgw/Program.cs
@@ -188,6 +188,7 @@ var gwModels = gatewayDatabase.GetCollection<BsonDocument>("llmgw_models");
 var gwModelExchanges = gatewayDatabase.GetCollection<BsonDocument>("llmgw_model_exchanges");
 var serviceKeys = gatewayDatabase.GetCollection<BsonDocument>("llmgw_service_keys");
 var serviceKeyDirectory = gatewayDatabase.GetCollection<BsonDocument>("llmgw_service_key_directory");
+await BackfillInternalTenantAsync(gatewayDatabase, internalTenantId, CancellationToken.None);
 await EnsureInternalTenantAsync(
     users,
     tenants,
@@ -4718,6 +4719,47 @@ static TenantSessionDto ToTenantSession(LlmGwTenant tenant, LlmGwMembership memb
     Role = membership.Role,
     TeamIds = membership.TeamIds,
 };
+
+static async Task BackfillInternalTenantAsync(
+    IMongoDatabase database,
+    string tenantId,
+    CancellationToken ct)
+{
+    var collections = new[]
+    {
+        "llmgw_app_callers",
+        "llmgw_model_pools",
+        "llmgw_platforms",
+        "llmgw_models",
+        "llmgw_model_exchanges",
+        "llmgw_service_keys",
+        "llmrequestlogs",
+        "llmshadow_comparisons",
+        "llmgw_operation_audits",
+        "llmgw_login_audits",
+        "llmgw_lifecycle_runs",
+        "llmgw_app_caller_rate_windows",
+        "llmgw_budget_months",
+        "llmgw_budget_reservations",
+        "llmgw_request_executions",
+        "llmgw_multipart_objects",
+        "llmgw_provider_concurrency_slots",
+        "llmgw_runtime_settings",
+        "llmgw_asset_registry",
+    };
+    var missingTenant = Builders<BsonDocument>.Filter.Or(
+        Builders<BsonDocument>.Filter.Exists("TenantId", false),
+        Builders<BsonDocument>.Filter.Eq("TenantId", ""),
+        Builders<BsonDocument>.Filter.Eq("TenantId", BsonNull.Value));
+
+    foreach (var collectionName in collections)
+    {
+        await database.GetCollection<BsonDocument>(collectionName).UpdateManyAsync(
+            missingTenant,
+            Builders<BsonDocument>.Update.Set("TenantId", tenantId),
+            cancellationToken: ct);
+    }
+}
 
 static async Task EnsureInternalTenantAsync(
     IMongoCollection<LlmGwUser> users,

--- a/prd-llmgw/Program.cs
+++ b/prd-llmgw/Program.cs
@@ -372,18 +372,21 @@ app.MapPost("/gw/auth/login", async (HttpContext http, [FromBody] LoginRequestDt
         return Json(ApiEnvelope<LoginResultDto>.Fail("INVALID_CREDENTIALS", "用户名或密码错误"), jsonOptions);
     }
 
-    var tenantId = !string.IsNullOrWhiteSpace(user.DefaultTenantId)
-        ? user.DefaultTenantId
-        : user.TenantIds.FirstOrDefault();
-    var membership = string.IsNullOrWhiteSpace(tenantId)
-        ? null
-        : await memberships.Find(x => x.TenantId == tenantId && x.UserId == user.Id && x.Status == "active").FirstOrDefaultAsync();
-    var tenant = membership is null
-        ? null
-        : await tenants.Find(x => x.Id == membership.TenantId && x.Status == "active").FirstOrDefaultAsync();
+    var activeMemberships = await memberships.Find(x => x.UserId == user.Id && x.Status == "active").ToListAsync();
+    var activeTenantIds = activeMemberships.Select(x => x.TenantId).Distinct(StringComparer.Ordinal).ToList();
+    var activeTenants = activeTenantIds.Count == 0
+        ? new List<LlmGwTenant>()
+        : await tenants.Find(x => activeTenantIds.Contains(x.Id) && x.Status == "active").ToListAsync();
+    var activeTenantById = activeTenants.ToDictionary(x => x.Id, StringComparer.Ordinal);
+    var membership = activeMemberships
+        .Where(x => activeTenantById.ContainsKey(x.TenantId) && LlmGwTenantRoles.All.Contains(x.Role))
+        .OrderByDescending(x => x.TenantId == user.DefaultTenantId)
+        .ThenBy(x => x.CreatedAt)
+        .FirstOrDefault();
+    var tenant = membership is null ? null : activeTenantById.GetValueOrDefault(membership.TenantId);
     if (tenant is null || membership is null || !LlmGwTenantRoles.All.Contains(membership.Role))
     {
-        await WriteLoginAuditAsync(loginAudits, http, tenantId ?? internalTenantId, username, user.Id, false, "TENANT_MEMBERSHIP_MISSING");
+        await WriteLoginAuditAsync(loginAudits, http, user.DefaultTenantId ?? internalTenantId, username, user.Id, false, "TENANT_MEMBERSHIP_MISSING");
         return Json(ApiEnvelope<LoginResultDto>.Fail("TENANT_ACCESS_DENIED", "账号没有可用的租户成员关系"), jsonOptions, 403);
     }
 

--- a/prd-llmgw/Program.cs
+++ b/prd-llmgw/Program.cs
@@ -10,6 +10,7 @@
 using System.Text;
 using System.Text.Json;
 using System.Security.Cryptography;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.IdentityModel.Tokens;
@@ -213,7 +214,8 @@ await serviceKeys.Indexes.CreateManyAsync(new[]
 
 app.Use(async (http, next) =>
 {
-    if (http.User.Identity?.IsAuthenticated != true)
+    if (http.User.Identity?.IsAuthenticated != true
+        || http.GetEndpoint()?.Metadata.GetMetadata<IAllowAnonymous>() is not null)
     {
         await next();
         return;

--- a/prd-llmgw/Program.cs
+++ b/prd-llmgw/Program.cs
@@ -4643,7 +4643,8 @@ app.MapPut("/gw/pools/{id}/default", async (HttpContext http, string id, ToggleD
     await targetPools.UpdateOneAsync(filter, Builders<BsonDocument>.Update.Set("IsDefaultForType", true).Set("UpdatedAt", DateTime.UtcNow));
     var fb = Builders<BsonDocument>.Filter;
     var others = fb.And(fb.Eq("ModelType", modelType), fb.Ne("_id", id));
-    var clearOthers = await targetPools.UpdateManyAsync(others, Builders<BsonDocument>.Update.Set("IsDefaultForType", false).Set("UpdatedAt", DateTime.UtcNow));
+    var scopedOthers = targetAuthority == "llm_gateway" ? TenantAccess.Filter(http, others) : others;
+    var clearOthers = await targetPools.UpdateManyAsync(scopedOthers, Builders<BsonDocument>.Update.Set("IsDefaultForType", false).Set("UpdatedAt", DateTime.UtcNow));
     await WriteOperationAuditAsync(
         operationAudits,
         http,

--- a/prd-llmgw/Program.cs
+++ b/prd-llmgw/Program.cs
@@ -669,7 +669,14 @@ app.MapPut("/gw/teams/{id}", async (HttpContext http, string id, [FromBody] Upda
     }
     if (updates.Count == 0) return Json(ApiEnvelope<object>.Fail("INVALID_TEAM", "没有可更新字段"), jsonOptions, 400);
     updates.Add(Builders<LlmGwTeam>.Update.Set(x => x.UpdatedAt, DateTime.UtcNow));
-    await teams.UpdateOneAsync(x => x.Id == id && x.TenantId == access.TenantId, Builders<LlmGwTeam>.Update.Combine(updates));
+    try
+    {
+        await teams.UpdateOneAsync(x => x.Id == id && x.TenantId == access.TenantId, Builders<LlmGwTeam>.Update.Combine(updates));
+    }
+    catch (MongoWriteException ex) when (ex.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+    {
+        return Json(ApiEnvelope<object>.Fail("TEAM_CONFLICT", "当前租户已存在同名团队"), jsonOptions, 409);
+    }
     await WriteOperationAuditAsync(operationAudits, http, "team.update", "llmgw_team", id, team.Name, true, null);
     return Json(ApiEnvelope<object>.Ok(new { id, updated = true }), jsonOptions);
 }).RequireAuthorization("OrganizationWrite");

--- a/prd-llmgw/Program.cs
+++ b/prd-llmgw/Program.cs
@@ -31,6 +31,9 @@ var gatewayMongoConn = config["LlmGateway:MongoConnectionString"]
     ?? config["LLMGW_MONGO_CONNECTION_STRING"];
 if (string.IsNullOrWhiteSpace(gatewayMongoConn)) gatewayMongoConn = mongoConn;
 var gatewayDbName = config["LlmGateway:DatabaseName"] ?? "llm_gateway";
+var internalTenantId = config["LlmGateway:InternalTenantId"]?.Trim() is { Length: > 0 } configuredInternalTenantId
+    ? configuredInternalTenantId
+    : "tenant_map_internal";
 
 const string DevJwtSecret = "llmgw-dev-secret-change-me-please-0001";
 
@@ -101,12 +104,32 @@ builder.Services.AddAuthorization(options =>
     // 服务端强制（而非仅前端守卫），确保缺省 admin/admin 在改密前无法真正读取观测数据。
     options.AddPolicy("LogsRead", policy =>
         policy.RequireAuthenticatedUser()
-            .RequireAssertion(ctx => !ctx.User.HasClaim(c => c.Type == "mcp" && c.Value == "1")));
-    // 配置写门：与 LogsRead 同门槛（已登录且非 mcp 首登态）。单管理员控制台，写与读同权；
-    // 独立命名便于将来收紧（如引入只读/可写角色）。写入直接落共享 Mongo，MAP 立即可见（跨部件配置同一份）。
+            .RequireAssertion(ctx => !ctx.User.HasClaim(c => c.Type == "mcp" && c.Value == "1")
+                && TenantAccess.HasPermission(ctx.User, LlmGwPermissions.LogsRead)));
+    options.AddPolicy("RequestBodyRead", policy =>
+        policy.RequireAuthenticatedUser()
+            .RequireAssertion(ctx => !ctx.User.HasClaim(c => c.Type == "mcp" && c.Value == "1")
+                && TenantAccess.HasPermission(ctx.User, LlmGwPermissions.RequestBodyRead)));
+    options.AddPolicy("UsageRead", policy =>
+        policy.RequireAuthenticatedUser()
+            .RequireAssertion(ctx => !ctx.User.HasClaim(c => c.Type == "mcp" && c.Value == "1")
+                && TenantAccess.HasPermission(ctx.User, LlmGwPermissions.UsageRead)));
+    options.AddPolicy("AuditRead", policy =>
+        policy.RequireAuthenticatedUser()
+            .RequireAssertion(ctx => !ctx.User.HasClaim(c => c.Type == "mcp" && c.Value == "1")
+                && TenantAccess.HasPermission(ctx.User, LlmGwPermissions.AuditRead)));
     options.AddPolicy("ConfigWrite", policy =>
         policy.RequireAuthenticatedUser()
-            .RequireAssertion(ctx => !ctx.User.HasClaim(c => c.Type == "mcp" && c.Value == "1")));
+            .RequireAssertion(ctx => !ctx.User.HasClaim(c => c.Type == "mcp" && c.Value == "1")
+                && TenantAccess.HasPermission(ctx.User, LlmGwPermissions.ConfigWrite)));
+    options.AddPolicy("OrganizationWrite", policy =>
+        policy.RequireAuthenticatedUser()
+            .RequireAssertion(ctx => !ctx.User.HasClaim(c => c.Type == "mcp" && c.Value == "1")
+                && TenantAccess.HasPermission(ctx.User, LlmGwPermissions.OrganizationWrite)));
+    options.AddPolicy("TenantOwner", policy =>
+        policy.RequireAuthenticatedUser()
+            .RequireAssertion(ctx => !ctx.User.HasClaim(c => c.Type == "mcp" && c.Value == "1")
+                && TenantAccess.HasPermission(ctx.User, LlmGwPermissions.TenantOwner)));
 });
 
 // ── CORS：内部观测工具，放开来源/头/方法（前端经 nginx 跨源访问）──
@@ -130,7 +153,6 @@ var app = builder.Build();
 // CORS 必须在 Auth 之前应用。
 app.UseCors(CorsPolicy);
 app.UseAuthentication();
-app.UseAuthorization();
 
 // ── 启动时幂等播种管理员账户（内置 admin/admin 引导，env 仅 bootstrap/破玻璃）──
 // 破玻璃（break-glass）：设 LLMGW_ADMIN_FORCE_RESET 为真值（1/true/yes/on，大小写不敏感）时，显式重置 admin
@@ -141,12 +163,15 @@ var forceResetRaw = (Environment.GetEnvironmentVariable("LLMGW_ADMIN_FORCE_RESET
 var forceResetAdmin = new[] { "1", "true", "yes", "on" }.Contains(forceResetRaw, StringComparer.OrdinalIgnoreCase);
 var adminBootstrapPwd = Environment.GetEnvironmentVariable("LLMGW_ADMIN_PASSWORD");
 var operationAudits = gatewayDatabase.GetCollection<BsonDocument>("llmgw_operation_audits");
-await SeedAdminAsync(gatewayDatabase, operationAudits, AdminUser, DefaultAdminPwd, forceResetAdmin, adminBootstrapPwd);
+await SeedAdminAsync(gatewayDatabase, operationAudits, AdminUser, DefaultAdminPwd, internalTenantId, forceResetAdmin, adminBootstrapPwd);
 
 // GW 请求日志由 llmgw-serve 写入独立 llm_gateway 库；控制台和 runtime gates 必须读取同一权威来源。
 var logs = gatewayDatabase.GetCollection<BsonDocument>("llmrequestlogs");
 // GW 自有账号和审计落独立库 llm_gateway，避免被 MAP 项目 env / shared DB 状态覆盖。
 var users = gatewayDatabase.GetCollection<LlmGwUser>("llmgw_console_users");
+var tenants = gatewayDatabase.GetCollection<LlmGwTenant>("llmgw_tenants");
+var teams = gatewayDatabase.GetCollection<LlmGwTeam>("llmgw_teams");
+var memberships = gatewayDatabase.GetCollection<LlmGwMembership>("llmgw_memberships");
 var loginAudits = gatewayDatabase.GetCollection<LlmGwLoginAudit>("llmgw_login_audits");
 var lifecycleRuns = gatewayDatabase.GetCollection<BsonDocument>("llmgw_lifecycle_runs");
 // 网关配置面：GW 自有集合优先，MAP 集合作为未迁移时期的兼容来源。
@@ -161,6 +186,59 @@ var gwPlatforms = gatewayDatabase.GetCollection<BsonDocument>("llmgw_platforms")
 var gwModels = gatewayDatabase.GetCollection<BsonDocument>("llmgw_models");
 var gwModelExchanges = gatewayDatabase.GetCollection<BsonDocument>("llmgw_model_exchanges");
 var serviceKeys = gatewayDatabase.GetCollection<BsonDocument>("llmgw_service_keys");
+var serviceKeyDirectory = gatewayDatabase.GetCollection<BsonDocument>("llmgw_service_key_directory");
+await EnsureInternalTenantAsync(
+    users,
+    tenants,
+    teams,
+    memberships,
+    AdminUser,
+    internalTenantId,
+    CancellationToken.None);
+await users.Indexes.CreateOneAsync(new CreateIndexModel<LlmGwUser>(
+    Builders<LlmGwUser>.IndexKeys.Ascending(x => x.Username),
+    new CreateIndexOptions { Name = "uniq_llmgw_console_user_username", Unique = true }));
+await serviceKeyDirectory.Indexes.CreateOneAsync(new CreateIndexModel<BsonDocument>(
+    Builders<BsonDocument>.IndexKeys.Ascending("KeyHash"),
+    new CreateIndexOptions { Name = "uniq_llmgw_service_key_directory_hash", Unique = true }));
+await serviceKeys.Indexes.CreateManyAsync(new[]
+{
+    new CreateIndexModel<BsonDocument>(
+        Builders<BsonDocument>.IndexKeys.Ascending("TenantId").Ascending("KeyHash"),
+        new CreateIndexOptions { Name = "uniq_llmgw_service_key_tenant_hash", Unique = true }),
+    new CreateIndexModel<BsonDocument>(
+        Builders<BsonDocument>.IndexKeys.Ascending("TenantId").Descending("CreatedAt"),
+        new CreateIndexOptions { Name = "idx_llmgw_service_key_tenant_created" }),
+});
+
+app.Use(async (http, next) =>
+{
+    if (http.User.Identity?.IsAuthenticated != true)
+    {
+        await next();
+        return;
+    }
+
+    var tenantAccess = await TenantAccess.ResolveAsync(
+        http,
+        memberships,
+        tenants,
+        CancellationToken.None);
+    if (tenantAccess is null)
+    {
+        http.Response.StatusCode = StatusCodes.Status401Unauthorized;
+        await http.Response.WriteAsJsonAsync(new
+        {
+            success = false,
+            error = new { code = "TENANT_SESSION_INVALID", message = "租户会话无效或成员权限已变更，请重新登录" },
+        });
+        return;
+    }
+
+    http.Items[TenantAccess.ItemKey] = tenantAccess;
+    await next();
+});
+app.UseAuthorization();
 var managedParameterCapabilities = new (string Name, string Label, string Category)[]
 {
     ("temperature", "Temperature", "sampling"),
@@ -222,9 +300,9 @@ app.MapGet("/gw/healthz", () => Results.Json(new
     time = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
 }, jsonOptions)).AllowAnonymous();
 
-app.MapGet("/gw/lifecycle/status", async () =>
+app.MapGet("/gw/lifecycle/status", async (HttpContext http) =>
 {
-    var latest = await lifecycleRuns.Find(FilterDefinition<BsonDocument>.Empty)
+    var latest = await lifecycleRuns.Find(TenantAccess.Filter(http))
         .Sort(Builders<BsonDocument>.Sort.Descending("StartedAt"))
         .FirstOrDefaultAsync();
     var expected = new Dictionary<string, string[]>(StringComparer.Ordinal)
@@ -273,7 +351,7 @@ app.MapGet("/gw/lifecycle/status", async () =>
         indexes,
         allIndexesReady = indexes.All(x => x.TryGetValue("ready", out var value) && value is true),
     }), jsonOptions);
-}).RequireAuthorization("LogsRead");
+}).RequireAuthorization("AuditRead");
 
 // ───────────────────────────── 登录（匿名）─────────────────────────────
 // 登录失败返回 HTTP 200 + success:false，避免前端把 401 当作"会话过期"自动清 session。
@@ -283,22 +361,37 @@ app.MapPost("/gw/auth/login", async (HttpContext http, [FromBody] LoginRequestDt
     var password = req.Password ?? "";
     if (username.Length == 0 || password.Length == 0)
     {
-        await WriteLoginAuditAsync(loginAudits, http, username, null, false, "EMPTY_CREDENTIALS");
+        await WriteLoginAuditAsync(loginAudits, http, internalTenantId, username, null, false, "EMPTY_CREDENTIALS");
         return Json(ApiEnvelope<LoginResultDto>.Fail("INVALID_CREDENTIALS", "用户名或密码不能为空"), jsonOptions);
     }
 
     var user = await users.Find(u => u.Username == username).FirstOrDefaultAsync();
     if (user is null || !user.IsActive || !PasswordHasher.Verify(password, user.PasswordHash))
     {
-        await WriteLoginAuditAsync(loginAudits, http, username, user?.Id, false, user is null ? "USER_NOT_FOUND" : "INVALID_PASSWORD");
+        await WriteLoginAuditAsync(loginAudits, http, user?.DefaultTenantId ?? internalTenantId, username, user?.Id, false, user is null ? "USER_NOT_FOUND" : "INVALID_PASSWORD");
         return Json(ApiEnvelope<LoginResultDto>.Fail("INVALID_CREDENTIALS", "用户名或密码错误"), jsonOptions);
+    }
+
+    var tenantId = !string.IsNullOrWhiteSpace(user.DefaultTenantId)
+        ? user.DefaultTenantId
+        : user.TenantIds.FirstOrDefault();
+    var membership = string.IsNullOrWhiteSpace(tenantId)
+        ? null
+        : await memberships.Find(x => x.TenantId == tenantId && x.UserId == user.Id && x.Status == "active").FirstOrDefaultAsync();
+    var tenant = membership is null
+        ? null
+        : await tenants.Find(x => x.Id == membership.TenantId && x.Status == "active").FirstOrDefaultAsync();
+    if (tenant is null || membership is null || !LlmGwTenantRoles.All.Contains(membership.Role))
+    {
+        await WriteLoginAuditAsync(loginAudits, http, tenantId ?? internalTenantId, username, user.Id, false, "TENANT_MEMBERSHIP_MISSING");
+        return Json(ApiEnvelope<LoginResultDto>.Fail("TENANT_ACCESS_DENIED", "账号没有可用的租户成员关系"), jsonOptions, 403);
     }
 
     await users.UpdateOneAsync(u => u.Id == user.Id,
         Builders<LlmGwUser>.Update.Set(u => u.LastLoginAt, DateTime.UtcNow));
-    await WriteLoginAuditAsync(loginAudits, http, username, user.Id, true, null);
+    await WriteLoginAuditAsync(loginAudits, http, tenant.Id, username, user.Id, true, null);
 
-    var (token, expiresAt) = gwJwt.Issue(user);
+    var (token, expiresAt) = gwJwt.Issue(user, tenant, membership);
     var data = new LoginResultDto
     {
         Token = token,
@@ -306,6 +399,7 @@ app.MapPost("/gw/auth/login", async (HttpContext http, [FromBody] LoginRequestDt
         DisplayName = string.IsNullOrEmpty(user.DisplayName) ? user.Username : user.DisplayName,
         ExpiresAt = expiresAt.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
         MustChangePassword = user.MustChangePassword,
+        Tenant = ToTenantSession(tenant, membership),
     };
     return Json(ApiEnvelope<LoginResultDto>.Ok(data), jsonOptions);
 }).AllowAnonymous();
@@ -382,19 +476,282 @@ app.MapPost("/gw/auth/change-password", async (HttpContext http, [FromBody] Chan
 
     // 重新签发 token（此时 MustChangePassword 已清，Issue 不再带 mcp claim）。
     user.MustChangePassword = false;
-    var (token, expiresAt) = gwJwt.Issue(user);
+    var tenantAccess = TenantAccess.GetRequired(http);
+    var membership = await memberships.Find(x => x.Id == tenantAccess.MembershipId && x.TenantId == tenantAccess.TenantId && x.UserId == user.Id && x.Status == "active").FirstOrDefaultAsync();
+    var tenant = membership is null ? null : await tenants.Find(x => x.Id == tenantAccess.TenantId && x.Status == "active").FirstOrDefaultAsync();
+    if (tenant is null || membership is null)
+        return Json(ApiEnvelope<ChangePasswordResultDto>.Fail("TENANT_ACCESS_DENIED", "租户成员关系已失效"), jsonOptions, 403);
+    var (token, expiresAt) = gwJwt.Issue(user, tenant, membership);
     var data = new ChangePasswordResultDto
     {
         Token = token,
         Username = user.Username,
         DisplayName = string.IsNullOrEmpty(user.DisplayName) ? user.Username : user.DisplayName,
         ExpiresAt = expiresAt.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
+        Tenant = ToTenantSession(tenant, membership),
     };
     return Json(ApiEnvelope<ChangePasswordResultDto>.Ok(data), jsonOptions);
 }).RequireAuthorization();
 
+app.MapGet("/gw/auth/context", (HttpContext http) =>
+{
+    var access = TenantAccess.GetRequired(http);
+    return Json(ApiEnvelope<TenantSessionDto>.Ok(new TenantSessionDto
+    {
+        Id = access.TenantId,
+        Name = access.TenantName,
+        Role = access.Role,
+        TeamIds = access.TeamIds.ToList(),
+    }), jsonOptions);
+}).RequireAuthorization("UsageRead");
+
+app.MapPost("/gw/auth/switch-tenant", async (HttpContext http, [FromBody] SwitchTenantRequestDto body) =>
+{
+    var requestedTenantId = (body.TenantId ?? string.Empty).Trim();
+    var userId = http.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+        ?? http.User.FindFirst("sub")?.Value;
+    if (requestedTenantId.Length == 0 || string.IsNullOrWhiteSpace(userId))
+        return Json(ApiEnvelope<LoginResultDto>.Fail("INVALID_TENANT", "tenantId 不能为空"), jsonOptions, 400);
+
+    var user = await users.Find(x => x.Id == userId && x.IsActive).FirstOrDefaultAsync();
+    var membership = user is null ? null : await memberships.Find(x => x.TenantId == requestedTenantId && x.UserId == user.Id && x.Status == "active").FirstOrDefaultAsync();
+    var tenant = membership is null ? null : await tenants.Find(x => x.Id == requestedTenantId && x.Status == "active").FirstOrDefaultAsync();
+    if (user is null || membership is null || tenant is null || !LlmGwTenantRoles.All.Contains(membership.Role))
+        return Json(ApiEnvelope<LoginResultDto>.Fail("TENANT_ACCESS_DENIED", "无权切换到该租户"), jsonOptions, 403);
+
+    await users.UpdateOneAsync(x => x.Id == user.Id, Builders<LlmGwUser>.Update.Set(x => x.DefaultTenantId, tenant.Id).Set(x => x.UpdatedAt, DateTime.UtcNow));
+    var (token, expiresAt) = gwJwt.Issue(user, tenant, membership);
+    return Json(ApiEnvelope<LoginResultDto>.Ok(new LoginResultDto
+    {
+        Token = token,
+        Username = user.Username,
+        DisplayName = string.IsNullOrEmpty(user.DisplayName) ? user.Username : user.DisplayName,
+        ExpiresAt = expiresAt.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
+        MustChangePassword = false,
+        Tenant = ToTenantSession(tenant, membership),
+    }), jsonOptions);
+}).RequireAuthorization("UsageRead");
+
+app.MapPost("/gw/tenants", async (HttpContext http, [FromBody] CreateTenantRequest body) =>
+{
+    var access = TenantAccess.GetRequired(http);
+    var name = (body.Name ?? string.Empty).Trim();
+    var slug = (body.Slug ?? string.Empty).Trim().ToLowerInvariant();
+    if (name.Length is < 2 or > 120 || slug.Length is < 2 or > 64
+        || slug.Any(c => !(char.IsAsciiLetterOrDigit(c) || c == '-')))
+        return Json(ApiEnvelope<object>.Fail("INVALID_TENANT", "名称需为 2-120 字符，slug 仅支持 2-64 位小写字母、数字和连字符"), jsonOptions, 400);
+
+    var now = DateTime.UtcNow;
+    var tenant = new LlmGwTenant
+    {
+        Name = name,
+        NormalizedName = name.ToUpperInvariant(),
+        Slug = slug,
+        NormalizedSlug = slug.ToUpperInvariant(),
+        CreatedAt = now,
+        UpdatedAt = now,
+    };
+    var team = new LlmGwTeam
+    {
+        TenantId = tenant.Id,
+        Name = "Default",
+        NormalizedName = "DEFAULT",
+        CreatedAt = now,
+        UpdatedAt = now,
+    };
+    var membership = new LlmGwMembership
+    {
+        TenantId = tenant.Id,
+        UserId = access.UserId,
+        Role = LlmGwTenantRoles.Owner,
+        TeamIds = new List<string> { team.Id },
+        CreatedAt = now,
+        UpdatedAt = now,
+    };
+    try
+    {
+        await tenants.InsertOneAsync(tenant);
+        await teams.InsertOneAsync(team);
+        await memberships.InsertOneAsync(membership);
+        await users.UpdateOneAsync(x => x.Id == access.UserId,
+            Builders<LlmGwUser>.Update.AddToSet(x => x.TenantIds, tenant.Id).Set(x => x.UpdatedAt, now));
+    }
+    catch (MongoWriteException ex) when (ex.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+    {
+        await tenants.DeleteOneAsync(x => x.Id == tenant.Id);
+        await teams.DeleteOneAsync(x => x.Id == team.Id && x.TenantId == tenant.Id);
+        await memberships.DeleteOneAsync(x => x.Id == membership.Id && x.TenantId == tenant.Id);
+        return Json(ApiEnvelope<object>.Fail("TENANT_CONFLICT", "租户 slug 已存在"), jsonOptions, 409);
+    }
+    await WriteOperationAuditAsync(operationAudits, http, "tenant.create", "llmgw_tenant", tenant.Id, tenant.Name, true, null,
+        new BsonDocument { { "slug", tenant.Slug } });
+    return Json(ApiEnvelope<object>.Ok(new { tenant.Id, tenant.Name, tenant.Slug, defaultTeamId = team.Id }), jsonOptions, 201);
+}).RequireAuthorization("TenantOwner");
+
+app.MapGet("/gw/organization", async (HttpContext http) =>
+{
+    var access = TenantAccess.GetRequired(http);
+    var tenant = await tenants.Find(x => x.Id == access.TenantId).FirstOrDefaultAsync();
+    var tenantTeams = await teams.Find(x => x.TenantId == access.TenantId)
+        .SortBy(x => x.Name).ToListAsync();
+    var tenantMemberships = await memberships.Find(x => x.TenantId == access.TenantId)
+        .SortBy(x => x.CreatedAt).ToListAsync();
+    var userIds = tenantMemberships.Select(x => x.UserId).Distinct(StringComparer.Ordinal).ToList();
+    var tenantUsers = await users.Find(Builders<LlmGwUser>.Filter.In(x => x.Id, userIds)).ToListAsync();
+    var userById = tenantUsers.ToDictionary(x => x.Id, StringComparer.Ordinal);
+    return Json(ApiEnvelope<object>.Ok(new
+    {
+        tenant = tenant is null ? null : new { tenant.Id, tenant.Name, tenant.Slug, tenant.Status, tenant.IsInternal },
+        teams = tenantTeams.Select(x => new { x.Id, x.Name, x.Status, x.CreatedAt, x.UpdatedAt }),
+        members = tenantMemberships.Select(x => new
+        {
+            x.Id,
+            x.UserId,
+            username = userById.GetValueOrDefault(x.UserId)?.Username,
+            displayName = userById.GetValueOrDefault(x.UserId)?.DisplayName,
+            x.Role,
+            x.TeamIds,
+            x.Status,
+            x.Version,
+            x.CreatedAt,
+            x.UpdatedAt,
+        }),
+    }), jsonOptions);
+}).RequireAuthorization("LogsRead");
+
+app.MapPost("/gw/teams", async (HttpContext http, [FromBody] CreateTeamRequest body) =>
+{
+    var access = TenantAccess.GetRequired(http);
+    var name = (body.Name ?? string.Empty).Trim();
+    if (name.Length is < 2 or > 120)
+        return Json(ApiEnvelope<object>.Fail("INVALID_TEAM", "团队名称需为 2-120 字符"), jsonOptions, 400);
+    var team = new LlmGwTeam
+    {
+        TenantId = access.TenantId,
+        Name = name,
+        NormalizedName = name.ToUpperInvariant(),
+    };
+    try
+    {
+        await teams.InsertOneAsync(team);
+    }
+    catch (MongoWriteException ex) when (ex.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+    {
+        return Json(ApiEnvelope<object>.Fail("TEAM_CONFLICT", "当前租户已存在同名团队"), jsonOptions, 409);
+    }
+    await WriteOperationAuditAsync(operationAudits, http, "team.create", "llmgw_team", team.Id, team.Name, true, null);
+    return Json(ApiEnvelope<object>.Ok(new { team.Id, team.Name, team.Status }), jsonOptions, 201);
+}).RequireAuthorization("OrganizationWrite");
+
+app.MapPut("/gw/teams/{id}", async (HttpContext http, string id, [FromBody] UpdateTeamRequest body) =>
+{
+    var access = TenantAccess.GetRequired(http);
+    var team = await teams.Find(x => x.Id == id && x.TenantId == access.TenantId).FirstOrDefaultAsync();
+    if (team is null) return Json(ApiEnvelope<object>.Fail("TEAM_NOT_FOUND", "团队不存在"), jsonOptions, 404);
+    var updates = new List<UpdateDefinition<LlmGwTeam>>();
+    if (body.Name is not null)
+    {
+        var name = body.Name.Trim();
+        if (name.Length is < 2 or > 120) return Json(ApiEnvelope<object>.Fail("INVALID_TEAM", "团队名称需为 2-120 字符"), jsonOptions, 400);
+        updates.Add(Builders<LlmGwTeam>.Update.Set(x => x.Name, name).Set(x => x.NormalizedName, name.ToUpperInvariant()));
+    }
+    if (body.Status is not null)
+    {
+        var status = body.Status.Trim().ToLowerInvariant();
+        if (status is not ("active" or "disabled")) return Json(ApiEnvelope<object>.Fail("INVALID_TEAM", "status 仅支持 active/disabled"), jsonOptions, 400);
+        updates.Add(Builders<LlmGwTeam>.Update.Set(x => x.Status, status));
+    }
+    if (updates.Count == 0) return Json(ApiEnvelope<object>.Fail("INVALID_TEAM", "没有可更新字段"), jsonOptions, 400);
+    updates.Add(Builders<LlmGwTeam>.Update.Set(x => x.UpdatedAt, DateTime.UtcNow));
+    await teams.UpdateOneAsync(x => x.Id == id && x.TenantId == access.TenantId, Builders<LlmGwTeam>.Update.Combine(updates));
+    await WriteOperationAuditAsync(operationAudits, http, "team.update", "llmgw_team", id, team.Name, true, null);
+    return Json(ApiEnvelope<object>.Ok(new { id, updated = true }), jsonOptions);
+}).RequireAuthorization("OrganizationWrite");
+
+app.MapPost("/gw/members", async (HttpContext http, [FromBody] CreateMemberRequest body) =>
+{
+    var access = TenantAccess.GetRequired(http);
+    var username = (body.Username ?? string.Empty).Trim();
+    var role = (body.Role ?? LlmGwTenantRoles.Viewer).Trim().ToLowerInvariant();
+    var teamIds = (body.TeamIds ?? []).Distinct(StringComparer.Ordinal).ToList();
+    if (username.Length is < 3 or > 80 || !LlmGwTenantRoles.All.Contains(role))
+        return Json(ApiEnvelope<object>.Fail("INVALID_MEMBER", "用户名或角色无效"), jsonOptions, 400);
+    if (role == LlmGwTenantRoles.Owner && access.Role != LlmGwTenantRoles.Owner)
+        return Json(ApiEnvelope<object>.Fail("OWNER_REQUIRED", "只有 owner 可以授予 owner 角色"), jsonOptions, 403);
+    if (teamIds.Count > 0 && await teams.CountDocumentsAsync(x => x.TenantId == access.TenantId && teamIds.Contains(x.Id) && x.Status == "active") != teamIds.Count)
+        return Json(ApiEnvelope<object>.Fail("INVALID_TEAM", "包含不属于当前租户的团队"), jsonOptions, 400);
+
+    var memberUser = await users.Find(x => x.Username == username).FirstOrDefaultAsync();
+    if (memberUser is null)
+    {
+        var initialPassword = body.InitialPassword ?? string.Empty;
+        if (initialPassword.Length < 12)
+            return Json(ApiEnvelope<object>.Fail("INVALID_PASSWORD", "新用户初始密码至少 12 位"), jsonOptions, 400);
+        memberUser = new LlmGwUser
+        {
+            Username = username,
+            DisplayName = string.IsNullOrWhiteSpace(body.DisplayName) ? username : body.DisplayName.Trim(),
+            PasswordHash = PasswordHasher.Hash(initialPassword),
+            MustChangePassword = true,
+            TenantIds = new List<string> { access.TenantId },
+            DefaultTenantId = access.TenantId,
+        };
+        await users.InsertOneAsync(memberUser);
+    }
+    if (await memberships.CountDocumentsAsync(x => x.TenantId == access.TenantId && x.UserId == memberUser.Id) > 0)
+        return Json(ApiEnvelope<object>.Fail("MEMBERSHIP_CONFLICT", "用户已是当前租户成员"), jsonOptions, 409);
+
+    var membership = new LlmGwMembership
+    {
+        TenantId = access.TenantId,
+        UserId = memberUser.Id,
+        Role = role,
+        TeamIds = teamIds,
+    };
+    await memberships.InsertOneAsync(membership);
+    await users.UpdateOneAsync(x => x.Id == memberUser.Id,
+        Builders<LlmGwUser>.Update.AddToSet(x => x.TenantIds, access.TenantId).Set(x => x.UpdatedAt, DateTime.UtcNow));
+    await WriteOperationAuditAsync(operationAudits, http, "membership.create", "llmgw_membership", membership.Id, memberUser.Username, true, null,
+        new BsonDocument { { "role", membership.Role }, { "userId", membership.UserId } });
+    return Json(ApiEnvelope<object>.Ok(new { membership.Id, membership.UserId, memberUser.Username, membership.Role, membership.TeamIds }), jsonOptions, 201);
+}).RequireAuthorization("OrganizationWrite");
+
+app.MapPut("/gw/members/{id}", async (HttpContext http, string id, [FromBody] UpdateMemberRequest body) =>
+{
+    var access = TenantAccess.GetRequired(http);
+    var membership = await memberships.Find(x => x.Id == id && x.TenantId == access.TenantId).FirstOrDefaultAsync();
+    if (membership is null) return Json(ApiEnvelope<object>.Fail("MEMBERSHIP_NOT_FOUND", "成员关系不存在"), jsonOptions, 404);
+    var role = body.Role?.Trim().ToLowerInvariant();
+    var status = body.Status?.Trim().ToLowerInvariant();
+    if (role is not null && !LlmGwTenantRoles.All.Contains(role)) return Json(ApiEnvelope<object>.Fail("INVALID_ROLE", "角色无效"), jsonOptions, 400);
+    if (status is not null && status is not ("active" or "disabled")) return Json(ApiEnvelope<object>.Fail("INVALID_STATUS", "status 仅支持 active/disabled"), jsonOptions, 400);
+    if ((membership.Role == LlmGwTenantRoles.Owner || role == LlmGwTenantRoles.Owner)
+        && access.Role != LlmGwTenantRoles.Owner)
+        return Json(ApiEnvelope<object>.Fail("OWNER_REQUIRED", "只有 owner 可以修改 owner 成员关系"), jsonOptions, 403);
+    var removesOwner = membership.Role == LlmGwTenantRoles.Owner
+        && (role is not null && role != LlmGwTenantRoles.Owner || status == "disabled");
+    if (removesOwner && await memberships.CountDocumentsAsync(x => x.TenantId == access.TenantId && x.Role == LlmGwTenantRoles.Owner && x.Status == "active") <= 1)
+        return Json(ApiEnvelope<object>.Fail("LAST_OWNER", "不能移除租户最后一个 owner"), jsonOptions, 409);
+    if (body.TeamIds is not null)
+    {
+        var teamIds = body.TeamIds.Distinct(StringComparer.Ordinal).ToList();
+        if (teamIds.Count > 0 && await teams.CountDocumentsAsync(x => x.TenantId == access.TenantId && teamIds.Contains(x.Id) && x.Status == "active") != teamIds.Count)
+            return Json(ApiEnvelope<object>.Fail("INVALID_TEAM", "包含不属于当前租户的团队"), jsonOptions, 400);
+        membership.TeamIds = teamIds;
+    }
+    if (role is not null) membership.Role = role;
+    if (status is not null) membership.Status = status;
+    membership.Version++;
+    membership.UpdatedAt = DateTime.UtcNow;
+    await memberships.ReplaceOneAsync(x => x.Id == id && x.TenantId == access.TenantId, membership);
+    await WriteOperationAuditAsync(operationAudits, http, "membership.update", "llmgw_membership", membership.Id, membership.UserId, true, null,
+        new BsonDocument { { "role", membership.Role }, { "status", membership.Status }, { "version", membership.Version } });
+    return Json(ApiEnvelope<object>.Ok(new { membership.Id, membership.Role, membership.Status, membership.TeamIds, membership.Version }), jsonOptions);
+}).RequireAuthorization("OrganizationWrite");
+
 // ───────────────────────────── 日志列表（需鉴权）─────────────────────────────
 app.MapGet("/gw/logs", async (
+    HttpContext http,
     int? page, int? pageSize, string? from, string? to, string? model, string? status,
     string? provider, string? appCallerCode, string? transport, string? requestType,
     string? sourceSystem, string? ingressProtocol, string? modelPolicy, string? releaseCommit,
@@ -404,7 +761,7 @@ app.MapGet("/gw/logs", async (
     var ps = pageSize is > 0 and <= 500 ? pageSize.Value : 50;
 
     var (fromUtc, toUtc) = ResolveRange(from, to, defaultDays: 7);
-    var filter = BuildFilter(fromUtc, toUtc, model, status, provider, appCallerCode, transport, requestType, sourceSystem, ingressProtocol, modelPolicy, releaseCommit, runId, requestId, sessionId);
+    var filter = TenantAccess.Filter(http, BuildFilter(fromUtc, toUtc, model, status, provider, appCallerCode, transport, requestType, sourceSystem, ingressProtocol, modelPolicy, releaseCommit, runId, requestId, sessionId));
 
     var total = await logs.CountDocumentsAsync(filter);
     var docs = await logs.Find(filter)
@@ -424,10 +781,10 @@ app.MapGet("/gw/logs", async (
 }).RequireAuthorization("LogsRead");
 
 // ───────────────────────────── 元信息（需鉴权）─────────────────────────────
-app.MapGet("/gw/logs/meta", async () =>
+app.MapGet("/gw/logs/meta", async (HttpContext http) =>
 {
     var since = DateTime.UtcNow.AddDays(-30);
-    var recent = Builders<BsonDocument>.Filter.Gte("StartedAt", since);
+    var recent = TenantAccess.Filter(http, Builders<BsonDocument>.Filter.Gte("StartedAt", since));
 
     var modelsRaw = await logs.Distinct<string>("Model", recent).ToListAsync();
     var statusesRaw = await logs.Distinct<string>("Status", recent).ToListAsync();
@@ -455,13 +812,14 @@ app.MapGet("/gw/logs/meta", async () =>
 
 // ───────────────────────────── 时间序列（需鉴权）─────────────────────────────
 app.MapGet("/gw/logs/timeseries", async (
+    HttpContext http,
     string? from, string? to, string? model, string? status,
     string? provider, string? appCallerCode, string? transport, string? requestType,
     string? sourceSystem, string? ingressProtocol, string? modelPolicy, string? releaseCommit,
     string? runId, string? requestId, string? sessionId) =>
 {
     var (fromUtc, toUtc) = ResolveRange(from, to, defaultDays: 7);
-    var filter = BuildFilter(fromUtc, toUtc, model, status, provider, appCallerCode, transport, requestType, sourceSystem, ingressProtocol, modelPolicy, releaseCommit, runId, requestId, sessionId);
+    var filter = TenantAccess.Filter(http, BuildFilter(fromUtc, toUtc, model, status, provider, appCallerCode, transport, requestType, sourceSystem, ingressProtocol, modelPolicy, releaseCommit, runId, requestId, sessionId));
 
     // 仅取 StartedAt 字段做内存分组（按 UTC 日期）。
     var projection = Builders<BsonDocument>.Projection.Include("StartedAt");
@@ -482,17 +840,18 @@ app.MapGet("/gw/logs/timeseries", async (
         .ToList();
 
     return Json(ApiEnvelope<TimeseriesData>.Ok(new TimeseriesData { Items = items }), jsonOptions);
-}).RequireAuthorization("LogsRead");
+}).RequireAuthorization("UsageRead");
 
 // ───────────────────────────── 窗口汇总（需鉴权）─────────────────────────────
 app.MapGet("/gw/logs/summary", async (
+    HttpContext http,
     string? from, string? to, string? model, string? status,
     string? provider, string? appCallerCode, string? transport, string? requestType,
     string? sourceSystem, string? ingressProtocol, string? modelPolicy, string? releaseCommit,
     string? runId, string? requestId, string? sessionId) =>
 {
     var (fromUtc, toUtc) = ResolveRange(from, to, defaultDays: 7);
-    var filter = BuildFilter(fromUtc, toUtc, model, status, provider, appCallerCode, transport, requestType, sourceSystem, ingressProtocol, modelPolicy, releaseCommit, runId, requestId, sessionId);
+    var filter = TenantAccess.Filter(http, BuildFilter(fromUtc, toUtc, model, status, provider, appCallerCode, transport, requestType, sourceSystem, ingressProtocol, modelPolicy, releaseCommit, runId, requestId, sessionId));
     var projection = Builders<BsonDocument>.Projection
         .Include("Status")
         .Include("DurationMs")
@@ -528,10 +887,10 @@ app.MapGet("/gw/logs/summary", async (
     data.TotalTokens = data.InputTokens + data.OutputTokens;
 
     return Json(ApiEnvelope<LogsSummaryData>.Ok(data), jsonOptions);
-}).RequireAuthorization("LogsRead");
+}).RequireAuthorization("UsageRead");
 
 // ───────────────────────────── 协议入口运行覆盖（需鉴权）─────────────────────────────
-app.MapGet("/gw/protocol-coverage", async (string? releaseCommit, int? sinceHours) =>
+app.MapGet("/gw/protocol-coverage", async (HttpContext http, string? releaseCommit, int? sinceHours) =>
 {
     var hours = sinceHours is > 0 and <= 24 * 30 ? sinceHours.Value : 24;
     var runtimeCommit = NormalizeCommitFilter(releaseCommit);
@@ -539,9 +898,9 @@ app.MapGet("/gw/protocol-coverage", async (string? releaseCommit, int? sinceHour
     var logFilter = runtimeCommit is null
         ? Builders<BsonDocument>.Filter.Gte("StartedAt", since)
         : Builders<BsonDocument>.Filter.Eq("ReleaseCommit", runtimeCommit);
-    logFilter = Builders<BsonDocument>.Filter.And(
+    logFilter = TenantAccess.Filter(http, Builders<BsonDocument>.Filter.And(
         logFilter,
-        Builders<BsonDocument>.Filter.Ne("IsHealthProbe", true));
+        Builders<BsonDocument>.Filter.Ne("IsHealthProbe", true)));
 
     var logProjection = Builders<BsonDocument>.Projection
         .Include("IngressProtocol")
@@ -552,7 +911,7 @@ app.MapGet("/gw/protocol-coverage", async (string? releaseCommit, int? sinceHour
         .Include("StartedAt")
         .Include("DroppedParameters");
     var logDocs = await logs.Find(logFilter).Project(logProjection).ToListAsync();
-    var appCallerDocs = await gwAppCallers.Find(FilterDefinition<BsonDocument>.Empty).ToListAsync();
+    var appCallerDocs = await gwAppCallers.Find(TenantAccess.Filter(http)).ToListAsync();
 
     var items = TargetIngressProtocols().Select(protocol =>
     {
@@ -634,6 +993,7 @@ app.MapGet("/gw/protocol-coverage", async (string? releaseCommit, int? sinceHour
 
 // ───────────────────────────── 会话聚合（需鉴权）─────────────────────────────
 app.MapGet("/gw/logs/sessions", async (
+    HttpContext http,
     string? from, string? to, int? page, int? pageSize,
     string? model, string? status, string? provider, string? appCallerCode, string? transport, string? requestType,
     string? sourceSystem, string? ingressProtocol, string? modelPolicy, string? releaseCommit,
@@ -643,7 +1003,7 @@ app.MapGet("/gw/logs/sessions", async (
     var ps = pageSize is > 0 and <= 500 ? pageSize.Value : 50;
 
     var (fromUtc, toUtc) = ResolveRange(from, to, defaultDays: 7);
-    var filter = BuildFilter(fromUtc, toUtc, model, status, provider, appCallerCode, transport, requestType, sourceSystem, ingressProtocol, modelPolicy, releaseCommit, runId, requestId, sessionId);
+    var filter = TenantAccess.Filter(http, BuildFilter(fromUtc, toUtc, model, status, provider, appCallerCode, transport, requestType, sourceSystem, ingressProtocol, modelPolicy, releaseCommit, runId, requestId, sessionId));
 
     var docs = await logs.Find(filter)
         .Sort(Builders<BsonDocument>.Sort.Descending("StartedAt"))
@@ -681,27 +1041,29 @@ app.MapGet("/gw/logs/sessions", async (
 }).RequireAuthorization("LogsRead");
 
 // ───────────────────────────── 日志详情（需鉴权）─────────────────────────────
-app.MapGet("/gw/logs/{id}", async (string id) =>
+app.MapGet("/gw/logs/{id}", async (HttpContext http, string id) =>
 {
-    var filter = Builders<BsonDocument>.Filter.Eq("_id", id);
+    var filter = TenantAccess.Filter(http, Builders<BsonDocument>.Filter.Eq("_id", id));
     var doc = await logs.Find(filter).FirstOrDefaultAsync();
     if (doc is null)
     {
         return Json(ApiEnvelope<LlmLogDetail>.Fail("NOT_FOUND", "日志不存在"), jsonOptions, statusCode: 404);
     }
     return Json(ApiEnvelope<LlmLogDetail>.Ok(MapDetail(doc)), jsonOptions);
-}).RequireAuthorization("LogsRead");
+}).RequireAuthorization("RequestBodyRead");
 
 // ─────────────── 网关配置面（只读，腿 B 第一刀）───────────────
 // 让网关控制台不只有日志，还能看模型池 / 平台 / 模型 / 影子比对。密钥字段一律不返回（只回 hasKey）。
 
 // 模型池列表
-app.MapGet("/gw/pools", async (string? modelType) =>
+app.MapGet("/gw/pools", async (HttpContext http, string? modelType) =>
 {
     var fb = Builders<BsonDocument>.Filter;
     var filter = string.IsNullOrWhiteSpace(modelType) ? fb.Empty : fb.Eq("ModelType", modelType);
-    var mapDocs = await modelGroups.Find(filter).Sort(Builders<BsonDocument>.Sort.Ascending("Priority")).ToListAsync();
-    var gwDocs = await gwModelPools.Find(filter).Sort(Builders<BsonDocument>.Sort.Ascending("Priority")).ToListAsync();
+    var mapDocs = TenantAccess.GetRequired(http).TenantId == internalTenantId
+        ? await modelGroups.Find(filter).Sort(Builders<BsonDocument>.Sort.Ascending("Priority")).ToListAsync()
+        : new List<BsonDocument>();
+    var gwDocs = await gwModelPools.Find(TenantAccess.Filter(http, filter)).Sort(Builders<BsonDocument>.Sort.Ascending("Priority")).ToListAsync();
     var gwIds = gwDocs.Select(d => d.GetStringOrEmpty("_id")).Where(x => !string.IsNullOrWhiteSpace(x)).ToHashSet(StringComparer.Ordinal);
     var docs = gwDocs.Concat(mapDocs.Where(d => !gwIds.Contains(d.GetStringOrEmpty("_id")))).ToList();
     var data = new PoolsData { Items = docs.Select(MapPool).ToList(), Total = docs.Count };
@@ -709,11 +1071,12 @@ app.MapGet("/gw/pools", async (string? modelType) =>
 }).RequireAuthorization("LogsRead");
 
 // 平台列表（密钥字段绝不外泄，只回 hasKey）
-app.MapGet("/gw/platforms", async () =>
+app.MapGet("/gw/platforms", async (HttpContext http) =>
 {
-    var mapDocs = await platforms.Find(FilterDefinition<BsonDocument>.Empty)
-        .Sort(Builders<BsonDocument>.Sort.Ascending("Name")).ToListAsync();
-    var gwDocs = await gwPlatforms.Find(FilterDefinition<BsonDocument>.Empty)
+    var mapDocs = TenantAccess.GetRequired(http).TenantId == internalTenantId
+        ? await platforms.Find(FilterDefinition<BsonDocument>.Empty).Sort(Builders<BsonDocument>.Sort.Ascending("Name")).ToListAsync()
+        : new List<BsonDocument>();
+    var gwDocs = await gwPlatforms.Find(TenantAccess.Filter(http))
         .Sort(Builders<BsonDocument>.Sort.Ascending("Name")).ToListAsync();
     var gwIds = gwDocs.Select(d => d.GetStringOrEmpty("_id")).Where(x => !string.IsNullOrWhiteSpace(x)).ToHashSet(StringComparer.Ordinal);
     var docs = gwDocs.Concat(mapDocs.Where(d => !gwIds.Contains(d.GetStringOrEmpty("_id")))).ToList();
@@ -722,15 +1085,17 @@ app.MapGet("/gw/platforms", async () =>
 }).RequireAuthorization("LogsRead");
 
 // 模型列表（密钥字段绝不外泄，只回 hasKey）
-app.MapGet("/gw/models", async (string? platformId, bool? enabled) =>
+app.MapGet("/gw/models", async (HttpContext http, string? platformId, bool? enabled) =>
 {
     var fb = Builders<BsonDocument>.Filter;
     var fs = new List<FilterDefinition<BsonDocument>>();
     if (!string.IsNullOrWhiteSpace(platformId)) fs.Add(fb.Eq("PlatformId", platformId));
     if (enabled is not null) fs.Add(fb.Eq("Enabled", enabled.Value));
     var filter = fs.Count > 0 ? fb.And(fs) : fb.Empty;
-    var mapDocs = await models.Find(filter).Sort(Builders<BsonDocument>.Sort.Ascending("Priority")).ToListAsync();
-    var gwDocs = await gwModels.Find(filter).Sort(Builders<BsonDocument>.Sort.Ascending("Priority")).ToListAsync();
+    var mapDocs = TenantAccess.GetRequired(http).TenantId == internalTenantId
+        ? await models.Find(filter).Sort(Builders<BsonDocument>.Sort.Ascending("Priority")).ToListAsync()
+        : new List<BsonDocument>();
+    var gwDocs = await gwModels.Find(TenantAccess.Filter(http, filter)).Sort(Builders<BsonDocument>.Sort.Ascending("Priority")).ToListAsync();
     var gwIds = gwDocs.Select(d => d.GetStringOrEmpty("_id")).Where(x => !string.IsNullOrWhiteSpace(x)).ToHashSet(StringComparer.Ordinal);
     var docs = gwDocs.Concat(mapDocs.Where(d => !gwIds.Contains(d.GetStringOrEmpty("_id")))).ToList();
     var data = new ModelsData { Items = docs.Select(MapModel).ToList(), Total = docs.Count };
@@ -766,12 +1131,14 @@ app.MapGet("/gw/parameter-capabilities/meta", () =>
 }).RequireAuthorization("LogsRead");
 
 // Exchange 列表（密钥字段绝不外泄，只回 hasKey）
-app.MapGet("/gw/exchanges", async (bool? enabled) =>
+app.MapGet("/gw/exchanges", async (HttpContext http, bool? enabled) =>
 {
     var fb = Builders<BsonDocument>.Filter;
     var filter = enabled is null ? fb.Empty : fb.Eq("Enabled", enabled.Value);
-    var mapDocs = await modelExchanges.Find(filter).Sort(Builders<BsonDocument>.Sort.Ascending("Name")).ToListAsync();
-    var gwDocs = await gwModelExchanges.Find(filter).Sort(Builders<BsonDocument>.Sort.Ascending("Name")).ToListAsync();
+    var mapDocs = TenantAccess.GetRequired(http).TenantId == internalTenantId
+        ? await modelExchanges.Find(filter).Sort(Builders<BsonDocument>.Sort.Ascending("Name")).ToListAsync()
+        : new List<BsonDocument>();
+    var gwDocs = await gwModelExchanges.Find(TenantAccess.Filter(http, filter)).Sort(Builders<BsonDocument>.Sort.Ascending("Name")).ToListAsync();
     var gwIds = gwDocs.Select(d => d.GetStringOrEmpty("_id")).Where(x => !string.IsNullOrWhiteSpace(x)).ToHashSet(StringComparer.Ordinal);
     var docs = gwDocs.Concat(mapDocs.Where(d => !gwIds.Contains(d.GetStringOrEmpty("_id")))).ToList();
     var data = new ExchangesData { Items = docs.Select(MapExchange).ToList(), Total = docs.Count };
@@ -779,14 +1146,14 @@ app.MapGet("/gw/exchanges", async (bool? enabled) =>
 }).RequireAuthorization("LogsRead");
 
 // GW-owned key 健康自检：只解密验证，不返回明文/密文/脱敏 key，不打上游，避免产生成本。
-app.MapGet("/gw/key-health", async () =>
+app.MapGet("/gw/key-health", async (HttpContext http) =>
 {
     var items = new List<KeyHealthItem>();
-    var gwPlatformDocs = await gwPlatforms.Find(FilterDefinition<BsonDocument>.Empty)
+    var gwPlatformDocs = await gwPlatforms.Find(TenantAccess.Filter(http))
         .Sort(Builders<BsonDocument>.Sort.Ascending("Name")).ToListAsync();
-    var gwModelDocs = await gwModels.Find(FilterDefinition<BsonDocument>.Empty)
+    var gwModelDocs = await gwModels.Find(TenantAccess.Filter(http))
         .Sort(Builders<BsonDocument>.Sort.Ascending("Name")).ToListAsync();
-    var gwExchangeDocs = await gwModelExchanges.Find(FilterDefinition<BsonDocument>.Empty)
+    var gwExchangeDocs = await gwModelExchanges.Find(TenantAccess.Filter(http))
         .Sort(Builders<BsonDocument>.Sort.Ascending("Name")).ToListAsync();
 
     items.AddRange(gwPlatformDocs.Select(d => MapKeyHealth(d, "platform", "ApiKeyEncrypted", config)));
@@ -812,17 +1179,19 @@ app.MapGet("/gw/key-health", async () =>
 }).RequireAuthorization("LogsRead");
 
 // 配置权威迁移报告：只读量化 MAP fallback 退场前的差距，不修改任何配置。
-app.MapGet("/gw/config-authority/report", async () =>
+app.MapGet("/gw/config-authority/report", async (HttpContext http) =>
 {
+    if (TenantAccess.GetRequired(http).TenantId != internalTenantId)
+        return Json(ApiEnvelope<ConfigAuthorityReportData>.Fail("INTERNAL_GOVERNANCE_ONLY", "该报告仅供内部租户使用"), jsonOptions, 403);
     var mapPoolDocs = await modelGroups.Find(FilterDefinition<BsonDocument>.Empty).ToListAsync();
-    var gwPoolDocs = await gwModelPools.Find(FilterDefinition<BsonDocument>.Empty).ToListAsync();
+    var gwPoolDocs = await gwModelPools.Find(TenantAccess.Filter(http)).ToListAsync();
     var mapPlatformDocs = await platforms.Find(FilterDefinition<BsonDocument>.Empty).ToListAsync();
-    var gwPlatformDocs = await gwPlatforms.Find(FilterDefinition<BsonDocument>.Empty).ToListAsync();
+    var gwPlatformDocs = await gwPlatforms.Find(TenantAccess.Filter(http)).ToListAsync();
     var mapModelDocs = await models.Find(FilterDefinition<BsonDocument>.Empty).ToListAsync();
-    var gwModelDocs = await gwModels.Find(FilterDefinition<BsonDocument>.Empty).ToListAsync();
+    var gwModelDocs = await gwModels.Find(TenantAccess.Filter(http)).ToListAsync();
     var mapExchangeDocs = await modelExchanges.Find(FilterDefinition<BsonDocument>.Empty).ToListAsync();
-    var gwExchangeDocs = await gwModelExchanges.Find(FilterDefinition<BsonDocument>.Empty).ToListAsync();
-    var appCallerDocs = await gwAppCallers.Find(FilterDefinition<BsonDocument>.Empty).ToListAsync();
+    var gwExchangeDocs = await gwModelExchanges.Find(TenantAccess.Filter(http)).ToListAsync();
+    var appCallerDocs = await gwAppCallers.Find(TenantAccess.Filter(http)).ToListAsync();
 
     static HashSet<string> IdSet(IEnumerable<BsonDocument> docs) =>
         docs.Select(d => d.GetStringOrEmpty("_id")).Where(x => !string.IsNullOrWhiteSpace(x)).ToHashSet(StringComparer.Ordinal);
@@ -972,21 +1341,23 @@ app.MapGet("/gw/config-authority/report", async () =>
 
 // 运行态发布 gate：聚合只读证据，直接回答“现在是否可以切 full-http”。
 // 这里不写配置、不读外部 provider，只把控制台已有证据压成可复核状态。
-app.MapGet("/gw/runtime-gates", async () =>
+app.MapGet("/gw/runtime-gates", async (HttpContext http) =>
 {
+    if (TenantAccess.GetRequired(http).TenantId != internalTenantId)
+        return Json(ApiEnvelope<RuntimeGatesData>.Fail("INTERNAL_GOVERNANCE_ONLY", "运行 gate 仅供内部租户使用"), jsonOptions, 403);
     var mapPoolDocs = await modelGroups.Find(FilterDefinition<BsonDocument>.Empty).Project(Builders<BsonDocument>.Projection.Include("_id")).ToListAsync();
-    var gwPoolDocs = await gwModelPools.Find(FilterDefinition<BsonDocument>.Empty).Project(
+    var gwPoolDocs = await gwModelPools.Find(TenantAccess.Filter(http)).Project(
         Builders<BsonDocument>.Projection.Include("_id").Include("Name").Include("Code").Include("Models")).ToListAsync();
     var mapPlatformDocs = await platforms.Find(FilterDefinition<BsonDocument>.Empty).Project(Builders<BsonDocument>.Projection.Include("_id")).ToListAsync();
-    var gwPlatformDocs = await gwPlatforms.Find(FilterDefinition<BsonDocument>.Empty).Project(
+    var gwPlatformDocs = await gwPlatforms.Find(TenantAccess.Filter(http)).Project(
         Builders<BsonDocument>.Projection.Include("_id").Include("Enabled")).ToListAsync();
     var mapModelDocs = await models.Find(FilterDefinition<BsonDocument>.Empty).Project(Builders<BsonDocument>.Projection.Include("_id")).ToListAsync();
-    var gwModelDocs = await gwModels.Find(FilterDefinition<BsonDocument>.Empty).Project(
+    var gwModelDocs = await gwModels.Find(TenantAccess.Filter(http)).Project(
         Builders<BsonDocument>.Projection.Include("_id").Include("ModelName").Include("Name").Include("PlatformId").Include("Enabled")).ToListAsync();
     var mapExchangeDocs = await modelExchanges.Find(FilterDefinition<BsonDocument>.Empty).Project(Builders<BsonDocument>.Projection.Include("_id")).ToListAsync();
-    var gwExchangeDocs = await gwModelExchanges.Find(FilterDefinition<BsonDocument>.Empty).Project(
+    var gwExchangeDocs = await gwModelExchanges.Find(TenantAccess.Filter(http)).Project(
         Builders<BsonDocument>.Projection.Include("_id").Include("Name").Include("Enabled").Include("ModelAlias").Include("ModelAliases").Include("Models")).ToListAsync();
-    var appCallerDocs = await gwAppCallers.Find(FilterDefinition<BsonDocument>.Empty).Project(
+    var appCallerDocs = await gwAppCallers.Find(TenantAccess.Filter(http)).Project(
         Builders<BsonDocument>.Projection
             .Include("_id")
             .Include("AppCallerCode")
@@ -1122,8 +1493,8 @@ app.MapGet("/gw/runtime-gates", async () =>
 
     var runtimeCommit = NormalizeCommitFilter(gitCommit);
     var shadowFilter = runtimeCommit is null
-        ? FilterDefinition<BsonDocument>.Empty
-        : Builders<BsonDocument>.Filter.Eq("ReleaseCommit", runtimeCommit);
+        ? TenantAccess.Filter(http)
+        : TenantAccess.Filter(http, Builders<BsonDocument>.Filter.Eq("ReleaseCommit", runtimeCommit));
     var shadowTotal = runtimeCommit is null ? 0 : await shadows.CountDocumentsAsync(shadowFilter);
     var shadowCritical = runtimeCommit is null ? 0 : await shadows.CountDocumentsAsync(Builders<BsonDocument>.Filter.And(shadowFilter, Builders<BsonDocument>.Filter.Eq("HasCritical", true)));
     var shadowHttpFail = runtimeCommit is null ? 0 : await shadows.CountDocumentsAsync(Builders<BsonDocument>.Filter.And(shadowFilter, Builders<BsonDocument>.Filter.Eq("HttpOk", false)));
@@ -1132,6 +1503,7 @@ app.MapGet("/gw/runtime-gates", async () =>
     {
         retainedShadowCandidates = await shadows.Aggregate()
             .Match(Builders<BsonDocument>.Filter.And(
+                TenantAccess.Filter(http),
                 Builders<BsonDocument>.Filter.Ne("ReleaseCommit", runtimeCommit),
                 Builders<BsonDocument>.Filter.Exists("ReleaseCommit", true),
                 Builders<BsonDocument>.Filter.Ne("ReleaseCommit", BsonNull.Value),
@@ -1162,10 +1534,10 @@ app.MapGet("/gw/runtime-gates", async () =>
             .ToListAsync();
     }
     var logReleaseFilter = runtimeCommit is null
-        ? FilterDefinition<BsonDocument>.Empty
-        : Builders<BsonDocument>.Filter.And(
+        ? TenantAccess.Filter(http)
+        : TenantAccess.Filter(http, Builders<BsonDocument>.Filter.And(
             Builders<BsonDocument>.Filter.Eq("ReleaseCommit", runtimeCommit),
-            Builders<BsonDocument>.Filter.Ne("IsHealthProbe", true));
+            Builders<BsonDocument>.Filter.Ne("IsHealthProbe", true)));
     var releaseLogTotal = runtimeCommit is null ? 0 : await logs.CountDocumentsAsync(logReleaseFilter);
     var httpTransportLogs = runtimeCommit is null
         ? 0
@@ -1220,9 +1592,9 @@ app.MapGet("/gw/runtime-gates", async () =>
         .OrderBy(code => code, StringComparer.Ordinal)
         .ToList();
     var keyHealthItems = new List<KeyHealthItem>();
-    keyHealthItems.AddRange((await gwPlatforms.Find(FilterDefinition<BsonDocument>.Empty).ToListAsync()).Select(d => MapKeyHealth(d, "platform", "ApiKeyEncrypted", config)));
-    keyHealthItems.AddRange((await gwModels.Find(FilterDefinition<BsonDocument>.Empty).ToListAsync()).Select(d => MapKeyHealth(d, "model", "ApiKeyEncrypted", config)));
-    keyHealthItems.AddRange((await gwModelExchanges.Find(FilterDefinition<BsonDocument>.Empty).ToListAsync()).Select(d => MapKeyHealth(d, "exchange", "TargetApiKeyEncrypted", config)));
+    keyHealthItems.AddRange((await gwPlatforms.Find(TenantAccess.Filter(http)).ToListAsync()).Select(d => MapKeyHealth(d, "platform", "ApiKeyEncrypted", config)));
+    keyHealthItems.AddRange((await gwModels.Find(TenantAccess.Filter(http)).ToListAsync()).Select(d => MapKeyHealth(d, "model", "ApiKeyEncrypted", config)));
+    keyHealthItems.AddRange((await gwModelExchanges.Find(TenantAccess.Filter(http)).ToListAsync()).Select(d => MapKeyHealth(d, "exchange", "TargetApiKeyEncrypted", config)));
     var keyPrimaryConfigured = GwApiKeyCrypto.HasDedicatedPrimarySecret(config);
     var keyUnreadable = keyHealthItems.Count(x => x.Status == "unreadable");
     var keyLegacyReadable = keyHealthItems.Count(x => x.UsedLegacySecret);
@@ -1715,6 +2087,8 @@ app.MapGet("/gw/runtime-gates", async () =>
 // 统一批量认领 MAP 配置：复制到 llm_gateway，自有对象默认不覆盖。
 app.MapPost("/gw/config-authority/bulk-claim", async (HttpContext http, [FromBody] BulkClaimConfigAuthorityRequest? body) =>
 {
+    if (TenantAccess.GetRequired(http).TenantId != internalTenantId)
+        return Json(ApiEnvelope<BulkClaimConfigAuthorityResult>.Fail("INTERNAL_GOVERNANCE_ONLY", "配置权威迁移仅供内部租户使用"), jsonOptions, 403);
     var overwrite = body?.Overwrite == true;
     var now = DateTime.UtcNow;
 
@@ -1734,7 +2108,7 @@ app.MapPost("/gw/config-authority/bulk-claim", async (HttpContext http, [FromBod
                 skipped++;
                 continue;
             }
-            var filter = Builders<BsonDocument>.Filter.Eq("_id", id);
+            var filter = TenantAccess.Filter(http, Builders<BsonDocument>.Filter.Eq("_id", id));
             var existing = await targetCollection.Find(filter).FirstOrDefaultAsync();
             if (existing is not null && !overwrite)
             {
@@ -1743,6 +2117,7 @@ app.MapPost("/gw/config-authority/bulk-claim", async (HttpContext http, [FromBod
             }
 
             var cloned = new BsonDocument(source);
+            cloned["TenantId"] = internalTenantId;
             cloned["SourceCollection"] = sourceName;
             cloned["Authority"] = "llm_gateway";
             cloned["ClaimedAt"] = existing?.AsNullableUtcDateTime("ClaimedAt") ?? now;
@@ -1794,8 +2169,10 @@ app.MapPost("/gw/config-authority/bulk-claim", async (HttpContext http, [FromBod
 // active appCaller 不能依赖 MAP fallback。这里仅绑定到同 requestType 的 GW 默认池；缺默认池时报告缺口，不做跨类型硬绑。
 app.MapPost("/gw/config-authority/bind-active-app-callers", async (HttpContext http) =>
 {
+    if (TenantAccess.GetRequired(http).TenantId != internalTenantId)
+        return Json(ApiEnvelope<BindActiveAppCallerPoolsResult>.Fail("INTERNAL_GOVERNANCE_ONLY", "配置权威迁移仅供内部租户使用"), jsonOptions, 403);
     var now = DateTime.UtcNow;
-    var gwPoolDocs = await gwModelPools.Find(FilterDefinition<BsonDocument>.Empty).ToListAsync();
+    var gwPoolDocs = await gwModelPools.Find(TenantAccess.Filter(http)).ToListAsync();
     var gwPoolIds = gwPoolDocs
         .Select(d => d.GetStringOrEmpty("_id"))
         .Where(x => !string.IsNullOrWhiteSpace(x))
@@ -1822,7 +2199,7 @@ app.MapPost("/gw/config-authority/bind-active-app-callers", async (HttpContext h
         .ToDictionary(g => g.Key, g => g.OrderBy(x => x.Name, StringComparer.Ordinal).First(), StringComparer.OrdinalIgnoreCase);
 
     var activeAppCallers = await gwAppCallers
-        .Find(Builders<BsonDocument>.Filter.Eq("Status", "active"))
+        .Find(TenantAccess.Filter(http, Builders<BsonDocument>.Filter.Eq("Status", "active")))
         .ToListAsync();
     var result = new BindActiveAppCallerPoolsResult();
     static bool IsSupportedAppCallerModelPolicy(string? policy)
@@ -1860,7 +2237,7 @@ app.MapPost("/gw/config-authority/bind-active-app-callers", async (HttpContext h
             }
 
             var policyUpdateResult = await gwAppCallers.UpdateOneAsync(
-                Builders<BsonDocument>.Filter.Eq("_id", appCallerId),
+                TenantAccess.Filter(http, Builders<BsonDocument>.Filter.Eq("_id", appCallerId)),
                 Builders<BsonDocument>.Update
                     .Set("ModelPolicy", "pool")
                     .Set("UpdatedAt", now));
@@ -1912,7 +2289,7 @@ app.MapPost("/gw/config-authority/bind-active-app-callers", async (HttpContext h
         };
 
         var updateResult = await gwAppCallers.UpdateOneAsync(
-            Builders<BsonDocument>.Filter.Eq("_id", appCallerId),
+            TenantAccess.Filter(http, Builders<BsonDocument>.Filter.Eq("_id", appCallerId)),
             Builders<BsonDocument>.Update.Combine(updates));
         if (updateResult.ModifiedCount > 0)
         {
@@ -1954,6 +2331,7 @@ app.MapPost("/gw/config-authority/bind-active-app-callers", async (HttpContext h
 
 // GW 自有 appCaller 注册表：由 llmgw-serve 入口层被动发现，控制台先只读展示。
 app.MapGet("/gw/app-callers", async (
+    HttpContext http,
     string? status,
     string? sourceSystem,
     string? ingressProtocol,
@@ -1992,7 +2370,7 @@ app.MapGet("/gw/app-callers", async (
             fb.Regex("LastObservedSessionId", pattern),
             fb.Regex("LastObservedRunId", pattern)));
     }
-    var filter = filters.Count > 0 ? fb.And(filters) : fb.Empty;
+    var filter = TenantAccess.Filter(http, filters.Count > 0 ? fb.And(filters) : fb.Empty);
     var total = await gwAppCallers.CountDocumentsAsync(filter);
     var docs = await gwAppCallers.Find(filter)
         .Sort(Builders<BsonDocument>.Sort.Descending("LastSeenAt").Ascending("AppCallerCode"))
@@ -2000,7 +2378,7 @@ app.MapGet("/gw/app-callers", async (
         .Limit(ps)
         .ToListAsync();
 
-    var recent = Builders<BsonDocument>.Filter.Empty;
+    var recent = TenantAccess.Filter(http);
     var statuses = NormalizeDistinct(await gwAppCallers.Distinct<string>("Status", recent).ToListAsync(), 80);
     var sourceSystems = NormalizeDistinct(await gwAppCallers.Distinct<string>("SourceSystem", recent).ToListAsync(), 80);
     var protocolDocs = await gwAppCallers.Find(recent)
@@ -2027,7 +2405,7 @@ app.MapPut("/gw/app-callers/{id}", async (HttpContext http, string id, [FromBody
 {
     if (body is null) return Json(ApiEnvelope<GatewayAppCallerItem>.Fail("INVALID_INPUT", "请求体不能为空"), jsonOptions, 400);
 
-    var filter = Builders<BsonDocument>.Filter.Eq("_id", id);
+    var filter = TenantAccess.Filter(http, Builders<BsonDocument>.Filter.Eq("_id", id));
     var doc = await gwAppCallers.Find(filter).FirstOrDefaultAsync();
     if (doc is null) return Json(ApiEnvelope<GatewayAppCallerItem>.Fail("NOT_FOUND", $"appCaller 不存在：{id}"), jsonOptions, 404);
 
@@ -2075,9 +2453,11 @@ app.MapPut("/gw/app-callers/{id}", async (HttpContext http, string id, [FromBody
         }
         else
         {
-            var poolFilter = Builders<BsonDocument>.Filter.Eq("_id", modelPoolId);
+            var poolFilter = TenantAccess.Filter(http, Builders<BsonDocument>.Filter.Eq("_id", modelPoolId));
             var pool = await gwModelPools.Find(poolFilter).FirstOrDefaultAsync()
-                       ?? await modelGroups.Find(poolFilter).FirstOrDefaultAsync();
+                       ?? (TenantAccess.GetRequired(http).TenantId == internalTenantId
+                           ? await modelGroups.Find(Builders<BsonDocument>.Filter.Eq("_id", modelPoolId)).FirstOrDefaultAsync()
+                           : null);
             if (pool is null)
             {
                 return Json(ApiEnvelope<GatewayAppCallerItem>.Fail("INVALID_INPUT", $"模型池不存在：{modelPoolId}"), jsonOptions, 400);
@@ -2242,6 +2622,7 @@ app.MapPut("/gw/app-callers/{id}", async (HttpContext http, string id, [FromBody
         gwPlatforms,
         gwModels,
         gwModelExchanges,
+        TenantAccess.GetRequired(http).TenantId,
         effectiveStatus,
         effectiveModelPoolId,
         effectiveModelPolicy,
@@ -2453,7 +2834,7 @@ app.MapPost("/gw/app-callers/bulk-governance", async (HttpContext http, [FromBod
         return Json(ApiEnvelope<BulkUpdateGatewayAppCallersResult>.Fail("INVALID_INPUT", "没有可更新字段"), jsonOptions, 400);
     }
 
-    var filter = fb.And(filters);
+    var filter = TenantAccess.Filter(http, fb.And(filters));
     if (body.MonthlyBudgetUsd is not null || body.BudgetReservationUsd is not null)
     {
         if (body.MonthlyBudgetUsd is < 0 || body.BudgetReservationUsd is < 0)
@@ -2486,6 +2867,7 @@ app.MapPost("/gw/app-callers/bulk-governance", async (HttpContext http, [FromBod
         gwPlatforms,
         gwModels,
         gwModelExchanges,
+        TenantAccess.GetRequired(http).TenantId,
         filter,
         targetStatus,
         targetModelPolicyTouched,
@@ -2525,6 +2907,7 @@ app.MapPost("/gw/app-callers/bulk-governance", async (HttpContext http, [FromBod
 
 // GW 操作审计：控制台配置动作统一写 llm_gateway.llmgw_operation_audits，此处提供只读筛选面。
 app.MapGet("/gw/audits", async (
+    HttpContext http,
     string? action,
     string? targetType,
     string? actor,
@@ -2558,7 +2941,7 @@ app.MapGet("/gw/audits", async (
             fb.Regex("ActorUsername", pattern)));
     }
 
-    var filter = filters.Count > 0 ? fb.And(filters) : fb.Empty;
+    var filter = TenantAccess.Filter(http, filters.Count > 0 ? fb.And(filters) : fb.Empty);
     var total = await operationAudits.CountDocumentsAsync(filter);
     var docs = await operationAudits.Find(filter)
         .Sort(Builders<BsonDocument>.Sort.Descending("CreatedAt"))
@@ -2566,7 +2949,7 @@ app.MapGet("/gw/audits", async (
         .Limit(ps)
         .ToListAsync();
 
-    var metaDocs = await operationAudits.Find(fb.Empty)
+    var metaDocs = await operationAudits.Find(TenantAccess.Filter(http))
         .Project(Builders<BsonDocument>.Projection
             .Include("Action")
             .Include("TargetType")
@@ -2585,12 +2968,12 @@ app.MapGet("/gw/audits", async (
         Actors = NormalizeDistinct(metaDocs.Select(d => d.AsNullableString("ActorUsername")).Where(x => !string.IsNullOrWhiteSpace(x)).Select(x => x!).ToList(), 200),
     };
     return Json(ApiEnvelope<OperationAuditsData>.Ok(data), jsonOptions);
-}).RequireAuthorization("LogsRead");
+}).RequireAuthorization("AuditRead");
 
 // M2M scoped key：明文只在创建响应返回一次，数据库只保存 SHA-256。
-app.MapGet("/gw/service-keys", async () =>
+app.MapGet("/gw/service-keys", async (HttpContext http) =>
 {
-    var docs = await serviceKeys.Find(Builders<BsonDocument>.Filter.Empty)
+    var docs = await serviceKeys.Find(TenantAccess.Filter(http))
         .Sort(Builders<BsonDocument>.Sort.Descending("CreatedAt"))
         .Limit(500)
         .ToListAsync();
@@ -2612,6 +2995,7 @@ app.MapGet("/gw/service-keys", async () =>
 
 app.MapPost("/gw/service-keys", async (HttpContext http, ServiceKeyCreateRequest body) =>
 {
+    var tenant = TenantAccess.GetRequired(http);
     var name = (body.Name ?? string.Empty).Trim();
     var sourceSystem = (body.SourceSystem ?? "external").Trim();
     var appCallerCodes = NormalizeDistinct(body.AppCallerCodes ?? [], 200);
@@ -2645,6 +3029,8 @@ app.MapPost("/gw/service-keys", async (HttpContext http, ServiceKeyCreateRequest
     await serviceKeys.InsertOneAsync(new BsonDocument
     {
         { "_id", id },
+        { "TenantId", tenant.TenantId },
+        { "TeamId", tenant.TeamIds.Count == 1 ? tenant.TeamIds[0] : BsonNull.Value },
         { "Name", name },
         { "KeyHash", keyHash },
         { "Enabled", true },
@@ -2656,6 +3042,22 @@ app.MapPost("/gw/service-keys", async (HttpContext http, ServiceKeyCreateRequest
         { "CreatedAt", now },
         { "UpdatedAt", now },
     });
+    try
+    {
+        await serviceKeyDirectory.InsertOneAsync(new BsonDocument
+        {
+            { "_id", id },
+            { "KeyHash", keyHash },
+            { "TenantId", tenant.TenantId },
+            { "ServiceKeyId", id },
+            { "CreatedAt", now },
+        });
+    }
+    catch
+    {
+        await serviceKeys.DeleteOneAsync(TenantAccess.Filter(http, Builders<BsonDocument>.Filter.Eq("_id", id)));
+        throw;
+    }
     await WriteOperationAuditAsync(
         operationAudits,
         http,
@@ -2688,11 +3090,12 @@ app.MapPost("/gw/service-keys", async (HttpContext http, ServiceKeyCreateRequest
 
 app.MapDelete("/gw/service-keys/{id}", async (HttpContext http, string id) =>
 {
-    var existing = await serviceKeys.Find(Builders<BsonDocument>.Filter.Eq("_id", id)).FirstOrDefaultAsync();
+    var keyFilter = TenantAccess.Filter(http, Builders<BsonDocument>.Filter.Eq("_id", id));
+    var existing = await serviceKeys.Find(keyFilter).FirstOrDefaultAsync();
     if (existing is null)
         return Json(ApiEnvelope<object>.Fail("SERVICE_KEY_NOT_FOUND", "service key 不存在"), jsonOptions, 404);
     await serviceKeys.UpdateOneAsync(
-        Builders<BsonDocument>.Filter.Eq("_id", id),
+        keyFilter,
         Builders<BsonDocument>.Update.Set("Enabled", false).Set("UpdatedAt", DateTime.UtcNow));
     await WriteOperationAuditAsync(
         operationAudits,
@@ -2707,7 +3110,7 @@ app.MapDelete("/gw/service-keys/{id}", async (HttpContext http, string id) =>
 }).RequireAuthorization("ConfigWrite");
 
 // 影子比对：汇总 + 最近 N 条
-app.MapGet("/gw/shadow-comparisons", async (int? limit, string? appCallerCode, string? kind, string? releaseCommit, double? sinceHours) =>
+app.MapGet("/gw/shadow-comparisons", async (HttpContext http, int? limit, string? appCallerCode, string? kind, string? releaseCommit, double? sinceHours) =>
 {
     var n = Math.Clamp(limit ?? 50, 1, 500);
     var fb = Builders<BsonDocument>.Filter;
@@ -2718,7 +3121,7 @@ app.MapGet("/gw/shadow-comparisons", async (int? limit, string? appCallerCode, s
     if (normalizedReleaseCommit is not null) filters.Add(fb.Eq("ReleaseCommit", normalizedReleaseCommit));
     var since = sinceHours is > 0 ? DateTime.UtcNow.AddHours(-sinceHours.Value) : (DateTime?)null;
     if (since is not null) filters.Add(fb.Gte("ComparedAt", since.Value));
-    var filter = filters.Count == 0 ? fb.Empty : fb.And(filters);
+    var filter = TenantAccess.Filter(http, filters.Count == 0 ? fb.Empty : fb.And(filters));
     var total = await shadows.CountDocumentsAsync(filter);
     var allMatch = await shadows.CountDocumentsAsync(fb.And(filter, fb.Eq("AllMatch", true)));
     var critical = await shadows.CountDocumentsAsync(fb.And(filter, fb.Eq("HasCritical", true)));
@@ -2765,15 +3168,19 @@ app.MapPut("/gw/platforms/{id}/enabled", async (HttpContext http, string id, Tog
 {
     // 缺 enabled 字段（空 body / 漏传）一律拒绝，避免默认 false 误关平台。
     if (body?.Enabled is not bool enabled) return Json(ApiEnvelope<PlatformItem>.Fail("INVALID_INPUT", "缺少 enabled 字段（true/false）"), jsonOptions, 400);
-    var filter = Builders<BsonDocument>.Filter.Eq("_id", id);
+    var sourceFilter = Builders<BsonDocument>.Filter.Eq("_id", id);
+    var filter = TenantAccess.Filter(http, sourceFilter);
     var doc = await gwPlatforms.Find(filter).FirstOrDefaultAsync();
     var targetPlatforms = gwPlatforms;
     var targetAuthority = "llm_gateway";
     if (doc is null)
     {
-        doc = await platforms.Find(filter).FirstOrDefaultAsync();
+        if (TenantAccess.GetRequired(http).TenantId != internalTenantId)
+            return Json(ApiEnvelope<PlatformItem>.Fail("NOT_FOUND", $"平台不存在：{id}"), jsonOptions, 404);
+        doc = await platforms.Find(sourceFilter).FirstOrDefaultAsync();
         targetPlatforms = platforms;
         targetAuthority = "map";
+        filter = sourceFilter;
     }
     if (doc is null) return Json(ApiEnvelope<PlatformItem>.Fail("NOT_FOUND", $"平台不存在：{id}"), jsonOptions, 404);
     var update = Builders<BsonDocument>.Update.Set("Enabled", enabled).Set("UpdatedAt", DateTime.UtcNow);
@@ -2801,15 +3208,19 @@ app.MapPut("/gw/models/{id}/enabled", async (HttpContext http, string id, Toggle
 {
     // 缺 enabled 字段一律拒绝，避免默认 false 误关模型。
     if (body?.Enabled is not bool enabled) return Json(ApiEnvelope<ModelItem>.Fail("INVALID_INPUT", "缺少 enabled 字段（true/false）"), jsonOptions, 400);
-    var filter = Builders<BsonDocument>.Filter.Eq("_id", id);
+    var sourceFilter = Builders<BsonDocument>.Filter.Eq("_id", id);
+    var filter = TenantAccess.Filter(http, sourceFilter);
     var doc = await gwModels.Find(filter).FirstOrDefaultAsync();
     var targetModels = gwModels;
     var targetAuthority = "llm_gateway";
     if (doc is null)
     {
-        doc = await models.Find(filter).FirstOrDefaultAsync();
+        if (TenantAccess.GetRequired(http).TenantId != internalTenantId)
+            return Json(ApiEnvelope<ModelItem>.Fail("NOT_FOUND", $"模型不存在：{id}"), jsonOptions, 404);
+        doc = await models.Find(sourceFilter).FirstOrDefaultAsync();
         targetModels = models;
         targetAuthority = "map";
+        filter = sourceFilter;
     }
     if (doc is null) return Json(ApiEnvelope<ModelItem>.Fail("NOT_FOUND", $"模型不存在：{id}"), jsonOptions, 404);
     var update = Builders<BsonDocument>.Update.Set("Enabled", enabled).Set("UpdatedAt", DateTime.UtcNow);
@@ -2835,13 +3246,17 @@ app.MapPut("/gw/models/{id}/enabled", async (HttpContext http, string id, Toggle
 // 平台认领：把 MAP 平台复制到 GW 自有 llm_gateway.llmgw_platforms。
 app.MapPut("/gw/platforms/{id}/claim", async (HttpContext http, string id) =>
 {
-    var filter = Builders<BsonDocument>.Filter.Eq("_id", id);
-    var source = await platforms.Find(filter).FirstOrDefaultAsync();
+    if (TenantAccess.GetRequired(http).TenantId != internalTenantId)
+        return Json(ApiEnvelope<PlatformItem>.Fail("INTERNAL_GOVERNANCE_ONLY", "仅内部租户可认领 MAP 平台"), jsonOptions, 403);
+    var sourceFilter = Builders<BsonDocument>.Filter.Eq("_id", id);
+    var filter = TenantAccess.Filter(http, sourceFilter);
+    var source = await platforms.Find(sourceFilter).FirstOrDefaultAsync();
     if (source is null) return Json(ApiEnvelope<PlatformItem>.Fail("NOT_FOUND", $"平台不存在：{id}"), jsonOptions, 404);
 
     var now = DateTime.UtcNow;
     var before = await gwPlatforms.Find(filter).FirstOrDefaultAsync();
     var claimed = new BsonDocument(source);
+    claimed["TenantId"] = internalTenantId;
     claimed["SourceCollection"] = "llmplatforms";
     claimed["Authority"] = "llm_gateway";
     claimed["ClaimedAt"] = now;
@@ -2871,7 +3286,7 @@ app.MapPut("/gw/platforms/{id}/claim", async (HttpContext http, string id) =>
 // 平台密钥轮换：只允许写入已认领到 GW 的平台，不直接修改 MAP 来源平台。
 app.MapPut("/gw/platforms/{id}/api-key", async (HttpContext http, string id, [FromBody] RotateApiKeyRequest body) =>
 {
-    var filter = Builders<BsonDocument>.Filter.Eq("_id", id);
+    var filter = TenantAccess.Filter(http, Builders<BsonDocument>.Filter.Eq("_id", id));
     var doc = await gwPlatforms.Find(filter).FirstOrDefaultAsync();
     if (doc is null) return Json(ApiEnvelope<PlatformItem>.Fail("NOT_GW_AUTHORITY", "请先将平台认领到 GW，再在 GW 中轮换密钥"), jsonOptions, 409);
     if (string.IsNullOrWhiteSpace(body?.ApiKey)) return Json(ApiEnvelope<PlatformItem>.Fail("INVALID_INPUT", "apiKey 不能为空"), jsonOptions, 400);
@@ -2912,7 +3327,7 @@ app.MapPut("/gw/platforms/{id}/api-key", async (HttpContext http, string id, [Fr
 // 平台密钥删除：只允许清理 GW 权威平台的密钥，MAP 来源平台必须先认领。
 app.MapDelete("/gw/platforms/{id}/api-key", async (HttpContext http, string id) =>
 {
-    var filter = Builders<BsonDocument>.Filter.Eq("_id", id);
+    var filter = TenantAccess.Filter(http, Builders<BsonDocument>.Filter.Eq("_id", id));
     var doc = await gwPlatforms.Find(filter).FirstOrDefaultAsync();
     if (doc is null) return Json(ApiEnvelope<PlatformItem>.Fail("NOT_GW_AUTHORITY", "请先将平台认领到 GW，再在 GW 中删除密钥"), jsonOptions, 409);
 
@@ -2941,13 +3356,17 @@ app.MapDelete("/gw/platforms/{id}/api-key", async (HttpContext http, string id) 
 // 模型认领：把 MAP 模型复制到 GW 自有 llm_gateway.llmgw_models。
 app.MapPut("/gw/models/{id}/claim", async (HttpContext http, string id) =>
 {
-    var filter = Builders<BsonDocument>.Filter.Eq("_id", id);
-    var source = await models.Find(filter).FirstOrDefaultAsync();
+    if (TenantAccess.GetRequired(http).TenantId != internalTenantId)
+        return Json(ApiEnvelope<ModelItem>.Fail("INTERNAL_GOVERNANCE_ONLY", "仅内部租户可认领 MAP 模型"), jsonOptions, 403);
+    var sourceFilter = Builders<BsonDocument>.Filter.Eq("_id", id);
+    var filter = TenantAccess.Filter(http, sourceFilter);
+    var source = await models.Find(sourceFilter).FirstOrDefaultAsync();
     if (source is null) return Json(ApiEnvelope<ModelItem>.Fail("NOT_FOUND", $"模型不存在：{id}"), jsonOptions, 404);
 
     var now = DateTime.UtcNow;
     var before = await gwModels.Find(filter).FirstOrDefaultAsync();
     var claimed = new BsonDocument(source);
+    claimed["TenantId"] = internalTenantId;
     claimed["SourceCollection"] = "llmmodels";
     claimed["Authority"] = "llm_gateway";
     claimed["ClaimedAt"] = now;
@@ -2978,7 +3397,7 @@ app.MapPut("/gw/models/{id}/claim", async (HttpContext http, string id) =>
 // 模型密钥轮换：只允许写入已认领到 GW 的模型；模型未配置 key 时仍可继承平台 key。
 app.MapPut("/gw/models/{id}/api-key", async (HttpContext http, string id, [FromBody] RotateApiKeyRequest body) =>
 {
-    var filter = Builders<BsonDocument>.Filter.Eq("_id", id);
+    var filter = TenantAccess.Filter(http, Builders<BsonDocument>.Filter.Eq("_id", id));
     var doc = await gwModels.Find(filter).FirstOrDefaultAsync();
     if (doc is null) return Json(ApiEnvelope<ModelItem>.Fail("NOT_GW_AUTHORITY", "请先将模型认领到 GW，再在 GW 中轮换密钥"), jsonOptions, 409);
     if (string.IsNullOrWhiteSpace(body?.ApiKey)) return Json(ApiEnvelope<ModelItem>.Fail("INVALID_INPUT", "apiKey 不能为空"), jsonOptions, 400);
@@ -3019,7 +3438,7 @@ app.MapPut("/gw/models/{id}/api-key", async (HttpContext http, string id, [FromB
 // 模型密钥删除：只允许清理 GW 权威模型的模型级密钥；删除后可继续继承平台 key。
 app.MapDelete("/gw/models/{id}/api-key", async (HttpContext http, string id) =>
 {
-    var filter = Builders<BsonDocument>.Filter.Eq("_id", id);
+    var filter = TenantAccess.Filter(http, Builders<BsonDocument>.Filter.Eq("_id", id));
     var doc = await gwModels.Find(filter).FirstOrDefaultAsync();
     if (doc is null) return Json(ApiEnvelope<ModelItem>.Fail("NOT_GW_AUTHORITY", "请先将模型认领到 GW，再在 GW 中删除密钥"), jsonOptions, 409);
 
@@ -3098,7 +3517,7 @@ app.MapPost("/gw/models/capabilities/bulk-update", async (HttpContext http, [Fro
         filterParts.Add("enabledOnly=true");
     }
     if (body.OnlyMissing == true) filterParts.Add("onlyMissing=true");
-    var targetFilter = filters.Count == 0 ? fb.Empty : fb.And(filters);
+    var targetFilter = TenantAccess.Filter(http, filters.Count == 0 ? fb.Empty : fb.And(filters));
     var docs = await gwModels.Find(targetFilter).ToListAsync();
     var modified = 0;
     var skipped = 0;
@@ -3129,7 +3548,7 @@ app.MapPost("/gw/models/capabilities/bulk-update", async (HttpContext http, [Fro
             .Select(kv => kv.Value)
             .ToList();
         await gwModels.UpdateOneAsync(
-            Builders<BsonDocument>.Filter.Eq("_id", doc.GetStringOrEmpty("_id")),
+            TenantAccess.Filter(http, Builders<BsonDocument>.Filter.Eq("_id", doc.GetStringOrEmpty("_id"))),
             Builders<BsonDocument>.Update
                 .Set("Capabilities", new BsonArray(nextCaps))
                 .Set("UpdatedAt", DateTime.UtcNow));
@@ -3170,13 +3589,17 @@ app.MapPost("/gw/models/capabilities/bulk-update", async (HttpContext http, [Fro
 // Exchange 认领：先只提供 API，不暴露密钥明文；resolver 会优先读 GW 自有 exchange。
 app.MapPut("/gw/exchanges/{id}/claim", async (HttpContext http, string id) =>
 {
-    var filter = Builders<BsonDocument>.Filter.Eq("_id", id);
-    var source = await modelExchanges.Find(filter).FirstOrDefaultAsync();
+    if (TenantAccess.GetRequired(http).TenantId != internalTenantId)
+        return Json(ApiEnvelope<ExchangeItem>.Fail("INTERNAL_GOVERNANCE_ONLY", "仅内部租户可认领 MAP Exchange"), jsonOptions, 403);
+    var sourceFilter = Builders<BsonDocument>.Filter.Eq("_id", id);
+    var filter = TenantAccess.Filter(http, sourceFilter);
+    var source = await modelExchanges.Find(sourceFilter).FirstOrDefaultAsync();
     if (source is null) return Json(ApiEnvelope<ExchangeItem>.Fail("NOT_FOUND", $"Exchange 不存在：{id}"), jsonOptions, 404);
 
     var now = DateTime.UtcNow;
     var before = await gwModelExchanges.Find(filter).FirstOrDefaultAsync();
     var claimed = new BsonDocument(source);
+    claimed["TenantId"] = internalTenantId;
     claimed["SourceCollection"] = "model_exchanges";
     claimed["Authority"] = "llm_gateway";
     claimed["ClaimedAt"] = now;
@@ -3206,7 +3629,7 @@ app.MapPut("/gw/exchanges/{id}/claim", async (HttpContext http, string id) =>
 // Exchange 密钥轮换：只允许写入已认领到 GW 的 Exchange。
 app.MapPut("/gw/exchanges/{id}/api-key", async (HttpContext http, string id, [FromBody] RotateApiKeyRequest body) =>
 {
-    var filter = Builders<BsonDocument>.Filter.Eq("_id", id);
+    var filter = TenantAccess.Filter(http, Builders<BsonDocument>.Filter.Eq("_id", id));
     var doc = await gwModelExchanges.Find(filter).FirstOrDefaultAsync();
     if (doc is null) return Json(ApiEnvelope<ExchangeItem>.Fail("NOT_GW_AUTHORITY", "请先将 Exchange 认领到 GW，再在 GW 中轮换密钥"), jsonOptions, 409);
     if (string.IsNullOrWhiteSpace(body?.ApiKey)) return Json(ApiEnvelope<ExchangeItem>.Fail("INVALID_INPUT", "apiKey 不能为空"), jsonOptions, 400);
@@ -3247,7 +3670,7 @@ app.MapPut("/gw/exchanges/{id}/api-key", async (HttpContext http, string id, [Fr
 // Exchange 密钥删除：只允许清理 GW 权威 Exchange 的目标密钥。
 app.MapDelete("/gw/exchanges/{id}/api-key", async (HttpContext http, string id) =>
 {
-    var filter = Builders<BsonDocument>.Filter.Eq("_id", id);
+    var filter = TenantAccess.Filter(http, Builders<BsonDocument>.Filter.Eq("_id", id));
     var doc = await gwModelExchanges.Find(filter).FirstOrDefaultAsync();
     if (doc is null) return Json(ApiEnvelope<ExchangeItem>.Fail("NOT_GW_AUTHORITY", "请先将 Exchange 认领到 GW，再在 GW 中删除密钥"), jsonOptions, 409);
 
@@ -3366,7 +3789,7 @@ app.MapPost("/gw/api-keys/bulk-rotate", async (HttpContext http, [FromBody] Bulk
         return Json(ApiEnvelope<BulkRotateApiKeysResult>.Fail("INVALID_INPUT", "platformId 仅支持 model 批量轮换"), jsonOptions, 400);
     }
 
-    var targetFilter = filters.Count == 0 ? fb.Empty : fb.And(filters);
+    var targetFilter = TenantAccess.Filter(http, filters.Count == 0 ? fb.Empty : fb.And(filters));
     var matchedCount = await targetCollection.CountDocumentsAsync(targetFilter);
     var skippedCount = ids.Count > 0 ? Math.Max(0, ids.Count - matchedCount) : 0;
     if (matchedCount == 0)
@@ -3439,6 +3862,7 @@ app.MapPost("/gw/pools", async (HttpContext http, [FromBody] CreatePoolRequest b
     var doc = new BsonDocument
     {
         ["_id"] = Guid.NewGuid().ToString("N"),
+        ["TenantId"] = TenantAccess.GetRequired(http).TenantId,
         ["Name"] = name,
         ["Code"] = code,
         ["Priority"] = body.Priority ?? 50,
@@ -3469,7 +3893,7 @@ app.MapPost("/gw/pools", async (HttpContext http, [FromBody] CreatePoolRequest b
     {
         var fb = Builders<BsonDocument>.Filter;
         await gwModelPools.UpdateManyAsync(
-            fb.And(fb.Eq("ModelType", modelType), fb.Ne("_id", doc.GetStringOrEmpty("_id"))),
+            TenantAccess.Filter(http, fb.And(fb.Eq("ModelType", modelType), fb.Ne("_id", doc.GetStringOrEmpty("_id")))),
             Builders<BsonDocument>.Update.Set("IsDefaultForType", false).Set("UpdatedAt", now));
     }
 
@@ -3497,11 +3921,14 @@ app.MapPut("/gw/pools/{id}", async (HttpContext http, string id, [FromBody] Upda
 {
     if (body is null) return Json(ApiEnvelope<PoolItem>.Fail("INVALID_INPUT", "请求体不能为空"), jsonOptions, 400);
 
-    var filter = Builders<BsonDocument>.Filter.Eq("_id", id);
+    var sourceFilter = Builders<BsonDocument>.Filter.Eq("_id", id);
+    var filter = TenantAccess.Filter(http, sourceFilter);
     var doc = await gwModelPools.Find(filter).FirstOrDefaultAsync();
     if (doc is null)
     {
-        var mapDoc = await modelGroups.Find(filter).FirstOrDefaultAsync();
+        var mapDoc = TenantAccess.GetRequired(http).TenantId == internalTenantId
+            ? await modelGroups.Find(sourceFilter).FirstOrDefaultAsync()
+            : null;
         if (mapDoc is not null)
         {
             return Json(ApiEnvelope<PoolItem>.Fail("MAP_POOL_NOT_CLAIMED", "请先将模型池认领到 GW，再编辑模型池属性"), jsonOptions, 409);
@@ -3598,7 +4025,7 @@ app.MapPut("/gw/pools/{id}", async (HttpContext http, string id, [FromBody] Upda
     {
         var fb = Builders<BsonDocument>.Filter;
         await gwModelPools.UpdateManyAsync(
-            fb.And(fb.Eq("ModelType", nextModelType), fb.Ne("_id", id)),
+            TenantAccess.Filter(http, fb.And(fb.Eq("ModelType", nextModelType), fb.Ne("_id", id))),
             Builders<BsonDocument>.Update.Set("IsDefaultForType", false).Set("UpdatedAt", now));
     }
 
@@ -3620,6 +4047,8 @@ app.MapPut("/gw/pools/{id}", async (HttpContext http, string id, [FromBody] Upda
 // 批量认领 MAP 模型池：把 MAP model_groups 复制到 llm_gateway，自有池默认不覆盖。
 app.MapPost("/gw/pools/bulk-claim", async (HttpContext http, [FromBody] BulkClaimPoolsRequest? body) =>
 {
+    if (TenantAccess.GetRequired(http).TenantId != internalTenantId)
+        return Json(ApiEnvelope<BulkClaimPoolsResult>.Fail("INTERNAL_GOVERNANCE_ONLY", "仅内部租户可认领 MAP 模型池"), jsonOptions, 403);
     var modelType = (body?.ModelType ?? string.Empty).Trim();
     var overwrite = body?.Overwrite == true;
     var fb = Builders<BsonDocument>.Filter;
@@ -3638,7 +4067,7 @@ app.MapPost("/gw/pools/bulk-claim", async (HttpContext http, [FromBody] BulkClai
             skipped++;
             continue;
         }
-        var filter = Builders<BsonDocument>.Filter.Eq("_id", id);
+        var filter = TenantAccess.Filter(http, Builders<BsonDocument>.Filter.Eq("_id", id));
         var exists = await gwModelPools.Find(filter).FirstOrDefaultAsync();
         if (exists is not null && !overwrite)
         {
@@ -3647,6 +4076,7 @@ app.MapPost("/gw/pools/bulk-claim", async (HttpContext http, [FromBody] BulkClai
         }
 
         var claimedDoc = new BsonDocument(source);
+        claimedDoc["TenantId"] = internalTenantId;
         claimedDoc["SourceCollection"] = "model_groups";
         claimedDoc["Authority"] = "llm_gateway";
         claimedDoc["ClaimedAt"] = exists?.AsNullableUtcDateTime("ClaimedAt") ?? now;
@@ -3696,7 +4126,7 @@ app.MapPost("/gw/pools/price-currency/bulk-calibrate", async (HttpContext http, 
     var onlyMissing = body.OnlyMissing != false;
     var includeMembersWithoutPrice = body.IncludeMembersWithoutPrice == true;
     var fb = Builders<BsonDocument>.Filter;
-    var poolFilter = modelType.Length == 0 ? fb.Empty : fb.Eq("ModelType", modelType);
+    var poolFilter = TenantAccess.Filter(http, modelType.Length == 0 ? fb.Empty : fb.Eq("ModelType", modelType));
     var poolDocs = await gwModelPools.Find(poolFilter).ToListAsync();
     var touchedPools = 0;
     var matchedMembers = 0;
@@ -3775,7 +4205,7 @@ app.MapPost("/gw/pools/price-currency/bulk-calibrate", async (HttpContext http, 
 app.MapPost("/gw/pools/{id}/models/bulk-import", async (HttpContext http, string id, [FromBody] BulkImportPoolModelsRequest? body) =>
 {
     body ??= new BulkImportPoolModelsRequest();
-    var poolFilter = Builders<BsonDocument>.Filter.Eq("_id", id);
+    var poolFilter = TenantAccess.Filter(http, Builders<BsonDocument>.Filter.Eq("_id", id));
     var pool = await gwModelPools.Find(poolFilter).FirstOrDefaultAsync();
     if (pool is null) return Json(ApiEnvelope<BulkImportPoolModelsResult>.Fail("NOT_GW_AUTHORITY", "请先将模型池认领到 GW，再在 GW 中批量导入成员"), jsonOptions, 409);
 
@@ -3802,8 +4232,11 @@ app.MapPost("/gw/pools/{id}/models/bulk-import", async (HttpContext http, string
     if (platformId.Length > 0) sourceFilters.Add(modelFb.Eq("PlatformId", platformId));
     if (body.EnabledOnly != false) sourceFilters.Add(modelFb.Eq("Enabled", true));
     var sourceFilter = sourceFilters.Count == 0 ? modelFb.Empty : modelFb.And(sourceFilters);
-    var gwModelDocs = await gwModels.Find(sourceFilter).ToListAsync();
-    var mapModelDocs = await models.Find(sourceFilter).ToListAsync();
+    var tenantSourceFilter = TenantAccess.Filter(http, sourceFilter);
+    var gwModelDocs = await gwModels.Find(tenantSourceFilter).ToListAsync();
+    var mapModelDocs = TenantAccess.GetRequired(http).TenantId == internalTenantId
+        ? await models.Find(sourceFilter).ToListAsync()
+        : new List<BsonDocument>();
 
     var byKey = new Dictionary<string, BsonDocument>(StringComparer.Ordinal);
     foreach (var modelDoc in gwModelDocs.Concat(mapModelDocs))
@@ -3930,7 +4363,7 @@ app.MapPost("/gw/pools/{id}/models/bulk-import", async (HttpContext http, string
 // 模型池成员 upsert：只允许写已认领到 GW 的池，避免继续把模型池权威写回 MAP。
 app.MapPut("/gw/pools/{id}/models", async (HttpContext http, string id, [FromBody] UpsertPoolModelRequest body) =>
 {
-    var poolFilter = Builders<BsonDocument>.Filter.Eq("_id", id);
+    var poolFilter = TenantAccess.Filter(http, Builders<BsonDocument>.Filter.Eq("_id", id));
     var pool = await gwModelPools.Find(poolFilter).FirstOrDefaultAsync();
     if (pool is null) return Json(ApiEnvelope<PoolItem>.Fail("NOT_GW_AUTHORITY", "请先将模型池认领到 GW，再在 GW 中管理池成员"), jsonOptions, 409);
     if (body is null) return Json(ApiEnvelope<PoolItem>.Fail("INVALID_INPUT", "请求体不能为空"), jsonOptions, 400);
@@ -3962,8 +4395,10 @@ app.MapPut("/gw/pools/{id}/models", async (HttpContext http, string id, [FromBod
     };
     if (platformId.Length > 0) modelFilters.Add(modelFb.Eq("PlatformId", platformId));
     var modelFilter = modelFilters.Count == 1 ? modelFilters[0] : modelFb.And(modelFilters);
-    var modelDoc = await gwModels.Find(modelFilter).FirstOrDefaultAsync()
-                   ?? await models.Find(modelFilter).FirstOrDefaultAsync();
+    var modelDoc = await gwModels.Find(TenantAccess.Filter(http, modelFilter)).FirstOrDefaultAsync()
+                   ?? (TenantAccess.GetRequired(http).TenantId == internalTenantId
+                       ? await models.Find(modelFilter).FirstOrDefaultAsync()
+                       : null);
     if (modelDoc is null)
     {
         return Json(ApiEnvelope<PoolItem>.Fail("INVALID_INPUT", $"模型不存在或平台不匹配：{modelId}"), jsonOptions, 400);
@@ -3976,8 +4411,10 @@ app.MapPut("/gw/pools/{id}/models", async (HttpContext http, string id, [FromBod
     }
 
     var platformFilter = Builders<BsonDocument>.Filter.Eq("_id", resolvedPlatformId);
-    var platformDoc = await gwPlatforms.Find(platformFilter).FirstOrDefaultAsync()
-                      ?? await platforms.Find(platformFilter).FirstOrDefaultAsync();
+    var platformDoc = await gwPlatforms.Find(TenantAccess.Filter(http, platformFilter)).FirstOrDefaultAsync()
+                      ?? (TenantAccess.GetRequired(http).TenantId == internalTenantId
+                          ? await platforms.Find(platformFilter).FirstOrDefaultAsync()
+                          : null);
     if (platformDoc is null)
     {
         return Json(ApiEnvelope<PoolItem>.Fail("INVALID_INPUT", $"平台不存在：{resolvedPlatformId}"), jsonOptions, 400);
@@ -4108,7 +4545,7 @@ app.MapDelete("/gw/pools/{id}/models", async (HttpContext http, string id, strin
     var normalizedPlatformId = (platformId ?? string.Empty).Trim();
     if (normalizedModelId.Length == 0) return Json(ApiEnvelope<PoolItem>.Fail("INVALID_INPUT", "modelId 不能为空"), jsonOptions, 400);
 
-    var poolFilter = Builders<BsonDocument>.Filter.Eq("_id", id);
+    var poolFilter = TenantAccess.Filter(http, Builders<BsonDocument>.Filter.Eq("_id", id));
     var pool = await gwModelPools.Find(poolFilter).FirstOrDefaultAsync();
     if (pool is null) return Json(ApiEnvelope<PoolItem>.Fail("NOT_GW_AUTHORITY", "请先将模型池认领到 GW，再在 GW 中管理池成员"), jsonOptions, 409);
 
@@ -4170,15 +4607,19 @@ app.MapPut("/gw/pools/{id}/default", async (HttpContext http, string id, ToggleD
     // 的唯一默认池清空，导致 MAP 调度该类型零默认（Bugbot Medium）。要切换默认：把另一个池设为默认即可，
     // 同类型互斥会自动取消原默认，全程始终有且仅有一个默认。
     if (!isDefault) return Json(ApiEnvelope<PoolItem>.Fail("INVALID_INPUT", "不支持直接取消默认；如需切换，请把另一个同类型池设为默认（原默认会自动取消）"), jsonOptions, 400);
-    var filter = Builders<BsonDocument>.Filter.Eq("_id", id);
+    var sourceFilter = Builders<BsonDocument>.Filter.Eq("_id", id);
+    var filter = TenantAccess.Filter(http, sourceFilter);
     var doc = await gwModelPools.Find(filter).FirstOrDefaultAsync();
     var targetPools = gwModelPools;
     var targetAuthority = "llm_gateway";
     if (doc is null)
     {
-        doc = await modelGroups.Find(filter).FirstOrDefaultAsync();
+        if (TenantAccess.GetRequired(http).TenantId != internalTenantId)
+            return Json(ApiEnvelope<PoolItem>.Fail("NOT_FOUND", $"模型池不存在：{id}"), jsonOptions, 404);
+        doc = await modelGroups.Find(sourceFilter).FirstOrDefaultAsync();
         targetPools = modelGroups;
         targetAuthority = "map";
+        filter = sourceFilter;
     }
     if (doc is null) return Json(ApiEnvelope<PoolItem>.Fail("NOT_FOUND", $"模型池不存在：{id}"), jsonOptions, 404);
     var modelType = doc.GetStringOrEmpty("ModelType");
@@ -4222,13 +4663,17 @@ app.MapPut("/gw/pools/{id}/default", async (HttpContext http, string id, ToggleD
 // 不删除 MAP 原池，回滚只需删除 GW 副本或把 appCaller 状态改回 configured/discovered。
 app.MapPut("/gw/pools/{id}/claim", async (HttpContext http, string id) =>
 {
-    var filter = Builders<BsonDocument>.Filter.Eq("_id", id);
-    var source = await modelGroups.Find(filter).FirstOrDefaultAsync();
+    if (TenantAccess.GetRequired(http).TenantId != internalTenantId)
+        return Json(ApiEnvelope<PoolItem>.Fail("INTERNAL_GOVERNANCE_ONLY", "仅内部租户可认领 MAP 模型池"), jsonOptions, 403);
+    var sourceFilter = Builders<BsonDocument>.Filter.Eq("_id", id);
+    var filter = TenantAccess.Filter(http, sourceFilter);
+    var source = await modelGroups.Find(sourceFilter).FirstOrDefaultAsync();
     if (source is null) return Json(ApiEnvelope<PoolItem>.Fail("NOT_FOUND", $"模型池不存在：{id}"), jsonOptions, 404);
 
     var now = DateTime.UtcNow;
     var before = await gwModelPools.Find(filter).FirstOrDefaultAsync();
     var claimed = new BsonDocument(source);
+    claimed["TenantId"] = internalTenantId;
     claimed["SourceCollection"] = "model_groups";
     claimed["Authority"] = "llm_gateway";
     claimed["ClaimedAt"] = now;
@@ -4261,6 +4706,99 @@ app.Run();
 
 // ─────────────────────────────── 辅助函数 ───────────────────────────────
 
+static TenantSessionDto ToTenantSession(LlmGwTenant tenant, LlmGwMembership membership) => new()
+{
+    Id = tenant.Id,
+    Name = tenant.Name,
+    Role = membership.Role,
+    TeamIds = membership.TeamIds,
+};
+
+static async Task EnsureInternalTenantAsync(
+    IMongoCollection<LlmGwUser> users,
+    IMongoCollection<LlmGwTenant> tenants,
+    IMongoCollection<LlmGwTeam> teams,
+    IMongoCollection<LlmGwMembership> memberships,
+    string adminUsername,
+    string tenantId,
+    CancellationToken ct)
+{
+    var now = DateTime.UtcNow;
+    var tenant = await tenants.Find(x => x.Id == tenantId).FirstOrDefaultAsync(ct);
+    if (tenant is null)
+    {
+        tenant = new LlmGwTenant
+        {
+            Id = tenantId,
+            Name = "MAP Internal",
+            NormalizedName = "MAP INTERNAL",
+            Slug = "map-internal",
+            NormalizedSlug = "MAP-INTERNAL",
+            Status = "active",
+            IsInternal = true,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+        await tenants.InsertOneAsync(tenant, cancellationToken: ct);
+    }
+
+    var defaultTeamId = $"{tenantId}_default";
+    if (!await teams.Find(x => x.Id == defaultTeamId && x.TenantId == tenantId).AnyAsync(ct))
+    {
+        await teams.InsertOneAsync(new LlmGwTeam
+        {
+            Id = defaultTeamId,
+            TenantId = tenantId,
+            Name = "Default",
+            NormalizedName = "DEFAULT",
+            Status = "active",
+            CreatedAt = now,
+            UpdatedAt = now,
+        }, cancellationToken: ct);
+    }
+
+    var admin = await users.Find(x => x.Username == adminUsername).FirstOrDefaultAsync(ct)
+        ?? throw new InvalidOperationException("LLM Gateway bootstrap admin 不存在，无法建立 internal tenant owner membership");
+    var membership = await memberships.Find(x => x.TenantId == tenantId && x.UserId == admin.Id).FirstOrDefaultAsync(ct);
+    if (membership is null)
+    {
+        await memberships.InsertOneAsync(new LlmGwMembership
+        {
+            TenantId = tenantId,
+            UserId = admin.Id,
+            Role = LlmGwTenantRoles.Owner,
+            TeamIds = new List<string> { defaultTeamId },
+            Status = "active",
+            Version = 1,
+            CreatedAt = now,
+            UpdatedAt = now,
+        }, cancellationToken: ct);
+    }
+
+    var userUpdate = Builders<LlmGwUser>.Update
+        .AddToSet(x => x.TenantIds, tenantId)
+        .Set(x => x.UpdatedAt, now);
+    if (string.IsNullOrWhiteSpace(admin.DefaultTenantId))
+        userUpdate = userUpdate.Set(x => x.DefaultTenantId, tenantId);
+    await users.UpdateOneAsync(x => x.Id == admin.Id, userUpdate, cancellationToken: ct);
+
+    await tenants.Indexes.CreateOneAsync(new CreateIndexModel<LlmGwTenant>(
+        Builders<LlmGwTenant>.IndexKeys.Ascending(x => x.NormalizedSlug),
+        new CreateIndexOptions { Name = "uniq_llmgw_tenant_slug", Unique = true }), cancellationToken: ct);
+    await teams.Indexes.CreateOneAsync(new CreateIndexModel<LlmGwTeam>(
+        Builders<LlmGwTeam>.IndexKeys.Ascending(x => x.TenantId).Ascending(x => x.NormalizedName),
+        new CreateIndexOptions { Name = "uniq_llmgw_team_tenant_name", Unique = true }), cancellationToken: ct);
+    await memberships.Indexes.CreateManyAsync(new[]
+    {
+        new CreateIndexModel<LlmGwMembership>(
+            Builders<LlmGwMembership>.IndexKeys.Ascending(x => x.TenantId).Ascending(x => x.UserId),
+            new CreateIndexOptions { Name = "uniq_llmgw_membership_tenant_user", Unique = true }),
+        new CreateIndexModel<LlmGwMembership>(
+            Builders<LlmGwMembership>.IndexKeys.Ascending(x => x.TenantId).Ascending(x => x.Status).Ascending(x => x.Role),
+            new CreateIndexOptions { Name = "idx_llmgw_membership_tenant_status_role" }),
+    }, cancellationToken: ct);
+}
+
 // 幂等播种管理员。优先级（从高到低）：
 //   1) forceReset（LLMGW_ADMIN_FORCE_RESET=1）：破玻璃，显式重置 admin 口令 + 强制改密。
 //   2) 已有账号：数据库哈希是长期权威，只保活，不再被 LLMGW_ADMIN_PASSWORD 覆盖。
@@ -4270,26 +4808,13 @@ static async Task SeedAdminAsync(
     IMongoCollection<BsonDocument> operationAudits,
     string username,
     string defaultPwd,
+    string tenantId,
     bool forceReset = false,
     string? envPassword = null)
 {
     var users = db.GetCollection<LlmGwUser>("llmgw_console_users");
 
-    // 单管理员模型：禁用历史遗留的其它用户名账号（防「改名后旧账号仍可登」）。真要多用户时再引入用户管理。
-    var deactivateOthers = Builders<LlmGwUser>.Update.Set(u => u.IsActive, false);
-    var deactivated = await users.UpdateManyAsync(u => u.Username != username && u.IsActive, deactivateOthers);
-    if (deactivated.ModifiedCount > 0)
-    {
-        await WriteSystemOperationAuditAsync(
-            operationAudits,
-            action: "admin.deactivate_legacy_users",
-            targetType: "llmgw_console_user",
-            targetId: null,
-            targetName: "non-admin active users",
-            success: true,
-            reason: null,
-            changes: new BsonDocument { { "deactivatedCount", deactivated.ModifiedCount } });
-    }
+    // 多租户账号由 membership 控制，不得在 bootstrap 时禁用其它租户用户。
 
     // 破玻璃优先级最高：显式打开时才改库中口令，用于账号被认领但口令丢失的死锁恢复。
     if (forceReset)
@@ -4321,7 +4846,8 @@ static async Task SeedAdminAsync(
                     { "mustChangePassword", new BsonDocument { { "from", existingForce.MustChangePassword }, { "to", resetMustChange } } },
                     { "passwordChangedByUser", new BsonDocument { { "from", existingForce.PasswordChangedByUser }, { "to", false } } },
                     { "wasActive", existingForce.IsActive },
-                });
+                },
+                tenantId: tenantId);
         }
         else
         {
@@ -4345,7 +4871,8 @@ static async Task SeedAdminAsync(
                 {
                     { "passwordSource", string.IsNullOrWhiteSpace(envPassword) ? "default" : "env" },
                     { "mustChangePassword", resetMustChange },
-                });
+                },
+                tenantId: tenantId);
         }
         return;
     }
@@ -4368,7 +4895,8 @@ static async Task SeedAdminAsync(
                 targetName: username,
                 success: true,
                 reason: null,
-                changes: BuildChangeDocument(("isActive", false, true)));
+                changes: BuildChangeDocument(("isActive", false, true)),
+                tenantId: tenantId);
         }
         return;
     }
@@ -4402,7 +4930,8 @@ static async Task SeedAdminAsync(
             {
                 { "passwordSource", string.IsNullOrWhiteSpace(envPassword) ? "default" : "env" },
                 { "mustChangePassword", mustChange },
-            });
+            },
+            tenantId: tenantId);
     }
     catch (MongoWriteException)
     {
@@ -4413,6 +4942,7 @@ static async Task SeedAdminAsync(
 static async Task WriteLoginAuditAsync(
     IMongoCollection<LlmGwLoginAudit> audits,
     HttpContext http,
+    string tenantId,
     string username,
     string? userId,
     bool success,
@@ -4422,6 +4952,7 @@ static async Task WriteLoginAuditAsync(
     {
         await audits.InsertOneAsync(new LlmGwLoginAudit
         {
+            TenantId = tenantId,
             Username = username,
             UserId = userId,
             Success = success,
@@ -4454,10 +4985,15 @@ static async Task WriteOperationAuditAsync(
             ?? http.User.FindFirst("sub")?.Value;
         var actorUsername = http.User.FindFirst(System.Security.Claims.ClaimTypes.Name)?.Value
             ?? http.User.Identity?.Name;
+        var tenantAccess = http.Items.TryGetValue(TenantAccess.ItemKey, out var accessValue)
+            ? accessValue as TenantAccessContext
+            : null;
 
         var doc = new BsonDocument
         {
             { "_id", Guid.NewGuid().ToString("N") },
+            { "TenantId", tenantAccess?.TenantId ?? http.User.FindFirst(TenantAccess.TenantClaim)?.Value ?? "tenant_map_internal" },
+            { "TeamId", ToBsonAuditValue(tenantAccess?.TeamIds.Count == 1 ? tenantAccess.TeamIds[0] : null) },
             { "Action", action },
             { "TargetType", targetType },
             { "TargetId", ToBsonAuditValue(targetId) },
@@ -4487,13 +5023,16 @@ static async Task WriteSystemOperationAuditAsync(
     string? targetName,
     bool success,
     string? reason,
-    BsonDocument? changes = null)
+    BsonDocument? changes = null,
+    string tenantId = "tenant_map_internal")
 {
     try
     {
         var doc = new BsonDocument
         {
             { "_id", Guid.NewGuid().ToString("N") },
+            { "TenantId", tenantId },
+            { "TeamId", BsonNull.Value },
             { "Action", action },
             { "TargetType", targetType },
             { "TargetId", ToBsonAuditValue(targetId) },
@@ -5365,6 +5904,7 @@ static async Task<string?> ValidateBulkActiveGatewayAppCallerConfigAsync(
     IMongoCollection<BsonDocument> gwPlatforms,
     IMongoCollection<BsonDocument> gwModels,
     IMongoCollection<BsonDocument> gwModelExchanges,
+    string tenantId,
     FilterDefinition<BsonDocument> filter,
     string? targetStatus,
     bool targetModelPolicyTouched,
@@ -5388,6 +5928,7 @@ static async Task<string?> ValidateBulkActiveGatewayAppCallerConfigAsync(
             gwPlatforms,
             gwModels,
             gwModelExchanges,
+            tenantId,
             effectiveStatus,
             effectiveModelPoolId,
             effectiveModelPolicy,
@@ -5406,6 +5947,7 @@ static async Task<string?> ValidateActiveGatewayAppCallerConfigAsync(
     IMongoCollection<BsonDocument> gwPlatforms,
     IMongoCollection<BsonDocument> gwModels,
     IMongoCollection<BsonDocument> gwModelExchanges,
+    string tenantId,
     string? status,
     string? modelPoolId,
     string? modelPolicy,
@@ -5428,7 +5970,9 @@ static async Task<string?> ValidateActiveGatewayAppCallerConfigAsync(
     }
 
     var pool = await gwModelPools
-        .Find(Builders<BsonDocument>.Filter.Eq("_id", modelPoolId.Trim()))
+        .Find(Builders<BsonDocument>.Filter.And(
+            Builders<BsonDocument>.Filter.Eq("TenantId", tenantId),
+            Builders<BsonDocument>.Filter.Eq("_id", modelPoolId.Trim())))
         .FirstOrDefaultAsync();
     if (pool is null)
     {
@@ -5481,17 +6025,20 @@ static async Task<bool> HasUsableGatewayPoolMemberAsync(
     IMongoCollection<BsonDocument> gwModelExchanges,
     BsonDocument pool)
 {
-    var enabledPlatformIds = (await gwPlatforms.Find(FilterDefinition<BsonDocument>.Empty)
+    var tenantId = pool.AsNullableString("TenantId");
+    if (string.IsNullOrWhiteSpace(tenantId)) return false;
+    var tenantFilter = Builders<BsonDocument>.Filter.Eq("TenantId", tenantId);
+    var enabledPlatformIds = (await gwPlatforms.Find(tenantFilter)
             .Project(Builders<BsonDocument>.Projection.Include("_id").Include("Enabled"))
             .ToListAsync())
         .Where(d => d.AsNullableBool("Enabled") ?? true)
         .Select(d => d.GetStringOrEmpty("_id"))
         .Where(x => !string.IsNullOrWhiteSpace(x))
         .ToHashSet(StringComparer.Ordinal);
-    var enabledModels = await gwModels.Find(Builders<BsonDocument>.Filter.Ne("Enabled", false))
+    var enabledModels = await gwModels.Find(Builders<BsonDocument>.Filter.And(tenantFilter, Builders<BsonDocument>.Filter.Ne("Enabled", false)))
         .Project(Builders<BsonDocument>.Projection.Include("_id").Include("ModelName").Include("Name").Include("PlatformId").Include("Enabled"))
         .ToListAsync();
-    var enabledExchanges = await gwModelExchanges.Find(Builders<BsonDocument>.Filter.Ne("Enabled", false))
+    var enabledExchanges = await gwModelExchanges.Find(Builders<BsonDocument>.Filter.And(tenantFilter, Builders<BsonDocument>.Filter.Ne("Enabled", false)))
         .Project(Builders<BsonDocument>.Projection.Include("_id").Include("Name").Include("Enabled").Include("ModelAlias").Include("ModelAliases").Include("Models"))
         .ToListAsync();
 

--- a/prd-llmgw/Program.cs
+++ b/prd-llmgw/Program.cs
@@ -123,6 +123,10 @@ builder.Services.AddAuthorization(options =>
         policy.RequireAuthenticatedUser()
             .RequireAssertion(ctx => !ctx.User.HasClaim(c => c.Type == "mcp" && c.Value == "1")
                 && TenantAccess.HasPermission(ctx.User, LlmGwPermissions.ConfigWrite)));
+    options.AddPolicy("ServiceKeyWrite", policy =>
+        policy.RequireAuthenticatedUser()
+            .RequireAssertion(ctx => !ctx.User.HasClaim(c => c.Type == "mcp" && c.Value == "1")
+                && TenantAccess.HasPermission(ctx.User, LlmGwPermissions.ServiceKeyWrite)));
     options.AddPolicy("OrganizationWrite", policy =>
         policy.RequireAuthenticatedUser()
             .RequireAssertion(ctx => !ctx.User.HasClaim(c => c.Type == "mcp" && c.Value == "1")
@@ -3099,7 +3103,7 @@ app.MapPost("/gw/service-keys", async (HttpContext http, ServiceKeyCreateRequest
         scopes,
         expiresAt,
     }), jsonOptions, 201);
-}).RequireAuthorization("ConfigWrite");
+}).RequireAuthorization("ServiceKeyWrite");
 
 app.MapDelete("/gw/service-keys/{id}", async (HttpContext http, string id) =>
 {
@@ -3120,7 +3124,7 @@ app.MapDelete("/gw/service-keys/{id}", async (HttpContext http, string id) =>
         true,
         null);
     return Json(ApiEnvelope<object>.Ok(new { id, revoked = true }), jsonOptions);
-}).RequireAuthorization("ConfigWrite");
+}).RequireAuthorization("ServiceKeyWrite");
 
 // 影子比对：汇总 + 最近 N 条
 app.MapGet("/gw/shadow-comparisons", async (HttpContext http, int? limit, string? appCallerCode, string? kind, string? releaseCommit, double? sinceHours) =>


### PR DESCRIPTION
## 摘要

为 LLM Gateway 建立 tenant/team/user/membership/RBAC 基座，租户只从已验证会话或 service key 解析，并将日志、配置、预算、审计、幂等、取消、并发和 service key 纳入 TenantId 隔离。保留现有 full-http、模型池和发布 gate，不重做迁移。

## 改动 diff

- `prd-llmgw`：新增租户、团队、成员、角色权限、租户切换和组织 API；所有控制台资源查询与写入按租户过滤。
- `PrdAgent.LlmGateway`：scoped key 通过 hash 目录解析租户，并以服务端验证结果覆盖请求自报 tenant；运行时治理集合 tenant-first。
- `PrdAgent.Infrastructure`：日志、shadow、模型解析、multipart、预算、幂等和 provider 并发增加 TenantId 与租户索引。
- `PrdAgent.Api.Tests`：增加跨租户 service key、幂等、取消和并发隔离测试。
- `doc/plan.platform.llm-gateway-external-platform.md`：更新 PR-1 执行状态和本地证据。

## 测试

- [x] `prd-api` dotnet build --no-restore 通过，0 error
- [x] `prd-llmgw` dotnet build --no-restore 通过，0 warning / 0 error
- [x] .NET 8 容器连接临时 Mongo 运行 Gateway 相关 101 项测试，0 失败
- [x] 真实 prd-llmgw HTTP 双租户验收：列表无泄漏、跨租户写 404、viewer 越权 403、无 membership 切换 403、旧 membership token 401
- [ ] CI、Bugbot、CDS 与预览环境验收

## 边界

- 不包含 PR-2 自助接入和网页 Quickstart。
- 不包含 PR-3 PromptPolicy。
- 不包含 PR-4 控制台 IA、图表和金额改造。
- 不修改 full-http、模型池调度或发布 gate。