### PR TITLE
每日熵减计划 2026-W32 — D6 补齐 storage-migration R2 章节 (3 条)

### DIFF
--- a/changelogs/.entropy-manifest.yml
+++ b/changelogs/.entropy-manifest.yml
@@ -515,3 +515,6 @@ processed:
   - 2026-07-29_cds-external-integrations.md
   - 2026-07-29_cds-release-center-overhaul.md
   - 2026-08-02_weekly-w31.md
+  - 2026-08-02_entropy-cleanup.md
+  - 2026-08-02_weekly-publish-dedup.md
+  - 2026-08-03_r2-recording-archive.md

--- a/changelogs/2026-08-05_entropy-cleanup.md
+++ b/changelogs/2026-08-05_entropy-cleanup.md
@@ -1,0 +1,1 @@
+| chore | doc | 每日熵减计划：D1-D3/D4/D7 全绿零欠账，D6 处理 3 条 changelog（2 条已由既有文档自建覆盖，1 条补 design.platform.storage-migration.md 的 R2 签名一致性章节），另 2 条无匹配设计文档暂缓（首页米多墨系改版、录音结果续播体验，需专门撰写，本轮不强行拼接） |

--- a/doc/design.platform.storage-migration.md
+++ b/doc/design.platform.storage-migration.md
@@ -105,6 +105,15 @@ Provider 切换只影响切换后的读写实现。历史记录中保存的完�
 - 用户资产误分风险以保护用户为先，无法判断时归为 `user`。
 - 迁移工具不得把访问密钥、签名 URL 或用户内容写入普通日志。
 
+### 7.1 R2 签名一致性（真实大小对象必测）
+
+Cloudflare R2 的 S3 兼容端点对真实录音大小的写入曾两次暴露签名相关的坑，都只在真实大小对象上复现、小探针测不出：
+
+- 浏览器录音的 `Content-Type` 常带编码参数（如 `audio/mp4;codecs=mp4a.40.2`），R2 端点会重写这类带参数的 header，导致服务端验签所见 header 与 SDK 签名输入不一致；写入前统一规范化为不带参数的 media type。
+- 对真实体量的负载使用免签流式（`UNSIGNED-PAYLOAD` / chunked）会偶发返回签名不匹配；改为固定携带 `Content-Length` 的完整签名负载、禁用分块编码。
+
+**验收口径**：就绪探针（见 8.）必须用**代表性大小的负载**（当前基线 640KB）做真实写-读-删，禁止用极小文本探针或只检查请求参数替代——那类探针无法复现上述两个坑，会把「探针绿、真实对象因签名失败」的组合误判为就绪。
+
 ## 8. 当前实现入口
 
 | 能力 | 事实入口 |
@@ -114,6 +123,8 @@ Provider 切换只影响切换后的读写实现。历史记录中保存的完�
 | 登记模型 | `prd-api/src/PrdAgent.Core/Models/AssetRegistryEntry.cs` |
 | 系统资产清单 | `prd-api/src/PrdAgent.Infrastructure/Services/AssetStorage/SystemAssetManifest.cs` |
 | 系统资产同步 API | `prd-api/src/PrdAgent.Api/Controllers/Api/StorageSyncController.cs` |
+| 就绪探针（代表性大小写读删） | `prd-api/src/PrdAgent.Api/Services/AssetStorageReadinessProbe.cs` |
+| R2 签名一致性处理 | `prd-api/src/PrdAgent.Infrastructure/Services/AssetStorage/CloudflareR2Storage.cs` |
 | Provider 装配 | `prd-api/src/PrdAgent.Api/Program.cs` |
 | MongoDB 集合入口 | `prd-api/src/PrdAgent.Infrastructure/Data/MongoDbContext.cs` |
 


### PR DESCRIPTION
## 熵清理摘要

- D1 命名规范：0 个违规
- D2 index.yml：+0/-0 条
- D3 guide.list：+0/-0 条
- D4 技能可发现性：0 条（审计全绿）
- D7 文档可读性棘轮：六项欠账均未上升，无死链
- D6 changelog→doc：本次处理 3 条，manifest 累计 515 条；另 2 条暂缓（见下）

## 改动 diff

- `doc/design.platform.storage-migration.md`：新增「7.1 R2 签名一致性（真实大小对象必测）」章节，记录 Content-Type 参数规范化 + 禁用免签流式两处签名坑，并在「8. 当前实现入口」补就绪探针与 R2 存储实现两行
- `changelogs/.entropy-manifest.yml`：新增 3 条已处理 changelog 记录
- `changelogs/2026-08-05_entropy-cleanup.md`：本次 changelog 碎片

## D6 处理明细

- `2026-08-02_entropy-cleanup.md`：自我归档的熵减碎片，无需追加设计文档覆盖（与其自身文本一致）
- `2026-08-02_weekly-publish-dedup.md`：两条改动分别已由 `weekly-update-summary` 技能自身文档（`--replace-same-date`/`--last-commit` 用法）与 `doc/debt.acceptance-center-cds.md`（分钟级时间戳去重键根因）自建覆盖，核对后无需新增章节
- `2026-08-03_r2-recording-archive.md`：已追加 `doc/design.platform.storage-migration.md` 新章节（见上）

## 本轮暂缓（无匹配设计文档，需专门撰写，未强行拼接）

- `2026-07-31_recording-result-continuity.md`（prd-admin 录音结果续播/波形/云端归档体验改造，约 10 条改动）：搜索 doc/ 未找到任何覆盖录音功能的 design/spec 文档，需要新起一篇 `design.prd-admin.recording.md` 之类的专题文档，非「追加既有章节」的机械操作范围，本轮不强拼进不相关文档
- `2026-08-02_home-ink-system.md`（prd-admin 三首页统一「米多墨系」配色与桌面首页「工位」改版，约 30 条改动）：同样缺少对应设计文档，且改动规模大（配色 token、导航记账、多组件重构），需要独立撰写会话核实设计意图与取舍，本轮不强拼

以上两条**未标记为已处理**，会在后续熵减周期继续被 D6 扫出，直到有对应设计文档承接。

## 需人工处理

无（D4 技能可发现性审计全绿，无 BLOCK 项）。

## 测试

- [x] 双向扫描完成（D1/D2/D3/D4/D7 全绿），diff 核验通过（仅 doc/ 与 changelogs/ 下的追加行，无删除行、无代码文件混入）
- [x] `python3 scripts/doc-readability-check.py --ratchet` 通过，六项欠账未上升
- [x] `python3 scripts/doc-readability-check.py --skills-audit` 通过，无 BLOCK
- [x] `bash scripts/validate-changelog-fragments.sh` 通过


---
_Generated by [Claude Code](https://claude.ai/code/session_01X4mCVNFukKSd53i1Gym9cE)_