### PR TITLE
fix(llmgw): 隔离正式协议 canary 密钥

### DIFF
--- a/changelogs/2026-07-26_llmgw-protocol-canary-key-fence.md
+++ b/changelogs/2026-07-26_llmgw-protocol-canary-key-fence.md
@@ -1,0 +1,1 @@
+| fix | llmgw | 正式发布四协议 canary 支持独立 sourceSystem fencing key，避免错误复用 MAP 业务 smoke key |

--- a/exec_dep.sh
+++ b/exec_dep.sh
@@ -45,8 +45,11 @@ set -eu
 #     非空时同样必须通过 stage runner，避免 raw 证据采样绕过 gate
 #   - LLMGW_GATE_BASE / GW_BASE：release gate 使用的 serving base URL（形如 https://host/gw/v1）
 #   - LLMGW_GATE_KEY / GW_KEY：release gate 使用的 X-Gateway-Key；未设时回退 LLMGW_SERVE_KEY
-#   - LLMGW_POST_DEPLOY_SERVICE_KEY：发布后 D 层 smoke / protocol canary 使用的 scoped service key；
-#     未设时兼容回退 LLMGW_GATE_KEY。全局 shadow/runtime gate 仍使用 LLMGW_GATE_KEY，禁止外部 smoke 复用 legacy key。
+#   - LLMGW_POST_DEPLOY_SERVICE_KEY：发布后 D 层业务 smoke 使用的 scoped service key；
+#     未设时兼容回退 LLMGW_GATE_KEY。
+#   - LLMGW_POST_DEPLOY_PROTOCOL_CANARY_KEY：四协议 canary 使用的 scoped service key；
+#     sourceSystem 应与 canary 请求的 X-Gateway-Source 一致。未设时兼容回退业务 smoke key。
+#     全局 shadow/runtime gate 仍使用 LLMGW_GATE_KEY，禁止外部 smoke/canary 复用 legacy key。
 #   - LLMGW_SERVE_BASE_URL：生产必须为 http://gateway，客户端会追加 /gw/v1/*，禁止 API 固定到单个 serving
 #   - LLMGW_READINESS_ASSET_PROBE_KEY：生产深度 readiness 使用的稳定对象 key，必须存在
 #   - LLMGW_GATE_MIN_TOTAL：全局 shadow 最小样本数，默认 30
