### PR TITLE
fix(cds): 修复每日验收发现的 smoke 200 HTML 假阳性

### DIFF
--- a/.claude/skills/cds/SKILL.md
+++ b/.claude/skills/cds/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: cds
-version: 0.12.0
+version: 0.12.1
 description: CDS (Cloud Dev Space) core skill — provides cross-Agent, project-scoped onboarding without copying keys or modifying shell profiles, hosts the canonical cdscli Python CLI, manages CDS authentication and project access, owns CDS service self-update, exposes managed deployment runs and versions, requires the companion preview-url skill to read actual preview URLs from CDS, and dispatches scanning or deployment work to the matching CDS skill. Activates for CDS onboarding, connect, authentication, deployment status, versions, rollback, self-update, preview URLs, or the bare word CDS when intent is unclear.
 ---
 
 # CDS — 核心技能：安全接入 / cdscli / 托管交付 / self-update / 分诊器
 
-> **版本**：v0.12.0 | **状态**：已落地 | **触发**：`/cds`、`/cds-auth`、"接入 CDS"、"CDS 授权"、"部署记录"、"版本回滚"、"cds 自更新"、"预览地址"
+> **版本**：v0.12.1 | **状态**：已落地 | **触发**：`/cds`、`/cds-auth`、"接入 CDS"、"CDS 授权"、"部署记录"、"版本回滚"、"cds 自更新"、"预览地址"
 
 > **冷热分离**：
 > - 接入新项目、生成 compose、上传 YAML → **`cds-project-scan`**（冷路径）

--- a/.claude/skills/cds/cli/cdscli.py
+++ b/.claude/skills/cds/cli/cdscli.py
@@ -44,7 +44,7 @@ import urllib.parse
 import urllib.request
 from typing import Any, Optional
 
-VERSION = "0.12.0"  # ← bumped on each SKILL.md change; 服务端自动读这一行
+VERSION = "0.12.1"  # ← bundled cli 变更时 bump；服务端自动读这一行
 _TRACE_ID: str = ""
 _HUMAN: bool = False
 _DRIFT_WARNED: bool = False  # 全进程只提示一次，避免每个请求都刷
@@ -7151,15 +7151,58 @@ def cmd_smoke(args: argparse.Namespace) -> None:
     results: list[dict[str, Any]] = []
 
     def probe(name: str, url: str, headers: dict[str, str] | None = None,
-              expect_status: int = 200) -> dict[str, Any]:
+              expect_status: int = 200,
+              json_contract: str | None = None) -> dict[str, Any]:
         req = urllib.request.Request(url, method="GET",
                                      headers={"User-Agent": "curl/8.5.0", **(headers or {})})
         try:
             with urllib.request.urlopen(req, timeout=10) as r:
-                raw = r.read()[:200].decode("utf-8", errors="replace")
-                return {"layer": name, "url": url, "status": r.status,
-                        "pass": r.status == expect_status,
-                        "preview": raw[:120]}
+                raw_bytes = r.read(65537 if json_contract else 200)
+                raw = raw_bytes.decode("utf-8", errors="replace")
+                content_type = str(r.headers.get("Content-Type", "")).strip()
+                result: dict[str, Any] = {
+                    "layer": name,
+                    "url": url,
+                    "status": r.status,
+                    "pass": r.status == expect_status,
+                    "preview": raw[:120],
+                }
+                if not json_contract:
+                    return result
+
+                result["contentType"] = content_type
+                media_type = content_type.split(";", 1)[0].strip().lower()
+                if media_type != "application/json" and not media_type.endswith("+json"):
+                    result["pass"] = False
+                    result["error"] = "expected_application_json"
+                    return result
+                if len(raw_bytes) > 65536:
+                    result["pass"] = False
+                    result["error"] = "json_response_too_large"
+                    return result
+                try:
+                    payload = json.loads(raw)
+                except (json.JSONDecodeError, UnicodeDecodeError):
+                    result["pass"] = False
+                    result["error"] = "invalid_json"
+                    return result
+
+                schema_ok = isinstance(payload, dict)
+                if json_contract == "version-check":
+                    version = payload.get("version") if isinstance(payload, dict) else None
+                    schema_ok = isinstance(version, int) and not isinstance(version, bool)
+                elif json_contract == "health":
+                    status = str(payload.get("status", "")).strip().lower() if isinstance(payload, dict) else ""
+                    schema_ok = isinstance(payload, dict) and (
+                        status in {"healthy", "ok", "ready", "success"}
+                        or payload.get("ok") is True
+                        or payload.get("healthy") is True
+                        or payload.get("success") is True
+                    )
+                if not schema_ok:
+                    result["pass"] = False
+                    result["error"] = "invalid_json_schema"
+                return result
         except urllib.error.HTTPError as e:
             return {"layer": name, "url": url, "status": e.code,
                     "pass": e.code == expect_status, "error": e.reason}
