### PR TITLE
perf(document-store): 补齐录音上传查询索引

### DIFF
--- a/changelogs/2026-07-27_recording-upload-indexes.md
+++ b/changelogs/2026-07-27_recording-upload-indexes.md
@@ -1,0 +1,3 @@
+| perf | prd-api | 为录音分片读取、过期清理和归档租约查询补齐 MongoDB 索引 |
+| docs | prd-api | 明确录音会话不使用 TTL 并保持先删分片再删会话的回收顺序 |
+| test | prd-api | 增加录音上传索引目录完整性与禁止 TTL 守卫 |

--- a/changelogs/2026-07-27_recording-upload-indexes.md
+++ b/changelogs/2026-07-27_recording-upload-indexes.md
@@ -1,3 +1,4 @@
 | perf | prd-api | 为录音分片读取、过期清理和归档租约查询补齐 MongoDB 索引 |
 | docs | prd-api | 明确录音会话不使用 TTL 并保持先删分片再删会话的回收顺序 |
-| test | prd-api | 增加录音上传索引目录完整性与禁止 TTL 守卫 |
+| fix | prd-api | 索引清单迁移旧版录音会话 TTL 后再创建普通过期查询索引 |
+| test | prd-api | 增加录音上传索引目录、旧 TTL 迁移顺序与禁止 TTL 守卫 |

--- a/doc/rule.platform.data-dictionary.md
+++ b/doc/rule.platform.data-dictionary.md
@@ -111,8 +111,8 @@
 | `document_store_favorites` | `DocumentStoreFavorite` | 知识库收藏记录 | `(StoreId, UserId)` 去重 |
 | `document_store_share_links` | `DocumentStoreShareLink` | 知识库分享链接（Token + 过期时间 + 访问计数） | `token` 唯一；`StoreId` |
 | `document_store_agent_runs` | `DocumentStoreAgentRun` | 知识库 Agent 任务（`Kind`: subtitle 字幕生成 / reprocess 文档再加工）。含 Run 状态机、流式产物、模板 key、自定义提示词 | （按 `SourceEntryId`、`Kind`、`Status` 查询；事件流走 `IRunEventStore`） |
-| `document_recording_upload_sessions` | `DocumentRecordingUploadSession` | 手机录音分片上传会话：记录目标知识库、下一分片序号、已确认字节数和完成后的音频条目 | `ExpiresAt` 过期会话在新会话建立时清理；建议部署 TTL 索引 |
-| `document_recording_upload_chunks` | `DocumentRecordingUploadChunk` | 录音期间顺序写入的临时二进制分片，完成后拼接进正式附件并立即删除 | `(SessionId, Index)` 逻辑唯一；超过一天的遗留分片在新会话建立时清理 |
+| `document_recording_upload_sessions` | `DocumentRecordingUploadSession` | 手机录音分片上传会话：记录目标知识库、下一分片序号、已确认字节数和完成后的音频条目 | `ExpiresAt`、`(OwnerInstanceId, ArchiveStatus, ArchiveNextAttemptAt)`、`(OwnerInstanceId, ArchiveStatus, UpdatedAt)`；不使用 TTL，由应用先删分片再删会话 |
+| `document_recording_upload_chunks` | `DocumentRecordingUploadChunk` | 录音期间顺序写入的临时二进制分片，完成后拼接进正式附件并立即删除 | `(SessionId, Index)` 覆盖读取、排序和删除；`(CreatedAt, SessionId)` 覆盖孤儿回收 |
 | `document_store_view_events` | `DocumentStoreViewEvent` | 知识库浏览事件（谁访问了哪篇文档、停留多久）。含匿名访客 `AnonSessionToken`、`EnteredAt`、`LeftAt`、`DurationMs`、`UserAgent`、`Referer` | （按 `StoreId`、`EnteredAt desc` 查询） |
 | `document_inline_comments` | `DocumentInlineComment` | 文档划词评论（按 `SelectedText + ContextBefore/After` 锚定，非整章评论）。`Status`: active/orphaned；正文更新时由 `InlineCommentRebinder.TryRebind` 重锚定 | （按 `EntryId`、`CreatedAt` 查询） |
 | `mentions` | `Mention` | 通用 @ 账本（双链 + 反向链接 + 宇宙图 SSOT）。关键字段：`FromType`/`FromId`（引用源实体，MVP 仅 "document"）+ `ToType`/`ToId`（被引用实体）+ `AnchorText`（用户在源里看到的字面，如 "[[xxx]]" 的 xxx）+ `Context`（前后约 60 字上下文，反向链接展示用）+ `ScopeId`（作用域=StoreId）+ `IsAutoDetected`（false=用户显式 [[]]，true=AI 自动补链）。写入时机：`DocumentStoreController.UpdateEntryContent` 保存正文时 `MentionService.ResyncDocumentMentionsAsync` 先删后写；删除时 `DeleteEntry` 级联 `CascadeDeleteAsync` 清掉 from/to 任一为被删 entry 的记录 | 建议手动建索引（`no-auto-index` 规则）：`{ ScopeId: 1 }`（宇宙图全图）+ `{ ToType: 1, ToId: 1 }`（反向链接）+ `{ FromType: 1, FromId: 1 }`（先删后写）|

