### PR TITLE
feat(llmgw): 重构模型池业务心智与维护分层

### DIFF
--- a/changelogs/2026-07-12_llmgw-model-pool-productization.md
+++ b/changelogs/2026-07-12_llmgw-model-pool-productization.md
@@ -1,0 +1,4 @@
+| feat | prd-llmgw | 为租户模型池补充 appCaller 绑定、近期流量、成功率和成员健康聚合 |
+| feat | prd-llmgw-web | 重构模型池首屏业务心智、详情抽屉与高级维护分层 |
+| feat | prd-llmgw-web | 支持按模型池精确查看 appCaller 和请求记录 |
+| test | prd-api | 更新 Gateway 数据域守卫覆盖模型池租户聚合与精确筛选 |

--- a/doc/plan.platform.llm-gateway.console-productization.md
+++ b/doc/plan.platform.llm-gateway.console-productization.md
@@ -103,9 +103,9 @@
 
 **验收标准**：
 
-- [ ] 用户无需滚动即可说清每个池负责什么、是否健康、由哪些 appCaller 使用。
-- [ ] 80% 常用操作在首屏完成，高级维护不遮挡主任务。
-- [ ] 页面不出现 P3、legacy、stub、full-http、Gate、权威迁移等开发阶段文案。
+- [x] 用户无需滚动即可说清每个池负责什么、是否健康、由哪些 appCaller 使用。
+- [x] 80% 常用操作在首屏完成，高级维护不遮挡主任务。
+- [x] 页面不出现 P3、legacy、stub、full-http、Gate、权威迁移等开发阶段文案。
 
 ### P3：根目录 `llmgw/` 收拢
 
@@ -159,8 +159,8 @@ llmgw/
 | 阶段 | 状态 | 分支 | 备注 |
 |---|---|---|---|
 | P0 | 已合并 | `codex/llmgw-console-productization-p0` | PR #1090 已合并到 `main`；双主题、请求记录、真实地址、安全直测、密钥解释和内部运维隔离已通过本地、GitHub CI 与 CDS 预览验收 |
-| P1 | 已完成，待 PR | `codex/llmgw-console-productization-p1` | 服务端租户首页聚合、全局概览和学习中心已通过编译、双租户 API 与双主题响应式浏览器验收 |
-| P2 | 待开始 | 待 P1 合并后创建 | 模型池信息架构与术语收口 |
+| P1 | 已合并 | `codex/llmgw-console-productization-p1` | PR #1091 已合并到 `main`；租户首页聚合、全局概览和学习中心已通过本地、GitHub CI 与 CDS 预览验收 |
+| P2 | 已完成，待 PR | `codex/llmgw-console-productization-p2` | 模型池业务心智、绑定与流量统计、健康卡片、详情抽屉和高级维护分层已通过编译、双租户 API 与双主题响应式浏览器验收 |
 | P3 | 待开始 | 待 P2 合并后创建 | 根目录收拢，运行语义不变 |
 
 每个阶段都使用独立分支、独立测试和独立验收；前一阶段未完成时，不把后一阶段的实现混入当前提交。Bugbot 因订阅停止记为不适用，不再等待。
@@ -170,3 +170,5 @@ P0 本地证据（2026-07-12）：`prd-llmgw-web` 生产构建通过；`prd-llmg
 P0 远端证据（2026-07-12）：实现提交 `f6427c02b` 与证据提交 `f9216f6f1` 已推送，独立 PR #1090 已创建。GitHub 共 15 个检查进入终态，9 个成功、6 个按变更范围跳过、0 个失败；`prd-api`、`prd-llmgw`、`prd-llmgw-web`、`prd-llmgw-serve` 四个相关镜像全部构建成功。CDS 分支绑定 PR #1090 和提交 `a92b6706f`，5/5 服务运行，镜像状态 ready，CI 结论 success，部署无漂移；预览环境的 `/llmgw/quickstart`、`/llmgw/logs`、`/llmgw/settings` 三个最终深链均返回 200。Bugbot 因订阅停止记为不适用。PR #1090 已 squash 合并到 `main`，合并提交为 `ec6596374`。
 
 P1 本地证据（2026-07-12）：`prd-llmgw-web` TypeScript 与 Vite 生产构建通过，`prd-llmgw` 编译 0 warning/0 error，Gateway 数据域守卫 65/65 通过。一次性 Mongo、真实 console API 与浏览器完成双租户验收：Alpha 为 5 请求、80% 成功率、900ms P95、730 token、2 个活跃身份、60% 价格覆盖、CNY/USD 分列、1 把租户密钥；Beta 为 2 请求、100% 成功率、250ms P95、140 token、1 个活跃身份、0% 价格覆盖、2 个 unknown cost、0 把租户密钥。Alpha 会话附带 Beta `tenantId` 查询参数时仍返回 Alpha 的 5 条请求与 Top appCaller，证明端点不信任自报租户。独立空租户返回 0 请求、null 成功率、null P95、0 个费用桶、0 把密钥和 0 条最近请求；非法日期与反向时间范围均返回 HTTP 400。桌面和移动端完成 Alpha/Beta 切换、浅色/深色、首页与学习中心验收，无横向溢出且浏览器 warning/error 为 0；学习中心包含三步首条请求路径、完整概念链、10 个术语及对应页面深链。验收未启动 serving，未调用任何模型；临时 API、Web、Mongo 与测试数据已删除。
+
+P2 本地证据（2026-07-12）：`prd-llmgw-web` TypeScript 与 Vite 生产构建通过，`prd-llmgw` 编译 0 warning/0 error。一次性 Mongo、真实 console API 与浏览器完成双租户验收：Alpha 模型池显示 2 个绑定 appCaller、近 7 天 4 次请求、3 成功、1 失败、75% 成功率；Beta 模型池显示 1 个绑定 appCaller、9 次请求、100% 成功率。Alpha 会话附带 Beta `tenantId` 查询参数时仍只返回 Alpha 模型池，模型池到 appCaller 与请求记录的精确深链分别只返回 Alpha 的 2 条和 4 条数据。桌面暗色、桌面浅色与 433px 移动视口均无横向溢出，移动详情抽屉宽度等于视口，租户切换后卡片统计即时刷新，浏览器 warning/error 为 0。流量统计在 Mongo 内按模型池聚合，不把窗口内全部日志加载到控制台 API 内存。验收未启动 serving，未调用任何模型。

--- a/doc/plan.platform.llm-gateway.console-productization.md
+++ b/doc/plan.platform.llm-gateway.console-productization.md
@@ -160,7 +160,7 @@ llmgw/
 |---|---|---|---|
 | P0 | 已合并 | `codex/llmgw-console-productization-p0` | PR #1090 已合并到 `main`；双主题、请求记录、真实地址、安全直测、密钥解释和内部运维隔离已通过本地、GitHub CI 与 CDS 预览验收 |
 | P1 | 已合并 | `codex/llmgw-console-productization-p1` | PR #1091 已合并到 `main`；租户首页聚合、全局概览和学习中心已通过本地、GitHub CI 与 CDS 预览验收 |
-| P2 | 已完成，待 PR | `codex/llmgw-console-productization-p2` | 模型池业务心智、绑定与流量统计、健康卡片、详情抽屉和高级维护分层已通过编译、双租户 API 与双主题响应式浏览器验收 |
+| P2 | 已完成，待合并 | `codex/llmgw-console-productization-p2` | PR #1092；模型池业务心智、绑定与流量统计、健康卡片、详情抽屉和高级维护分层已通过本地、GitHub CI 与 CDS 预览验收 |
 | P3 | 待开始 | 待 P2 合并后创建 | 根目录收拢，运行语义不变 |
 
 每个阶段都使用独立分支、独立测试和独立验收；前一阶段未完成时，不把后一阶段的实现混入当前提交。Bugbot 因订阅停止记为不适用，不再等待。
@@ -172,3 +172,5 @@ P0 远端证据（2026-07-12）：实现提交 `f6427c02b` 与证据提交 `f921
 P1 本地证据（2026-07-12）：`prd-llmgw-web` TypeScript 与 Vite 生产构建通过，`prd-llmgw` 编译 0 warning/0 error，Gateway 数据域守卫 65/65 通过。一次性 Mongo、真实 console API 与浏览器完成双租户验收：Alpha 为 5 请求、80% 成功率、900ms P95、730 token、2 个活跃身份、60% 价格覆盖、CNY/USD 分列、1 把租户密钥；Beta 为 2 请求、100% 成功率、250ms P95、140 token、1 个活跃身份、0% 价格覆盖、2 个 unknown cost、0 把租户密钥。Alpha 会话附带 Beta `tenantId` 查询参数时仍返回 Alpha 的 5 条请求与 Top appCaller，证明端点不信任自报租户。独立空租户返回 0 请求、null 成功率、null P95、0 个费用桶、0 把密钥和 0 条最近请求；非法日期与反向时间范围均返回 HTTP 400。桌面和移动端完成 Alpha/Beta 切换、浅色/深色、首页与学习中心验收，无横向溢出且浏览器 warning/error 为 0；学习中心包含三步首条请求路径、完整概念链、10 个术语及对应页面深链。验收未启动 serving，未调用任何模型；临时 API、Web、Mongo 与测试数据已删除。
 
 P2 本地证据（2026-07-12）：`prd-llmgw-web` TypeScript 与 Vite 生产构建通过，`prd-llmgw` 编译 0 warning/0 error。一次性 Mongo、真实 console API 与浏览器完成双租户验收：Alpha 模型池显示 2 个绑定 appCaller、近 7 天 4 次请求、3 成功、1 失败、75% 成功率；Beta 模型池显示 1 个绑定 appCaller、9 次请求、100% 成功率。Alpha 会话附带 Beta `tenantId` 查询参数时仍只返回 Alpha 模型池，模型池到 appCaller 与请求记录的精确深链分别只返回 Alpha 的 2 条和 4 条数据。桌面暗色、桌面浅色与 433px 移动视口均无横向溢出，移动详情抽屉宽度等于视口，租户切换后卡片统计即时刷新，浏览器 warning/error 为 0。流量统计在 Mongo 内按模型池聚合，不把窗口内全部日志加载到控制台 API 内存。验收未启动 serving，未调用任何模型。
