### PR TITLE
fix(llmgw): 区分维护发布与首次切流门禁

### DIFF
--- a/changelogs/2026-07-13_llmgw-maintenance-runtime-gate.md
+++ b/changelogs/2026-07-13_llmgw-maintenance-runtime-gate.md
@@ -1,0 +1,1 @@
+| fix | llmgw | 修复已审计 full-http 维护发布仍重复执行首次切流 runtime gate 的问题，继续保留 serving 探针和显式 canary |

--- a/exec_dep.sh
+++ b/exec_dep.sh
@@ -1219,7 +1219,9 @@ run_llmgw_post_deploy_verification_if_needed() {
   esac
 
   require_runtime_gates_compact="$(printf '%s' "${LLMGW_GATE_REQUIRE_RUNTIME_GATES:-}" | xargs || true)"
-  if [ "$mode" = "http" ] || [ "$require_runtime_gates_compact" = "1" ] || [ "$require_runtime_gates_compact" = "true" ]; then
+  if [ "$mode" = "http" ] && [ "$maintenance_release" = "1" ]; then
+    echo "LLM Gateway post-deploy runtime gates: skipped for audited full-http maintenance release; serving probe and requested canaries remain required"
+  elif [ "$mode" = "http" ] || [ "$require_runtime_gates_compact" = "1" ] || [ "$require_runtime_gates_compact" = "true" ]; then
     echo "LLM Gateway post-deploy runtime gates: required (/gw/runtime-gates readyForHttpFull)"
     runtime_gate_expect_arg=""
     if [ -n "$expect_commit" ]; then

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -784,6 +784,8 @@ public class GatewayDataDomainGuardTests
         Assert.Contains("python3 scripts/llmgw-protocol-canary.py", script);
         Assert.Contains("protocol_canary_arg=\"--protocol-canary-json $protocol_canary_json\"", script);
         Assert.Contains("$protocol_canary_arg --require-runtime-gates", script);
+        Assert.Contains("[ \"$mode\" = \"http\" ] && [ \"$maintenance_release\" = \"1\" ]", script);
+        Assert.Contains("skipped for audited full-http maintenance release", script);
         Assert.Contains("LLM Gateway post-deploy runtime gates: allowing self-finalizing full_http_rollout_ledger only", script);
         Assert.Contains("--allow-pending-http-full-ledger", script);
         Assert.Contains("LLMGW_GATE_SERVING_PROBE_SAMPLES", script);


### PR DESCRIPTION
## 摘要
修复已审计 full-http 维护发布仍重复执行首次切流 runtime gate 的问题。维护发布继续强制不可变提交、生产预检、配置权威、provider audit、serving probe 与显式启用的 canary，只跳过面向首次切流的同提交 appCaller/shadow/ledger 门。

## 改动 diff
- `exec_dep.sh`：审计基线有效的 full-http 维护发布不再重复运行首次切流 runtime gates。
- `prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs`：增加维护发布分支守卫。
- `changelogs/2026-07-13_llmgw-maintenance-runtime-gate.md`：新增 changelog 碎片。

## 测试
- [x] `sh -n exec_dep.sh`
- [x] GatewayDataDomainGuardTests 68/68
- [x] `dotnet build prd-api/PrdAgent.sln --no-restore -m:1`，0 error
- [x] `git diff --check`