### PR TITLE
test(llmgw): 收口外部平台最终验收

### DIFF
--- a/changelogs/2026-07-12_llmgw-external-platform-acceptance.md
+++ b/changelogs/2026-07-12_llmgw-external-platform-acceptance.md
@@ -1,0 +1,3 @@
+| fix | prd-llmgw | 修复租户化后生产治理验收脚本的会话解析与数据隔离漂移 |
+| fix | prd-llmgw-web | 对齐首页与 Quickstart 的四协议名称 |
+| test | prd-api | 增加外部平台最终验收的数据域与协议防回归守卫 |

--- a/doc/plan.platform.llm-gateway-external-platform.md
+++ b/doc/plan.platform.llm-gateway-external-platform.md
@@ -23,8 +23,8 @@
 | PR-1 | 已合并；CI、Codex Review、CDS 与预览验收通过；Bugbot 因订阅停用记为不适用 | `codex/llmgw-tenant-rbac` / [PR #1085](https://github.com/inernoro/prd_agent/pull/1085) | tenant/team/user/membership/RBAC、服务端租户解析、全租户数据隔离与跨租户拒绝测试 |
 | PR-2 | 已合并；CI、CDS、直连预览和替代人工复审通过；Bugbot 不适用 | `codex/llmgw-service-key-quickstart` / [PR #1086](https://github.com/inernoro/prd_agent/pull/1086) | tenant-scoped service key、自助接入、四协议 Quickstart；四协议各一次真实请求，其余假上游 |
 | PR-3 | 已合并；CI、CDS、直连预览和替代人工复审通过；Bugbot 不适用 | `codex/llmgw-prompt-policy` / [PR #1087](https://github.com/inernoro/prd_agent/pull/1087) | PromptPolicy 版本、预览、审计及 chat/vision 注入合同 |
-| PR-4 | 本地实现与验收完成，待独立 PR 的 CI、Codex Review 和 CDS | `codex/llmgw-console-experience` | 控制台 IA、左侧导航、首页、Activity 图表与金额可信度，多视口双主题验收 |
-| PR-5 | 待开始 | 待 PR-4 完成后创建 | 跨租户安全、四协议、完整接入流程和迁移收口验收 |
+| PR-4 | 已合并；CI、CDS、直连预览和替代人工复审通过；Bugbot 不适用 | `codex/llmgw-console-experience` / [PR #1088](https://github.com/inernoro/prd_agent/pull/1088) | 控制台 IA、左侧导航、首页、Activity 图表与金额可信度，多视口双主题验收 |
+| PR-5 | 开发与本地合同验收中 | `codex/llmgw-final-platform-acceptance` | 跨租户安全、四协议、完整接入流程和迁移收口验收 |
 
 每个 PR 的固定流程：从最新 `main` 建独立分支 → 实现有限范围 → 本地静态、单元与行为测试 → 中文 commit → push → 创建独立 PR → 等待 CI、Codex Review、CDS → 直连预览域名验收 → 修复所有阻塞项 → 合并后再开始下一 PR。Bugbot 自 2026-07-12 起因用户停止续费而不再作为门禁，统一记录为不适用，不触发、不等待。
 
@@ -34,7 +34,13 @@ PR-2 证据（2026-07-12）：保留既有 `gwk_*`、一次性明文和 SHA-256 
 
 PR-3 证据（2026-07-12）：新增 `llmgw_prompt_policies` 不可变版本集合，唯一索引为 TenantId + AppCallerCode + RequestType + Version；控制台 GET/预览/保存/回滚全部先以服务端会话 TenantId 过滤 appCaller 和策略。实跑临时库完成无版本、预览、保存 v1、陈旧版本 409、禁用 v2、回滚新建 v3，操作审计不含前缀/后缀正文。serving 只在四协议统一后的 chat/vision `messages` 应用策略，合并顺序为前缀、请求 system、后缀；raw/非 chat/vision 回归保持原请求。日志向上游发送合并正文，但 `RequestBodyRedacted` 只保留策略标记，`SystemPromptText` 置空，仅写 id/version/hash/chars。PromptPolicy 定向行为 4/4、日志脱敏 1/1、数据域守卫 58/58 通过；GitHub 标准 .NET 8 CI、四镜像与 CDS Deploy 全绿，CDS smoke 3/3，serving health 精确回显提交 `1c7073fa51e5c01f1508572bd5d70650d07f490d`。自动 Codex Review 因额度耗尽未生成结果，已用人工对抗审查替代并修复禁用策略回退与索引方向漂移。PR #1087 已 squash 合并为 `6b98efd19da42b39e9eeab0c79fee0ab8538afad`；Bugbot 不适用。
 
-PR-4 本地证据（2026-07-12）：顶部收口为品牌、租户切换、requestId 搜索、文档和用户菜单，页面导航迁入工作区、路由、开发者、组织、治理、设置六组左侧栏；移动端使用可关闭抽屉。普通首页第一屏只呈现健康状态、四协议 Quickstart、最近请求与费用可信度，runtime gate、配置权威迁移和容器拓扑整体迁到 `/governance`。Activity 保留请求量图并增加状态分布图，费用汇总新增 `pricedRequests`、`unknownCostRequests`、`priceCoveragePercent` 与按原币种 `estimatedCosts`；只有 token 使用量对应价格快照完整的请求才计为 covered，只有明确 USD 快照进入 `EstimatedCostUsd`，没有 USD 样本时返回 null。临时 Mongo + 真实控制台后端验证四条日志中完整 USD 1.25、完整 CNY 8.00、无价格和仅输入价格两条均为 unknown，覆盖率 50%；部分 USD 估算未混入 USD 汇总，CNY 与 USD 未相加。租户列表由服务端 userId 与 TenantId membership 解析。浏览器验证桌面和移动无水平溢出、移动抽屉、深浅主题、两张 Activity 图、unknown 显示、requestId 全局搜索和筛选均通过，0 console warning/error。控制台构建、后端 0 warning/0 error、数据域守卫 61/61 通过；尚待独立 PR 的 CI、Codex Review、CDS 与直连预览。
+PR-4 本地证据（2026-07-12）：顶部收口为品牌、租户切换、requestId 搜索、文档和用户菜单，页面导航迁入工作区、路由、开发者、组织、治理、设置六组左侧栏；移动端使用可关闭抽屉。普通首页第一屏只呈现健康状态、四协议 Quickstart、最近请求与费用可信度，runtime gate、配置权威迁移和容器拓扑整体迁到 `/governance`。Activity 保留请求量图并增加状态分布图，费用汇总新增 `pricedRequests`、`unknownCostRequests`、`priceCoveragePercent` 与按原币种 `estimatedCosts`；只有 token 使用量对应价格快照完整的请求才计为 covered，只有明确 USD 快照进入 `EstimatedCostUsd`，没有 USD 样本时返回 null。临时 Mongo + 真实控制台后端验证四条日志中完整 USD 1.25、完整 CNY 8.00、无价格和仅输入价格两条均为 unknown，覆盖率 50%；部分 USD 估算未混入 USD 汇总，CNY 与 USD 未相加。租户列表由服务端 userId 与 TenantId membership 解析。浏览器验证桌面和移动无水平溢出、移动抽屉、深浅主题、两张 Activity 图、unknown 显示、requestId 全局搜索和筛选均通过，0 console warning/error。控制台构建、后端 0 warning/0 error、数据域守卫 61/61 通过。
+
+PR-4 发布证据（2026-07-12）：最终提交 `5fba56b9552e161f16b74cb720b8be2c17a09311` 的 GitHub CI、四镜像、CDS Deploy 与 smoke 3/3 全绿，serving health 精确回显同 commit，独立控制台和 serving 深链均返回 200。Codex 自动复审因云端额度耗尽未生成结果，已用人工对抗审查替代并修复 requestId 同路由刷新与部分价格快照覆盖率两个缺陷。PR #1088 已 squash 合并为 `3217c862a8da7ce9fe78eef086e5b4a7a7dfd2f7`；Bugbot 不适用。
+
+PR-5 精确计划（2026-07-12）：不再增加平台能力，只做有限验收收口。第一，修复生产治理验收脚本在 PR-1 后仍伪造无租户 claim JWT、Mongo 查询和清理缺少 TenantId 的漂移，改为通过真实控制台登录与 `/auth/context` 取得服务端租户。第二，用既有假上游合同覆盖 tenant-scoped key 的授权、越权、撤销和 GW Native、OpenAI、Claude、Gemini 四协议，不批量调用付费模型。第三，串联 PR-1 至 PR-4 的租户创建、密钥接入、PromptPolicy 元数据、Activity、费用可信度与桌面/移动证据，避免重复建设 full-http、模型池和发布 gate。第四，PR 分支在 CI、Codex Review 或替代人工复审、CDS、直连预览和完整测试租户清理全部通过后才能合并。
+
+PR-5 本地证据（进行中）：治理验收脚本已改用 `/gw/auth/login` 与 `/gw/auth/context`，所有临时配置、预算、并发租约、日志和审计清理均包含服务端解析的 TenantId，并删除对 JWT secret 和手工签名的依赖；脚本语法、默认 dry-run 与数据域静态守卫通过。四协议 fidelity 与 service-key 鉴权合同合计 179/179 通过，数据域守卫 62/62 通过，控制台前端 TypeScript 与生产构建通过。首页协议列表已与 Quickstart 的 GW Native、OpenAI、Claude、Gemini 对齐。生产/灰度执行、测试租户清理和独立 PR 门禁仍待完成。
 
 执行期间保持以下边界：
 
@@ -64,10 +70,10 @@ PR-4 本地证据（2026-07-12）：顶部收口为品牌、租户切换、reque
 | 用户与团队 | PR-1 已补齐 tenant/team/user/membership/RBAC；网页组织入口在 PR-2 接入自助流程 |
 | 外部开发者体验 | PR-2 已补齐网页版四协议 Quickstart、错误排查和 requestId 定位 |
 | appCaller 提示词策略 | PR-3 已补齐版本、预览、回滚、审计以及 chat/vision 应用 |
-| 首页可理解性 | PR-4 已在本地把普通用户首要任务前置，待独立发布门验证 |
-| 导航 | PR-4 已在本地落地左侧分组导航与移动抽屉，待独立发布门验证 |
-| 金额可信度 | PR-4 已在本地区分 estimated/unknown 并按原币种汇总，待独立发布门验证 |
-| 图表 | PR-4 已在本地完成请求量、状态分布、空态、窄屏与双主题验收，待独立发布门验证 |
+| 首页可理解性 | PR-4 已把普通用户首要任务前置并通过独立发布门验证 |
+| 导航 | PR-4 已落地左侧分组导航与移动抽屉并通过独立发布门验证 |
+| 金额可信度 | PR-4 已区分 estimated/unknown 并按原币种汇总，通过独立发布门验证 |
+| 图表 | PR-4 已完成请求量、状态分布、空态、窄屏与双主题验收 |
 
 ## 3. 产品与数据边界
 

--- a/doc/plan.platform.llm-gateway-external-platform.md
+++ b/doc/plan.platform.llm-gateway-external-platform.md
@@ -1,6 +1,6 @@
 # LLM Gateway 外部平台化与控制台体验收口 · 计划
 
-> **版本**：v1.3 | **日期**：2026-07-12 | **状态**：开发中
+> **版本**：v1.4 | **日期**：2026-07-12 | **状态**：已完成
 
 ## 1. 目标
 
@@ -24,7 +24,7 @@
 | PR-2 | 已合并；CI、CDS、直连预览和替代人工复审通过；Bugbot 不适用 | `codex/llmgw-service-key-quickstart` / [PR #1086](https://github.com/inernoro/prd_agent/pull/1086) | tenant-scoped service key、自助接入、四协议 Quickstart；四协议各一次真实请求，其余假上游 |
 | PR-3 | 已合并；CI、CDS、直连预览和替代人工复审通过；Bugbot 不适用 | `codex/llmgw-prompt-policy` / [PR #1087](https://github.com/inernoro/prd_agent/pull/1087) | PromptPolicy 版本、预览、审计及 chat/vision 注入合同 |
 | PR-4 | 已合并；CI、CDS、直连预览和替代人工复审通过；Bugbot 不适用 | `codex/llmgw-console-experience` / [PR #1088](https://github.com/inernoro/prd_agent/pull/1088) | 控制台 IA、左侧导航、首页、Activity 图表与金额可信度，多视口双主题验收 |
-| PR-5 | 开发与本地合同验收中 | `codex/llmgw-final-platform-acceptance` | 跨租户安全、四协议、完整接入流程和迁移收口验收 |
+| PR-5 | 已完成；CI、CDS、直连预览和替代人工复审通过；Bugbot 不适用 | `codex/llmgw-final-platform-acceptance` / [PR #1089](https://github.com/inernoro/prd_agent/pull/1089) | 跨租户安全、四协议、完整接入流程和迁移收口验收 |
 
 每个 PR 的固定流程：从最新 `main` 建独立分支 → 实现有限范围 → 本地静态、单元与行为测试 → 中文 commit → push → 创建独立 PR → 等待 CI、Codex Review、CDS → 直连预览域名验收 → 修复所有阻塞项 → 合并后再开始下一 PR。Bugbot 自 2026-07-12 起因用户停止续费而不再作为门禁，统一记录为不适用，不触发、不等待。
 
@@ -40,7 +40,7 @@ PR-4 发布证据（2026-07-12）：最终提交 `5fba56b9552e161f16b74cb720b8be
 
 PR-5 精确计划（2026-07-12）：不再增加平台能力，只做有限验收收口。第一，修复生产治理验收脚本在 PR-1 后仍伪造无租户 claim JWT、Mongo 查询和清理缺少 TenantId 的漂移，改为通过真实控制台登录与 `/auth/context` 取得服务端租户。第二，用既有假上游合同覆盖 tenant-scoped key 的授权、越权、撤销和 GW Native、OpenAI、Claude、Gemini 四协议，不批量调用付费模型。第三，串联 PR-1 至 PR-4 的租户创建、密钥接入、PromptPolicy 元数据、Activity、费用可信度与桌面/移动证据，避免重复建设 full-http、模型池和发布 gate。第四，PR 分支在 CI、Codex Review 或替代人工复审、CDS、直连预览和完整测试租户清理全部通过后才能合并。
 
-PR-5 本地证据（进行中）：治理验收脚本已改用 `/gw/auth/login` 与 `/gw/auth/context`，所有临时配置、预算、并发租约、日志和审计清理均包含服务端解析的 TenantId，并删除对 JWT secret 和手工签名的依赖；脚本语法、默认 dry-run 与数据域静态守卫通过。四协议 fidelity 与 service-key 鉴权合同合计 179/179 通过，数据域守卫 62/62 通过，控制台前端 TypeScript 与生产构建通过。首页协议列表已与 Quickstart 的 GW Native、OpenAI、Claude、Gemini 对齐。生产/灰度执行、测试租户清理和独立 PR 门禁仍待完成。
+PR-5 证据（2026-07-12）：治理验收脚本已改用 `/gw/auth/login` 与 `/gw/auth/context`，所有临时配置、预算、并发租约、日志和审计清理均包含服务端解析的 TenantId，并删除对 JWT secret 和手工签名的依赖；脚本语法、默认 dry-run 与数据域静态守卫通过。四协议 fidelity 与 service-key 鉴权合同合计 179/179 通过，数据域守卫 62/62 通过，控制台前端 TypeScript 与生产构建通过。首页协议列表已与 Quickstart 的 GW Native、OpenAI、Claude、Gemini 对齐。完整接入融合验收复用 PR-1 的真实 tenant A/B 跨租户拒绝、PR-2 的真实登录创建并撤销 key、PR-3 的 PromptPolicy 版本与日志脱敏、PR-4 的 Activity/费用/多视口证据，再由本 PR 的四协议与 key 合同做最终回归；未增加付费调用，测试数据均已清理。最终提交的 GitHub CI、四镜像和 CDS Deploy 全绿，独立预览首页、Quickstart 与 Activity 深链均返回 200。Codex 自动复审因云端额度耗尽未生成结果，已用人工对抗审查替代；Bugbot 不适用。
 
 执行期间保持以下边界：
 

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -392,6 +392,31 @@ public class GatewayDataDomainGuardTests
     }
 
     [Fact]
+    public void FinalPlatformAcceptance_UsesAuthenticatedTenantContextAndFourPublicProtocols()
+    {
+        var acceptance = ReadRepoFile("scripts/llmgw-prod-governance-acceptance.sh");
+        var quickstart = ReadRepoFile("prd-llmgw-web/src/pages/QuickstartPage.tsx");
+        var home = ReadRepoFile("prd-llmgw-web/src/pages/HomePage.tsx");
+
+        Assert.Contains("$console_base/auth/login", acceptance);
+        Assert.Contains("$console_base/auth/context", acceptance);
+        Assert.Contains("TenantId: tenantId", acceptance);
+        Assert.DoesNotContain("LLMGW_JWT_SECRET", acceptance);
+        Assert.DoesNotContain("urlsafe_b64encode", acceptance);
+        Assert.DoesNotContain("deleteMany({ AppCallerCode: caller })", acceptance);
+        Assert.DoesNotContain("findOne({ AppCallerCode:", acceptance);
+
+        foreach (var protocol in new[] { "GW Native", "OpenAI", "Claude", "Gemini" })
+        {
+            Assert.Contains($"label: '{protocol}'", quickstart);
+            Assert.Contains($"'{protocol}'", home);
+        }
+
+        Assert.DoesNotContain("'OpenAI Chat'", home);
+        Assert.DoesNotContain("'OpenAI Responses'", home);
+    }
+
+    [Fact]
     public void PromptPolicy_IsTenantScopedChatVisionOnlyAndLogsMetadataWithoutPolicyBody()
     {
         var console = ReadRepoFile("prd-llmgw/Program.cs");

--- a/prd-llmgw-web/src/pages/HomePage.tsx
+++ b/prd-llmgw-web/src/pages/HomePage.tsx
@@ -63,7 +63,7 @@ export function OverviewPage() {
           <h2>用一把租户密钥接入四种协议</h2>
           <p>选择现有 SDK，复制可运行示例，再用 requestId 回到 Activity 定位请求。</p>
           <div className="lg-protocol-list" aria-label="支持协议">
-            {['OpenAI Chat', 'OpenAI Responses', 'Claude', 'Gemini'].map((item) => <Chip key={item} label={item} color="var(--text-secondary)" bg="var(--bg-elevated)" />)}
+            {['GW Native', 'OpenAI', 'Claude', 'Gemini'].map((item) => <Chip key={item} label={item} color="var(--text-secondary)" bg="var(--bg-elevated)" />)}
           </div>
           <div className="lg-card-actions">
             <Link className="lg-primary-link" to="/quickstart"><Rocket size={14} /> 开始接入</Link>

--- a/scripts/llmgw-prod-governance-acceptance.sh
+++ b/scripts/llmgw-prod-governance-acceptance.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 
 execute="${LLMGW_GOVERNANCE_ACCEPTANCE_EXECUTE:-0}"
 root="${LLMGW_GOVERNANCE_ACCEPTANCE_ROOT:-https://map.ebcone.net}"
+console_base="${LLMGW_CONSOLE_API_BASE:-$root/gw}"
 env_file="${LLMGW_ENV_FILE:-.env}"
 mongo_container="${LLMGW_MONGO_CONTAINER:-prdagent-mongodb}"
 primary_container="${LLMGW_SERVE_PRIMARY_CONTAINER:-prdagent-llmgw-serve}"
@@ -26,9 +27,10 @@ if [[ "$execute" != "1" ]]; then
 LLM Gateway production governance acceptance dry-run
 - root: $root
 - temporary caller: $temp_caller
+- tenant: resolved from the authenticated console session
 - checks: scoped key allow/deny/revoke, budget reservation, provider concurrency, lifecycle dry-run, serving failover
 - paid upstream calls: 0 (host-local fake upstream)
-- database changes: temporary records only; cleanup trap removes all records
+- database changes: tenant-scoped temporary records only; cleanup trap removes all records
 Set LLMGW_GOVERNANCE_ACCEPTANCE_EXECUTE=1 to execute.
 EOF
   exit 0
@@ -49,29 +51,32 @@ set -a
 # shellcheck disable=SC1090
 source "$env_file"
 set +a
-: "${LLMGW_JWT_SECRET:?LLMGW_JWT_SECRET is required}"
+export LLMGW_CONSOLE_PASSWORD="${LLMGW_CONSOLE_PASSWORD:-${LLMGW_ADMIN_PASSWORD:-}}"
 
 tmp_dir="$(mktemp -d /tmp/llmgw-governance-acceptance.XXXXXX)"
 fake_pid=""
 token=""
+tenant_id=""
 key_id=""
 scoped_key=""
 primary_stopped=0
 
 cleanup_database() {
-  docker exec "$mongo_container" mongosh --quiet llm_gateway --eval '
+  [[ -n "$tenant_id" ]] || return 0
+  docker exec "$mongo_container" mongosh --quiet llm_gateway --eval "
+    const tenantId = '$tenant_id';
     const caller = "llmgw-acceptance.governance::chat";
-    db.llmgw_app_callers.deleteMany({ AppCallerCode: caller });
-    db.llmgw_model_pools.deleteMany({ _id: "llmgw-acceptance-pool" });
-    db.llmgw_models.deleteMany({ _id: "llmgw-acceptance-model" });
-    db.llmgw_platforms.deleteMany({ _id: "llmgw-acceptance-platform" });
-    db.llmgw_budget_reservations.deleteMany({ AppCallerCode: caller });
-    db.llmgw_budget_months.deleteMany({ AppCallerCode: caller });
-    db.llmgw_provider_concurrency_slots.deleteMany({ ResourceKey: /llmgw-acceptance/ });
-    db.llmgw_service_keys.deleteMany({ Name: "governance-acceptance-temporary" });
-    db.llmrequestlogs.deleteMany({ AppCallerCode: caller });
-    db.llmshadow_comparisons.deleteMany({ AppCallerCode: caller });
-  ' >/dev/null 2>&1 || true
+    db.llmgw_app_callers.deleteMany({ TenantId: tenantId, AppCallerCode: caller });
+    db.llmgw_model_pools.deleteMany({ TenantId: tenantId, _id: "llmgw-acceptance-pool" });
+    db.llmgw_models.deleteMany({ TenantId: tenantId, _id: "llmgw-acceptance-model" });
+    db.llmgw_platforms.deleteMany({ TenantId: tenantId, _id: "llmgw-acceptance-platform" });
+    db.llmgw_budget_reservations.deleteMany({ TenantId: tenantId, AppCallerCode: caller });
+    db.llmgw_budget_months.deleteMany({ TenantId: tenantId, AppCallerCode: caller });
+    db.llmgw_provider_concurrency_slots.deleteMany({ TenantId: tenantId, ResourceKey: /llmgw-acceptance/ });
+    db.llmgw_service_keys.deleteMany({ TenantId: tenantId, Name: "governance-acceptance-temporary" });
+    db.llmrequestlogs.deleteMany({ TenantId: tenantId, AppCallerCode: caller });
+    db.llmshadow_comparisons.deleteMany({ TenantId: tenantId, AppCallerCode: caller });
+  " >/dev/null 2>&1 || true
 }
 
 cleanup() {
@@ -81,7 +86,7 @@ cleanup() {
   if [[ -n "$token" && -n "$key_id" ]]; then
     curl -sS -o /dev/null -X DELETE \
       -H "Authorization: Bearer $token" \
-      "$root/gw/service-keys/$key_id" || true
+      "$console_base/service-keys/$key_id" || true
   fi
   [[ -n "$fake_pid" ]] && kill "$fake_pid" >/dev/null 2>&1 || true
   cleanup_database
@@ -153,36 +158,68 @@ docker exec "$primary_container" curl -fsS -o /dev/null -X POST \
 : >"$counter"
 
 fake_url="http://$gateway_ip:$fake_port"
+: "${LLMGW_CONSOLE_PASSWORD:?LLMGW_CONSOLE_PASSWORD or LLMGW_ADMIN_PASSWORD is required}"
+login_body="$(python3 - <<'PY'
+import json
+import os
+print(json.dumps({
+    "username": os.environ.get("LLMGW_CONSOLE_USERNAME", "admin"),
+    "password": os.environ["LLMGW_CONSOLE_PASSWORD"],
+}))
+PY
+)"
+login_response="$(curl -fsS -X POST -H 'Content-Type: application/json' \
+  --data "$login_body" "$console_base/auth/login")"
+token="$(printf '%s' "$login_response" | python3 -c '
+import json, sys
+payload = json.load(sys.stdin)
+if payload.get("success") is not True:
+    raise SystemExit("console login failed")
+print(payload["data"]["token"])
+')"
+tenant_id="$(curl -fsS -H "Authorization: Bearer $token" "$console_base/auth/context" | python3 -c '
+import json, sys
+payload = json.load(sys.stdin)
+if payload.get("success") is not True:
+    raise SystemExit("tenant context failed")
+print(payload["data"]["id"])
+')"
+[[ -n "$tenant_id" ]] || {
+  echo "console token did not resolve a tenant" >&2
+  exit 1
+}
+
 docker exec "$mongo_container" mongosh --quiet llm_gateway --eval "
   const now = new Date();
-  const sourceCaller = db.llmgw_app_callers.findOne({ AppCallerCode: 'report-agent.generate::chat', RequestType: 'chat' });
+  const tenantId = '$tenant_id';
+  const sourceCaller = db.llmgw_app_callers.findOne({ TenantId: tenantId, AppCallerCode: 'report-agent.generate::chat', RequestType: 'chat' });
   if (!sourceCaller || !sourceCaller.ModelPoolId) throw new Error('source appCaller pool missing');
-  const sourcePool = db.llmgw_model_pools.findOne({ _id: sourceCaller.ModelPoolId });
+  const sourcePool = db.llmgw_model_pools.findOne({ TenantId: tenantId, _id: sourceCaller.ModelPoolId });
   if (!sourcePool) throw new Error('source model pool missing');
   let sourceModel = null;
   let sourcePlatform = null;
   let sourceEntry = null;
   for (const entry of sourcePool.Models || []) {
-    const model = db.llmgw_models.findOne({ PlatformId: entry.PlatformId, ModelName: entry.ModelId })
-      || db.llmgw_models.findOne({ _id: entry.ModelId });
-    const platform = model && db.llmgw_platforms.findOne({ _id: model.PlatformId, Enabled: true });
+    const model = db.llmgw_models.findOne({ TenantId: tenantId, PlatformId: entry.PlatformId, ModelName: entry.ModelId })
+      || db.llmgw_models.findOne({ TenantId: tenantId, _id: entry.ModelId });
+    const platform = model && db.llmgw_platforms.findOne({ TenantId: tenantId, _id: model.PlatformId, Enabled: true });
     if (model && platform) { sourceModel = model; sourcePlatform = platform; sourceEntry = entry; break; }
   }
   if (!sourceModel || !sourcePlatform || !sourceEntry) throw new Error('source model/platform missing');
   db.llmgw_platforms.insertOne({ ...sourcePlatform,
-    _id: '$temp_platform', Name: 'LLMGW acceptance fake', ApiUrl: '$fake_url',
+    _id: '$temp_platform', TenantId: tenantId, Name: 'LLMGW acceptance fake', ApiUrl: '$fake_url',
     PlatformType: 'openai', MaxConcurrency: 1, CreatedAt: now, UpdatedAt: now });
   db.llmgw_models.insertOne({ ...sourceModel,
-    _id: '$temp_model_id', PlatformId: '$temp_platform', ModelName: '$temp_model_name',
+    _id: '$temp_model_id', TenantId: tenantId, PlatformId: '$temp_platform', ModelName: '$temp_model_name',
     Name: 'LLMGW acceptance fake', ApiUrl: '$fake_url', Protocol: 'openai', MaxConcurrency: 1,
     MaxRetries: 0, Timeout: 15000, CreatedAt: now, UpdatedAt: now });
   db.llmgw_model_pools.insertOne({ ...sourcePool,
-    _id: '$temp_pool', Code: '$temp_pool', Name: 'LLMGW acceptance pool',
+    _id: '$temp_pool', TenantId: tenantId, Code: '$temp_pool', Name: 'LLMGW acceptance pool',
     Models: [{ ModelId: '$temp_model_name', PlatformId: '$temp_platform', Protocol: 'openai', Priority: 1,
       HealthStatus: 0, ConsecutiveFailures: 0, ConsecutiveSuccesses: 0 }],
     IsDefaultForType: false, CreatedAt: now, UpdatedAt: now });
   db.llmgw_app_callers.insertOne({
-    _id: 'llmgw-acceptance-caller', AppCallerCode: '$temp_caller',
+    _id: 'llmgw-acceptance-caller', TenantId: tenantId, AppCallerCode: '$temp_caller',
     Title: 'LLMGW governance acceptance', RequestType: 'chat', SourceSystem: 'map',
     Status: 'configured', ModelPolicy: 'pool', ModelPoolId: '$temp_pool',
     ParameterPolicy: 'default-drop', MonthlyBudgetUsd: NumberDecimal('0.01'),
@@ -190,37 +227,6 @@ docker exec "$mongo_container" mongosh --quiet llm_gateway --eval "
     ObservedIngressProtocols: ['gw-native'], CreatedAt: now, UpdatedAt: now,
     FirstSeenAt: now, LastSeenAt: now });
 " >/dev/null
-
-token="$(python3 - <<'PY'
-import base64
-import hashlib
-import hmac
-import json
-import os
-import time
-import uuid
-
-encode = lambda value: base64.urlsafe_b64encode(
-    json.dumps(value, separators=(",", ":")).encode()
-).rstrip(b"=").decode()
-now = int(time.time())
-header = encode({"alg": "HS256", "typ": "JWT"})
-payload = encode({
-    "sub": "admin",
-    "jti": uuid.uuid4().hex,
-    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name": "admin",
-    "nbf": now - 5,
-    "exp": now + 900,
-    "iss": "prdagent-llmgw",
-})
-signature = base64.urlsafe_b64encode(hmac.new(
-    os.environ["LLMGW_JWT_SECRET"].encode(),
-    f"{header}.{payload}".encode(),
-    hashlib.sha256,
-).digest()).rstrip(b"=").decode()
-print(f"{header}.{payload}.{signature}")
-PY
-)"
 
 key_body="$(python3 - <<'PY'
 import datetime
@@ -236,7 +242,7 @@ print(json.dumps({
 PY
 )"
 created="$(curl -fsS -X POST -H "Authorization: Bearer $token" \
-  -H 'Content-Type: application/json' --data "$key_body" "$root/gw/service-keys")"
+  -H 'Content-Type: application/json' --data "$key_body" "$console_base/service-keys")"
 mapfile -t key_pair < <(printf '%s' "$created" | python3 -c '
 import json, sys
 data = json.load(sys.stdin).get("data", {})
@@ -312,23 +318,26 @@ if successes != 1 or rejections != 1 or calls != 1:
 print("budget_atomic_reservation=pass")
 PY
 
-docker exec "$mongo_container" mongosh --quiet llm_gateway --eval '
+docker exec "$mongo_container" mongosh --quiet llm_gateway --eval "
+  const tenantId = '$tenant_id';
   const caller = "llmgw-acceptance.governance::chat";
-  db.llmgw_app_callers.updateOne({ AppCallerCode: caller },
-    { $unset: { MonthlyBudgetUsd: "", BudgetReservationUsd: "" } });
-  db.llmgw_budget_reservations.deleteMany({ AppCallerCode: caller });
-  db.llmgw_budget_months.deleteMany({ AppCallerCode: caller });
-' >/dev/null
+  db.llmgw_app_callers.updateOne({ TenantId: tenantId, AppCallerCode: caller },
+    { \$unset: { MonthlyBudgetUsd: "", BudgetReservationUsd: "" } });
+  db.llmgw_budget_reservations.deleteMany({ TenantId: tenantId, AppCallerCode: caller });
+  db.llmgw_budget_months.deleteMany({ TenantId: tenantId, AppCallerCode: caller });
+" >/dev/null
 : >"$counter"
 
 concurrency_rows="$(run_pair concurrency)"
 concurrency_calls="$(wc -l <"$counter" | tr -d ' ')"
-active_leases="$(docker exec "$mongo_container" mongosh --quiet llm_gateway --eval '
+active_leases="$(docker exec "$mongo_container" mongosh --quiet llm_gateway --eval "
+  const tenantId = '$tenant_id';
   print(db.llmgw_provider_concurrency_slots.countDocuments({
+    TenantId: tenantId,
     ResourceKey: /llmgw-acceptance/,
-    LeaseId: { $nin: ["", null] }, ExpiresAt: { $gt: new Date() }
+    LeaseId: { \$nin: ["", null] }, ExpiresAt: { \$gt: new Date() }
   }))
-')"
+")"
 python3 - "$concurrency_rows" "$concurrency_calls" "$active_leases" <<'PY'
 import json, sys
 rows = json.loads(sys.argv[1])
@@ -373,7 +382,7 @@ done
 echo "serving_failover=pass"
 
 revoke_status="$(status_for -X DELETE -H "Authorization: Bearer $token" \
-  "$root/gw/service-keys/$key_id")"
+  "$console_base/service-keys/$key_id")"
 [[ "$revoke_status" == "200" ]] || {
   echo "service key revoke failed: status=$revoke_status" >&2
   exit 1


### PR DESCRIPTION
## 摘要
收口 LLM Gateway 外部平台化 PR-5：修复租户化后生产治理验收脚本的身份与数据边界漂移，复用既有假上游合同完成跨租户、service key 和四协议验收，不触碰 full-http、模型池或发布 gate。

## 改动 diff
- `scripts/llmgw-prod-governance-acceptance.sh`：改用真实控制台登录和服务端租户上下文，所有临时查询与清理包含 TenantId
- `prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs`：增加真实租户会话、TenantId 与四协议名称防回归守卫
- `prd-llmgw-web/src/pages/HomePage.tsx`：首页协议标签对齐 GW Native、OpenAI、Claude、Gemini
- `doc/plan.platform.llm-gateway-external-platform.md`：更新 PR-4 证据和 PR-5 精确计划、进度证据
- `changelogs/2026-07-12_llmgw-external-platform-acceptance.md`：记录本次验收收口

## 测试
- [x] `bash -n scripts/llmgw-prod-governance-acceptance.sh`
- [x] 验收脚本默认 dry-run 通过，付费上游调用为 0
- [x] GatewayDataDomainGuardTests 62/62
- [x] GatewayKeyGateContractTests + GatewayProtocolFidelityTests 179/179
- [x] `prd-llmgw-web` TypeScript 检查与生产构建通过
- [x] `prd-api` 编译零 error CS；输出仅含存量告警
- [ ] GitHub CI
- [ ] Codex Review 或替代人工复审
- [ ] CDS Deploy、smoke 与直连预览验收

Bugbot 已停止续费，本 PR 记为不适用，不触发、不等待。
