### PR TITLE
fix(llmgw): 修复 Exchange 日志详情跳转

### DIFF
--- a/changelogs/2026-07-23_llmgw-exchange-log-detail-link.md
+++ b/changelogs/2026-07-23_llmgw-exchange-log-detail-link.md
@@ -1,0 +1,1 @@
+| fix | llmgw | 修复日志中的 Exchange 被误当作普通 Provider 打开，改为进入对应 Exchange 详情抽屉 |

--- a/llmgw/web/src/components/EntityPreviewDrawer.tsx
+++ b/llmgw/web/src/components/EntityPreviewDrawer.tsx
@@ -19,13 +19,15 @@ type EntityPreviewDrawerProps = {
   buttonLabel: string;
   title: string;
   kicker: string;
+  icon?: ReactNode;
   summary: ReactNode;
   sections: EntityPreviewSection[];
   status?: Array<{ label: string; tone?: 'neutral' | 'good' | 'warning' }>;
+  initiallyOpen?: boolean;
 };
 
-export function EntityPreviewDrawer({ buttonLabel, title, kicker, summary, sections, status = [] }: EntityPreviewDrawerProps) {
-  const [open, setOpen] = useState(false);
+export function EntityPreviewDrawer({ buttonLabel, title, kicker, icon, summary, sections, status = [], initiallyOpen = false }: EntityPreviewDrawerProps) {
+  const [open, setOpen] = useState(initiallyOpen);
   const titleId = useId();
   const triggerButtonRef = useRef<HTMLButtonElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
@@ -87,9 +89,12 @@ export function EntityPreviewDrawer({ buttonLabel, title, kicker, summary, secti
             style={{ ...drawerStyle, height: '100dvh', maxHeight: '100dvh' }}
           >
             <header style={headerStyle}>
-              <div style={{ minWidth: 0 }}>
-                <div style={kickerStyle}>{kicker}</div>
-                <h2 id={titleId} style={titleStyle}>{title}</h2>
+              <div style={{ minWidth: 0, display: 'flex', alignItems: 'center', gap: 12 }}>
+                {icon ? <span style={headerIconStyle}>{icon}</span> : null}
+                <div style={{ minWidth: 0 }}>
+                  <div style={kickerStyle}>{kicker}</div>
+                  <h2 id={titleId} style={titleStyle}>{title}</h2>
+                </div>
               </div>
               <button ref={closeButtonRef} type="button" aria-label="关闭" onClick={() => setOpen(false)} style={closeStyle}>
                 <X size={17} />
@@ -170,7 +175,7 @@ const backdropStyle: React.CSSProperties = {
   position: 'absolute',
   inset: 0,
   border: 0,
-  background: 'rgba(4, 8, 15, 0.64)',
+  background: 'var(--drawer-backdrop)',
   cursor: 'default',
 };
 
@@ -179,7 +184,7 @@ const drawerStyle: React.CSSProperties = {
   zIndex: 1,
   display: 'flex',
   flexDirection: 'column',
-  width: 'min(520px, 100vw)',
+  width: 'min(820px, 100vw)',
   minWidth: 0,
   overflow: 'hidden',
   background: 'var(--bg-surface)',
@@ -212,11 +217,23 @@ const titleStyle: React.CSSProperties = {
   overflowWrap: 'anywhere',
 };
 
+const headerIconStyle: React.CSSProperties = {
+  width: 40,
+  height: 40,
+  flexShrink: 0,
+  display: 'grid',
+  placeItems: 'center',
+  border: '1px solid color-mix(in srgb, var(--accent) 38%, var(--border-subtle))',
+  borderRadius: 'var(--radius)',
+  background: 'var(--accent-soft)',
+  color: 'var(--accent)',
+};
+
 const closeStyle: React.CSSProperties = {
   display: 'grid',
   placeItems: 'center',
-  width: 32,
-  height: 32,
+  width: 44,
+  height: 44,
   flexShrink: 0,
   border: '1px solid var(--border-subtle)',
   borderRadius: 'var(--radius-sm)',
@@ -259,7 +276,7 @@ const sectionDescriptionStyle: React.CSSProperties = {
 
 const fieldListStyle: React.CSSProperties = {
   display: 'grid',
-  gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
   gap: 8,
   margin: '9px 0 0',
 };

--- a/llmgw/web/src/components/LogsView.tsx
+++ b/llmgw/web/src/components/LogsView.tsx
@@ -139,8 +139,17 @@ function modelDetailsHref(item: Pick<LlmLogListItem, 'logicalModelId' | 'logical
   return `/models/view?${query.toString()}`;
 }
 
+function isExchangeProvider(item: Pick<LlmLogListItem, 'platformName' | 'provider'>) {
+  return /^exchange\s*:/i.test((item.platformName || item.provider || '').trim());
+}
+
 function providerDetailsHref(item: Pick<LlmLogListItem, 'platformId' | 'platformName' | 'provider'>) {
   const query = new URLSearchParams();
+  if (isExchangeProvider(item)) {
+    if (item.platformId) query.set('exchangeId', item.platformId);
+    if (item.platformName || item.provider) query.set('name', item.platformName || item.provider);
+    return `/exchanges?${query.toString()}`;
+  }
   if (item.platformId) query.set('id', item.platformId);
   if (item.platformName || item.provider) query.set('name', item.platformName || item.provider);
   return `/platforms/view?${query.toString()}`;
@@ -444,13 +453,16 @@ export function LogsView() {
       }
       case 'provider': {
         const providerName = it.platformName || it.provider || DASH;
+        const exchangeProvider = isExchangeProvider(it);
         return (
           <LogEntityHoverCard
             href={providerDetailsHref(it)}
             label={providerName}
-            subtitle={[it.protocol || 'Provider', it.transport].filter(Boolean).join(' · ')}
-            description="进入详情可查看连接方式、托管模型、并发与最近请求；不会显示密钥明文。"
-            actionLabel="查看 Provider"
+            subtitle={[exchangeProvider ? 'Exchange' : it.protocol || 'Provider', it.transport].filter(Boolean).join(' · ')}
+            description={exchangeProvider
+              ? '进入详情可查看 adapter、目标接口、认证边界与模型映射；不会显示密钥明文，也不会试连上游。'
+              : '进入详情可查看连接方式、托管模型、并发与最近请求；不会显示密钥明文。'}
+            actionLabel={exchangeProvider ? '查看 Exchange' : '查看 Provider'}
             icon={<ProviderEntityIcon provider={providerName} size="lg" />}
           >
             <span className="lg-log-entity" title={providerName}>
@@ -554,13 +566,16 @@ export function LogsView() {
         );
       case 'provider': {
         const providerName = it.platformName || it.provider || DASH;
+        const exchangeProvider = isExchangeProvider(it);
         return (
           <LogEntityHoverCard
             href={providerDetailsHref(it)}
             label={providerName}
-            subtitle={[it.protocol || 'Provider', it.transport].filter(Boolean).join(' · ')}
-            description="进入详情可查看连接方式、托管模型、并发与最近请求。"
-            actionLabel="查看 Provider"
+            subtitle={[exchangeProvider ? 'Exchange' : it.protocol || 'Provider', it.transport].filter(Boolean).join(' · ')}
+            description={exchangeProvider
+              ? '进入详情可查看 adapter、目标接口、认证边界与模型映射。'
+              : '进入详情可查看连接方式、托管模型、并发与最近请求。'}
+            actionLabel={exchangeProvider ? '查看 Exchange' : '查看 Provider'}
             icon={<ProviderEntityIcon provider={providerName} size="lg" />}
           >
             <span className="lg-log-entity"><ProviderEntityIcon provider={providerName} /><span className="lg-truncate">{providerName}</span></span>

--- a/llmgw/web/src/pages/ExchangesPage.tsx
+++ b/llmgw/web/src/pages/ExchangesPage.tsx
@@ -2,7 +2,7 @@
 // tenantId 永远由服务端会话解析；密钥仅写入，不从 API 读回。
 import { useEffect, useState } from 'react';
 import { ArrowRight, CheckCircle2, KeyRound, Pencil, Plus, Route, Trash2 } from 'lucide-react';
-import { Link } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import {
   bulkRotateApiKeys,
   claimExchangeToGateway,
@@ -60,6 +60,8 @@ const emptyForm = (): ExchangeFormState => ({
 
 export function ExchangesPage() {
   const { tenant } = useAuth();
+  const [searchParams] = useSearchParams();
+  const focusedExchangeId = searchParams.get('exchangeId')?.trim() || null;
   const canWrite = canUseCapability(tenant?.role, 'configWrite');
   const [items, setItems] = useState<ExchangeItem[] | null>(null);
   const [meta, setMeta] = useState<ExchangeMetaData | null>(null);
@@ -98,6 +100,11 @@ export function ExchangesPage() {
     });
     return () => { alive = false; };
   }, []);
+
+  useEffect(() => {
+    if (!focusedExchangeId || items === null || items.some((item) => item.id === focusedExchangeId)) return;
+    setNotice('当前租户中没有找到该 Exchange');
+  }, [focusedExchangeId, items]);
 
   function openCreate() {
     setForm(emptyForm());
@@ -382,6 +389,8 @@ export function ExchangesPage() {
                     buttonLabel="查看路由"
                     kicker="Exchange 路由预览"
                     title={item.name || item.id}
+                    icon={<Route size={20} />}
+                    initiallyOpen={item.id === focusedExchangeId}
                     summary="从当前卡片直接查看 adapter 如何把 Gateway 请求转换并发往上游。这里只展示配置与请求边界，不会试连目标地址，也不会读取通讯密钥。"
                     status={[
                       { label: item.enabled ? '已启用' : '已停用', tone: item.enabled ? 'good' : 'warning' },

--- a/llmgw/web/src/theme.css
+++ b/llmgw/web/src/theme.css
@@ -35,6 +35,7 @@
   --radius-sm: 6px;
   --shadow-card: none;
   --shadow-drawer: -18px 0 48px rgba(0, 0, 0, 0.5);
+  --drawer-backdrop: rgba(0, 0, 0, 0.32);
 }
 
 /* 登录页：未登录状态也清楚说明当前服务、数据边界和下一步。 */
@@ -626,6 +627,7 @@
 
   --shadow-card: none;
   --shadow-drawer: -18px 0 48px rgba(15, 23, 42, 0.12);
+  --drawer-backdrop: rgba(15, 23, 42, 0.16);
 }
 
 * {


### PR DESCRIPTION
## 摘要

修复日志中的 Exchange 被当作普通 Provider 打开，导致详情页提示“当前租户中没有找到该 Provider”。Exchange 日志现在进入 Exchange 页面并自动打开对应的右侧详情抽屉；普通 Provider 跳转保持不变。

## 改动 diff

- `llmgw/web/src/components/LogsView.tsx`：识别 `Exchange:` Provider，切换详情地址、悬浮说明与动作标签。
- `llmgw/web/src/pages/ExchangesPage.tsx`：支持通过 `exchangeId` 精确定位，并自动打开对应详情。
- `llmgw/web/src/components/EntityPreviewDrawer.tsx`：支持路由驱动的初始打开状态。
- `changelogs/2026-07-23_llmgw-exchange-log-detail-link.md`：记录本次修复。

## 测试

- [x] `pnpm --dir llmgw/web build`
- [x] CDS 五服务运行，Gateway Web 精确提交 `6fe7ae0c7bc3c9ff75c531c754823a3f13212c0d`
- [x] 浏览器直连测试环境，`exchangeId` 自动打开目标 Exchange 详情抽屉
- [x] 浅色与深色桌面截图取证
- [x] 独立视觉判别智能体复核通过：P0/P1/P2 均为 0
