### PR TITLE
feat(llm): 迁移至 GPT-5.6 模型系列

### DIFF
--- a/changelogs/2026-07-20_gpt-5-6-family-migration.md
+++ b/changelogs/2026-07-20_gpt-5-6-family-migration.md
@@ -1,0 +1,2 @@
+| feat | prd-api | 将 OpenAI 默认与转写文案模型按角色迁移到 GPT-5.6 Sol/Terra，并兼容推理参数与输出 token 参数 |
+| feat | prd-admin | 将管理端模型示例迁移到 GPT-5.6 分层模型并补齐 Sol/Terra/Luna 能力识别 |

--- a/prd-admin/src/components/exchange/ExchangeTestPanel.tsx
+++ b/prd-admin/src/components/exchange/ExchangeTestPanel.tsx
@@ -167,7 +167,12 @@ export function ExchangeTestPanel({
     }
     if (!showVisual) {
       return JSON.stringify(
-        { messages: [{ role: 'user', content: 'Hello, how are you?' }], model: 'gpt-4o', max_tokens: 100 },
+        {
+          messages: [{ role: 'user', content: 'Hello, how are you?' }],
+          model: 'gpt-5.6-terra',
+          max_completion_tokens: 100,
+          reasoning_effort: 'none',
+        },
         null, 2
       );
     }

--- a/prd-admin/src/lib/cherryStudioModelTags.ts
+++ b/prd-admin/src/lib/cherryStudioModelTags.ts
@@ -116,7 +116,7 @@ const visionAllowedModels = [
   'gpt-4.1(?:-[\\w-]+)?',
   'gpt-4o(?:-[\\w-]+)?',
   'gpt-4.5(?:-[\\w-]+)',
-  'gpt-5(?:-[\\w-]+)?',
+  'gpt-5(?:\\.\\d+)?(?:-[\\w-]+)?',
   'chatgpt-4o(?:-[\\w-]+)?',
   'o1(?:-[\\w-]+)?',
   'o3(?:-[\\w-]+)?',
@@ -204,7 +204,7 @@ const FUNCTION_CALLING_MODELS = [
   'gpt-4',
   'gpt-4.5',
   'gpt-oss(?:-[\\w-]+)',
-  'gpt-5(?:-[0-9-]+)?',
+  'gpt-5(?:\\.\\d+)?(?:-[\\w-]+)?',
   'o(1|3|4)(?:-[\\w-]+)?',
   'claude',
   'qwen',
@@ -298,15 +298,13 @@ function isOpenAIReasoningModel(model: CherryModelInput): boolean {
 
 function isSupportedReasoningEffortOpenAIModel(model: CherryModelInput): boolean {
   const modelId = getLowerBaseModelName(model.id);
-  const isGPT5SeriesModel = modelId.includes('gpt-5') && !modelId.includes('gpt-5.1') && !modelId.includes('gpt-5.2');
-  const isGPT51SeriesModel = modelId.includes('gpt-5.1');
-  const isGPT52SeriesModel = modelId.includes('gpt-5.2');
+  const isGPT5SeriesModel = /(?:^|\/)gpt-5(?:\.\d+)?(?:-|$)/.test(modelId);
   return (
     (modelId.includes('o1') && !(modelId.includes('o1-preview') || modelId.includes('o1-mini'))) ||
     modelId.includes('o3') ||
     modelId.includes('o4') ||
     modelId.includes('gpt-oss') ||
-    ((isGPT5SeriesModel || isGPT51SeriesModel || isGPT52SeriesModel) && !modelId.includes('chat'))
+    (isGPT5SeriesModel && !modelId.includes('chat'))
   );
 }
 
@@ -578,5 +576,4 @@ export function matchCherryAvailableTab(tab: CherryAvailableTab, model: CherryMo
   // reasoning tab（Cherry：严格 isReasoningModel）
   return isReasoningModel(model);
 }
-
 

--- a/prd-admin/src/lib/modelPresetTags.test.ts
+++ b/prd-admin/src/lib/modelPresetTags.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { inferPresetTagKeys } from './modelPresetTags';
+
+describe('GPT-5.6 model preset tags', () => {
+  it.each(['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'])('识别 %s 的核心能力', (modelName) => {
+    const tags = inferPresetTagKeys(modelName, modelName, 'openai', 'openai');
+
+    expect(tags).toContain('reasoning');
+    expect(tags).toContain('vision');
+    expect(tags).toContain('function_calling');
+    expect(tags).toContain('websearch');
+  });
+});

--- a/prd-admin/src/pages/ModelManagePage.tsx
+++ b/prd-admin/src/pages/ModelManagePage.tsx
@@ -2376,7 +2376,7 @@ export default function ModelManagePage() {
                 onChange={(e) => setModelForm((s) => ({ ...s, modelName: e.target.value }))}
                 className="h-10 w-full rounded-[14px] px-4 text-sm outline-none"
                 style={inputStyle}
-                placeholder="如 gpt-4o"
+                placeholder="如 gpt-5.6-sol"
               />
             </div>
 

--- a/prd-admin/src/services/mock/db.ts
+++ b/prd-admin/src/services/mock/db.ts
@@ -35,8 +35,8 @@ export const db = {
     { id: 'p_qwen', name: '通义千问', platformType: 'qwen', apiUrl: 'https://dashscope.aliyuncs.com', apiKeyMasked: 'sk-****************', enabled: false },
   ] as Platform[],
   models: [
-    { id: 'm_1', name: 'GPT-4o', modelName: 'gpt-4o', platformId: 'p_openai', enabled: true, isMain: true, isIntent: false, isVision: false, isImageGen: false, group: 'openai-gpt', enablePromptCache: true },
-    { id: 'm_2', name: 'GPT-4o mini', modelName: 'gpt-4o-mini', platformId: 'p_openai', enabled: true, isMain: false, isIntent: true, isVision: false, isImageGen: false, group: 'openai-gpt', enablePromptCache: true },
+    { id: 'm_1', name: 'GPT-5.6 Sol', modelName: 'gpt-5.6-sol', platformId: 'p_openai', enabled: true, isMain: true, isIntent: false, isVision: false, isImageGen: false, group: 'openai-gpt-5.6', enablePromptCache: true },
+    { id: 'm_2', name: 'GPT-5.6 Luna', modelName: 'gpt-5.6-luna', platformId: 'p_openai', enabled: true, isMain: false, isIntent: true, isVision: false, isImageGen: false, group: 'openai-gpt-5.6', enablePromptCache: true },
     { id: 'm_3', name: 'Claude 3.5 Sonnet', modelName: 'claude-3-5-sonnet-20241022', platformId: 'p_anthropic', enabled: true, isMain: false, isIntent: false, isVision: false, isImageGen: false, group: 'anthropic-claude', enablePromptCache: true },
     { id: 'm_4', name: 'Qwen2.5', modelName: 'qwen2.5-72b-instruct', platformId: 'p_qwen', enabled: false, isMain: false, isIntent: false, isVision: false, isImageGen: false, group: 'qwen-qwen2', enablePromptCache: true },
   ] as Model[],
@@ -57,7 +57,7 @@ export const db = {
     {
       id: 'c_2',
       provider: 'OpenAI',
-      model: 'gpt-4o',
+      model: 'gpt-5.6-sol',
       apiEndpoint: 'https://api.openai.com',
       maxTokens: 8192,
       temperature: 0.6,

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ImageGenController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ImageGenController.cs
@@ -414,7 +414,7 @@ public class ImageGenController : ControllerBase
     /// <summary>
     /// 获取模型适配信息（尺寸选项、能力等，纯静态注册表查询，无需数据库）
     /// </summary>
-    /// <param name="modelId">平台侧模型ID（如 doubao-seedream-4-5、gpt-4-turbo）</param>
+    /// <param name="modelId">平台侧模型ID（如 doubao-seedream-4-5、gpt-image-1.5）</param>
     [HttpGet("adapter-info")]
     public IActionResult GetAdapterInfo([FromQuery] string modelId)
     {

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ModelsController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ModelsController.cs
@@ -707,7 +707,7 @@ public class ModelsController : ControllerBase
     /// <summary>
     /// 根据平台侧模型ID直接获取适配信息（无需查询数据库，支持任意模型）
     /// </summary>
-    /// <param name="modelId">平台侧模型ID（如 doubao-seedream-4-5、gpt-4-turbo）</param>
+    /// <param name="modelId">平台侧模型ID（如 doubao-seedream-4-5、gpt-5.6-sol）</param>
     [HttpGet("adapter-info")]
     public IActionResult GetAdapterInfoByModelId([FromQuery] string modelId)
     {

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/PlatformsController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/PlatformsController.cs
@@ -738,7 +738,7 @@ public class PlatformsController : ControllerBase
             "  \"tags\": string[],     // 仅允许这些值：vision, embedding, rerank, function_calling, web_search, reasoning, free\n" +
             "  \"confidence\": number  // 0-1，可选\n" +
             "}\n\n" +
-            "分组建议：按产品家族/系列（例如 doubao-vision, doubao-1.5, qwen2.5, gpt-4o 等），避免过长；不要返回空字符串。\n" +
+            "分组建议：按产品家族/系列（例如 doubao-vision, doubao-1.5, qwen2.5, gpt-5.6 等），避免过长；不要返回空字符串。\n" +
             "标签规则：一个模型可同时拥有多个标签；不确定时可只给 reasoning。\n";
 
         var input = new

--- a/prd-api/src/PrdAgent.Api/Services/TranscriptRunWorker.cs
+++ b/prd-api/src/PrdAgent.Api/Services/TranscriptRunWorker.cs
@@ -301,13 +301,14 @@ public class TranscriptRunWorker : BackgroundService
         // 构建 OpenAI 格式的 chat 请求体
         var requestBody = new JsonObject
         {
-            ["model"] = "gpt-4",
+            ["model"] = "gpt-5.6-terra",
             ["messages"] = new JsonArray
             {
                 new JsonObject { ["role"] = "system", ["content"] = systemPrompt },
                 new JsonObject { ["role"] = "user", ["content"] = $"以下是需要整理的转写文本：\n\n{transcriptText}" }
             },
-            ["max_tokens"] = 4096
+            ["max_completion_tokens"] = 4096,
+            ["reasoning_effort"] = "none"
         };
 
         var request = new GatewayRequest

--- a/prd-api/src/PrdAgent.Core/Models/CapsuleTypeRegistry.cs
+++ b/prd-api/src/PrdAgent.Core/Models/CapsuleTypeRegistry.cs
@@ -1183,7 +1183,7 @@ public static class CapsuleTypeRegistry
                 new() { Value = "codex-sdk", Label = "Codex SDK" },
                 new() { Value = "fake", Label = "Fake Runtime（仅用于链路自测）" },
             }},
-            new() { Key = "model", Label = "模型", FieldType = "text", Required = false, Placeholder = "claude-sonnet-4-5 / gpt-5.2 / 自定义模型名" },
+            new() { Key = "model", Label = "模型", FieldType = "text", Required = false, Placeholder = "claude-sonnet-4-5 / gpt-5.6-sol / 自定义模型名" },
             new() { Key = "toolPolicy", Label = "工具策略", FieldType = "select", Required = false, DefaultValue = "readonly-auto", Options = new()
             {
                 new() { Value = "readonly-auto", Label = "只读自动允许" },

--- a/prd-api/src/PrdAgent.Core/Models/ImageAsset.cs
+++ b/prd-api/src/PrdAgent.Core/Models/ImageAsset.cs
@@ -53,9 +53,8 @@ public class ImageAsset
     public DateTime? DescriptionExtractedAt { get; set; }
 
     /// <summary>
-    /// 提取描述时使用的模型标识（如 gpt-4o、claude-3-5-sonnet）。
+    /// 提取描述时使用的模型标识（如 gpt-5.6-sol、claude-3-5-sonnet）。
     /// </summary>
     public string? DescriptionModelId { get; set; }
 }
-
 

--- a/prd-api/src/PrdAgent.Core/Models/LLMModel.cs
+++ b/prd-api/src/PrdAgent.Core/Models/LLMModel.cs
@@ -35,10 +35,10 @@ public class LLMModel
     /// <summary>模型ID（通过 IIdGenerator 生成）</summary>
     public string Id { get; set; } = string.Empty;
     
-    /// <summary>模型显示名称 (如: GPT-4 Turbo)</summary>
+    /// <summary>模型显示名称 (如: GPT-5.6 Sol)</summary>
     public string Name { get; set; } = string.Empty;
     
-    /// <summary>模型ID/实际调用名 (如: gpt-4-turbo-preview)</summary>
+    /// <summary>模型ID/实际调用名 (如: gpt-5.6-sol)</summary>
     public string ModelName { get; set; } = string.Empty;
     
     /// <summary>API地址 (可继承自平台)</summary>
@@ -128,4 +128,3 @@ public class LLMModel
     /// <summary>更新时间</summary>
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 }
-

--- a/prd-api/src/PrdAgent.Infrastructure/LLM/LLMJsonContext.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LLM/LLMJsonContext.cs
@@ -168,7 +168,9 @@ internal class ClaudeUsage
 internal class OpenAIRequest
 {
     public string Model { get; set; } = string.Empty;
-    public int MaxTokens { get; set; }
+    public int? MaxTokens { get; set; }
+    public int? MaxCompletionTokens { get; set; }
+    public string? ReasoningEffort { get; set; }
     public double Temperature { get; set; }
     public List<OpenAIRequestMessage> Messages { get; set; } = new();
     public bool Stream { get; set; }
@@ -266,4 +268,3 @@ internal class OpenAIPromptTokensDetails
 }
 
 #endregion
-

--- a/prd-api/src/PrdAgent.Infrastructure/LLM/OpenAIClient.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LLM/OpenAIClient.cs
@@ -13,6 +13,8 @@ namespace PrdAgent.Infrastructure.LLM;
 /// </summary>
 public class OpenAIClient : ILLMClient
 {
+    private const string DefaultModel = "gpt-5.6-sol";
+
     private readonly HttpClient _httpClient;
     private readonly string _apiKey;
     private readonly string _model;
@@ -30,7 +32,7 @@ public class OpenAIClient : ILLMClient
     public OpenAIClient(
         HttpClient httpClient,
         string apiKey,
-        string model = "gpt-4-turbo",
+        string model = DefaultModel,
         int maxTokens = 4096,
         double temperature = 0.7,
         bool enablePromptCache = true,
@@ -125,10 +127,13 @@ public class OpenAIClient : ILLMClient
             });
         }
 
+        var isGpt56Family = IsGpt56FamilyModel(_model);
         var requestBody = new OpenAIRequest
         {
             Model = _model,
-            MaxTokens = _maxTokens,
+            MaxTokens = isGpt56Family ? null : _maxTokens,
+            MaxCompletionTokens = isGpt56Family ? _maxTokens : null,
+            ReasoningEffort = isGpt56Family ? "none" : null,
             Temperature = _temperature,
             Messages = allMessages,
             Stream = true,
@@ -154,7 +159,9 @@ public class OpenAIClient : ILLMClient
             var reqForLog = new
             {
                 model = _model,
-                max_tokens = _maxTokens,
+                max_tokens = isGpt56Family ? (int?)null : _maxTokens,
+                max_completion_tokens = isGpt56Family ? _maxTokens : (int?)null,
+                reasoning_effort = isGpt56Family ? "none" : null,
                 temperature = _temperature,
                 stream = true,
                 stream_options = new { include_usage = true },
@@ -421,6 +428,15 @@ public class OpenAIClient : ILLMClient
                         FinishReason: finishReason));
             }
         }
+    }
+
+    private static bool IsGpt56FamilyModel(string model)
+    {
+        var normalized = (model ?? string.Empty).Trim().ToLowerInvariant();
+        var slash = normalized.LastIndexOf('/');
+        if (slash >= 0 && slash < normalized.Length - 1)
+            normalized = normalized[(slash + 1)..];
+        return normalized == "gpt-5.6" || normalized.StartsWith("gpt-5.6-", StringComparison.Ordinal);
     }
 
     private static OpenAIStreamEvent? TryParseEvent(string data)

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/LlmGateway.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/LlmGateway.cs
@@ -48,6 +48,7 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
     };
     private const string InvalidAppCallerErrorCode = "APP_CALLER_INVALID";
     private const string MaxTokensField = "max_tokens";
+    private const string MaxCompletionTokensField = "max_completion_tokens";
 
     public LlmGateway(
         IModelResolver modelResolver,
@@ -109,9 +110,15 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
         if (cap is not > 0)
             return null;
 
-        if (!requestBody.TryGetPropertyValue(MaxTokensField, out var raw) || raw == null)
+        var tokenField = UsesOpenAiProtocol(resolution)
+                         && IsGpt56FamilyModel(resolution.ActualModel)
+                         && requestBody["messages"] is JsonArray
+            ? MaxCompletionTokensField
+            : MaxTokensField;
+
+        if (!requestBody.TryGetPropertyValue(tokenField, out var raw) || raw == null)
         {
-            requestBody[MaxTokensField] = cap.Value;
+            requestBody[tokenField] = cap.Value;
             return cap.Value;
         }
 
@@ -120,7 +127,7 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
 
         if (requested > cap.Value)
         {
-            requestBody[MaxTokensField] = cap.Value;
+            requestBody[tokenField] = cap.Value;
             return cap.Value;
         }
 
@@ -313,6 +320,7 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
                 var requestBody = CloneEffectiveRequestBody(request);
                 requestBody["model"] = activeResolution.ActualModel;
                 requestBody["stream"] = false;
+                ApplyGpt56ChatCompletionsCompatibility(requestBody, activeResolution);
                 var cappedMaxTokens = ApplyResolvedMaxTokensCap(requestBody, activeResolution);
                 if (cappedMaxTokens.HasValue)
                 {
@@ -554,6 +562,7 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
                 var requestBody = CloneEffectiveRequestBody(request);
                 requestBody["model"] = resolution.ActualModel;
                 requestBody["stream"] = true;
+                ApplyGpt56ChatCompletionsCompatibility(requestBody, resolution);
                 var cappedMaxTokens = ApplyResolvedMaxTokensCap(requestBody, resolution);
                 if (cappedMaxTokens.HasValue)
                 {
@@ -1290,6 +1299,8 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
         {
             var requestBody = request.RequestBody?.DeepClone() as JsonObject ?? new JsonObject();
             requestBody["model"] = resolution.ActualModel;
+            if (IsChatCompletionsEndpoint(request.EndpointPath))
+                ApplyGpt56ChatCompletionsCompatibility(requestBody, resolution);
             ApplyResolvedMaxTokensCap(requestBody, resolution);
             if (TryBuildRawCapabilityFailure(request, resolution, requestBody, out var capabilityError))
             {
@@ -1533,6 +1544,8 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
                 // JSON 请求
                 var requestBody = request.RequestBody ?? new JsonObject();
                 requestBody["model"] = resolution.ActualModel;
+                if (IsChatCompletionsEndpoint(request.EndpointPath))
+                    ApplyGpt56ChatCompletionsCompatibility(requestBody, resolution);
                 ApplyResolvedMaxTokensCap(requestBody, resolution);
                 if (TryBuildRawCapabilityFailure(request, resolution, requestBody, out var capabilityError))
                 {
@@ -2661,6 +2674,62 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
         => requestBody.TryGetPropertyValue("tools", out var tools)
            && tools is System.Text.Json.Nodes.JsonArray arr && arr.Count > 0;
 
+    private static void ApplyGpt56ChatCompletionsCompatibility(JsonObject requestBody, ModelResolutionResult resolution)
+    {
+        if (!UsesOpenAiProtocol(resolution)
+            || !IsGpt56FamilyModel(resolution.ActualModel)
+            || requestBody["messages"] is not JsonArray)
+        {
+            return;
+        }
+
+        if (!requestBody.ContainsKey("reasoning_effort"))
+            requestBody["reasoning_effort"] = "none";
+
+        if (requestBody.TryGetPropertyValue(MaxTokensField, out var maxTokens))
+        {
+            if (!requestBody.ContainsKey(MaxCompletionTokensField))
+                requestBody[MaxCompletionTokensField] = maxTokens?.DeepClone();
+            requestBody.Remove(MaxTokensField);
+        }
+    }
+
+    private static bool UsesOpenAiProtocol(ModelResolutionResult resolution)
+    {
+        var protocol = string.IsNullOrWhiteSpace(resolution.Protocol)
+            ? resolution.PlatformType
+            : resolution.Protocol;
+        return string.Equals(protocol, "openai", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsGpt56FamilyModel(string? model)
+    {
+        var normalized = (model ?? string.Empty).Trim().ToLowerInvariant();
+        var slash = normalized.LastIndexOf('/');
+        if (slash >= 0 && slash < normalized.Length - 1)
+            normalized = normalized[(slash + 1)..];
+        return normalized == "gpt-5.6" || normalized.StartsWith("gpt-5.6-", StringComparison.Ordinal);
+    }
+
+    private static bool IsChatCompletionsEndpoint(string? endpointPath)
+        => !string.IsNullOrWhiteSpace(endpointPath)
+           && endpointPath.Contains("chat/completions", StringComparison.OrdinalIgnoreCase);
+
+    private static bool HasIncompatibleGpt56ToolReasoning(JsonObject requestBody, ModelResolutionResult resolution)
+    {
+        if (!UsesOpenAiProtocol(resolution)
+            || !IsGpt56FamilyModel(resolution.ActualModel)
+            || !RequestHasTools(requestBody))
+        {
+            return false;
+        }
+
+        return !requestBody.TryGetPropertyValue("reasoning_effort", out var effort)
+               || effort is not JsonValue effortValue
+               || !effortValue.TryGetValue<string>(out var effortText)
+               || !string.Equals(effortText, "none", StringComparison.OrdinalIgnoreCase);
+    }
+
     private static bool TryBuildCapabilityFailure(GatewayRequest request, ModelResolutionResult resolution, JsonObject requestBody, out GatewayResponse? error)
     {
         error = null;
@@ -2675,6 +2744,15 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
         if (TryBuildStrictParameterCapabilityFailure(request.Context, resolution, requestBody, out var parameterError))
         {
             error = parameterError;
+            return true;
+        }
+
+        if (HasIncompatibleGpt56ToolReasoning(requestBody, resolution))
+        {
+            error = GatewayResponse.Fail(
+                "GPT56_TOOLS_REQUIRE_REASONING_NONE",
+                $"模型 {resolution.ActualModel} 通过 Chat Completions 调用函数工具时 reasoning_effort 必须为 none；需要推理与工具并用时请改用 Responses API。",
+                400);
             return true;
         }
 
@@ -2771,6 +2849,15 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
         if (TryBuildStrictParameterCapabilityRawFailure(request.Context, resolution, requestBody, out var parameterError))
         {
             error = parameterError;
+            return true;
+        }
+
+        if (requestBody is not null && HasIncompatibleGpt56ToolReasoning(requestBody, resolution))
+        {
+            error = GatewayRawResponse.Fail(
+                "GPT56_TOOLS_REQUIRE_REASONING_NONE",
+                $"模型 {resolution.ActualModel} 通过 Chat Completions 调用函数工具时 reasoning_effort 必须为 none；需要推理与工具并用时请改用 Responses API。",
+                400);
             return true;
         }
 

--- a/prd-api/src/PrdAgent.Infrastructure/ModelPool/Models/PoolEndpoint.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/ModelPool/Models/PoolEndpoint.cs
@@ -12,7 +12,7 @@ public class PoolEndpoint
     public string EndpointId { get; set; } = string.Empty;
 
     /// <summary>
-    /// 模型名称（如 gpt-4o, claude-3-opus）
+    /// 模型名称（如 gpt-5.6-terra, claude-3-opus）
     /// </summary>
     public string ModelId { get; set; } = string.Empty;
 

--- a/prd-api/tests/PrdAgent.Api.Tests/Services/LlmGatewayTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Services/LlmGatewayTests.cs
@@ -2196,6 +2196,75 @@ public class LlmGatewayTests
 
     #region Helper Methods
 
+    [Fact]
+    public async Task SendAsync_Gpt56ChatCompletions_NormalizesLegacyParameters()
+    {
+        var http = new SequenceHttpClientFactory();
+        var gateway = CreateGatewayForModel("gpt-5.6-sol", http);
+
+        var response = await gateway.SendAsync(new GatewayRequest
+        {
+            AppCallerCode = AppCallerRegistry.Admin.Lab.Chat,
+            ModelType = ModelTypes.Chat,
+            RequestBody = new JsonObject
+            {
+                ["messages"] = new JsonArray
+                {
+                    new JsonObject { ["role"] = "user", ["content"] = "hi" }
+                },
+                ["max_tokens"] = 128,
+                ["tools"] = new JsonArray
+                {
+                    new JsonObject
+                    {
+                        ["type"] = "function",
+                        ["function"] = new JsonObject { ["name"] = "lookup" }
+                    }
+                }
+            }
+        });
+
+        Assert.True(response.Success);
+        var body = JsonNode.Parse(Assert.Single(http.RequestBodies))!.AsObject();
+        Assert.Equal("gpt-5.6-sol", (string?)body["model"]);
+        Assert.Equal("none", (string?)body["reasoning_effort"]);
+        Assert.Equal(128, (int?)body["max_completion_tokens"]);
+        Assert.False(body.ContainsKey("max_tokens"));
+    }
+
+    [Fact]
+    public async Task SendAsync_Gpt56ToolsWithReasoning_FailsBeforeHttp()
+    {
+        var http = new SequenceHttpClientFactory();
+        var gateway = CreateGatewayForModel("gpt-5.6-terra", http);
+
+        var response = await gateway.SendAsync(new GatewayRequest
+        {
+            AppCallerCode = AppCallerRegistry.Admin.Lab.Chat,
+            ModelType = ModelTypes.Chat,
+            RequestBody = new JsonObject
+            {
+                ["messages"] = new JsonArray
+                {
+                    new JsonObject { ["role"] = "user", ["content"] = "hi" }
+                },
+                ["reasoning_effort"] = "low",
+                ["tools"] = new JsonArray
+                {
+                    new JsonObject
+                    {
+                        ["type"] = "function",
+                        ["function"] = new JsonObject { ["name"] = "lookup" }
+                    }
+                }
+            }
+        });
+
+        Assert.False(response.Success);
+        Assert.Equal("GPT56_TOOLS_REQUIRE_REASONING_NONE", response.ErrorCode);
+        Assert.Empty(http.RequestBodies);
+    }
+
     private static LlmGateway CreateCapabilityGateGateway(string modelType, params LLMModelCapability[] capabilities)
     {
         var resolver = new InMemoryModelResolver()
@@ -2229,6 +2298,40 @@ public class LlmGatewayTests
             });
 
         return new LlmGateway(resolver, new TestHttpClientFactory(), new TestLogger<LlmGateway>());
+    }
+
+    private static LlmGateway CreateGatewayForModel(string modelId, IHttpClientFactory httpClientFactory)
+    {
+        var resolver = new InMemoryModelResolver()
+            .WithPlatform(new LLMPlatform
+            {
+                Id = "openai-platform",
+                Name = "OpenAI",
+                PlatformType = "openai",
+                ApiUrl = "https://api.openai.com",
+                Enabled = true
+            }, "sk-test-key")
+            .WithModelGroup(new ModelGroup
+            {
+                Id = "gpt-5-6-pool",
+                Name = "GPT-5.6 Pool",
+                Code = "gpt-5-6-pool",
+                ModelType = ModelTypes.Chat,
+                IsDefaultForType = true,
+                Priority = 0,
+                Models = new List<ModelGroupItem>
+                {
+                    new()
+                    {
+                        PlatformId = "openai-platform",
+                        ModelId = modelId,
+                        Priority = 0,
+                        HealthStatus = ModelHealthStatus.Healthy
+                    }
+                }
+            });
+
+        return new LlmGateway(resolver, httpClientFactory, new TestLogger<LlmGateway>());
     }
 
     private static LlmGateway CreateTestGateway()


### PR DESCRIPTION
## 摘要

将仓库中的 OpenAI 默认模型、任务示例和管理端模型能力识别迁移到 GPT-5.6 Sol、Terra、Luna。保持现有 Chat Completions 调用方式，并补齐 GPT-5.6 的推理参数、输出 token 参数和函数工具兼容保护。

## 改动 diff

- `prd-api/src/PrdAgent.Infrastructure/LlmGateway/LlmGateway.cs`：为 GPT-5.6 Chat Completions 统一转换 `max_completion_tokens`，默认 `reasoning_effort: none`，拦截推理与函数工具的不兼容组合
- `prd-api/src/PrdAgent.Infrastructure/LLM/OpenAIClient.cs`：默认模型迁移到 `gpt-5.6-sol`，同步请求序列化和日志字段
- `prd-api/src/PrdAgent.Api/Services/TranscriptRunWorker.cs`：转写整理任务迁移到 `gpt-5.6-terra`
- `prd-admin/src/services/mock/db.ts`：管理端示例按主模型和意图模型映射到 Sol 与 Luna
- `prd-admin/src/lib/cherryStudioModelTags.ts`：支持带小版本号的 GPT-5 系列能力识别
- `prd-api/tests/PrdAgent.Api.Tests/Services/LlmGatewayTests.cs`、`prd-admin/src/lib/modelPresetTags.test.ts`：补充网关参数转换和 Sol/Terra/Luna 能力测试
- `changelogs/2026-07-20_gpt-5-6-family-migration.md`：新增 changelog 碎片

## 测试

- [x] `dotnet build --no-restore` 通过，0 个错误
- [x] GPT-5.6 网关专项测试 2/2 通过
- [x] `pnpm tsc --noEmit` 通过
- [x] 变更文件 ESLint 0 个错误；ModelManagePage 保留 10 条既有警告
- [x] 前端测试 103 个文件、796 项通过
- [x] `pnpm build` 通过
- [ ] 全量 API 回归受本地 MongoDB 认证及 .NET 8 TestHost 在 .NET 9 上运行的环境问题影响；此前结果为 1714 项通过、31 项环境性失败

## 验收

- 模型平台示例：https://gpt-5-6-family-migration-agent-prd-agent.miduo.org/mds?tab=platforms
- 模型中继示例：https://gpt-5-6-family-migration-agent-prd-agent.miduo.org/mds?tab=exchange
- CDS 分支查询当前超时，以上域名由 cdscli 同源公式回退生成，待自动部署就绪后验收

## 风险与后续

- 生产模型池存储在数据库中，本 PR 不直接修改运行态数据；上线前需确认实际池条目已配置为 GPT-5.6 Sol、Terra 或 Luna
- 需要推理与函数工具并用的调用应迁移到 Responses API，本 PR 对 Chat Completions 中的不兼容组合返回明确错误
