### PR TITLE
fix(llmgw): 收敛周报 GW 权威专属池

### DIFF
--- a/changelogs/2026-07-13_report-agent-gw-authority-pool.md
+++ b/changelogs/2026-07-13_report-agent-gw-authority-pool.md
@@ -1,0 +1,3 @@
+| fix | llmgw | 周报专属模型池同步写入 GW 权威库并拒绝裁剪共享池 |
+| security | llmgw | 周报池生产修复从权威调用方推导租户并为配置与审计写入 TenantId |
+| ops | llmgw | 周报池执行前同时备份 MAP 与 GW 受影响集合并生成校验和 |

--- a/doc/plan.report-agent.model-governance.md
+++ b/doc/plan.report-agent.model-governance.md
@@ -1,6 +1,6 @@
 # Report Agent 模型质量治理 · 计划
 
-> **版本**：v1.0 | **日期**：2026-07-12 | **状态**：开发中
+> **版本**：v1.1 | **日期**：2026-07-13 | **状态**：开发中
 
 ## 概述
 
@@ -19,16 +19,18 @@
 
 | 阶段 | 范围 | 验收标准 | 状态 |
 |---|---|---|---|
-| P1 代码治理 | 独立周报模型池脚本、精确 AppCaller 绑定、规则兜底原因持久化 | 默认不再继承通用大池；原因代码不包含上游错误原文 | 进行中 |
-| P2 用户可见性 | 编辑器展示实际模型，规则草稿使用独立警告样式和原因文案 | 用户能直接判断内容来自 AI 还是规则 | 进行中 |
-| P3 生产配置 | dry-run、备份、创建 `report-agent-weekly` 池并绑定 | 池为非默认池，成员数量受控，原大池不删除 | 待开始 |
+| P1 代码治理 | 独立周报模型池脚本、精确 AppCaller 绑定、规则兜底原因持久化 | 默认不再继承通用大池；原因代码不包含上游错误原文 | 已完成 |
+| P2 用户可见性 | 编辑器展示实际模型，规则草稿使用独立警告样式和原因文案 | 用户能直接判断内容来自 AI 还是规则 | 已完成 |
+| P3 生产配置 | dry-run、双库受影响集合备份、创建 GW 权威 `report-agent-weekly` 池并绑定 | 池为非默认池，成员数量为 1，原共享大池不删除也不裁剪 | 进行中 |
 | P4 单次验收 | 假上游回归加一次真实周报生成 | LLM 日志模型与页面展示一致；失败不会无感伪装 | 待开始 |
 
 ## 数据变更
 
 - `report_weekly_reports.AutoGenerationFallbackReason`：只保存稳定原因代码，不保存上游错误、密钥或响应正文。
-- `model_groups`：创建代码为 `report-agent-weekly` 的非默认池。
-- `llm_app_callers`：`report-agent.generate::chat` 的 chat 需求精确绑定该池，不继续附带旧通用池。
+- `prdagent.model_groups`：保留兼容配置，创建代码为 `report-agent-weekly` 的非默认池。
+- `prdagent.llm_app_callers`：保留兼容绑定，chat 需求精确指向该池。
+- `llm_gateway.llmgw_model_pools`：创建同 ID、同代码、带 `TenantId` 的 GW 权威非默认池，成员严格为 1。
+- `llm_gateway.llmgw_app_callers`：从权威 caller 或服务端内部租户配置推导 `TenantId`，只把 `report-agent.generate::chat` 改为 `modelPolicy=pool` 并绑定专属池；禁止接收外部自报 `tenantId`。
 
 ## 风险与依赖
 
@@ -45,3 +47,6 @@
 |---|---|---|
 | 2026-07-12 | 完成生产事实审计 | 周报最近调用实际模型为 DeepSeek V4 Flash；应用绑定显示 1 个池、224 个模型 |
 | 2026-07-12 | 创建独立修复分支 | `codex/fix-report-agent-model-governance` |
+| 2026-07-13 | 确认生产 full-http 实际权威数据 | 周报池 `fc839911...` 有 224 个成员且被 6 个调用方共享，不能原地裁剪 |
+| 2026-07-13 | 完成模型切换事实对比 | `gpt-5.5`（至 07-05）→ `HealthGPT-L14`（07-06 至 07-07）→ `DeepSeek-V4-Flash`（07-07 起） |
+| 2026-07-13 | 增补 GW 权威池收敛 | 默认 dry-run、MAP 与 GW 双库备份、租户范围推导、共享引用拒绝、写后验证与 TenantId 审计 |

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -1144,6 +1144,18 @@ public class GatewayDataDomainGuardTests
         Assert.Contains("ModelGroupIds: isolatePool ? [pool._id]", script);
         Assert.Contains("isolated bootstrap refuses pool with Code=", script);
         Assert.Contains("IsDefaultForType: false", script);