@@ -1458,6 +1461,7 @@ run_llmgw_post_deploy_verification_if_needed() {
   gate_base="${LLMGW_POST_DEPLOY_GATE_BASE:-}"
   gate_key="${LLMGW_POST_DEPLOY_GATE_KEY:-}"
   smoke_key="${LLMGW_POST_DEPLOY_SMOKE_KEY:-$gate_key}"
+  protocol_canary_key="${LLMGW_POST_DEPLOY_PROTOCOL_CANARY_KEY:-$smoke_key}"
   expect_commit="${LLMGW_POST_DEPLOY_EXPECT_COMMIT:-}"
 
   if [ -z "$gate_base" ]; then
@@ -1512,6 +1516,10 @@ run_llmgw_post_deploy_verification_if_needed() {
         echo "ERROR: LLM Gateway post-deploy protocol canary requires immutable --commit/sha tag so --expect-commit can be enforced." >&2
         exit 1
       fi
+      if [ -z "$protocol_canary_key" ]; then
+        echo "ERROR: LLM Gateway post-deploy protocol canary requires LLMGW_POST_DEPLOY_PROTOCOL_CANARY_KEY or a compatible smoke key." >&2
+        exit 1
+      fi
       protocol_canary_json="${LLMGW_POST_DEPLOY_PROTOCOL_CANARY_JSON_OUT:-}"
       protocol_canary_md="${LLMGW_POST_DEPLOY_PROTOCOL_CANARY_REPORT_MD:-}"
       protocol_canary_max_runtime_calls="${LLMGW_POST_DEPLOY_PROTOCOL_CANARY_MAX_RUNTIME_CALLS:-${LLMGW_PROTOCOL_CANARY_MAX_RUNTIME_CALLS:-4}}"
@@ -1535,7 +1543,7 @@ run_llmgw_post_deploy_verification_if_needed() {
       fi
       echo "LLM Gateway post-deploy protocol canary: required before runtime gates"
       # shellcheck disable=SC2086
-      GW_KEY="$smoke_key" python3 scripts/llmgw-protocol-canary.py \
+      GW_KEY="$protocol_canary_key" python3 scripts/llmgw-protocol-canary.py \
         --base "$gate_base" \
         --expect-commit "$expect_commit" \
         --execute \

--- a/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs
@@ -1255,6 +1255,7 @@ public class GatewayDataDomainGuardTests
         Assert.Contains("GW_EXPECT_COMMIT=\"$expect_commit\"", script);
         Assert.Contains("LLMGW_POST_DEPLOY_SMOKE_KEY=\"${LLMGW_POST_DEPLOY_SERVICE_KEY:-$gate_key}\"", script);
         Assert.Contains("smoke_key=\"${LLMGW_POST_DEPLOY_SMOKE_KEY:-$gate_key}\"", script);
+        Assert.Contains("protocol_canary_key=\"${LLMGW_POST_DEPLOY_PROTOCOL_CANARY_KEY:-$smoke_key}\"", script);
         Assert.Contains("GW_BASE=\"$gate_base\" GW_KEY=\"$smoke_key\" GW_TIMEOUT=\"${LLMGW_GATE_SMOKE_TIMEOUT_SECONDS:-120}\" GW_EXPECT_COMMIT=\"$expect_commit\" python3 scripts/gw-smoke.py", script);
         Assert.Contains("LLMGW_GATE_RUN_SERVING_PROBE", script);
         Assert.Contains("LLMGW_SERVING_PROBE_JSON_OUT", script);
@@ -1304,6 +1305,8 @@ public class GatewayDataDomainGuardTests
         Assert.Contains("LLM Gateway post-deploy protocol canary: required before runtime gates", script);
         Assert.Contains("LLM Gateway post-deploy protocol canary: disabled; not passing unverified JSON to runtime gates", script);
         Assert.Contains("python3 scripts/llmgw-protocol-canary.py", script);
+        Assert.Contains("GW_KEY=\"$protocol_canary_key\" python3 scripts/llmgw-protocol-canary.py", script);
+        Assert.DoesNotContain("GW_KEY=\"$smoke_key\" python3 scripts/llmgw-protocol-canary.py", script);
         Assert.Contains("protocol_canary_arg=\"--protocol-canary-json $protocol_canary_json\"", script);
         Assert.Contains("$protocol_canary_arg --require-runtime-gates", script);
         Assert.Contains("[ \"$mode\" = \"http\" ] && [ \"$maintenance_release\" = \"1\" ]", script);

--- a/scripts/llmgw-prod-stage.sh
+++ b/scripts/llmgw-prod-stage.sh
@@ -49,7 +49,10 @@ Required environment for deploy stages:
   LLMGW_CONSOLE_BASE and LLMGW_CONSOLE_TOKEN, or LLMGW_CONSOLE_USER/PASSWORD
                               Required for config-authority and http-full stages
   LLMGW_POST_DEPLOY_SERVICE_KEY
-                              Optional scoped service key for post-deploy smoke/protocol canary.
+                              Optional scoped service key for post-deploy business smoke.
+  LLMGW_POST_DEPLOY_PROTOCOL_CANARY_KEY
+                              Optional independently fenced key for sourceSystem=canary protocol requests.
+                              Falls back to the business smoke key for compatibility.
                               Global shadow/runtime gates continue to use LLMGW_GATE_KEY.
   LLMGW_STAGE_MIN_FREE_MB minimum free disk MB before execute deploy stages, default 4096
   LLMGW_STAGE_AUTO_RESTORE_SHADOW_ON_FAILURE=1 restores shadow/low-sample after failed high-sample shadow-start (default)

--- a/scripts/tests/test_llmgw_release_dual_keys.py
+++ b/scripts/tests/test_llmgw_release_dual_keys.py
@@ -21,9 +21,14 @@ class ReleaseDualKeyContractTests(unittest.TestCase):
         )
         self.assertIn('smoke_key="${LLMGW_POST_DEPLOY_SMOKE_KEY:-$gate_key}"', self.source)
 
-    def test_business_smoke_and_protocol_canary_use_scoped_key(self) -> None:
+    def test_business_smoke_and_protocol_canary_support_independent_scoped_keys(self) -> None:
         self.assertIn('GW_BASE="$gate_base" GW_KEY="$smoke_key"', self.source)
-        self.assertIn('GW_KEY="$smoke_key" python3 scripts/llmgw-protocol-canary.py', self.source)
+        self.assertIn(
+            'protocol_canary_key="${LLMGW_POST_DEPLOY_PROTOCOL_CANARY_KEY:-$smoke_key}"',
+            self.source,
+        )
+        self.assertIn('GW_KEY="$protocol_canary_key" python3 scripts/llmgw-protocol-canary.py', self.source)
+        self.assertNotIn('GW_KEY="$smoke_key" python3 scripts/llmgw-protocol-canary.py', self.source)
 
     def test_global_runtime_gate_keeps_release_gate_key(self) -> None:
         self.assertIn(


### PR DESCRIPTION
## 摘要
修复正式发布把 MAP 业务 smoke key 强制复用于 sourceSystem=canary 四协议请求的问题。新增独立 `LLMGW_POST_DEPLOY_PROTOCOL_CANARY_KEY`，未设置时仍兼容回退 smoke key，不改变既有发布调用。

## 改动 diff
- `exec_dep.sh`：业务 smoke 与协议 canary 分别选择 scoped key，协议 canary 不再固定使用 smoke key。
- `scripts/llmgw-prod-stage.sh`：补充独立 canary key 发布参数说明。
- `scripts/tests/test_llmgw_release_dual_keys.py`：验证独立 key、兼容回退和禁止错误复用。
- `prd-api/tests/PrdAgent.Tests/GatewayDataDomainGuardTests.cs`：同步发布脚本安全合同断言。
- `changelogs/2026-07-26_llmgw-protocol-canary-key-fence.md`：记录修复。

## 测试
- [x] Python 发布双 key 合同 6/6 通过
- [x] bash -n 通过
- [x] .NET 定向合同测试 1/1 通过
- [x] pre-commit C# build 通过
- [x] 手工正式四协议 Quickstart dry-run 4/4 通过，未调用上游

## 预览
- https://llmgw-protocol-canary-key-fence-codex-prd-agent.miduo.org/