### PR TITLE
fix(llmgw): 修复严格权限下静态发布根页五百错误

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       admin: ${{ steps.filter.outputs.admin }}
       desktop: ${{ steps.filter.outputs.desktop }}
       cds: ${{ steps.filter.outputs.cds }}
+      release_scripts: ${{ steps.filter.outputs.release_scripts }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -44,6 +45,32 @@ jobs:
             cds:
               - 'cds/**'
               - '.github/workflows/ci.yml'
+            release_scripts:
+              - 'exec_dep.sh'
+              - 'scripts/lib/static-release.sh'
+              - 'scripts/prd-agent-public-surface-smoke.py'
+              - 'scripts/tests/static-release-*.test.sh'
+              - 'scripts/tests/public-surface-smoke.test.py'
+              - 'deploy/nginx/**'
+              - '.github/workflows/ci.yml'
+
+  release-script-test:
+    name: Production Release Script Test
+    needs: changes
+    if: needs.changes.outputs.release_scripts == 'true' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Static release layout
+        run: sh scripts/tests/static-release-layout.test.sh
+
+      - name: Static release through nginx worker
+        run: sh scripts/tests/static-release-nginx.test.sh
+
+      - name: Public surface smoke unit test
+        run: python3 scripts/tests/public-surface-smoke.test.py
 
   # 后端服务构建和测试
   server-build:

--- a/changelogs/2026-07-17_llmgw-static-permission-hotfix.md
+++ b/changelogs/2026-07-17_llmgw-static-permission-hotfix.md
@@ -1,3 +1,4 @@
 | fix | llmgw | 修复严格 umask 下原子静态发布目录不可被 Nginx worker 读取导致生产根页 500 的问题 |
 | test | llmgw | 增加静态发布目录与文件权限归一化回归测试 |
 | ci | llmgw | 增加生产发布脚本与真实 Nginx worker 的独立 CI 检查 |
+| docs | llmgw | 记录严格 umask 生产故障、精确备份恢复与 PR #1176 防回归证据 |

--- a/changelogs/2026-07-17_llmgw-static-permission-hotfix.md
+++ b/changelogs/2026-07-17_llmgw-static-permission-hotfix.md
@@ -1,0 +1,3 @@
+| fix | llmgw | 修复严格 umask 下原子静态发布目录不可被 Nginx worker 读取导致生产根页 500 的问题 |
+| test | llmgw | 增加静态发布目录与文件权限归一化回归测试 |
+| ci | llmgw | 增加生产发布脚本与真实 Nginx worker 的独立 CI 检查 |

--- a/doc/debt.platform.production-release.md
+++ b/doc/debt.platform.production-release.md
@@ -1,10 +1,10 @@
 # 生产发布安全 · 债务台账
 
-> **版本**：v1.1 | **日期**：2026-07-17 | **状态**：已落地
+> **版本**：v1.2 | **日期**：2026-07-17 | **状态**：已落地
 
 ## 总览
 
-当前 open: 0 / paid: 6 / 总计: 6
+当前 open: 0 / paid: 7 / 总计: 7
 
 ## 债务列表
 
@@ -22,6 +22,7 @@
 | 2026-07-12-release-command-compatibility | PR #1174 | 2026-07-17 | `./exec_dep.sh release` 明确映射 latest 并输出迁移提示，`--help` 同时展示兼容命令和不可变 `--commit` 推荐路径；不可变静态产物不再允许跳过 SHA256。 |
 | 2026-07-12-release-forensic-ledger | PR #1174 | 2026-07-17 | 每次执行写不可覆盖 JSON，记录操作者、主机、release shell PID、开始结束时间、目标 ref、产物 URL/实际与期望 SHA256、校验结论、切换前后 owner/mode/current/previous、公网探针、首个失败阶段与回滚结果。2026-07-12 首次把目录改为 `700` 的历史进程无法追溯，属于不可恢复历史事实；后续发布已具备归因链。 |
 | 2026-07-17-independent-public-surface-watch | PR #1174 | 2026-07-17 | `LLM Gateway Shadow Watch` 新增无密钥 `public-surface` 独立 job，每 6 小时先验证 MAP 根页、真实资源、API 与网关双健康，再以独立 Gateway 模式验证网关产品标识、真实 JS/CSS、Console/Serving 精确提交和 GW Native、OpenAI、Claude、Gemini 四协议无密钥 401；两份 JSON 均上传保存，不依赖发布动作。 |
+| 2026-07-17-static-release-umask-worker-access | PR #1176 | 2026-07-17 | 生产发布在 `umask 077` 下创建的 `.releases` 和版本根目录为 `700`，完整产物仍会被 Nginx worker 拒绝并导致根页 500。发布表面探针拒绝完成后，通过发布前静态与 Nginx 精确备份恢复根页 200，网关容器 ID/IP 保持不变。PR #1176 在原子切换前把目录固定为 `755`、文件固定为 `644`，增加严格 umask 单测、真实 Nginx worker 测试和独立 CI 门禁。 |
 
 ## 关闭条件
 

--- a/doc/rule.platform.production-release-safety.md
+++ b/doc/rule.platform.production-release-safety.md
@@ -1,6 +1,6 @@
 # 生产发布表面健康与可追溯性 · 规则
 
-> **版本**：v1.1 | **日期**：2026-07-17 | **状态**：已落地
+> **版本**：v1.2 | **日期**：2026-07-17 | **状态**：已落地
 
 ## 核心原则
 
@@ -15,6 +15,8 @@
 已经证实的直接原因是静态目录不可遍历；首次把目录设置为 `700` 的具体进程无法从现有证据中确定。系统级根因是发布脚本没有固定权限后置条件、没有原子切换、没有产品表面验证，也没有保存足够的权限变化证据。
 
 同日还确认了发布命令兼容性退化：旧流程中 `./exec_dep.sh release` 等价于部署 latest，新参数解析会把 `release` 当作版本 ref，继而请求不存在的产物并输出多层错误。发布入口改变语义时没有兼容别名和迁移提示，也属于本规则治理范围。
+
+2026-07-17 的首次稳定根目录生产发布进一步确认：CDS 发布命令为保护临时凭据使用 `umask 077`，原子发布库却没有在切换前固定最终权限，导致新建 `.releases` 与发布根目录为 `700`。产物、`current`/`previous` 链接和入口文件本身都完整，但 Nginx worker 无法遍历目录，SPA fallback 最终返回 500。公网表面探针正确阻止完成声明，精确发布前备份恢复根页 200；PR #1176 把目录固定为 `755`、文件固定为 `644`，并增加真实 Nginx worker 回归。该事件证明“校验文件存在”不能替代“以实际服务用户读取”。
 
 ## 规则条目
 
@@ -109,11 +111,12 @@
 
 ## 当前实现
 
-- `exec_dep.sh`：不可变静态产物必须通过 SHA256；在 gateway 已挂载的稳定 `deploy/web/dist` 根目录内，用 `.staging-*` 离线解压和校验，再通过 `scripts/lib/static-release.sh` 原子切换 `current`，`previous` 保存上一版。Nginx 的 standalone root 固定指向 bind 根内的 `current`，切换不需要重建容器。
+- `exec_dep.sh`：不可变静态产物必须通过 SHA256；在 gateway 已挂载的稳定 `deploy/web/dist` 根目录内，用 `.staging-*` 离线解压和校验，再通过 `scripts/lib/static-release.sh` 把目录精确归一为 `755`、文件归一为 `644`，最后原子切换 `current`，`previous` 保存上一版。Nginx 的 standalone root 固定指向 bind 根内的 `current`，切换不需要重建容器。
 - 代理稳定：非 gateway 服务重建后立即使用当前配置原地 reload gateway，先刷新 API 与 LLMGW 容器地址，再等待较长的 Serving readiness；静态切换后的任一强制阶段失败都会恢复 previous，并再次执行 `nginx -t` 与 reload 后复跑公网表面探针。`llmgw-rollback-inproc.sh` 和 `llmgw-restore-shadow-safe.sh` 同样只重启 API、原地 reload gateway。正常发布、静态复用、inproc 回滚和 shadow 恢复都不改变 gateway 容器 IP。
 - `scripts/prd-agent-public-surface-smoke.py`：验证根 HTML、实际同源 JS/CSS、根级 `/health`、`/api/version`、LLMGW 页面及 Console/Serving 双健康；发布后强制运行，并由 `llmgw-shadow-watch.yml` 每 6 小时独立运行。
 - `scripts/prd-agent-release-evidence.py`：按唯一发布编号写不可覆盖 JSON，记录操作者、主机、release PID、开始结束时间、ref、产物 URL 与 hash、静态链接和权限、公网探针、首个失败阶段和回滚结果。
 - `./exec_dep.sh release`：保留 latest 兼容语义并提示迁移到不可变 `--commit`；`--help` 同时展示兼容与推荐命令。
+- `.github/workflows/ci.yml`：独立执行静态布局、严格 umask、真实 `nginx:1.27-alpine` worker 和公网探针单测，防止只有发布时才发现权限退化。
 
 ## 关联债务
 

--- a/scripts/lib/static-release.sh
+++ b/scripts/lib/static-release.sh
@@ -4,6 +4,20 @@ STATIC_RELEASE_SWITCH_PERFORMED="${STATIC_RELEASE_SWITCH_PERFORMED:-0}"
 STATIC_RELEASE_TARGET="${STATIC_RELEASE_TARGET:-}"
 STATIC_RELEASE_ROLLBACK_TARGET="${STATIC_RELEASE_ROLLBACK_TARGET:-}"
 
+static_release_make_web_readable() {
+  web_root="$1"
+  if [ ! -d "$web_root" ]; then
+    echo "ERROR: static web root is missing: $web_root" >&2
+    return 1
+  fi
+
+  # CDS production release commands intentionally use umask 077 for secrets.
+  # A staged web tree inherits that umask, but nginx workers are unprivileged
+  # and must be able to traverse every directory and read every asset.
+  find "$web_root" -type d -exec chmod 755 {} +
+  find "$web_root" -type f -exec chmod 644 {} +
+}
+
 static_release_atomic_link() {
   link_path="$1"
   link_target="$2"
@@ -43,6 +57,7 @@ static_release_activate() {
     return 1
   fi
   mkdir -p "$releases_dir"
+  chmod 755 "$static_root" "$releases_dir"
 
   original_current_target="$(readlink "$static_root/current" 2>/dev/null || true)"
   original_previous_target="$(readlink "$static_root/previous" 2>/dev/null || true)"
@@ -67,10 +82,12 @@ static_release_activate() {
       rm -rf "$legacy_dir"
       return 1
     fi
+    static_release_make_web_readable "$legacy_dir"
     rollback_target="$legacy_target"
   fi
 
   mv "$staging_dir" "$release_dir"
+  static_release_make_web_readable "$release_dir"
 
   STATIC_RELEASE_TARGET="$release_target"
   STATIC_RELEASE_ROLLBACK_TARGET="$rollback_target"

--- a/scripts/tests/static-release-layout.test.sh
+++ b/scripts/tests/static-release-layout.test.sh
@@ -77,4 +77,26 @@ test ! -L "$failure_root/current"
 grep -F 'old' "$failure_root/assets/app.js" >/dev/null
 grep -F 'restoring the original layout' "$tmp_root/failure.log" >/dev/null
 
+restricted_root="$tmp_root/restricted-web/dist"
+mkdir -p "$restricted_root/assets" "$restricted_root/.staging-restricted/assets"
+printf 'old\n' > "$restricted_root/index.html"
+printf 'old\n' > "$restricted_root/assets/app.js"
+printf '<script src="/assets/app.js"></script>\n' > "$restricted_root/.staging-restricted/index.html"
+printf 'new\n' > "$restricted_root/.staging-restricted/assets/app.js"
+chmod 700 "$restricted_root" "$restricted_root/assets" "$restricted_root/.staging-restricted" "$restricted_root/.staging-restricted/assets"
+chmod 600 "$restricted_root/index.html" "$restricted_root/assets/app.js" "$restricted_root/.staging-restricted/index.html" "$restricted_root/.staging-restricted/assets/app.js"
+(
+  umask 077
+  static_release_activate "$restricted_root/.staging-restricted" "$restricted_root" "restricted" >/dev/null
+)
+test "$(stat -c '%a' "$restricted_root/.releases" 2>/dev/null || stat -f '%Lp' "$restricted_root/.releases")" = "755"
+test "$(stat -c '%a' "$restricted_root/.releases/restricted" 2>/dev/null || stat -f '%Lp' "$restricted_root/.releases/restricted")" = "755"
+test "$(stat -c '%a' "$restricted_root/.releases/restricted/assets" 2>/dev/null || stat -f '%Lp' "$restricted_root/.releases/restricted/assets")" = "755"
+test "$(stat -c '%a' "$restricted_root/.releases/restricted/index.html" 2>/dev/null || stat -f '%Lp' "$restricted_root/.releases/restricted/index.html")" = "644"
+test "$(stat -c '%a' "$restricted_root/.releases/restricted/assets/app.js" 2>/dev/null || stat -f '%Lp' "$restricted_root/.releases/restricted/assets/app.js")" = "644"
+test -r "$restricted_root/current/index.html"
+test -r "$restricted_root/current/assets/app.js"
+find "$restricted_root/.releases/restricted" -type d -exec test -x {} \;
+find "$restricted_root/.releases/restricted" -type f -exec test -r {} \;
+
 echo "Static release layout test: PASS"

--- a/scripts/tests/static-release-nginx.test.sh
+++ b/scripts/tests/static-release-nginx.test.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env sh
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+. "$repo_root/scripts/lib/static-release.sh"
+
+if ! command -v docker >/dev/null 2>&1 || ! docker info >/dev/null 2>&1; then
+  echo "Static release nginx test: SKIP docker unavailable"
+  exit 0
+fi
+
+tmp_root="$(mktemp -d)"
+container_name="static-release-nginx-$$"
+cleanup() {
+  docker rm -f "$container_name" >/dev/null 2>&1 || true
+  rm -rf "$tmp_root"
+}
+trap cleanup EXIT HUP INT TERM
+
+static_root="$tmp_root/web"
+staging="$static_root/.staging-restricted"
+mkdir -p "$static_root/assets" "$staging/assets"
+printf '<div>old</div>\n' > "$static_root/index.html"
+printf 'old\n' > "$static_root/assets/app.js"
+printf '<script src="/assets/app.js"></script>\n' > "$staging/index.html"
+printf 'new\n' > "$staging/assets/app.js"
+chmod 700 "$static_root" "$static_root/assets" "$staging" "$staging/assets"
+chmod 600 "$static_root/index.html" "$static_root/assets/app.js" "$staging/index.html" "$staging/assets/app.js"
+
+(
+  umask 077
+  static_release_activate "$staging" "$static_root" "restricted" >/dev/null
+)
+
+nginx_conf="$tmp_root/default.conf"
+printf '%s\n' \
+  'server {' \
+  '  listen 80;' \
+  '  server_name _;' \
+  '  root /usr/share/nginx/html/current;' \
+  '  index index.html;' \
+  '  location ^~ /assets/ { try_files $uri =404; }' \
+  '  location / { try_files $uri /index.html; }' \
+  '}' > "$nginx_conf"
+chmod 644 "$nginx_conf"
+
+docker run --rm -d \
+  --name "$container_name" \
+  -p 127.0.0.1::80 \
+  -v "$static_root:/usr/share/nginx/html:ro" \
+  -v "$nginx_conf:/etc/nginx/conf.d/default.conf:ro" \
+  nginx:1.27-alpine >/dev/null
+
+port="$(docker port "$container_name" 80/tcp | awk -F: 'NR == 1 {print $NF}')"
+[ -n "$port" ] || { echo "ERROR: nginx test port unavailable" >&2; exit 1; }
+
+attempt=1
+while [ "$attempt" -le 20 ]; do
+  if curl -fsS "http://127.0.0.1:$port/" > "$tmp_root/root.html" 2>/dev/null; then
+    break
+  fi
+  sleep 1
+  attempt=$((attempt + 1))
+done
+
+grep -F '/assets/app.js' "$tmp_root/root.html" >/dev/null
+test "$(curl -fsS "http://127.0.0.1:$port/assets/app.js")" = "new"
+
+echo "Static release nginx test: PASS"


### PR DESCRIPTION
## 摘要

修复生产发布在 `umask 077` 下创建 `.releases` 和发布目录为 700，导致非特权 Nginx worker 无法读取根页面并返回 500 的问题。静态切换前现在统一把目录归一为 755、文件归一为 644，并用真实 Nginx 容器固化回归。

## 改动 diff

- `scripts/lib/static-release.sh`：原子切换前统一发布目录和静态文件权限。
- `scripts/tests/static-release-layout.test.sh`：增加严格 umask、目录 755、文件 644 断言。
- `scripts/tests/static-release-nginx.test.sh`：增加真实非特权 Nginx worker 根页与资源回归。
- `.github/workflows/ci.yml`：新增独立生产发布脚本检查。
- `changelogs/2026-07-17_llmgw-static-permission-hotfix.md`：记录修复与测试。

## 生产事件

- 首次发布在切换前因历史证据链接缺失退出，未改变线上。
- 第二次发布在切换前因失败工作树残留退出，未改变线上。
- 第三次发布发现静态目录权限缺陷，公网表面探针判定失败并尝试回滚。
- 已通过精确发布前备份恢复生产根页 200；后端 Console 与 Serving 仍保持合并提交运行。

## 测试

- [x] `sh scripts/tests/static-release-layout.test.sh`
- [x] `sh scripts/tests/static-release-nginx.test.sh`
- [x] `python3 scripts/tests/public-surface-smoke.test.py`
- [x] CI YAML 解析通过
- [x] `git diff --check`
- [ ] GitHub Actions 全部通过
- [ ] 合并后 CDS 与生产公网最终入口验收
