### PR TITLE
feat(llmgw): 增加非付费正式发布冒烟

### DIFF
--- a/changelogs/2026-07-24_llmgw-nonpaid-release-smoke.md
+++ b/changelogs/2026-07-24_llmgw-nonpaid-release-smoke.md
@@ -1,0 +1,2 @@
+| feat | llmgw | 新增覆盖 invoke、send 与双流式入口的非付费正式发布 smoke |
+| test | llmgw | 四协议发布 canary 支持受治理的 Quickstart dry-run 并记录未调用上游 |

--- a/llmgw/serving/GatewayHttpEndpoints.cs
+++ b/llmgw/serving/GatewayHttpEndpoints.cs
@@ -1526,24 +1526,42 @@ public static class GatewayHttpEndpoints
         http.Response.Headers["X-Request-Id"] = requestId;
         http.Response.Headers["X-Gateway-Upstream-Called"] = "false";
         http.Response.StatusCode = StatusCodes.Status200OK;
-        http.Response.ContentType = "application/json";
+        http.Response.ContentType = IsQuickstartDryRunSsePath(path)
+            ? "text/event-stream"
+            : "application/json";
         await http.Response.WriteAsync(BuildQuickstartDryRunSuccess(path, requestId, jsonOpts));
         return true;
     }
 
     private static bool IsQuickstartDryRunPath(string path)
         => path.Equals("/gw/v1/invoke", StringComparison.OrdinalIgnoreCase)
+           || path.Equals("/gw/v1/send", StringComparison.OrdinalIgnoreCase)
+           || path.Equals("/gw/v1/stream", StringComparison.OrdinalIgnoreCase)
+           || path.Equals("/gw/v1/client-stream", StringComparison.OrdinalIgnoreCase)
            || path.Equals("/v1/chat/completions", StringComparison.OrdinalIgnoreCase)
            || path.Equals("/v1/messages", StringComparison.OrdinalIgnoreCase)
            || path.StartsWith("/v1beta/models/", StringComparison.OrdinalIgnoreCase)
               && path.EndsWith(":generateContent", StringComparison.OrdinalIgnoreCase);
 
+    private static bool IsQuickstartDryRunSsePath(string path)
+        => path.Equals("/gw/v1/stream", StringComparison.OrdinalIgnoreCase)
+           || path.Equals("/gw/v1/client-stream", StringComparison.OrdinalIgnoreCase);
+
     private static string? ResolveQuickstartDryRunRequestType(string path, JsonObject body)
     {
-        if (path.Equals("/gw/v1/invoke", StringComparison.OrdinalIgnoreCase))
+        if (path.Equals("/gw/v1/invoke", StringComparison.OrdinalIgnoreCase)
+            || path.Equals("/gw/v1/send", StringComparison.OrdinalIgnoreCase)
+            || path.Equals("/gw/v1/stream", StringComparison.OrdinalIgnoreCase))
         {
             var requestType = ReadString(body, "ModelType") ?? ReadString(body, "modelType");
             return requestType is "chat" or "vision" && (body["RequestBody"] ?? body["requestBody"]) is JsonObject
+                ? requestType
+                : null;
+        }
+        if (path.Equals("/gw/v1/client-stream", StringComparison.OrdinalIgnoreCase))
+        {
+            var requestType = ReadString(body, "ModelType") ?? ReadString(body, "modelType");
+            return requestType is "chat" or "vision" && (body["Messages"] ?? body["messages"]) is JsonArray
                 ? requestType
                 : null;
         }
@@ -1602,6 +1620,25 @@ public static class GatewayHttpEndpoints
     private static string BuildQuickstartDryRunSuccess(string path, string requestId, JsonSerializerOptions jsonOpts)
     {
         var gateway = new { requestId, dryRun = true, upstreamCalled = false };
+        if (IsQuickstartDryRunSsePath(path))
+        {
+            var content = JsonSerializer.Serialize(new
+            {
+                Type = "content",
+                Content = "Gateway dry-run passed",
+                Resolution = new { ActualModel = "dry-run" },
+                UpstreamCalled = false,
+            }, jsonOpts);
+            var done = JsonSerializer.Serialize(new
+            {
+                Type = "done",
+                Content = "",
+                FinishReason = "stop",
+                Resolution = new { ActualModel = "dry-run" },
+                UpstreamCalled = false,
+            }, jsonOpts);
+            return $"data: {content}\n\ndata: {done}\n\n";
+        }
         if (path.Equals("/v1/chat/completions", StringComparison.OrdinalIgnoreCase))
         {
             return JsonSerializer.Serialize(new
@@ -1645,6 +1682,7 @@ public static class GatewayHttpEndpoints
             mode = "dry-run",
             upstreamCalled = false,
             content = "Gateway dry-run passed",
+            resolution = new { actualModel = "dry-run" },
         }, jsonOpts);
     }
 

--- a/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayKeyGateContractTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Gateway/GatewayKeyGateContractTests.cs
@@ -2695,12 +2695,15 @@ public class GatewayKeyGateContractTests
                     Title = "Content Vision Quickstart",
                 },
             ]);
