### PR TITLE
fix(llmgw): 修复维护发布台账误判

### DIFF
--- a/changelogs/2026-07-13_llmgw-maintenance-ledger-runtime-skip.md
+++ b/changelogs/2026-07-13_llmgw-maintenance-ledger-runtime-skip.md
@@ -1,0 +1,2 @@
+| fix | llmgw | 修复已审计 full-http 维护发布跳过运行时 Gate 后被台账误判失败的问题 |
+| test | prd-api | 补充维护发布台账严格放行与普通发布拒绝跳过 Gate 的回归测试 |

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -852,6 +852,8 @@ public class GatewayDataDomainGuardTests
         Assert.Contains("maintenance evidence commit must differ from the new release commit", stage);
         Assert.Contains("shadow_evidence_commit=\"$(python3 - \"$maintenance_baseline_json\"", stage);
         Assert.Contains("--shadow-evidence-commit \"$shadow_evidence_commit\"", stage);
+        Assert.Contains("--maintenance-baseline-commit \"$maintenance_from_commit\"", stage);
+        Assert.Contains("--maintenance-baseline-json \"$maintenance_baseline_json\"", stage);
         Assert.Contains("export LLMGW_GATE_SHADOW_RELEASE_COMMIT=\"$shadow_evidence_commit\"", stage);
         Assert.Contains("export LLMGW_MAINTENANCE_BASELINE_COMMIT=\"$maintenance_from_commit\"", stage);
         Assert.Contains("export LLMGW_MAINTENANCE_BASELINE_JSON=\"$maintenance_baseline_json\"", stage);
@@ -861,6 +863,9 @@ public class GatewayDataDomainGuardTests
         Assert.Contains("[ \"$maintenance_release\" != \"1\" ]", deploy);
         Assert.Contains("LLMGW_POST_DEPLOY_EXPECT_COMMIT=\"$expect_commit\"", deploy);
         Assert.Contains("shadowEvidenceCommit", ledger);
+        Assert.Contains("maintenanceBaselineCommit", ledger);
+        Assert.Contains("maintenanceBaselineJson", ledger);
+        Assert.Contains("allow_skipped_runtime_gates=bool(maintenance_baseline_commit)", ledger);
         Assert.Contains("args.shadow_evidence_commit or args.commit", ledger);
         Assert.Contains("def maintenance_baseline(args: argparse.Namespace)", ledger);
         Assert.Contains("maintenance baseline is stale because a later negative event exists", ledger);
@@ -933,12 +938,18 @@ public class GatewayDataDomainGuardTests
                 },
                 runtimeGates = new
                 {
-                    required = true,
-                    ok = true,
-                    readyForHttpFull = true,
+                    required = false,
+                    ok = false,
+                    readyForHttpFull = false,
                     remainingRuntimeGates = Array.Empty<string>(),
                     allowedPendingRuntimeGates = Array.Empty<string>(),
                 },
+            });
+            var maintenanceBaseline = WriteJson("maintenance-baseline.json", new
+            {
+                verdict = "pass",
+                commit = shadowCommit,
+                shadowEvidenceCommit = shadowCommit,
             });
             var report = Path.Combine(tempDir, "stage.json");
 
@@ -956,6 +967,8 @@ public class GatewayDataDomainGuardTests
                     "--status", "success",
                     "--commit", releaseCommit,
                     "--shadow-evidence-commit", shadowCommit,
+                    "--maintenance-baseline-commit", shadowCommit,
+                    "--maintenance-baseline-json", maintenanceBaseline,
                     "--disable-map-config-fallback-for-active-app-callers", "true",
                     "--protocol-router-audit-json", protocolRouter,
                     "--prod-preflight-json", preflight,
@@ -972,6 +985,73 @@ public class GatewayDataDomainGuardTests
             Assert.True(process.ExitCode == 0, stderr + stdout);
             var reportJson = File.ReadAllText(report);
             Assert.Contains($"\"shadowEvidenceCommit\": \"{shadowCommit}\"", reportJson);
