### PR TITLE
fix(llmgw): 修复 ASR canary multipart 清单缺失

### DIFF
--- a/changelogs/2026-07-24_llmgw-asr-canary-manifest.md
+++ b/changelogs/2026-07-24_llmgw-asr-canary-manifest.md
@@ -1,0 +1,1 @@
+| fix | llmgw | 修复正式 ASR canary 上传 multipart 文件后未写租户 manifest，导致 serving 回读对象被误判不存在 |

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/LlmGatewayOpsCanaryController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/LlmGatewayOpsCanaryController.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Microsoft.AspNetCore.Mvc;
 using PrdAgent.Core.Interfaces;
 using PrdAgent.Core.Models;
+using PrdAgent.Infrastructure.Database;
 using PrdAgent.Infrastructure.LlmGateway;
 using PrdAgent.Infrastructure.Services.AssetStorage;
 
@@ -20,6 +21,7 @@ public sealed class LlmGatewayOpsCanaryController : ControllerBase
     private readonly ILogger<LlmGatewayOpsCanaryController> _logger;
     private readonly ILLMRequestContextAccessor _ctxAccessor;
     private readonly IAssetStorage _assetStorage;
+    private readonly LlmGatewayDataContext _gatewayData;
 
     public LlmGatewayOpsCanaryController(
         IHttpClientFactory httpFactory,
@@ -27,7 +29,8 @@ public sealed class LlmGatewayOpsCanaryController : ControllerBase
         ILogger<HttpLlmGatewayClient> gatewayLogger,
         ILogger<LlmGatewayOpsCanaryController> logger,
         ILLMRequestContextAccessor ctxAccessor,
-        IAssetStorage assetStorage)
+        IAssetStorage assetStorage,
+        LlmGatewayDataContext gatewayData)
     {
         _httpFactory = httpFactory;
         _config = config;
@@ -35,6 +38,7 @@ public sealed class LlmGatewayOpsCanaryController : ControllerBase
         _logger = logger;
         _ctxAccessor = ctxAccessor;
         _assetStorage = assetStorage;
+        _gatewayData = gatewayData;
     }
 
     [HttpPost("asr")]
@@ -70,7 +74,8 @@ public sealed class LlmGatewayOpsCanaryController : ControllerBase
             _config,
             _gatewayLogger,
             _ctxAccessor,
-            _assetStorage);
+            _assetStorage,
+            _gatewayData);
 
         using var scope = _ctxAccessor.BeginScope(new LlmRequestContext(
             RequestId: requestId,

--- a/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayMultipartHttpTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayMultipartHttpTests.cs
@@ -151,6 +151,73 @@ public class GatewayMultipartHttpTests
     }
 
     [Fact]
+    public async Task HttpClient_WithGatewayData_WritesTenantManifestForServingRehydrate()
+    {
+        var testDatabase = await TryCreateDatabaseAsync();
+        if (testDatabase is null) return;
+        await using var scope = testDatabase;
+        var storage = new MemoryAssetStorage();
+        GatewayRawRequest? captured = null;
+        var handler = new CapturingHandler(async request =>
+        {
+            captured = JsonSerializer.Deserialize<GatewayRawRequest>(
+                await request.Content!.ReadAsStringAsync(),
+                PascalJson);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new GatewayRawResponse
+                {
+                    Success = true,
+                    StatusCode = 200,
+                    Content = "ok",
+                }, options: PascalJson),
+            };
+        });
+        var client = new HttpLlmGatewayClient(
+            new SingleClientFactory(new HttpClient(handler)),
+            Config("http://llmgw.test"),
+            NullLogger<HttpLlmGatewayClient>.Instance,
+            assetStorage: storage,
+            gatewayData: scope.Context);
+        var bytes = Encoding.UTF8.GetBytes("manifest-voice-bytes");
+
+        var response = await client.SendRawWithResolutionAsync(
+            new GatewayRawRequest
+            {
+                AppCallerCode = "document-store.subtitle::asr",
+                ModelType = "asr",
+                IsMultipart = true,
+                MultipartFiles = new Dictionary<string, (string FileName, byte[] Content, string MimeType)>
+                {
+                    ["file"] = ("voice.wav", bytes, "audio/wav"),
+                },
+                Context = new GatewayRequestContext
+                {
+                    TenantId = "tenant-asr-canary",
+                    RequestId = "asr-canary-manifest-test",
+                },
+            },
+            new GatewayModelResolution
+            {
+                Success = true,
+                ActualModel = "asr-model",
+            });
+
+        response.Success.ShouldBeTrue();
+        captured.ShouldNotBeNull();
+        var fileRef = captured!.MultipartFileRefs!["file"];
+        var manifest = await scope.Context.Database
+            .GetCollection<GatewayMultipartObjectRecord>("llmgw_multipart_objects")
+            .Find(x => x.TenantId == "tenant-asr-canary" && x.RefKey == fileRef.RefKey)
+            .SingleOrDefaultAsync();
+        manifest.ShouldNotBeNull();
+        manifest!.RequestId.ShouldBe("asr-canary-manifest-test");
+        manifest.Sha256.ShouldBe(Sha256Hex(bytes));
+        manifest.SizeBytes.ShouldBe(bytes.LongLength);
+        manifest.Status.ShouldBe("uploaded");
+    }
+
+    [Fact]
     public async Task RawEndpoint_RehydratesMultipartFileRefs_BeforeGatewaySend()
     {
         var bytes = Encoding.UTF8.GetBytes("image-bytes");


### PR DESCRIPTION
## 摘要
修复正式 ASR HTTP canary 上传临时音频后未写入租户 multipart manifest，导致 llmgw-serve 按安全边界回读时误报 `MULTIPART_REF_NOT_FOUND`。复用现有 `LlmGatewayDataContext`，不修改 API、DTO、密钥边界或普通业务路径。

## 改动 diff
- `prd-api/src/PrdAgent.Api/Controllers/Api/LlmGatewayOpsCanaryController.cs`：向手工创建的 `HttpLlmGatewayClient` 注入已有 Gateway 数据上下文。
- `prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayMultipartHttpTests.cs`：新增上传后租户 manifest 持久化回归测试。
- `changelogs/2026-07-24_llmgw-asr-canary-manifest.md`：新增修复记录。

## 测试
- [x] GatewayMultipartHttpTests 8/8 通过
- [x] `dotnet build prd-api/PrdAgent.sln --no-restore` 零错误
- [ ] 合并部署后正式 ASR 单入口 canary 通过