### PR TITLE
fix(llm): 修复 GPT-5.6 默认 raw Chat 参数转换

### DIFF
--- a/changelogs/2026-07-20_gpt-5-6-raw-chat-default-fix.md
+++ b/changelogs/2026-07-20_gpt-5-6-raw-chat-default-fix.md
@@ -1,0 +1,1 @@
+| fix | prd-api | 修复默认 raw Chat 路径未应用 GPT-5.6 请求参数兼容的问题 |

--- a/prd-api/src/PrdAgent.Infrastructure/LlmGateway/LlmGateway.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/LlmGateway/LlmGateway.cs
@@ -1299,7 +1299,7 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
         {
             var requestBody = request.RequestBody?.DeepClone() as JsonObject ?? new JsonObject();
             requestBody["model"] = resolution.ActualModel;
-            if (IsChatCompletionsEndpoint(request.EndpointPath))
+            if (IsChatCompletionsEndpoint(endpoint))
                 ApplyGpt56ChatCompletionsCompatibility(requestBody, resolution);
             ApplyResolvedMaxTokensCap(requestBody, resolution);
             if (TryBuildRawCapabilityFailure(request, resolution, requestBody, out var capabilityError))
@@ -1544,7 +1544,7 @@ public class LlmGateway : ILlmGateway, CoreGateway.ILlmGateway
                 // JSON 请求
                 var requestBody = request.RequestBody ?? new JsonObject();
                 requestBody["model"] = resolution.ActualModel;
-                if (IsChatCompletionsEndpoint(request.EndpointPath))
+                if (IsChatCompletionsEndpoint(endpoint))
                     ApplyGpt56ChatCompletionsCompatibility(requestBody, resolution);
                 ApplyResolvedMaxTokensCap(requestBody, resolution);
                 if (TryBuildRawCapabilityFailure(request, resolution, requestBody, out var capabilityError))

--- a/prd-api/tests/PrdAgent.Api.Tests/Services/LlmGatewayTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Services/LlmGatewayTests.cs
@@ -1604,6 +1604,48 @@ public class LlmGatewayTests
     }
 
     [Fact]
+    public async Task SendRawWithResolutionAsync_WhenGpt56UsesDefaultChatEndpoint_ShouldNormalizeLegacyParameters()
+    {
+        var resolution = new GatewayModelResolution
+        {
+            Success = true,
+            ResolutionType = "DirectModel",
+            ActualModel = "gpt-5.6-terra",
+            ActualPlatformId = "openai-platform",
+            ActualPlatformName = "OpenAI",
+            PlatformType = "openai",
+            Protocol = "openai",
+            ApiUrl = "https://api.openai.com",
+            ApiKey = "sk-test-key"
+        };
+        var http = new SequenceHttpClientFactory();
+        var gateway = new LlmGateway(new InMemoryModelResolver(), http, new TestLogger<LlmGateway>());
+
+        var response = await gateway.SendRawWithResolutionAsync(new GatewayRawRequest
+        {
+            AppCallerCode = AppCallerRegistry.System.HealthProbe.Chat,
+            ModelType = ModelTypes.Chat,
+            RequestBody = new JsonObject
+            {
+                ["messages"] = new JsonArray
+                {
+                    new JsonObject { ["role"] = "user", ["content"] = "hi" }
+                },
+                ["max_tokens"] = 8,
+                ["stream"] = false
+            }
+        }, resolution);
+
+        Assert.True(response.Success, response.ErrorMessage);
+        Assert.Equal("https://api.openai.com/v1/chat/completions", Assert.Single(http.RequestUris));
+        var body = JsonNode.Parse(Assert.Single(http.RequestBodies))!.AsObject();
+        Assert.Equal("gpt-5.6-terra", (string?)body["model"]);
+        Assert.Equal("none", (string?)body["reasoning_effort"]);
+        Assert.Equal(8, (int?)body["max_completion_tokens"]);
+        Assert.False(body.ContainsKey("max_tokens"));
+    }
+
+    [Fact]
     public async Task SendRawWithResolutionAsync_WhenOpenRouter_ShouldPrefixAppAttributionTitle()
     {
         var resolution = new GatewayModelResolution


### PR DESCRIPTION
## 摘要

修复已合并 PR #1201 中 Codex Review 指出的 P1：当 raw Chat 请求未设置 `EndpointPath` 时，网关虽然最终发送到默认 `/v1/chat/completions`，却没有应用 GPT-5.6 参数兼容。

## 根因

兼容判断检查的是可空的 `request.EndpointPath`，而默认 Chat 路径由适配器或网关稍后解析得到。健康探测和运行时上游配置测试均不显式设置该字段，因此 GPT-5.6 请求仍携带 `max_tokens` 且缺少 `reasoning_effort`。

## 改动 diff

- `prd-api/src/PrdAgent.Infrastructure/LlmGateway/LlmGateway.cs`：改为根据最终解析的实际 endpoint 判断 Chat Completions，覆盖显式路径、适配器默认路径和兜底路径
- `prd-api/tests/PrdAgent.Api.Tests/Services/LlmGatewayTests.cs`：新增无 `EndpointPath` 的 GPT-5.6 raw Chat 回归测试，断言默认 URL、参数转换和旧字段移除
- `changelogs/2026-07-20_gpt-5-6-raw-chat-default-fix.md`：新增修复记录

## 测试

- [x] `dotnet build --no-restore` 通过，0 个错误
- [x] GPT-5.6 专项测试 3/3 通过
- [x] 完整 `LlmGatewayTests` 129/129 通过
- [x] `git diff --check` 通过

## 验收

- 模型池页面：https://fix-gpt-5-6-raw-chat-default-agent-prd-agent.miduo.org/mds?tab=pools
- CDS 分支查询当前超时，域名由 cdscli 同源公式回退生成，待自动部署就绪后验收
