### PR TITLE
fix(llmgw): 打通一把 key 四协议 Quickstart

### DIFF
--- a/changelogs/2026-07-15_llmgw-quickstart-four-protocol-key.md
+++ b/changelogs/2026-07-15_llmgw-quickstart-four-protocol-key.md
@@ -1,0 +1,3 @@
+| fix | llmgw | 修复 Quickstart 生成后切换协议仍使用旧协议 bundle 的错位，一把非通配 scoped key 精确覆盖四种网页协议 |
+| polish | llmgw | 接入配置生成后锁定团队、appCaller 与环境，明确修改身份不会自动撤销已签发密钥 |
+| test | llmgw | 补充四协议同钥、无密钥 401、零费用 dry-run 与 requestId 日志回查证据 |

--- a/doc/plan.platform.llm-gateway-authoritative-tutorial.md
+++ b/doc/plan.platform.llm-gateway-authoritative-tutorial.md
@@ -90,7 +90,7 @@
 | Provider | 教程假上游 | 不付费完成配置与故障测试 |
 | 模型 | 教程聊天模型、教程视觉模型 | 演示 chat/vision 与价格覆盖 |
 | 默认池 | 默认对话池、默认视觉池 | 演示程序池类型与 append-only |
-| appCaller | `G-tutorial-support`、`G-tutorial-content` | 演示业务身份、策略和费用归属 |
+| appCaller | `tutorial.gateway-book::chat`、`tutorial.gateway-book::vision` | 演示业务身份、策略和费用归属；OpenRouter 的 App 列显示为 `G-{appCallerCode}`，前缀不是 Gateway 内部 code 的一部分 |
 | key | test / prod 两组临时测试 key | 演示环境隔离、轮换、撤销和审计 |
 
 所有名称在运行时增加唯一后缀，避免并发验收冲突；教程正文只显示稳定的人类名称。
@@ -100,8 +100,8 @@
 | 批次 | 范围 | 进入条件 | 完成门 |
 |---|---|---|---|
 | T0 | 公开入口、登录说明、账号来源、返回入口 | 公开页面可访问 | 新手知道从哪里来、账号从哪里得、登录后能做什么 |
-| T1 | 空租户、Provider、模型、默认池、appCaller | 隔离预览可写 | 从空状态建立最小可用路由，失败可恢复 |
-| T2 | 一键 key、四协议安全测试、curl、Agent 技能 | T1 可用 | 无 key 不能测试；4/4 安全直测产生可定位 requestId |
+| T1 | 空租户、Provider、模型、默认池 | 隔离预览可写 | 从空状态建立最小可用路由，失败可恢复 |
+| T2 | appCaller、一键 key、四协议安全测试、curl、Agent 技能 | T1 可用 | 无 key 不能测试；4/4 安全直测产生可定位 requestId |
 | T3 | PromptPolicy、日志、费用、审计、组织 | T2 有测试日志 | chat/vision、生效证据、费用口径和审计完整 |
 | T4 | 双主题、移动端、负面路径、低理解力复验 | 正文与截图完成 | 新手独立完成首请求和至少一条故障排查 |
 | T5 | MAP 教程库与 CDS L2 报告发布 | T4 通过 | 分享页、章节、图片、验收报告均可打开 |
@@ -124,8 +124,8 @@
 |---|---|---|---|
 | 事实审计 | 已完成 | 已确认 17 个页面、6 组导航、页面—API 关系和公开登录断点 | 在后续实测中持续记录新增断点 |
 | 教程设计 | 已完成 | 33 章三级目录、连续测试数据和截图合同已冻结 | 随实测补齐每章异常树，不改变连续主线 |
