### PR TITLE
test(llmgw): 同步维护发布审计断言

### DIFF
--- a/changelogs/2026-07-23_llmgw-provider-audit-test-contract.md
+++ b/changelogs/2026-07-23_llmgw-provider-audit-test-contract.md
@@ -1,0 +1,1 @@
+| test | llmgw | 同步维护发布免重复 Provider 审计后的生产脚本守卫断言 |

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -1265,7 +1265,7 @@ public class GatewayDataDomainGuardTests
         Assert.Contains("LLMGW_DEPLOY_MIN_FREE_MB:-4096", script);
         Assert.Contains("LLM Gateway exec_dep deploy", script);
         Assert.Contains("provider_audit_required=0", script);
-        Assert.Contains("if [ \"$mode\" = \"http\" ] || [ \"$canary_stage\" = \"video-asr\" ]; then", script);
+        Assert.Contains("if { [ \"$mode\" = \"http\" ] && [ \"$maintenance_release\" != \"1\" ]; } || [ \"$canary_stage\" = \"video-asr\" ]; then", script);
         Assert.Contains("scripts/llmgw-prod-provider-config-audit.py", script);
         Assert.Contains("LLMGW_PROVIDER_AUDIT_JSON_OUT", script);
         Assert.Contains("LLMGW_PROVIDER_AUDIT_REPORT_MD", script);


### PR DESCRIPTION
## 摘要

同步 PR #1239 已落地的维护发布 Provider 审计条件，修复 main 上仍断言旧脚本字符串的确定性测试失败。本 PR 只调整一条守卫断言，不修改生产逻辑。

## 改动 diff

- `prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs`：断言维护发布跳过重复 Provider 审计，video-asr 仍必须审计。
- `changelogs/2026-07-23_llmgw-provider-audit-test-contract.md`：记录测试契约同步。

## 测试

- [x] `dotnet build PrdAgent.sln --no-restore` 编译通过
- [x] pre-commit C# 检查通过
- [ ] GitHub Linux .NET 8 完整测试

本机只有 .NET 9 runtime，目标 net8.0 testhost 无法启动；因此以 GitHub Linux .NET 8 和 CDS 作为运行时验证。