-            var authorizer = new CapturingScopedKeyAuthorizer(scope => scope == "invoke");
+            var authorizer = new CapturingScopedKeyAuthorizer(scope => scope is "invoke" or "stream:invoke");
             await using var app = BuildHostWithGateway(new ThrowingGateway(), keyAuthorizer: authorizer, gatewayData: data);
             await app.StartAsync();
             (string Path, string Body, string AppCallerCode, string RequestType)[] cases =
             {
                 ("/gw/v1/invoke", "{\"appCallerCode\":\"content.quickstart::chat\",\"modelType\":\"chat\",\"requestBody\":{\"messages\":[{\"role\":\"user\",\"content\":\"OK\"}]},\"context\":{\"sourceSystem\":\"external\"}}", "content.quickstart::chat", "chat"),
+                ("/gw/v1/send", "{\"appCallerCode\":\"content.quickstart::chat\",\"modelType\":\"chat\",\"requestBody\":{\"messages\":[{\"role\":\"user\",\"content\":\"OK\"}]},\"context\":{\"sourceSystem\":\"external\"}}", "content.quickstart::chat", "chat"),
+                ("/gw/v1/stream", "{\"appCallerCode\":\"content.quickstart::chat\",\"modelType\":\"chat\",\"stream\":true,\"requestBody\":{\"messages\":[{\"role\":\"user\",\"content\":\"OK\"}],\"stream\":true},\"context\":{\"sourceSystem\":\"external\"}}", "content.quickstart::chat", "chat"),
+                ("/gw/v1/client-stream", "{\"appCallerCode\":\"content.quickstart::chat\",\"modelType\":\"chat\",\"messages\":[{\"role\":\"user\",\"content\":\"OK\"}],\"context\":{\"sourceSystem\":\"external\"}}", "content.quickstart::chat", "chat"),
                 ("/v1/chat/completions", "{\"model\":\"auto\",\"messages\":[{\"role\":\"user\",\"content\":\"OK\"}],\"stream\":false}", "content.quickstart::chat", "chat"),
                 ("/v1/messages", "{\"model\":\"auto\",\"max_tokens\":8,\"messages\":[{\"role\":\"user\",\"content\":\"OK\"}]}", "content.quickstart::chat", "chat"),
                 ("/v1beta/models/auto:generateContent", "{\"contents\":[{\"role\":\"user\",\"parts\":[{\"text\":\"OK\"}]}]}", "content.quickstart::chat", "chat"),
@@ -2733,13 +2736,19 @@ public class GatewayKeyGateContractTests
                 response.Headers.GetValues("X-Request-Id").Single().ShouldBe(requestId);
                 response.Headers.GetValues("X-Gateway-Upstream-Called").Single().ShouldBe("false");
                 responseBody.ShouldContain("dry");
+                if (cases[index].Path.Contains("stream", StringComparison.Ordinal))
+                {
+                    response.Content.Headers.ContentType!.MediaType.ShouldBe("text/event-stream");
+                    responseBody.ShouldContain("data: ");
+                    responseBody.ShouldContain("\"Type\":\"done\"");
+                }
             }
 
             var logs = await data.Database.GetCollection<BsonDocument>("llmrequestlogs")
                 .Find(Builders<BsonDocument>.Filter.Eq("Provider", "gateway-dry-run"))
                 .Sort(Builders<BsonDocument>.Sort.Ascending("RequestId"))
                 .ToListAsync();
