### PR TITLE
fix(llmgw): 对齐发布冒烟请求来源

### DIFF
--- a/changelogs/2026-07-19_llmgw-release-smoke-source.md
+++ b/changelogs/2026-07-19_llmgw-release-smoke-source.md
@@ -1,0 +1,1 @@
+| fix | llmgw | 修复正式发布冒烟请求头与请求体来源不一致导致 scoped service key 被拒绝 |

--- a/scripts/gw-smoke.py
+++ b/scripts/gw-smoke.py
@@ -346,7 +346,7 @@ def main():
             "AppCallerCode": accode, "ModelType": mtype, "Stream": False,
             "TimeoutSeconds": SMOKE_REQUEST_TIMEOUT,
             "RequestBody": {"messages": [{"role": "user", "content": SMOKE_PROMPT}], "max_tokens": SMOKE_MAX_TOKENS},
-            "Context": {"UserId": "smoke-test", "IsHealthProbe": True, "GatewayTransport": "http", "SourceSystem": "release-probe", "IngressProtocol": "gw-native"},
+            "Context": {"UserId": "smoke-test", "IsHealthProbe": True, "GatewayTransport": "http", "SourceSystem": SMOKE_SOURCE_SYSTEM, "IngressProtocol": "gw-native"},
         }
         code, raw = _req("POST", "/invoke", body)
         d = _envelope_data(raw) or {}
@@ -365,7 +365,7 @@ def main():
             "Stream": False,
             "TimeoutSeconds": SMOKE_REQUEST_TIMEOUT,
             "RequestBody": {"messages": [{"role": "user", "content": SMOKE_PROMPT}], "max_tokens": SMOKE_MAX_TOKENS},
-            "Context": {"UserId": "smoke-test", "IsHealthProbe": True, "GatewayTransport": "http", "SourceSystem": "release-probe", "IngressProtocol": "gw-native"},
+            "Context": {"UserId": "smoke-test", "IsHealthProbe": True, "GatewayTransport": "http", "SourceSystem": SMOKE_SOURCE_SYSTEM, "IngressProtocol": "gw-native"},
         }
         code, raw = _req("POST", "/send", send_body)
         d = _envelope_data(raw) or {}
@@ -387,7 +387,7 @@ def main():
                 "max_tokens": SMOKE_MAX_TOKENS,
                 "stream": True,
             },
-            "Context": {"UserId": "smoke-test", "IsHealthProbe": True, "GatewayTransport": "http", "SourceSystem": "release-probe", "IngressProtocol": "gw-native"},
+            "Context": {"UserId": "smoke-test", "IsHealthProbe": True, "GatewayTransport": "http", "SourceSystem": SMOKE_SOURCE_SYSTEM, "IngressProtocol": "gw-native"},
         }
         code, raw, events = _sse_req("/stream", stream_body)
         stream_text = "".join(str(e.get("Content") or "") for e in events if isinstance(e, dict))
@@ -418,7 +418,7 @@ def main():
             "SystemPrompt": "Reply briefly.",
             "Messages": [{"Role": "user", "Content": SMOKE_PROMPT}],
             "EnablePromptCache": True,
-            "Context": {"UserId": "smoke-test", "IsHealthProbe": True, "GatewayTransport": "http", "SourceSystem": "release-probe", "IngressProtocol": "gw-native"},
+            "Context": {"UserId": "smoke-test", "IsHealthProbe": True, "GatewayTransport": "http", "SourceSystem": SMOKE_SOURCE_SYSTEM, "IngressProtocol": "gw-native"},
         }
         code, raw, events = _sse_req("/client-stream", client_stream_body)
         client_stream_text = "".join(str(e.get("Content") or "") for e in events if isinstance(e, dict))
@@ -480,7 +480,7 @@ def main():
 
     # 8) canary：指向不存在的入口，必须失败（证明探测有效）
     body = {"AppCallerCode": "nonexistent.canary::chat", "ModelType": "chat",
-            "RequestBody": {"messages": [{"role": "user", "content": "x"}]}, "Context": {"UserId": "smoke-test", "IsHealthProbe": True, "GatewayTransport": "http", "SourceSystem": "release-probe", "IngressProtocol": "gw-native"}}
+            "RequestBody": {"messages": [{"role": "user", "content": "x"}]}, "Context": {"UserId": "smoke-test", "IsHealthProbe": True, "GatewayTransport": "http", "SourceSystem": SMOKE_SOURCE_SYSTEM, "IngressProtocol": "gw-native"}}
     code, raw = _req("POST", "/invoke", body)
     d = _envelope_data(raw) or {}
     canary_caught = not (code == 200 and d.get("Success") is True)

--- a/scripts/tests/test_llmgw_release_dual_keys.py
+++ b/scripts/tests/test_llmgw_release_dual_keys.py
@@ -38,6 +38,11 @@ class ReleaseDualKeyContractTests(unittest.TestCase):
         self.assertIn('r.add_header("X-Gateway-App-Caller", app_caller)', smoke_source)
         self.assertIn('path.startswith("/pools?")', smoke_source)
 
+    def test_smoke_body_uses_the_same_configured_source_as_headers(self) -> None:
+        smoke_source = (ROOT / "scripts" / "gw-smoke.py").read_text(encoding="utf-8")
+        self.assertEqual(smoke_source.count('"SourceSystem": SMOKE_SOURCE_SYSTEM'), 5)
+        self.assertNotIn('"SourceSystem": "release-probe"', smoke_source)
+
     def test_public_llmgw_proxy_does_not_cut_off_gateway_timeout(self) -> None:
         nginx_source = STANDALONE_NGINX.read_text(encoding="utf-8")
         public_proxy = nginx_source.split("proxy_pass http://llmgw-web:80;", maxsplit=1)[1]


### PR DESCRIPTION
## 摘要

修复正式发布 D 层 smoke 在使用 scoped service key 时，请求头来源可配置、请求体来源却固定为 `release-probe`，导致网关以 `GATEWAY_SOURCE_SYSTEM_MISMATCH` 拒绝真实 invoke/send/stream 的问题。所有 smoke 请求体改为复用现有 `GW_SMOKE_SOURCE_SYSTEM`，使同一最小权限 key 可以同时通过请求头和请求体身份校验。

## 改动 diff

- `scripts/gw-smoke.py`：五类请求的 `Context.SourceSystem` 统一读取 `SMOKE_SOURCE_SYSTEM`。
- `scripts/tests/test_llmgw_release_dual_keys.py`：新增请求头与请求体来源一致性合同测试。
- `changelogs/2026-07-19_llmgw-release-smoke-source.md`：记录发布冒烟修复。

## 测试

- [x] `python3 -m unittest discover -s scripts/tests -p 'test_*.py'`：11 项通过。
- [x] `GW_SMOKE_SELF_TEST=1 python3 scripts/gw-smoke.py`：通过。
- [x] `python3 scripts/llmgw-protocol-router-audit.py`：10/10 通过。
- [x] 正式 `https://map.ebcone.net/llmgw/gw/v1` 使用临时 scoped key：health、pools、invoke、send、stream、client-stream、负向 canary 7/7 通过。
- [x] GitHub Branch Image：成功。
- [x] `git merge-tree --write-tree origin/main HEAD`：无冲突。

## 风险与回滚

- 不修改网关鉴权、服务运行时、数据库或 UI，仅修正发布 smoke 自身的来源字段。
- 默认来源仍为 `release-probe`，未设置环境变量时行为不变。
- 回滚为撤销本提交；正式发布仍由 `llmgw-prod-stage.sh` 的 main、镜像、健康、协议、配置权威及静态原子切换门控制。