### PR TITLE
fix(llmgw): 排除 multipart 边界日志的 Provider 误判

### DIFF
--- a/changelogs/2026-07-24_llmgw-provider-audit-multipart.md
+++ b/changelogs/2026-07-24_llmgw-provider-audit-multipart.md
@@ -1,0 +1,1 @@
+| fix | llmgw | 修复 Provider 审计将 Gateway multipart 文件引用错误误判为上游 ASR 故障 |

--- a/scripts/llmgw-prod-provider-config-audit.py
+++ b/scripts/llmgw-prod-provider-config-audit.py
@@ -36,10 +36,12 @@ DEFAULT_ASR_TRANSFORMER = "doubao-asr"
 GATEWAY_BOUNDARY_ERROR_PREFIXES = (
     "GATEWAY_KEY_",
     "GATEWAY_LEGACY_KEY_",
+    "MULTIPART_",
 )
 GATEWAY_BOUNDARY_ERROR_CODES = {
     "GATEWAY_APP_CALLER_MISMATCH",
     "GATEWAY_APP_CALLER_REQUIRED",
+    "GATEWAY_REQUEST_REJECTED",
     "GATEWAY_SOURCE_SYSTEM_MISMATCH",
 }
 DEFAULT_VIDEO_TRANSFORMER = "volcengine-video"
@@ -486,7 +488,7 @@ def _gateway_log_error_text(log: dict[str, Any]) -> str:
 def _gateway_boundary_rejection_code(error_text: str) -> str | None:
     """Return a pre-provider gateway identity rejection code, if present."""
 
-    for code in re.findall(r"\bGATEWAY_[A-Z0-9_]+\b", error_text.upper()):
+    for code in re.findall(r"\b(?:GATEWAY|MULTIPART)_[A-Z0-9_]+\b", error_text.upper()):
         if code in GATEWAY_BOUNDARY_ERROR_CODES or code.startswith(GATEWAY_BOUNDARY_ERROR_PREFIXES):
             return code
     return None
@@ -1168,6 +1170,16 @@ def _self_test_report() -> dict[str, Any]:
                 "Error": '{"error":{"code":"GATEWAY_KEY_SCOPE_DENIED","message":"scope denied"}}',
             },
             {
+                "_id": "fixture-asr-multipart-ref-not-found",
+                "AppCallerCode": "document-store.subtitle::asr",
+                "RequestType": "raw",
+                "GatewayTransport": "http",
+                "Model": "",
+                "Status": "failed",
+                "StatusCode": 404,
+                "Error": "GATEWAY_REQUEST_REJECTED",
+            },
+            {
                 "_id": "fixture-video-model-not-open",
                 "AppCallerCode": "video-agent.videogen::video-gen",
                 "RequestType": "raw",
@@ -1261,6 +1273,23 @@ def _self_test_report() -> dict[str, Any]:
             for item in blockers
         )
     )
+    multipart_log = next(
+        (
+            item
+            for item in ((audit.get("recentGatewayLogs") or {}).get("failed") or [])
+            if str(item.get("id") or "") == "fixture-asr-multipart-ref-not-found"
+        ),
+        None,
+    )
+    multipart_excluded = bool(
+        multipart_log
+        and multipart_log.get("providerRelevant") is False
+        and multipart_log.get("gatewayBoundaryCode") == "GATEWAY_REQUEST_REJECTED"
+        and not any(
+            str(item.get("logId") or "") == "fixture-asr-multipart-ref-not-found"
+            for item in blockers
+        )
+    )
     ok = (
         not missing
         and not missing_pairs
@@ -1268,6 +1297,7 @@ def _self_test_report() -> dict[str, Any]:
         and not unbound_leaked_as_blocker
         and request_type_validation_pass
         and gateway_scope_excluded
+        and multipart_excluded
     )
     return {
         "generatedAt": datetime.now(timezone.utc).isoformat(),
@@ -1282,6 +1312,7 @@ def _self_test_report() -> dict[str, Any]:
         "unboundPoolLeakedAsBlocker": unbound_leaked_as_blocker,
         "requestTypeValidationPass": request_type_validation_pass,
         "gatewayScopeExcludedFromProviderAudit": gateway_scope_excluded,
+        "multipartExcludedFromProviderAudit": multipart_excluded,
         "sampleAuditVerdict": audit.get("verdict"),
         "sampleAuditExternalBlockers": blockers,
     }


### PR DESCRIPTION
## 摘要
修复正式发布 Provider 审计把 Gateway 入口阶段的 multipart 文件引用失败误判为上游 ASR 故障。真实生产日志会将具体 multipart 错误归一记录为 `GATEWAY_REQUEST_REJECTED`；该日志仅在模型生命周期尚未开始时写入，因此不得作为 Provider 阻塞。

## 改动 diff
- `scripts/llmgw-prod-provider-config-audit.py`：识别 `GATEWAY_REQUEST_REJECTED` 与 multipart 边界错误，排除 Provider 误判，并补充确定性自测。
- `changelogs/2026-07-24_llmgw-provider-audit-multipart.md`：记录修复。

## 测试
- [x] Provider audit self-test 通过
- [x] Python 编译检查通过
- [x] git diff --check 通过
- [x] 正式生产 Mongo 只读复测通过：failureCount=0，blockerCount=0，历史 404 标记 providerRelevant=false