### PR TITLE
feat(llmgw): 打通 vision 快速接入与策略入口

### DIFF
--- a/changelogs/2026-07-15_llmgw-vision-quickstart.md
+++ b/changelogs/2026-07-15_llmgw-vision-quickstart.md
@@ -1,0 +1,2 @@
+| feat | llmgw | Quickstart 支持 chat 与 vision 自助创建、四协议零费用测试及 PromptPolicy 直达 |
+| test | prd-api | 补齐 chat/vision 八格协议、安全上游和租户费用边界回归 |

--- a/doc/plan.platform.llm-gateway-authoritative-tutorial.md
+++ b/doc/plan.platform.llm-gateway-authoritative-tutorial.md
@@ -121,7 +121,11 @@ T4-G2 只读逐页审计确认模型池规则和 PromptPolicy 数据边界无需
 
 G2-A 已关闭：PR #1143 正常合并为 `6f4d4937dfc795a8703c94ecbafbda08d7273df9`；标准非集成套件 1654 项通过、4 项跳过，publisher 定向与真实 Mongo 行为测试 26 项通过，三轮独立对抗复审最终为 0 个 P0、0 个未关闭 P1。CDS 单 profile 使用目标提交镜像通过 TCP/HTTP 探测；公网验收覆盖 401、403、created、noop、陈旧 CAS 409、安全回滚 200，临时知识库与 Key 清理回查均为 0。
 
-G2-B 当前进入发布验证阶段：前端以 `llmgw/console-api/Auth/TenantAccessContext.cs` 为服务端权威镜像五角色权限，未知角色在控制台布局与业务 API 挂载前失败关闭；导航、顶部 requestId 搜索、旧深链和配置写控件统一走中央能力表。Viewer 的 Quickstart 保留教程与示例但不创建 appCaller/key、不执行直测；Developer 可管理团队内 appCaller 与 scoped key，但不能创建通配 key、进入 PromptPolicy、审计或修改路由配置；Billing 只保留概览、用量、学习中心和本地设置。前端生产构建通过，Gateway 数据域与 RBAC 合同 79/79、CI 同口径标准测试 675/675 通过；独立复审最终为 0 个 P0、0 个 P1。PR、CI、CDS 与浏览器五角色负向取证完成前仍不得关闭 G2-B。
+G2-B 已关闭：PR #1145 正常 squash 合并为 `5aae0be79cdef75be17de39918e767a85141e961`。前端以 `llmgw/console-api/Auth/TenantAccessContext.cs` 为服务端权威镜像五角色权限，未知角色在控制台布局与业务 API 挂载前失败关闭；导航、顶部 requestId 搜索、旧深链和配置写控件统一走中央能力表。Viewer 的 Quickstart 保留教程与示例但不创建 appCaller/key、不执行直测；Developer 可管理团队内 appCaller 与 scoped key，但不能创建通配 key、进入 PromptPolicy、审计或修改路由配置；Billing 只保留概览、用量、学习中心和本地设置。前端生产构建、Gateway 数据域与 RBAC 合同 79/79、CI 同口径标准测试 675/675、GitHub CI、四镜像、CDS 完整部署和独立网关子域终验均通过；七张截图、十二项断言、双主题、零截图告警，独立复审为 0 个 P0、0 个 P1。不可变终验报告为 [G2-B 五角色 RBAC 独立子域终验](https://cds.miduo.org/reports?project=prd-agent&folder=4167d445397245de99b642ad507a38eb&report=4fcf98a863dd4b709c1b0a5ab329c9eb)。
+
+G2-C 精确计划：后端自助创建、PromptPolicy 版本与 serving 注入已经支持 `chat/vision`，本批不重写这些能力。当前断点仅在 Quickstart：`requestType`、appCaller 后缀校验、四协议示例和安全请求体全部写死为 chat，创建完成后也没有直达当前 appCaller 策略预览的入口。本批只做以下四项：第一，增加 chat/vision 调用类型选择，并自动保持 `appCallerCode` 的 `::chat/::vision` 后缀一致，手工输入不一致时在创建前明确拒绝；第二，为 GW Native、OpenAI、Claude、Gemini 分别生成 chat 或 vision 的真实协议形状，vision 仅携带内嵌占位图片并继续使用 `X-Gateway-Dry-Run: quickstart`，必须在模型解析和上游发送前结束；第三，在生成结果中显示 appCaller 类型、策略适用范围和当前角色可用的 PromptPolicy 预览入口，Developer 无配置权限时只说明由 Owner/Admin 管理；第四，把请求体、安全 header、`upstreamCalled=false` 成功门和“本页不提供付费开关”收进默认折叠的安全选项。完成门为 chat/vision 各自四协议共八个合同用例全部返回 requestId、写入同 TenantId/TeamId/ServiceKeyId 日志且无费用字段，上游对象若被调用则测试立即失败；前端生产构建、标准回归、CI、CDS、双主题与负向页面证据全部通过后才合并。
+
+G2-C 本地实现证据：Quickstart 已能选择文字对话或图片理解，自动同步 `::chat/::vision` 后缀；Viewer 可切换两类示例但不能创建，Developer 能创建团队 scoped 身份但只看到由 Owner/Admin 管理策略的说明，Owner/Admin 在生成后可直达对应 appCaller 的 PromptPolicy。创建阶段锁定身份字段，避免 appCaller 已按一种类型创建、界面却切换到另一类型的竞态。前端生产构建通过；chat/vision × GW Native/OpenAI/Claude/Gemini 八格安全测试使用 ThrowingGateway 通过，证明没有调用上游；Gateway 数据域守卫 79/79、协议与 key gate 92/92、标准非集成套件 1654 项通过且 4 项跳过、CI 同口径数据域套件 675/675 通过，解决方案编译 0 error。PR、CDS 和浏览器视觉证据未完成前仍保持进行中。
 
 逐页审计同时确认：Quickstart 的四协议 dry-run 只证明地址、鉴权、团队、appCaller、协议形状、日志和 requestId，不证明真实模型路由、流式、vision 或参数语义保真。第 27 章必须另用假上游契约测试覆盖这些内容，每类真实协议最多一次。
 
