### PR TITLE
fix(llmgw): 修复只读发布门鉴权

### DIFF
--- a/changelogs/2026-07-17_llmgw-release-gate-readonly.md
+++ b/changelogs/2026-07-17_llmgw-release-gate-readonly.md
@@ -1,0 +1,1 @@
+| fix | llmgw | 将 shadow 比对读取纳入内部只读发布预检 scope，修复 full-http 维护发布被租户鉴权错误拦截 |

--- a/llmgw/serving/GatewayHttpEndpoints.cs
+++ b/llmgw/serving/GatewayHttpEndpoints.cs
@@ -1665,7 +1665,9 @@ public static class GatewayHttpEndpoints
     private static string ResolveRequiredScope(string path)
     {
         if (path.Equals("/gw/v1/readyz", StringComparison.OrdinalIgnoreCase)) return GatewayLegacyProbeScopes.Readiness;
-        if (path.Equals("/gw/v1/route-self-test", StringComparison.OrdinalIgnoreCase)) return GatewayLegacyProbeScopes.Route;
+        if (path.Equals("/gw/v1/route-self-test", StringComparison.OrdinalIgnoreCase)
+            || path.Equals("/gw/v1/shadow-comparisons", StringComparison.OrdinalIgnoreCase))
+            return GatewayLegacyProbeScopes.Route;
         if (path.Equals("/gw/v1/profile-test", StringComparison.OrdinalIgnoreCase)) return "profile:test";
         // requestId 是用户输入，可能恰好叫 resolve/raw/pools。请求控制路由必须先按
         // 固定形状匹配，不能让 path 子串把 cancel/status 错分到其它 scope。
@@ -1677,8 +1679,7 @@ public static class GatewayHttpEndpoints
             || path.Equals("/gw/v1/client-stream", StringComparison.OrdinalIgnoreCase)
             || path.Contains(":streamGenerateContent", StringComparison.OrdinalIgnoreCase)) return "stream:invoke";
         if (path.Contains("/resolve", StringComparison.OrdinalIgnoreCase)
-            || path.Contains("/pools", StringComparison.OrdinalIgnoreCase)
-            || path.Contains("shadow-comparisons", StringComparison.OrdinalIgnoreCase)) return "route:read";
+            || path.Contains("/pools", StringComparison.OrdinalIgnoreCase)) return "route:read";
         return "invoke";
     }
 

--- a/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayKeyGateContractTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayKeyGateContractTests.cs
@@ -2572,6 +2572,30 @@ public class GatewayKeyGateContractTests
         }
     }
 
+    [Fact]
+    public async Task ShadowComparisons_UsesServerDerivedLegacyPreflightScope()
+    {
+        var authorizer = new CapturingScopedKeyAuthorizer(_ => false);
+        await using var app = BuildHostWithGateway(new ThrowingGateway(), keyAuthorizer: authorizer);
+        await app.StartAsync();
+        try
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, "/gw/v1/shadow-comparisons?sinceHours=48");
+            request.Headers.Add("X-Gateway-Key", "legacy-or-scoped-key");
+
+            var response = await app.GetTestClient().SendAsync(request);
+
+            response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+            authorizer.SourceSystem.ShouldBe("external");
+            authorizer.AppCallerCode.ShouldBeEmpty();
+            authorizer.RequiredScope.ShouldBe(GatewayLegacyProbeScopes.Route);
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
     /// <summary>
     /// 上游 stub：任何方法被调用即抛。401 应在中间件层短路，永远到不了这里；
     /// 若哪个受保护端点在无 key 时仍触达 gateway，会抛出而不是静默 200，暴露密钥门漏洞。


### PR DESCRIPTION
## 摘要
修复 full-http 维护发布读取全局 shadow 证据时，被租户鉴权误判为外部普通路由并返回 403 的问题。仅将精确的 `/gw/v1/shadow-comparisons` 映射到已有内部只读预检 scope，不放宽任何写协议、普通路由或外部 scoped key 权限。

## 改动 diff
- `llmgw/serving/GatewayHttpEndpoints.cs`：shadow 比对读取复用只读发布预检 scope。
- `prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayKeyGateContractTests.cs`：新增服务端 scope 派生契约，证明客户端不能自报权限。
- `changelogs/2026-07-17_llmgw-release-gate-readonly.md`：新增修复记录。

## 测试
- [x] serving build：0 error
- [x] 新增定向契约：1/1
- [x] Gateway 密钥门契约：93/93
- [x] 完整非集成回归：2382 通过、4 跳过、0 失败
- [x] `python3 scripts/llmgw-release-gate.py --self-test`
- [x] `git diff --check`
- [ ] CDS 五服务预览与合并后生产 gate 实跑