### PR TITLE
fix(llmgw): 统一 OpenRouter 应用归因前缀

### DIFF
--- a/changelogs/2026-07-13_openrouter-app-title.md
+++ b/changelogs/2026-07-13_openrouter-app-title.md
@@ -1,0 +1,1 @@
+| fix | prd-api | OpenRouter App 归因名称统一增加 G- 前缀 |

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/LlmGateway.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/LlmGateway.cs
@@ -2332,7 +2332,7 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
     }
 
     /// <summary>
-    /// OpenRouter 应用归属：通过 HTTP-Referer + X-Title header 告诉 OpenRouter 本次调用来自哪个 AppCaller。
+    /// OpenRouter 应用归属：通过 HTTP-Referer + X-OpenRouter-Title header 告诉 OpenRouter 本次调用来自哪个 AppCaller。
     /// 仅在 ApiUrl 指向 openrouter.ai 时注入，避免污染其他严格校验 header/body 的上游（DeepSeek、通义、
     /// Claude 原生、各类中转站等）。body 不动，彻底规避未知字段导致 400 的风险。
     /// </summary>
@@ -2347,7 +2347,7 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
         httpRequest.Headers.TryAddWithoutValidation("HTTP-Referer", "https://prd-agent.miduo.org");
         if (!string.IsNullOrWhiteSpace(appCallerCode))
         {
-            httpRequest.Headers.TryAddWithoutValidation("X-Title", appCallerCode);
+            httpRequest.Headers.TryAddWithoutValidation("X-OpenRouter-Title", $"G-{appCallerCode}");
         }
     }
 

--- a/prd-api/tests/PrdAgent.Api.Tests/Services/LlmGatewayTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Services/LlmGatewayTests.cs
@@ -1527,6 +1527,82 @@ public class LlmGatewayTests
     }
 
     [Fact]