+            Assert.Contains($"\"maintenanceBaselineCommit\": \"{shadowCommit}\"", reportJson);
+            Assert.Contains($"\"maintenanceBaselineJson\": \"{maintenanceBaseline.Replace("\\", "\\\\")}\"", reportJson);
+
+            var ledger = Path.Combine(tempDir, "rollout.jsonl");
+            using var appendProcess = Process.Start(new ProcessStartInfo
+            {
+                FileName = "python3",
+                WorkingDirectory = root,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                ArgumentList =
+                {
+                    "scripts/llmgw-rollout-ledger.py", "append",
+                    "--ledger", ledger,
+                    "--stage", "http-full",
+                    "--status", "success",
+                    "--commit", releaseCommit,
+                    "--evidence-json", report,
+                    "--shadow-evidence-commit", shadowCommit,
+                    "--maintenance-baseline-commit", shadowCommit,
+                    "--maintenance-baseline-json", maintenanceBaseline,
+                    "--disable-map-config-fallback-for-active-app-callers", "true",
+                    "--protocol-router-audit-json", protocolRouter,
+                    "--prod-preflight-json", preflight,
+                    "--serving-probe-json", serving,
+                    "--release-gate-json", releaseGate,
+                    "--release-gate-required", "1",
+                    "--smoke-required", "0",
+                }
+            })!;
+            var appendStdout = appendProcess.StandardOutput.ReadToEnd();
+            var appendStderr = appendProcess.StandardError.ReadToEnd();
+            appendProcess.WaitForExit();
+
+            Assert.True(appendProcess.ExitCode == 0, appendStderr + appendStdout);
+            Assert.Contains($"\"maintenanceBaselineCommit\": \"{shadowCommit}\"", File.ReadAllText(ledger));
+
+            var rejectedReport = Path.Combine(tempDir, "stage-without-maintenance-marker.json");
+            using var rejectedProcess = Process.Start(new ProcessStartInfo
+            {
+                FileName = "python3",
+                WorkingDirectory = root,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                ArgumentList =
+                {
+                    "scripts/llmgw-rollout-ledger.py", "stage-report",
+                    "--json-out", rejectedReport,
+                    "--stage", "http-full",
+                    "--status", "success",
+                    "--commit", releaseCommit,
+                    "--shadow-evidence-commit", shadowCommit,
+                    "--disable-map-config-fallback-for-active-app-callers", "true",
+                    "--protocol-router-audit-json", protocolRouter,
+                    "--prod-preflight-json", preflight,
+                    "--serving-probe-json", serving,
+                    "--release-gate-json", releaseGate,
+                    "--release-gate-required", "1",
+                    "--smoke-required", "0",
+                }
+            })!;
+            var rejectedStdout = rejectedProcess.StandardOutput.ReadToEnd();
+            var rejectedStderr = rejectedProcess.StandardError.ReadToEnd();
+            rejectedProcess.WaitForExit();
+
+            Assert.NotEqual(0, rejectedProcess.ExitCode);
+            Assert.Contains("runtimeGates is not required+ok+ready", rejectedStderr + rejectedStdout);
 
             string WriteJson(string name, object value)
             {

--- a/scripts/llmgw-prod-stage.sh
+++ b/scripts/llmgw-prod-stage.sh
@@ -748,6 +748,8 @@ append_ledger_entry() {
     --evidence-md "$stage_md" \
     --release-gate-json "$release_gate_json" \
     --shadow-evidence-commit "$shadow_evidence_commit" \
+    --maintenance-baseline-commit "$maintenance_from_commit" \
+    --maintenance-baseline-json "$maintenance_baseline_json" \
     --release-gate-required "${release_gate_required:-0}" \
     --prod-preflight-json "$prod_preflight_json" \
     --prod-health-preflight-json "$prod_health_preflight_json" \
@@ -1673,6 +1675,8 @@ if [ "$execute" = "1" ]; then
     --gate-base "$gate_base" \
     --release-gate-json "$release_gate_json" \
     --shadow-evidence-commit "$shadow_evidence_commit" \
+    --maintenance-baseline-commit "$maintenance_from_commit" \
+    --maintenance-baseline-json "$maintenance_baseline_json" \
     --release-gate-required "$release_gate_required" \
     --prod-preflight-json "$prod_preflight_json" \
     --prod-health-preflight-json "$prod_health_preflight_json" \

--- a/scripts/llmgw-rollout-ledger.py
+++ b/scripts/llmgw-rollout-ledger.py
@@ -132,6 +132,25 @@ def _require_stage_evidence_matches_entry(path: str, label: str, entry: dict) ->
             f"ERROR: {label} releaseMainSha mismatch: {path} actual={actual_main_sha or 'empty'} expected={expected_main_sha or 'empty'}"
         )
 
+    expected_maintenance_commit = _normalize_commit(entry.get("maintenanceBaselineCommit"))
+    actual_maintenance_commit = _normalize_commit(
+        payload.get("maintenanceBaselineCommit") or payload.get("MaintenanceBaselineCommit")
+    )
+    if expected_maintenance_commit != actual_maintenance_commit:
+        raise SystemExit(
+            f"ERROR: {label} maintenanceBaselineCommit mismatch: {path} "
+            f"actual={actual_maintenance_commit or 'empty'} expected={expected_maintenance_commit or 'empty'}"
+        )
+    expected_maintenance_json = str(entry.get("maintenanceBaselineJson") or "").strip()
+    actual_maintenance_json = str(
+        payload.get("maintenanceBaselineJson") or payload.get("MaintenanceBaselineJson") or ""
+    ).strip()
+    if expected_maintenance_json != actual_maintenance_json:
+        raise SystemExit(
+            f"ERROR: {label} maintenanceBaselineJson mismatch: {path} "
+            f"actual={actual_maintenance_json or 'empty'} expected={expected_maintenance_json or 'empty'}"
+        )
+
 
 def _require_serving_probe_for_commit(path: str, label: str, commit: str) -> None:
     payload = _require_pass_json(path, label)
@@ -295,7 +314,13 @@ def _require_smoke_route_matrix(path: str, label: str) -> None:
         )
 
 