+
+P2 远端证据（2026-07-12）：实现提交 `c6e37c25f` 已推送，独立 PR #1092 已创建。GitHub 16 项检查进入终态，10 项成功、6 项按变更范围跳过、0 项失败；`prd-api`、`prd-llmgw`、`prd-llmgw-web`、`prd-llmgw-serve` 四个相关镜像和 Server Build & Test 全部通过。CDS 分支绑定 PR #1092 和同一提交，5/5 服务运行，镜像状态 ready，CI 结论 success，部署无漂移；预览环境的 `/llmgw/pools`、`/llmgw/app-callers?modelPoolId=test`、`/llmgw/logs?modelPoolId=test` 三个最终深链均返回 200。Bugbot 因订阅停止记为不适用。

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -148,12 +148,14 @@ public class GatewayDataDomainGuardTests
         Assert.Contains("activeBoundPoolWithoutUsableMember", ReadRepoFile("scripts/llmgw-release-gate.py"));
         Assert.Contains("activeBoundPoolWithoutUsableMember", ReadRepoFile("scripts/llmgw-config-authority-apply.py"));
         Assert.Contains("activeBoundPoolWithoutUsableMember", ReadRepoFile("scripts/llmgw-rollout-ledger.py"));
-        Assert.Contains("默认 GW 模型池必须至少包含一个可解析、非 unavailable 的成员", consoleProgram);
+        Assert.Contains("默认模型池必须至少包含一个可用成员", consoleProgram);
         Assert.Contains("body.IsDefaultForType == true", consoleProgram);
         Assert.Contains("targetAuthority == \"llm_gateway\"", consoleProgram);
         Assert.Contains("action: \"pool.set_default\"", consoleProgram);
         Assert.Contains("ValidateDefaultGatewayPoolMembersAsync", consoleProgram);
-        Assert.Contains("默认 GW 模型池必须保留至少一个可解析、非 unavailable 的成员", consoleProgram);
+        Assert.Contains("默认模型池必须保留至少一个可用成员", consoleProgram);
+        Assert.Contains("TenantAccess.Filter(http, logFilter)", consoleProgram);
+        Assert.Contains("fb.Eq(\"ModelPoolId\", modelPoolId.Trim())", consoleProgram);
         Assert.Contains("action: \"pool.models.bulk_import\"", consoleProgram);
         Assert.Contains("action: wasExisting ? \"pool.model.update\" : \"pool.model.add\"", consoleProgram);
         Assert.Contains("action: \"pool.model.remove\"", consoleProgram);

--- a/prd-llmgw-web/src/components/LogsView.tsx
+++ b/prd-llmgw-web/src/components/LogsView.tsx
@@ -70,6 +70,7 @@ export function LogsView() {
   const [filterRunId, setFilterRunId] = useState(() => initialQueryValue('runId'));
   const [filterRequestId, setFilterRequestId] = useState(() => initialQueryValue('requestId'));
   const [filterSessionId, setFilterSessionId] = useState(() => initialQueryValue('sessionId'));
+  const [filterModelPoolId, setFilterModelPoolId] = useState(() => initialQueryValue('modelPoolId'));
 
   const [meta, setMeta] = useState<{
     models: string[];
@@ -120,6 +121,7 @@ export function LogsView() {
     setFilterRunId(query.get('runId') ?? '');
     setFilterRequestId(query.get('requestId') ?? '');
     setFilterSessionId(query.get('sessionId') ?? '');
+    setFilterModelPoolId(query.get('modelPoolId') ?? '');
     setFilterStatus(query.get('status') ?? '');
     setFilterAppCaller(query.get('appCallerCode') ?? '');
   }, [location.search]);
@@ -146,8 +148,9 @@ export function LogsView() {
       runId: filterRunId.trim() || undefined,
       requestId: filterRequestId.trim() || undefined,
       sessionId: filterSessionId.trim() || undefined,
+      modelPoolId: filterModelPoolId.trim() || undefined,
     }),