-| 产品修复 | 进行中 | T0 已补公开入口与登录说明；T1 已实现租户内 Provider、模型自助创建，并复用 13 类 append-only 默认池 | T1 独立 PR 通过后进入 appCaller、key 与安全直测 |
-| 连续实测 | 进行中 | 隔离租户已完成 Provider、聊天模型创建；13 个默认池中仅 chat 追加 1 个模型；同租户重复被拒、跨租户同名互不冲突 | 从 chat 默认池继续创建 appCaller 和第一把测试 key |
+| 产品修复 | 进行中 | T0、T1 已合并；T2 修正一键 key 只绑单协议与页面切换协议后仍使用旧 bundle 的断点，改为一把非通配 scoped key 精确覆盖四协议 | T2 独立 PR 通过后进入 PromptPolicy、费用与审计 |
+| 连续实测 | 进行中 | 隔离租户已从 chat 默认池继续创建 `tutorial.gateway-book::chat` 与 test key；无 key 返回 401；OpenAI 与 Claude 共用同一四协议 key 均 dry-run 成功，日志为 0 token、unknown cost、provider=`gateway-dry-run` | 用既有四协议集成测试补齐 GW Native、Gemini 证据，并核验 Agent Skill 文案 |
 | 低理解力复验 | 基线完成 | 无背景智能体无法从公开入口完成首请求 | 教程发布后重新复验 |
 | MAP 发布 | 已建空库 | 已创建私有知识库“模型网关权威教程”，正文完成前不对外分享 | T4 通过后写入章节、图片并创建分享入口 |
 | CDS 验收归档 | 待开始 | L2、双主题、移动端、负面路径合同已冻结 | 完成后发布验收报告并验证可开 |

--- a/llmgw/web/src/pages/QuickstartPage.tsx
+++ b/llmgw/web/src/pages/QuickstartPage.tsx
@@ -19,12 +19,15 @@ type AccessBundle = {
   key: string;
   keyId: string;
   keyPrefix: string;
-  protocol: Protocol;
-  baseUrl: string;
   appCallerCode: string;
   clientCode: string;
   environment: string;
   teamId: string;
+};
+
+type DisplayBundle = AccessBundle & {
+  protocol: Protocol;
+  baseUrl: string;
 };
 
 const PROTOCOLS: ProtocolDefinition[] = [
@@ -74,16 +77,16 @@ export function QuickstartPage() {
     return () => { active = false; };
   }, []);
 
