### PR TITLE
security(cds): 隔离项目级 Key 的项目列表

### DIFF
--- a/cds/src/routes/projects.ts
+++ b/cds/src/routes/projects.ts
@@ -1503,7 +1503,9 @@ export function createProjectsRouter(deps: ProjectsRouterDeps): Router {
     }
   }
 
-  // GET /api/projects — list all projects.
+  // GET /api/projects — list projects visible to the current caller.
+  // Project-scoped keys must only discover their bound project; browser
+  // sessions, bootstrap keys and unscoped callers retain the full list.
   //
   // Wrapped in try/catch so an unexpected exception inside
   // statsFor (e.g. a malformed branch entry in state.json)
@@ -1513,7 +1515,12 @@ export function createProjectsRouter(deps: ProjectsRouterDeps): Router {
   // what triggered the failure.
   router.get('/projects', (req, res) => {
     try {
-      const projects = stateService.getProjects();
+      const projectScope = (
+        req as unknown as { cdsProjectKey?: { projectId: string } }
+      ).cdsProjectKey?.projectId;
+      const projects = stateService
+        .getProjects()
+        .filter((project) => !projectScope || project.id === projectScope);
       const usageMap = resourceUsageLookup();
       // SECURITY P1 (2026-05-09): mask customEnv/defaultEnv for non-owners.
       // Static AI_ACCESS_KEY / cdsg_ global key callers get key names but

--- a/cds/tests/routes/agent-keys.test.ts
+++ b/cds/tests/routes/agent-keys.test.ts
@@ -4,7 +4,8 @@
  * Covers:
  *   1) sign → list → revoke happy path
  *   2) auth with project-key permits project-scoped routes for its own project
- *   3) auth with project-key rejects another project's routes with 403
+ *   3) project list discovery is isolated to the key's own project
+ *   4) auth with project-key rejects another project's routes with 403
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -198,6 +199,31 @@ describe('Agent Keys (project-scoped)', () => {
     // assertProjectAccess helper: direct unit check too.
     const allow = assertProjectAccess({ cdsProjectKey: match! }, 'default');
     expect(allow).toBeNull();
+  });
+
+  it('project-key only discovers its bound project in the project list', async () => {
+    const signRes = await request(server, 'POST', '/api/projects/default/agent-keys', {});
+    expect(signRes.status).toBe(201);
+    const plaintext = signRes.body.plaintext as string;
+
+    const scopedList = await request(
+      server,
+      'GET',
+      '/api/projects',
+      undefined,
+      { 'X-AI-Access-Key': plaintext },
+    );
+    expect(scopedList.status).toBe(200);
+    expect(scopedList.body.total).toBe(1);
+    expect(scopedList.body.projects.map((project: Project) => project.id)).toEqual(['default']);
+
+    const unscopedList = await request(server, 'GET', '/api/projects');
+    expect(unscopedList.status).toBe(200);
+    expect(unscopedList.body.total).toBe(2);
+    expect(unscopedList.body.projects.map((project: Project) => project.id).sort()).toEqual([
+      'alt-proj-id',
+      'default',
+    ]);
   });
 
   it('project-key is refused on a different project (403 project_mismatch)', async () => {

--- a/changelogs/2026-07-22_cds-project-key-project-list-isolation.md
+++ b/changelogs/2026-07-22_cds-project-key-project-list-isolation.md
@@ -1,0 +1,1 @@
+| security | cds | 项目级 Agent Key 的项目列表仅返回绑定项目，防止跨项目元数据泄露 |


### PR DESCRIPTION
## 摘要
修复项目级 CDS Key 调用 GET /api/projects 时能发现其他项目摘要的问题，使其只返回绑定项目，同时保留管理员、浏览器会话和非项目级调用方的既有完整列表行为。

## 改动 diff
- cds/src/routes/projects.ts：按 cdsProjectKey.projectId 收窄项目列表。
- cds/tests/routes/agent-keys.test.ts：新增项目列表隔离与无作用域兼容回归。
- changelogs/2026-07-22_cds-project-key-project-list-isolation.md：记录安全修复。

## 测试
- [x] 项目路由与 Agent Key 测试 91/91
- [x] 全局 Agent Key 回归 18/18
- [x] pnpm --dir cds build
- [x] git diff --check