-    [range, filterModel, filterStatus, filterProvider, filterAppCaller, filterTransport, filterRequestType, filterSourceSystem, filterIngressProtocol, filterModelPolicy, filterReleaseCommit, filterRunId, filterRequestId, filterSessionId],
+    [range, filterModel, filterStatus, filterProvider, filterAppCaller, filterTransport, filterRequestType, filterSourceSystem, filterIngressProtocol, filterModelPolicy, filterReleaseCommit, filterRunId, filterRequestId, filterSessionId, filterModelPoolId],
   );
 
   useEffect(() => {
@@ -581,6 +584,7 @@ export function LogsView() {
     filterRunId.trim(),
     filterRequestId.trim(),
     filterSessionId.trim(),
+    filterModelPoolId.trim(),
   ].filter(Boolean).length;
   const clearFilters = () => {
     setFilterModel('');
@@ -596,6 +600,7 @@ export function LogsView() {
     setFilterRunId('');
     setFilterRequestId('');
     setFilterSessionId('');
+    setFilterModelPoolId('');
   };
 
   function SummaryTile({
@@ -782,6 +787,13 @@ export function LogsView() {
             value={filterSessionId}
             onChange={(e) => setFilterSessionId(e.target.value)}
             placeholder="会话 ID"
+            spellCheck={false}
+            style={inputStyle}
+          />
+          <input
+            value={filterModelPoolId}
+            onChange={(e) => setFilterModelPoolId(e.target.value)}
+            placeholder="模型池 ID"
             spellCheck={false}
             style={inputStyle}
           />

--- a/prd-llmgw-web/src/components/poolsHelpers.ts
+++ b/prd-llmgw-web/src/components/poolsHelpers.ts
@@ -2,13 +2,13 @@
 export function healthChip(status: number): { label: string; color: string; bg: string } {
   switch (status) {
     case 0:
-      return { label: 'Healthy', color: '#3fb950', bg: 'rgba(63,185,80,0.14)' };
+      return { label: '健康', color: '#3fb950', bg: 'rgba(63,185,80,0.14)' };
     case 1:
-      return { label: 'Degraded', color: '#d29922', bg: 'rgba(210,153,34,0.14)' };
+      return { label: '部分异常', color: '#d29922', bg: 'rgba(210,153,34,0.14)' };
     case 2:
-      return { label: 'Unavailable', color: '#f85149', bg: 'rgba(248,81,73,0.14)' };
+      return { label: '不可用', color: '#f85149', bg: 'rgba(248,81,73,0.14)' };
     default:
-      return { label: 'Unknown', color: 'var(--text-muted)', bg: 'var(--bg-elevated)' };
+      return { label: '未知', color: 'var(--text-muted)', bg: 'var(--bg-elevated)' };
   }
 }
 

--- a/prd-llmgw-web/src/lib/api.ts
+++ b/prd-llmgw-web/src/lib/api.ts
@@ -262,8 +262,8 @@ export function getLogDetail(id: string): Promise<ApiResponse<LlmLogDetail>> {
 }
 
 // ── 配置面（只读）──
-export function getPools(modelType?: string): Promise<ApiResponse<PoolsData>> {
-  return apiRequest<PoolsData>('/pools', { query: { modelType } });
+export function getPools(modelType?: string, sinceHours = 168): Promise<ApiResponse<PoolsData>> {
+  return apiRequest<PoolsData>('/pools', { query: { modelType, sinceHours } });
 }
 export function getPlatforms(): Promise<ApiResponse<PlatformsData>> {
   return apiRequest<PlatformsData>('/platforms');
@@ -303,6 +303,7 @@ export function getGatewayAppCallers(params?: {
   sourceSystem?: string;
   ingressProtocol?: string;
   requestType?: string;
+  modelPoolId?: string;
   drift?: string;
   search?: string;
 }): Promise<ApiResponse<GatewayAppCallersData>> {
@@ -314,6 +315,7 @@ export function getGatewayAppCallers(params?: {
       sourceSystem: params?.sourceSystem,
       ingressProtocol: params?.ingressProtocol,
       requestType: params?.requestType,
+      modelPoolId: params?.modelPoolId,
       drift: params?.drift,
       search: params?.search,
     },

--- a/prd-llmgw-web/src/lib/types.ts
+++ b/prd-llmgw-web/src/lib/types.ts
@@ -341,6 +341,7 @@ export type LogsListParams = {
   runId?: string;
   requestId?: string;
   sessionId?: string;
+  modelPoolId?: string;
 };
 
 export type LogsListData = {
@@ -389,6 +390,12 @@ export type ModelPool = {
   isDefaultForType: boolean; strategyType: number; description?: string | null;
   sourceCollection: string; authority: string; claimedAt?: string | null;
   createdAt?: string | null; updatedAt?: string | null; models: PoolModelInfo[];
+  boundAppCallerCount: number;
+  boundAppCallers: Array<{ id: string; appCallerCode: string; title?: string | null; status: string }>;
+  recentRequests: number; recentSucceeded: number; recentFailed: number;
+  recentSuccessRatePercent?: number | null; lastRequestAt?: string | null; trafficWindowHours: number;
+  health: 'healthy' | 'degraded' | 'unavailable' | 'empty';
+  healthyMembers: number; degradedMembers: number; unavailableMembers: number;
 };
 export type PoolsData = { items: ModelPool[]; total: number };
 export type CreatePoolRequest = {

--- a/prd-llmgw-web/src/pages/AppCallersPage.tsx
+++ b/prd-llmgw-web/src/pages/AppCallersPage.tsx
@@ -82,6 +82,7 @@ export function AppCallersPage() {
   const [ingressProtocol, setIngressProtocol] = useState(() => searchParams.get('ingressProtocol') || '');
   const [requestType, setRequestType] = useState(() => searchParams.get('requestType') || '');
   const [drift, setDrift] = useState(() => searchParams.get('drift') || '');
+  const [modelPoolId, setModelPoolId] = useState(() => searchParams.get('modelPoolId') || '');
 
   const loadCurrentPage = async () => {
     setError(null);
@@ -94,6 +95,7 @@ export function AppCallersPage() {
       ingressProtocol: ingressProtocol || undefined,
       requestType: requestType || undefined,
       drift: drift || undefined,
+      modelPoolId: modelPoolId || undefined,
     });
     if (res.success) setData(res.data);
     else setError(res.error?.message || '加载失败');
@@ -111,6 +113,7 @@ export function AppCallersPage() {
       ingressProtocol: ingressProtocol || undefined,
       requestType: requestType || undefined,
       drift: drift || undefined,
+      modelPoolId: modelPoolId || undefined,
     }).then((res) => {
       if (!alive) return;
       if (res.success) setData(res.data);
@@ -119,7 +122,7 @@ export function AppCallersPage() {
     return () => {
       alive = false;
     };
-  }, [page, search, status, sourceSystem, ingressProtocol, requestType, drift]);
+  }, [page, search, status, sourceSystem, ingressProtocol, requestType, drift, modelPoolId]);
 
   useEffect(() => {
     let alive = true;
@@ -243,6 +246,7 @@ export function AppCallersPage() {
   return (
     <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', gap: 10 }}>
       <div style={{ flexShrink: 0, display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+        {modelPoolId ? <span style={{ display: 'inline-flex', alignItems: 'center', gap: 7, padding: '6px 9px', borderRadius: 'var(--radius-sm)', background: 'var(--accent-soft)', color: 'var(--accent)', fontSize: 11 }}>当前模型池绑定<button type="button" onClick={() => { setPage(1); setModelPoolId(''); }} style={{ border: 0, background: 'transparent', color: 'inherit', cursor: 'pointer', padding: 0 }}>清除</button></span> : null}
         <input
           value={search}
           onChange={(e) => {

--- a/prd-llmgw-web/src/pages/ModelPoolsPage.tsx
+++ b/prd-llmgw-web/src/pages/ModelPoolsPage.tsx
@@ -1,6 +1,7 @@
 // 模型池：每个池一张卡，展示策略/类型/默认标记 + 池内每个模型的健康 chip。
 // 「默认池」可就地切换：GW 权威池写 llm_gateway，MAP 来源池写旧集合。
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { bulkCalibratePoolPriceCurrency, bulkClaimPools, bulkImportPoolModels, claimPoolToGateway, createPool, getModels, getParameterCapabilitiesMeta, getPools, removePoolModel, setPoolDefault, updatePool, upsertPoolModel } from '@/lib/api';
 import type { ModelCapability, ModelItem, ModelPool, ParameterCapabilityMetaItem, PoolModelInfo } from '@/lib/types';
 import { Chip, SectionLoader, Button } from '@/components/ui';
@@ -34,6 +35,7 @@ export function ModelPoolsPage() {
   const [memberParameterCaps, setMemberParameterCaps] = useState<Record<string, string>>({});
   const [memberPriorities, setMemberPriorities] = useState<Record<string, string>>({});
   const [editDrafts, setEditDrafts] = useState<Record<string, PoolEditDraft>>({});
+  const [drawer, setDrawer] = useState<{ kind: 'create' } | { kind: 'pool'; poolId: string } | null>(null);
 
   useEffect(() => {
     let alive = true;
@@ -70,7 +72,7 @@ export function ModelPoolsPage() {
     const res = await claimPoolToGateway(pool.id);
     setBusyId(null);
     if (res.success) {
-      setPools((prev) => (prev ? prev.map((x) => (x.id === res.data.id ? res.data : x)) : prev));
+      setPools((prev) => (prev ? prev.map((x) => (x.id === res.data.id ? mergePoolMutation(x, res.data) : x)) : prev));
       setToast(`已将「${res.data.name}」导入平台模型池`);
     } else {
       setToast(res.error?.message || '操作失败');
@@ -114,7 +116,8 @@ export function ModelPoolsPage() {
         return [res.data, ...normalized];
       });
       setCreateDraft({ name: '', code: '', modelType, priority: '50', isDefaultForType: false, description: '' });
-      setToast(`已创建 GW 模型池「${res.data.name}」`);
+      setDrawer({ kind: 'pool', poolId: res.data.id });
+      setToast(`已创建模型池「${res.data.name}」`);
     } else {
       setToast(res.error?.message || '操作失败');
     }
@@ -162,7 +165,7 @@ export function ModelPoolsPage() {
         modelType: pool.modelType || 'chat',
         priority: String(pool.priority),
         strategyType: String(pool.strategyType),
-        description: pool.description || '',
+        description: publicPoolDescription(pool.description) || '',
       },
     }));
   }
@@ -220,7 +223,7 @@ export function ModelPoolsPage() {
         const normalized = res.data.isDefaultForType
           ? prev.map((p) => (p.modelType === res.data.modelType ? { ...p, isDefaultForType: false } : p))
           : prev;
-        return normalized.map((p) => (p.id === res.data.id ? res.data : p));
+        return normalized.map((p) => (p.id === res.data.id ? mergePoolMutation(p, res.data) : p));
       });
       cancelEditPool(pool.id);
       setToast(`已保存模型池「${res.data.name}」`);
@@ -258,7 +261,7 @@ export function ModelPoolsPage() {
     });
     setBusyId(null);
     if (res.success) {
-      setPools((prev) => (prev ? prev.map((x) => (x.id === res.data.id ? res.data : x)) : prev));
+      setPools((prev) => (prev ? prev.map((x) => (x.id === res.data.id ? mergePoolMutation(x, res.data) : x)) : prev));
       setAddDrafts((prev) => ({ ...prev, [pool.id]: emptyMemberDraft() }));
       setToast(`已更新「${res.data.name}」的模型池成员`);
     } else {
@@ -286,7 +289,7 @@ export function ModelPoolsPage() {
     setBusyId(null);
     if (res.success) {
       if (res.data.pool) {
-        setPools((prev) => (prev ? prev.map((x) => (x.id === res.data.pool?.id ? res.data.pool : x)) : prev));
+        setPools((prev) => (prev ? prev.map((x) => (x.id === res.data.pool?.id ? mergePoolMutation(x, res.data.pool) : x)) : prev));
       }
       setToast(`批量导入完成：新增 ${res.data.imported}，更新 ${res.data.updated}，跳过已有 ${res.data.skippedExisting}`);
     } else {
@@ -319,7 +322,7 @@ export function ModelPoolsPage() {
     });
     setBusyId(null);
     if (res.success) {
-      setPools((prev) => (prev ? prev.map((x) => (x.id === res.data.id ? res.data : x)) : prev));
+      setPools((prev) => (prev ? prev.map((x) => (x.id === res.data.id ? mergePoolMutation(x, res.data) : x)) : prev));
       setMemberParameterCaps((prev) => {
         const next = { ...prev };
         delete next[key];
@@ -354,7 +357,7 @@ export function ModelPoolsPage() {
     const res = await removePoolModel(pool.id, member.modelId, member.platformId);
     setBusyId(null);
     if (res.success) {
-      setPools((prev) => (prev ? prev.map((x) => (x.id === res.data.id ? res.data : x)) : prev));
+      setPools((prev) => (prev ? prev.map((x) => (x.id === res.data.id ? mergePoolMutation(x, res.data) : x)) : prev));
       setToast(`已从「${res.data.name}」移除「${member.modelId}」`);
     } else {
       setToast(res.error?.message || '操作失败');
@@ -365,187 +368,204 @@ export function ModelPoolsPage() {
   if (!pools) return <SectionLoader text="正在加载模型池…" />;
   const modelTypes = Array.from(new Set(pools.map((p) => p.modelType).filter(Boolean))).sort();
   const platformIds = Array.from(new Set(models.map((m) => m.platformId).filter((x): x is string => !!x))).sort();
+  const selectedPool = drawer?.kind === 'pool' ? pools.find((pool) => pool.id === drawer.poolId) ?? null : null;
+  const totalBoundAppCallers = pools.reduce((sum, pool) => sum + pool.boundAppCallerCount, 0);
+  const totalRecentRequests = pools.reduce((sum, pool) => sum + pool.recentRequests, 0);
+  const attentionPools = pools.filter((pool) => pool.health === 'unavailable' || pool.health === 'empty').length;
 
   return (
-    <div style={{ flex: 1, minHeight: 0, overflowY: 'auto', overscrollBehavior: 'contain', display: 'flex', flexDirection: 'column', gap: 12 }}>
+    <div style={{ flex: 1, minHeight: 0, overflowY: 'auto', overscrollBehavior: 'contain', display: 'flex', flexDirection: 'column', gap: 16 }}>
       <ParameterCapabilityOptions parameterMeta={parameterMeta} />
+      <section style={{ display: 'flex', gap: 16, alignItems: 'flex-start', justifyContent: 'space-between', flexWrap: 'wrap' }}>
+        <div style={{ maxWidth: 760 }}>
+          <h1 style={{ margin: 0, color: 'var(--text-primary)', fontSize: 24 }}>模型池</h1>
+          <p style={{ margin: '7px 0 0', color: 'var(--text-muted)', fontSize: 13, lineHeight: 1.7 }}>
+            模型池把同一类业务需要的多个模型组织成一条稳定路由。先看它服务谁、承接多少请求和是否健康，需要调整时再进入详情。
+          </p>
+        </div>
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+          <Button size="sm" variant="secondary" onClick={() => setDrawer({ kind: 'create' })}>新建模型池</Button>
+          <Link to="/learn" style={{ alignSelf: 'center', color: 'var(--accent)', fontSize: 12, textDecoration: 'none' }}>了解模型池如何参与路由</Link>
+        </div>
+      </section>
       {toast ? (
         <div style={{ flexShrink: 0, fontSize: 12, color: 'var(--text-secondary)', padding: '6px 10px', background: 'var(--bg-elevated)', border: '1px solid var(--border-subtle)', borderRadius: 'var(--radius-sm)' }}>{toast}</div>
       ) : null}
-      <PoolCreateBar
-        draft={createDraft}
-        modelTypes={modelTypes}
-        busyId={busyId}
-        bulkModelType={bulkModelType}
-        priceCurrencyDraft={priceCurrencyDraft}
-        onDraftChange={setCreateDraft}
-        onBulkModelTypeChange={setBulkModelType}
-        onPriceCurrencyDraftChange={setPriceCurrencyDraft}
-        onCreate={() => void createGatewayPool()}
-        onBulkClaim={() => void bulkClaim()}
-        onCalibratePriceCurrency={() => void calibratePriceCurrency()}
-      />
+      <section style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 180px), 1fr))', gap: 10 }}>
+        <PoolMetric label="模型池" value={String(pools.length)} hint={`${modelTypes.length} 类业务路由`} />
+        <PoolMetric label="已绑定 appCaller" value={String(totalBoundAppCallers)} hint="明确绑定到模型池的调用方" />
+        <PoolMetric label="近 7 天请求" value={String(totalRecentRequests)} hint="按当前租户请求记录统计" />
+        <PoolMetric label="需要处理" value={String(attentionPools)} hint={attentionPools ? '无可用成员或尚未配置成员' : '所有模型池均有可用成员'} tone={attentionPools ? '#d29922' : '#3fb950'} />
+      </section>
       {pools.length === 0 ? <Empty text="暂无模型池，可先新建第一个模型池" /> : null}
-      {pools.map((p) => (
-        <div
-          key={p.id}
-          style={{
-            background: 'var(--bg-surface)',
-            border: '1px solid var(--border-subtle)',
-            borderRadius: 'var(--radius)',
-            padding: 16,
-          }}
-        >
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap', marginBottom: 10 }}>
-            <span style={{ fontSize: 15, fontWeight: 700, color: 'var(--text-primary)' }}>{p.name}</span>
-            <Chip label={p.modelType || 'chat'} color="var(--accent)" bg="var(--accent-soft)" />
-            <Chip label={STRATEGY_LABEL[p.strategyType] || `策略${p.strategyType}`} color="var(--text-secondary)" bg="var(--bg-elevated)" />
-            {p.isDefaultForType ? <Chip label="默认池" color="#3fb950" bg="rgba(63,185,80,0.14)" /> : null}
-            {p.authority === 'llm_gateway' ? (
-              <Chip label="平台配置" color="#7aa2ff" bg="rgba(122,162,255,0.14)" title={p.claimedAt ? `导入于 ${p.claimedAt}` : undefined} />
-            ) : (
-              <Chip label="待导入" color="var(--text-muted)" bg="var(--bg-elevated)" />
-            )}
-            <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>优先级 {p.priority}</span>
-            <span style={{ marginLeft: 'auto', display: 'inline-flex', alignItems: 'center', gap: 10 }}>
-              <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>{p.models.length} 个模型</span>
-              {p.authority === 'llm_gateway' ? null : (
-                <Button size="sm" variant="ghost" disabled={busyId === p.id} onClick={() => void claimPool(p)}>
-                  {busyId === p.id ? '处理中…' : '导入到平台'}
-                </Button>
-              )}
-              {p.authority === 'llm_gateway' ? (
-                <Button size="sm" variant="ghost" disabled={busyId === `pool-edit:${p.id}`} onClick={() => (editDrafts[p.id] ? cancelEditPool(p.id) : startEditPool(p))}>
-                  {editDrafts[p.id] ? '取消编辑' : '编辑属性'}
-                </Button>
-              ) : null}
-              {p.isDefaultForType ? null : (
-                <Button size="sm" variant="secondary" disabled={busyId === p.id} onClick={() => void makeDefault(p)}>
-                  {busyId === p.id ? '处理中…' : '设为默认'}
-                </Button>
-              )}
-            </span>
-          </div>
-          {editDrafts[p.id] ? (
-            <PoolEditBar
-              draft={editDrafts[p.id]}
-              busy={busyId === `pool-edit:${p.id}`}
-              onDraftChange={(next) => setEditDrafts((prev) => ({ ...prev, [p.id]: next }))}
-              onSave={() => void savePool(p)}
-              onCancel={() => cancelEditPool(p.id)}
-            />
-          ) : null}
-          {p.description ? (
-            <div style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: 10 }}>{p.description}</div>
-          ) : null}
-          {p.authority === 'llm_gateway' ? (
-            <>
-              <PoolBulkImportBar
-                pool={p}
-                platformIds={platformIds}
-                draft={bulkImportDrafts[p.id] || emptyBulkImportDraft()}
+      <section style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 330px), 1fr))', gap: 12 }}>
+        {pools.map((pool) => <PoolOverviewCard key={pool.id} pool={pool} busyId={busyId} onOpen={() => setDrawer({ kind: 'pool', poolId: pool.id })} onMakeDefault={() => void makeDefault(pool)} />)}
+      </section>
+      <details style={{ border: '1px solid var(--border-subtle)', borderRadius: 'var(--radius)', background: 'var(--bg-surface)', padding: 12 }}>
+        <summary style={{ cursor: 'pointer', color: 'var(--text-secondary)', fontSize: 13, fontWeight: 600 }}>高级维护</summary>
+        <p style={{ color: 'var(--text-muted)', fontSize: 12, lineHeight: 1.6 }}>用于批量导入历史配置和校准价格币种。日常查看与路由判断不需要操作这里。</p>
+        <PoolCreateBar
+          mode="advanced"
+          draft={createDraft}
+          modelTypes={modelTypes}
+          busyId={busyId}
+          bulkModelType={bulkModelType}
+          priceCurrencyDraft={priceCurrencyDraft}
+          onDraftChange={setCreateDraft}
+          onBulkModelTypeChange={setBulkModelType}
+          onPriceCurrencyDraftChange={setPriceCurrencyDraft}
+          onCreate={() => void createGatewayPool()}
+          onBulkClaim={() => void bulkClaim()}
+          onCalibratePriceCurrency={() => void calibratePriceCurrency()}
+        />
+      </details>
+      {drawer ? (
+        <div role="presentation" onMouseDown={(event) => { if (event.currentTarget === event.target) setDrawer(null); }} style={{ position: 'fixed', inset: 0, zIndex: 80, background: 'rgba(0,0,0,0.42)', display: 'flex', justifyContent: 'flex-end' }}>
+          <aside role="dialog" aria-modal="true" aria-label={drawer.kind === 'create' ? '新建模型池' : '模型池详情'} style={{ width: 'min(680px, 100vw)', height: '100%', overflowY: 'auto', background: 'var(--bg-surface)', borderLeft: '1px solid var(--border-subtle)', padding: 18, boxShadow: '-16px 0 40px rgba(0,0,0,0.22)' }}>
+            <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12, marginBottom: 18 }}>
+              <div style={{ flex: 1 }}><h2 style={{ margin: 0, color: 'var(--text-primary)', fontSize: 19 }}>{drawer.kind === 'create' ? '新建模型池' : selectedPool?.name || '模型池详情'}</h2><p style={{ margin: '5px 0 0', color: 'var(--text-muted)', fontSize: 12 }}>{drawer.kind === 'create' ? '先定义业务类型，再添加实际承接流量的模型。' : poolPurpose(selectedPool)}</p></div>
+              <Button size="sm" variant="ghost" onClick={() => setDrawer(null)}>关闭</Button>
+            </div>
+            {drawer.kind === 'create' ? (
+              <PoolCreateBar
+                mode="create"
+                draft={createDraft}
+                modelTypes={modelTypes}
                 busyId={busyId}
-                onDraftChange={(next) => setBulkImportDrafts((prev) => ({ ...prev, [p.id]: next }))}
-                onImport={() => void bulkImportModels(p)}
+                bulkModelType={bulkModelType}
+                priceCurrencyDraft={priceCurrencyDraft}
+                onDraftChange={setCreateDraft}
+                onBulkModelTypeChange={setBulkModelType}
+                onPriceCurrencyDraftChange={setPriceCurrencyDraft}
+                onCreate={() => void createGatewayPool()}
+                onBulkClaim={() => void bulkClaim()}
+                onCalibratePriceCurrency={() => void calibratePriceCurrency()}
               />
-              <PoolMemberEditor
-                pool={p}
-                models={models}
-                parameterMeta={parameterMeta}
-                draft={addDrafts[p.id] || emptyMemberDraft()}
-                busyId={busyId}
-                onDraftChange={(next) => setAddDrafts((prev) => ({ ...prev, [p.id]: next }))}
-                onAdd={() => void addPoolModel(p)}
-              />
-            </>
-          ) : null}
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-            {p.models.map((m, i) => {
-              const chip = healthChip(m.healthStatus);
-              const key = memberKey(p.id, m);
-              return (
-                <div
-                  key={`${m.modelId}-${i}`}
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 10,
-                    flexWrap: 'wrap',
-                    padding: '8px 10px',
-                    background: 'var(--bg-elevated)',
-                    borderRadius: 'var(--radius-sm)',
-                    fontSize: 12,
-                  }}
-                >
-                  <Chip label={chip.label} color={chip.color} bg={chip.bg} title={`连续失败 ${m.consecutiveFailures} / 连续成功 ${m.consecutiveSuccesses}`} />
-                  <span style={{ fontFamily: 'ui-monospace, monospace', color: 'var(--text-primary)' }}>{m.modelId}</span>
-                  {m.protocol ? <span style={{ color: 'var(--text-muted)' }}>{m.protocol}</span> : null}
-                  <CapabilityTags labels={capabilityLabelsForMember(m)} />
-                  {p.authority === 'llm_gateway' ? (
-                    <label style={{ display: 'inline-flex', alignItems: 'center', gap: 6, color: 'var(--text-muted)' }}>
-                      P
-                      <input
-                        value={memberPriorities[key] ?? String(m.priority)}
-                        onChange={(e) => setMemberPriorities((prev) => ({ ...prev, [key]: e.target.value }))}
-                        style={smallInputStyle(56)}
-                        inputMode="numeric"
-                      />
-                    </label>
-                  ) : (
-                    <span style={{ color: 'var(--text-muted)' }}>P{m.priority}</span>
-                  )}
-                  {m.maxTokens ? <span style={{ color: 'var(--text-muted)' }}>maxTokens {m.maxTokens}</span> : null}
-	                  {p.authority === 'llm_gateway' ? (
-	                    <select
-	                      value={(m.priceCurrency || 'CNY').toUpperCase()}
-	                      onChange={(e) => updateMemberPriceCurrency(p.id, m, e.target.value)}
-	                      style={smallSelectStyle(74)}
-                      aria-label="价格币种"
-                      title="价格币种：CNY 为历史模型池价格默认值；USD 可参与月预算美元统计"
-                    >
-                      <option value="CNY">CNY</option>
-                      <option value="USD">USD</option>
-                    </select>
-                  ) : m.priceCurrency ? (
-                    <span style={{ color: 'var(--text-muted)' }}>{m.priceCurrency}</span>
-                  ) : null}
-                  {m.consecutiveFailures > 0 ? (
-                    <span style={{ color: '#f85149' }}>连败 {m.consecutiveFailures}</span>
-                  ) : null}
-                  {p.authority === 'llm_gateway' ? (
-                    <input
-                      value={memberParameterCaps[key] ?? parameterCapabilityText(m.capabilities)}
-                      onChange={(e) => setMemberParameterCaps((prev) => ({ ...prev, [key]: e.target.value }))}
-                      placeholder="seed, stop=false"
-                      list="gw-parameter-capability-options"
-                      style={{ ...inputStyle, flex: '1 1 180px', minWidth: 160 }}
-                      aria-label="字段级参数能力"
-                      title="字段级参数能力，例：seed, stop=false；保存为 parameter:<name>"
-                    />
-                  ) : null}
-                  <span style={{ marginLeft: 'auto', display: 'inline-flex', gap: 6 }}>
-                    {p.authority === 'llm_gateway' ? (
-                      <>
-                        <Button size="sm" variant="ghost" disabled={busyId === key} onClick={() => void savePoolModelPriority(p, m)}>
-                          {busyId === key ? '处理中…' : '保存'}
-                        </Button>
-                        <Button size="sm" variant="ghost" disabled={busyId === key} onClick={() => void deletePoolModel(p, m)}>
-                          移除
-                        </Button>
-                      </>
-                    ) : null}
-                  </span>
+            ) : selectedPool ? (
+              <>
+                <PoolDetailSummary pool={selectedPool} />
+                <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', margin: '14px 0' }}>
+                  {selectedPool.authority === 'llm_gateway' ? <Button size="sm" variant="secondary" onClick={() => (editDrafts[selectedPool.id] ? cancelEditPool(selectedPool.id) : startEditPool(selectedPool))}>{editDrafts[selectedPool.id] ? '取消编辑' : '编辑属性'}</Button> : <Button size="sm" variant="secondary" disabled={busyId === selectedPool.id} onClick={() => void claimPool(selectedPool)}>导入为可维护配置</Button>}
+                  {!selectedPool.isDefaultForType ? <Button size="sm" variant="ghost" disabled={busyId === selectedPool.id} onClick={() => void makeDefault(selectedPool)}>设为默认池</Button> : null}
+                  <Link to={`/app-callers?modelPoolId=${encodeURIComponent(selectedPool.id)}`} style={{ alignSelf: 'center', color: 'var(--accent)', fontSize: 12, textDecoration: 'none' }}>查看 appCaller</Link>
+                  <Link to={`/logs?modelPoolId=${encodeURIComponent(selectedPool.id)}`} style={{ alignSelf: 'center', color: 'var(--accent)', fontSize: 12, textDecoration: 'none' }}>查看请求记录</Link>
                 </div>
-              );
-            })}
-          </div>
+                {editDrafts[selectedPool.id] ? <PoolEditBar draft={editDrafts[selectedPool.id]} busy={busyId === `pool-edit:${selectedPool.id}`} onDraftChange={(next) => setEditDrafts((prev) => ({ ...prev, [selectedPool.id]: next }))} onSave={() => void savePool(selectedPool)} onCancel={() => cancelEditPool(selectedPool.id)} /> : null}
+                {selectedPool.authority === 'llm_gateway' ? <PoolMemberEditor pool={selectedPool} models={models} parameterMeta={parameterMeta} draft={addDrafts[selectedPool.id] || emptyMemberDraft()} busyId={busyId} onDraftChange={(next) => setAddDrafts((prev) => ({ ...prev, [selectedPool.id]: next }))} onAdd={() => void addPoolModel(selectedPool)} /> : null}
+                <h3 style={{ color: 'var(--text-primary)', fontSize: 14, margin: '18px 0 8px' }}>模型成员</h3>
+                <PoolMembers pool={selectedPool} busyId={busyId} memberPriorities={memberPriorities} memberParameterCaps={memberParameterCaps} onPriorityChange={(key, value) => setMemberPriorities((prev) => ({ ...prev, [key]: value }))} onParameterChange={(key, value) => setMemberParameterCaps((prev) => ({ ...prev, [key]: value }))} onCurrencyChange={updateMemberPriceCurrency} onSave={savePoolModelPriority} onDelete={deletePoolModel} />
+                {selectedPool.authority === 'llm_gateway' ? <details style={{ marginTop: 16, borderTop: '1px solid var(--border-subtle)', paddingTop: 12 }}><summary style={{ cursor: 'pointer', color: 'var(--text-secondary)', fontSize: 12 }}>高级成员维护</summary><div style={{ marginTop: 10 }}><PoolBulkImportBar pool={selectedPool} platformIds={platformIds} draft={bulkImportDrafts[selectedPool.id] || emptyBulkImportDraft()} busyId={busyId} onDraftChange={(next) => setBulkImportDrafts((prev) => ({ ...prev, [selectedPool.id]: next }))} onImport={() => void bulkImportModels(selectedPool)} /></div></details> : null}
+              </>
+            ) : <Empty text="模型池不存在或已被移除" />}
+          </aside>
         </div>
-      ))}
+      ) : null}
     </div>
   );
 }
 
+function PoolMetric({ label, value, hint, tone = 'var(--text-primary)' }: { label: string; value: string; hint: string; tone?: string }) {
+  return <div style={{ padding: 14, border: '1px solid var(--border-subtle)', borderRadius: 'var(--radius)', background: 'var(--bg-surface)' }}><div style={{ color: 'var(--text-muted)', fontSize: 11 }}>{label}</div><div style={{ marginTop: 5, color: tone, fontSize: 23, fontWeight: 700 }}>{value}</div><div style={{ marginTop: 4, color: 'var(--text-muted)', fontSize: 11, lineHeight: 1.5 }}>{hint}</div></div>;
+}
+
+function PoolOverviewCard({ pool, busyId, onOpen, onMakeDefault }: { pool: ModelPool; busyId: string | null; onOpen: () => void; onMakeDefault: () => void }) {
+  const status = poolHealthChip(pool);
+  const visibleModels = pool.models.slice().sort((a, b) => a.priority - b.priority).slice(0, 3);
+  return (
+    <article style={{ display: 'flex', flexDirection: 'column', gap: 13, padding: 16, border: '1px solid var(--border-subtle)', borderRadius: 'var(--radius)', background: 'var(--bg-surface)' }}>
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
+        <div style={{ flex: 1, minWidth: 0 }}><div style={{ display: 'flex', gap: 7, alignItems: 'center', flexWrap: 'wrap' }}><strong style={{ color: 'var(--text-primary)', fontSize: 15 }}>{pool.name}</strong><Chip label={pool.modelType || 'chat'} color="var(--accent)" bg="var(--accent-soft)" />{pool.isDefaultForType ? <Chip label="默认路由" color="#3fb950" bg="rgba(63,185,80,0.14)" /> : null}</div><p style={{ color: 'var(--text-muted)', fontSize: 12, lineHeight: 1.65, margin: '7px 0 0' }}>{poolPurpose(pool)}</p></div>
+        <Chip label={status.label} color={status.color} bg={status.bg} />
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, minmax(0, 1fr))', gap: 8 }}>
+        <CardStat label="绑定" value={`${pool.boundAppCallerCount} 个`} />
+        <CardStat label="近 7 天" value={`${pool.recentRequests} 次`} />
+        <CardStat label="成功率" value={pool.recentSuccessRatePercent == null ? '暂无数据' : `${pool.recentSuccessRatePercent}%`} />
+      </div>
+      <div>
+        <div style={{ color: 'var(--text-muted)', fontSize: 11, marginBottom: 7 }}>模型组成</div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+          {visibleModels.length ? visibleModels.map((model) => { const chip = healthChip(model.healthStatus); return <div key={`${model.platformId}:${model.modelId}`} style={{ display: 'flex', alignItems: 'center', gap: 7, minWidth: 0, color: 'var(--text-secondary)', fontSize: 12 }}><span style={{ width: 7, height: 7, borderRadius: '50%', flexShrink: 0, background: chip.color }} /><span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{model.modelId}</span><span style={{ marginLeft: 'auto', color: 'var(--text-muted)', flexShrink: 0 }}>优先级 {model.priority}</span></div>; }) : <span style={{ color: 'var(--text-muted)', fontSize: 12 }}>尚未添加模型，当前不能承接请求。</span>}
+          {pool.models.length > visibleModels.length ? <span style={{ color: 'var(--text-muted)', fontSize: 11 }}>另有 {pool.models.length - visibleModels.length} 个模型</span> : null}
+        </div>
+      </div>
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginTop: 'auto' }}><Button size="sm" variant="secondary" onClick={onOpen}>查看与维护</Button>{!pool.isDefaultForType ? <Button size="sm" variant="ghost" disabled={busyId === pool.id} onClick={onMakeDefault}>设为默认</Button> : null}<span style={{ marginLeft: 'auto', color: 'var(--text-muted)', fontSize: 11 }}>{formatRecentTime(pool.lastRequestAt)}</span></div>
+    </article>
+  );
+}
+
+function CardStat({ label, value }: { label: string; value: string }) {
+  return <div style={{ padding: '9px 8px', background: 'var(--bg-elevated)', borderRadius: 'var(--radius-sm)', minWidth: 0 }}><div style={{ color: 'var(--text-muted)', fontSize: 10 }}>{label}</div><div style={{ color: 'var(--text-primary)', fontSize: 13, fontWeight: 650, marginTop: 4, overflow: 'hidden', textOverflow: 'ellipsis' }}>{value}</div></div>;
+}
+
+function PoolDetailSummary({ pool }: { pool: ModelPool }) {
+  const status = poolHealthChip(pool);
+  return <section style={{ display: 'flex', flexDirection: 'column', gap: 10, padding: 14, border: '1px solid var(--border-subtle)', borderRadius: 'var(--radius)', background: 'var(--bg-elevated)' }}><div style={{ display: 'flex', gap: 7, flexWrap: 'wrap' }}><Chip label={status.label} color={status.color} bg={status.bg} /><Chip label={STRATEGY_LABEL[pool.strategyType] || `策略 ${pool.strategyType}`} color="var(--text-secondary)" bg="var(--bg-surface)" />{pool.isDefaultForType ? <Chip label={`${pool.modelType} 默认池`} color="#3fb950" bg="rgba(63,185,80,0.14)" /> : null}</div><div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))', gap: 8 }}><CardStat label="绑定 appCaller" value={`${pool.boundAppCallerCount} 个`} /><CardStat label="近 7 天请求" value={`${pool.recentRequests} 次`} /><CardStat label="成功率" value={pool.recentSuccessRatePercent == null ? '暂无数据' : `${pool.recentSuccessRatePercent}%`} /><CardStat label="成员健康" value={`${pool.healthyMembers} 健康 / ${pool.unavailableMembers} 不可用`} /></div>{pool.boundAppCallers.length ? <div style={{ color: 'var(--text-muted)', fontSize: 12, lineHeight: 1.65 }}>服务对象：{pool.boundAppCallers.map((caller) => caller.title || caller.appCallerCode).join('、')}{pool.boundAppCallerCount > pool.boundAppCallers.length ? ` 等 ${pool.boundAppCallerCount} 个` : ''}</div> : <div style={{ color: '#d29922', fontSize: 12 }}>尚无明确绑定的 appCaller。若它是默认池，仍可能承接同类型的自动路由流量。</div>}</section>;
+}
+
+function PoolMembers({ pool, busyId, memberPriorities, memberParameterCaps, onPriorityChange, onParameterChange, onCurrencyChange, onSave, onDelete }: { pool: ModelPool; busyId: string | null; memberPriorities: Record<string, string>; memberParameterCaps: Record<string, string>; onPriorityChange: (key: string, value: string) => void; onParameterChange: (key: string, value: string) => void; onCurrencyChange: (poolId: string, member: PoolModelInfo, value: string) => void; onSave: (pool: ModelPool, member: PoolModelInfo) => Promise<void>; onDelete: (pool: ModelPool, member: PoolModelInfo) => Promise<void> }) {
+  if (!pool.models.length) return <div style={{ padding: 16, border: '1px dashed var(--border-subtle)', borderRadius: 'var(--radius-sm)', color: 'var(--text-muted)', fontSize: 12 }}>暂无模型成员。添加至少一个健康模型后，这个池才能承接请求。</div>;
+  return <div style={{ display: 'flex', flexDirection: 'column', gap: 7 }}>{pool.models.slice().sort((a, b) => a.priority - b.priority).map((member) => { const chip = healthChip(member.healthStatus); const key = memberKey(pool.id, member); return <div key={key} style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', padding: 10, background: 'var(--bg-elevated)', borderRadius: 'var(--radius-sm)', fontSize: 12 }}><Chip label={chip.label} color={chip.color} bg={chip.bg} /><span style={{ color: 'var(--text-primary)', fontFamily: 'ui-monospace, monospace', overflowWrap: 'anywhere' }}>{member.modelId}</span>{member.protocol ? <span style={{ color: 'var(--text-muted)' }}>{member.protocol}</span> : null}<CapabilityTags labels={capabilityLabelsForMember(member)} />{pool.authority === 'llm_gateway' ? <><label style={inlineCheckStyle}>优先级<input value={memberPriorities[key] ?? String(member.priority)} onChange={(event) => onPriorityChange(key, event.target.value)} style={smallInputStyle(58)} inputMode="numeric" /></label><select value={(member.priceCurrency || 'CNY').toUpperCase()} onChange={(event) => onCurrencyChange(pool.id, member, event.target.value)} style={smallSelectStyle(74)} aria-label="价格币种"><option value="CNY">CNY</option><option value="USD">USD</option></select><input value={memberParameterCaps[key] ?? parameterCapabilityText(member.capabilities)} onChange={(event) => onParameterChange(key, event.target.value)} placeholder="字段能力，例如 seed" list="gw-parameter-capability-options" style={{ ...inputStyle, flex: '1 1 170px' }} aria-label="字段级参数能力" /><span style={{ marginLeft: 'auto', display: 'flex', gap: 6 }}><Button size="sm" variant="ghost" disabled={busyId === key} onClick={() => void onSave(pool, member)}>保存</Button><Button size="sm" variant="ghost" disabled={busyId === key} onClick={() => void onDelete(pool, member)}>移除</Button></span></> : <span style={{ marginLeft: 'auto', color: 'var(--text-muted)' }}>优先级 {member.priority}</span>}</div>; })}</div>;
+}
+
+function poolPurpose(pool: ModelPool | null) {
+  if (!pool) return '';
+  if (pool.boundAppCallerCount > 0) {
+    const names = pool.boundAppCallers.slice(0, 2).map((caller) => caller.title || caller.appCallerCode).filter(Boolean);
+    return `为 ${names.join('、')}${pool.boundAppCallerCount > names.length ? ` 等 ${pool.boundAppCallerCount} 个 appCaller` : ''} 提供 ${pool.modelType || 'chat'} 路由。`;
+  }
+  if (pool.isDefaultForType) return `作为 ${pool.modelType || 'chat'} 类型的默认路由，在调用方未指定其他池时提供模型选择。`;
+  return `用于组织 ${pool.modelType || 'chat'} 模型；尚未绑定业务，当前不会承接已登记 appCaller 的指定流量。`;
+}
+
+function poolHealthChip(pool: ModelPool) {
+  if (pool.health === 'healthy') return { label: '运行健康', color: '#3fb950', bg: 'rgba(63,185,80,0.14)' };
+  if (pool.health === 'degraded') return { label: '部分模型异常', color: '#d29922', bg: 'rgba(210,153,34,0.14)' };
+  if (pool.health === 'unavailable') return { label: '无可用模型', color: '#f85149', bg: 'rgba(248,81,73,0.14)' };
+  return { label: '尚未配置模型', color: 'var(--text-muted)', bg: 'var(--bg-elevated)' };
+}
+
+function formatRecentTime(value?: string | null) {
+  if (!value) return '近 7 天无请求';
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? '最近有请求' : `最近请求 ${date.toLocaleString()}`;
+}
+
+function publicPoolDescription(value?: string | null) {
+  if (!value) return null;
+  return /\b(?:P\d+|legacy|stub|full-http|gate)\b|权威|迁移|兜底/i.test(value) ? null : value;
+}
+
+function mergePoolMutation(previous: ModelPool, next: ModelPool): ModelPool {
+  const healthyMembers = next.models.filter((model) => model.healthStatus === 0).length;
+  const degradedMembers = next.models.filter((model) => model.healthStatus === 1).length;
+  const unavailableMembers = next.models.filter((model) => model.healthStatus === 2).length;
+  const health: ModelPool['health'] = next.models.length === 0
+    ? 'empty'
+    : healthyMembers === 0
+      ? 'unavailable'
+      : degradedMembers > 0 || unavailableMembers > 0
+        ? 'degraded'
+        : 'healthy';
+  return {
+    ...next,
+    boundAppCallerCount: previous.boundAppCallerCount,
+    boundAppCallers: previous.boundAppCallers,
+    recentRequests: previous.recentRequests,
+    recentSucceeded: previous.recentSucceeded,
+    recentFailed: previous.recentFailed,
+    recentSuccessRatePercent: previous.recentSuccessRatePercent,
+    lastRequestAt: previous.lastRequestAt,
+    trafficWindowHours: previous.trafficWindowHours,
+    health,
+    healthyMembers,
+    degradedMembers,
+    unavailableMembers,
+  };
+}
+
 function PoolCreateBar({
+  mode,
   draft,
   modelTypes,
   busyId,
@@ -558,6 +578,7 @@ function PoolCreateBar({
   onBulkClaim,
   onCalibratePriceCurrency,
 }: {
+  mode: 'create' | 'advanced';
   draft: { name: string; code: string; modelType: string; priority: string; isDefaultForType: boolean; description: string };
   modelTypes: string[];
   busyId: string | null;
@@ -583,13 +604,13 @@ function PoolCreateBar({
         background: 'var(--bg-surface)',
       }}
     >
-      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, alignItems: 'center' }}>
+      {mode === 'create' ? <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, alignItems: 'center' }}>
         <input
           value={draft.name}
           onChange={(e) => onDraftChange({ ...draft, name: e.target.value })}
-          placeholder="新 GW 模型池名称"
+          placeholder="模型池名称，例如客服对话"
           style={{ ...inputStyle, flex: '1 1 180px' }}
-          aria-label="新 GW 模型池名称"
+          aria-label="新模型池名称"
         />
         <input
           value={draft.code}
@@ -626,18 +647,19 @@ function PoolCreateBar({
           默认
         </label>
         <Button size="sm" variant="secondary" disabled={busyId === 'create-pool'} onClick={onCreate}>
-          {busyId === 'create-pool' ? '处理中…' : '新建 GW 池'}
+          {busyId === 'create-pool' ? '处理中…' : '创建模型池'}
         </Button>
-      </div>
-      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, alignItems: 'center' }}>
+        <input value={draft.description} onChange={(e) => onDraftChange({ ...draft, description: e.target.value })} placeholder="业务说明（可选）" style={{ ...inputStyle, flex: '1 1 100%' }} aria-label="模型池业务说明" />
+      </div> : null}
+      {mode === 'advanced' ? <><div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, alignItems: 'center' }}>
         <select value={bulkModelType} onChange={(e) => onBulkModelTypeChange(e.target.value)} style={{ ...selectStyle, width: 180 }} aria-label="批量认领模型类型">
           <option value="">全部类型</option>
           {modelTypes.map((type) => <option key={type} value={type}>{type}</option>)}
         </select>
         <Button size="sm" variant="ghost" disabled={busyId === 'bulk-claim-pools'} onClick={onBulkClaim}>
-          {busyId === 'bulk-claim-pools' ? '处理中…' : '批量认领 MAP 池'}
+          {busyId === 'bulk-claim-pools' ? '处理中…' : '批量导入历史模型池'}
         </Button>
-        <span style={{ fontSize: 11, color: 'var(--text-muted)' }}>默认跳过已存在的 GW 池，不覆盖已有调整。</span>
+        <span style={{ fontSize: 11, color: 'var(--text-muted)' }}>默认跳过已存在的平台模型池，不覆盖已有调整。</span>
       </div>
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, alignItems: 'center' }}>
         <select
@@ -678,7 +700,7 @@ function PoolCreateBar({
           {busyId === 'bulk-calibrate-price-currency' ? '处理中…' : '校准价格币种'}
         </Button>
         <span style={{ fontSize: 11, color: 'var(--text-muted)' }}>只更新平台配置中的模型池，默认仅校准已有价格字段的历史成员。</span>
-      </div>
+      </div></> : null}
     </div>
   );
 }

--- a/prd-llmgw/Models/Dtos.cs
+++ b/prd-llmgw/Models/Dtos.cs
@@ -689,6 +689,25 @@ public sealed class PoolItem
     public string? ClaimedAt { get; set; }
     public string? CreatedAt { get; set; } public string? UpdatedAt { get; set; }
     public List<PoolModelItem> Models { get; set; } = new();
+    public long BoundAppCallerCount { get; set; }
+    public List<PoolAppCallerItem> BoundAppCallers { get; set; } = new();
+    public long RecentRequests { get; set; }
+    public long RecentSucceeded { get; set; }
+    public long RecentFailed { get; set; }
+    public decimal? RecentSuccessRatePercent { get; set; }
+    public string? LastRequestAt { get; set; }
+    public int TrafficWindowHours { get; set; } = 168;
+    public string Health { get; set; } = "empty";
+    public int HealthyMembers { get; set; }
+    public int DegradedMembers { get; set; }
+    public int UnavailableMembers { get; set; }
+}
+public sealed class PoolAppCallerItem
+{
+    public string Id { get; set; } = "";
+    public string AppCallerCode { get; set; } = "";
+    public string? Title { get; set; }
+    public string Status { get; set; } = "";
 }
 public sealed class PoolModelItem
 {

--- a/prd-llmgw/Program.cs
+++ b/prd-llmgw/Program.cs
@@ -821,13 +821,13 @@ app.MapGet("/gw/logs", async (
     int? page, int? pageSize, string? from, string? to, string? model, string? status,
     string? provider, string? appCallerCode, string? transport, string? requestType,
     string? sourceSystem, string? ingressProtocol, string? modelPolicy, string? releaseCommit,
-    string? runId, string? requestId, string? sessionId) =>
+    string? runId, string? requestId, string? sessionId, string? modelPoolId) =>
 {
     var p = page is > 0 ? page.Value : 1;
     var ps = pageSize is > 0 and <= 500 ? pageSize.Value : 50;
 
     var (fromUtc, toUtc) = ResolveRange(from, to, defaultDays: 7);
-    var filter = TenantAccess.Filter(http, BuildFilter(fromUtc, toUtc, model, status, provider, appCallerCode, transport, requestType, sourceSystem, ingressProtocol, modelPolicy, releaseCommit, runId, requestId, sessionId));
+    var filter = TenantAccess.Filter(http, BuildFilter(fromUtc, toUtc, model, status, provider, appCallerCode, transport, requestType, sourceSystem, ingressProtocol, modelPolicy, releaseCommit, runId, requestId, sessionId, modelPoolId));
 
     var total = await logs.CountDocumentsAsync(filter);
     var docs = await logs.Find(filter)
@@ -882,10 +882,10 @@ app.MapGet("/gw/logs/timeseries", async (
     string? from, string? to, string? model, string? status,
     string? provider, string? appCallerCode, string? transport, string? requestType,
     string? sourceSystem, string? ingressProtocol, string? modelPolicy, string? releaseCommit,
-    string? runId, string? requestId, string? sessionId) =>
+    string? runId, string? requestId, string? sessionId, string? modelPoolId) =>
 {
     var (fromUtc, toUtc) = ResolveRange(from, to, defaultDays: 7);
-    var filter = TenantAccess.Filter(http, BuildFilter(fromUtc, toUtc, model, status, provider, appCallerCode, transport, requestType, sourceSystem, ingressProtocol, modelPolicy, releaseCommit, runId, requestId, sessionId));
+    var filter = TenantAccess.Filter(http, BuildFilter(fromUtc, toUtc, model, status, provider, appCallerCode, transport, requestType, sourceSystem, ingressProtocol, modelPolicy, releaseCommit, runId, requestId, sessionId, modelPoolId));
 
     // 仅取 StartedAt 字段做内存分组（按 UTC 日期）。
     var projection = Builders<BsonDocument>.Projection.Include("StartedAt");
@@ -914,10 +914,10 @@ app.MapGet("/gw/logs/summary", async (
     string? from, string? to, string? model, string? status,
     string? provider, string? appCallerCode, string? transport, string? requestType,
     string? sourceSystem, string? ingressProtocol, string? modelPolicy, string? releaseCommit,
-    string? runId, string? requestId, string? sessionId) =>
+    string? runId, string? requestId, string? sessionId, string? modelPoolId) =>
 {
     var (fromUtc, toUtc) = ResolveRange(from, to, defaultDays: 7);
-    var filter = TenantAccess.Filter(http, BuildFilter(fromUtc, toUtc, model, status, provider, appCallerCode, transport, requestType, sourceSystem, ingressProtocol, modelPolicy, releaseCommit, runId, requestId, sessionId));
+    var filter = TenantAccess.Filter(http, BuildFilter(fromUtc, toUtc, model, status, provider, appCallerCode, transport, requestType, sourceSystem, ingressProtocol, modelPolicy, releaseCommit, runId, requestId, sessionId, modelPoolId));
     var projection = Builders<BsonDocument>.Projection
         .Include("Status")
         .Include("DurationMs")
@@ -1257,13 +1257,13 @@ app.MapGet("/gw/logs/sessions", async (
     string? from, string? to, int? page, int? pageSize,
     string? model, string? status, string? provider, string? appCallerCode, string? transport, string? requestType,
     string? sourceSystem, string? ingressProtocol, string? modelPolicy, string? releaseCommit,
-    string? runId, string? requestId, string? sessionId) =>
+    string? runId, string? requestId, string? sessionId, string? modelPoolId) =>
 {
     var p = page is > 0 ? page.Value : 1;
     var ps = pageSize is > 0 and <= 500 ? pageSize.Value : 50;
 
     var (fromUtc, toUtc) = ResolveRange(from, to, defaultDays: 7);
-    var filter = TenantAccess.Filter(http, BuildFilter(fromUtc, toUtc, model, status, provider, appCallerCode, transport, requestType, sourceSystem, ingressProtocol, modelPolicy, releaseCommit, runId, requestId, sessionId));
+    var filter = TenantAccess.Filter(http, BuildFilter(fromUtc, toUtc, model, status, provider, appCallerCode, transport, requestType, sourceSystem, ingressProtocol, modelPolicy, releaseCommit, runId, requestId, sessionId, modelPoolId));
 
     var docs = await logs.Find(filter)
         .Sort(Builders<BsonDocument>.Sort.Descending("StartedAt"))
@@ -1316,7 +1316,7 @@ app.MapGet("/gw/logs/{id}", async (HttpContext http, string id) =>
 // 让网关控制台不只有日志，还能看模型池 / 平台 / 模型 / 影子比对。密钥字段一律不返回（只回 hasKey）。
 
 // 模型池列表
-app.MapGet("/gw/pools", async (HttpContext http, string? modelType) =>
+app.MapGet("/gw/pools", async (HttpContext http, string? modelType, int? sinceHours) =>
 {
     var fb = Builders<BsonDocument>.Filter;
     var filter = string.IsNullOrWhiteSpace(modelType) ? fb.Empty : fb.Eq("ModelType", modelType);
@@ -1326,7 +1326,76 @@ app.MapGet("/gw/pools", async (HttpContext http, string? modelType) =>
     var gwDocs = await gwModelPools.Find(TenantAccess.Filter(http, filter)).Sort(Builders<BsonDocument>.Sort.Ascending("Priority")).ToListAsync();
     var gwIds = gwDocs.Select(d => d.GetStringOrEmpty("_id")).Where(x => !string.IsNullOrWhiteSpace(x)).ToHashSet(StringComparer.Ordinal);
     var docs = gwDocs.Concat(mapDocs.Where(d => !gwIds.Contains(d.GetStringOrEmpty("_id")))).ToList();
-    var data = new PoolsData { Items = docs.Select(MapPool).ToList(), Total = docs.Count };
+    var hours = sinceHours is > 0 and <= 24 * 90 ? sinceHours.Value : 24 * 7;
+    var since = DateTime.UtcNow.AddHours(-hours);
+    var appCallerDocs = await gwAppCallers.Find(TenantAccess.Filter(http))
+        .Project(Builders<BsonDocument>.Projection
+            .Include("_id")
+            .Include("AppCallerCode")
+            .Include("Title")
+            .Include("Status")
+            .Include("ModelPoolId"))
+        .ToListAsync();
+    var logFilter = Builders<BsonDocument>.Filter.Gte("StartedAt", since);
+    var logStatsDocs = await logs.Aggregate()
+        .Match(TenantAccess.Filter(http, logFilter))
+        .Group(new BsonDocument
+        {
+            { "_id", "$ModelPoolId" },
+            { "Requests", new BsonDocument("$sum", 1) },
+            { "Succeeded", new BsonDocument("$sum", new BsonDocument("$cond", new BsonArray
+                {
+                    new BsonDocument("$eq", new BsonArray { "$Status", "succeeded" }), 1, 0,
+                })) },
+            { "Failed", new BsonDocument("$sum", new BsonDocument("$cond", new BsonArray
+                {
+                    new BsonDocument("$eq", new BsonArray { "$Status", "failed" }), 1, 0,
+                })) },
+            { "LastRequestAt", new BsonDocument("$max", "$StartedAt") },
+        })
+        .ToListAsync();
+    var logStatsByPool = logStatsDocs
+        .Where(d => !string.IsNullOrWhiteSpace(d.GetStringOrEmpty("_id")))
+        .ToDictionary(d => d.GetStringOrEmpty("_id"), StringComparer.Ordinal);
+    var items = docs.Select(MapPool).ToList();
+    foreach (var item in items)
+    {
+        var bound = appCallerDocs
+            .Where(d => string.Equals(d.AsNullableString("ModelPoolId"), item.Id, StringComparison.Ordinal))
+            .OrderByDescending(d => string.Equals(d.AsNullableString("Status"), "active", StringComparison.OrdinalIgnoreCase))
+            .ThenBy(d => d.AsNullableString("Title") ?? d.GetStringOrEmpty("AppCallerCode"), StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        item.BoundAppCallerCount = bound.Count;
+        item.BoundAppCallers = bound.Take(5).Select(d => new PoolAppCallerItem
+        {
+            Id = d.GetStringOrEmpty("_id"),
+            AppCallerCode = d.GetStringOrEmpty("AppCallerCode"),
+            Title = d.AsNullableString("Title"),
+            Status = d.AsNullableString("Status") ?? "discovered",
+        }).ToList();
+
+        item.TrafficWindowHours = hours;
+        logStatsByPool.TryGetValue(item.Id, out var stats);
+        item.RecentRequests = stats?.AsNullableLong("Requests") ?? 0;
+        item.RecentSucceeded = stats?.AsNullableLong("Succeeded") ?? 0;
+        item.RecentFailed = stats?.AsNullableLong("Failed") ?? 0;
+        item.RecentSuccessRatePercent = item.RecentRequests == 0
+            ? null
+            : Math.Round(item.RecentSucceeded * 100m / item.RecentRequests, 1, MidpointRounding.AwayFromZero);
+        item.LastRequestAt = stats?.AsNullableUtcDateTime("LastRequestAt").ToIso();
+
+        item.HealthyMembers = item.Models.Count(model => model.HealthStatus == 0);
+        item.DegradedMembers = item.Models.Count(model => model.HealthStatus == 1);
+        item.UnavailableMembers = item.Models.Count(model => model.HealthStatus == 2);
+        item.Health = item.Models.Count == 0
+            ? "empty"
+            : item.HealthyMembers == 0
+                ? "unavailable"
+                : item.DegradedMembers > 0 || item.UnavailableMembers > 0
+                    ? "degraded"
+                    : "healthy";
+    }
+    var data = new PoolsData { Items = items, Total = docs.Count };
     return Json(ApiEnvelope<PoolsData>.Ok(data), jsonOptions);
 }).RequireAuthorization("LogsRead");
 
@@ -2596,6 +2665,7 @@ app.MapGet("/gw/app-callers", async (
     string? sourceSystem,
     string? ingressProtocol,
     string? requestType,
+    string? modelPoolId,
     string? drift,
     string? search,
     int? page,
@@ -2618,6 +2688,7 @@ app.MapGet("/gw/app-callers", async (
             fb.AnyEq("ObservedIngressProtocols", protocolNormalized)));
     }
     if (!string.IsNullOrWhiteSpace(requestType)) filters.Add(fb.Eq("RequestType", requestType.Trim()));
+    if (!string.IsNullOrWhiteSpace(modelPoolId)) filters.Add(fb.Eq("ModelPoolId", modelPoolId.Trim()));
     var driftFilter = BuildAppCallerDriftFilter(drift);
     if (driftFilter is not null) filters.Add(driftFilter);
     if (!string.IsNullOrWhiteSpace(search))
@@ -4341,7 +4412,7 @@ app.MapPost("/gw/pools", async (HttpContext http, [FromBody] CreatePoolRequest b
     {
         return Json(ApiEnvelope<PoolItem>.Fail(
             "INVALID_INPUT",
-            "默认 GW 模型池必须至少包含一个可解析、非 unavailable 的成员；请先创建为非默认池并添加 enabled 模型或 Exchange。"),
+            "默认模型池必须至少包含一个可用成员；请先创建为非默认池并添加可用模型。"),
             jsonOptions,
             400);
     }
@@ -4389,7 +4460,7 @@ app.MapPut("/gw/pools/{id}", async (HttpContext http, string id, [FromBody] Upda
             : null;
         if (mapDoc is not null)
         {
-            return Json(ApiEnvelope<PoolItem>.Fail("MAP_POOL_NOT_CLAIMED", "请先将模型池认领到 GW，再编辑模型池属性"), jsonOptions, 409);
+            return Json(ApiEnvelope<PoolItem>.Fail("MAP_POOL_NOT_CLAIMED", "请先将模型池导入为平台配置，再编辑模型池属性"), jsonOptions, 409);
         }
         return Json(ApiEnvelope<PoolItem>.Fail("NOT_FOUND", $"模型池不存在：{id}"), jsonOptions, 404);
     }
@@ -4472,7 +4543,7 @@ app.MapPut("/gw/pools/{id}", async (HttpContext http, string id, [FromBody] Upda
     {
         return Json(ApiEnvelope<PoolItem>.Fail(
             "INVALID_INPUT",
-            "默认 GW 模型池必须至少包含一个可解析、非 unavailable 的成员；请先添加 enabled 模型或 Exchange。"),
+            "默认模型池必须至少包含一个可用成员；请先添加可用模型。"),
             jsonOptions,
             400);
     }
@@ -4665,7 +4736,7 @@ app.MapPost("/gw/pools/{id}/models/bulk-import", async (HttpContext http, string
     body ??= new BulkImportPoolModelsRequest();
     var poolFilter = TenantAccess.Filter(http, Builders<BsonDocument>.Filter.Eq("_id", id));
     var pool = await gwModelPools.Find(poolFilter).FirstOrDefaultAsync();
-    if (pool is null) return Json(ApiEnvelope<BulkImportPoolModelsResult>.Fail("NOT_GW_AUTHORITY", "请先将模型池认领到 GW，再在 GW 中批量导入成员"), jsonOptions, 409);
+    if (pool is null) return Json(ApiEnvelope<BulkImportPoolModelsResult>.Fail("NOT_GW_AUTHORITY", "请先将模型池导入为平台配置，再批量导入成员"), jsonOptions, 409);
 
     var capabilityFilter = (body.CapabilityFilter ?? "compatible").Trim().ToLowerInvariant();
     var allowedFilters = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
@@ -4823,7 +4894,7 @@ app.MapPut("/gw/pools/{id}/models", async (HttpContext http, string id, [FromBod
 {
     var poolFilter = TenantAccess.Filter(http, Builders<BsonDocument>.Filter.Eq("_id", id));
     var pool = await gwModelPools.Find(poolFilter).FirstOrDefaultAsync();
-    if (pool is null) return Json(ApiEnvelope<PoolItem>.Fail("NOT_GW_AUTHORITY", "请先将模型池认领到 GW，再在 GW 中管理池成员"), jsonOptions, 409);
+    if (pool is null) return Json(ApiEnvelope<PoolItem>.Fail("NOT_GW_AUTHORITY", "请先将模型池导入为平台配置，再管理池成员"), jsonOptions, 409);
     if (body is null) return Json(ApiEnvelope<PoolItem>.Fail("INVALID_INPUT", "请求体不能为空"), jsonOptions, 400);
 
     var modelId = (body.ModelId ?? string.Empty).Trim();
@@ -5005,7 +5076,7 @@ app.MapDelete("/gw/pools/{id}/models", async (HttpContext http, string id, strin
 
     var poolFilter = TenantAccess.Filter(http, Builders<BsonDocument>.Filter.Eq("_id", id));
     var pool = await gwModelPools.Find(poolFilter).FirstOrDefaultAsync();
-    if (pool is null) return Json(ApiEnvelope<PoolItem>.Fail("NOT_GW_AUTHORITY", "请先将模型池认领到 GW，再在 GW 中管理池成员"), jsonOptions, 409);
+    if (pool is null) return Json(ApiEnvelope<PoolItem>.Fail("NOT_GW_AUTHORITY", "请先将模型池导入为平台配置，再管理池成员"), jsonOptions, 409);
 
     var modelsArr = pool.TryGetValue("Models", out var mv) && mv.IsBsonArray ? mv.AsBsonArray : new BsonArray();
     var members = modelsArr.Where(x => x.IsBsonDocument).Select(x => new BsonDocument(x.AsBsonDocument)).ToList();
@@ -5086,7 +5157,7 @@ app.MapPut("/gw/pools/{id}/default", async (HttpContext http, string id, ToggleD
     {
         return Json(ApiEnvelope<PoolItem>.Fail(
             "INVALID_INPUT",
-            "默认 GW 模型池必须至少包含一个可解析、非 unavailable 的成员；请先添加 enabled 模型或 Exchange。"),
+            "默认模型池必须至少包含一个可用成员；请先添加可用模型。"),
             jsonOptions,
             400);
     }
@@ -5639,7 +5710,8 @@ static FilterDefinition<BsonDocument> BuildFilter(
     string? releaseCommit,
     string? runId,
     string? requestId,
-    string? sessionId)
+    string? sessionId,
+    string? modelPoolId)
 {
     var fb = Builders<BsonDocument>.Filter;
     var filters = new List<FilterDefinition<BsonDocument>>
@@ -5659,6 +5731,7 @@ static FilterDefinition<BsonDocument> BuildFilter(
     if (!string.IsNullOrWhiteSpace(runId)) filters.Add(fb.Eq("RunId", runId.Trim()));
     if (!string.IsNullOrWhiteSpace(requestId)) filters.Add(fb.Eq("RequestId", requestId.Trim()));
     if (!string.IsNullOrWhiteSpace(sessionId)) filters.Add(fb.Eq("SessionId", sessionId.Trim()));
+    if (!string.IsNullOrWhiteSpace(modelPoolId)) filters.Add(fb.Eq("ModelPoolId", modelPoolId.Trim()));
     var normalizedReleaseCommit = NormalizeCommitFilter(releaseCommit);
     if (normalizedReleaseCommit is not null) filters.Add(fb.Eq("ReleaseCommit", normalizedReleaseCommit));
     return fb.And(filters);
@@ -6553,7 +6626,7 @@ static async Task<string?> ValidateDefaultGatewayPoolMembersAsync(
         return null;
     }
 
-    return "默认 GW 模型池必须保留至少一个可解析、非 unavailable 的成员；请先添加 enabled 模型或 Exchange，再删除或覆盖现有成员。";
+    return "默认模型池必须保留至少一个可用成员；请先添加可用模型，再删除或覆盖现有成员。";
 }
 
 static async Task<bool> HasUsableGatewayPoolMemberAsync(


### PR DESCRIPTION
## 摘要
将模型池从维护表单页重构为租户业务路由总览：首屏解释用途、绑定 appCaller、近 7 天流量、成功率、健康和模型组成；创建与成员维护进入抽屉，高级批量操作默认折叠。

## 改动 diff
- `prd-llmgw/Program.cs`、`Models/Dtos.cs`：租户范围内聚合模型池绑定、流量和健康，并支持按模型池筛选请求记录与 appCaller。
- `prd-llmgw-web/src/pages/ModelPoolsPage.tsx`：新增业务概览卡、详情抽屉和高级维护分层。
- `LogsView.tsx`、`AppCallersPage.tsx`、API/types：补充模型池精确深链。
- `GatewayDataDomainGuardTests.cs`：守卫租户聚合与模型池筛选。
- SSOT 与 changelog：记录 P2 实施和验收证据。

## 测试
- [x] `dotnet build prd-llmgw/prd-llmgw.csproj --no-restore`，0 warning / 0 error
- [x] `pnpm --dir prd-llmgw-web build`
- [x] Gateway 数据域守卫 65/65
- [x] 双租户真实 API：Alpha 2 绑定/4 请求/75%，Beta 1 绑定/9 请求/100%，自报 tenantId 被忽略
- [x] 桌面暗色、桌面浅色、433px 移动视口与详情抽屉验收，无横向溢出，浏览器 warning/error 为 0
- [x] 未调用任何模型或付费上游
- [ ] GitHub CI
- [ ] CDS 预览验收

Bugbot 因订阅停止记为不适用。