### PR TITLE
fix(llmgw): 修复汇总后协议审计误判

### DIFF
--- a/changelogs/2026-07-14_llmgw-protocol-audit-assembled-changelog.md
+++ b/changelogs/2026-07-14_llmgw-protocol-audit-assembled-changelog.md
@@ -1,0 +1,2 @@
+| fix | scripts | 修复 LLM Gateway 协议路由审计在 changelog 碎片汇总后误判报告证据缺失 |
+| test | prd-api | 增加已汇总 CHANGELOG 场景的协议路由审计回归测试 |

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -1152,6 +1152,42 @@ public class GatewayDataDomainGuardTests
     }
 
     [Fact]
+    public void ProtocolRouterAudit_AcceptsAssembledChangelogWhenFragmentWasConsumed()
+    {
+        var root = LocateRepoRoot();
+        var report = Path.Combine(Path.GetTempPath(), $"llmgw-protocol-router-audit-{Guid.NewGuid():N}.json");
+
+        try
+        {
+            using var process = Process.Start(new ProcessStartInfo
+            {
+                FileName = "python3",
+                WorkingDirectory = root,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                ArgumentList =
+                {
+                    "scripts/llmgw-protocol-router-audit.py",
+                    "--json-out", report,
+                }
+            })!;
+            var stdout = process.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+
+            Assert.True(process.ExitCode == 0, stderr + stdout);
+            var reportJson = File.ReadAllText(report);
+            Assert.Contains("\"verdict\": \"pass\"", reportJson);
+            Assert.Contains("\"name\": \"readiness_and_changelog_capture_protocol_router_progress\"", reportJson);
+            Assert.Contains("\"CHANGELOG.md\"", reportJson);
+        }
+        finally
+        {
+            File.Delete(report);
+        }
+    }
+
+    [Fact]
     public void ConsoleRuntimeGateEvidenceLinks_CanDeepLinkToFilteredEvidence()
     {
         var overview = ReadRepoFile("llmgw/web/src/pages/OverviewPage.tsx");

--- a/scripts/llmgw-protocol-router-audit.py
+++ b/scripts/llmgw-protocol-router-audit.py
@@ -128,7 +128,8 @@ def build_report() -> dict[str, Any]:
     compose = _read("docker-compose.yml")
     cds_compose = _read("cds-compose.yml")
     readiness = _read("scripts/llmgw-readiness-audit.py")
-    changelog = _read("changelogs/2026-07-09_llmgw-protocol-router.md")
+    protocol_router_changelog = _read("changelogs/2026-07-09_llmgw-protocol-router.md")
+    assembled_changelog = _read("CHANGELOG.md")
 
     checks: list[dict[str, Any]] = []
 
@@ -481,7 +482,7 @@ def build_report() -> dict[str, Any]:
     ))
 
     ok, detail = _contains_all(
-        readiness + "\n" + changelog,
+        readiness + "\n" + protocol_router_changelog + "\n" + assembled_changelog,
         [
             "config_authority_stage_backup_is_local_auditable_and_safe",
             "prod_stage_runner_sequences_shadow_canary_http_and_rollback",
@@ -498,6 +499,7 @@ def build_report() -> dict[str, Any]:
         [
             "scripts/llmgw-readiness-audit.py",
             "changelogs/2026-07-09_llmgw-protocol-router.md",
+            "CHANGELOG.md",
         ],
     ))
 


### PR DESCRIPTION
## 摘要
修复 LLM Gateway 协议路由审计仅识别 changelog 碎片、在碎片汇总进 CHANGELOG.md 后误判报告证据缺失的问题。保留原有全部证据短语要求，不增加 skip 或 waiver。

## 改动 diff
- `scripts/llmgw-protocol-router-audit.py`：同时读取协议路由碎片与已汇总 `CHANGELOG.md`
- `prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs`：真实执行审计器并断言汇总场景 PASS
- `changelogs/2026-07-14_llmgw-protocol-audit-assembled-changelog.md`：新增 changelog 碎片

## 测试
- [x] Python protocol router audit：10/10 PASS
- [x] GatewayDataDomainGuardTests：69/69 PASS
- [x] `dotnet build prd-api/PrdAgent.sln --no-restore --nologo`：0 error
- [ ] GitHub CI
- [ ] CDS 预览验收