### PR TITLE
fix(cds): 应用账号档的 mysqldump 必须带 --no-tablespaces（E45 第二层）

### DIFF
--- a/cds/src/services/infra-backup-schedule.ts
+++ b/cds/src/services/infra-backup-schedule.ts
@@ -643,7 +643,12 @@ const MYSQL_CREDENTIAL_LINES: readonly string[] = [
   // 随机 root 口令的容器走这一档：只备应用账号那个库，但至少有备份。
   '  export MYSQL_PWD="$CDS_APP_PW"',
   '  CDS_MYSQL_USER="$CDS_APP_USER"',
-  '  CDS_MYSQL_SCOPE="--databases $CDS_APP_DB"',
+  // `--no-tablespaces` 不是可选项：mysqldump 8.0 默认要读 INFORMATION_SCHEMA.FILES
+  // 导出表空间定义，那需要**全局** PROCESS 权限。而这类账号拿到的是
+  // `GRANT ALL ON <db>.*` + `GRANT USAGE ON *.*`（实测 webhook@% 就是这样），
+  // 全局权限一个都没有，于是 dump 一上来就 Access denied、产出一个 20 字节的空 gzip。
+  // root 那一档不加：它有 PROCESS，保持原命令逐字不变，四个在用的容器行为不动。
+  '  CDS_MYSQL_SCOPE="--databases $CDS_APP_DB --no-tablespaces"',
   '  CDS_MYSQL_IS_ROOT=0',
   '  CDS_MYSQL_SCOPE_LABEL="database:$CDS_APP_DB"',
   'else',

--- a/cds/tests/services/infra-backup-mysql-paths.test.ts
+++ b/cds/tests/services/infra-backup-mysql-paths.test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
-import { buildMysqlRestoreScript, buildMysqlTableCountScript } from '../../src/services/infra-backup-schedule.js';
+import { buildMysqlDumpScript, buildMysqlRestoreScript, buildMysqlTableCountScript } from '../../src/services/infra-backup-schedule.js';
 
 /**
  * E41：mysql 的手工下载与恢复。
@@ -167,6 +167,15 @@ describe('mysql 恢复脚本：管道两端的失败都要报出来', () => {
     expect(r.code).toBe(0);
     expect(r.mysqlUser).toBe('webhook');
     expect(r.flushed, '应用账号没有 RELOAD 权限，强来只会让恢复整条失败').toBe(false);
+  });
+
+  it('应用账号档必须带 --no-tablespaces，root 档不带', () => {
+    // 应用账号只有 `GRANT ALL ON <db>.*` + `GRANT USAGE ON *.*`，没有全局 PROCESS，
+    // 而 mysqldump 8.0 默认要读 INFORMATION_SCHEMA.FILES 导表空间——少这个开关，
+    // dump 一上来就 Access denied，产出 20 字节空 gzip（实测 cloudbridge-db 就这样）。
+    const dump = buildMysqlDumpScript();
+    expect(dump).toMatch(/CDS_MYSQL_SCOPE="--databases \$CDS_APP_DB --no-tablespaces"/);
+    expect(dump).toMatch(/CDS_MYSQL_SCOPE="--all-databases"/);
   });
 
   it('凭据一套都凑不齐：明确退 78，不去连库', () => {

--- a/changelogs/2026-08-18_cds-infra-backup-status.md
+++ b/changelogs/2026-08-18_cds-infra-backup-status.md
@@ -1,2 +1,3 @@
 | docs | cds | 看板收尾 miduo-backen mysql（已补卷、已收窄、数据已回灌并独立验过）；新增 E44 离机失败连本地副本一起删、E45 cloudbridge-db root 口令不符 |
 | fix | cds | mysqldump/恢复不再写死 -uroot：没有 root 口令时回落应用账号备它自己那个库（E45，修 cloudbridge-db 长期零备份） |
+| fix | cds | 应用账号档的 mysqldump 补 --no-tablespaces：该账号没有全局 PROCESS，缺这个开关会产出 20 字节空 gzip |


### PR DESCRIPTION
## 摘要

#1397 部署后实测：`cloudbridge-db` 仍然只导出 **20 字节的空 gzip**。凭据这一层修对了（应用账号 `webhook@%` 实测可连、`webhook_platform` 有 10 张表），但下面还有一层。

mysqldump 8.0 默认要读 `INFORMATION_SCHEMA.FILES` 导出表空间定义，那需要**全局** `PROCESS` 权限。实测该账号的授权是：

```
GRANT USAGE ON *.* TO `webhook`@`%`
GRANT ALL PRIVILEGES ON `webhook_platform`.* TO `webhook`@`%`
```

全局权限一个都没有 —— 所以 dump 一上来就 Access denied，什么都没写出来，gzip 干净地收了个空流。

## 改动 diff

### cds 后端

- `cds/src/services/infra-backup-schedule.ts` — 应用账号档的 `CDS_MYSQL_SCOPE` 加 `--no-tablespaces`。**root 档不加**：它有 PROCESS，命令保持逐字不变，四个在用的容器行为完全不动。

### 测试

- `cds/tests/services/infra-backup-mysql-paths.test.ts` — 断言应用账号档带 `--no-tablespaces`、root 档不带。

### changelog

- `changelogs/2026-08-18_cds-infra-backup-status.md`

## 测试

- `pnpm vitest run`：408 文件 / 5499 项通过，2 文件 3 项跳过。
- `pnpm tsc --noEmit`：零错误。
- 线上取证已做的部分：`SHOW GRANTS FOR CURRENT_USER()` 确认该账号无全局权限（这就是本 PR 的直接判据）；合并部署后会再拉一次 `cloudbridge-db` 的备份，按字节数与 `gzip -t` 核验能否从 20 字节变成真产物。

## 风险与已知边界

- `--no-tablespaces` 意味着这一档的 dump 不含 `CREATE TABLESPACE`。对使用 InnoDB 默认表空间的库没有影响；若某个库真用了独立表空间，恢复到空实例时需要先建好表空间。该档本来就只覆盖单库、不含系统库，边界一致。
- 顺带记一笔（本 PR 未改）：下载端点在 dump 失败时已经 `res.destroy()`，但响应头和那 20 字节已经先发出去了，宽松的 HTTP 客户端（如 urllib）会当成一次正常的 200。协议层的截断信号是在的，只是「200 + 合法空 gzip」这个形状对人依然有迷惑性。要根治得缓冲后再发，与流式下载的初衷冲突，留作后续。
- Codex 自动 review 因用量额度用尽未跑到。

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hh3um5bQssBfk2msGGy72V)_