### PR TITLE
fix(llmgw): 修复维护发布账本校验

### DIFF
--- a/changelogs/2026-07-24_llmgw-maintenance-ledger-scoped-shadow.md
+++ b/changelogs/2026-07-24_llmgw-maintenance-ledger-scoped-shadow.md
@@ -1,0 +1,1 @@
+| fix | llmgw | 允许发布账本仅在已审计维护基线且零阈值 scoped shadow 形状下接受空 shadowChecks |

--- a/scripts/llmgw-rollout-ledger.py
+++ b/scripts/llmgw-rollout-ledger.py
@@ -321,6 +321,7 @@ def _require_release_gate_for_commit(
     require_config_authority: bool = False,
     allow_skipped_runtime_gates: bool = False,
     allow_skipped_config_authority: bool = False,
+    allow_skipped_shadow_checks: bool = False,
 ) -> None:
     payload = _require_pass_json(path, label)
     expected = _normalize_commit(commit)
@@ -332,18 +333,31 @@ def _require_release_gate_for_commit(
         raise SystemExit(f"ERROR: {label} shadowReleaseCommit mismatch: {path} actual={shadow_commit or 'empty'} expected={expected}")
 
     checks = payload.get("shadowChecks") or payload.get("ShadowChecks") or []
-    if not isinstance(checks, list) or not checks:
+    if not isinstance(checks, list):
         raise SystemExit(f"ERROR: {label} missing shadowChecks for same-commit evidence: {path}")
-    for index, item in enumerate(checks, start=1):
-        if not isinstance(item, dict):
-            raise SystemExit(f"ERROR: {label} shadowChecks[{index}] is not an object: {path}")
-        item_commit = _normalize_commit(item.get("releaseCommit") or item.get("ReleaseCommit"))
-        if item_commit != expected:
-            item_label = item.get("label") or item.get("Label") or index
-            raise SystemExit(
-                f"ERROR: {label} shadowChecks[{item_label}] releaseCommit mismatch: "
-                f"{path} actual={item_commit or 'empty'} expected={expected}"
-            )
+    thresholds = payload.get("thresholds") or payload.get("Thresholds") or {}
+    if not isinstance(thresholds, dict):
+        thresholds = {}
+    audited_maintenance_shadow_skip = (
+        allow_skipped_shadow_checks
+        and not checks
+        and bool(thresholds.get("skipGlobalCells") if "skipGlobalCells" in thresholds else thresholds.get("SkipGlobalCells"))
+        and thresholds.get("minTotal", thresholds.get("MinTotal")) == 0
+        and thresholds.get("minPerApp", thresholds.get("MinPerApp")) == 0
+    )
+    if not checks and not audited_maintenance_shadow_skip:
+        raise SystemExit(f"ERROR: {label} missing shadowChecks for same-commit evidence: {path}")
+    if checks:
+        for index, item in enumerate(checks, start=1):
+            if not isinstance(item, dict):
+                raise SystemExit(f"ERROR: {label} shadowChecks[{index}] is not an object: {path}")
+            item_commit = _normalize_commit(item.get("releaseCommit") or item.get("ReleaseCommit"))
+            if item_commit != expected:
+                item_label = item.get("label") or item.get("Label") or index
+                raise SystemExit(
+                    f"ERROR: {label} shadowChecks[{item_label}] releaseCommit mismatch: "
+                    f"{path} actual={item_commit or 'empty'} expected={expected}"
+                )
 
     if require_config_authority:
         config = payload.get("configAuthority") or payload.get("ConfigAuthority") or {}
@@ -1167,6 +1181,7 @@ def append(args: argparse.Namespace) -> int:
                     require_config_authority=args.stage == "http-full",
                     allow_skipped_runtime_gates=bool(maintenance_baseline_commit),
                     allow_skipped_config_authority=bool(maintenance_baseline_commit),
+                    allow_skipped_shadow_checks=bool(maintenance_baseline_commit),
                 )
             if _bool_flag(args.protocol_canary_required):
                 _require_protocol_canary_for_commit(args.protocol_canary_json, "protocol canary evidence", args.commit)

--- a/scripts/tests/test_llmgw_maintenance_ledger_gate.py
+++ b/scripts/tests/test_llmgw_maintenance_ledger_gate.py
@@ -91,6 +91,47 @@ class MaintenanceLedgerGateTests(unittest.TestCase):
                 allow_skipped_config_authority=True,
             )
 
+    def test_audited_maintenance_release_allows_exact_scoped_shadow_skip_shape(self) -> None:
+        payload = gate_payload(SKIPPED_CONFIG, SKIPPED_RUNTIME)
+        payload["shadowChecks"] = []
+        payload["thresholds"] = {
+            "skipGlobalCells": True,
+            "minTotal": 0,
+            "minPerApp": 0,
+        }
+        with tempfile.TemporaryDirectory() as raw:
+            path = self.write_gate(Path(raw), payload)
+            LEDGER._require_release_gate_for_commit(
+                path,
+                "maintenance gate",
+                COMMIT,
+                require_config_authority=True,
+                allow_skipped_runtime_gates=True,
+                allow_skipped_config_authority=True,
+                allow_skipped_shadow_checks=True,
+            )
+
+    def test_audited_maintenance_release_rejects_empty_shadow_without_exact_skip_shape(self) -> None:
+        payload = gate_payload(SKIPPED_CONFIG, SKIPPED_RUNTIME)
+        payload["shadowChecks"] = []
+        payload["thresholds"] = {
+            "skipGlobalCells": True,
+            "minTotal": 1,
+            "minPerApp": 0,
+        }
+        with tempfile.TemporaryDirectory() as raw:
+            path = self.write_gate(Path(raw), payload)
+            with self.assertRaises(SystemExit):
+                LEDGER._require_release_gate_for_commit(
+                    path,
+                    "maintenance gate",
+                    COMMIT,
+                    require_config_authority=True,
+                    allow_skipped_runtime_gates=True,
+                    allow_skipped_config_authority=True,
+                    allow_skipped_shadow_checks=True,
+                )
+
     def test_non_maintenance_release_rejects_skipped_config_authority(self) -> None:
         with tempfile.TemporaryDirectory() as raw:
             path = self.write_gate(Path(raw), gate_payload(SKIPPED_CONFIG, SKIPPED_RUNTIME))


### PR DESCRIPTION
## 摘要

修复已审计维护发布在明确使用零阈值 scoped shadow 形状时，发布账本仍强制要求非空 `shadowChecks`，导致公网发布全部通过后无法形成成功账本的问题。

账本仅在同时满足以下条件时接受空 `shadowChecks`：存在已验证维护基线、`skipGlobalCells=true`、`minTotal=0`、`minPerApp=0`。普通发布以及形状不完整的维护发布继续 fail-closed。

## 改动 diff

- `scripts/llmgw-rollout-ledger.py`：增加严格受限的维护发布 shadow skip 校验，并仅由已验证维护基线启用。
- `scripts/tests/test_llmgw_maintenance_ledger_gate.py`：覆盖精确允许形状和非零阈值拒绝形状。
- `changelogs/2026-07-24_llmgw-maintenance-ledger-scoped-shadow.md`：记录本次发布账本修复。

## 测试

- [x] `python3 -m py_compile scripts/llmgw-rollout-ledger.py`
- [x] `python3 -m unittest scripts.tests.test_llmgw_maintenance_ledger_gate`，9 项通过
- [x] `python3 -m unittest discover -s scripts/tests -p 'test_llmgw_*.py'`，15 项通过
- [ ] CDS 分支部署与正式账本重放
