### PR TITLE
fix(cds): 统一无协议 GitHub 仓库身份

### DIFF
--- a/cds/src/services/release-strategy.ts
+++ b/cds/src/services/release-strategy.ts
@@ -72,6 +72,7 @@ export function normalizeRepositoryIdentity(value?: string): string {
     }
   }
   return repositoryPath
+    .replace(/^(?:www\.)?github\.com[/:]/i, '')
     .replace(/^\/+|\/+$/g, '')
     .replace(/\.git$/i, '')
     .toLowerCase();

--- a/cds/tests/services/release-strategy.test.ts
+++ b/cds/tests/services/release-strategy.test.ts
@@ -126,6 +126,7 @@ describe('release strategy discovery and generation', () => {
     expect(normalizeRepositoryIdentity('Owner/Repo')).toBe('owner/repo');
     expect(normalizeRepositoryIdentity('https://github.com/Owner/Repo.git')).toBe('owner/repo');
     expect(normalizeRepositoryIdentity('git@github.com:Owner/Repo.git')).toBe('owner/repo');
+    expect(normalizeRepositoryIdentity('github.com/Owner/Repo')).toBe('owner/repo');
   });
 
   it('executes a generated static release twice and preserves atomic current and previous versions', () => {

--- a/changelogs/2026-07-20_cds-release-repository-normalization.md
+++ b/changelogs/2026-07-20_cds-release-repository-normalization.md
@@ -1,0 +1,1 @@
+| fix | cds | 修复无协议 GitHub origin 被正式发布预检误判为跨项目仓库 |


### PR DESCRIPTION
## 摘要
修复正式发布预检将无协议 GitHub origin 误判为跨项目仓库的问题，同时保持项目身份锁与跨项目拒绝不变。

## 改动 diff
- cds/src/services/release-strategy.ts：规范化 github.com/Owner/Repo 形式
- cds/tests/services/release-strategy.test.ts：新增无协议 origin 回归测试
- changelogs/2026-07-20_cds-release-repository-normalization.md：新增修复记录

## 测试
- [x] pnpm exec vitest run tests/services/release-strategy.test.ts，6/6 通过
- [x] pnpm build 通过
- [x] git diff --check 通过