+        Assert.Contains("const gatewayDb = db.getSiblingDB(gatewayDbName)", script);
+        Assert.Contains("GW authority caller must resolve exactly once", script);
+        Assert.Contains("isolated GW authority bootstrap requires caller binding", script);
+        Assert.Contains("tenantSource: callerTenantId ? \"caller\" : \"server-internal-default\"", script);
+        Assert.Contains("otherGatewayReferences.length > 0", script);
+        Assert.Contains("ModelPolicy: \"pool\"", script);
+        Assert.Contains("TenantId: tenantId", script);
+        Assert.Contains("GW authority post-write verification failed", script);
+        Assert.Contains("backup_collection \"$gateway_db\" llmgw_model_pools", shell);
+        Assert.Contains("--collection \"$backup_collection_name\" --archive --gzip", shell);
+        Assert.Contains("SHA256SUMS", shell);
+        Assert.DoesNotContain("LLMGW_CHAT_BOOTSTRAP_TENANT_ID", shell + script);
         Assert.DoesNotContain("const defaultPool = db.model_groups.findOne", script);
     }
 

--- a/scripts/llmgw-prod-chat-pool-bootstrap.js
+++ b/scripts/llmgw-prod-chat-pool-bootstrap.js
@@ -22,6 +22,10 @@ const isolatePoolRaw = (process.env.LLMGW_CHAT_BOOTSTRAP_ISOLATE_POOL || "1").to
 const isolatePool = !(isolatePoolRaw === "0" || isolatePoolRaw === "false");
 const requestedPriority = Number.parseInt(process.env.LLMGW_CHAT_BOOTSTRAP_PRIORITY || "1", 10);
 const priority = Number.isFinite(requestedPriority) && requestedPriority > 0 ? requestedPriority : 1;