-def _require_release_gate_for_commit(path: str, label: str, commit: str, require_config_authority: bool = False) -> None:
+def _require_release_gate_for_commit(
+    path: str,
+    label: str,
+    commit: str,
+    require_config_authority: bool = False,
+    allow_skipped_runtime_gates: bool = False,
+) -> None:
     payload = _require_pass_json(path, label)
     expected = _normalize_commit(commit)
     if not expected:
@@ -381,13 +406,55 @@ def _require_release_gate_for_commit(path: str, label: str, commit: str, require
             and remaining == ["full_http_rollout_ledger"]
             and allowed_pending == ["full_http_rollout_ledger"]
         )
-        if not runtime_required or not runtime_ok or (not runtime_ready and not pending_http_full_ledger_only):
+        audited_maintenance_skip = (
+            allow_skipped_runtime_gates
+            and not runtime_required
+            and not runtime_ok
+            and not runtime_ready
+            and not remaining
+            and not allowed_pending
+            and not self_finalizing
+        )
+        if not audited_maintenance_skip and (
+            not runtime_required or not runtime_ok or (not runtime_ready and not pending_http_full_ledger_only)
+        ):
             raise SystemExit(
                 f"ERROR: {label} runtimeGates is not required+ok+ready for http-full gate: "
                 f"{path} required={runtime_required} ok={runtime_ok} readyForHttpFull={runtime_ready} "
                 f"remaining={','.join(str(x) for x in remaining) or 'none'} "
                 f"allowedPending={','.join(str(x) for x in allowed_pending) or 'none'}"
             )
+
+
+def _validated_maintenance_baseline_commit(args: argparse.Namespace) -> str:
+    commit = _normalize_commit(args.maintenance_baseline_commit)
+    if not commit:
+        if args.maintenance_baseline_json:
+            raise SystemExit("ERROR: maintenance baseline JSON requires a maintenance baseline commit")
+        return ""
+    if len(commit) != 40 or any(char not in "0123456789abcdef" for char in commit):
+        raise SystemExit("ERROR: maintenance baseline commit must be a complete 40-character commit")
+    if args.stage != "http-full":
+        raise SystemExit("ERROR: maintenance baseline commit is only valid for stage http-full")
+    if commit == _normalize_commit(args.commit):
+        raise SystemExit("ERROR: maintenance baseline commit must differ from the new release commit")
+    payload = _require_pass_json(args.maintenance_baseline_json, "maintenance baseline audit")
+    audited_commit = _normalize_commit(payload.get("commit") or payload.get("Commit"))
+    if audited_commit != commit:
+        raise SystemExit(
+            "ERROR: maintenance baseline audit commit mismatch: "
+            f"actual={audited_commit or 'empty'} expected={commit}"
+        )
+    audited_shadow_commit = _normalize_commit(
+        payload.get("shadowEvidenceCommit") or payload.get("ShadowEvidenceCommit") or audited_commit
+    )
+    expected_shadow_commit = _normalize_commit(args.shadow_evidence_commit)
+    if not expected_shadow_commit or audited_shadow_commit != expected_shadow_commit:
+        raise SystemExit(
+            "ERROR: maintenance baseline audit shadowEvidenceCommit mismatch: "
+            f"actual={audited_shadow_commit or 'empty'} expected={expected_shadow_commit or 'empty'}"
+        )
+    return commit
 
 
 def _require_prod_preflight_for_commit(path: str, label: str, commit: str, stage: str = "") -> None:
@@ -835,10 +902,19 @@ def _entry_evidence_failures(entry: dict) -> list[str]:
     if _bool_flag(str(entry.get("releaseGateRequired") or "0")):
         try:
             shadow_evidence_commit = _normalize_commit(entry.get("shadowEvidenceCommit")) or commit
+            maintenance_baseline_commit = _validated_maintenance_baseline_commit(argparse.Namespace(
+                maintenance_baseline_commit=str(entry.get("maintenanceBaselineCommit") or ""),
+                maintenance_baseline_json=str(entry.get("maintenanceBaselineJson") or ""),
+                shadow_evidence_commit=shadow_evidence_commit,
+                stage=stage,
+                commit=commit,
+            ))
             _require_release_gate_for_commit(
                 str(entry.get("releaseGateJson") or ""),
                 f"{stage} release gate evidence",
                 shadow_evidence_commit,
+                require_config_authority=stage == "http-full",
+                allow_skipped_runtime_gates=bool(maintenance_baseline_commit),
             )
         except SystemExit as exc:
             failures.append(str(exc))
@@ -1036,6 +1112,7 @@ def append(args: argparse.Namespace) -> int:
     parent = os.path.dirname(args.ledger)
     if parent:
         os.makedirs(parent, exist_ok=True)
+    maintenance_baseline_commit = _validated_maintenance_baseline_commit(args)
     if args.status == "success":
         _require_http_full_map_fallback_exit(
             args.stage,
@@ -1063,6 +1140,7 @@ def append(args: argparse.Namespace) -> int:
                     "release gate evidence",
                     args.shadow_evidence_commit or args.commit,
                     require_config_authority=args.stage == "http-full",
+                    allow_skipped_runtime_gates=bool(maintenance_baseline_commit),
                 )
             if _bool_flag(args.protocol_canary_required):
                 _require_protocol_canary_for_commit(args.protocol_canary_json, "protocol canary evidence", args.commit)
@@ -1098,6 +1176,8 @@ def append(args: argparse.Namespace) -> int:
         "evidenceMarkdown": args.evidence_md,
         "releaseGateJson": args.release_gate_json,
         "shadowEvidenceCommit": _normalize_commit(args.shadow_evidence_commit) or args.commit.lower(),
+        "maintenanceBaselineCommit": maintenance_baseline_commit,
+        "maintenanceBaselineJson": args.maintenance_baseline_json,
         "releaseGateRequired": _bool_flag(args.release_gate_required),
         "prodPreflightJson": args.prod_preflight_json,
         "prodHealthPreflightJson": args.prod_health_preflight_json,
@@ -1170,6 +1250,8 @@ def _write_markdown(path: str, report: dict) -> None:
         fh.write(f"- allowlist: `{cell(report['allowlist'])}`\n")
         fh.write(f"- disableMapConfigFallbackForActiveAppCallers: `{cell(report['disableMapConfigFallbackForActiveAppCallers'])}`\n")
         fh.write(f"- releaseGateRequired: `{cell(report['releaseGateRequired'])}`\n")
+        fh.write(f"- maintenanceBaselineCommit: `{cell(report['maintenanceBaselineCommit'])}`\n")
+        fh.write(f"- maintenanceBaselineJson: `{cell(report['maintenanceBaselineJson'])}`\n")
         fh.write(f"- rollbackRehearsal: `{cell(report['rollbackRehearsal'])}`\n")
         fh.write(f"- allowOutOfOrder: `{cell(report['allowOutOfOrder'])}`\n")
         fh.write(f"- allowOutOfOrderReason: `{cell(report['allowOutOfOrderReason'])}`\n")
