### PR TITLE
fix(llmgw): 补齐实体详情教程漂移映射

### DIFF
--- a/changelogs/2026-07-23_llmgw-tutorial-entity-drift.md
+++ b/changelogs/2026-07-23_llmgw-tutorial-entity-drift.md
@@ -1,0 +1,1 @@
+| fix | llmgw | 补齐模型、Provider 与 App 详情页的教程漂移映射和回归测试 |

--- a/llmgw/tutorial/maintenance-map.json
+++ b/llmgw/tutorial/maintenance-map.json
@@ -14,6 +14,7 @@
     {"id":"home","pagePath":"llmgw/web/src/pages/OverviewPage.tsx","tutorialSourceIds":["chapter-03"]},
     {"id":"logs","pagePath":"llmgw/web/src/pages/LogsPage.tsx","tutorialSourceIds":["chapter-13","chapter-21","chapter-30","practical-image-03","practical-image-04"]},
     {"id":"log-detail","pagePath":"llmgw/web/src/pages/LogDetailPage.tsx","tutorialSourceIds":["chapter-13","chapter-21"]},
+    {"id":"log-entity-details","pagePath":"llmgw/web/src/pages/EntityDetailsPages.tsx","tutorialSourceIds":["chapter-06","chapter-07","chapter-09","chapter-13","chapter-14","chapter-18","chapter-21","practical-image-01","practical-image-02","practical-image-03","practical-image-04"]},
     {"id":"app-callers","pagePath":"llmgw/web/src/pages/AppCallersPage.tsx","tutorialSourceIds":["chapter-09","chapter-14","practical-image-02"]},
     {"id":"prompt-policy","pagePath":"llmgw/web/src/pages/PromptPolicyPage.tsx","tutorialSourceIds":["chapter-20","chapter-24"]},
     {"id":"model-pools","pagePath":"llmgw/web/src/pages/ModelPoolsPage.tsx","tutorialSourceIds":["chapter-08","chapter-17","chapter-18"]},

--- a/llmgw/tutorial/test_maintenance.py
+++ b/llmgw/tutorial/test_maintenance.py
@@ -41,6 +41,39 @@ class TutorialMaintenanceTests(unittest.TestCase):
         self.assertEqual("drift", report["status"])
         self.assertEqual("P1", report["findings"][0]["severity"])
 
+    def test_log_entity_details_maps_to_model_provider_app_tutorials(self) -> None:
+        report = analyze(
+            REPO_ROOT,
+            self.mapping,
+            self.manifest,
+            [
+                "llmgw/web/src/pages/EntityDetailsPages.tsx",
+                "llmgw/tutorial/chapters/13-first-request.md",
+            ],
+            self.now,
+        )
+
+        self.assertEqual("healthy", report["status"])
+        self.assertEqual([], report["findings"])
+        self.assertEqual("log-entity-details", report["affectedTutorials"][0]["surface"])
+        self.assertTrue(report["affectedTutorials"][0]["tutorialChanged"])
+        self.assertEqual(
+            [
+                "chapter-06",
+                "chapter-07",
+                "chapter-09",
+                "chapter-13",
+                "chapter-14",
+                "chapter-18",
+                "chapter-21",
+                "practical-image-01",
+                "practical-image-02",
+                "practical-image-03",
+                "practical-image-04",
+            ],
+            report["affectedTutorials"][0]["tutorialSourceIds"],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 摘要
补齐日志模型、Provider 与 App 独立详情页的教程维护映射，消除日常漂移工作流的 P1 误报。

## 改动 diff
- `llmgw/tutorial/maintenance-map.json`：把实体详情页映射到模型、Provider、App、日志和实战教程章节。
- `llmgw/tutorial/test_maintenance.py`：新增详情页映射回归测试。
- `changelogs/2026-07-23_llmgw-tutorial-entity-drift.md`：记录本次有限修复。

## 测试
- [x] `python3 llmgw/tutorial/publisher.py check`
- [x] `python3 -m unittest llmgw/tutorial/test_publisher.py llmgw/tutorial/test_maintenance.py`，12 项通过
- [x] 日常漂移工作流同参数运行，P0/P1/P2 均为 0