### PR TITLE
feat(prd-admin/api): 周报划词评论支持黄色下划线定位

### DIFF
--- a/changelogs/2026-07-27_report-comment-underline.md
+++ b/changelogs/2026-07-27_report-comment-underline.md
@@ -1,2 +1,3 @@
 | feat | prd-admin | 周报详情支持划词评论：选中正文弹出评论按钮，被评论文字显示黄色下划线并可点角标跳到评论线程 |
 | feat | prd-api | 周报评论 ReportComment 新增划词锚定字段（SelectedText/前后上下文/偏移），创建端点支持写入 |
+| polish | prd-admin | 划词评论浮出按钮修复变形（max-content + nowrap）并精简样式；移除下划线尾部数字角标，改为点击下划线本身查看评论 |

--- a/changelogs/2026-07-27_report-comment-underline.md
+++ b/changelogs/2026-07-27_report-comment-underline.md
@@ -1,0 +1,2 @@
+| feat | prd-admin | 周报详情支持划词评论：选中正文弹出评论按钮，被评论文字显示黄色下划线并可点角标跳到评论线程 |
+| feat | prd-api | 周报评论 ReportComment 新增划词锚定字段（SelectedText/前后上下文/偏移），创建端点支持写入 |

--- a/prd-admin/src/components/doc-browser/InlineCommentOverlay.tsx
+++ b/prd-admin/src/components/doc-browser/InlineCommentOverlay.tsx
@@ -64,7 +64,8 @@ export function locateInSegments(
 }
 
 // DOM 适配层：收集容器内所有文本节点 → 交给纯核心匹配 → 把结果映射回 Range。跳过 UI 控件文本。
