### PR TITLE
每日熵减计划 2026-W30 — D6 核对 5 条历史 changelog (0 处需追加设计文档)

### DIFF
--- a/changelogs/.entropy-manifest.yml
+++ b/changelogs/.entropy-manifest.yml
@@ -480,3 +480,8 @@ processed:
   - 2026-07-21_cds-release-dialog-perf-fixes.md
   - 2026-07-21_entropy-cleanup.md
   - 2026-07-21_recording-upload-dedup.md
+  - 2026-07-22_acceptance-report-gap-time.md
+  - 2026-07-22_cds-hot-restart-waiting-poll.md
+  - 2026-07-22_cds-preview-url-actual-source.md
+  - 2026-07-22_cds-project-key-project-list-isolation.md
+  - 2026-07-22_entropy-cleanup.md

--- a/changelogs/2026-07-24_entropy-cleanup.md
+++ b/changelogs/2026-07-24_entropy-cleanup.md
@@ -1,0 +1,1 @@
+| chore | doc | 每日熵减计划：D1-D4 全部干净（doc/ 命名、index.yml、guide.list、CLAUDE.md 技能表均无缺项/幽灵项，0 改动），D6 处理 5 条 changelog（验收报告顶部缺口统计口径修复/CDS 热重启等待页轮询与叙事动画重做/CDS 预览地址真实来源与安全隐藏/CDS 项目级 Agent Key 项目列表隔离/上一轮熵减自身记录），均无匹配的 design 文档章节需要追加（预览地址行为已由 CLAUDE.md §11 覆盖；其余为窄范围 bug fix/安全修复，无对应 design 文档），仅登记 manifest，manifest 累计 482 条 |


### PR DESCRIPTION
## 熵清理摘要

- D1 doc/ 命名规范：0 违规
- D2 index.yml：+0/-0 条
- D3 guide.list：+0/-0 条
- D4 CLAUDE.md 技能表：+0/-0 条
- D5 codebase-snapshot：未改动（需人工专项复核，超出本次自动化范围）
- D6 changelog→doc：本次核对 5 条历史 changelog，manifest 累计 482 条；逐条核实均无匹配的 `design.*.md` 章节需要追加（验收报告顶部缺口统计口径修复、CDS 项目级 Agent Key 项目列表隔离为窄范围 bug fix/安全修复，无对应设计文档；CDS 预览地址真实来源与安全隐藏行为已由 `CLAUDE.md §11` 覆盖；CDS 热重启等待页轮询与叙事动画重做已由 `doc/debt.cds.nginx-loading-pages.md` 台账追踪；上一轮熵减自身记录为元信息，无需处理）

## 改动 diff

- `changelogs/.entropy-manifest.yml`：追加 5 条已处理 changelog 记录（2026-07-22_acceptance-report-gap-time.md / 2026-07-22_cds-hot-restart-waiting-poll.md / 2026-07-22_cds-preview-url-actual-source.md / 2026-07-22_cds-project-key-project-list-isolation.md / 2026-07-22_entropy-cleanup.md）
- `changelogs/2026-07-24_entropy-cleanup.md`：新增本次熵减 changelog 碎片

## 测试

- [x] D1-D4 双向扫描完成（补缺 + 删幽灵），`git diff` 核验：仅 manifest 追加行，无删除行
- [x] 运行两次验证：第二次扫描 D1-D4 净变更为 0（本次即为第二次运行的结果，历史欠债此前已清零）
- [x] 无代码文件混入，改动范围严格限定在 `changelogs/` 目录

---
_Generated by [Claude Code](https://claude.ai/code/session_01KeXzmogaXE4CZh3rMhFAEb)_