@@ -141,13 +145,13 @@ G2-B 当前进入发布验证阶段：前端以 `llmgw/console-api/Auth/TenantAc
 |---|---|---|---|
 | 事实审计 | 已完成 | 已确认 17 个页面、6 组导航、页面—API 关系和公开登录断点 | 在后续实测中持续记录新增断点 |
 | 教程设计 | 已完成 | 33 章三级目录、连续测试数据和截图合同已冻结 | 随实测补齐每章异常树，不改变连续主线 |
-| 产品修复 | 已完成当前教程前置批次 | T0、T1、T2、T3 均已独立合并；T3 PR #1134 修复提示词字符口径含混、请求日志多记字符数、操作审计多记字符数/上限/开关、费用页术语难懂和 appCaller 心智缺失五个问题，合并提交 `aef8d21cc` | T4 实测若发现新的断头流程，只在独立修复 PR 中处理，不把修复混入教程内容 PR |
+| 产品修复 | G2-C 进行中 | T0、T1、T2、T3 均已独立合并；G2-A、G2-B 已独立合并并验收，G2-B 合并提交为 `5aae0be79` | 在独立 G2-C 分支只修复 vision PromptPolicy 自助断链；不把费用或 Exchange 混入 |
 | 连续实测 | 进行中 | 四协议同钥、无 key 401、unknown cost 已通过；PromptPolicy 已完成 v1、v2、回滚生成 v3、当前运行态保存 v5；页面和 MongoDB 双向确认 v5 审计只含目标 id、version、policyHash；chat/vision、日志和四种费用状态定向测试 9/9 通过；PR #1134 CI/CDS 全绿，公网 health commit 一致，未登录审计与费用接口均返回 401 | T4 按 33 章顺序生成正文和截图，完成双主题、移动端、负面路径与新手复验 |
 | T4 流程补洞 | G1 已关闭 | 真实编写第 5 章时发现“后端已有成员生命周期、前端只能查看”的功能孤岛；已补齐创建成员、分配团队、改角色与状态、强制重新登录，并修正首次改密页公共默认口令误导和前后端 12 位口令门槛。对抗审查继续找出并修复旧页面并发覆盖、无团队 Developer、隐藏停用团队、自我锁死、Billing 死入口、既有全局账号被无确认挂载、授权范围审计缺失、停用 Owner 无法清理、跨租户用户名抢占、长租户 slug 与账号短名契约冲突、Developer 省略停用团队范围以及 pending 审计幂等误报成功等边界；成员关键变更先写包含 TenantId 的 pending 审计意图，再执行业务写入并收口完成态。隔离租户完成页面、HTTP API、审计集合与 MongoDB 双向验证，23 项行为断言与 91 项成员策略/数据域守卫通过，成功操作没有残留 pending 审计，故障注入下 pending 幂等重放被拒绝；PR #1138、CI、CDS、公网独立网关子域及浏览器复验全部通过，合并提交 `29f4e38e` | G1 已关闭；本地验收账号在证据归档完成后已定向清理。下一步只推进 G2 的 33 章连续实测，不把后续内容混回已合并修复 PR |
 | T4 视觉验收 | G1、G3、G4 已关闭 | 完成 18 张有效标注截图的逐张人工回读；覆盖点击导航、租户边界、Developer 无团队负例、创建与列表读回、自我锁死保护、强制重新登录、成员审计、首次口令、短口令拒绝、Billing 导航、浅色、深色和手机抽屉。manifest 为 18/18 已标注、0 warning，自动捕获 P0/P1 为 0；公网独立网关子域页面与主脚本 200，未登录组织接口 401，health commit 对齐，浏览器跳登录页且页面错误为 0 | 继续 G2 正文与 G5 新手复验；整本教程最终报告仍等待五门全部关闭 |
 | 低理解力复验 | 基线完成 | 无背景智能体无法从公开入口完成首请求 | 教程发布后重新复验 |
 | MAP 发布 | 在途总览已发布 | “模型网关权威教程”已建立唯一在途文档“LLM Gateway 权威教程：实时验收总览”，展示固定权重、PR、证据、问题和未完成项；仓库与本地在途报告已更新为总进度 62%、T4 3/5 | 持续更新同一文档；恢复 MAP SSO 会话后同步同一固定数值，G2 完成后再写入 33 章正文和图片 |
-| CDS 验收归档 | T4-G1 合并后报告已完成 | [T4-G1 合并后验收报告](https://cds.miduo.org/reports?project=prd-agent&folder=4167d445397245de99b642ad507a38eb&report=12f1a576458d4ba1b042edd1a8e707c8) 已按项目和月份归档；真实浏览器命中标题 1、报告 iframe 1、图片节点 54、`Verdict: 通过` 1 | 整本教程最终报告仍须等待 G2、G5；当前报告保持内部登录态，不扩大为匿名公开 |
+| CDS 验收归档 | G1、G2-B 增量报告已完成 | [T4-G1 合并后验收报告](https://cds.miduo.org/reports?project=prd-agent&folder=4167d445397245de99b642ad507a38eb&report=12f1a576458d4ba1b042edd1a8e707c8) 与 [G2-B 独立子域终验报告](https://cds.miduo.org/reports?project=prd-agent&folder=4167d445397245de99b642ad507a38eb&report=4fcf98a863dd4b709c1b0a5ab329c9eb) 已归档并由登录态浏览器实开 | 整本教程最终报告仍须等待 G2、G5；增量报告保持内部登录态，不扩大为匿名公开 |
 
 ## 八、实时可见与固定进度
 

--- a/llmgw/web/src/pages/QuickstartPage.tsx
+++ b/llmgw/web/src/pages/QuickstartPage.tsx
@@ -8,6 +8,7 @@ import { useAuth } from '@/lib/auth';
 import { canUseCapability } from '@/lib/access';
 
 type Protocol = 'native' | 'openai' | 'claude' | 'gemini';
+type RequestType = 'chat' | 'vision';
 type SnippetTab = 'curl' | 'env' | 'skill';
 
 type ProtocolDefinition = {
@@ -21,7 +22,9 @@ type AccessBundle = {
   key: string;
   keyId: string;
   keyPrefix: string;
+  appCallerId: string;
   appCallerCode: string;
+  requestType: RequestType;
   clientCode: string;
   environment: string;
   teamId: string;
@@ -39,10 +42,19 @@ const PROTOCOLS: ProtocolDefinition[] = [
   { id: 'gemini', label: 'Gemini', path: '/v1beta/models/auto:generateContent', ingressProtocol: 'gemini-compatible' },
 ];
 
+const REQUEST_TYPES: Array<{ id: RequestType; label: string; description: string }> = [
+  { id: 'chat', label: '文字对话', description: '发送普通文字消息，适合问答、总结和 Agent 推理。' },
+  { id: 'vision', label: '图片理解', description: '发送一张内嵌测试图片，验证多模态请求与 vision 策略链。' },
+];
+
+const TEST_IMAGE_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
+
 export function QuickstartPage() {
   const { tenant } = useAuth();
   const canCreateAccess = canUseCapability(tenant?.role, 'appCallerWrite') && canUseCapability(tenant?.role, 'serviceKeyWrite');
+  const canManagePromptPolicy = canUseCapability(tenant?.role, 'configWrite');
   const [protocol, setProtocol] = useState<Protocol>('openai');
+  const [requestType, setRequestType] = useState<RequestType>('chat');
   const [baseUrl, setBaseUrl] = useState(resolveDefaultServingBaseUrl);
   const [appCallerCode, setAppCallerCode] = useState('my-agent.quickstart::chat');
   const [clientCode, setClientCode] = useState('my-agent');
@@ -61,6 +73,7 @@ export function QuickstartPage() {
 
   const selectedProtocol = protocolDefinition(protocol);
   const activeTeams = organization?.teams.filter((team) => team.status === 'active') ?? [];
+  const identityLocked = Boolean(bundle) || creatingStage !== null;
 
   useEffect(() => {
     let active = true;
@@ -85,18 +98,20 @@ export function QuickstartPage() {
     key: bundle?.key ?? '',
     keyId: bundle?.keyId ?? '',
     keyPrefix: bundle?.keyPrefix ?? 'gwk_',
+    appCallerId: bundle?.appCallerId ?? '',
     protocol,
     baseUrl: baseUrl.replace(/\/$/, ''),
     appCallerCode: bundle?.appCallerCode ?? (appCallerCode.trim() || 'my-agent.quickstart::chat'),
+    requestType: bundle?.requestType ?? requestType,
     clientCode: bundle?.clientCode ?? (clientCode.trim() || 'my-agent'),
     environment: bundle?.environment ?? environment,
     teamId: bundle?.teamId ?? teamId,
   };
   const snippets = useMemo(() => ({
-    curl: exampleFor(displayBundle.protocol, displayBundle.baseUrl, displayBundle.appCallerCode),
+    curl: exampleFor(displayBundle.protocol, displayBundle.requestType, displayBundle.baseUrl, displayBundle.appCallerCode),
     env: environmentSnippet(displayBundle),
     skill: agentSkillSnippet(displayBundle),
-  }), [displayBundle.protocol, displayBundle.baseUrl, displayBundle.appCallerCode, displayBundle.key, displayBundle.clientCode, displayBundle.environment]);
+  }), [displayBundle.protocol, displayBundle.requestType, displayBundle.baseUrl, displayBundle.appCallerCode, displayBundle.key, displayBundle.clientCode, displayBundle.environment]);
   const visibleSnippet = snippets[snippetTab];
 
   const copyText = async (name: string, value: string) => {
@@ -109,8 +124,8 @@ export function QuickstartPage() {
     const normalizedCode = appCallerCode.trim();
     const normalizedClient = clientCode.trim().toLowerCase();
     const normalizedBaseUrl = baseUrl.trim().replace(/\/$/, '');
-    if (!teamId || !normalizedBaseUrl || !isValidAppCaller(normalizedCode) || !/^[a-z][a-z0-9._-]{1,79}$/.test(normalizedClient)) {
-      setActionError('请确认团队、Gateway 地址、appCallerCode 和 clientCode 均有效。');
+    if (!teamId || !normalizedBaseUrl || !isValidAppCaller(normalizedCode, requestType) || !/^[a-z][a-z0-9._-]{1,79}$/.test(normalizedClient)) {
+      setActionError(`请确认团队、Gateway 地址和 clientCode 有效，并让 appCallerCode 以 ::${requestType} 结尾。`);
       return;
     }
     if (bundle && !window.confirm('将签发一把新密钥，现有密钥不会自动撤销。确认继续？')) return;
@@ -121,8 +136,8 @@ export function QuickstartPage() {
     const callerResponse = await createGatewayAppCaller({
       teamId,
       appCallerCode: normalizedCode,
-      requestType: 'chat',
-      title: `${normalizedClient} Quickstart`,
+      requestType,
+      title: `${normalizedClient} ${requestType === 'vision' ? '图片理解' : '文字对话'} Quickstart`,
       ingressProtocol: selectedProtocol.ingressProtocol,
     });
     if (!callerResponse.success) {
@@ -154,7 +169,9 @@ export function QuickstartPage() {
       key: keyResponse.data.key,
       keyId: keyResponse.data.id,
       keyPrefix: keyResponse.data.keyPrefix,
+      appCallerId: callerResponse.data.id,
       appCallerCode: normalizedCode,
+      requestType,
       clientCode: normalizedClient,
       environment,
       teamId,
@@ -181,7 +198,7 @@ export function QuickstartPage() {
           'X-Gateway-Dry-Run': 'quickstart',
           'X-Request-Id': requestId,
         },
-        body: JSON.stringify(dryRunBody(protocol, bundle.appCallerCode, requestId)),
+        body: JSON.stringify(dryRunBody(protocol, bundle.requestType, bundle.appCallerCode, requestId)),
         credentials: 'omit',
       });
       const payload = await response.json().catch(() => null) as Record<string, unknown> | null;
@@ -190,7 +207,7 @@ export function QuickstartPage() {
       if (!response.ok) {
         setTestResult({ ok: false, message: readErrorMessage(payload) || `dry-run 失败，HTTP ${response.status}`, requestId: actualRequestId });
       } else if (upstreamCalled === false) {
-        setTestResult({ ok: true, message: `${definition.label} 协议、团队边界和密钥鉴权均通过；已写入请求记录，未访问上游。`, requestId: actualRequestId });
+        setTestResult({ ok: true, message: `${definition.label} 的 ${requestTypeLabel(bundle.requestType)}、团队边界和密钥鉴权均通过；已写入请求记录，未访问上游。`, requestId: actualRequestId });
       } else {
         setTestResult({ ok: false, message: 'Gateway 未明确证明 upstreamCalled=false，本次结果不计为安全验收。', requestId: actualRequestId });
       }
@@ -209,8 +226,19 @@ export function QuickstartPage() {
     setSnippetTab('curl');
   };
 
+  const changeRequestType = (next: RequestType) => {
+    setRequestType(next);
+    setAppCallerCode((current) => {
+      const trimmed = current.trim();
+      if (/::(?:chat|vision)$/.test(trimmed)) return trimmed.replace(/::(?:chat|vision)$/, `::${next}`);
+      if (!trimmed.includes('::')) return `${trimmed}::${next}`;
+      return trimmed;
+    });
+    setTestResult(null);
+  };
+
   return (
-    <div style={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
+    <div style={{ flex: 1, minHeight: 0, overflow: 'auto', overscrollBehavior: 'contain' }}>
       <div style={{ maxWidth: 1080, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 16 }}>
         <header>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}><Rocket size={18} /><h1 style={{ margin: 0, fontSize: 18 }}>Quickstart</h1></div>
@@ -218,7 +246,7 @@ export function QuickstartPage() {
         </header>
 
         <section className="lg-quickstart-steps" style={{ ...gridStyle, gridTemplateColumns: 'repeat(3, minmax(0, 1fr))' }}>
-          <Step number="1" title="确认用途" text="选择团队、协议和 appCallerCode。appCaller 表示为什么调用，密钥表示谁在调用。" />
+          <Step number="1" title="确认用途" text="选择文字对话或图片理解、团队、协议和 appCallerCode。appCaller 表示为什么调用，密钥表示谁在调用。" />
           <Step number="2" title="生成配置" text="同页创建 appCaller 并签发团队密钥。明文只保存在本页内存，刷新后不可找回。" />
           <Step number="3" title="测试并回查" text="点击测试当前协议，Gateway 不访问上游，但会返回 requestId 并写入租户请求记录。" />
         </section>
@@ -230,13 +258,31 @@ export function QuickstartPage() {
           {organizationError ? <div className="lg-test-result is-error">{organizationError}</div> : null}
           {!organizationLoading ? (
             <div className="lg-quickstart-inputs" style={{ display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: 10 }}>
-              <label style={labelStyle}>团队<select value={teamId} disabled={!canCreateAccess || Boolean(bundle)} onChange={(event) => setTeamId(event.target.value)} style={inputStyle}>
+              <div style={{ gridColumn: '1 / -1' }}>
+                <div style={labelStyle}>调用类型</div>
+                <div className="lg-quickstart-request-types" style={{ display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: 8, marginTop: 5 }}>
+                  {REQUEST_TYPES.map((item) => (
+                    <button
+                      key={item.id}
+                      type="button"
+                      disabled={identityLocked}
+                      onClick={() => changeRequestType(item.id)}
+                      aria-pressed={requestType === item.id}
+                      style={{ padding: '10px 12px', textAlign: 'left', cursor: identityLocked ? 'not-allowed' : 'pointer', borderRadius: 'var(--radius-sm)', border: requestType === item.id ? '1px solid var(--accent)' : '1px solid var(--border-subtle)', background: requestType === item.id ? 'var(--accent-soft)' : 'var(--bg-input)', color: 'var(--text-primary)', opacity: identityLocked ? 0.7 : 1 }}
+                    >
+                      <strong style={{ display: 'block', fontSize: 12 }}>{item.label}</strong>
+                      <span style={{ display: 'block', marginTop: 3, color: 'var(--text-muted)', fontSize: 11, lineHeight: 1.45 }}>{item.description}</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+              <label style={labelStyle}>团队<select value={teamId} disabled={!canCreateAccess || identityLocked} onChange={(event) => setTeamId(event.target.value)} style={inputStyle}>
                 <option value="">选择团队</option>
                 {activeTeams.map((team) => <option key={team.id} value={team.id}>{team.name}</option>)}
               </select></label>
-              <Field label="appCallerCode" value={appCallerCode} onChange={setAppCallerCode} placeholder="my-agent.quickstart::chat" disabled={!canCreateAccess || Boolean(bundle)} />
-              <Field label="Client code" value={clientCode} onChange={setClientCode} placeholder="my-agent" disabled={!canCreateAccess || Boolean(bundle)} />
-              <label style={labelStyle}>环境<select value={environment} disabled={!canCreateAccess || Boolean(bundle)} onChange={(event) => setEnvironment(event.target.value)} style={inputStyle}>
+              <Field label={`appCallerCode（必须以 ::${requestType} 结尾）`} value={appCallerCode} onChange={setAppCallerCode} placeholder={`my-agent.quickstart::${requestType}`} disabled={!canCreateAccess || identityLocked} />
+              <Field label="Client code" value={clientCode} onChange={setClientCode} placeholder="my-agent" disabled={!canCreateAccess || identityLocked} />
+              <label style={labelStyle}>环境<select value={environment} disabled={!canCreateAccess || identityLocked} onChange={(event) => setEnvironment(event.target.value)} style={inputStyle}>
                 <option value="development">开发</option><option value="test">测试</option><option value="staging">预发布</option><option value="production">生产</option>
               </select></label>
             </div>
@@ -253,7 +299,7 @@ export function QuickstartPage() {
           <details className="lg-advanced-base-url"><summary>使用其他 Gateway 地址</summary><Field label="自定义 Gateway 地址" value={baseUrl} onChange={setBaseUrl} /></details>
 
           <div className="lg-quickstart-actions">
-            <div><strong>{creatingStage === 'app-caller' ? '正在创建 appCaller' : creatingStage === 'key' ? '正在签发团队密钥' : bundle ? '接入配置已生成' : '尚未生成接入配置'}</strong><small>{bundle ? `密钥 ${bundle.keyPrefix}，只授权当前 appCaller 和上方四种协议；切换协议后可直接测试。` : '不会创建通配 key，也不会调用付费模型。'}</small></div>
+            <div><strong>{creatingStage === 'app-caller' ? '正在创建 appCaller' : creatingStage === 'key' ? '正在签发团队密钥' : bundle ? '接入配置已生成' : '尚未生成接入配置'}</strong><small>{bundle ? `密钥 ${bundle.keyPrefix}，只授权当前 ${requestTypeLabel(bundle.requestType)} appCaller 和上方四种协议；切换协议后可直接测试。` : '不会创建通配 key，也不会调用付费模型。'}</small></div>
             <div style={{ display: 'flex', gap: 7, flexWrap: 'wrap', justifyContent: 'flex-end' }}>
               {canCreateAccess && bundle ? <Button variant="ghost" onClick={editIdentity}>修改身份</Button> : null}
               {canCreateAccess ? <Button variant="primary" disabled={organizationLoading || creatingStage !== null || activeTeams.length === 0} onClick={() => void createAccessBundle()}><KeyRound size={14} />{creatingStage ? '生成中' : bundle ? '再签一把同配置 key' : '一键生成 appCaller 与 key'}</Button> : null}
@@ -269,11 +315,28 @@ export function QuickstartPage() {
           ) : null}
           {actionError ? <div className="lg-test-result is-error" role="alert">{actionError}</div> : null}
 
+          {bundle ? (
+            <div style={{ marginTop: 12, padding: 12, border: '1px solid var(--border-subtle)', borderRadius: 'var(--radius-sm)', background: 'var(--bg-input)', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10, flexWrap: 'wrap' }}>
+              <div><strong style={{ fontSize: 12 }}>下一步：给这个 {requestTypeLabel(bundle.requestType)} appCaller 配置提示词策略</strong><small style={{ display: 'block', marginTop: 4, color: 'var(--text-muted)', fontSize: 11 }}>策略预览不保存、不调用模型；保存后日志只记录 policy id、version 和 hash。</small></div>
+              {canManagePromptPolicy ? <Link to={`/app-callers/${encodeURIComponent(bundle.appCallerId)}/prompt-policy`} style={{ color: 'var(--accent)', fontSize: 12, fontWeight: 650 }}>打开提示词策略</Link> : <span style={{ color: 'var(--text-muted)', fontSize: 11 }}>请由 Owner 或 Admin 配置策略</span>}
+            </div>
+          ) : null}
+
           <div className="lg-safe-test-panel" style={{ marginTop: 12 }}>
-            <div><Play size={17} /><span><strong>测试当前协议</strong><small>请求会发送到 {selectedProtocol.path}，经过 service key 与团队治理后写日志，并在模型解析前结束。</small></span></div>
+            <div><Play size={17} /><span><strong>测试当前协议与调用类型</strong><small>请求会发送到 {selectedProtocol.path}，按 {requestTypeLabel(displayBundle.requestType)} 的真实请求形状通过 service key 与团队治理，并在模型解析前结束。</small></span></div>
             <div className="lg-safe-test-controls">{canCreateAccess ? <Button variant="primary" disabled={!bundle || testing} onClick={() => void runDryRun()}>{testing ? '正在测试并写日志' : '点击测试'}</Button> : null}<span style={{ alignSelf: 'center', color: 'var(--text-muted)', fontSize: 11 }}>{canCreateAccess ? '明确返回 upstreamCalled=false 才算通过' : '请联系 Owner、Admin 或 Developer 完成签发与测试'}</span></div>
             {testResult ? <div className={testResult.ok ? 'lg-test-result is-ok' : 'lg-test-result is-error'} role="status">{testResult.message}{testResult.requestId ? <Link to={`/logs?requestId=${encodeURIComponent(testResult.requestId)}`}>打开 requestId 请求记录</Link> : null}</div> : null}
           </div>
+
+          <details className="lg-quickstart-safety" style={{ marginTop: 10, padding: '10px 12px', border: '1px solid var(--border-subtle)', borderRadius: 'var(--radius-sm)', background: 'var(--bg-surface)' }}>
+            <summary style={{ cursor: 'pointer', color: 'var(--text-primary)', fontSize: 12, fontWeight: 650 }}>展开安全测试选项</summary>
+            <dl style={{ ...dlStyle, marginTop: 10 }}>
+              <RouteRow name="固定安全模式" text="始终发送 X-Gateway-Dry-Run: quickstart；本页不提供关闭开关，也不会访问付费上游。" />
+              <RouteRow name="调用类型" text={displayBundle.requestType === 'vision' ? '图片理解：使用内嵌的 1×1 测试图片，只验证多模态协议形状，不读取用户文件。' : '文字对话：使用固定的测试文字，只验证 chat 协议形状。'} />
+              <RouteRow name="通过标准" text="HTTP 成功、返回 requestId，并且 Gateway 明确返回 upstreamCalled=false；缺少任一项都不算通过。" />
+              <RouteRow name="审计边界" text="日志记录服务端解析的 tenant、team、service key、client 和 environment；不记录密钥明文，费用保持 unknown。" />
+            </dl>
+          </details>
 
           <div className="lg-snippet-tabs">
             <Button size="sm" variant={snippetTab === 'curl' ? 'primary' : 'ghost'} onClick={() => setSnippetTab('curl')}>cURL</Button>
@@ -310,8 +373,7 @@ export function QuickstartPage() {
         <section style={cardStyle}>
           <h2 style={headingStyle}><KeyRound size={15} />能力边界</h2>
           <div style={{ display: 'flex', flexWrap: 'wrap', gap: 7 }}>
-            <Chip label="本页一键测试: chat 四协议" color="#3fb950" bg="rgba(63,185,80,0.14)" />
-            <Chip label="vision: 同一治理链，需多模态请求体" color="#8b949e" bg="rgba(139,148,158,0.14)" />
+            <Chip label="本页一键测试: chat/vision 四协议" color="#3fb950" bg="rgba(63,185,80,0.14)" />
             <Chip label="dry-run: 不访问上游" color="#58a6ff" bg="rgba(88,166,255,0.14)" />
             <Chip label="费用: dry-run 保持未知" color="#d29922" bg="rgba(210,153,34,0.14)" />
           </div>
@@ -337,8 +399,12 @@ function normalizeClientCode(value: string) {
   return normalized.length >= 2 ? `${normalized}-agent`.slice(0, 80) : 'my-agent';
 }
 
-function isValidAppCaller(value: string) {
-  return /^[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)+::chat$/.test(value) && value.length <= 200;
+function isValidAppCaller(value: string, requestType: RequestType) {
+  return new RegExp(`^[a-z][a-z0-9-]*(\\.[a-z][a-z0-9-]*)+::${requestType}$`).test(value) && value.length <= 200;
+}
+
+function requestTypeLabel(requestType: RequestType) {
+  return requestType === 'vision' ? '图片理解' : '文字对话';
 }
 
 function createRequestId() {
@@ -348,16 +414,37 @@ function createRequestId() {
   return `quickstart-${suffix.slice(0, 24)}`;
 }
 
-function dryRunBody(protocol: Protocol, appCallerCode: string, requestId: string) {
+function dryRunBody(protocol: Protocol, requestType: RequestType, appCallerCode: string, requestId: string) {
   if (protocol === 'native') return {
     appCallerCode,
-    modelType: 'chat',
-    requestBody: { messages: [{ role: 'user', content: 'Reply with OK' }] },
+    modelType: requestType,
+    requestBody: { messages: [{ role: 'user', content: requestType === 'vision' ? visionOpenAiContent() : 'Reply with OK' }] },
     context: { requestId, sourceSystem: 'external', modelPolicy: 'auto' },
   };
-  if (protocol === 'claude') return { model: 'auto', model_policy: 'auto', max_tokens: 64, messages: [{ role: 'user', content: 'Reply with OK' }] };
-  if (protocol === 'gemini') return { model_policy: 'auto', contents: [{ role: 'user', parts: [{ text: 'Reply with OK' }] }] };
-  return { model: 'auto', model_policy: 'auto', messages: [{ role: 'user', content: 'Reply with OK' }], stream: false };
+  if (protocol === 'claude') return { model: 'auto', model_policy: 'auto', max_tokens: 64, messages: [{ role: 'user', content: requestType === 'vision' ? visionClaudeContent() : 'Reply with OK' }] };
+  if (protocol === 'gemini') return { model_policy: 'auto', contents: [{ role: 'user', parts: requestType === 'vision' ? visionGeminiParts() : [{ text: 'Reply with OK' }] }] };
+  return { model: 'auto', model_policy: 'auto', messages: [{ role: 'user', content: requestType === 'vision' ? visionOpenAiContent() : 'Reply with OK' }], stream: false };
+}
+
+function visionOpenAiContent() {
+  return [
+    { type: 'text', text: 'Describe this test image' },
+    { type: 'image_url', image_url: { url: `data:image/png;base64,${TEST_IMAGE_BASE64}` } },
+  ];
+}
+
+function visionClaudeContent() {
+  return [
+    { type: 'text', text: 'Describe this test image' },
+    { type: 'image', source: { type: 'base64', media_type: 'image/png', data: TEST_IMAGE_BASE64 } },
+  ];
+}
+
+function visionGeminiParts() {
+  return [
+    { text: 'Describe this test image' },
+    { inlineData: { mimeType: 'image/png', data: TEST_IMAGE_BASE64 } },
+  ];
 }
 
 function readRequestId(response: Response, payload: Record<string, unknown> | null) {
@@ -391,6 +478,7 @@ function environmentSnippet(bundle: DisplayBundle) {
   return `export LLMGW_BASE_URL="${bundle.baseUrl}"
 export LLMGW_API_KEY="${bundle.key || 'YOUR_ONE_TIME_LLMGW_KEY'}"
 export LLMGW_APP_CALLER="${bundle.appCallerCode}"