@@ -7170,8 +7213,12 @@ def cmd_smoke(args: argparse.Namespace) -> None:
     # L1 根路径无认证
     results.append(probe("L1-root", f"{preview}/"))
     # L2 无认证 API (常见路径)
-    for path in ("/api/shortcuts/version-check", "/healthz", "/api/health"):
-        r = probe(f"L2{path}", f"{preview}{path}")
+    for path, contract in (
+        ("/api/shortcuts/version-check", "version-check"),
+        ("/healthz", "health"),
+        ("/api/health", "health"),
+    ):
+        r = probe(f"L2{path}", f"{preview}{path}", json_contract=contract)
         results.append(r)
         if r["pass"]:
             break

--- a/.claude/skills/cds/cli/cdscli.py
+++ b/.claude/skills/cds/cli/cdscli.py
@@ -7211,34 +7211,46 @@ def cmd_smoke(args: argparse.Namespace) -> None:
                     "error": str(e)[:80]}
 
     # L1 根路径无认证
-    results.append(probe("L1-root", f"{preview}/"))
+    l1_result = probe("L1-root", f"{preview}/")
+    results.append(l1_result)
     # L2 无认证 API (常见路径)
+    l2_results: list[dict[str, Any]] = []
     for path, contract in (
         ("/api/shortcuts/version-check", "version-check"),
         ("/healthz", "health"),
         ("/api/health", "health"),
     ):
         r = probe(f"L2{path}", f"{preview}{path}", json_contract=contract)
+        l2_results.append(r)
         results.append(r)
         if r["pass"]:
             break
     # L3 认证 API
     key = os.environ.get("AI_ACCESS_KEY", "")
     user = os.environ.get("MAP_AI_USER", "")
+    l3_result: dict[str, Any] | None = None
     if key:
         hdrs = {"X-AI-Access-Key": key}
         if user:
             hdrs["X-AI-Impersonate"] = user
-        results.append(probe("L3-authed", f"{preview}/api/users?pageSize=1",
-                             headers=hdrs, expect_status=200))
+        l3_result = probe("L3-authed", f"{preview}/api/users?pageSize=1",
+                          headers=hdrs, expect_status=200)
+        results.append(l3_result)
 
-    passed = sum(1 for r in results if r["pass"])
+    layers = [
+        {"layer": "L1", "pass": bool(l1_result["pass"])},
+        {"layer": "L2", "pass": any(r["pass"] for r in l2_results)},
+    ]
+    if l3_result is not None:
+        layers.append({"layer": "L3", "pass": bool(l3_result["pass"])})
+    passed = sum(1 for layer in layers if layer["pass"])
     summary = {"branchId": branch_id, "preview": preview,
-               "passed": f"{passed}/{len(results)}", "probes": results}
-    if passed == len(results):
-        ok(summary, note=f"冒烟全绿 ({passed}/{len(results)})")
+               "passed": f"{passed}/{len(layers)}", "layers": layers,
+               "probes": results}
+    if passed == len(layers):
+        ok(summary, note=f"冒烟全绿 ({passed}/{len(layers)})")
         return