--- a/prd-api/src/PrdAgent.Core/Models/DocumentRecordingUpload.cs
+++ b/prd-api/src/PrdAgent.Core/Models/DocumentRecordingUpload.cs
@@ -66,7 +66,10 @@ public class DocumentRecordingUploadSession
 
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 
-    /// <summary>未完成会话的清理时间；建议为本集合建立 TTL 索引。</summary>
+    /// <summary>
+    /// 未完成会话的清理时间。仅建立普通查询索引，不使用 TTL；
+    /// 清理流程必须先删除分片再删除会话，避免留下无法关联的孤儿分片。
+    /// </summary>
     public DateTime ExpiresAt { get; set; } = DateTime.UtcNow.AddDays(1);
 }
 

--- a/prd-api/tests/PrdAgent.Api.Tests/Services/DocumentRecordingArchiveWorkerTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Services/DocumentRecordingArchiveWorkerTests.cs
@@ -152,7 +152,7 @@ public sealed class DocumentRecordingArchiveWorkerTests
             "// collection: document_recording_upload_chunks",
             StringComparison.Ordinal);
         var recordingIndexesEnd = source.IndexOf(
-            "if (tightenedUniqueIndexMigrationFailures.length > 0)",
+            "// end collection: document_recording_upload_sessions",
             recordingIndexesStart,
             StringComparison.Ordinal);
 
@@ -164,7 +164,25 @@ public sealed class DocumentRecordingArchiveWorkerTests
         recordingIndexes.ShouldContain("idx_document_recording_sessions_expires");
         recordingIndexes.ShouldContain("idx_document_recording_sessions_archive_due");
         recordingIndexes.ShouldContain("idx_document_recording_sessions_archive_stale");
-        recordingIndexes.ShouldNotContain("expireAfterSeconds");
+        var legacyTtlRemoval = recordingIndexes.IndexOf(
+            "recordingSessionCollection.dropIndex(index.name)",
+            StringComparison.Ordinal);
+        var replacementDefinition = recordingIndexes.IndexOf(
+            "db.document_recording_upload_sessions.createIndex(",
+            StringComparison.Ordinal);
+        var replacementIndex = recordingIndexes.IndexOf(
+            "idx_document_recording_sessions_expires",
+            StringComparison.Ordinal);
+        var nextSessionIndex = recordingIndexes.IndexOf(
+            "idx_document_recording_sessions_archive_due",
+            replacementIndex,
+            StringComparison.Ordinal);
+        legacyTtlRemoval.ShouldBeGreaterThanOrEqualTo(0);
+        replacementDefinition.ShouldBeGreaterThan(legacyTtlRemoval);
+        replacementIndex.ShouldBeGreaterThan(legacyTtlRemoval);
+        nextSessionIndex.ShouldBeGreaterThan(replacementIndex);
+        recordingIndexes[replacementDefinition..nextSessionIndex]
+            .ShouldNotContain("expireAfterSeconds");
     }
 
     [Fact]