+export LLMGW_REQUEST_TYPE="${bundle.requestType}"
 export LLMGW_PROTOCOL="${protocolDefinition(bundle.protocol).ingressProtocol}"
 export LLMGW_CLIENT_CODE="${bundle.clientCode}"
 export LLMGW_ENVIRONMENT="${bundle.environment}"`;
@@ -410,6 +498,7 @@ description: 通过团队 scoped key 使用 LLM Gateway 的 ${definition.label} 
 - LLMGW_BASE_URL=${bundle.baseUrl}
 - LLMGW_API_KEY 由部署 Secret 注入，禁止写入仓库
 - LLMGW_APP_CALLER=${bundle.appCallerCode}
+- LLMGW_REQUEST_TYPE=${bundle.requestType}
 
 ## 执行规则
 
@@ -427,14 +516,14 @@ description: 通过团队 scoped key 使用 LLM Gateway 的 ${definition.label} 
 - 401 时轮换密钥；403 时检查 team、appCaller、协议和 scope，禁止通过扩大到通配 key 绕过。`;
 }
 
-function exampleFor(protocol: Protocol, baseUrl: string, appCaller: string) {
+function exampleFor(protocol: Protocol, requestType: RequestType, baseUrl: string, appCaller: string) {
   const definition = protocolDefinition(protocol);
   const common = `-H "Authorization: Bearer \$LLMGW_API_KEY" \\
   -H "X-Gateway-Source: external" \\
   -H "X-Gateway-App-Caller: ${appCaller}" \\
   -H "X-Gateway-Dry-Run: quickstart" \\
   -H "X-Request-Id: quickstart-\$(date +%s)"`;
-  const body = JSON.stringify(dryRunBody(protocol, appCaller, 'quickstart-curl'), null, 2);
+  const body = JSON.stringify(dryRunBody(protocol, requestType, appCaller, 'quickstart-curl'), null, 2);
   const extra = protocol === 'claude' ? ' \\\n  -H "anthropic-version: 2023-06-01"' : '';
   return `curl "${baseUrl}${definition.path}" \\
   ${common}${extra} \\

--- a/llmgw/web/src/theme.css
+++ b/llmgw/web/src/theme.css
@@ -194,7 +194,8 @@ a:focus-visible {
 
   .lg-quickstart-steps,
   .lg-quickstart-detail-grid,
-  .lg-quickstart-inputs {
+  .lg-quickstart-inputs,
+  .lg-quickstart-request-types {
     grid-template-columns: minmax(0, 1fr) !important;
   }
 

--- a/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayKeyGateContractTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayKeyGateContractTests.cs
@@ -2366,7 +2366,7 @@ public class GatewayKeyGateContractTests
     }
 
     [Fact]
-    public async Task QuickstartDryRun_UsesFourRealProtocolPathsWithoutCallingUpstreamAndWritesIdentityLogs()
+    public async Task QuickstartDryRun_UsesChatAndVisionAcrossFourProtocolsWithoutCallingUpstream()
     {
         var connectionString = Environment.GetEnvironmentVariable("MONGODB_TEST_CONNECTION")
                                ?? "mongodb://127.0.0.1:27017";
@@ -2376,48 +2376,51 @@ public class GatewayKeyGateContractTests
         var data = new LlmGatewayDataContext(connectionString, databaseName);
         try
         {
-            await data.Database.GetCollection<GatewayAppCallerRecord>("llmgw_app_callers").InsertOneAsync(new GatewayAppCallerRecord
-            {
-                TenantId = "tenant-test",
-                TeamId = "team-test",
-                AppCallerCode = "content.quickstart::chat",
-                RequestType = "chat",
-                SourceSystem = "external",
-                Status = "configured",
-                ModelPolicy = "auto",
-                ParameterPolicy = "default-drop",
-                Title = "Content Quickstart",
-            });
+            await data.Database.GetCollection<GatewayAppCallerRecord>("llmgw_app_callers").InsertManyAsync(
+            [
+                new GatewayAppCallerRecord
+                {
+                    TenantId = "tenant-test",
+                    TeamId = "team-test",
+                    AppCallerCode = "content.quickstart::chat",
+                    RequestType = "chat",
+                    SourceSystem = "external",
+                    Status = "configured",
+                    ModelPolicy = "auto",
+                    ParameterPolicy = "default-drop",
+                    Title = "Content Chat Quickstart",
+                },
+                new GatewayAppCallerRecord
+                {
+                    TenantId = "tenant-test",
+                    TeamId = "team-test",
+                    AppCallerCode = "content.quickstart::vision",
+                    RequestType = "vision",
+                    SourceSystem = "external",
+                    Status = "configured",
+                    ModelPolicy = "auto",
+                    ParameterPolicy = "default-drop",
+                    Title = "Content Vision Quickstart",
+                },
+            ]);
             var authorizer = new CapturingScopedKeyAuthorizer(scope => scope == "invoke");
             await using var app = BuildHostWithGateway(new ThrowingGateway(), keyAuthorizer: authorizer, gatewayData: data);
             await app.StartAsync();
-            var cases = new[]
+            (string Path, string Body, string AppCallerCode, string RequestType)[] cases =
             {
-                new
-                {
-                    Path = "/gw/v1/invoke",
-                    Body = "{\"appCallerCode\":\"content.quickstart::chat\",\"modelType\":\"chat\",\"requestBody\":{\"messages\":[{\"role\":\"user\",\"content\":\"OK\"}]},\"context\":{\"sourceSystem\":\"external\"}}",
-                },
-                new
-                {
-                    Path = "/v1/chat/completions",
-                    Body = "{\"model\":\"auto\",\"messages\":[{\"role\":\"user\",\"content\":\"OK\"}],\"stream\":false}",
-                },
-                new
-                {
-                    Path = "/v1/messages",
-                    Body = "{\"model\":\"auto\",\"max_tokens\":8,\"messages\":[{\"role\":\"user\",\"content\":\"OK\"}]}",
-                },
-                new
-                {
-                    Path = "/v1beta/models/auto:generateContent",
-                    Body = "{\"contents\":[{\"role\":\"user\",\"parts\":[{\"text\":\"OK\"}]}]}",
-                },
+                ("/gw/v1/invoke", "{\"appCallerCode\":\"content.quickstart::chat\",\"modelType\":\"chat\",\"requestBody\":{\"messages\":[{\"role\":\"user\",\"content\":\"OK\"}]},\"context\":{\"sourceSystem\":\"external\"}}", "content.quickstart::chat", "chat"),
+                ("/v1/chat/completions", "{\"model\":\"auto\",\"messages\":[{\"role\":\"user\",\"content\":\"OK\"}],\"stream\":false}", "content.quickstart::chat", "chat"),
+                ("/v1/messages", "{\"model\":\"auto\",\"max_tokens\":8,\"messages\":[{\"role\":\"user\",\"content\":\"OK\"}]}", "content.quickstart::chat", "chat"),
+                ("/v1beta/models/auto:generateContent", "{\"contents\":[{\"role\":\"user\",\"parts\":[{\"text\":\"OK\"}]}]}", "content.quickstart::chat", "chat"),
+                ("/gw/v1/invoke", "{\"appCallerCode\":\"content.quickstart::vision\",\"modelType\":\"vision\",\"requestBody\":{\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"Describe\"},{\"type\":\"image_url\",\"image_url\":{\"url\":\"data:image/png;base64,AAAA\"}}]}]},\"context\":{\"sourceSystem\":\"external\"}}", "content.quickstart::vision", "vision"),
+                ("/v1/chat/completions", "{\"model\":\"auto\",\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"Describe\"},{\"type\":\"image_url\",\"image_url\":{\"url\":\"data:image/png;base64,AAAA\"}}]}],\"stream\":false}", "content.quickstart::vision", "vision"),
+                ("/v1/messages", "{\"model\":\"auto\",\"max_tokens\":8,\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"Describe\"},{\"type\":\"image\",\"source\":{\"type\":\"base64\",\"media_type\":\"image/png\",\"data\":\"AAAA\"}}]}]}", "content.quickstart::vision", "vision"),
+                ("/v1beta/models/auto:generateContent", "{\"contents\":[{\"role\":\"user\",\"parts\":[{\"text\":\"Describe\"},{\"inlineData\":{\"mimeType\":\"image/png\",\"data\":\"AAAA\"}}]}]}", "content.quickstart::vision", "vision"),
             };
 
             for (var index = 0; index < cases.Length; index++)
             {
-                var requestId = $"quickstart-four-protocols-{index}";
+                var requestId = $"quickstart-{cases[index].RequestType}-{index}";
                 using var request = new HttpRequestMessage(HttpMethod.Post, cases[index].Path)
                 {
                     Content = new StringContent(cases[index].Body, System.Text.Encoding.UTF8, "application/json"),
@@ -2425,7 +2428,7 @@ public class GatewayKeyGateContractTests
                     {
                         { "X-Gateway-Key", "scoped-test-key" },
                         { "X-Gateway-Source", "external" },
-                        { "X-Gateway-App-Caller", "content.quickstart::chat" },
+                        { "X-Gateway-App-Caller", cases[index].AppCallerCode },
                         { "X-Gateway-Dry-Run", "quickstart" },
                         { "X-Request-Id", requestId },
                     },
@@ -2444,7 +2447,7 @@ public class GatewayKeyGateContractTests
                 .Find(Builders<BsonDocument>.Filter.Eq("Provider", "gateway-dry-run"))
                 .Sort(Builders<BsonDocument>.Sort.Ascending("RequestId"))
                 .ToListAsync();
-            logs.Count.ShouldBe(4);
+            logs.Count.ShouldBe(8);
             logs.Select(x => x["IngressProtocol"].AsString).ToHashSet().SetEquals(new[]
             {
                 "gw-native", "openai-compatible", "claude-compatible", "gemini-compatible",
@@ -2457,18 +2460,23 @@ public class GatewayKeyGateContractTests
                 log["ClientCode"].AsString.ShouldBe("content-agent");
                 log["Environment"].AsString.ShouldBe("test");
                 log["Status"].AsString.ShouldBe("succeeded");
+                log["RequestType"].AsString.ShouldBe(log["AppCallerCode"].AsString.EndsWith("::vision", StringComparison.Ordinal) ? "vision" : "chat");
                 log.Contains("EstimatedCost").ShouldBeFalse();
                 log.Contains("EstimatedCostUsd").ShouldBeFalse();
             }
 
-            var caller = await data.Database.GetCollection<GatewayAppCallerRecord>("llmgw_app_callers")
-                .Find(x => x.TenantId == "tenant-test" && x.AppCallerCode == "content.quickstart::chat")
-                .SingleAsync();
-            caller.TotalSeen.ShouldBe(4);
-            caller.ObservedIngressProtocols.ToHashSet().SetEquals(new[]
+            var callers = await data.Database.GetCollection<GatewayAppCallerRecord>("llmgw_app_callers")
+                .Find(x => x.TenantId == "tenant-test" && x.AppCallerCode.StartsWith("content.quickstart::"))
+                .ToListAsync();
+            callers.Count.ShouldBe(2);
+            foreach (var caller in callers)
             {
-                "gw-native", "openai-compatible", "claude-compatible", "gemini-compatible",
-            }).ShouldBeTrue();
+                caller.TotalSeen.ShouldBe(4);
+                caller.ObservedIngressProtocols.ToHashSet().SetEquals(new[]
+                {
+                    "gw-native", "openai-compatible", "claude-compatible", "gemini-compatible",
+                }).ShouldBeTrue();
+            }
         }
         finally
         {

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -3145,7 +3145,17 @@ public class GatewayDataDomainGuardTests
 
         Assert.Contains("scopes: ['invoke']", quickstart);
         Assert.Contains("ingressProtocols: PROTOCOLS.map((item) => item.ingressProtocol)", quickstart);
-        Assert.Contains("disabled={!canCreateAccess || Boolean(bundle)}", quickstart);
+        Assert.Contains("type RequestType = 'chat' | 'vision'", quickstart);
+        Assert.Contains("requestType,", quickstart);
+        Assert.DoesNotContain("requestType: 'chat'", quickstart);
+        Assert.Contains("visionOpenAiContent", quickstart);
+        Assert.Contains("visionClaudeContent", quickstart);
+        Assert.Contains("visionGeminiParts", quickstart);
+        Assert.Contains("upstreamCalled=false", quickstart);
+        Assert.Contains("本页不提供关闭开关", quickstart);
+        Assert.Contains("/prompt-policy", quickstart);
+        Assert.Contains("const identityLocked = Boolean(bundle) || creatingStage !== null", quickstart);
+        Assert.Contains("disabled={!canCreateAccess || identityLocked}", quickstart);
         Assert.Contains("修改身份", quickstart);
         Assert.DoesNotContain("tenantId:", quickstart);
         Assert.DoesNotContain("['*']", quickstart);


### PR DESCRIPTION
## 摘要

打通外部新租户从 Quickstart 创建 chat/vision appCaller、签发团队 scoped key、执行四协议零费用安全测试并进入对应 PromptPolicy 的连续链路。后端策略内核、模型池、full-http 和付费调用保持不变。

## 改动 diff

- `llmgw/web/src/pages/QuickstartPage.tsx`：增加 chat/vision 用途选择、后缀一致性、四协议 vision 请求体、创建中身份锁、策略直达和折叠安全说明
- `llmgw/web/src/theme.css`：用途选择器在窄屏改单列
- `prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayKeyGateContractTests.cs`：扩展为 chat/vision × 四协议八格 dry-run，断言上游未调用、租户身份日志和 unknown cost
- `prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs`：补齐租户权威、最小权限、vision 形状与付费开关守卫
- `doc/plan.platform.llm-gateway-authoritative-tutorial.md`：记录 G2-B 关闭证据和 G2-C 精确计划、当前证据
- `changelogs/2026-07-15_llmgw-vision-quickstart.md`：新增本 PR changelog 碎片

## 测试

- [x] `pnpm --dir llmgw/web build`
- [x] `dotnet build prd-api/PrdAgent.sln --no-restore`，0 error
- [x] chat/vision 八格协议定向集成测试，1/1
- [x] `GatewayDataDomainGuardTests`，79/79
- [x] `GatewayKeyGateContractTests`，92/92
- [x] 标准非 Integration/Manual：API 1654 通过、4 跳过；数据域 675/675
- [x] `human-verify`：修复创建中切换用途竞态，未关闭 P0/P1/P2 为 0
- [x] `scope-check`：foreign 0，shared 仅新增 changelog
- [ ] GitHub CI 与 CDS Deploy
- [ ] 独立 LLM Gateway 子域的双主题、移动端、角色负向视觉验收
- [ ] CDS 不可变验收报告归档并以登录态实开

## 安全边界

- 页面不发送 tenantId，租户仍只由服务端会话或 service key 解析
- 页面不提供关闭 dry-run 的付费测试开关
- vision 使用固定 1×1 内嵌测试图片，不读取用户文件，不访问上游
- 日志继续只记录策略 id、version、hash，不记录提示词正文或 key 明文
