### PR TITLE
fix(llmgw): 修复正式字体资源子路径

### DIFF
--- a/changelogs/2026-07-23_llmgw-font-assets-subpath.md
+++ b/changelogs/2026-07-23_llmgw-font-assets-subpath.md
@@ -1,0 +1,1 @@
+| fix | llmgw | 修复正式控制台字体资源误请求 MAP 根路径导致 Plus Jakarta 回退系统字体的问题 |

--- a/llmgw/web/nginx.conf
+++ b/llmgw/web/nginx.conf
@@ -101,6 +101,14 @@ server {
     }
 
     # 静态资源缓存
+    # CDS 独立预览会直接访问 llmgw-web 容器，浏览器仍按正式公开 base 请求
+    # /llmgw/assets/*；alias 保证独立域名与 MAP 子路径使用同一份不可变产物。
+    location ^~ /llmgw/assets/ {
+        alias /usr/share/nginx/html/assets/;
+        expires 7d;
+        add_header Cache-Control "public, max-age=604800, immutable";
+    }
+
     location /assets/ {
         expires 7d;
         add_header Cache-Control "public, max-age=604800, immutable";

--- a/llmgw/web/vite.config.ts
+++ b/llmgw/web/vite.config.ts
@@ -9,6 +9,9 @@ import path from 'path';
 // 不能默认 5000——那是主 API（prd-api），不提供 /gw/auth/login、/gw/logs 等 console 端点（Codex P2）。
 // 本地直接 dotnet run llmgw/console-api（监听 8090）时，用 LLMGW_PROXY_TARGET=http://localhost:8090 覆盖。
 export default defineConfig({
+  // 正式控制台挂载在 /llmgw/。固定公开 base，确保 CSS 内嵌的字体 URL 也落到
+  // /llmgw/assets，而不是误请求 MAP 主站的 /assets 并得到 404。
+  base: '/llmgw/',
   plugins: [react()],
   resolve: {
     alias: {

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -3565,6 +3565,17 @@ public class GatewayDataDomainGuardTests
     }
 
     [Fact]
+    public void GatewayWeb_UsesPublicSubpathForEntryAndFontAssets()
+    {
+        var vite = ReadRepoFile("llmgw/web/vite.config.ts");
+        var nginx = ReadRepoFile("llmgw/web/nginx.conf");
+
+        Assert.Contains("base: '/llmgw/'", vite);
+        Assert.Contains("location ^~ /llmgw/assets/", nginx);
+        Assert.Contains("alias /usr/share/nginx/html/assets/;", nginx);
+    }
+
+    [Fact]
     public void ExternalTenant_CannotMasqueradeAsMapServiceKeyPurpose()
     {
         var console = ReadRepoFile("llmgw/console-api/Program.cs");


### PR DESCRIPTION
## 摘要
修复 LLM Gateway 挂载在 `/llmgw/` 时，Plus Jakarta 字体仍请求 MAP 根路径 `/assets` 并返回 404，导致实际回退系统字体的问题。统一公开构建 base，并让独立 llmgw-web 预览兼容 `/llmgw/assets/`。

## 改动 diff
- `llmgw/web/vite.config.ts`：固定公开 base 为 `/llmgw/`，入口与字体产物使用同一子路径。
- `llmgw/web/nginx.conf`：为 CDS 独立预览补充 `/llmgw/assets/` alias。
- `GatewayDataDomainGuardTests.cs`：增加字体与入口资源子路径回归守卫。
- `changelogs/2026-07-23_llmgw-font-assets-subpath.md`：记录修复。

## 测试
- [x] `pnpm --dir llmgw/web exec tsc --noEmit`
- [x] `pnpm --dir llmgw/web run build`
- [x] 构建后 HTML、CSS 与三份字体均引用 `/llmgw/assets/`
- [x] 真实 nginx：根 HTML 200；字体 200、`font/woff2`、27348 字节
- [x] pre-commit C# 与 TypeScript 检查通过
- [ ] CDS 预览与独立视觉判别待 CI 镜像完成后执行