### PR TITLE
fix(llmgw): 统一正式烟测调用方配置

### DIFF
--- a/changelogs/2026-07-24_llmgw-smoke-appcaller-ssot.md
+++ b/changelogs/2026-07-24_llmgw-smoke-appcaller-ssot.md
@@ -1,0 +1,1 @@
+| fix | llmgw | 修复正式发布烟测未在全部 chat 路径使用配置 AppCaller 的问题 |

--- a/scripts/gw-smoke.py
+++ b/scripts/gw-smoke.py
@@ -65,6 +65,8 @@ def _selected_sample_codes():
         model_types = DEFAULT_LOW_COST_MODEL_TYPES
     selected = []
     for app_caller, model_type in DEFAULT_SAMPLE_CODES:
+        if model_type.lower() == "chat":
+            app_caller = SMOKE_APP_CALLER
         if model_types and model_type.lower() not in model_types:
             continue
         if app_callers and app_caller.lower() not in app_callers:
@@ -333,6 +335,10 @@ def main():
         rows.append(("sample-scope", False, "GW_SMOKE_MODEL_TYPES/GW_SMOKE_APP_CALLERS selected no cases"))
 
     has_chat = any(mtype == "chat" for _, mtype in sample_codes)
+    chat_app_caller = next(
+        (app_caller for app_caller, model_type in sample_codes if model_type == "chat"),
+        SMOKE_APP_CALLER,
+    )
 
     # 2) pools（每类抽样入口）
     for accode, mtype in sample_codes:
@@ -360,7 +366,7 @@ def main():
     # 4) send 兼容入口：MAP 旧客户端仍用 /send，只抽 chat 一类避免 D 层冒烟成本膨胀。
     if has_chat:
         send_body = {
-            "AppCallerCode": "report-agent.generate::chat",
+            "AppCallerCode": chat_app_caller,
             "ModelType": "chat",
             "Stream": False,
             "TimeoutSeconds": SMOKE_REQUEST_TIMEOUT,
@@ -378,7 +384,7 @@ def main():
     # 5) stream：真实 SSE 边界。只抽 chat 一类，避免 D 层冒烟成本膨胀。
     if has_chat:
         stream_body = {
-            "AppCallerCode": "report-agent.generate::chat",
+            "AppCallerCode": chat_app_caller,
             "ModelType": "chat",
             "Stream": True,
             "TimeoutSeconds": SMOKE_REQUEST_TIMEOUT,
@@ -410,7 +416,7 @@ def main():
     # 6) client-stream：CreateClient/ILLMClient 跨进程 SSE 边界。
     if has_chat:
         client_stream_body = {
-            "AppCallerCode": "report-agent.generate::chat",
+            "AppCallerCode": chat_app_caller,
             "ModelType": "chat",
             "MaxTokens": SMOKE_MAX_TOKENS,
             "Temperature": 0.2,

--- a/scripts/tests/test_gw_smoke_app_caller.py
+++ b/scripts/tests/test_gw_smoke_app_caller.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""守卫正式发布烟测的 chat AppCaller 单一事实源。"""
+
+import ast
+import importlib.util
+import os
+from pathlib import Path
+import unittest
+from unittest.mock import patch
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "gw-smoke.py"
+
+
+def load_smoke_module():
+    spec = importlib.util.spec_from_file_location("gw_smoke_app_caller_test", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class GatewaySmokeAppCallerTests(unittest.TestCase):
+    def test_configured_app_caller_replaces_default_chat_sample(self):
+        configured = "release-probe.stable::chat"
+        with patch.dict(
+            os.environ,
+            {
+                "GW_SMOKE_APP_CALLER": configured,
+                "GW_SMOKE_MODEL_TYPES": "chat",
+            },
+            clear=False,
+        ):
+            module = load_smoke_module()
+
+        self.assertEqual(module._selected_sample_codes(), [(configured, "chat")])
+
+    def test_request_bodies_do_not_hardcode_default_chat_app_caller(self):
+        tree = ast.parse(SCRIPT_PATH.read_text(encoding="utf-8"))
+        hardcoded_request_values = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Dict):
+                continue
+            for key, value in zip(node.keys, node.values):
+                if (
+                    isinstance(key, ast.Constant)
+                    and key.value == "AppCallerCode"
+                    and isinstance(value, ast.Constant)
+                    and value.value == "report-agent.generate::chat"
+                ):
+                    hardcoded_request_values.append(value.lineno)
+
+        self.assertEqual(
+            hardcoded_request_values,
+            [],
+            f"请求体仍硬编码默认 chat AppCaller，行号: {hardcoded_request_values}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要
修复正式发布烟测虽然读取 `GW_SMOKE_APP_CALLER`，但 `/send`、`/stream`、`/client-stream` 请求体仍硬编码默认调用方的问题。全部 chat 冒烟路径现在使用同一配置值，便于隔离验证稳定模型池。

## 改动 diff
- `scripts/gw-smoke.py`：让 chat 样本、invoke、send、stream、client-stream 统一使用配置 AppCaller。
- `scripts/tests/test_gw_smoke_app_caller.py`：新增环境变量行为测试与硬编码 AST 守卫。
- `changelogs/2026-07-24_llmgw-smoke-appcaller-ssot.md`：记录修复。

## 测试
- [x] 8 项定向 unittest 通过
- [x] `GW_SMOKE_SELF_TEST=1 python3 scripts/gw-smoke.py` 通过
- [x] Python 编译检查通过
- [x] `git diff --check` 通过