+    public async Task SendRawWithResolutionAsync_WhenOpenRouter_ShouldPrefixAppAttributionTitle()
+    {
+        var resolution = new GatewayModelResolution
+        {
+            Success = true,
+            ResolutionType = "Pinned",
+            ActualModel = "deepseek/deepseek-chat",
+            ActualPlatformId = "openrouter",
+            ActualPlatformName = "OpenRouter",
+            PlatformType = "openrouter",
+            Protocol = "openai",
+            ApiUrl = "https://openrouter.ai/api/v1",
+            ApiKey = "sk-test",
+        };
+        var http = new SequenceHttpClientFactory((200, "{\"choices\":[{\"message\":{\"content\":\"ok\"}}]}"));
+        var gateway = new LlmGateway(new InMemoryModelResolver(), http, new TestLogger<LlmGateway>(), new CapturingLogWriter());
+
+        var response = await gateway.SendRawWithResolutionAsync(new GatewayRawRequest
+        {
+            AppCallerCode = "product-agent.marketing-consult::chat",
+            ModelType = "chat",
+            RequestBody = new JsonObject
+            {
+                ["messages"] = new JsonArray
+                {
+                    new JsonObject { ["role"] = "user", ["content"] = "hi" }
+                }
+            }
+        }, resolution);
+
+        Assert.True(response.Success, response.ErrorMessage);
+        var headers = Assert.Single(http.RequestHeaders);
+        Assert.Equal("https://prd-agent.miduo.org", Assert.Single(headers["HTTP-Referer"]));
+        Assert.Equal("G-product-agent.marketing-consult::chat", Assert.Single(headers["X-OpenRouter-Title"]));
+        Assert.False(headers.ContainsKey("X-Title"));
+    }
+
+    [Fact]
+    public async Task SendRawWithResolutionAsync_WhenProviderIsNotOpenRouter_ShouldNotAddAppAttributionHeaders()
+    {
+        var resolution = new GatewayModelResolution
+        {
+            Success = true,
+            ResolutionType = "Pinned",
+            ActualModel = "deepseek-chat",
+            ActualPlatformId = "deepseek",
+            ActualPlatformName = "DeepSeek",
+            PlatformType = "openai",
+            Protocol = "openai",
+            ApiUrl = "https://api.deepseek.com",
+            ApiKey = "sk-test",
+        };
+        var http = new SequenceHttpClientFactory((200, "{\"choices\":[{\"message\":{\"content\":\"ok\"}}]}"));
+        var gateway = new LlmGateway(new InMemoryModelResolver(), http, new TestLogger<LlmGateway>(), new CapturingLogWriter());
+
+        var response = await gateway.SendRawWithResolutionAsync(new GatewayRawRequest
+        {
+            AppCallerCode = "product-agent.marketing-consult::chat",
+            ModelType = "chat",
+            RequestBody = new JsonObject
+            {
+                ["messages"] = new JsonArray
+                {
+                    new JsonObject { ["role"] = "user", ["content"] = "hi" }
+                }
+            }
+        }, resolution);
+
+        Assert.True(response.Success, response.ErrorMessage);
+        var headers = Assert.Single(http.RequestHeaders);
+        Assert.False(headers.ContainsKey("HTTP-Referer"));
+        Assert.False(headers.ContainsKey("X-OpenRouter-Title"));
+        Assert.False(headers.ContainsKey("X-Title"));
+    }
+
+    [Fact]
     public async Task SendRawWithResolutionAsync_WhenMultipartImageArrayKeys_ShouldSendImageArrayFields()
     {
         var resolution = new GatewayModelResolution
@@ -2139,25 +2215,31 @@ internal sealed class SequenceHttpClientFactory : IHttpClientFactory
     private readonly Queue<(int StatusCode, string Body)> _responses;
     public List<string> RequestBodies { get; } = new();
     public List<string> RequestUris { get; } = new();
+    public List<IReadOnlyDictionary<string, string[]>> RequestHeaders { get; } = new();
 
     public SequenceHttpClientFactory(params (int StatusCode, string Body)[] responses)
     {
         _responses = new Queue<(int StatusCode, string Body)>(responses);
     }
 
-    public HttpClient CreateClient(string name) => new(new SequenceHttpMessageHandler(_responses, RequestBodies, RequestUris));
+    public HttpClient CreateClient(string name) => new(new SequenceHttpMessageHandler(_responses, RequestBodies, RequestUris, RequestHeaders));
 }
 
 internal sealed class SequenceHttpMessageHandler(
     Queue<(int StatusCode, string Body)> responses,
     List<string> requestBodies,
-    List<string> requestUris) : HttpMessageHandler
+    List<string> requestUris,
+    List<IReadOnlyDictionary<string, string[]>> requestHeaders) : HttpMessageHandler
 {
     protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         var body = request.Content?.ReadAsStringAsync(cancellationToken).GetAwaiter().GetResult() ?? "";
         requestBodies.Add(body);
         requestUris.Add(request.RequestUri?.ToString() ?? string.Empty);
+        requestHeaders.Add(request.Headers.ToDictionary(
+            header => header.Key,
+            header => header.Value.ToArray(),
+            StringComparer.OrdinalIgnoreCase));
         var next = responses.Count > 0
             ? responses.Dequeue()
             : (200, "{\"choices\":[{\"message\":{\"content\":\"ok\"}}]}");


### PR DESCRIPTION
## 摘要

修复 OpenRouter Logs 的 App 列直接显示原始 appCallerCode 的问题。内部 appCallerCode、模型路由、租户隔离和日志字段保持原值，仅将发往 OpenRouter 的应用显示名称改为 `G-${appCallerCode}`。

## 改动 diff

- `prd-api/src/PrdAgent.Infrastructure/LlmGateway/LlmGateway.cs`：改用官方 `X-OpenRouter-Title`，值统一为 `G-${appCallerCode}`；固定 `HTTP-Referer` 保持不变。
- `prd-api/tests/PrdAgent.Api.Tests/Services/LlmGatewayTests.cs`：新增 OpenRouter 前缀和非 OpenRouter 不注入归因 header 的回归测试。
- `changelogs/2026-07-13_openrouter-app-title.md`：新增 changelog 碎片。

## 测试

- [x] OpenRouter/非 OpenRouter 定向测试 2/2 通过
- [x] `LlmGatewayTests` 107/107 通过
- [x] `dotnet build prd-api/PrdAgent.sln --no-restore` 通过，0 error
- [x] C# 静态分析无 `error CS` 或 `warning CS`
- [ ] CDS 分支部署与生产 OpenRouter Logs 验收