-    die(f"冒烟失败 ({passed}/{len(results)} 通过)", code=2, extra={"data": summary})
+    die(f"冒烟失败 ({passed}/{len(layers)} 通过)", code=2, extra={"data": summary})
 
 
 def cmd_help_me_check(args: argparse.Namespace) -> None:

--- a/.claude/skills/cds/reference/smoke.md
+++ b/.claude/skills/cds/reference/smoke.md
@@ -51,6 +51,8 @@ curl -sf "$PREVIEW_URL/api/shortcuts/version-check"
 `/api/shortcuts/version-check` 必须包含数值型 `version`；健康端点必须明确返回
 `status=healthy|ok|ready|success`，或布尔型 `ok/healthy/success=true`。API 路径
 返回 HTTP 200 的 HTML/SPA、非法 JSON 或不匹配的 JSON 结构都判为 L2 失败。
+这些路径是候选替代关系：CLI 会保留每次探测结果用于诊断，但任一候选满足对应
+契约即可判定 L2 通过；只有全部候选失败时才判定 L2 失败。
 
 ## L3 — 认证 API
 

--- a/.claude/skills/cds/reference/smoke.md
+++ b/.claude/skills/cds/reference/smoke.md
@@ -9,7 +9,7 @@
 | 层 | 何时通过才进下一层 | 目的 |
 |----|---------------------|------|
 | **L1** 根路径 | HTTP 200 | 前端静态资源可访问，CDS 代理正常 |
-| **L2** 无认证 API | HTTP 200 | 后端进程活着，路由注册完成 |
+| **L2** 无认证 API | HTTP 200 + JSON Content-Type + 端点 schema 正确 | 后端进程活着，路由注册完成，且没有被 SPA fallback 假阳性冒充 |
 | **L3** 认证 API | HTTP 200 + 数据正确 | `AI_ACCESS_KEY` / impersonate 链路正常 |
 
 CLI 封装：`cdscli smoke <branchId>` 一次性跑完三层。