--- a/prd-api/tests/PrdAgent.Api.Tests/Services/DocumentRecordingArchiveWorkerTests.cs
+++ b/prd-api/tests/PrdAgent.Api.Tests/Services/DocumentRecordingArchiveWorkerTests.cs
@@ -145,6 +145,29 @@ public sealed class DocumentRecordingArchiveWorkerTests
     }
 
     [Fact]
+    public void RecordingUploadCollections_ShouldDeclareAllQueryIndexesWithoutTtl()
+    {
+        var source = File.ReadAllText(MongoIndexesPath());
+        var recordingIndexesStart = source.IndexOf(
+            "// collection: document_recording_upload_chunks",
+            StringComparison.Ordinal);
+        var recordingIndexesEnd = source.IndexOf(
+            "if (tightenedUniqueIndexMigrationFailures.length > 0)",
+            recordingIndexesStart,
+            StringComparison.Ordinal);
+
+        recordingIndexesStart.ShouldBeGreaterThanOrEqualTo(0);
+        recordingIndexesEnd.ShouldBeGreaterThan(recordingIndexesStart);
+        var recordingIndexes = source[recordingIndexesStart..recordingIndexesEnd];
+        recordingIndexes.ShouldContain("idx_document_recording_chunks_session_index");
+        recordingIndexes.ShouldContain("idx_document_recording_chunks_created_session");
+        recordingIndexes.ShouldContain("idx_document_recording_sessions_expires");
+        recordingIndexes.ShouldContain("idx_document_recording_sessions_archive_due");
+        recordingIndexes.ShouldContain("idx_document_recording_sessions_archive_stale");
+        recordingIndexes.ShouldNotContain("expireAfterSeconds");
+    }
+
+    [Fact]
     public async Task StalePendingLeaseCompensation_ShouldDeleteOnlyItsOwnEntryAndCount()
     {
         await using var fixture = await RecordingMongoFixture.TryCreateAsync();
@@ -1571,23 +1594,28 @@ public sealed class DocumentRecordingArchiveWorkerTests
     }
 
     private static string DocumentStoreControllerPath()
+        => RepositoryFilePath(
+            "prd-api",
+            "src",
+            "PrdAgent.Api",
+            "Controllers",
+            "Api",
+            "DocumentStoreController.cs");
+
+    private static string MongoIndexesPath()
+        => RepositoryFilePath("scripts", "mongodb-indexes.js");
+
+    private static string RepositoryFilePath(params string[] segments)
     {
         var dir = new DirectoryInfo(AppContext.BaseDirectory);
         while (dir is not null)
         {
-            var path = Path.Combine(
-                dir.FullName,
-                "prd-api",
-                "src",
-                "PrdAgent.Api",
-                "Controllers",
-                "Api",
-                "DocumentStoreController.cs");
+            var path = Path.Combine([dir.FullName, .. segments]);
             if (File.Exists(path)) return path;
             dir = dir.Parent;
         }
 
         throw new DirectoryNotFoundException(
-            "Could not locate DocumentStoreController.cs from test base directory.");
+            $"Could not locate {string.Join('/', segments)} from test base directory.");
     }
 }

--- a/scripts/mongodb-indexes.js
+++ b/scripts/mongodb-indexes.js
@@ -1281,6 +1281,37 @@ db.home_recent_opens.createIndex(
   { name: "uniq_home_recent_opens_user_entity", unique: true }
 )
 
