### PR TITLE
fix(llmgw): 防止活跃 provisioning 被修复器误回滚

### DIFF
--- a/changelogs/2026-07-20_llmgw-recovery-lease-heartbeat.md
+++ b/changelogs/2026-07-20_llmgw-recovery-lease-heartbeat.md
@@ -1,0 +1,2 @@
+| fix | llmgw | 为租户、成员和 owner provisioning 增加 recovery lease 心跳，防止长耗时正常请求被硬退出修复器误回滚 |
+| test | prd-api | 增加 live provisioning 续租与到期后可修复的竞态回归测试 |

--- a/changelogs/2026-07-20_llmgw-recovery-lease-heartbeat.md
+++ b/changelogs/2026-07-20_llmgw-recovery-lease-heartbeat.md
@@ -1,2 +1,3 @@
 | fix | llmgw | 为租户、成员和 owner provisioning 增加 recovery lease 心跳，防止长耗时正常请求被硬退出修复器误回滚 |
+| fix | llmgw | 收敛 heartbeat 停止期间的瞬时续租失败，避免成功的 provisioning 在响应清理阶段误报 500 |
 | test | prd-api | 增加 live provisioning 续租与到期后可修复的竞态回归测试 |

--- a/llmgw/console-api/Program.cs
+++ b/llmgw/console-api/Program.cs
@@ -1014,6 +1014,7 @@ app.MapPost("/gw/tenants", async (HttpContext http, [FromBody] CreateTenantReque
         team.Id,
         membership.Id);
     await recoveryOperations.InsertOneAsync(recoveryOperation, cancellationToken: CancellationToken.None);
+    await using var recoveryHeartbeat = await GatewayRecoveryOperations.StartHeartbeatAsync(recoveryOperations, recoveryOperation.Id);
     try
     {
         await tenants.InsertOneAsync(tenant);
@@ -1390,6 +1391,7 @@ app.MapPost("/gw/members", async (HttpContext http, [FromBody] CreateMemberReque
         memberUser.Id,
         membershipId: membership.Id);
     await recoveryOperations.InsertOneAsync(recoveryOperation, cancellationToken: CancellationToken.None);
+    await using var recoveryHeartbeat = await GatewayRecoveryOperations.StartHeartbeatAsync(recoveryOperations, recoveryOperation.Id);
     try
     {
         await users.InsertOneAsync(memberUser);
@@ -1514,6 +1516,7 @@ app.MapPut("/gw/members/{id}", async (HttpContext http, string id, [FromBody] Up
             { "version", membership.Version },
         });
     GatewayRecoveryOperation? recoveryOperation = null;
+    IAsyncDisposable? recoveryHeartbeat = null;
     if (ownerBoundaryMutation)
     {
         recoveryOperation = GatewayRecoveryOperations.New(
@@ -1526,7 +1529,9 @@ app.MapPut("/gw/members/{id}", async (HttpContext http, string id, [FromBody] Up
         recoveryOperation.TargetStatus = membership.Status;
         recoveryOperation.TargetTeamIds = membership.TeamIds.ToList();
         await recoveryOperations.InsertOneAsync(recoveryOperation, cancellationToken: CancellationToken.None);
+        recoveryHeartbeat = await GatewayRecoveryOperations.StartHeartbeatAsync(recoveryOperations, recoveryOperation.Id);
     }
+    await using var recoveryHeartbeatScope = recoveryHeartbeat;
 
     OwnerRemovalDecision? ownerRemoval = null;
     if (removesOwner)

--- a/llmgw/console-api/Provisioning/GatewayRecoveryOperations.cs
+++ b/llmgw/console-api/Provisioning/GatewayRecoveryOperations.cs
@@ -395,6 +395,10 @@ internal sealed class GatewayRecoveryHeartbeat : IAsyncDisposable
                 {
                     if (!await RenewAsync()) return;
                 }
+                catch (Exception) when (_stop.IsCancellationRequested)
+                {
+                    return;
+                }
                 catch when (!_stop.IsCancellationRequested)
                 {
                     // Mongo 短暂不可用时保留下一次续租机会；业务写入仍由调用链自行失败并补偿。

--- a/llmgw/console-api/Provisioning/GatewayRecoveryOperations.cs
+++ b/llmgw/console-api/Provisioning/GatewayRecoveryOperations.cs
@@ -157,6 +157,7 @@ public static class TenantOwnerAuthority
 public static class GatewayRecoveryOperations
 {
     private static readonly TimeSpan OperationLease = TimeSpan.FromMinutes(2);
+    private static readonly TimeSpan HeartbeatInterval = TimeSpan.FromSeconds(30);
 
     public static GatewayRecoveryOperation New(
         string kind,
@@ -186,6 +187,20 @@ public static class GatewayRecoveryOperations
                 .Set(x => x.Detail, detail)
                 .Set(x => x.UpdatedAt, DateTime.UtcNow),
             cancellationToken: CancellationToken.None);
+
+    public static async Task<IAsyncDisposable> StartHeartbeatAsync(
+        IMongoCollection<GatewayRecoveryOperation> operations,
+        string operationId,
+        TimeSpan? heartbeatInterval = null)
+    {
+        var heartbeat = new GatewayRecoveryHeartbeat(
+            operations,
+            operationId,
+            heartbeatInterval ?? HeartbeatInterval,
+            OperationLease);
+        await heartbeat.StartAsync();
+        return heartbeat;
+    }
 
     public static async Task<int> RepairExpiredAsync(IMongoDatabase database)
     {
@@ -329,5 +344,77 @@ public static class GatewayRecoveryOperations
 
         await TenantOwnerAuthority.RestoreAsync(tenants, operation.TenantId, operation.MembershipId);
         return "owner-removal-conflict-restored";
+    }
+}
+
+internal sealed class GatewayRecoveryHeartbeat : IAsyncDisposable
+{
+    private readonly IMongoCollection<GatewayRecoveryOperation> _operations;
+    private readonly string _operationId;
+    private readonly TimeSpan _interval;
+    private readonly TimeSpan _lease;
+    private readonly CancellationTokenSource _stop = new();
+    private Task _runTask = Task.CompletedTask;
+
+    public GatewayRecoveryHeartbeat(
+        IMongoCollection<GatewayRecoveryOperation> operations,
+        string operationId,
+        TimeSpan interval,
+        TimeSpan lease)
+    {
+        if (interval <= TimeSpan.Zero || interval >= lease)
+            throw new ArgumentOutOfRangeException(nameof(interval), "心跳间隔必须大于零且小于 recovery lease");
+        _operations = operations;
+        _operationId = operationId;
+        _interval = interval;
+        _lease = lease;
+    }
+
+    public async Task StartAsync()
+    {
+        if (!await RenewAsync())
+            throw new InvalidOperationException("recovery operation 不存在或已被其他修复器接管");
+        _runTask = RunAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _stop.CancelAsync();
+        await _runTask;
+        _stop.Dispose();
+    }
+
+    private async Task RunAsync()
+    {
+        using var timer = new PeriodicTimer(_interval);
+        try
+        {
+            while (await timer.WaitForNextTickAsync(_stop.Token))
+            {
+                try
+                {
+                    if (!await RenewAsync()) return;
+                }
+                catch when (!_stop.IsCancellationRequested)
+                {
+                    // Mongo 短暂不可用时保留下一次续租机会；业务写入仍由调用链自行失败并补偿。
+                }
+            }
+        }
+        catch (OperationCanceledException) when (_stop.IsCancellationRequested)
+        {
+        }
+    }
+
+    private async Task<bool> RenewAsync()
+    {
+        var now = DateTime.UtcNow;
+        var result = await _operations.UpdateOneAsync(
+            x => x.Id == _operationId && x.Status == "pending" && x.RepairToken == null,
+            Builders<GatewayRecoveryOperation>.Update
+                .Set(x => x.LeaseExpiresAt, now.Add(_lease))
+                .Set(x => x.UpdatedAt, now),
+            cancellationToken: CancellationToken.None);
+        return result.MatchedCount == 1;
     }
 }

--- a/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayConsoleTenantAccessTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayConsoleTenantAccessTests.cs
@@ -216,6 +216,60 @@ public sealed class GatewayConsoleTenantAccessTests
     }
 
     [Fact]
+    public async Task HardExitRepairer_DoesNotClaimProvisioningWhileLiveRequestRenewsLease()
+    {
+        var database = await TryCreateDatabaseAsync();
+        if (database is null) return;
+        await using var scope = database;
+        var tenants = scope.Database.GetCollection<LlmGwTenant>("llmgw_tenants");
+        var operations = scope.Database.GetCollection<GatewayRecoveryOperation>("llmgw_recovery_operations");
+        await tenants.InsertOneAsync(new LlmGwTenant
+        {
+            Id = "tenant-live",
+            Name = "Live",
+            OwnerAuthorityInitialized = true,
+            ActiveOwnerMembershipIds = ["owner-live"],
+            OwnerFenceGeneration = 1,
+        });
+        await operations.InsertOneAsync(new GatewayRecoveryOperation
+        {
+            Id = "op-live",
+            Kind = GatewayRecoveryKinds.TenantCreate,
+            TenantId = "tenant-live",
+            MembershipId = "owner-live",
+            LeaseExpiresAt = DateTime.UtcNow.AddMinutes(-1),
+        });
+
+        await using (await GatewayRecoveryOperations.StartHeartbeatAsync(
+                         operations,
+                         "op-live",
+                         TimeSpan.FromMilliseconds(20)))
+        {
+            await operations.UpdateOneAsync(
+                x => x.Id == "op-live",
+                Builders<GatewayRecoveryOperation>.Update.Set(x => x.LeaseExpiresAt, DateTime.UtcNow.AddSeconds(-1)));
+            GatewayRecoveryOperation? active = null;
+            for (var attempt = 0; attempt < 100; attempt++)
+            {
+                active = await operations.Find(x => x.Id == "op-live").SingleAsync();
+                if (active.LeaseExpiresAt > DateTime.UtcNow.AddMinutes(1)) break;
+                await Task.Delay(20);
+            }
+            (await GatewayRecoveryOperations.RepairExpiredAsync(scope.Database)).ShouldBe(0);
+            active.ShouldNotBeNull();
+            active.Status.ShouldBe("pending");
+            active.LeaseExpiresAt.ShouldBeGreaterThan(DateTime.UtcNow.AddMinutes(1));
+            (await tenants.CountDocumentsAsync(x => x.Id == "tenant-live")).ShouldBe(1);
+        }
+
+        await operations.UpdateOneAsync(
+            x => x.Id == "op-live",
+            Builders<GatewayRecoveryOperation>.Update.Set(x => x.LeaseExpiresAt, DateTime.UtcNow.AddSeconds(-1)));
+        (await GatewayRecoveryOperations.RepairExpiredAsync(scope.Database)).ShouldBe(1);
+        (await tenants.CountDocumentsAsync(x => x.Id == "tenant-live")).ShouldBe(0);
+    }
+
+    [Fact]
     public async Task OwnerAuthority_ConcurrentRemovalsAtomicallyPreserveOneOwner()
     {
         var database = await TryCreateDatabaseAsync();

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -3781,7 +3781,11 @@ public class GatewayDataDomainGuardTests
         Assert.Contains("TenantOwnerAuthority.TryRemoveAsync", console);
         Assert.Contains("ActiveOwnerMembershipIds", recovery);
         Assert.Contains("OwnerFenceGeneration", recovery);
+        Assert.Contains("StartHeartbeatAsync", recovery);
         Assert.Contains("GatewayRecoveryOperations.RepairExpiredAsync", console);
+        Assert.True(
+            console.Split("GatewayRecoveryOperations.StartHeartbeatAsync", StringSplitOptions.None).Length - 1 >= 3,
+            "租户创建、成员创建和 owner 边界修改都必须在 live request 期间续租 recovery operation");
         Assert.DoesNotContain("OwnerMutationLock", console);
         Assert.Contains("MEMBERSHIP_VERSION_CONFLICT", console);
         Assert.Contains("idempotentReplay = true", console);

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -3782,6 +3782,7 @@ public class GatewayDataDomainGuardTests
         Assert.Contains("ActiveOwnerMembershipIds", recovery);
         Assert.Contains("OwnerFenceGeneration", recovery);
         Assert.Contains("StartHeartbeatAsync", recovery);
+        Assert.Contains("catch (Exception) when (_stop.IsCancellationRequested)", recovery);
         Assert.Contains("GatewayRecoveryOperations.RepairExpiredAsync", console);
         Assert.True(
             console.Split("GatewayRecoveryOperations.StartHeartbeatAsync", StringSplitOptions.None).Length - 1 >= 3,


### PR DESCRIPTION
## 摘要

修复 PR #1191 合并后评审发现的 recovery lease 竞态：租户创建、成员创建和 owner 边界修改在正常执行期间持续续租，避免超过两分钟的活跃 provisioning 被后台 hard-exit 修复器误判并回滚。

## 改动 diff

- `llmgw/console-api/Provisioning/GatewayRecoveryOperations.cs`：增加 30 秒 heartbeat，只有 pending 且未被修复器接管的 operation 可以续租。
- `llmgw/console-api/Program.cs`：为租户创建、成员创建和 owner 边界修改三个入口绑定 heartbeat 生命周期。
- `prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayConsoleTenantAccessTests.cs`：验证周期续租期间修复器不接管，停止续租并过期后仍能完成修复。
- `prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs`：守卫三个入口都必须启用 heartbeat。
- `changelogs/2026-07-20_llmgw-recovery-lease-heartbeat.md`：记录修复与测试。

## 测试

- [x] Console API build：0 warning，0 error
- [x] prd-api solution build：0 error
- [x] GatewayConsoleTenantAccessTests：20/20 通过
- [x] 完整非 Integration/Manual 回归：2450 通过，4 个既有显式跳过，0 失败
- [x] LLMGW 教程漂移 workflow 首次手动运行通过

## 边界

- 不变更预算、速率、owner authority 数据模型和 API 合同。
- 不包含多上游 Provider/Endpoint/Offering 架构。