@@ -46,6 +46,11 @@ curl -sf "$PREVIEW_URL/" -o /dev/null -w "code=%{http_code}\n"
 curl -sf "$PREVIEW_URL/api/shortcuts/version-check"
 # 期望: {"version":N,...}
 ```
+
+`cdscli smoke` 会同时校验 `Content-Type: application/json` 和端点最小 schema。
+`/api/shortcuts/version-check` 必须包含数值型 `version`；健康端点必须明确返回
+`status=healthy|ok|ready|success`，或布尔型 `ok/healthy/success=true`。API 路径
+返回 HTTP 200 的 HTML/SPA、非法 JSON 或不匹配的 JSON 结构都判为 L2 失败。
 
 ## L3 — 认证 API
 

--- a/.claude/skills/cds/tests/test_cdscli_project_branch_phase16.py
+++ b/.claude/skills/cds/tests/test_cdscli_project_branch_phase16.py
@@ -579,6 +579,51 @@ def test_smoke_rejects_api_html_200(monkeypatch):
                for probe in l2_probes)
 
 
+def test_smoke_accepts_any_valid_l2_candidate(monkeypatch):
+    """L2 候选是替代关系；保留失败探测，但任一合法端点即可通过。"""
+    monkeypatch.setenv("CDS_PROJECT_KEY", "project-key-not-real")
+    monkeypatch.delenv("AI_ACCESS_KEY", raising=False)
+    monkeypatch.setattr(
+        cdscli,
+        "_call_safe",
+        lambda method, path, timeout=30: {
+            "branches": [{
+                "id": "proj-a-health-fallback",
+                "previewUrl": "https://health-fallback.example",
+            }],
+        },
+    )
+
+    def fake_urlopen(req, timeout=10):
+        if req.full_url.endswith("/api/health"):
+            return _FakeHttpResponse(b'{"status":"ok"}', "application/json")
+        return _FakeHttpResponse(
+            b"<!doctype html><title>SPA fallback</title>",
+            "text/html; charset=utf-8",
+        )
+
+    monkeypatch.setattr(cdscli.urllib.request, "urlopen", fake_urlopen)
+
+    code, out = call_main(["smoke", "proj-a-health-fallback"])
+
+    assert code == 0, out
+    payload = parse_ok(out)
+    assert payload["data"]["passed"] == "2/2"
+    assert payload["data"]["layers"] == [
+        {"layer": "L1", "pass": True},
+        {"layer": "L2", "pass": True},
+    ]
+    l2_probes = [
+        probe for probe in payload["data"]["probes"]
+        if probe["layer"].startswith("L2")
+    ]
+    assert [probe["pass"] for probe in l2_probes] == [False, False, True]
+    assert [probe["error"] for probe in l2_probes[:2]] == [
+        "expected_application_json",
+        "expected_application_json",
+    ]
+
+
 def test_smoke_rejects_version_check_without_numeric_version(monkeypatch):
     """L2 version-check 必须满足最小 JSON schema，不能只看 JSON 类型。"""
     monkeypatch.setenv("CDS_PROJECT_KEY", "project-key-not-real")
@@ -594,9 +639,7 @@ def test_smoke_rejects_version_check_without_numeric_version(monkeypatch):
     )
 
     def fake_urlopen(req, timeout=10):
-        if req.full_url.endswith("/api/shortcuts/version-check"):
-            return _FakeHttpResponse(b'{"ok":true}', "application/json")
-        return _FakeHttpResponse(b'{"status":"ok"}', "application/json")
+        return _FakeHttpResponse(b'{"state":"up"}', "application/json")
 
     monkeypatch.setattr(cdscli.urllib.request, "urlopen", fake_urlopen)
 
@@ -611,6 +654,11 @@ def test_smoke_rejects_version_check_without_numeric_version(monkeypatch):
     assert version_probe["pass"] is False
     assert version_probe["contentType"] == "application/json"
     assert version_probe["error"] == "invalid_json_schema"
+    assert all(
+        probe["error"] == "invalid_json_schema"
+        for probe in payload["data"]["probes"]
+        if probe["layer"].startswith("L2")
+    )
 
 
 # ── project clone (SSE) ──────────────────────────────────────────────

--- a/.claude/skills/cds/tests/test_cdscli_project_branch_phase16.py
+++ b/.claude/skills/cds/tests/test_cdscli_project_branch_phase16.py
@@ -488,10 +488,14 @@ def test_preview_url_command_refuses_local_fallback(monkeypatch):
 
 
 class _FakeHttpResponse:
-    status = 200
+    def __init__(self, body: bytes = b'{"version":3}',
+                 content_type: str = "application/json"):
+        self.status = 200
+        self._body = body
+        self.headers = {"Content-Type": content_type}
 
-    def read(self):
-        return b'{"ok":true}'
+    def read(self, size: int = -1):
+        return self._body if size < 0 else self._body[:size]
 
     def __enter__(self):
         return self
@@ -534,6 +538,79 @@ def test_smoke_uses_api_primary_preview_url(monkeypatch):
     assert all(url.startswith("https://primary.example/") for url in requested)
     assert all("must-not-be-used" not in url for url in requested)
     assert all("secondary.example" not in url for url in requested)
+
+
+def test_smoke_rejects_api_html_200(monkeypatch):
+    """L2 API 路径返回 SPA HTML 时，即使 HTTP 200 也必须判失败。"""
+    monkeypatch.setenv("CDS_PROJECT_KEY", "project-key-not-real")
+    monkeypatch.setattr(
+        cdscli,
+        "_call_safe",
+        lambda method, path, timeout=30: {
+            "branches": [{
+                "id": "proj-a-html-fallback",
+                "previewUrl": "https://html-fallback.example",
+            }],
+        },
+    )
+
+    monkeypatch.setattr(
+        cdscli.urllib.request,
+        "urlopen",
+        lambda req, timeout=10: _FakeHttpResponse(
+            b"<!doctype html><title>LLM Gateway</title>",
+            "text/html; charset=utf-8",
+        ),
+    )
+
+    code, out = call_main(["smoke", "proj-a-html-fallback"])
+
+    assert code == 2, out
+    payload = json.loads(out.strip().split("\n")[-1])
+    l2_probes = [
+        probe for probe in payload["data"]["probes"]
+        if probe["layer"].startswith("L2")
+    ]
+    assert l2_probes
+    assert all(probe["pass"] is False for probe in l2_probes)
+    assert all(probe["contentType"] == "text/html; charset=utf-8"
+               for probe in l2_probes)
+    assert all(probe["error"] == "expected_application_json"
+               for probe in l2_probes)
+
+
+def test_smoke_rejects_version_check_without_numeric_version(monkeypatch):
+    """L2 version-check 必须满足最小 JSON schema，不能只看 JSON 类型。"""
+    monkeypatch.setenv("CDS_PROJECT_KEY", "project-key-not-real")
+    monkeypatch.setattr(
+        cdscli,
+        "_call_safe",
+        lambda method, path, timeout=30: {
+            "branches": [{
+                "id": "proj-a-invalid-schema",
+                "previewUrl": "https://invalid-schema.example",
+            }],
+        },
+    )
+
+    def fake_urlopen(req, timeout=10):
+        if req.full_url.endswith("/api/shortcuts/version-check"):
+            return _FakeHttpResponse(b'{"ok":true}', "application/json")
+        return _FakeHttpResponse(b'{"status":"ok"}', "application/json")
+
+    monkeypatch.setattr(cdscli.urllib.request, "urlopen", fake_urlopen)
+
+    code, out = call_main(["smoke", "proj-a-invalid-schema"])
+
+    assert code == 2, out
+    payload = json.loads(out.strip().split("\n")[-1])
+    version_probe = next(
+        probe for probe in payload["data"]["probes"]
+        if probe["layer"] == "L2/api/shortcuts/version-check"
+    )
+    assert version_probe["pass"] is False
+    assert version_probe["contentType"] == "application/json"
+    assert version_probe["error"] == "invalid_json_schema"
 
 
 # ── project clone (SSE) ──────────────────────────────────────────────

--- a/changelogs/2026-07-27_cds-smoke-content-contract.md
+++ b/changelogs/2026-07-27_cds-smoke-content-contract.md
@@ -1,1 +1,1 @@
-| fix | cds | 修复分层 smoke 将 API 路径返回的 HTTP 200 HTML 误判为通过的问题 |
+| fix | cds | 修复分层 smoke 将 HTTP 200 HTML 误判为通过，并按候选替代关系汇总 L2 结果 |

--- a/changelogs/2026-07-27_cds-smoke-content-contract.md
+++ b/changelogs/2026-07-27_cds-smoke-content-contract.md
@@ -1,0 +1,1 @@
+| fix | cds | 修复分层 smoke 将 API 路径返回的 HTTP 200 HTML 误判为通过的问题 |


### PR DESCRIPTION
## 摘要

修复 2026-07-26 每日验收发现的 CDS 分层 smoke 假阳性：L2 API 路径即使返回 HTTP 200，也必须同时满足 JSON Content-Type 与端点最小 schema。当前产品合同证据为现行 `.claude/skills/cds/reference/smoke.md` 和 `doc/guide.acceptance.daily-sop.md`；根因是 `cdscli smoke` 的通用 `probe()` 只比较状态码。最小修复不改部署系统、不改 PR #1262 产品代码，也不修改来源验收报告。

## 来源验收

- 每日验收报告：https://miduo.org/reports?project=prd-agent&folder=95a19d5ce91348a3a45708338cdc3c28&report=a6cabf0cf3404305a9ba44e923e4bba3
- 目标日期：2026-07-26
- 测试 commit：`6fb201e2cba8ec8da030dcfa773e6348be3d4f5b`
- 报告 origin/main commit：`6fb201e2cba8ec8da030dcfa773e6348be3d4f5b`
- 修复时最新 origin/main commit：`f684ca862461a888a75553a3c9c13fc7d19c9288`
- 当前产品合同证据：现行 `.claude/skills/cds/reference/smoke.md` 明确要求 version-check 返回 `{"version":N,...}`；`doc/guide.acceptance.daily-sop.md` 要求关键 API 内容契约正确
- 缺陷编号/等级：P1
- 证据图：图01
- 原始现象：PR #1262 当时四个服务 error 且部署漂移；`/api/shortcuts/version-check` 实际返回 LLM Gateway SPA 的 `text/html`，通用 smoke 仍把 HTTP 200 判绿
- 预期结果：L2 只有在 HTTP 200、JSON Content-Type 与端点最小 schema 同时满足时通过

## 改动 diff

- `.claude/skills/cds/cli/cdscli.py`：L2 probe 校验 JSON media type、64 KiB 响应上限、JSON 解析与 version/health 最小 schema；版本升至 0.12.1
- `.claude/skills/cds/SKILL.md`：同步技能版本 0.12.1
- `.claude/skills/cds/reference/smoke.md`：明确 L2 内容契约与 SPA fallback 失败语义
- `.claude/skills/cds/tests/test_cdscli_project_branch_phase16.py`：新增 HTTP 200 HTML 与错误 JSON schema 两条回归
- `changelogs/2026-07-27_cds-smoke-content-contract.md`：新增修复记录

## 复现与修复

- 修复前复现：通过。定向回归返回 exit code 0 和“冒烟全绿 (3/3)”，L2 preview 明确为 `<!doctype html><title>LLM Gateway</title>`
- 根因：`probe()` 仅使用 `r.status == expect_status` 设置 pass，没有读取 Content-Type 或解析业务 JSON
- 修复后结果：同一 HTML 200 断言改为 exit code 2，错误为 `expected_application_json`；缺少数值型 `version` 的 JSON 返回 `invalid_json_schema`
- 线上反向复测：PR #1262 当前 HEAD `1f96fa7b38d634acb8e3cc1fb7fb9059d52ec0fe` 已恢复 5/5 running、CI success、无 drift；修改后 CLI 对相同预览 smoke 3/3，L2 显示 `application/json; charset=utf-8`
- 预览深链：https://daily-fix-2026-07-26-cds-smoke-content-contract-automa-a43e832a.miduo.org/api/shortcuts/version-check

## 测试

- [x] `python3 -m py_compile .claude/skills/cds/cli/cdscli.py`
- [x] `/opt/anaconda3/bin/pytest .claude/skills/cds/tests -q`：180 passed
- [x] `pnpm exec vitest run tests/services/cdscli-version.test.ts`：2 passed
- [x] 修改后真实 PR #1262 预览 `cdscli smoke`：3/3
- [x] 反向复测每日验收失败断言：HTTP 200 HTML 从错误通过变为 L2 失败
- [x] 当前产品合同复核：现行 smoke reference、每日验收 SOP 与最新 main 无取代性提交

## 未处理项

- PR #1262 当时四服务 error/部署漂移未修改：后续提交与重新部署已使当前 HEAD 精确运行、5/5 running、无 drift，不应重复修复旧运行状态
- 未覆盖项 4 个：PR #1262 复制集业务链路、ASR 真实录音 E2E、LLMGW 登录后日志实体跳转、真实触控移动端；它们是覆盖缺口，不伪装为已修复
- 来源报告未修改
- 未发现与当前产品合同冲突的旧测试或验收守卫

## 人类 reviewer 关注点

- 确认 version-check 的数值型 `version` 与健康端点的最小 schema 覆盖所有受支持部署栈
- 确认 64 KiB L2 JSON 上限符合 smoke 的轻量探测边界
- 此 PR 只修 CLI 假阳性，不应被解读为完成 PR #1262 的四条未覆盖业务链路