-  const displayBundle = bundle ?? {
-    key: '',
-    keyId: '',
-    keyPrefix: 'gwk_',
+  const displayBundle: DisplayBundle = {
+    key: bundle?.key ?? '',
+    keyId: bundle?.keyId ?? '',
+    keyPrefix: bundle?.keyPrefix ?? 'gwk_',
     protocol,
     baseUrl: baseUrl.replace(/\/$/, ''),
-    appCallerCode: appCallerCode.trim() || 'my-agent.quickstart::chat',
-    clientCode: clientCode.trim() || 'my-agent',
-    environment,
-    teamId,
+    appCallerCode: bundle?.appCallerCode ?? (appCallerCode.trim() || 'my-agent.quickstart::chat'),
+    clientCode: bundle?.clientCode ?? (clientCode.trim() || 'my-agent'),
+    environment: bundle?.environment ?? environment,
+    teamId: bundle?.teamId ?? teamId,
   };
   const snippets = useMemo(() => ({
     curl: exampleFor(displayBundle.protocol, displayBundle.baseUrl, displayBundle.appCallerCode),
@@ -126,13 +129,13 @@ export function QuickstartPage() {
 
     setCreatingStage('key');
     const keyResponse = await createServiceKey({
-      name: `${normalizedClient}-${protocol}-quickstart`,
+      name: `${normalizedClient}-quickstart`,
       sourceSystem: 'external',
       clientCode: normalizedClient,
       environment,
       purpose: 'external-platform',
       appCallerCodes: [normalizedCode],
-      ingressProtocols: [selectedProtocol.ingressProtocol],
+      ingressProtocols: PROTOCOLS.map((item) => item.ingressProtocol),
       scopes: ['invoke'],
       teamId,
       allowedCidrs: [],
@@ -147,8 +150,6 @@ export function QuickstartPage() {
       key: keyResponse.data.key,
       keyId: keyResponse.data.id,
       keyPrefix: keyResponse.data.keyPrefix,
-      protocol,
-      baseUrl: normalizedBaseUrl,
       appCallerCode: normalizedCode,
       clientCode: normalizedClient,
       environment,
@@ -162,10 +163,11 @@ export function QuickstartPage() {
     setTesting(true);
     setTestResult(null);
     setActionError(null);
-    const definition = protocolDefinition(bundle.protocol);
+    const definition = protocolDefinition(protocol);
+    const normalizedBaseUrl = baseUrl.trim().replace(/\/$/, '');
     const requestId = createRequestId();
     try {
-      const response = await fetch(new URL(definition.path, `${bundle.baseUrl}/`).toString(), {
+      const response = await fetch(new URL(definition.path, `${normalizedBaseUrl}/`).toString(), {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${bundle.key}`,
@@ -175,7 +177,7 @@ export function QuickstartPage() {
           'X-Gateway-Dry-Run': 'quickstart',
           'X-Request-Id': requestId,
         },
-        body: JSON.stringify(dryRunBody(bundle.protocol, bundle.appCallerCode, requestId)),
+        body: JSON.stringify(dryRunBody(protocol, bundle.appCallerCode, requestId)),
         credentials: 'omit',
       });
       const payload = await response.json().catch(() => null) as Record<string, unknown> | null;
@@ -193,6 +195,14 @@ export function QuickstartPage() {
     } finally {
       setTesting(false);
     }
+  };
+
+  const editIdentity = () => {
+    if (!bundle) return;
+    if (!window.confirm('当前一次性密钥明文将从页面清除；已签发密钥仍然有效，可到“接入密钥”页撤销。确认修改身份？')) return;
+    setBundle(null);
+    setTestResult(null);
+    setSnippetTab('curl');
   };
 
   return (
@@ -215,13 +225,13 @@ export function QuickstartPage() {
           {organizationError ? <div className="lg-test-result is-error">{organizationError}</div> : null}
           {!organizationLoading ? (
             <div className="lg-quickstart-inputs" style={{ display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: 10 }}>
-              <label style={labelStyle}>团队<select value={teamId} onChange={(event) => setTeamId(event.target.value)} style={inputStyle}>
+              <label style={labelStyle}>团队<select value={teamId} disabled={Boolean(bundle)} onChange={(event) => setTeamId(event.target.value)} style={inputStyle}>
                 <option value="">选择团队</option>
                 {activeTeams.map((team) => <option key={team.id} value={team.id}>{team.name}</option>)}
               </select></label>
-              <Field label="appCallerCode" value={appCallerCode} onChange={setAppCallerCode} placeholder="my-agent.quickstart::chat" />
-              <Field label="Client code" value={clientCode} onChange={setClientCode} placeholder="my-agent" />
-              <label style={labelStyle}>环境<select value={environment} onChange={(event) => setEnvironment(event.target.value)} style={inputStyle}>
+              <Field label="appCallerCode" value={appCallerCode} onChange={setAppCallerCode} placeholder="my-agent.quickstart::chat" disabled={Boolean(bundle)} />
+              <Field label="Client code" value={clientCode} onChange={setClientCode} placeholder="my-agent" disabled={Boolean(bundle)} />
+              <label style={labelStyle}>环境<select value={environment} disabled={Boolean(bundle)} onChange={(event) => setEnvironment(event.target.value)} style={inputStyle}>
                 <option value="development">开发</option><option value="test">测试</option><option value="staging">预发布</option><option value="production">生产</option>
               </select></label>
             </div>
@@ -238,8 +248,11 @@ export function QuickstartPage() {
           <details className="lg-advanced-base-url"><summary>使用其他 Gateway 地址</summary><Field label="自定义 Gateway 地址" value={baseUrl} onChange={setBaseUrl} /></details>
 
           <div className="lg-quickstart-actions">
-            <div><strong>{creatingStage === 'app-caller' ? '正在创建 appCaller' : creatingStage === 'key' ? '正在签发团队密钥' : bundle ? '接入配置已生成' : '尚未生成接入配置'}</strong><small>{bundle ? `密钥 ${bundle.keyPrefix}，仅授权 ${protocolDefinition(bundle.protocol).label} 与当前 appCaller。` : '不会创建通配 key，也不会调用付费模型。'}</small></div>
-            <Button variant="primary" disabled={organizationLoading || creatingStage !== null || activeTeams.length === 0} onClick={() => void createAccessBundle()}><KeyRound size={14} />{creatingStage ? '生成中' : bundle ? '重新生成' : '一键生成 appCaller 与 key'}</Button>
+            <div><strong>{creatingStage === 'app-caller' ? '正在创建 appCaller' : creatingStage === 'key' ? '正在签发团队密钥' : bundle ? '接入配置已生成' : '尚未生成接入配置'}</strong><small>{bundle ? `密钥 ${bundle.keyPrefix}，只授权当前 appCaller 和上方四种协议；切换协议后可直接测试。` : '不会创建通配 key，也不会调用付费模型。'}</small></div>
+            <div style={{ display: 'flex', gap: 7, flexWrap: 'wrap', justifyContent: 'flex-end' }}>
+              {bundle ? <Button variant="ghost" onClick={editIdentity}>修改身份</Button> : null}
+              <Button variant="primary" disabled={organizationLoading || creatingStage !== null || activeTeams.length === 0} onClick={() => void createAccessBundle()}><KeyRound size={14} />{creatingStage ? '生成中' : bundle ? '再签一把同配置 key' : '一键生成 appCaller 与 key'}</Button>
+            </div>
           </div>
 
           {bundle ? (
@@ -252,7 +265,7 @@ export function QuickstartPage() {
           {actionError ? <div className="lg-test-result is-error" role="alert">{actionError}</div> : null}
 
           <div className="lg-safe-test-panel" style={{ marginTop: 12 }}>
-            <div><Play size={17} /><span><strong>测试当前协议</strong><small>请求会发送到 {bundle ? protocolDefinition(bundle.protocol).path : selectedProtocol.path}，经过 service key 与团队治理后写日志，并在模型解析前结束。</small></span></div>
+            <div><Play size={17} /><span><strong>测试当前协议</strong><small>请求会发送到 {selectedProtocol.path}，经过 service key 与团队治理后写日志，并在模型解析前结束。</small></span></div>
             <div className="lg-safe-test-controls"><Button variant="primary" disabled={!bundle || testing} onClick={() => void runDryRun()}>{testing ? '正在测试并写日志' : '点击测试'}</Button><span style={{ alignSelf: 'center', color: 'var(--text-muted)', fontSize: 11 }}>明确返回 upstreamCalled=false 才算通过</span></div>
             {testResult ? <div className={testResult.ok ? 'lg-test-result is-ok' : 'lg-test-result is-error'} role="status">{testResult.message}{testResult.requestId ? <Link to={`/logs?requestId=${encodeURIComponent(testResult.requestId)}`}>打开 requestId 请求记录</Link> : null}</div> : null}
           </div>
@@ -369,7 +382,7 @@ function stringValue(value: unknown) {
   return typeof value === 'string' ? value : undefined;
 }
 
-function environmentSnippet(bundle: AccessBundle) {
+function environmentSnippet(bundle: DisplayBundle) {
   return `export LLMGW_BASE_URL="${bundle.baseUrl}"
 export LLMGW_API_KEY="${bundle.key || 'YOUR_ONE_TIME_LLMGW_KEY'}"
 export LLMGW_APP_CALLER="${bundle.appCallerCode}"
@@ -378,7 +391,7 @@ export LLMGW_CLIENT_CODE="${bundle.clientCode}"
 export LLMGW_ENVIRONMENT="${bundle.environment}"`;
 }
 
-function agentSkillSnippet(bundle: AccessBundle) {
+function agentSkillSnippet(bundle: DisplayBundle) {
   const definition = protocolDefinition(bundle.protocol);
   return `---
 name: llmgw-${bundle.clientCode}
@@ -428,8 +441,8 @@ function Step({ number, title, text }: { number: string; title: string; text: st
   return <article style={cardStyle}><div style={{ color: 'var(--accent)', fontSize: 11, fontWeight: 700 }}>STEP {number}</div><h2 style={{ margin: '6px 0', fontSize: 13 }}>{title}</h2><p style={{ margin: 0, color: 'var(--text-muted)', fontSize: 12, lineHeight: 1.55 }}>{text}</p></article>;
 }
 
-function Field({ label, value, onChange, placeholder }: { label: string; value: string; onChange: (value: string) => void; placeholder?: string }) {
-  return <label style={labelStyle}>{label}<input value={value} onChange={(event) => onChange(event.target.value)} placeholder={placeholder} style={inputStyle} /></label>;
+function Field({ label, value, onChange, placeholder, disabled = false }: { label: string; value: string; onChange: (value: string) => void; placeholder?: string; disabled?: boolean }) {
+  return <label style={labelStyle}>{label}<input value={value} disabled={disabled} onChange={(event) => onChange(event.target.value)} placeholder={placeholder} style={inputStyle} /></label>;
 }
 
 function RouteRow({ name, text }: { name: string; text: string }) {

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -2951,7 +2951,12 @@ public class GatewayDataDomainGuardTests
         Assert.Contains("createGatewayAppCaller", quickstart);
         Assert.Contains("createServiceKey", quickstart);
         Assert.Contains("X-Gateway-Dry-Run", quickstart);
-        Assert.Contains("protocolDefinition(bundle.protocol).path", quickstart);
+        Assert.Contains("const definition = protocolDefinition(protocol);", quickstart);
+        Assert.Contains("PROTOCOLS.map((item) => item.ingressProtocol)", quickstart);
+        var quickstartTestStart = quickstart.IndexOf("const runDryRun", StringComparison.Ordinal);
+        var quickstartTestEnd = quickstart.IndexOf("const editIdentity", quickstartTestStart, StringComparison.Ordinal);
+        Assert.True(quickstartTestStart >= 0 && quickstartTestEnd > quickstartTestStart);
+        Assert.DoesNotContain("bundle.protocol", quickstart[quickstartTestStart..quickstartTestEnd]);
         Assert.Contains("upstreamCalled === false", quickstart);
         Assert.Contains("/logs?requestId=", quickstart);
         Assert.Contains("Agent Skill", quickstart);
@@ -3014,7 +3019,9 @@ public class GatewayDataDomainGuardTests
         Assert.True(System.Text.RegularExpressions.Regex.Matches(console, "TeamId = d.AsNullableString\\(\\\"TeamId\\\"\\)").Count >= 4);
 
         Assert.Contains("scopes: ['invoke']", quickstart);
-        Assert.Contains("ingressProtocols: [selectedProtocol.ingressProtocol]", quickstart);
+        Assert.Contains("ingressProtocols: PROTOCOLS.map((item) => item.ingressProtocol)", quickstart);
+        Assert.Contains("disabled={Boolean(bundle)}", quickstart);
+        Assert.Contains("修改身份", quickstart);
         Assert.DoesNotContain("tenantId:", quickstart);
         Assert.DoesNotContain("['*']", quickstart);
         Assert.Contains("location ^~ /gw/v1/", webNginx);


### PR DESCRIPTION
## 摘要

修复 Quickstart 一键签发后协议切换与密钥授权范围错位的问题。现在一把非通配、仅 `invoke` 的租户团队密钥精确覆盖四种 Gateway 协议，身份字段在签发后锁定，切换协议可直接安全测试且不会调用上游。

## 改动 diff

- `llmgw/web/src/pages/QuickstartPage.tsx`：解除协议与临时 bundle 的错误绑定；四协议共用一把 scoped key；锁定团队、appCaller、Client 与环境；补充修改身份提示。
- `prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs`：增加四协议同钥、切换协议不回退旧 bundle、禁止 tenantId 与禁止通配 key 的源码契约断言。
- `doc/plan.platform.llm-gateway-authoritative-tutorial.md`：写回 T2 实测证据并校正内部 appCallerCode 与 OpenRouter App 展示名的边界。
- `changelogs/2026-07-15_llmgw-quickstart-four-protocol-key.md`：记录修复、体验与测试变更。

## 测试

- [x] `pnpm --dir llmgw/web exec tsc --noEmit`
- [x] `pnpm --dir llmgw/web build`
- [x] 四协议 Quickstart 集成测试 1/1 通过，断言 GW Native、OpenAI、Claude、Gemini 均不调用上游并写入身份日志
- [x] GatewayDataDomainGuardTests 相关测试 2/2 通过
- [x] 隔离 Mongo 与本地浏览器实测：同一把 key 的 OpenAI、Claude dry-run 成功；无 key 返回 401；日志费用为 unknown 而非 0
- [x] `git diff --check` 与敏感信息扫描通过
- [ ] CI 通过
- [ ] CDS 公网预览通过

## 边界

- 不修改模型迁移、模型池、发布 gate、容器拓扑或生产密钥。
- Quickstart 测试仅走 dry-run，明确返回 `upstreamCalled=false`，不产生付费模型调用。
- Bugbot 已停用，本 PR 不等待 Bugbot。