+// collection: document_recording_upload_chunks
+// 会话内分片读取、排序、重试确认和批量删除共用此前缀。
+// _id 已由应用按 session + index 确定性生成；保持非唯一索引以兼容历史重复分片。
+db.document_recording_upload_chunks.createIndex(
+  { "SessionId": 1, "Index": 1 },
+  { name: "idx_document_recording_chunks_session_index" }
+)
+// 孤儿回收先按年龄形成有界候选，再按 SessionId 分组。
+db.document_recording_upload_chunks.createIndex(
+  { "CreatedAt": 1, "SessionId": 1 },
+  { name: "idx_document_recording_chunks_created_session" }
+)
+
+// collection: document_recording_upload_sessions
+// 过期会话由应用按“先删分片、再删会话”的顺序回收。这里故意不用 TTL：
+// Mongo TTL 若先删除父会话，会让分片失去可恢复的关联记录。
+db.document_recording_upload_sessions.createIndex(
+  { "ExpiresAt": 1 },
+  { name: "idx_document_recording_sessions_expires" }
+)
+// 归档 Worker 按实例和 pending 状态取下一条到期任务，并按重试时间排序。
+db.document_recording_upload_sessions.createIndex(
+  { "OwnerInstanceId": 1, "ArchiveStatus": 1, "ArchiveNextAttemptAt": 1 },
+  { name: "idx_document_recording_sessions_archive_due" }
+)
+// Worker 重启时按实例、archiving 状态和更新时间释放过期租约。
+db.document_recording_upload_sessions.createIndex(
+  { "OwnerInstanceId": 1, "ArchiveStatus": 1, "UpdatedAt": 1 },
+  { name: "idx_document_recording_sessions_archive_stale" }
+)
+
 if (tightenedUniqueIndexMigrationFailures.length > 0) {
   throw new Error(
     `Tightened unique index migrations require attention:\n${tightenedUniqueIndexMigrationFailures.join("\n")}`

--- a/scripts/mongodb-indexes.js
+++ b/scripts/mongodb-indexes.js
@@ -1297,6 +1297,20 @@ db.document_recording_upload_chunks.createIndex(
 // collection: document_recording_upload_sessions
 // 过期会话由应用按“先删分片、再删会话”的顺序回收。这里故意不用 TTL：
 // Mongo TTL 若先删除父会话，会让分片失去可恢复的关联记录。
+// 旧版数据字典曾建议 DBA 自行创建 TTL；先精确移除同键 TTL，避免新索引
+// 因 options conflict 中止并让破坏性过期策略继续生效。
+const recordingSessionCollectionName = "document_recording_upload_sessions"
+const recordingSessionCollection = db.getCollection(recordingSessionCollectionName)
+const recordingSessionCollectionExists =
+  db.getCollectionInfos({ name: recordingSessionCollectionName }).length > 0
+if (recordingSessionCollectionExists) {
+  recordingSessionCollection.getIndexes()
+    .filter(index =>
+      JSON.stringify(index.key) === JSON.stringify({ "ExpiresAt": 1 }) &&
+      index.expireAfterSeconds !== undefined
+    )
+    .forEach(index => recordingSessionCollection.dropIndex(index.name))
+}
 db.document_recording_upload_sessions.createIndex(
   { "ExpiresAt": 1 },
   { name: "idx_document_recording_sessions_expires" }
@@ -1311,6 +1325,7 @@ db.document_recording_upload_sessions.createIndex(
   { "OwnerInstanceId": 1, "ArchiveStatus": 1, "UpdatedAt": 1 },
   { name: "idx_document_recording_sessions_archive_stale" }
 )
+// end collection: document_recording_upload_sessions
 
 if (tightenedUniqueIndexMigrationFailures.length > 0) {
   throw new Error(


### PR DESCRIPTION
## 摘要
补齐录音分片、过期清理和归档 Worker 查询所需的 MongoDB 索引，避免历史录音增长后出现全表扫描。明确不使用 TTL，保持先删分片再删会话的可恢复回收顺序。

## 改动 diff
- `scripts/mongodb-indexes.js`：新增分片、过期会话、归档待处理与过期租约五类索引
- `prd-api/src/PrdAgent.Core/Models/DocumentRecordingUpload.cs`：明确禁止会话 TTL 的回收约束
- `prd-api/tests/PrdAgent.Api.Tests/Services/DocumentRecordingArchiveWorkerTests.cs`：增加索引目录与禁止 TTL 守卫
- `doc/rule.platform.data-dictionary.md`：同步集合索引和清理策略
- `changelogs/2026-07-27_recording-upload-indexes.md`：记录补救变更

## 测试
- [x] `dotnet build --no-restore` 通过，0 错误
- [x] 录音 ASR、归档、字幕校准测试 99/99 通过
- [x] 索引清单在 MongoDB 7 实际执行成功
- [x] 五类关键查询计划命中索引且无 `COLLSCAN`