-            logs.Count.ShouldBe(8);
+            logs.Count.ShouldBe(11);
             logs.Select(x => x["IngressProtocol"].AsString).ToHashSet().SetEquals(new[]
             {
                 "gw-native", "openai-compatible", "claude-compatible", "gemini-compatible",
@@ -2763,7 +2772,7 @@ public class GatewayKeyGateContractTests
             callers.Count.ShouldBe(2);
             foreach (var caller in callers)
             {
-                caller.TotalSeen.ShouldBe(4);
+                caller.TotalSeen.ShouldBe(caller.RequestType == "chat" ? 7 : 4);
                 caller.ObservedIngressProtocols.ToHashSet().SetEquals(new[]
                 {
                     "gw-native", "openai-compatible", "claude-compatible", "gemini-compatible",

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -1420,7 +1420,7 @@ public class GatewayDataDomainGuardTests
         Assert.Contains("export LLMGW_MAINTENANCE_BASELINE_JSON=\"$maintenance_baseline_json\"", stage);
         Assert.Contains("LLMGW_GATE_SHADOW_RELEASE_COMMIT:-$expect_commit", deploy);
         Assert.Contains("LLM Gateway maintenance release: audited baseline accepted", deploy);
-        Assert.Contains("args=\"--base $gate_base --min-total 0 --min-per-app 0\"", deploy);
+        Assert.Contains("args=\"--base $gate_base --min-total 0 --min-per-app 0 --skip-global-cells\"", deploy);
         Assert.Contains("[ \"$maintenance_release\" != \"1\" ]", deploy);
         Assert.Contains("{ [ \"$mode\" = \"http\" ] && [ \"$maintenance_release\" != \"1\" ]; }", deploy);
         Assert.Contains("config-authority inherited from audited full-http maintenance baseline", deploy);

--- a/scripts/gw-smoke.py
+++ b/scripts/gw-smoke.py
@@ -36,6 +36,7 @@ SMOKE_MAX_TOKENS = int(os.environ.get("GW_SMOKE_MAX_TOKENS", "4"))
 SMOKE_REQUEST_TIMEOUT = int(os.environ.get("GW_SMOKE_REQUEST_TIMEOUT_SECONDS", os.environ.get("GW_TIMEOUT", "120")))
 SMOKE_SOURCE_SYSTEM = os.environ.get("GW_SMOKE_SOURCE_SYSTEM", "release-probe").strip() or "release-probe"
 SMOKE_APP_CALLER = os.environ.get("GW_SMOKE_APP_CALLER", "report-agent.generate::chat").strip() or "report-agent.generate::chat"
+QUICKSTART_DRY_RUN = os.environ.get("GW_SMOKE_QUICKSTART_DRY_RUN", "").strip().lower() in {"1", "true", "yes", "on"}
 
 # 每类 ModelType 抽 1 个代表入口（D1×D2 抽样）。真机存在性以 /gw/v1/pools 为准。
 # 默认只跑低成本 chat provider canary；intent/vision 需要通过 GW_SMOKE_MODEL_TYPES 显式打开。
@@ -92,6 +93,8 @@ def _req(method, path, body=None):
         app_caller = str((query.get("appCallerCode") or [app_caller])[0]).strip()
     r.add_header("X-Gateway-Source", source_system)
     r.add_header("X-Gateway-App-Caller", app_caller)
+    if QUICKSTART_DRY_RUN and method == "POST":
+        r.add_header("X-Gateway-Dry-Run", "quickstart")
     # 预览域名走 Cloudflare：默认 Python-urllib UA 会被 CF 按浏览器签名拦截（error 1010 / 403）。
     # 带一个正常浏览器 UA 即可放行（与真人浏览器/curl 一致）。
     r.add_header("User-Agent", "Mozilla/5.0 (X11; Linux x86_64) gw-smoke/1.0")
@@ -356,11 +359,16 @@ def main():
         }
         code, raw = _req("POST", "/invoke", body)
         d = _envelope_data(raw) or {}
-        res = d.get("Resolution") or {}
-        ok = (code == 200 and d.get("Success") is True
-              and bool(d.get("Content")) and bool(res.get("ActualModel")))
+        res = _pick(d, "resolution") or {}
+        success = _pick(d, "success")
+        content = _pick(d, "content")
+        actual_model = _pick(res, "actualModel")
+        upstream_called = _pick(d, "upstreamCalled")
+        ok = (code == 200 and success is True
+              and bool(content) and bool(actual_model)
+              and (not QUICKSTART_DRY_RUN or upstream_called is False))
         # 无"选 A 给 B"：若请求指定了 expectedModel，actualModel 应一致（此处未指定，仅记录）。
-        detail = f"{code} success={d.get('Success')} model={res.get('ActualModel')} contentLen={len(d.get('Content') or '')}"
+        detail = f"{code} success={success} model={actual_model} contentLen={len(content or '')} upstreamCalled={upstream_called}"
         rows.append((f"invoke[{mtype}]", ok, detail))
 
     # 4) send 兼容入口：MAP 旧客户端仍用 /send，只抽 chat 一类避免 D 层冒烟成本膨胀。
@@ -375,10 +383,15 @@ def main():
         }
         code, raw = _req("POST", "/send", send_body)
         d = _envelope_data(raw) or {}
-        res = d.get("Resolution") or {}
-        ok = (code == 200 and d.get("Success") is True
-              and bool(d.get("Content")) and bool(res.get("ActualModel")))
-        detail = f"{code} success={d.get('Success')} model={res.get('ActualModel')} contentLen={len(d.get('Content') or '')}"
+        res = _pick(d, "resolution") or {}
+        success = _pick(d, "success")
+        content = _pick(d, "content")
+        actual_model = _pick(res, "actualModel")
+        upstream_called = _pick(d, "upstreamCalled")
+        ok = (code == 200 and success is True
+              and bool(content) and bool(actual_model)
+              and (not QUICKSTART_DRY_RUN or upstream_called is False))
+        detail = f"{code} success={success} model={actual_model} contentLen={len(content or '')} upstreamCalled={upstream_called}"
         rows.append(("send-compat[chat]", ok, detail))
 
     # 5) stream：真实 SSE 边界。只抽 chat 一类，避免 D 层冒烟成本膨胀。
@@ -396,21 +409,24 @@ def main():
             "Context": {"UserId": "smoke-test", "IsHealthProbe": True, "GatewayTransport": "http", "SourceSystem": SMOKE_SOURCE_SYSTEM, "IngressProtocol": "gw-native"},
         }
         code, raw, events = _sse_req("/stream", stream_body)
-        stream_text = "".join(str(e.get("Content") or "") for e in events if isinstance(e, dict))
+        stream_text = "".join(str(_pick(e, "content") or "") for e in events if isinstance(e, dict))
         stream_model = next(
             (
-                (e.get("Resolution") or {}).get("ActualModel")
+                _pick(_pick(e, "resolution") or {}, "actualModel")
                 for e in events
-                if isinstance(e, dict) and isinstance(e.get("Resolution"), dict)
+                if isinstance(e, dict) and isinstance(_pick(e, "resolution"), dict)
             ),
             None,
         )
         stream_done = any(
             isinstance(e, dict)
-            and (e.get("FinishReason") or str(e.get("Type")).lower() in {"done", "4"})
+            and (_pick(e, "finishReason") or str(_pick(e, "type")).lower() in {"done", "4"})
             for e in events
         )
-        ok = code == 200 and len(events) >= 2 and bool(stream_text) and bool(stream_model) and stream_done
+        dry_run_safe = not QUICKSTART_DRY_RUN or all(
+            _pick(e, "upstreamCalled") is False for e in events if isinstance(e, dict)
+        )
+        ok = code == 200 and len(events) >= 2 and bool(stream_text) and bool(stream_model) and stream_done and dry_run_safe
         rows.append(("stream[chat]", ok, f"{code} events={len(events)} model={stream_model} contentLen={len(stream_text)}"))
 
     # 6) client-stream：CreateClient/ILLMClient 跨进程 SSE 边界。
@@ -427,12 +443,15 @@ def main():
             "Context": {"UserId": "smoke-test", "IsHealthProbe": True, "GatewayTransport": "http", "SourceSystem": SMOKE_SOURCE_SYSTEM, "IngressProtocol": "gw-native"},
         }
         code, raw, events = _sse_req("/client-stream", client_stream_body)
-        client_stream_text = "".join(str(e.get("Content") or "") for e in events if isinstance(e, dict))
+        client_stream_text = "".join(str(_pick(e, "content") or "") for e in events if isinstance(e, dict))
         client_stream_done = any(
-            isinstance(e, dict) and str(e.get("Type")).lower() in {"done", "4"}
+            isinstance(e, dict) and str(_pick(e, "type")).lower() in {"done", "4"}
             for e in events
         )
-        ok = code == 200 and len(events) >= 2 and bool(client_stream_text) and client_stream_done
+        dry_run_safe = not QUICKSTART_DRY_RUN or all(
+            _pick(e, "upstreamCalled") is False for e in events if isinstance(e, dict)
+        )
+        ok = code == 200 and len(events) >= 2 and bool(client_stream_text) and client_stream_done and dry_run_safe
         rows.append(("client-stream[chat]", ok, f"{code} events={len(events)} contentLen={len(client_stream_text)}"))
 
     # 7) route matrix：只打 /resolve，不消耗上游模型 token。用于证明 auto/pool/pinned 路由策略进入 GW router。
@@ -516,6 +535,8 @@ def main():
         "base": base,
         "expectedCommit": EXPECTED_COMMIT,
         "healthCommit": health_commit,
+        "mode": "quickstart-dry-run" if QUICKSTART_DRY_RUN else "runtime",
+        "upstreamCalled": False if QUICKSTART_DRY_RUN else None,
         "passed": passed,
         "total": len(rows),
         "rows": report_rows,

--- a/scripts/llmgw-protocol-canary.py
+++ b/scripts/llmgw-protocol-canary.py
@@ -27,6 +27,12 @@ from typing import Any
 TARGET_PROTOCOLS = ("gw-native", "openai-compatible", "claude-compatible", "gemini-compatible")
 DEFAULT_APP_CALLER = "report-agent.generate::chat"
 DEFAULT_MAX_RUNTIME_CALLS = 4
+QUICKSTART_DRY_RUN = os.environ.get("LLMGW_PROTOCOL_CANARY_QUICKSTART_DRY_RUN", "").strip().lower() in {
+    "1",
+    "true",
+    "yes",
+    "on",
+}
 
 
 def _default_base() -> str:
@@ -127,6 +133,11 @@ def _existing_report_covers(
     mode = str(payload.get("mode") or payload.get("Mode") or "").strip().lower()
     if verdict != "pass" or mode != "execute":
         return False, f"existing verdict/mode is not reusable: verdict={verdict or 'empty'} mode={mode or 'empty'}"
+    if QUICKSTART_DRY_RUN and (
+        payload.get("quickstartDryRun") is not True
+        or payload.get("upstreamCalled") is not False
+    ):
+        return False, "existing report is not a verified quickstart dry-run"
 
     existing_root = _normalized_root(payload.get("root") or payload.get("Root"))
     if root and existing_root and existing_root != _normalized_root(root):
@@ -207,6 +218,8 @@ def _headers_for_protocol(protocol: str, run_id: str) -> dict[str, str]:
         "X-Gateway-Run-Id": run_id,
         "X-Gateway-Model-Policy": "auto",
     }
+    if QUICKSTART_DRY_RUN:
+        headers["X-Gateway-Dry-Run"] = "quickstart"
     if protocol in {"openai-compatible", "claude-compatible", "gemini-compatible"}:
         headers["X-Gateway-App-Title"] = "LLM Gateway protocol canary"
     return headers
@@ -401,6 +414,8 @@ def _self_test() -> int:
                 "verdict": "pass",
                 "mode": "execute",
                 "root": "https://example.test",
+                "quickstartDryRun": QUICKSTART_DRY_RUN,
+                "upstreamCalled": False if QUICKSTART_DRY_RUN else None,
                 "health": {"commit": "abc123"},
                 "cases": [
                     {"protocol": "gw-native", "ok": True},
@@ -501,6 +516,8 @@ def main() -> int:
         "runId": run_id,
         "maxTokens": max_tokens,
         "maxRuntimeCalls": max_runtime_calls,
+        "quickstartDryRun": QUICKSTART_DRY_RUN,
+        "upstreamCalled": False if QUICKSTART_DRY_RUN else None,
         "reusedExisting": False,
         "protocols": list(selected_protocols),
         "health": {},

--- a/scripts/tests/test_gw_smoke_app_caller.py
+++ b/scripts/tests/test_gw_smoke_app_caller.py
@@ -21,6 +21,43 @@ def load_smoke_module():
 
 
 class GatewaySmokeAppCallerTests(unittest.TestCase):
+    def test_quickstart_dry_run_header_is_sent_for_post_requests(self):
+        with patch.dict(
+            os.environ,
+            {
+                "GW_SMOKE_QUICKSTART_DRY_RUN": "1",
+                "GW_BASE": "https://gateway.example.test/gw/v1",
+            },
+            clear=False,
+        ):
+            module = load_smoke_module()
+
+        captured = {}
+
+        class FakeResponse:
+            status = 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            @staticmethod
+            def read():
+                return b"{}"
+
+        def fake_urlopen(request, timeout):
+            captured["headers"] = dict(request.header_items())
+            captured["timeout"] = timeout
+            return FakeResponse()
+
+        with patch.object(module.urllib.request, "urlopen", side_effect=fake_urlopen):
+            status, _ = module._req("POST", "/invoke", {"AppCallerCode": "release-probe.stable::chat"})
+
+        self.assertEqual(status, 200)
+        self.assertEqual(captured["headers"].get("X-gateway-dry-run"), "quickstart")
+
     def test_configured_app_caller_replaces_default_chat_sample(self):
         configured = "release-probe.stable::chat"
         with patch.dict(


### PR DESCRIPTION
## 摘要
为正式发布增加受 scoped key、租户、团队和 AppCaller 治理保护的 Quickstart dry-run smoke。invoke、send、stream、client-stream 与四兼容协议仍走真实公网入口、鉴权、日志和 SSE 解析，但在模型解析、预算预占和上游发送前结束，并证明 `upstreamCalled=false`。

## 改动 diff
- `llmgw/serving/GatewayHttpEndpoints.cs`：扩展非付费 dry-run 到 send 与双流式入口，输出可校验的模型解析和 SSE 事件。
- `scripts/gw-smoke.py`：新增非付费 smoke 模式，验证四个 GW Native 路径和未调用上游。
- `scripts/llmgw-protocol-canary.py`：四协议 execute canary 可使用相同 dry-run 边界，禁止复用非 dry-run 证据。
- `prd-api/tests/.../GatewayKeyGateContractTests.cs`：扩展到 11 条真实日志和双 SSE 断言。
- `scripts/tests/test_gw_smoke_app_caller.py`：验证 dry-run 请求头。
- `changelogs/2026-07-24_llmgw-nonpaid-release-smoke.md`：新增 changelog 碎片。

## 测试
- [x] .NET build 0 error
- [x] Quickstart dry-run Mongo 集成测试通过
- [x] 9 项 Python 单元测试通过
- [x] gw-smoke self-test 通过
- [x] protocol canary self-test 通过
- [x] Python 编译与 diff 检查通过