+const gatewayDbName = (process.env.LLMGW_CHAT_BOOTSTRAP_GW_DB || "llm_gateway").trim();
+// 这是服务端部署配置，不是 HTTP 请求参数。租户范围优先从 GW 权威 caller 读取；
+// 只有旧 full-http 数据尚未回填 TenantId 时，才使用与 console-api 相同的内部租户默认值。
+const configuredInternalTenantId = (process.env.LLMGW_INTERNAL_TENANT_ID || "tenant_map_internal").trim();
 
 function fail(message) {
   print(`ERROR: ${message}`);
@@ -42,6 +46,24 @@ function uniq(values) {
 function modelSortValue(model) {
   const value = Number(model.Priority);
   return Number.isFinite(value) ? value : 1000000;
+}
+
+function legacyOrTenantFilter(tenantId) {
+  return {
+    $or: [
+      { TenantId: tenantId },
+      { TenantId: { $exists: false } },
+      { TenantId: null },
+      { TenantId: "" },
+    ],
+  };
+}
+
+function exactCallerCandidates(collection, code) {
+  return collection.find({
+    AppCallerCode: code,
+    RequestType: "chat",
+  }).toArray();
 }
 
 const modelQuery = { Enabled: true, ModelName: modelName };
@@ -120,6 +142,117 @@ const modelItem = {
   PricePerCall: null,
 };
 
+if (isolatePool && targetCallers.length !== 1) {
+  fail(`isolated GW authority bootstrap requires exactly one target caller; got ${targetCallers.length}`);
+}
+if (targetCallers.length === 0) {
+  fail("chat pool bootstrap requires at least one target caller");
+}
+if (isolatePool && !bindCallers) {
+  fail("isolated GW authority bootstrap requires caller binding");
+}
+
+const gatewayDb = db.getSiblingDB(gatewayDbName);
+const gatewayCallerCandidates = exactCallerCandidates(gatewayDb.llmgw_app_callers, targetCallers[0]);
+if (gatewayCallerCandidates.length !== 1) {
+  fail(`GW authority caller must resolve exactly once for ${targetCallers[0]}; got ${gatewayCallerCandidates.length}`);
+}
+
+const gatewayCaller = gatewayCallerCandidates[0];
+const callerTenantId = String(gatewayCaller.TenantId || "").trim();
+const tenantId = callerTenantId || configuredInternalTenantId;
+if (!tenantId) {
+  fail("GW authority caller has no TenantId and server internal tenant configuration is empty");
+}
+
+const tenantScope = legacyOrTenantFilter(tenantId);
+const gatewayCodePools = gatewayDb.llmgw_model_pools.find({
+  Code: requestedPoolCode,
+  ModelType: "chat",
+  ...tenantScope,
+}).toArray();
+if (gatewayCodePools.length > 1) {
+  fail(`GW authority pool is ambiguous for tenant=${tenantId} code=${requestedPoolCode}; got ${gatewayCodePools.length}`);
+}
+
+let gatewayPool = gatewayCodePools[0] || null;
+let gatewayPoolWillBeCreated = false;
+if (gatewayPool && gatewayPool.IsDefaultForType === true) {
+  fail(`isolated GW authority pool must not be default: ${gatewayPool._id}`);
+}
+if (!gatewayPool) {
+  const conflictingId = gatewayDb.llmgw_model_pools.findOne({ _id: pool._id });
+  if (conflictingId) {
+    fail(`GW authority pool id is already used by another pool: ${pool._id}`);
+  }
+  const now = new Date();
+  gatewayPool = {
+    _id: pool._id,
+    TenantId: tenantId,
+    Name: requestedPoolName,
+    Code: requestedPoolCode,
+    Priority: 10,
+    ModelType: "chat",
+    IsDefaultForType: false,
+    Models: [],
+    StrategyType: 0,
+    Description: "周报草稿生成专用；模型不可用时失败，不允许漂移到通用大池",
+    ConfigAuthority: "llm_gateway",
+    CreatedAt: now,
+    UpdatedAt: now,
+  };
+  gatewayPoolWillBeCreated = true;
+}
+
+const otherGatewayReferences = gatewayDb.llmgw_app_callers.find({
+  ModelPoolId: gatewayPool._id,
+  _id: { $ne: gatewayCaller._id },
+  ...tenantScope,
+}, { AppCallerCode: 1 }).toArray();
+if (otherGatewayReferences.length > 0) {
+  fail(`isolated GW authority pool is referenced by other callers: ${otherGatewayReferences.map((x) => x.AppCallerCode).join(", ")}`);
+}
+
+const currentGatewayPoolId = String(gatewayCaller.ModelPoolId || "").trim();
+const currentGatewayPool = currentGatewayPoolId
+  ? gatewayDb.llmgw_model_pools.findOne({ _id: currentGatewayPoolId, ...tenantScope })
+  : null;
+const currentGatewayMembers = currentGatewayPool && Array.isArray(currentGatewayPool.Models)
+  ? currentGatewayPool.Models
+  : [];
+const currentGatewayMember = currentGatewayMembers.find((item) => {
+  return String(item.ModelId || "") === modelName
+    && String(item.PlatformId || "") === String(selectedPlatform._id);
+});
+
+const gatewayModel = gatewayDb.llmgw_models.findOne({
+  $and: [
+    {
+      $or: [
+        { _id: modelName },
+        { ModelName: modelName },
+        { Name: modelName },
+      ],
+    },
+    { PlatformId: selectedPlatform._id },
+    tenantScope,
+  ],
+});
+const gatewayPlatform = gatewayDb.llmgw_platforms.findOne({
+  _id: selectedPlatform._id,
+  ...tenantScope,
+});
+if (!currentGatewayMember && (!gatewayModel || !gatewayPlatform)) {
+  fail(`verified model is not available in GW authority for tenant=${tenantId}: ${modelName}`);
+}
+
+const gatewayModelItem = {
+  ...(currentGatewayMember || modelItem),
+  ModelId: modelName,
+  PlatformId: selectedPlatform._id,
+  Priority: priority,
+};
+
 const planned = {
   dryRun,
   poolId: pool._id,
@@ -133,11 +266,23 @@ const planned = {
   bindCallers,
   isolatePool,
   targetCallers,
+  gatewayAuthority: {
+    database: gatewayDbName,
+    tenantId,
+    tenantSource: callerTenantId ? "caller" : "server-internal-default",
+    callerId: gatewayCaller._id,
+    callerCurrentPoolId: currentGatewayPoolId,
+    poolId: gatewayPool._id,
+    poolWillBeCreated: gatewayPoolWillBeCreated,
+    otherReferenceCount: otherGatewayReferences.length,
+    memberCountAfter: 1,
+    isDefaultAfter: false,
+  },
 };
 printjson(planned);
 
 if (dryRun) {
-  print("LLM Gateway chat pool bootstrap dry-run: no data changed");
+  print("LLM Gateway chat pool bootstrap dry-run: MAP and GW authority data unchanged");
   quit(0);
 }
 
@@ -199,6 +344,104 @@ if (bindCallers) {
 } else {
   print("LLM Gateway chat pool bootstrap: caller binding skipped");
 }
+
+if (gatewayPoolWillBeCreated) {
+  gatewayDb.llmgw_model_pools.insertOne(gatewayPool);
+}
+gatewayDb.llmgw_model_pools.updateOne(
+  { _id: gatewayPool._id, ...legacyOrTenantFilter(tenantId) },
+  {
+    $set: {
+      TenantId: tenantId,
+      Name: requestedPoolName,
+      Code: requestedPoolCode,
+      Priority: 10,
+      ModelType: "chat",
+      IsDefaultForType: false,
+      Models: [gatewayModelItem],
+      StrategyType: 0,
+      Description: "周报草稿生成专用；模型不可用时失败，不允许漂移到通用大池",
+      ConfigAuthority: "llm_gateway",
+      UpdatedAt: now,
+    },
+  },
+);
+
+if (bindCallers) {
+  const callerWriteFilter = callerTenantId
+    ? { _id: gatewayCaller._id, TenantId: tenantId, AppCallerCode: targetCallers[0], RequestType: "chat" }
+    : { _id: gatewayCaller._id, AppCallerCode: targetCallers[0], RequestType: "chat", ...legacyOrTenantFilter(tenantId) };
+  const callerWrite = gatewayDb.llmgw_app_callers.updateOne(
+    callerWriteFilter,
+    {
+      $set: {
+        TenantId: tenantId,
+        ModelPoolId: gatewayPool._id,
+        ModelPolicy: "pool",
+        UpdatedAt: now,
+      },
+    },
+  );
+  if (callerWrite.matchedCount !== 1) {
+    fail(`GW authority caller changed during apply; matched=${callerWrite.matchedCount}`);
+  }
+}
+
+gatewayDb.llmgw_operation_audits.insertOne({
+  _id: new ObjectId().toString(),
+  TenantId: tenantId,
+  Action: "report_agent.pool.isolate",
+  TargetType: "llmgw_app_caller",
+  TargetId: String(gatewayCaller._id),
+  TargetName: targetCallers[0],
+  Success: true,
+  Reason: null,
+  Changes: {
+    previousPoolId: currentGatewayPoolId || null,
+    modelPoolId: String(gatewayPool._id),
+    modelPolicy: "pool",
+    modelId: modelName,
+    memberCount: 1,
+    authority: "llm_gateway",
+  },
+  CreatedAt: now,
+});
+
+const verifiedGatewayPool = gatewayDb.llmgw_model_pools.findOne({
+  _id: gatewayPool._id,
+  TenantId: tenantId,
+  Code: requestedPoolCode,
+  ModelType: "chat",
+  IsDefaultForType: false,
+});
+const verifiedGatewayCaller = gatewayDb.llmgw_app_callers.findOne({
+  _id: gatewayCaller._id,
+  TenantId: tenantId,
+  AppCallerCode: targetCallers[0],
+  RequestType: "chat",
+  ModelPoolId: gatewayPool._id,
+  ModelPolicy: "pool",
+});
+const verifiedMembers = verifiedGatewayPool && Array.isArray(verifiedGatewayPool.Models)
+  ? verifiedGatewayPool.Models
+  : [];
+if (!verifiedGatewayCaller || verifiedMembers.length !== 1
+    || String(verifiedMembers[0].ModelId || "") !== modelName
+    || String(verifiedMembers[0].PlatformId || "") !== String(selectedPlatform._id)) {
+  fail("GW authority post-write verification failed");
+}
+
+printjson({
+  verified: true,
+  tenantId,
+  appCallerCode: targetCallers[0],
+  modelPolicy: "pool",
+  poolId: gatewayPool._id,
+  poolCode: requestedPoolCode,
+  memberCount: verifiedMembers.length,
+  modelName,
+  platformId: selectedPlatform._id,
+});
 
 print("LLM Gateway chat pool bootstrap completed");
 })();

--- a/scripts/llmgw-prod-chat-pool-bootstrap.sh
+++ b/scripts/llmgw-prod-chat-pool-bootstrap.sh
@@ -10,6 +10,7 @@ repo_root=$(CDPATH= cd -- "$script_dir/.." && pwd)
 compose_file="${LLMGW_CHAT_BOOTSTRAP_COMPOSE_FILE:-$repo_root/docker-compose.yml}"
 mongo_service="${LLMGW_CHAT_BOOTSTRAP_MONGO_SERVICE:-mongodb}"
 mongo_db="${LLMGW_CHAT_BOOTSTRAP_DB:-prdagent}"
+gateway_db="${LLMGW_CHAT_BOOTSTRAP_GW_DB:-llm_gateway}"
 dry_run="${LLMGW_CHAT_BOOTSTRAP_DRY_RUN:-1}"
 backup_root="${LLMGW_CHAT_BOOTSTRAP_BACKUP_ROOT:-/root/backups}"
 backup_stamp="$(date '+%Y%m%dT%H%M%S%z' 2>/dev/null || date '+%Y%m%dT%H%M%S')"
@@ -38,6 +39,7 @@ echo "LLM Gateway chat pool bootstrap"
 echo "  compose: $compose_file"
 echo "  mongoService: $mongo_service"
 echo "  database: $mongo_db"
+echo "  gatewayDatabase: $gateway_db"
 echo "  dryRun: $dry_run"
 echo "  modelName: ${LLMGW_CHAT_BOOTSTRAP_MODEL_NAME:-deepseek-ai/DeepSeek-V4-Flash}"
 echo "  platformId: ${LLMGW_CHAT_BOOTSTRAP_PLATFORM_ID:-auto}"
@@ -52,11 +54,24 @@ if [ "$dry_run" = "1" ] || [ "$dry_run" = "true" ]; then
 else
   "$script_dir/llmgw-disk-space-guard.sh" "$backup_dir" "${LLMGW_CHAT_BOOTSTRAP_MIN_FREE_MB:-6144}" "LLM Gateway chat pool bootstrap backup"
   mkdir -p "$backup_dir"
-  echo "LLM Gateway chat pool bootstrap: writing Mongo backup"
-  # shellcheck disable=SC2086
-  $COMPOSE -f "$compose_file" exec -T "$mongo_service" \
-    mongodump --db "$mongo_db" --archive \
-    | gzip > "$backup_dir/mongo-$mongo_db-chat-pool-bootstrap.archive.gz"
+  echo "LLM Gateway chat pool bootstrap: writing affected-collection backups"
+  backup_collection() {
+    backup_database="$1"
+    backup_collection_name="$2"
+    backup_file="$backup_dir/mongo-$backup_database-$backup_collection_name.archive.gz"
+    # 使用 mongodump 内建 gzip，避免管道末端成功掩盖 dump 失败。
+    # shellcheck disable=SC2086
+    $COMPOSE -f "$compose_file" exec -T "$mongo_service" \
+      mongodump --db "$backup_database" --collection "$backup_collection_name" --archive --gzip \
+      > "$backup_file"
+    test -s "$backup_file"
+  }
+  backup_collection "$mongo_db" model_groups
+  backup_collection "$mongo_db" llm_app_callers
+  backup_collection "$gateway_db" llmgw_model_pools
+  backup_collection "$gateway_db" llmgw_app_callers
+  backup_collection "$gateway_db" llmgw_operation_audits
+  sha256sum "$backup_dir"/*.archive.gz > "$backup_dir/SHA256SUMS"
 fi
 
 # shellcheck disable=SC2086
@@ -71,7 +86,9 @@ $COMPOSE -f "$compose_file" exec -T \
   -e LLMGW_CHAT_BOOTSTRAP_TARGET_CALLERS="${LLMGW_CHAT_BOOTSTRAP_TARGET_CALLERS:-report-agent.generate::chat}" \
   -e LLMGW_CHAT_BOOTSTRAP_BIND_CALLERS="${LLMGW_CHAT_BOOTSTRAP_BIND_CALLERS:-1}" \
   -e LLMGW_CHAT_BOOTSTRAP_PRIORITY="${LLMGW_CHAT_BOOTSTRAP_PRIORITY:-1}" \
-  "$mongo_service" mongosh "$mongo_db" --quiet < "$script_dir/llmgw-prod-chat-pool-bootstrap.js"
+  -e LLMGW_CHAT_BOOTSTRAP_GW_DB="$gateway_db" \
+  -e LLMGW_INTERNAL_TENANT_ID="${LLMGW_INTERNAL_TENANT_ID:-tenant_map_internal}" \
+  "$mongo_service" mongosh "$mongo_db" --quiet --file /dev/stdin < "$script_dir/llmgw-prod-chat-pool-bootstrap.js"
 
 if [ "$dry_run" = "1" ] || [ "$dry_run" = "true" ]; then
   echo "LLM Gateway chat pool bootstrap dry-run completed"

--- a/scripts/llmgw-readiness-audit.py
+++ b/scripts/llmgw-readiness-audit.py
@@ -567,7 +567,7 @@ def _static_checks() -> list[dict]:
         chat_bootstrap + "\n" + chat_bootstrap_js,
         [
             "LLMGW_CHAT_BOOTSTRAP_DRY_RUN:-1",
-            "mongodump --db \"$mongo_db\" --archive",
+            "backup_collection \"$mongo_db\" model_groups",
             "llmgw-disk-space-guard.sh",
             "LLMGW_CHAT_BOOTSTRAP_MIN_FREE_MB:-6144",
             "llmgw-prod-before-chat-pool-bootstrap",
@@ -589,14 +589,25 @@ def _static_checks() -> list[dict]:
             "ModelGroupIds: isolatePool ? [pool._id]",
             "ModelGroupIds",
             "ModelGroupId",
+            "db.getSiblingDB(gatewayDbName)",
+            "GW authority caller must resolve exactly once",
+            "isolated GW authority bootstrap requires caller binding",
+            "otherGatewayReferences.length > 0",
+            "ModelPolicy: \"pool\"",
+            "TenantId: tenantId",
+            "GW authority post-write verification failed",
+            "backup_collection \"$gateway_db\" llmgw_model_pools",
+            "--collection \"$backup_collection_name\" --archive --gzip",
+            "SHA256SUMS",
         ],
     )
     chat_bootstrap_executable = bool(chat_bootstrap_path.exists() and (chat_bootstrap_path.stat().st_mode & stat.S_IXUSR))
     chat_bootstrap_destructive = any(item in chat_bootstrap + chat_bootstrap_js for item in ["dropDatabase", "deleteMany", "remove(", "docker volume rm", "down -v"])
+    chat_bootstrap_accepts_tenant_input = "LLMGW_CHAT_BOOTSTRAP_TENANT_ID" in chat_bootstrap + chat_bootstrap_js
     checks.append(_check(
         "prod_chat_pool_bootstrap_is_backed_up_and_dry_run_first",
-        ok and chat_bootstrap_executable and not chat_bootstrap_destructive,
-        f"{detail}; executable={chat_bootstrap_executable}; destructive={chat_bootstrap_destructive}",
+        ok and chat_bootstrap_executable and not chat_bootstrap_destructive and not chat_bootstrap_accepts_tenant_input,
+        f"{detail}; executable={chat_bootstrap_executable}; destructive={chat_bootstrap_destructive}; acceptsTenantInput={chat_bootstrap_accepts_tenant_input}",
     ))
 
     ok, detail = _contains_all(


### PR DESCRIPTION
## 摘要
修复 full-http 下周报仍绑定 GW 共享默认大池的问题。脚本现在同时维护 MAP 兼容配置和 GW 权威配置，创建单模型非默认专属池，并只绑定 `report-agent.generate::chat`。

## 改动 diff
- `scripts/llmgw-prod-chat-pool-bootstrap.js`：从权威 caller 推导租户范围，创建 GW 专属池、拒绝共享引用、写入 TenantId 审计并执行写后验证
- `scripts/llmgw-prod-chat-pool-bootstrap.sh`：执行前备份 MAP/GW 受影响集合并生成 SHA256 校验和
- `scripts/llmgw-readiness-audit.py`：补充 GW 权威池、TenantId 和备份门禁
- `prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs`：补充静态守卫
- `doc/plan.report-agent.model-governance.md`：记录生产共享池事实、历史模型切换与 P3 权威数据方案
- `changelogs/2026-07-13_report-agent-gw-authority-pool.md`：新增变更碎片

## 测试
- [x] pre-commit C# 检查通过
- [x] JS、Shell、Python 静态语法检查通过
- [x] 临时 Mongo：dry-run 零写入
- [x] 临时 Mongo：execute 后专属池成员为 1、非默认，原共享池 224 个成员保持不变
- [x] 临时 Mongo：其他 caller 保持原绑定，重复执行无重复池
- [x] 临时 Mongo：专属池被其他 caller 引用时执行失败
- [x] CDS 四类镜像构建通过
- [x] CDS 五服务 running，分层冒烟 3/3
- [ ] 生产 dry-run、备份、执行和单次真实 chat 验收