-function findTextRange(root: HTMLElement, query: string, contextBefore?: string): Range | null {
+// export：周报划词评论（ReportSelectionCommentLayer）复用同一套锚定，避免两份匹配逻辑漂移。
+export function findTextRange(root: HTMLElement, query: string, contextBefore?: string): Range | null {
   const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
     acceptNode(node) {
       for (let el = node.parentElement; el && el !== root; el = el.parentElement) {

--- a/prd-admin/src/pages/report-agent/ReportDetailPage.tsx
+++ b/prd-admin/src/pages/report-agent/ReportDetailPage.tsx
@@ -16,6 +16,8 @@ import { PlanComparisonPanel } from './components/PlanComparisonPanel';
 import { RichTextMarkdownContent } from './components/RichTextMarkdownContent';
 import { ReportTableSectionView } from './components/ReportTableSectionView';
 import { RightRailPanel } from './components/RightRailPanel';
+import { ReportSelectionCommentLayer } from './components/ReportSelectionCommentLayer';
+import { underlineStroke, type ReportCommentAnchor } from './components/reportCommentAnchor';
 import { useDataTheme } from './hooks/useDataTheme';
 import { useStatusChipConfig } from './hooks/useStatusChipConfig';
 
@@ -65,8 +67,13 @@ export default function ReportDetailPage(props: ReportDetailPageProps = {}) {
   const [canReview, setCanReview] = useState(false);
   const [comments, setComments] = useState<ReportComment[]>([]);
   const [activeTab, setActiveTab] = useState<TabKey>('content');
-  const [replyTo, setReplyTo] = useState<{ sectionIndex: number; parentId?: string } | null>(null);
+  const [replyTo, setReplyTo] = useState<{ sectionIndex: number; parentId?: string; anchor?: ReportCommentAnchor } | null>(null);
   const [commentText, setCommentText] = useState('');
+  /** 正文容器（划词评论层的定位坐标系） */
+  const contentRef = useRef<HTMLDivElement>(null);
+  /** 点击下划线角标后短暂标亮的目标评论 */
+  const [flashCommentId, setFlashCommentId] = useState<string | null>(null);
+  const flashTimerRef = useRef<number | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [viewSummary, setViewSummary] = useState<ReportViewSummary>({ count: 0, totalViewCount: 0, users: [] });
   const currentUserId = useAuthStore((s) => s.user?.userId);
@@ -164,11 +171,17 @@ export default function ReportDetailPage(props: ReportDetailPageProps = {}) {
   const handleCreateComment = async () => {
     if (!replyTo || !commentText.trim() || !reportId) return;
     setSubmitting(true);
+    const anchor = !replyTo.parentId ? replyTo.anchor : undefined;
     const res = await createComment({
       reportId,
       sectionIndex: replyTo.sectionIndex,
       content: commentText.trim(),
       parentCommentId: replyTo.parentId,
+      selectedText: anchor?.selectedText,
+      contextBefore: anchor?.contextBefore,
+      contextAfter: anchor?.contextAfter,
+      startOffset: anchor?.startOffset,
+      endOffset: anchor?.endOffset,
     });
     setSubmitting(false);
     if (res.success) {
@@ -207,12 +220,28 @@ export default function ReportDetailPage(props: ReportDetailPageProps = {}) {
   }, [reportId, loadComments]);
 
   const openCommentInput = (sectionIndex: number, parentId?: string) => {
-    const isSameTarget = replyTo?.sectionIndex === sectionIndex && replyTo?.parentId === parentId;
+    const isSameTarget = replyTo?.sectionIndex === sectionIndex && replyTo?.parentId === parentId && !replyTo?.anchor;
     if (!isSameTarget) {
       setCommentText('');
     }
     setReplyTo({ sectionIndex, parentId });
   };
+
+  /** 划词后点「评论」：带锚点打开该段落的评论输入框 */
+  const handleSelectionComment = useCallback((sectionIndex: number, anchor: ReportCommentAnchor) => {
+    setCommentText('');
+    setReplyTo({ sectionIndex, anchor });
+  }, []);
+
+  /** 点击正文黄色下划线角标 → 滚动并短暂标亮对应评论 */
+  const handleActivateThread = useCallback((comment: ReportComment) => {
+    setFlashCommentId(comment.id);
+    if (flashTimerRef.current != null) window.clearTimeout(flashTimerRef.current);
+    flashTimerRef.current = window.setTimeout(() => setFlashCommentId(null), 2400);
+    requestAnimationFrame(() => {
+      document.getElementById(`report-comment-${comment.id}`)?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    });
+  }, []);
 
   const handleReview = async () => {
     if (!reportId) return;
@@ -397,6 +426,8 @@ export default function ReportDetailPage(props: ReportDetailPageProps = {}) {
       <div className="flex-1 min-h-0 overflow-auto">
         {activeTab === 'content' && (
           <GlassCard variant="subtle" className="p-6">
+            {/* relative：划词评论层（下划线/角标/评论按钮）的定位坐标系 */}
+            <div ref={contentRef} className="relative">
             {report.sections.map((section, idx) => {
               const sectionComments = commentsBySection[idx] || [];
               const topLevel = sectionComments.filter((c) => !c.parentCommentId);
@@ -438,6 +469,8 @@ export default function ReportDetailPage(props: ReportDetailPageProps = {}) {
                       {section.templateSection.title}
                     </span>
                   </div>
+                  {/* data-report-section：划词评论的段落锚定根（选区必须完整落在同一块内） */}
+                  <div data-report-section={idx}>
                   {section.items.length === 0 ? (
                     <div className="text-[12px] ml-10" style={{ color: 'var(--text-muted)' }}>（未填写）</div>
                   ) : section.templateSection.inputType === ReportInputType.IssueList ? (
@@ -518,6 +551,7 @@ export default function ReportDetailPage(props: ReportDetailPageProps = {}) {
                       ))}
                     </ul>
                   )}
+                  </div>
 
                   {/* Section comments */}
                   {topLevel.length > 0 && (
@@ -528,13 +562,23 @@ export default function ReportDetailPage(props: ReportDetailPageProps = {}) {
                       {topLevel.map((comment) => {
                         const replies = sectionComments.filter((c) => c.parentCommentId === comment.id);
                         return (
-                          <div key={comment.id} className="mb-2">
+                          <div
+                            key={comment.id}
+                            id={`report-comment-${comment.id}`}
+                            className="mb-2"
+                            style={{
+                              borderRadius: 10,
+                              transition: 'box-shadow 0.3s',
+                              boxShadow: flashCommentId === comment.id ? `0 0 0 2px ${underlineStroke(isLight, true)}` : undefined,
+                            }}
+                          >
                             <CommentItem
                               comment={comment}
                               isMine={comment.authorUserId === currentUserId}
                               onDelete={() => handleDeleteComment(comment.id)}
                               onReply={() => openCommentInput(idx, comment.id)}
                               onEdit={(newContent) => handleUpdateComment(comment.id, newContent)}
+                              quoteUnderline={underlineStroke(isLight)}
                             />
                             {replies.map((reply) => (
                               <div key={reply.id} className="ml-4 mt-1">
@@ -565,7 +609,18 @@ export default function ReportDetailPage(props: ReportDetailPageProps = {}) {
                   {replyTo?.sectionIndex === idx && (
                     <div className="mt-2 ml-7 p-3 rounded-xl" style={{ background: 'var(--bg-secondary)', border: '1px solid var(--border-primary)' }}>
                       <div className="text-[11px] mb-1.5" style={{ color: 'var(--text-muted)' }}>
-                        {replyTo.parentId ? '回复评论' : `评论「${report.sections[replyTo.sectionIndex]?.templateSection?.title || ''}」`}
+                        {replyTo.parentId
+                          ? '回复评论'
+                          : replyTo.anchor
+                            ? (
+                              <>
+                                评论选中内容：
+                                <span style={{ borderBottom: `2px solid ${underlineStroke(isLight)}`, paddingBottom: 1 }}>
+                                  「{replyTo.anchor.selectedText.length > 40 ? `${replyTo.anchor.selectedText.slice(0, 40)}…` : replyTo.anchor.selectedText}」
+                                </span>
+                              </>
+                            )
+                            : `评论「${report.sections[replyTo.sectionIndex]?.templateSection?.title || ''}」`}
                       </div>
                       <div className="flex items-center gap-2">
                         <input
@@ -589,6 +644,15 @@ export default function ReportDetailPage(props: ReportDetailPageProps = {}) {
                 </div>
               );
             })}
+            <ReportSelectionCommentLayer
+              containerRef={contentRef}
+              comments={comments}
+              isLight={isLight}
+              reflowKey={`${report.id}:${report.sections.length}`}
+              onCreateFromSelection={handleSelectionComment}
+              onActivateThread={handleActivateThread}
+            />
+            </div>
           </GlassCard>
         )}
 
@@ -746,6 +810,7 @@ function CommentItem({
   onReply,
   onEdit,
   isReply,
+  quoteUnderline,
 }: {
   comment: ReportComment;
   isMine: boolean;
@@ -753,6 +818,8 @@ function CommentItem({
   onReply: () => void;
   onEdit: (newContent: string) => Promise<boolean>;
   isReply?: boolean;
+  /** 划词评论引用片段的下划线颜色（与正文黄色下划线同色，视觉上连成一体） */
+  quoteUnderline?: string;
 }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(comment.content);
@@ -808,6 +875,14 @@ function CommentItem({
             </span>
           )}
         </div>
+        {comment.selectedText && (
+          <div className="text-[11px] mt-1 truncate" style={{ color: 'var(--text-muted)' }} title={comment.selectedText}>
+            引用：
+            <span style={{ borderBottom: `2px solid ${quoteUnderline ?? 'rgba(234, 179, 8, 0.75)'}`, paddingBottom: 1 }}>
+              {comment.selectedText.length > 60 ? `${comment.selectedText.slice(0, 60)}…` : comment.selectedText}
+            </span>
+          </div>
+        )}
         {editing ? (
           <div className="mt-1.5">
             <textarea

--- a/prd-admin/src/pages/report-agent/components/ReportDetailPanel.tsx
+++ b/prd-admin/src/pages/report-agent/components/ReportDetailPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { X, MessageSquare, CornerDownRight, Trash2, Send, GitCompare } from 'lucide-react';
 import { formatWeekDateRange } from '../utils/weekRange';
 import { GlassCard } from '@/components/design/GlassCard';
@@ -13,6 +13,8 @@ import { ReportTableSectionView } from './ReportTableSectionView';
 import { RichTextMarkdownContent } from './RichTextMarkdownContent';
 import { ReportLikeBar } from './ReportLikeBar';
 import { useDataTheme } from '../hooks/useDataTheme';
+import { ReportSelectionCommentLayer } from './ReportSelectionCommentLayer';
+import { underlineStroke, type ReportCommentAnchor } from './reportCommentAnchor';
 
 interface Props {
   reportId: string;
@@ -39,10 +41,15 @@ export function ReportDetailPanel({ reportId, onClose, onReview, onReturn }: Pro
   const [report, setReport] = useState<WeeklyReport | null>(null);
   const [comments, setComments] = useState<ReportComment[]>([]);
   const [activeTab, setActiveTab] = useState<TabKey>('content');
-  const [replyTo, setReplyTo] = useState<{ sectionIndex: number; parentId?: string } | null>(null);
+  const [replyTo, setReplyTo] = useState<{ sectionIndex: number; parentId?: string; anchor?: ReportCommentAnchor } | null>(null);
   const [commentText, setCommentText] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const currentUserId = useAuthStore((s) => s.user?.userId);
+  /** 正文容器（划词评论层的定位坐标系） */
+  const contentRef = useRef<HTMLDivElement>(null);
+  /** 点击下划线角标后短暂标亮的目标评论 */
+  const [flashCommentId, setFlashCommentId] = useState<string | null>(null);
+  const flashTimerRef = useRef<number | null>(null);
 
   useEffect(() => {
     (async () => {
@@ -60,11 +67,17 @@ export function ReportDetailPanel({ reportId, onClose, onReview, onReturn }: Pro
   const handleCreateComment = async () => {
     if (!replyTo || !commentText.trim()) return;
     setSubmitting(true);
+    const anchor = !replyTo.parentId ? replyTo.anchor : undefined;
     const res = await createComment({
       reportId,
       sectionIndex: replyTo.sectionIndex,
       content: commentText.trim(),
       parentCommentId: replyTo.parentId,
+      selectedText: anchor?.selectedText,
+      contextBefore: anchor?.contextBefore,
+      contextAfter: anchor?.contextAfter,
+      startOffset: anchor?.startOffset,
+      endOffset: anchor?.endOffset,
     });
     setSubmitting(false);
     if (res.success) {
@@ -86,12 +99,28 @@ export function ReportDetailPanel({ reportId, onClose, onReview, onReturn }: Pro
   };
 
   const openCommentInput = (sectionIndex: number, parentId?: string) => {
-    const isSameTarget = replyTo?.sectionIndex === sectionIndex && replyTo?.parentId === parentId;
+    const isSameTarget = replyTo?.sectionIndex === sectionIndex && replyTo?.parentId === parentId && !replyTo?.anchor;
     if (!isSameTarget) {
       setCommentText('');
     }
     setReplyTo({ sectionIndex, parentId });
   };
+
+  /** 划词后点「评论」：带锚点打开该段落的评论输入框 */
+  const handleSelectionComment = useCallback((sectionIndex: number, anchor: ReportCommentAnchor) => {
+    setCommentText('');
+    setReplyTo({ sectionIndex, anchor });
+  }, []);
+
+  /** 点击正文黄色下划线角标 → 滚动并短暂标亮对应评论 */
+  const handleActivateThread = useCallback((comment: ReportComment) => {
+    setFlashCommentId(comment.id);
+    if (flashTimerRef.current != null) window.clearTimeout(flashTimerRef.current);
+    flashTimerRef.current = window.setTimeout(() => setFlashCommentId(null), 2400);
+    requestAnimationFrame(() => {
+      document.getElementById(`report-panel-comment-${comment.id}`)?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    });
+  }, []);
 
   const commentsBySection = useMemo(() => {
     const map: Record<number, ReportComment[]> = {};
@@ -182,7 +211,8 @@ export function ReportDetailPanel({ reportId, onClose, onReview, onReturn }: Pro
         {/* Content */}
         <div className="flex-1 min-h-0 overflow-auto px-6 py-5">
           {activeTab === 'content' && (
-            <>
+            // relative：划词评论层（下划线/角标/评论按钮）的定位坐标系
+            <div ref={contentRef} className="relative">
               {report.sections.map((section, idx) => {
                 const sectionComments = commentsBySection[idx] || [];
                 const topLevel = sectionComments.filter((c) => !c.parentCommentId);
@@ -213,6 +243,8 @@ export function ReportDetailPanel({ reportId, onClose, onReview, onReturn }: Pro
                         {section.templateSection.title}
                       </span>
                     </div>
+                    {/* data-report-section：划词评论的段落锚定根（选区必须完整落在同一块内） */}
+                    <div data-report-section={idx}>
                     {section.items.length === 0 ? (
                       <div className="text-[12px] ml-7" style={{ color: 'var(--text-muted)' }}>（未填写）</div>
                     ) : section.templateSection.inputType === ReportInputType.IssueList ? (
@@ -288,6 +320,7 @@ export function ReportDetailPanel({ reportId, onClose, onReview, onReturn }: Pro
                         ))}
                       </ul>
                     )}
+                    </div>
 
                     {/* Section comments */}
                     {topLevel.length > 0 && (
@@ -295,12 +328,22 @@ export function ReportDetailPanel({ reportId, onClose, onReview, onReturn }: Pro
                         {topLevel.map((comment) => {
                           const replies = sectionComments.filter((c) => c.parentCommentId === comment.id);
                           return (
-                            <div key={comment.id} className="mb-2">
+                            <div
+                              key={comment.id}
+                              id={`report-panel-comment-${comment.id}`}
+                              className="mb-2"
+                              style={{
+                                borderRadius: 10,
+                                transition: 'box-shadow 0.3s',
+                                boxShadow: flashCommentId === comment.id ? `0 0 0 2px ${underlineStroke(isLight, true)}` : undefined,
+                              }}
+                            >
                               <CommentItem
                                 comment={comment}
                                 isMine={comment.authorUserId === currentUserId}
                                 onDelete={() => handleDeleteComment(comment.id)}
                                 onReply={() => openCommentInput(idx, comment.id)}
+                                quoteUnderline={underlineStroke(isLight)}
                               />
                               {replies.map((reply) => (
                                 <div key={reply.id} className="ml-4 mt-1">
@@ -330,7 +373,18 @@ export function ReportDetailPanel({ reportId, onClose, onReview, onReturn }: Pro
                     {replyTo?.sectionIndex === idx && (
                       <div className="mt-2 ml-7 p-3 rounded-xl" style={{ background: 'var(--bg-secondary)', border: '1px solid var(--border-primary)' }}>
                         <div className="text-[11px] mb-1.5" style={{ color: 'var(--text-muted)' }}>
-                          {replyTo.parentId ? '回复评论' : `评论「${report.sections[replyTo.sectionIndex]?.templateSection?.title || ''}」`}
+                          {replyTo.parentId
+                            ? '回复评论'
+                            : replyTo.anchor
+                              ? (
+                                <>
+                                  评论选中内容：
+                                  <span style={{ borderBottom: `2px solid ${underlineStroke(isLight)}`, paddingBottom: 1 }}>
+                                    「{replyTo.anchor.selectedText.length > 40 ? `${replyTo.anchor.selectedText.slice(0, 40)}…` : replyTo.anchor.selectedText}」
+                                  </span>
+                                </>
+                              )
+                              : `评论「${report.sections[replyTo.sectionIndex]?.templateSection?.title || ''}」`}
                         </div>
                         <div className="flex items-center gap-2">
                           <input
@@ -354,7 +408,15 @@ export function ReportDetailPanel({ reportId, onClose, onReview, onReturn }: Pro
                   </div>
                 );
               })}
-            </>
+              <ReportSelectionCommentLayer
+                containerRef={contentRef}
+                comments={comments}
+                isLight={isLight}
+                reflowKey={`${report.id}:${report.sections.length}`}
+                onCreateFromSelection={handleSelectionComment}
+                onActivateThread={handleActivateThread}
+              />
+            </div>
           )}
 
           {activeTab === 'plan-comparison' && <PlanComparisonPanel reportId={reportId} />}
@@ -386,12 +448,15 @@ function CommentItem({
   onDelete,
   onReply,
   isReply,
+  quoteUnderline,
 }: {
   comment: ReportComment;
   isMine: boolean;
   onDelete: () => void;
   onReply: () => void;
   isReply?: boolean;
+  /** 划词评论引用片段的下划线颜色（与正文黄色下划线同色） */
+  quoteUnderline?: string;
 }) {
   return (
     <div className="group flex items-start gap-1.5">
@@ -414,6 +479,14 @@ function CommentItem({
             {new Date(comment.createdAt).toLocaleString('zh-CN', { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' })}
           </span>
         </div>
+        {comment.selectedText && (
+          <div className="text-[11px] mt-1 truncate" style={{ color: 'var(--text-muted)' }} title={comment.selectedText}>
+            引用：
+            <span style={{ borderBottom: `2px solid ${quoteUnderline ?? 'rgba(234, 179, 8, 0.75)'}`, paddingBottom: 1 }}>
+              {comment.selectedText.length > 60 ? `${comment.selectedText.slice(0, 60)}…` : comment.selectedText}
+            </span>
+          </div>
+        )}
         <div className="text-[12px] leading-relaxed mt-1 whitespace-pre-wrap break-words" style={{ color: 'var(--text-secondary)' }}>{comment.content}</div>
       </div>
       <div className="opacity-0 group-hover:opacity-100 flex items-center gap-0.5 transition-opacity">

--- a/prd-admin/src/pages/report-agent/components/ReportSelectionCommentLayer.tsx
+++ b/prd-admin/src/pages/report-agent/components/ReportSelectionCommentLayer.tsx
@@ -13,7 +13,8 @@ import {
 // 周报划词评论层：
 //   1. 捕获正文选区（限单个段落容器 [data-report-section] 内）→ 浮出「评论」按钮；
 //   2. 把带锚点的评论重定位回已渲染 DOM，画「黄色下划线」（非底色高亮，遵循用户要求）；
-//   3. 下划线末尾放评论数角标，点击联动滚动到该段落下的评论线程。
+//   3. 下划线本身可点（贴线的细条命中区），点击联动滚动到该段落下的评论线程；
+//      不放数字角标（用户 2026-07-27 反馈：不要在文字后面显示数字）。
 // 锚定算法复用知识库 SSOT（findTextRange / locateInSegments），本层只做周报侧的轻量视觉。
 // 坐标系同 doc-browser InlineCommentOverlay：本层是 relative 容器内 0x0 的 absolute 原点，
 // 子元素位置 = 文本 rect 减本层 rect，随内容一起滚动，无需监听 scroll。
@@ -21,7 +22,6 @@ import {
 interface UnderlineMark {
   key: string;
   rects: Array<{ top: number; left: number; width: number; height: number }>;
-  badge: { top: number; left: number };
   comments: ReportComment[];
 }
 
@@ -97,13 +97,7 @@ export function ReportSelectionCommentLayer({
         width: r.width,
         height: r.height,
       }));
-      const last = rectList[rectList.length - 1];
-      next.push({
-        key,
-        rects,
-        badge: { top: last.top - oRect.top - 4, left: last.right - oRect.left + 3 },
-        comments: list,
-      });
+      next.push({ key, rects, comments: list });
     });
     setMarks(next);
   }, [comments, containerRef]);
@@ -191,11 +185,7 @@ export function ReportSelectionCommentLayer({
     };
   }, [containerRef]);
 
-  // 角标：黄金底 + 统一深墨字（两种主题的黄底上对比度都 >=4.5，无需按主题翻转）。
-  // 深色字面量写 rgba 形式——它衬在黄底上、双主题都成立，
-  // 不属于 themeHardcodeRatchet 要拦的「浅色主题下漂浮暗块」场景
-  const badgeBg = isLight ? '#ca8a04' : '#eab308';
-  const badgeFg = 'rgba(26, 18, 5, 0.92)';
+  const accentGold = isLight ? '#ca8a04' : '#eab308';
 
   return (
     <div ref={overlayRef} style={{ position: 'absolute', top: 0, left: 0, width: 0, height: 0 }}>
@@ -204,7 +194,7 @@ export function ReportSelectionCommentLayer({
         const stroke = underlineStroke(isLight, emphasized);
         return (
           <div key={m.key}>
-            {/* 黄色下划线：常态只画线不铺底色；hover 角标时加柔和底色提示范围。
+            {/* 黄色下划线（视觉层）：常态只画线不铺底色；hover 时线加深并出柔和底色提示范围。
                 pointerEvents:none —— 不挡正文再次划词/点击链接 */}
             {m.rects.map((r, i) => (
               <div
@@ -223,43 +213,47 @@ export function ReportSelectionCommentLayer({
                 }}
               />
             ))}
-            {/* 评论数角标：点击滚到该线程 */}
-            <button
-              type="button"
-              onClick={(e) => { e.stopPropagation(); onActivateThread(m.comments[0]); }}
-              onMouseEnter={() => setHoveredKey(m.key)}
-              onMouseLeave={() => setHoveredKey((k) => (k === m.key ? null : k))}
-              title={`${m.comments.length} 条划词评论，点击查看`}
-              className="cursor-pointer"
-              style={{
-                position: 'absolute',
-                top: m.badge.top,
-                left: m.badge.left,
-                minWidth: 16,
-                height: 16,
-                padding: '0 4px',
-                borderRadius: 8,
-                border: 'none',
-                background: badgeBg,
-                color: badgeFg,
-                fontSize: 9,
-                fontWeight: 800,
-                lineHeight: '16px',
-                pointerEvents: 'auto',
-                zIndex: 6,
-                boxShadow: '0 1px 3px rgba(0,0,0,0.35)',
-              }}
-            >
-              {m.comments.length}
-            </button>
+            {/* 命中层：贴着下划线的细条，点击滚到该评论线程。
+                只占行底部 ~8px，不遮文字主体，正文仍可正常划词 */}
+            {m.rects.map((r, i) => (
+              <div
+                key={`hit-${i}`}
+                role="button"
+                tabIndex={-1}
+                onClick={(e) => { e.stopPropagation(); onActivateThread(m.comments[0]); }}
+                onMouseEnter={() => setHoveredKey(m.key)}
+                onMouseLeave={() => setHoveredKey((k) => (k === m.key ? null : k))}
+                title={m.comments.length > 1 ? `${m.comments.length} 条划词评论，点击查看` : '点击查看划词评论'}
+                style={{
+                  position: 'absolute',
+                  top: r.top + r.height - 6,
+                  left: r.left,
+                  width: r.width,
+                  height: 8,
+                  cursor: 'pointer',
+                  pointerEvents: 'auto',
+                  background: 'transparent',
+                  zIndex: 5,
+                }}
+              />
+            ))}
           </div>
         );
       })}
 
-      {/* 选中后浮出的「评论」按钮 */}
+      {/* 选中后浮出的「评论」按钮。
+          注意：本层 overlay 是 0x0 原点，绝对定位子元素的 shrink-to-fit 可用宽度为 0，
+          不显式给 width:max-content + nowrap 会被压成竖排圆团（2026-07-27 用户反馈的变形根因） */}
       {pending && (
         <div
-          style={{ position: 'absolute', top: pending.pos.top, left: pending.pos.left, zIndex: 20, pointerEvents: 'auto' }}
+          style={{
+            position: 'absolute',
+            top: pending.pos.top,
+            left: pending.pos.left,
+            width: 'max-content',
+            zIndex: 20,
+            pointerEvents: 'auto',
+          }}
         >
           <button
             type="button"
@@ -270,15 +264,22 @@ export function ReportSelectionCommentLayer({
               setPending(null);
               window.getSelection()?.removeAllRanges();
             }}
-            className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-full text-[12px] font-medium cursor-pointer"
+            className="inline-flex items-center cursor-pointer"
             style={{
+              gap: 6,
+              padding: '5px 12px 5px 10px',
+              whiteSpace: 'nowrap',
+              borderRadius: 999,
+              fontSize: 12,
+              fontWeight: 500,
+              lineHeight: '16px',
               background: 'var(--bg-elevated)',
               color: 'var(--text-primary)',
-              border: `1px solid ${underlineStroke(isLight, true)}`,
-              boxShadow: '0 4px 14px rgba(0,0,0,0.28)',
+              border: '1px solid var(--border-primary)',
+              boxShadow: '0 6px 18px rgba(0,0,0,0.22)',
             }}
           >
-            <MessageSquarePlus size={13} style={{ color: badgeBg }} />
+            <MessageSquarePlus size={13} style={{ color: accentGold, flexShrink: 0 }} />
             评论
           </button>
         </div>

--- a/prd-admin/src/pages/report-agent/components/ReportSelectionCommentLayer.tsx
+++ b/prd-admin/src/pages/report-agent/components/ReportSelectionCommentLayer.tsx
@@ -1,0 +1,288 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type RefObject } from 'react';
+import { MessageSquarePlus } from 'lucide-react';
+import type { ReportComment } from '@/services/contracts/reportAgent';
+import { findTextRange } from '@/components/doc-browser/InlineCommentOverlay';
+import { groupKey } from '@/components/doc-browser/inlineCommentShared';
+import {
+  buildAnchorFromText,
+  underlineStroke,
+  underlineTint,
+  type ReportCommentAnchor,
+} from './reportCommentAnchor';
+
+// 周报划词评论层：
+//   1. 捕获正文选区（限单个段落容器 [data-report-section] 内）→ 浮出「评论」按钮；
+//   2. 把带锚点的评论重定位回已渲染 DOM，画「黄色下划线」（非底色高亮，遵循用户要求）；
+//   3. 下划线末尾放评论数角标，点击联动滚动到该段落下的评论线程。
+// 锚定算法复用知识库 SSOT（findTextRange / locateInSegments），本层只做周报侧的轻量视觉。
+// 坐标系同 doc-browser InlineCommentOverlay：本层是 relative 容器内 0x0 的 absolute 原点，
+// 子元素位置 = 文本 rect 减本层 rect，随内容一起滚动，无需监听 scroll。
+
+interface UnderlineMark {
+  key: string;
+  rects: Array<{ top: number; left: number; width: number; height: number }>;
+  badge: { top: number; left: number };
+  comments: ReportComment[];
+}
+
+interface PendingSelection {
+  sectionIndex: number;
+  anchor: ReportCommentAnchor;
+  pos: { top: number; left: number };
+}
+
+function elementOf(node: Node | null): Element | null {
+  if (!node) return null;
+  return node.nodeType === Node.ELEMENT_NODE ? (node as Element) : node.parentElement;
+}
+
+export function ReportSelectionCommentLayer({
+  containerRef,
+  comments,
+  isLight,
+  reflowKey,
+  onCreateFromSelection,
+  onActivateThread,
+}: {
+  /** relative 定位的正文容器（内含带 data-report-section 的段落内容块） */
+  containerRef: RefObject<HTMLDivElement | null>;
+  comments: ReportComment[];
+  isLight: boolean;
+  /** 正文内容变化时触发重排（报告 id / 段落数等拼接串） */
+  reflowKey: string | number;
+  /** 用户选中一段正文并点「评论」 */
+  onCreateFromSelection: (sectionIndex: number, anchor: ReportCommentAnchor) => void;
+  /** 点击下划线角标 → 滚到对应评论线程（传该组第一条顶级评论） */
+  onActivateThread: (comment: ReportComment) => void;
+}) {
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const rafRef = useRef<number | null>(null);
+  const [marks, setMarks] = useState<UnderlineMark[]>([]);
+  const [hoveredKey, setHoveredKey] = useState<string | null>(null);
+  const [pending, setPending] = useState<PendingSelection | null>(null);
+
+  // ---------- 下划线重定位 ----------
+  const recompute = useCallback(() => {
+    const container = containerRef.current;
+    const overlay = overlayRef.current;
+    if (!container || !overlay) { setMarks([]); return; }
+
+    // 顶级 + 带锚点的评论按「段落 + 归一化选中文本」分组，同一段文字多条评论共用一条下划线
+    const groups = new Map<string, ReportComment[]>();
+    for (const c of comments) {
+      if (c.parentCommentId || !c.selectedText) continue;
+      const text = groupKey(c.selectedText);
+      if (!text) continue;
+      const key = `${c.sectionIndex}::${text}`;
+      const g = groups.get(key) ?? [];
+      g.push(c);
+      groups.set(key, g);
+    }
+    if (groups.size === 0) { setMarks([]); return; }
+
+    const oRect = overlay.getBoundingClientRect();
+    const next: UnderlineMark[] = [];
+    groups.forEach((list, key) => {
+      const sectionIndex = list[0].sectionIndex;
+      const root = container.querySelector<HTMLElement>(`[data-report-section="${sectionIndex}"]`);
+      if (!root) return;
+      const text = groupKey(list[0].selectedText ?? '');
+      const range = findTextRange(root, text, list[0].contextBefore ?? undefined);
+      if (!range) return; // 正文已更新且找不到原片段：不画线，评论列表仍可见（优雅降级）
+      const rectList = Array.from(range.getClientRects());
+      if (rectList.length === 0) return;
+      const rects = rectList.map((r) => ({
+        top: r.top - oRect.top,
+        left: r.left - oRect.left,
+        width: r.width,
+        height: r.height,
+      }));
+      const last = rectList[rectList.length - 1];
+      next.push({
+        key,
+        rects,
+        badge: { top: last.top - oRect.top - 4, left: last.right - oRect.left + 3 },
+        comments: list,
+      });
+    });
+    setMarks(next);
+  }, [comments, containerRef]);
+
+  const schedule = useCallback(() => {
+    if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
+    rafRef.current = requestAnimationFrame(() => { rafRef.current = null; recompute(); });
+  }, [recompute]);
+
+  useLayoutEffect(() => {
+    recompute();
+    // markdown 图片/字体异步就位后再对齐两次（同 doc-browser 经验值）
+    const t1 = window.setTimeout(recompute, 120);
+    const t2 = window.setTimeout(recompute, 500);
+    const container = containerRef.current;
+    const ro = container ? new ResizeObserver(schedule) : null;
+    if (container && ro) ro.observe(container);
+    window.addEventListener('resize', schedule);
+    return () => {
+      window.clearTimeout(t1);
+      window.clearTimeout(t2);
+      if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
+      ro?.disconnect();
+      window.removeEventListener('resize', schedule);
+    };
+  }, [recompute, schedule, reflowKey, containerRef]);
+
+  // ---------- 选区捕获 ----------
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const handlePointerUp = () => {
+      // 等浏览器把选区结算完再读（双击选词等场景 pointerup 时选区未定）
+      window.setTimeout(() => {
+        const overlay = overlayRef.current;
+        if (!overlay || !containerRef.current) return;
+        const sel = window.getSelection();
+        if (!sel || sel.isCollapsed || sel.rangeCount === 0) return;
+        const range = sel.getRangeAt(0);
+        const startEl = elementOf(range.startContainer);
+        const endEl = elementOf(range.endContainer);
+        const root = startEl?.closest<HTMLElement>('[data-report-section]') ?? null;
+        // 选区必须完整落在同一个段落内容块内（跨段落/选到标题、评论区一律忽略）
+        if (!root || !endEl || endEl.closest('[data-report-section]') !== root) return;
+        const sectionIndex = Number(root.getAttribute('data-report-section'));
+        if (!Number.isFinite(sectionIndex)) return;
+
+        // 选区起点相对段落纯文本的偏移：selectNodeContents + setEnd 的标准算法
+        const pre = range.cloneRange();
+        pre.selectNodeContents(root);
+        pre.setEnd(range.startContainer, range.startOffset);
+        const start = pre.toString().length;
+        const end = start + range.toString().length;
+        const anchor = buildAnchorFromText(root.textContent ?? '', start, end);
+        if (!anchor) return;
+
+        const rect = range.getBoundingClientRect();
+        const oRect = overlay.getBoundingClientRect();
+        setPending({
+          sectionIndex,
+          anchor,
+          pos: {
+            top: rect.bottom - oRect.top + 6,
+            left: Math.min(
+              Math.max(0, rect.left - oRect.left),
+              Math.max(0, containerRef.current.clientWidth - 130),
+            ),
+          },
+        });
+      }, 0);
+    };
+
+    // 选区塌陷（点击空白等）即收起「评论」按钮
+    const handleSelectionChange = () => {
+      const sel = window.getSelection();
+      if (!sel || sel.isCollapsed) setPending(null);
+    };
+
+    container.addEventListener('pointerup', handlePointerUp);
+    document.addEventListener('selectionchange', handleSelectionChange);
+    return () => {
+      container.removeEventListener('pointerup', handlePointerUp);
+      document.removeEventListener('selectionchange', handleSelectionChange);
+    };
+  }, [containerRef]);
+
+  // 角标：黄金底 + 统一深墨字（两种主题的黄底上对比度都 >=4.5，无需按主题翻转）。
+  // 深色字面量写 rgba 形式——它衬在黄底上、双主题都成立，
+  // 不属于 themeHardcodeRatchet 要拦的「浅色主题下漂浮暗块」场景
+  const badgeBg = isLight ? '#ca8a04' : '#eab308';
+  const badgeFg = 'rgba(26, 18, 5, 0.92)';
+
+  return (
+    <div ref={overlayRef} style={{ position: 'absolute', top: 0, left: 0, width: 0, height: 0 }}>
+      {marks.map((m) => {
+        const emphasized = hoveredKey === m.key;
+        const stroke = underlineStroke(isLight, emphasized);
+        return (
+          <div key={m.key}>
+            {/* 黄色下划线：常态只画线不铺底色；hover 角标时加柔和底色提示范围。
+                pointerEvents:none —— 不挡正文再次划词/点击链接 */}
+            {m.rects.map((r, i) => (
+              <div
+                key={i}
+                style={{
+                  position: 'absolute',
+                  top: r.top,
+                  left: r.left,
+                  width: r.width,
+                  height: r.height,
+                  background: emphasized ? underlineTint(isLight) : 'transparent',
+                  borderBottom: `2px solid ${stroke}`,
+                  borderRadius: 2,
+                  pointerEvents: 'none',
+                  transition: 'background 0.12s, border-color 0.12s',
+                }}
+              />
+            ))}
+            {/* 评论数角标：点击滚到该线程 */}
+            <button
+              type="button"
+              onClick={(e) => { e.stopPropagation(); onActivateThread(m.comments[0]); }}
+              onMouseEnter={() => setHoveredKey(m.key)}
+              onMouseLeave={() => setHoveredKey((k) => (k === m.key ? null : k))}
+              title={`${m.comments.length} 条划词评论，点击查看`}
+              className="cursor-pointer"
+              style={{
+                position: 'absolute',
+                top: m.badge.top,
+                left: m.badge.left,
+                minWidth: 16,
+                height: 16,
+                padding: '0 4px',
+                borderRadius: 8,
+                border: 'none',
+                background: badgeBg,
+                color: badgeFg,
+                fontSize: 9,
+                fontWeight: 800,
+                lineHeight: '16px',
+                pointerEvents: 'auto',
+                zIndex: 6,
+                boxShadow: '0 1px 3px rgba(0,0,0,0.35)',
+              }}
+            >
+              {m.comments.length}
+            </button>
+          </div>
+        );
+      })}
+
+      {/* 选中后浮出的「评论」按钮 */}
+      {pending && (
+        <div
+          style={{ position: 'absolute', top: pending.pos.top, left: pending.pos.left, zIndex: 20, pointerEvents: 'auto' }}
+        >
+          <button
+            type="button"
+            // preventDefault：避免 pointerdown 令选区塌陷 → selectionchange 把按钮先收掉
+            onPointerDown={(e) => e.preventDefault()}
+            onClick={() => {
+              onCreateFromSelection(pending.sectionIndex, pending.anchor);
+              setPending(null);
+              window.getSelection()?.removeAllRanges();
+            }}
+            className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-full text-[12px] font-medium cursor-pointer"
+            style={{
+              background: 'var(--bg-elevated)',
+              color: 'var(--text-primary)',
+              border: `1px solid ${underlineStroke(isLight, true)}`,
+              boxShadow: '0 4px 14px rgba(0,0,0,0.28)',
+            }}
+          >
+            <MessageSquarePlus size={13} style={{ color: badgeBg }} />
+            评论
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/prd-admin/src/pages/report-agent/components/__tests__/reportCommentAnchor.test.ts
+++ b/prd-admin/src/pages/report-agent/components/__tests__/reportCommentAnchor.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildAnchorFromText,
+  collapseWhitespace,
+  MAX_SELECTED_TEXT,
+  CONTEXT_LEN,
+} from '../reportCommentAnchor';
+
+describe('collapseWhitespace', () => {
+  it('折叠换行与连续空格为单空格并去两端空白', () => {
+    expect(collapseWhitespace('  本周\n完成了   周报  ')).toBe('本周 完成了 周报');
+  });
+});
+
+describe('buildAnchorFromText', () => {
+  const fullText = '本周完成了周报智能体的划词评论功能，被评论的内容显示黄色下划线状态，下周继续优化。';
+
+  it('正常构造锚点：选中片段 + 前后上下文 + 偏移', () => {
+    const start = fullText.indexOf('划词评论功能');
+    const end = start + '划词评论功能'.length;
+    const anchor = buildAnchorFromText(fullText, start, end);
+    expect(anchor).not.toBeNull();
+    expect(anchor!.selectedText).toBe('划词评论功能');
+    expect(anchor!.contextBefore).toBe(fullText.slice(0, start));
+    expect(anchor!.contextAfter).toBe(fullText.slice(end, end + CONTEXT_LEN));
+    expect(anchor!.startOffset).toBe(start);
+    expect(anchor!.endOffset).toBe(end);
+  });
+
+  it('文首选区：contextBefore 为空且不越界', () => {
+    const anchor = buildAnchorFromText(fullText, 0, 4);
+    expect(anchor).not.toBeNull();
+    expect(anchor!.contextBefore).toBe('');
+    expect(anchor!.selectedText).toBe('本周完成');
+  });
+
+  it('文末选区：contextAfter 为空且不越界', () => {
+    const anchor = buildAnchorFromText(fullText, fullText.length - 5, fullText.length);
+    expect(anchor).not.toBeNull();
+    expect(anchor!.contextAfter).toBe('');
+  });
+
+  it('上下文最长 50 字符', () => {
+    const long = 'a'.repeat(200) + '目标片段' + 'b'.repeat(200);
+    const start = 200;
+    const end = start + 4;
+    const anchor = buildAnchorFromText(long, start, end);
+    expect(anchor!.contextBefore).toBe('a'.repeat(CONTEXT_LEN));
+    expect(anchor!.contextAfter).toBe('b'.repeat(CONTEXT_LEN));
+  });
+
+  it('选中文本内的换行/多空格被折叠为单空格', () => {
+    const text = '第一行\n  第二行  结束';
+    const anchor = buildAnchorFromText(text, 0, text.length);
+    expect(anchor!.selectedText).toBe('第一行 第二行 结束');
+  });
+
+  it('去空白后不足 2 字符返回 null', () => {
+    expect(buildAnchorFromText('a  b', 1, 3)).toBeNull();
+    expect(buildAnchorFromText('x', 0, 1)).toBeNull();
+  });
+
+  it('非法偏移返回 null', () => {
+    expect(buildAnchorFromText(fullText, -1, 5)).toBeNull();
+    expect(buildAnchorFromText(fullText, 5, 5)).toBeNull();
+    expect(buildAnchorFromText(fullText, 0, fullText.length + 1)).toBeNull();
+  });
+
+  it('超长选区截断到上限', () => {
+    const long = '长'.repeat(MAX_SELECTED_TEXT + 100);
+    const anchor = buildAnchorFromText(long, 0, long.length);
+    expect(anchor!.selectedText.length).toBe(MAX_SELECTED_TEXT);
+  });
+});

--- a/prd-admin/src/pages/report-agent/components/reportCommentAnchor.ts
+++ b/prd-admin/src/pages/report-agent/components/reportCommentAnchor.ts
@@ -1,0 +1,58 @@
+// 周报划词评论的锚点纯逻辑（无 DOM 依赖，可在 node 环境单测）。
+// 定位/匹配算法复用知识库 SSOT：
+//   - locateInSegments / findTextRange（components/doc-browser/InlineCommentOverlay.tsx）
+// 本文件只负责：从"段落纯文本 + 选区偏移"构造锚点，以及黄色下划线的主题配色。
+
+export interface ReportCommentAnchor {
+  /** 被选中的原文片段（空白折叠为单空格） */
+  selectedText: string;
+  /** 选中片段前上下文（约 50 字符，同段多处命中时消歧） */
+  contextBefore: string;
+  /** 选中片段后上下文（约 50 字符） */
+  contextAfter: string;
+  /** 相对段落纯文本的起始字符偏移（定位 hint） */
+  startOffset: number;
+  /** 结束字符偏移（定位 hint） */
+  endOffset: number;
+}
+
+/** 选区文本存储上限：超长选区截断保存，下划线按截断后的片段定位 */
+export const MAX_SELECTED_TEXT = 500;
+/** 前后上下文截取长度 */
+export const CONTEXT_LEN = 50;
+
+/** 折叠空白：换行/连续空格归一为单空格，两端去空白（与 doc-browser groupKey 同口径） */
+export function collapseWhitespace(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * 由段落纯文本与选区偏移构造锚点。
+ * 选区过短（去空白后 < 2 字符）或偏移非法时返回 null。
+ */
+export function buildAnchorFromText(fullText: string, start: number, end: number): ReportCommentAnchor | null {
+  if (start < 0 || end > fullText.length || end <= start) return null;
+  const selected = collapseWhitespace(fullText.slice(start, end));
+  if (selected.length < 2) return null;
+  return {
+    selectedText: selected.slice(0, MAX_SELECTED_TEXT),
+    contextBefore: collapseWhitespace(fullText.slice(Math.max(0, start - CONTEXT_LEN), start)),
+    contextAfter: collapseWhitespace(fullText.slice(end, end + CONTEXT_LEN)),
+    startOffset: start,
+    endOffset: end,
+  };
+}
+
+// ---------- 黄色下划线配色（双主题，随主题微调保证协调） ----------
+// 暗色底用亮黄（yellow-500 系），浅色暖纸底用深金黄（yellow-600/700 系）保对比度。
+
+/** 下划线描边色 */
+export function underlineStroke(isLight: boolean, emphasized = false): string {
+  if (isLight) return emphasized ? 'rgba(161, 98, 7, 0.95)' : 'rgba(202, 138, 4, 0.8)';
+  return emphasized ? 'rgba(250, 204, 21, 0.95)' : 'rgba(234, 179, 8, 0.75)';
+}
+
+/** hover/激活时的柔和底色提示（常态不铺底色，保持"下划线"而非"高亮块"） */
+export function underlineTint(isLight: boolean): string {
+  return isLight ? 'rgba(202, 138, 4, 0.10)' : 'rgba(234, 179, 8, 0.12)';
+}

--- a/prd-admin/src/services/contracts/reportAgent.ts
+++ b/prd-admin/src/services/contracts/reportAgent.ts
@@ -716,6 +716,14 @@ export interface ReportComment {
   content: string;
   createdAt: string;
   updatedAt?: string;
+  /** 划词锚定：被选中的原文片段（无则为传统段落级评论） */
+  selectedText?: string;
+  /** 选中片段前上下文（多处命中时消歧） */
+  contextBefore?: string;
+  /** 选中片段后上下文 */
+  contextAfter?: string;
+  startOffset?: number;
+  endOffset?: number;
 }
 
 export interface ReportLikeUser {
@@ -759,6 +767,12 @@ export type CreateCommentContract = (input: {
   sectionIndex: number;
   content: string;
   parentCommentId?: string;
+  /** 划词锚定（可选，仅顶级评论生效） */
+  selectedText?: string;
+  contextBefore?: string;
+  contextAfter?: string;
+  startOffset?: number;
+  endOffset?: number;
 }) => Promise<ApiResponse<{ comment: ReportComment }>>;
 
 export type UpdateCommentContract = (input: {

--- a/prd-api/src/PrdAgent.Api/Controllers/Api/ReportAgentController.cs
+++ b/prd-api/src/PrdAgent.Api/Controllers/Api/ReportAgentController.cs
@@ -134,6 +134,14 @@ public class ReportAgentController : ControllerBase
 
     private string GetUserId() => this.GetRequiredUserId();
 
+    /// <summary>裁剪可空字符串到指定长度；空白视为 null（划词锚点字段用）</summary>
+    private static string? Truncate(string? value, int maxLength)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+        var trimmed = value.Trim();
+        return trimmed.Length <= maxLength ? trimmed : trimmed[..maxLength];
+    }
+
     private string? GetUsername()
         => User.FindFirst("name")?.Value
            ?? User.FindFirst(ClaimTypes.Name)?.Value;
@@ -3791,6 +3799,10 @@ public class ReportAgentController : ControllerBase
                 return BadRequest(ApiResponse<object>.Fail("NOT_FOUND", "父评论不存在"));
         }
 
+        // 划词锚点仅顶级评论生效；裁剪长度防止超长选区/上下文膨胀存储
+        var isReply = !string.IsNullOrEmpty(req.ParentCommentId);
+        var selectedText = isReply ? null : Truncate(req.SelectedText, 500);
+
         var comment = new ReportComment
         {
             ReportId = id,
@@ -3799,7 +3811,12 @@ public class ReportAgentController : ControllerBase
             ParentCommentId = string.IsNullOrEmpty(req.ParentCommentId) ? null : req.ParentCommentId,
             AuthorUserId = userId,
             AuthorDisplayName = authorDisplayName,
-            Content = req.Content.Trim()
+            Content = req.Content.Trim(),
+            SelectedText = selectedText,
+            ContextBefore = selectedText == null ? null : Truncate(req.ContextBefore, 100),
+            ContextAfter = selectedText == null ? null : Truncate(req.ContextAfter, 100),
+            StartOffset = selectedText == null ? null : req.StartOffset,
+            EndOffset = selectedText == null ? null : req.EndOffset
         };
 
         await _db.ReportComments.InsertOneAsync(comment);
@@ -5366,6 +5383,13 @@ public class CreateCommentRequest
     public int SectionIndex { get; set; }
     public string Content { get; set; } = string.Empty;
     public string? ParentCommentId { get; set; }
+
+    // 划词锚定（可选）：仅顶级评论生效，回复不携带锚点
+    public string? SelectedText { get; set; }
+    public string? ContextBefore { get; set; }
+    public string? ContextAfter { get; set; }
+    public int? StartOffset { get; set; }
+    public int? EndOffset { get; set; }
 }
 
 public class UpdateCommentRequest

--- a/prd-api/src/PrdAgent.Core/Models/ReportComment.cs
+++ b/prd-api/src/PrdAgent.Core/Models/ReportComment.cs
@@ -31,6 +31,25 @@ public class ReportComment
     /// <summary>评论内容</summary>
     public string Content { get; set; } = string.Empty;
 
+    /// <summary>
+    /// 划词锚定：被选中的原文片段（null 表示传统段落级评论，无正文定位）。
+    /// 前端按 SelectedText + 前后上下文在已渲染正文中重定位并画黄色下划线；
+    /// 正文更新后找不到原片段时仅不再画线，评论本身保留展示。
+    /// </summary>
+    public string? SelectedText { get; set; }
+
+    /// <summary>选中片段前的上下文（约 50 字符，用于同一段文字多处出现时消歧）</summary>
+    public string? ContextBefore { get; set; }
+
+    /// <summary>选中片段后的上下文（约 50 字符）</summary>
+    public string? ContextAfter { get; set; }
+
+    /// <summary>选区起始字符偏移（相对该段落纯文本，仅作定位 hint）</summary>
+    public int? StartOffset { get; set; }
+
+    /// <summary>选区结束字符偏移（仅作定位 hint）</summary>
+    public int? EndOffset { get; set; }
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime? UpdatedAt { get; set; }
 }


### PR DESCRIPTION
## 摘要

实现周报详情的划词评论：用户选中正文任意文字弹出「评论」按钮，提交后被评论文字在正文中显示黄色下划线（非底色高亮），点击下划线滚动并标亮对应评论线程。前端通过文本锚点（选中片段 + 前后上下文）在已渲染 DOM 中重定位下划线，定位算法复用知识库划词评论的 SSOT；后端为 ReportComment 增加可空锚点字段，存量段落级评论行为完全不变。

## 改动 diff

### 后端 (prd-api)

- `PrdAgent.Core/Models/ReportComment.cs`：新增划词锚定字段（SelectedText / ContextBefore / ContextAfter / StartOffset / EndOffset），全部可空，null 即传统段落级评论
- `Controllers/Api/ReportAgentController.cs`：CreateComment 端点接收并写入锚点字段，仅顶级评论生效（回复不携带），超长自动裁剪（选中文本 500 字符、上下文各 100 字符）；新增 Truncate 私有助手

### 前端 (prd-admin)

- `services/contracts/reportAgent.ts`：ReportComment 与 CreateCommentContract 增加可选锚点字段（real service 透传，无需改动）
- `pages/report-agent/components/reportCommentAnchor.ts`（新增）：锚点纯逻辑模块——buildAnchorFromText（段落纯文本 + 选区偏移 → 锚点）、collapseWhitespace、underlineStroke / underlineTint（黄色下划线双主题配色：暗色 yellow-500 系、浅色暖纸底深金黄）
- `pages/report-agent/components/__tests__/reportCommentAnchor.test.ts`（新增）：锚点构造单测 9 例（正常 / 文首文末 / 上下文截断 / 空白折叠 / 超长截断 / 非法偏移）
- `pages/report-agent/components/ReportSelectionCommentLayer.tsx`（新增）：划词评论层——捕获选区（限单个 `[data-report-section]` 段落内）浮出「评论」按钮；按「段落 + 归一化选中文本」分组评论并重定位画黄色下划线；下划线贴线 8px 命中区可点击，联动滚动标亮评论；正文更新找不到原片段时优雅降级（不画线、评论保留）
- `pages/report-agent/ReportDetailPage.tsx` / `components/ReportDetailPanel.tsx`：接入划词评论层；评论输入框支持带锚点打开（标题显示「评论选中内容」）；评论项展示「引用：…」片段（同色下划线）并支持点击下划线后短暂标亮
- `components/doc-browser/InlineCommentOverlay.tsx`：导出 findTextRange 供周报侧复用（仅加 export，无行为变化）

### 体验修正（用户预览后反馈，commit b1c17e4）

- 「评论」浮出按钮变形修复：overlay 原点为 0x0，绝对定位子元素 shrink-to-fit 可用宽度为 0 被压成竖排圆团；补 width:max-content + white-space:nowrap，样式精简为中性描边 + 金色图标胶囊
- 移除被评论文字尾部的数字角标，改为点击黄色下划线本身查看评论

### 文档

- `changelogs/2026-07-27_report-comment-underline.md`：changelog 碎片（feat x2 + polish）

## 测试

- [x] 前端 `pnpm tsc --noEmit` + `pnpm lint` 通过（本次改动文件零新增告警；ReportDetailPanel 的 1 条 exhaustive-deps warning 为存量，已核对 HEAD 版本同样存在）
- [x] 前端 `pnpm test` 全绿：124 文件 / 880 用例（含新增锚点单测 9 例、themeSystem 主题守卫、themeHardcodeRatchet 双皮肤棘轮）
- [x] 后端编译经远端验证：开发沙箱无 dotnet SDK，由 GitHub Actions「Build prd-api image」构建成功 + CDS Deploy check 绿灯（真实 .NET 编译，零 error CS）代偿
- [ ] Server Build & Test / Admin Dashboard Build 两个 check 提交本描述时仍在运行，以 PR Checks 面板最终状态为准
- [ ] 真人预览域名验收：开发沙箱网络策略拦截 cds.miduo.org，cdscli preview-url 无法取回地址；可从 CDS Deploy check 的 Details 进入分支面板验收。验收路径：登录 → 周报智能体 → 打开任一周报详情 → 划选正文 → 提交评论 → 确认黄色下划线与点击联动（请浅色 / 深色两主题各验一次）

## 风险与已知边界

- 锚点字段全部可空，存量段落级评论展示与交互零变化；回复不携带锚点
- 正文更新后若找不到原选中片段，仅不再画下划线，评论本身保留展示（无孤儿数据）
- 下划线命中区为贴线 8px 细条，不遮文字、不影响在同一段落再次划词

## 后续事项

- P2：点击评论内「引用」片段反向滚动定位到正文对应位置
- P2：表格单元格内选区的下划线定位在极端窄列下的表现微调

https://claude.ai/code/session_01FEqHUpKeuzxRHeeAaRxR7K