### PR TITLE
fix(llmgw): 围栏过期的 Provisioning 修复器写入

### DIFF
--- a/changelogs/2026-07-23_llmgw-repair-generation-fencing.md
+++ b/changelogs/2026-07-23_llmgw-repair-generation-fencing.md
@@ -1,0 +1,2 @@
+| fix | llmgw | 修复 Provisioning 修复租约被更高 generation 接管后旧持有者仍可继续写入业务数据的问题 |
+| test | llmgw | 增加旧 repair token 与 generation 失效后的业务写入围栏回归测试 |

--- a/llmgw/console-api/Provisioning/GatewayRecoveryOperations.cs
+++ b/llmgw/console-api/Provisioning/GatewayRecoveryOperations.cs
@@ -158,6 +158,7 @@ public static class GatewayRecoveryOperations
 {
     private static readonly TimeSpan OperationLease = TimeSpan.FromMinutes(2);
     private static readonly TimeSpan HeartbeatInterval = TimeSpan.FromSeconds(30);
+    private const string RepairLeaseLostDetail = "repair-lease-lost";
 
     public static GatewayRecoveryOperation New(
         string kind,
@@ -231,21 +232,16 @@ public static class GatewayRecoveryOperations
 
             try
             {
-                var detail = operation.Kind switch
-                {
-                    GatewayRecoveryKinds.TenantCreate => await RepairTenantCreateAsync(database, operation),
-                    GatewayRecoveryKinds.MemberCreate => await RepairMemberCreateAsync(database, operation),
-                    GatewayRecoveryKinds.OwnerMutation => await RepairOwnerMutationAsync(database, operation),
-                    _ => "unknown-operation-kind",
-                };
-                await operations.UpdateOneAsync(
+                var detail = await RepairClaimedAsync(database, operation, token);
+                if (detail == RepairLeaseLostDetail) continue;
+                var completed = await operations.UpdateOneAsync(
                     x => x.Id == operation.Id && x.Status == "repairing" && x.RepairToken == token,
                     Builders<GatewayRecoveryOperation>.Update
                         .Set(x => x.Status, detail == "unknown-operation-kind" ? "repair-failed" : "repaired")
                         .Set(x => x.Detail, detail)
                         .Set(x => x.UpdatedAt, DateTime.UtcNow),
                     cancellationToken: CancellationToken.None);
-                repaired++;
+                if (completed.ModifiedCount == 1) repaired++;
             }
             catch (Exception ex)
             {
@@ -262,22 +258,53 @@ public static class GatewayRecoveryOperations
         return repaired;
     }
 
-    private static async Task<string> RepairTenantCreateAsync(IMongoDatabase database, GatewayRecoveryOperation operation)
+    internal static async Task<string> RepairClaimedAsync(
+        IMongoDatabase database,
+        GatewayRecoveryOperation operation,
+        string repairToken)
     {
+        try
+        {
+            await RenewRepairLeaseOrThrowAsync(database, operation, repairToken);
+            return operation.Kind switch
+            {
+                GatewayRecoveryKinds.TenantCreate => await RepairTenantCreateAsync(database, operation, repairToken),
+                GatewayRecoveryKinds.MemberCreate => await RepairMemberCreateAsync(database, operation, repairToken),
+                GatewayRecoveryKinds.OwnerMutation => await RepairOwnerMutationAsync(database, operation, repairToken),
+                _ => "unknown-operation-kind",
+            };
+        }
+        catch (GatewayRecoveryLeaseLostException)
+        {
+            return RepairLeaseLostDetail;
+        }
+    }
+
+    private static async Task<string> RepairTenantCreateAsync(
+        IMongoDatabase database,
+        GatewayRecoveryOperation operation,
+        string repairToken)
+    {
+        await RenewRepairLeaseOrThrowAsync(database, operation, repairToken);
         await database.GetCollection<LlmGwMembership>("llmgw_memberships")
             .DeleteOneAsync(x => x.Id == operation.MembershipId && x.TenantId == operation.TenantId, CancellationToken.None);
+        await RenewRepairLeaseOrThrowAsync(database, operation, repairToken);
         await database.GetCollection<LlmGwTeam>("llmgw_teams")
             .DeleteOneAsync(x => x.Id == operation.TeamId && x.TenantId == operation.TenantId, CancellationToken.None);
+        await RenewRepairLeaseOrThrowAsync(database, operation, repairToken);
         await database.GetCollection<LlmGwTenant>("llmgw_tenants")
             .DeleteOneAsync(x => x.Id == operation.TenantId, CancellationToken.None);
+        await RenewRepairLeaseOrThrowAsync(database, operation, repairToken);
         await database.GetCollection<LlmGwUser>("llmgw_console_users").UpdateOneAsync(
             x => x.Id == operation.UserId,
             Builders<LlmGwUser>.Update
                 .Pull(x => x.TenantIds, operation.TenantId)
                 .Set(x => x.UpdatedAt, DateTime.UtcNow),
             cancellationToken: CancellationToken.None);
+        await RenewRepairLeaseOrThrowAsync(database, operation, repairToken);
         await database.GetCollection<MongoDB.Bson.BsonDocument>("llmgw_model_pool_types")
             .DeleteManyAsync(Builders<MongoDB.Bson.BsonDocument>.Filter.Eq("TenantId", operation.TenantId), CancellationToken.None);
+        await RenewRepairLeaseOrThrowAsync(database, operation, repairToken);
         await database.GetCollection<MongoDB.Bson.BsonDocument>("llmgw_model_pools")
             .DeleteManyAsync(Builders<MongoDB.Bson.BsonDocument>.Filter.And(
                 Builders<MongoDB.Bson.BsonDocument>.Filter.Eq("TenantId", operation.TenantId),
@@ -285,20 +312,29 @@ public static class GatewayRecoveryOperations
         return "tenant-create-rolled-back";
     }
 
-    private static async Task<string> RepairMemberCreateAsync(IMongoDatabase database, GatewayRecoveryOperation operation)
+    private static async Task<string> RepairMemberCreateAsync(
+        IMongoDatabase database,
+        GatewayRecoveryOperation operation,
+        string repairToken)
     {
+        await RenewRepairLeaseOrThrowAsync(database, operation, repairToken);
         await TenantOwnerAuthority.DiscardProvisionedOwnerAsync(
             database.GetCollection<LlmGwTenant>("llmgw_tenants"),
             operation.TenantId,
             operation.MembershipId);
+        await RenewRepairLeaseOrThrowAsync(database, operation, repairToken);
         await database.GetCollection<LlmGwMembership>("llmgw_memberships")
             .DeleteOneAsync(x => x.Id == operation.MembershipId && x.TenantId == operation.TenantId && x.UserId == operation.UserId, CancellationToken.None);
+        await RenewRepairLeaseOrThrowAsync(database, operation, repairToken);
         await database.GetCollection<LlmGwUser>("llmgw_console_users")
             .DeleteOneAsync(x => x.Id == operation.UserId, CancellationToken.None);
         return "member-create-rolled-back";
     }
 
-    private static async Task<string> RepairOwnerMutationAsync(IMongoDatabase database, GatewayRecoveryOperation operation)
+    private static async Task<string> RepairOwnerMutationAsync(
+        IMongoDatabase database,
+        GatewayRecoveryOperation operation,
+        string repairToken)
     {
         var tenants = database.GetCollection<LlmGwTenant>("llmgw_tenants");
         var memberships = database.GetCollection<LlmGwMembership>("llmgw_memberships");
@@ -313,6 +349,7 @@ public static class GatewayRecoveryOperations
                 && membership.Role == operation.TargetRole
                 && membership.Status == operation.TargetStatus)
             {
+                await RenewRepairLeaseOrThrowAsync(database, operation, repairToken);
                 await TenantOwnerAuthority.AddAsync(tenants, operation.TenantId, operation.MembershipId);
                 return "owner-promotion-completed";
             }
@@ -330,6 +367,7 @@ public static class GatewayRecoveryOperations
             membership.TeamIds = operation.TargetTeamIds;
             membership.Version++;
             membership.UpdatedAt = DateTime.UtcNow;
+            await RenewRepairLeaseOrThrowAsync(database, operation, repairToken);
             var replaced = await memberships.ReplaceOneAsync(
                 x => x.Id == membership.Id && x.TenantId == membership.TenantId && x.Version == operation.ExpectedMembershipVersion,
                 membership,
@@ -342,9 +380,34 @@ public static class GatewayRecoveryOperations
         if (membership.Role == operation.TargetRole && membership.Status == operation.TargetStatus)
             return "owner-removal-already-completed";
 
+        await RenewRepairLeaseOrThrowAsync(database, operation, repairToken);
         await TenantOwnerAuthority.RestoreAsync(tenants, operation.TenantId, operation.MembershipId);
         return "owner-removal-conflict-restored";
     }
+
+    private static async Task RenewRepairLeaseOrThrowAsync(
+        IMongoDatabase database,
+        GatewayRecoveryOperation operation,
+        string repairToken)
+    {
+        var now = DateTime.UtcNow;
+        var operations = database.GetCollection<GatewayRecoveryOperation>("llmgw_recovery_operations");
+        var result = await operations.UpdateOneAsync(
+            x => x.Id == operation.Id
+                 && x.Status == "repairing"
+                 && x.RepairToken == repairToken
+                 && x.RepairGeneration == operation.RepairGeneration
+                 && x.LeaseExpiresAt > now,
+            Builders<GatewayRecoveryOperation>.Update
+                .Set(x => x.LeaseExpiresAt, now.Add(OperationLease))
+                .Set(x => x.UpdatedAt, now),
+            cancellationToken: CancellationToken.None);
+        if (result.MatchedCount != 1) throw new GatewayRecoveryLeaseLostException();
+    }
+}
+
+internal sealed class GatewayRecoveryLeaseLostException : Exception
+{
 }
 
 internal sealed class GatewayRecoveryHeartbeat : IAsyncDisposable

--- a/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayConsoleTenantAccessTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayConsoleTenantAccessTests.cs
@@ -265,6 +265,83 @@ public sealed class GatewayConsoleTenantAccessTests
         (await users.Find(x => x.Id == owner.Id).SingleAsync()).TenantIds.ShouldBe(["home"]);
         (await tenants.Find(x => x.Id == "tenant-stable").SingleAsync()).ActiveOwnerMembershipIds.ShouldBe(["stable-owner"]);
         (await operations.CountDocumentsAsync(x => x.Status == "repaired")).ShouldBe(2);
+        var reclaimedMemberOperation = await operations.Find(x => x.Id == "op-member").SingleAsync();
+        reclaimedMemberOperation.RepairGeneration.ShouldBe(2);
+        reclaimedMemberOperation.RepairToken.ShouldNotBe("crashed-repairer");
+    }
+
+    [Fact]
+    public async Task Repairer_StaleGenerationCannotApplyBusinessWritesAfterTakeover()
+    {
+        var database = await TryCreateDatabaseAsync();
+        if (database is null) return;
+        await using var scope = database;
+        var users = scope.Database.GetCollection<LlmGwUser>("llmgw_console_users");
+        var tenants = scope.Database.GetCollection<LlmGwTenant>("llmgw_tenants");
+        var memberships = scope.Database.GetCollection<LlmGwMembership>("llmgw_memberships");
+        var operations = scope.Database.GetCollection<GatewayRecoveryOperation>("llmgw_recovery_operations");
+        var member = new LlmGwMembership
+        {
+            Id = "member-protected-by-new-generation",
+            TenantId = "tenant-a",
+            UserId = "user-a",
+            Role = LlmGwTenantRoles.Owner,
+        };
+        await users.InsertOneAsync(new LlmGwUser
+        {
+            Id = member.UserId,
+            Username = member.UserId,
+            TenantIds = [member.TenantId],
+        });
+        await tenants.InsertOneAsync(new LlmGwTenant
+        {
+            Id = member.TenantId,
+            Name = "Tenant A",
+            OwnerAuthorityInitialized = true,
+            ActiveOwnerMembershipIds = [member.Id],
+            OwnerFenceGeneration = 2,
+        });
+        await memberships.InsertOneAsync(member);
+        await operations.InsertOneAsync(new GatewayRecoveryOperation
+        {
+            Id = "op-member-stale",
+            Kind = GatewayRecoveryKinds.MemberCreate,
+            Status = "repairing",
+            TenantId = member.TenantId,
+            UserId = member.UserId,
+            MembershipId = member.Id,
+            RepairToken = "new-repairer",
+            RepairGeneration = 2,
+            LeaseExpiresAt = DateTime.UtcNow.AddMinutes(2),
+        });
+        var staleClaim = new GatewayRecoveryOperation
+        {
+            Id = "op-member-stale",
+            Kind = GatewayRecoveryKinds.MemberCreate,
+            Status = "repairing",
+            TenantId = member.TenantId,
+            UserId = member.UserId,
+            MembershipId = member.Id,
+            RepairToken = "old-repairer",
+            RepairGeneration = 1,
+            LeaseExpiresAt = DateTime.UtcNow.AddMinutes(-1),
+        };
+
+        var repairClaimed = typeof(GatewayRecoveryOperations).GetMethod(
+            "RepairClaimedAsync",
+            System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
+        repairClaimed.ShouldNotBeNull();
+        var repairTask = repairClaimed.Invoke(
+            null,
+            [scope.Database, staleClaim, "old-repairer"]) as Task<string>;
+        Assert.NotNull(repairTask);
+        var detail = await repairTask!;
+
+        detail.ShouldBe("repair-lease-lost");
+        (await memberships.CountDocumentsAsync(x => x.Id == member.Id)).ShouldBe(1);
+        (await users.CountDocumentsAsync(x => x.Id == member.UserId)).ShouldBe(1);
+        (await tenants.Find(x => x.Id == member.TenantId).SingleAsync())
+            .ActiveOwnerMembershipIds.ShouldBe([member.Id]);
     }
 
     [Fact]


### PR DESCRIPTION
## 摘要
修复 Provisioning recovery operation 被更高 repair generation 接管后，旧持有者仍可继续修改成员、租户与 owner 权威数据的问题。每一步业务写入前均原子校验 operation、repair token、generation 与有效租约，失去租约立即退出且不覆盖新持有者状态。

## 改动 diff
- `llmgw/console-api/Provisioning/GatewayRecoveryOperations.cs`：增加逐步 repair lease fencing，并仅统计成功提交最终状态的修复。
- `prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayConsoleTenantAccessTests.cs`：增加旧 generation 失效后不得写业务数据的回归，补强崩溃修复器由 generation 2 接管的断言。
- `changelogs/2026-07-23_llmgw-repair-generation-fencing.md`：记录有限修复与测试。

## 测试
- [x] Console API build：0 warning，0 error
- [x] 三项定向回归：164/164
- [x] 完整非 Integration/Manual 回归：Core 727/727；API 1855 通过、4 个既有显式跳过、0 失败
- [x] CDS commit cb2aa06c8 五服务 running，CI 预构建 success

## 预览
- https://llmgw-three-capabilities-acceptance-codex-prd-agent-llmgw-web.miduo.org/teams