@@ -1235,6 +1317,7 @@ def _write_markdown(path: str, report: dict) -> None:
 
 def stage_report(args: argparse.Namespace) -> int:
     failures: list[str] = []
+    maintenance_baseline_commit = _validated_maintenance_baseline_commit(args)
     provider_external_blockers = _provider_external_blockers(args.provider_audit_json)
     video_canary_external_blockers = _canary_external_blockers(args.video_canary_json)
     asr_http_canary_external_blockers = _canary_external_blockers(args.asr_http_canary_json)
@@ -1286,6 +1369,7 @@ def stage_report(args: argparse.Namespace) -> int:
                     label,
                     args.shadow_evidence_commit or args.commit,
                     require_config_authority=args.stage == "http-full",
+                    allow_skipped_runtime_gates=bool(maintenance_baseline_commit),
                 )
             elif label == "prodPreflightJson":
                 _require_prod_preflight_for_commit(path, label, args.commit, args.stage)
@@ -1328,6 +1412,8 @@ def stage_report(args: argparse.Namespace) -> int:
         "gateBase": args.gate_base,
         "releaseGateRequired": _bool_flag(args.release_gate_required),
         "shadowEvidenceCommit": _normalize_commit(args.shadow_evidence_commit) or args.commit.lower(),
+        "maintenanceBaselineCommit": maintenance_baseline_commit,
+        "maintenanceBaselineJson": args.maintenance_baseline_json,
         "rollbackRehearsal": args.stage == ROLLBACK_REHEARSAL_STAGE,
         "allowOutOfOrder": _bool_flag(args.allow_out_of_order),
         "allowOutOfOrderReason": args.allow_out_of_order_reason.strip(),
@@ -1619,6 +1705,8 @@ def main() -> int:
     append_parser.add_argument("--evidence-md", default="")
     append_parser.add_argument("--release-gate-json", default="")
     append_parser.add_argument("--shadow-evidence-commit", default="")
+    append_parser.add_argument("--maintenance-baseline-commit", default="")
+    append_parser.add_argument("--maintenance-baseline-json", default="")
     append_parser.add_argument("--release-gate-required", default="0")
     append_parser.add_argument("--prod-preflight-json", default="")
     append_parser.add_argument("--prod-health-preflight-json", default="")
@@ -1662,6 +1750,8 @@ def main() -> int:
     report_parser.add_argument("--gate-base", default="")
     report_parser.add_argument("--release-gate-json", default="")
     report_parser.add_argument("--shadow-evidence-commit", default="")
+    report_parser.add_argument("--maintenance-baseline-commit", default="")
+    report_parser.add_argument("--maintenance-baseline-json", default="")
     report_parser.add_argument("--release-gate-required", default="0")
     report_parser.add_argument("--prod-preflight-json", default="")
     report_parser.add_argument("--prod-health-preflight-json", default="")


### PR DESCRIPTION
## 摘要
修复已审计 full-http 维护发布跳过 runtime gate 后被最终台账误判失败的问题。仅在维护基线审计证据完整、提交关系匹配、runtime gate 明确为跳过且无剩余项时放行，普通发布仍保持失败关闭。

## 改动 diff
- `scripts/llmgw-rollout-ledger.py`：校验维护基线审计，严格识别 runtime gate 跳过态，并写入可追溯台账字段
- `scripts/llmgw-prod-stage.sh`：向阶段报告与最终台账传递维护基线提交和审计文件
- `prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs`：覆盖维护发布成功、台账 append 成功和普通发布拒绝跳过 Gate
- `changelogs/2026-07-13_llmgw-maintenance-ledger-runtime-skip.md`：新增更新记录碎片

## 测试
- [x] `python3 -m py_compile scripts/llmgw-rollout-ledger.py`
- [x] `bash -n scripts/llmgw-prod-stage.sh`
- [x] `dotnet test prd-api/tests/PrdAgent.Tests/PrdAgent.Tests.csproj --no-restore --filter FullyQualifiedName~GatewayDataDomainGuardTests`，68/68 通过
- [x] `dotnet build prd-api/PrdAgent.sln --no-restore --nologo`，0 error
- [ ] GitHub CI 与 CDS 预览验收