### PR TITLE
Refactor theme mode selection: add system preference, consolidate registry

### DIFF
--- a/changelogs/2026-08-25_sidebar-avatar-user-menu.md
+++ b/changelogs/2026-08-25_sidebar-avatar-user-menu.md
@@ -2,3 +2,13 @@
 | feat | prd-admin | 头像点击语义改为两段：菜单关着时点头像开用户菜单，菜单开着时再点一次头像才进「修改我的头像」；菜单头部加一行提示让这条交互可见 |
 | refactor | prd-admin | 用户菜单改受控（modal={false}）：点击判定落在 pointerdown 并 preventDefault，绕开 Radix Trigger 自带的 toggle；展开态用户名按钮退回普通 toggle 按钮，一个 Root 只保留头像这一个锚点 |
 | test | prd-admin | 新增 accountAvatarAction 判定源与守卫用例（4 例）：两段点击语义各一例，另加「AppShell 走唯一判定源」「头像是菜单触发器且侧栏不再有 MoreHorizontal」两条源码守卫，已跑红绿闭环 |
+| fix | prd-admin | 侧栏头像真正贴到底：移除 globals.css 里为「左下角 CDS 徽章」留的 52px 底部空位——CDS widget 桌面端早已改锚右侧安全区，这段留白只是把头像顶高了 52px |
+| feat | prd-admin | 皮肤切换从侧栏挪进用户菜单，改为横排三选项：白天（太阳）/ 黑夜（月亮）/ 随系统（电脑），点选不关菜单，当场看到整屏换肤 |
+| feat | prd-admin | 外观偏好新增「随系统」：跟随 prefers-color-scheme，选中后系统深浅一变页面实时跟着变 |
+| refactor | prd-admin | 新增 themeModeRegistry 作为外观选项唯一数据源（标签/描述/图标），侧栏用户菜单、设置-皮肤设置、周报工具条三处改为消费它，不再各写一份 OPTIONS |
+| fix | prd-admin | 加「随系统」的涟漪修复：移动端首页皮肤与分享阅读页主题钮原先直接拿偏好比 'dark'/'light'，选随系统时永远判 false（DOM 已暗、组件按浅色渲染）；新增 useResolvedThemeMode 统一取解析后的明暗 |
+| test | prd-admin | 新增 themeModeRegistry 守卫（11 例）：三选项顺序与图标装配、system 双向解析、三处入口都走注册表、落 DOM 前先 resolve、两处涟漪点不许再比较偏好；cdsCompatibility 守卫改为盯 CDS widget 的右锚判据。均跑过红绿闭环 |
+| fix | prd-admin | Codex review 修复：AppShell 之外的独立全屏页（分享阅读页 / 数据同步授权页 / 回调页）选「随系统」后系统切深浅，DOM 不会重新落主题——各自的 effect 只把偏好放进 deps，而 'system' 下偏好不变；新增 useApplyDocumentTheme 共享 hook 把解析后的明暗一并放进 deps，三页统一改用它 |
+| fix | prd-admin | Codex review 修复：展开态用户名按钮从 DropdownMenu.Trigger 退回普通 button 后丢了键盘激活（Enter/Space 不发 pointerdown），对键盘用户是死的；补 isMenuKeyboardActivation + onKeyDown |
+| refactor | prd-admin | AppShell 删掉自己那份 matchMedia 监听，改为把 useResolvedThemeMode 放进既有 effect 的 deps——「订阅系统深浅」只保留 hook 里这一份实现 |
+| test | prd-admin | 新增 4 条守卫：applyDocumentThemeMode 只许在共享 hook 与壳层里调用（防下一个独立页再抄错）、三页都走 hook、hook 与壳层的 deps 都含解析值、用户名按钮 pointer+keyboard 双通道；均跑过红绿闭环 |

--- a/changelogs/2026-08-25_sidebar-avatar-user-menu.md
+++ b/changelogs/2026-08-25_sidebar-avatar-user-menu.md
@@ -14,3 +14,4 @@
 | test | prd-admin | 新增 4 条守卫：applyDocumentThemeMode 只许在共享 hook 与壳层里调用（防下一个独立页再抄错）、三页都走 hook、hook 与壳层的 deps 都含解析值、用户名按钮 pointer+keyboard 双通道；均跑过红绿闭环 |
 | fix | prd-admin | Codex review 二轮修复：选「随系统」在 Safari 14 之前的浏览器上直接抛（那些 MediaQueryList 只有 addListener，没有 addEventListener），整档功能用不了；新增 lib/mediaQuerySubscribe 共享订阅带老旧回退，watchSystemThemeChange 改走它 |
 | test | prd-admin | 新增 mediaQuerySubscribe 用例（6 例）：现代/老旧/两者皆无/SSR 四种环境的订阅与取消订阅行为，外加「老旧回退不许再抄第五份」棘轮与「随系统不自己 addEventListener」守卫；已跑红绿闭环 |
+| test | prd-admin | Codex review 三轮：新增「首屏由 render() 落 pos」接线守卫——原守卫只断言 defaultWidgetLeft 的返回值，删掉 render 里那两行落 inline style 的代码它照样全绿，而徽章会退回 CSS 默认 left:12px 压住贴底头像；顺带修了自己判据里的形状 8（初判据把注释掉的 `// render();` 也当成证据，红绿闭环时不变红才发现，已收紧成只认整行调用） |

--- a/changelogs/2026-08-25_sidebar-avatar-user-menu.md
+++ b/changelogs/2026-08-25_sidebar-avatar-user-menu.md
@@ -1,0 +1,4 @@
+| feat | prd-admin | 侧栏底部移除「···」按钮，用户菜单改由点击头像打开；头像因此落到侧栏最底部（同时去掉尾部 1px 占位间距） |
+| feat | prd-admin | 头像点击语义改为两段：菜单关着时点头像开用户菜单，菜单开着时再点一次头像才进「修改我的头像」；菜单头部加一行提示让这条交互可见 |
+| refactor | prd-admin | 用户菜单改受控（modal={false}）：点击判定落在 pointerdown 并 preventDefault，绕开 Radix Trigger 自带的 toggle；展开态用户名按钮退回普通 toggle 按钮，一个 Root 只保留头像这一个锚点 |
+| test | prd-admin | 新增 accountAvatarAction 判定源与守卫用例（4 例）：两段点击语义各一例，另加「AppShell 走唯一判定源」「头像是菜单触发器且侧栏不再有 MoreHorizontal」两条源码守卫，已跑红绿闭环 |

--- a/changelogs/2026-08-25_sidebar-avatar-user-menu.md
+++ b/changelogs/2026-08-25_sidebar-avatar-user-menu.md
@@ -15,3 +15,5 @@
 | fix | prd-admin | Codex review 二轮修复：选「随系统」在 Safari 14 之前的浏览器上直接抛（那些 MediaQueryList 只有 addListener，没有 addEventListener），整档功能用不了；新增 lib/mediaQuerySubscribe 共享订阅带老旧回退，watchSystemThemeChange 改走它 |
 | test | prd-admin | 新增 mediaQuerySubscribe 用例（6 例）：现代/老旧/两者皆无/SSR 四种环境的订阅与取消订阅行为，外加「老旧回退不许再抄第五份」棘轮与「随系统不自己 addEventListener」守卫；已跑红绿闭环 |
 | test | prd-admin | Codex review 三轮：新增「首屏由 render() 落 pos」接线守卫——原守卫只断言 defaultWidgetLeft 的返回值，删掉 render 里那两行落 inline style 的代码它照样全绿，而徽章会退回 CSS 默认 left:12px 压住贴底头像；顺带修了自己判据里的形状 8（初判据把注释掉的 `// render();` 也当成证据，红绿闭环时不变红才发现，已收紧成只认整行调用） |
+| fix | prd-admin | Codex review 四轮：用户菜单里的外观三选项此前是 DropdownMenu.Item + 自己写 role="radio"，子元素 role 覆盖掉 Item 给的 menuitem，菜单里挂出几个裸 radio，屏幕阅读器读到的结构与导航上下文是坏的；改用 Radix 原生 RadioGroup / RadioItem（落 role="group" 与 role="menuitemradio" + aria-checked），选中态由 RadioGroup 的 value 驱动 |
+| test | prd-admin | 新增 test-utils/sourceScan 的 stripComments：源码扫描类守卫扫之前先去注释。本 PR 同一个坑连踩三次（addEventListener 误红、注释掉的 render() 被当成调用、role="radio" 命中解释性注释），三次都在打补丁收紧正则；改为在判据前统一去注释，并把二轮/三轮/四轮那三条判据都收到它上面。含 7 例行为用例（行注释/块注释/JSX 注释/字符串与模板串不误伤/转义引号），另加 3 例菜单单选角色守卫；均跑红绿闭环 |

--- a/changelogs/2026-08-25_sidebar-avatar-user-menu.md
+++ b/changelogs/2026-08-25_sidebar-avatar-user-menu.md
@@ -12,3 +12,5 @@
 | fix | prd-admin | Codex review 修复：展开态用户名按钮从 DropdownMenu.Trigger 退回普通 button 后丢了键盘激活（Enter/Space 不发 pointerdown），对键盘用户是死的；补 isMenuKeyboardActivation + onKeyDown |
 | refactor | prd-admin | AppShell 删掉自己那份 matchMedia 监听，改为把 useResolvedThemeMode 放进既有 effect 的 deps——「订阅系统深浅」只保留 hook 里这一份实现 |
 | test | prd-admin | 新增 4 条守卫：applyDocumentThemeMode 只许在共享 hook 与壳层里调用（防下一个独立页再抄错）、三页都走 hook、hook 与壳层的 deps 都含解析值、用户名按钮 pointer+keyboard 双通道；均跑过红绿闭环 |
+| fix | prd-admin | Codex review 二轮修复：选「随系统」在 Safari 14 之前的浏览器上直接抛（那些 MediaQueryList 只有 addListener，没有 addEventListener），整档功能用不了；新增 lib/mediaQuerySubscribe 共享订阅带老旧回退，watchSystemThemeChange 改走它 |
+| test | prd-admin | 新增 mediaQuerySubscribe 用例（6 例）：现代/老旧/两者皆无/SSR 四种环境的订阅与取消订阅行为，外加「老旧回退不许再抄第五份」棘轮与「随系统不自己 addEventListener」守卫；已跑红绿闭环 |

--- a/changelogs/2026-08-25_sidebar-theme-tri-state.md
+++ b/changelogs/2026-08-25_sidebar-theme-tri-state.md
@@ -1,6 +1,0 @@
-| fix | prd-admin | 侧栏头像真正贴到底：移除 globals.css 里为「左下角 CDS 徽章」留的 52px 底部空位——CDS widget 桌面端早已改锚右侧安全区，这段留白只是把头像顶高了 52px |
-| feat | prd-admin | 皮肤切换从侧栏挪进用户菜单，改为横排三选项：白天（太阳）/ 黑夜（月亮）/ 随系统（电脑），点选不关菜单，当场看到整屏换肤 |
-| feat | prd-admin | 外观偏好新增「随系统」：跟随 prefers-color-scheme，选中后系统深浅一变页面实时跟着变 |
-| refactor | prd-admin | 新增 themeModeRegistry 作为外观选项唯一数据源（标签/描述/图标），侧栏用户菜单、设置-皮肤设置、周报工具条三处改为消费它，不再各写一份 OPTIONS |
-| fix | prd-admin | 加「随系统」的涟漪修复：移动端首页皮肤与分享阅读页主题钮原先直接拿偏好比 'dark'/'light'，选随系统时永远判 false（DOM 已暗、组件按浅色渲染）；新增 useResolvedThemeMode 统一取解析后的明暗 |
-| test | prd-admin | 新增 themeModeRegistry 守卫（11 例）：三选项顺序与图标装配、system 双向解析、三处入口都走注册表、落 DOM 前先 resolve、两处涟漪点不许再比较偏好；cdsCompatibility 守卫改为盯 CDS widget 的右锚判据。均跑过红绿闭环 |

--- a/changelogs/2026-08-25_sidebar-theme-tri-state.md
+++ b/changelogs/2026-08-25_sidebar-theme-tri-state.md
@@ -1,0 +1,6 @@
+| fix | prd-admin | 侧栏头像真正贴到底：移除 globals.css 里为「左下角 CDS 徽章」留的 52px 底部空位——CDS widget 桌面端早已改锚右侧安全区，这段留白只是把头像顶高了 52px |
+| feat | prd-admin | 皮肤切换从侧栏挪进用户菜单，改为横排三选项：白天（太阳）/ 黑夜（月亮）/ 随系统（电脑），点选不关菜单，当场看到整屏换肤 |
+| feat | prd-admin | 外观偏好新增「随系统」：跟随 prefers-color-scheme，选中后系统深浅一变页面实时跟着变 |
+| refactor | prd-admin | 新增 themeModeRegistry 作为外观选项唯一数据源（标签/描述/图标），侧栏用户菜单、设置-皮肤设置、周报工具条三处改为消费它，不再各写一份 OPTIONS |
+| fix | prd-admin | 加「随系统」的涟漪修复：移动端首页皮肤与分享阅读页主题钮原先直接拿偏好比 'dark'/'light'，选随系统时永远判 false（DOM 已暗、组件按浅色渲染）；新增 useResolvedThemeMode 统一取解析后的明暗 |
+| test | prd-admin | 新增 themeModeRegistry 守卫（11 例）：三选项顺序与图标装配、system 双向解析、三处入口都走注册表、落 DOM 前先 resolve、两处涟漪点不许再比较偏好；cdsCompatibility 守卫改为盯 CDS widget 的右锚判据。均跑过红绿闭环 |

--- a/prd-admin/src/hooks/useApplyDocumentTheme.ts
+++ b/prd-admin/src/hooks/useApplyDocumentTheme.ts
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+
+import { applyDocumentThemeMode } from '@/lib/themeTransition';
+import { useMobileThemeStore, useResolvedThemeMode } from '@/stores/mobileThemeStore';
+
+/**
+ * 把全局明暗偏好落到 <html data-theme> 上，并且**跟着系统变化重新落一次**。
+ *
+ * 给 AppShell 之外的独立全屏页用（分享阅读页、数据同步授权/回调页……）。
+ * 这些页面不在 AppShell 里，拿不到壳层的主题接线，各自写一个 effect 就会漏掉一件事：
+ *
+ *   偏好是 'system' 时，用户在系统里切深浅，store 里的 mode **没有变**。
+ *   只把 mode 放进 deps 的 effect 于是不会重跑，DOM 停在旧主题，
+ *   而页面上的主题图标（读的是解析后的值）已经变了 —— 图标和实际配色对不上。
+ *
+ * 所以这里把解析后的值一起放进 deps。新增独立全屏页一律用这个 hook，
+ * 不要再自己写 applyDocumentThemeMode 的 effect（有守卫盯着，见
+ * lib/__tests__/themeModeRegistry.test.ts）。
+ */
+export function useApplyDocumentTheme(pathname: string): void {
+  const mode = useMobileThemeStore((state) => state.mode);
+  const resolved = useResolvedThemeMode();
+
+  useEffect(() => {
+    applyDocumentThemeMode(mode, pathname);
+    // resolved 必须在 deps 里：'system' 偏好下它是唯一会变的那个值。
+  }, [mode, resolved, pathname]);
+}

--- a/prd-admin/src/layouts/AppShell.cdsCompatibility.test.ts
+++ b/prd-admin/src/layouts/AppShell.cdsCompatibility.test.ts
@@ -3,13 +3,15 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
+import { stripComments } from '@/test-utils/sourceScan';
+
 const testDirectory = path.dirname(fileURLToPath(import.meta.url));
 const layoutSource = readFileSync(path.resolve(testDirectory, 'AppShell.tsx'), 'utf8');
 const globalsSource = readFileSync(path.resolve(testDirectory, '../styles/globals.css'), 'utf8');
 // 跨模块读 CDS 注入脚本：侧栏留不留底部空位，取决于它把徽章锚在哪一侧。
-const widgetSource = readFileSync(
-  path.resolve(testDirectory, '../../../cds/src/widget-script.ts'),
-  'utf8',
+// 去注释再扫：判据要回答「这行代码在不在」，注释掉的调用不算在。
+const widgetSource = stripComments(
+  readFileSync(path.resolve(testDirectory, '../../../cds/src/widget-script.ts'), 'utf8'),
 );
 
 describe('AppShell CDS preview compatibility', () => {
@@ -43,13 +45,13 @@ describe('AppShell CDS preview compatibility', () => {
     expect(renderBody).toContain("root.style.bottom=pos.y+'px'");
 
     // 而且 render() 必须在初始化时就被调用一次（不是等到某个交互）。
-    // 判据只认「整行就是这个调用」：最初写成 /── Initial[\s\S]{0,200}?render\(\);/，
-    // 结果把 `// render();` 这种注释掉的调用也判成了证据（红绿闭环时才发现它不变红）。
-    const initBlock = widgetSource.slice(widgetSource.indexOf('── Initial'));
-    const initCalls = initBlock
+    // 定位靠缩进：注入脚本整体包在一个 IIFE 里，顶层语句缩进 2 格，函数体内的调用
+    // 都更深。全文件 29 处 render()，只有初始化那一处在顶层。
+    // （不能用 trim() —— 那会把 29 处全算上；也不能拿注释里的 `── Initial` 当锚点，
+    //   widgetSource 已经去过注释，而且注释本来就不该充当判据。）
+    const topLevelCalls = widgetSource
       .split('\n')
-      .slice(0, 8)
-      .filter((line) => line.trim() === 'render();');
-    expect(initCalls).toHaveLength(1);
+      .filter((line) => /^ {2}render\(\);\s*$/.test(line));
+    expect(topLevelCalls).toHaveLength(1);
   });
 });

--- a/prd-admin/src/layouts/AppShell.cdsCompatibility.test.ts
+++ b/prd-admin/src/layouts/AppShell.cdsCompatibility.test.ts
@@ -26,4 +26,30 @@ describe('AppShell CDS preview compatibility', () => {
     );
     expect(globalsSource).not.toContain('[data-cds-widget-root]) [data-app-sidebar-account]');
   });
+
+  // 上一条只证明「算出来的锚点在右侧」，不证明「这个值真的落到了元素上」。
+  // 徽章的 CSS 默认值是 left:12px（左下角，正好压住贴底的头像），只有 inline style
+  // 覆盖掉它才轮不到 CSS 生效。而 setWidgetPosition() 只在拖拽/缩放时才调 ——
+  // 首屏靠的是 render() 里那两行直接落 pos。这两行删掉，上面的断言依旧全绿，
+  // 徽章却会退回左下角压住头像。所以这条单独盯「接线」。
+  it('首屏由 render() 把 pos 落成 inline style，CSS 默认的 left:12px 轮不到生效', () => {
+    // render() 的函数体：从 function render(){ 到下一个顶层函数 renderLogModal 之前。
+    const renderBody = widgetSource.slice(
+      widgetSource.indexOf('function render(){'),
+      widgetSource.indexOf('function renderLogModal(){'),
+    );
+    expect(renderBody).not.toHaveLength(0);
+    expect(renderBody).toContain("root.style.left=pos.x+'px'");
+    expect(renderBody).toContain("root.style.bottom=pos.y+'px'");
+
+    // 而且 render() 必须在初始化时就被调用一次（不是等到某个交互）。
+    // 判据只认「整行就是这个调用」：最初写成 /── Initial[\s\S]{0,200}?render\(\);/，
+    // 结果把 `// render();` 这种注释掉的调用也判成了证据（红绿闭环时才发现它不变红）。
+    const initBlock = widgetSource.slice(widgetSource.indexOf('── Initial'));
+    const initCalls = initBlock
+      .split('\n')
+      .slice(0, 8)
+      .filter((line) => line.trim() === 'render();');
+    expect(initCalls).toHaveLength(1);
+  });
 });

--- a/prd-admin/src/layouts/AppShell.cdsCompatibility.test.ts
+++ b/prd-admin/src/layouts/AppShell.cdsCompatibility.test.ts
@@ -6,11 +6,24 @@ import { describe, expect, it } from 'vitest';
 const testDirectory = path.dirname(fileURLToPath(import.meta.url));
 const layoutSource = readFileSync(path.resolve(testDirectory, 'AppShell.tsx'), 'utf8');
 const globalsSource = readFileSync(path.resolve(testDirectory, '../styles/globals.css'), 'utf8');
+// 跨模块读 CDS 注入脚本：侧栏留不留底部空位，取决于它把徽章锚在哪一侧。
+const widgetSource = readFileSync(
+  path.resolve(testDirectory, '../../../cds/src/widget-script.ts'),
+  'utf8',
+);
 
 describe('AppShell CDS preview compatibility', () => {
-  it('keeps the sidebar account controls clear of the injected CDS badge', () => {
+  it('侧栏账户区仍是 CDS 徽章避让的锚点（挂钩属性不能被改名）', () => {
     expect(layoutSource).toContain('data-app-sidebar-account');
-    expect(globalsSource).toContain('body:has(> [data-cds-widget-root]) [data-app-sidebar-account]');
-    expect(globalsSource).toContain('padding-bottom: 52px');
+  });
+
+  it('CDS 徽章桌面端锚右侧安全区，所以账户区不再为它留底部空位', () => {
+    // 这两条断言必须一起看：右锚是因，去掉留白是果。
+    // 哪天 widget 改回左下角，第一条会红 —— 那时要把 globals.css 的 52px 留白加回来，
+    // 否则头像又会被徽章压住。
+    expect(widgetSource).toMatch(
+      /function defaultWidgetLeft\(\)\{[\s\S]{0,400}?window\.innerWidth-492/,
+    );
+    expect(globalsSource).not.toContain('[data-cds-widget-root]) [data-app-sidebar-account]');
   });
 });

--- a/prd-admin/src/layouts/AppShell.tsx
+++ b/prd-admin/src/layouts/AppShell.tsx
@@ -69,7 +69,8 @@ import { AvatarEditDialog } from '@/components/ui/AvatarEditDialog';
 import { Dialog } from '@/components/ui/Dialog';
 import { MobileDrawer } from '@/components/ui/MobileDrawer';
 import { MobileTabBar } from '@/components/ui/MobileTabBar';
-import { useMobileThemeStore } from '@/stores/mobileThemeStore';
+import { useMobileThemeStore, watchSystemThemeChange, type MobileThemeMode } from '@/stores/mobileThemeStore';
+import { THEME_MODE_OPTIONS } from '@/lib/themeModeRegistry';
 import { useReaderChromeStore } from '@/stores/readerChromeStore';
 import { MobileSafeBoundary } from '@/components/MobileSafeBoundary';
 import { MobileCompatGate } from '@/components/MobileCompatGate';
@@ -89,7 +90,6 @@ import { FLOATING_DOCK_COLLAPSED_KEY, FLOATING_DOCK_EVENT } from '@/components/d
 import { getSidebarMenuItems } from '@/lib/adminMenuCatalog';
 import { resolveLlmGatewaySso } from '@/lib/llmGatewaySso';
 import { toast } from '@/lib/toast';
-import { ThemeModeToggle } from '@/components/ui/ThemeModeToggle';
 import { MapBrandMark } from '@/components/ui/MapBrandMark';
 import { applyDocumentThemeMode, transitionThemeMode } from '@/lib/themeTransition';
 
@@ -231,14 +231,24 @@ export default function AppShell() {
     ownsThemeRef.current = true;
   }, [mobileThemeMode, location.pathname]);
 
-  const handleThemeModeToggle = useCallback<React.MouseEventHandler<HTMLButtonElement>>((event) => {
+  const handleThemeModeSelect = useCallback((next: MobileThemeMode, event: React.MouseEvent<HTMLElement>) => {
+    if (next === mobileThemeMode) return;
     transitionThemeMode({
-      mode: mobileThemeMode === 'light' ? 'dark' : 'light',
+      mode: next,
       pathname: location.pathname,
       origin: event,
       commit: setThemeMode,
     });
   }, [location.pathname, mobileThemeMode, setThemeMode]);
+
+  // 「随系统」要真的跟着系统走：选了它之后，用户在系统里切深浅，页面得当场变。
+  // 只在 mode === 'system' 时订阅，否则系统怎么变都不该覆盖用户的显式选择。
+  useEffect(() => {
+    if (mobileThemeMode !== 'system') return;
+    return watchSystemThemeChange(() => {
+      applyDocumentThemeMode('system', location.pathname);
+    });
+  }, [mobileThemeMode, location.pathname]);
 
   // 壳层卸载(登出回登录页):清掉自己设置的主题,不让移动浅色泄漏到登录页(Codex P2)
   useEffect(
@@ -1459,18 +1469,7 @@ export default function AppShell() {
               collapsed ? 'flex flex-col items-center gap-1 py-1' : 'px-1 py-1'
             )}
           >
-            <div className="mb-1 flex justify-center px-1">
-              <ThemeModeToggle mode={mobileThemeMode} onToggle={handleThemeModeToggle} />
-            </div>
-            {/* 分隔线 */}
-            <div
-              className={cn('mx-auto mb-2', collapsed ? '' : 'mx-3')}
-              style={{
-                height: 1,
-                background: 'var(--border-faint)',
-                width: collapsed ? 24 : undefined,
-              }}
-            />
+            {/* 皮肤切换已挪进用户菜单（横排三选项），侧栏底部只留头像，让它真正贴底 */}
             <div
               className={cn(
                 'group relative shrink-0 rounded-[10px]',
@@ -1585,6 +1584,52 @@ export default function AppShell() {
                   {/* 让「再点一次头像改头像」这条隐式交互可被看见，不靠用户自己撞出来 */}
                   <div className="mt-2 text-[10px] leading-relaxed" style={{ color: 'var(--text-muted)' }}>
                     再点一次侧栏头像即可修改头像
+                  </div>
+                </div>
+
+                <DropdownMenu.Separator
+                  className="h-px mx-2 my-1"
+                  style={{ background: 'linear-gradient(90deg, transparent 0%, var(--nested-block-bg) 20%, var(--nested-block-bg) 80%, transparent 100%)' }}
+                />
+
+                {/* 外观：横排三选项（白天 / 黑夜 / 随系统）。
+                    用 DropdownMenu.Item 而不是裸 button —— 菜单里的键盘上下键才够得到它；
+                    onSelect 里 preventDefault 让点完菜单不关，用户能当场看见整屏换肤。 */}
+                <div
+                  className="mx-1 mb-1 mt-0.5 rounded-[12px] p-1"
+                  style={{ background: 'var(--nested-block-bg)' }}
+                  role="radiogroup"
+                  aria-label="外观"
+                >
+                  <div className="flex items-stretch gap-1">
+                    {THEME_MODE_OPTIONS.map((option) => {
+                      const Icon = option.icon;
+                      const selected = option.value === mobileThemeMode;
+                      return (
+                        <DropdownMenu.Item
+                          key={option.value}
+                          asChild
+                          onSelect={(event) => event.preventDefault()}
+                        >
+                          <button
+                            type="button"
+                            role="radio"
+                            aria-checked={selected}
+                            title={option.description}
+                            onClick={(event) => handleThemeModeSelect(option.value, event)}
+                            className="flex flex-1 cursor-pointer flex-col items-center justify-center gap-1 rounded-[9px] px-2 py-2 outline-none transition-colors duration-150 focus-visible:ring-2 focus-visible:ring-[var(--border-focus)]"
+                            style={
+                              selected
+                                ? { background: 'var(--selection-icon-bg)', color: 'var(--selection-text)' }
+                                : { background: 'transparent', color: 'var(--text-secondary)' }
+                            }
+                          >
+                            <Icon size={15} aria-hidden />
+                            <span className="text-[11px] leading-none">{option.label}</span>
+                          </button>
+                        </DropdownMenu.Item>
+                      );
+                    })}
                   </div>
                 </div>
 

--- a/prd-admin/src/layouts/AppShell.tsx
+++ b/prd-admin/src/layouts/AppShell.tsx
@@ -1597,45 +1597,48 @@ export default function AppShell() {
                 />
 
                 {/* 外观：横排三选项（白天 / 黑夜 / 随系统）。
-                    用 DropdownMenu.Item 而不是裸 button —— 菜单里的键盘上下键才够得到它；
+                    用 Radix 的 RadioGroup / RadioItem，不是 Item + 自己写 role="radio" ——
+                    后者会把 Item 给的 role="menuitem" 覆盖掉，菜单里就多出几个裸 radio，
+                    屏幕阅读器读到的结构和导航上下文都是坏的（Codex review 四轮 P2）。
+                    RadioGroup 落 role="group"、RadioItem 落 role="menuitemradio" + aria-checked，
+                    这两个才是 menu 的合法子角色，选中态也不用自己声明。
+                    不传 onValueChange：提交只走 button 的 onClick 一条路（它需要鼠标事件当
+                    换肤动画的原点），避免两条路各提交一次。
                     onSelect 里 preventDefault 让点完菜单不关，用户能当场看见整屏换肤。 */}
-                <div
-                  className="mx-1 mb-1 mt-0.5 rounded-[12px] p-1"
-                  style={{ background: 'var(--nested-block-bg)' }}
-                  role="radiogroup"
+                <DropdownMenu.RadioGroup
+                  value={mobileThemeMode}
                   aria-label="外观"
+                  className="mx-1 mb-1 mt-0.5 flex items-stretch gap-1 rounded-[12px] p-1"
+                  style={{ background: 'var(--nested-block-bg)' }}
                 >
-                  <div className="flex items-stretch gap-1">
-                    {THEME_MODE_OPTIONS.map((option) => {
-                      const Icon = option.icon;
-                      const selected = option.value === mobileThemeMode;
-                      return (
-                        <DropdownMenu.Item
-                          key={option.value}
-                          asChild
-                          onSelect={(event) => event.preventDefault()}
+                  {THEME_MODE_OPTIONS.map((option) => {
+                    const Icon = option.icon;
+                    const selected = option.value === mobileThemeMode;
+                    return (
+                      <DropdownMenu.RadioItem
+                        key={option.value}
+                        value={option.value}
+                        asChild
+                        onSelect={(event) => event.preventDefault()}
+                      >
+                        <button
+                          type="button"
+                          title={option.description}
+                          onClick={(event) => handleThemeModeSelect(option.value, event)}
+                          className="flex flex-1 cursor-pointer flex-col items-center justify-center gap-1 rounded-[9px] px-2 py-2 outline-none transition-colors duration-150 focus-visible:ring-2 focus-visible:ring-[var(--border-focus)]"
+                          style={
+                            selected
+                              ? { background: 'var(--selection-icon-bg)', color: 'var(--selection-text)' }
+                              : { background: 'transparent', color: 'var(--text-secondary)' }
+                          }
                         >
-                          <button
-                            type="button"
-                            role="radio"
-                            aria-checked={selected}
-                            title={option.description}
-                            onClick={(event) => handleThemeModeSelect(option.value, event)}
-                            className="flex flex-1 cursor-pointer flex-col items-center justify-center gap-1 rounded-[9px] px-2 py-2 outline-none transition-colors duration-150 focus-visible:ring-2 focus-visible:ring-[var(--border-focus)]"
-                            style={
-                              selected
-                                ? { background: 'var(--selection-icon-bg)', color: 'var(--selection-text)' }
-                                : { background: 'transparent', color: 'var(--text-secondary)' }
-                            }
-                          >
-                            <Icon size={15} aria-hidden />
-                            <span className="text-[11px] leading-none">{option.label}</span>
-                          </button>
-                        </DropdownMenu.Item>
-                      );
-                    })}
-                  </div>
-                </div>
+                          <Icon size={15} aria-hidden />
+                          <span className="text-[11px] leading-none">{option.label}</span>
+                        </button>
+                      </DropdownMenu.RadioItem>
+                    );
+                  })}
+                </DropdownMenu.RadioGroup>
 
                 <DropdownMenu.Separator
                   className="h-px mx-2 my-1"

--- a/prd-admin/src/layouts/AppShell.tsx
+++ b/prd-admin/src/layouts/AppShell.tsx
@@ -46,7 +46,6 @@ import {
   GraduationCap,
   Droplets,
   ExternalLink,
-  MoreHorizontal,
   type LucideIcon,
 } from 'lucide-react';
 import * as LucideIcons from 'lucide-react';
@@ -75,6 +74,7 @@ import { useReaderChromeStore } from '@/stores/readerChromeStore';
 import { MobileSafeBoundary } from '@/components/MobileSafeBoundary';
 import { MobileCompatGate } from '@/components/MobileCompatGate';
 import { resolveAvatarUrl } from '@/lib/avatar';
+import { resolveAccountAvatarAction } from './accountAvatarAction';
 import { UserAvatar } from '@/components/ui/UserAvatar';
 import { AvatarProgressRing } from '@/components/daily-tips/AvatarProgressRing';
 import { createLlmGatewaySsoTicket, getAdminNotifications, handleAdminNotification, handleAllAdminNotifications, uploadMyAvatar } from '@/services';
@@ -273,6 +273,36 @@ export default function AppShell() {
     return Array.from(merged);
   }, [defaultNavHidden, navHidden, navOrder]);
   const [avatarOpen, setAvatarOpen] = useState(false);
+  // 侧栏用户菜单：受控开关。头像同时承担「打开菜单」与「再点一次改头像」两种语义，
+  // 不能交给 Radix Trigger 自己 toggle，否则第二次点击只会把菜单关掉。
+  const [userMenuOpen, setUserMenuOpen] = useState(false);
+  const userMenuOpenRef = useRef(false);
+  // 从菜单直接跳进头像编辑弹窗时，别让菜单把焦点抢回头像，否则和 Dialog 的焦点陷阱打架。
+  const skipUserMenuRefocusRef = useRef(false);
+  const handleUserMenuOpenChange = useCallback((next: boolean) => {
+    userMenuOpenRef.current = next;
+    setUserMenuOpen(next);
+  }, []);
+  // 头像点击语义：第一次点开用户菜单，菜单开着时再点一次才进「修改我的头像」。
+  // 判定必须落在 pointerdown —— Radix 的 Trigger 也挂在 pointerdown 上，
+  // composeEventHandlers 见到 defaultPrevented 就会跳过它，菜单开合于是完全由这里决定。
+  const handleAccountAvatarPointerDown = useCallback((event: React.PointerEvent<HTMLButtonElement>) => {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    if (resolveAccountAvatarAction(userMenuOpenRef.current) === 'edit-avatar') {
+      skipUserMenuRefocusRef.current = true;
+      handleUserMenuOpenChange(false);
+      setAvatarOpen(true);
+      return;
+    }
+    handleUserMenuOpenChange(true);
+  }, [handleUserMenuOpenChange]);
+  // 展开态的用户名按钮：纯 toggle，不再是 Trigger（一个 Root 只能有一个锚点，锚点归头像）。
+  const handleUserMenuTogglePointerDown = useCallback((event: React.PointerEvent<HTMLButtonElement>) => {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    handleUserMenuOpenChange(!userMenuOpenRef.current);
+  }, [handleUserMenuOpenChange]);
   const [notificationDialogOpen, setNotificationDialogOpen] = useState(false);
   const [notificationDialogTab, setNotificationDialogTab] = useState<'list' | 'subscriptions'>('list');
   const [notifications, setNotifications] = useState<AdminNotificationItem[]>([]);
@@ -1455,60 +1485,51 @@ export default function AppShell() {
               />
 
               <div className={cn('relative flex items-center', collapsed ? 'flex-col justify-center gap-1' : 'gap-3')}>
-                {/* 头像直接打开编辑器，用户名保留用户菜单入口。 */}
-                <DropdownMenu.Root>
+                {/* 头像是唯一的用户菜单入口：点一次开菜单，菜单开着时再点一次进「修改我的头像」。
+                    原来的「···」按钮已移除，头像因此落到侧栏最底部。 */}
+                <DropdownMenu.Root open={userMenuOpen} onOpenChange={handleUserMenuOpenChange} modal={false}>
                   <div className={cn('flex items-center', collapsed ? 'flex-col gap-1' : 'gap-3 flex-1 min-w-0')}>
-                    <button
-                      type="button"
-                      onClick={() => setAvatarOpen(true)}
-                      className="shrink-0 cursor-pointer rounded-full transition-opacity hover:opacity-85 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-focus)]"
-                      aria-label="修改我的头像"
-                      title="修改我的头像"
-                    >
-                      {/* 头像外圈 = 教程掌握度进度环(诉求 12):已学会本页教程占比,满环加毕业角标 */}
-                      <AvatarProgressRing size={30} stroke={2.5}>
-                        <UserAvatar
-                          src={resolveAvatarUrl({
-                            username: user?.username,
-                            userType: user?.userType,
-                            botKind: user?.botKind,
-                            avatarFileName: user?.avatarFileName ?? null,
-                            avatarUrl: user?.avatarUrl,
-                          })}
-                          alt="avatar"
-                          className="h-full w-full object-cover"
-                        />
-                      </AvatarProgressRing>
-                    </button>
-
-                    {collapsed && (
-                      <DropdownMenu.Trigger asChild>
-                        <button
-                          type="button"
-                          className="flex h-7 w-8 cursor-pointer items-center justify-center rounded-[8px] text-token-muted transition-colors hover-bg-soft focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-focus)]"
-                          aria-label="打开用户菜单"
-                          title="用户菜单"
-                        >
-                          <MoreHorizontal size={16} />
-                        </button>
-                      </DropdownMenu.Trigger>
-                    )}
+                    <DropdownMenu.Trigger asChild>
+                      <button
+                        type="button"
+                        onPointerDown={handleAccountAvatarPointerDown}
+                        className="shrink-0 cursor-pointer rounded-full transition-opacity hover:opacity-85 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-focus)]"
+                        aria-label={userMenuOpen ? '修改我的头像' : '打开用户菜单'}
+                        title={userMenuOpen ? '修改我的头像' : '用户菜单（再点一次头像可修改头像）'}
+                      >
+                        {/* 头像外圈 = 教程掌握度进度环(诉求 12):已学会本页教程占比,满环加毕业角标 */}
+                        <AvatarProgressRing size={30} stroke={2.5}>
+                          <UserAvatar
+                            src={resolveAvatarUrl({
+                              username: user?.username,
+                              userType: user?.userType,
+                              botKind: user?.botKind,
+                              avatarFileName: user?.avatarFileName ?? null,
+                              avatarUrl: user?.avatarUrl,
+                            })}
+                            alt="avatar"
+                            className="h-full w-full object-cover"
+                          />
+                        </AvatarProgressRing>
+                      </button>
+                    </DropdownMenu.Trigger>
 
                     {/* 用户信息（仅展开时显示，点击后打开用户菜单） */}
                     {!collapsed && (
-                      <DropdownMenu.Trigger asChild>
-                        <button
-                          type="button"
-                          className="min-w-0 flex-1 cursor-pointer rounded-[8px] text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-focus)]"
-                          title="用户菜单"
-                        >
+                      <button
+                        type="button"
+                        onPointerDown={handleUserMenuTogglePointerDown}
+                        className="min-w-0 flex-1 cursor-pointer rounded-[8px] text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-focus)]"
+                        aria-haspopup="menu"
+                        aria-expanded={userMenuOpen}
+                        title="用户菜单"
+                      >
                         <div className="min-w-0 flex-1">
                           <div className="text-[12px] font-semibold truncate" style={{ color: 'var(--text-primary)', letterSpacing: '-0.01em' }}>
                             {user?.displayName || 'Admin'}
                           </div>
                         </div>
-                        </button>
-                      </DropdownMenu.Trigger>
+                      </button>
                     )}
                   </div>
 
@@ -1519,6 +1540,11 @@ export default function AppShell() {
                 sideOffset={8}
                 side="top"
                 align="start"
+                onCloseAutoFocus={(event) => {
+                  if (!skipUserMenuRefocusRef.current) return;
+                  skipUserMenuRefocusRef.current = false;
+                  event.preventDefault();
+                }}
               >
                 {/* 用户信息区 */}
                 <div className="px-2 py-3">
@@ -1555,6 +1581,10 @@ export default function AppShell() {
                         {user?.role === 'ADMIN' ? '系统管理员' : user?.role || ''}
                       </div>
                     </div>
+                  </div>
+                  {/* 让「再点一次头像改头像」这条隐式交互可被看见，不靠用户自己撞出来 */}
+                  <div className="mt-2 text-[10px] leading-relaxed" style={{ color: 'var(--text-muted)' }}>
+                    再点一次侧栏头像即可修改头像
                   </div>
                 </div>
 
@@ -1769,8 +1799,7 @@ export default function AppShell() {
             </div>
           </div>
 
-          {/* 底部间距 */}
-          <div className="shrink-0 h-1" />
+          {/* 头像已是侧栏最后一个控件，不再留额外底部间距，让它真正贴到底 */}
 
           <AvatarEditDialog
             open={avatarOpen}

--- a/prd-admin/src/layouts/AppShell.tsx
+++ b/prd-admin/src/layouts/AppShell.tsx
@@ -69,13 +69,13 @@ import { AvatarEditDialog } from '@/components/ui/AvatarEditDialog';
 import { Dialog } from '@/components/ui/Dialog';
 import { MobileDrawer } from '@/components/ui/MobileDrawer';
 import { MobileTabBar } from '@/components/ui/MobileTabBar';
-import { useMobileThemeStore, watchSystemThemeChange, type MobileThemeMode } from '@/stores/mobileThemeStore';
+import { useMobileThemeStore, useResolvedThemeMode, type MobileThemeMode } from '@/stores/mobileThemeStore';
 import { THEME_MODE_OPTIONS } from '@/lib/themeModeRegistry';
 import { useReaderChromeStore } from '@/stores/readerChromeStore';
 import { MobileSafeBoundary } from '@/components/MobileSafeBoundary';
 import { MobileCompatGate } from '@/components/MobileCompatGate';
 import { resolveAvatarUrl } from '@/lib/avatar';
-import { resolveAccountAvatarAction } from './accountAvatarAction';
+import { isMenuKeyboardActivation, resolveAccountAvatarAction } from './accountAvatarAction';
 import { UserAvatar } from '@/components/ui/UserAvatar';
 import { AvatarProgressRing } from '@/components/daily-tips/AvatarProgressRing';
 import { createLlmGatewaySsoTicket, getAdminNotifications, handleAdminNotification, handleAllAdminNotifications, uploadMyAvatar } from '@/services';
@@ -212,6 +212,9 @@ export default function AppShell() {
   const { isMobile } = useBreakpoint();
   const mobileThemeMode = useMobileThemeStore((st) => st.mode);
   const setThemeMode = useMobileThemeStore((st) => st.setMode);
+  // 解析后的明暗（'system' 已展开）。订阅系统深浅变化这件事收在 hook 里，
+  // 壳层不再自己写一份 matchMedia 监听 —— 两份实现迟早漂移。
+  const resolvedThemeMode = useResolvedThemeMode();
   // 壳层是否"持有"过 data-theme:只有自己设过的才负责清,避免动到
   // 仍保留纸面身份的独立页面主题。
   const ownsThemeRef = useRef(false);
@@ -221,6 +224,8 @@ export default function AppShell() {
   // 壳层统一落 <html data-theme>。deps 带 pathname:自管主题的页面卸载清属性后,
   // 导航到普通页由这里重申。自管主题路由(独立纸面身份,页面自己 set/remove data-theme)
   // 壳层不插手,否则父 effect 晚于子 effect 运行,会把页面刚设好的主题清掉。
+  // resolvedThemeMode 必须在 deps 里：偏好是 'system' 时 mobileThemeMode 不变、
+  // 只有它会跟着系统深浅翻面 —— 少了它，选「随系统」后系统切换不会重新落 DOM。
   useEffect(() => {
     if (!applyDocumentThemeMode(mobileThemeMode, location.pathname)) {
       // 属性所有权移交给页面:壳层卸载也不清理,避免误清页面自管的主题(Codex P2 二轮)。
@@ -229,7 +234,7 @@ export default function AppShell() {
       return;
     }
     ownsThemeRef.current = true;
-  }, [mobileThemeMode, location.pathname]);
+  }, [mobileThemeMode, resolvedThemeMode, location.pathname]);
 
   const handleThemeModeSelect = useCallback((next: MobileThemeMode, event: React.MouseEvent<HTMLElement>) => {
     if (next === mobileThemeMode) return;
@@ -240,15 +245,6 @@ export default function AppShell() {
       commit: setThemeMode,
     });
   }, [location.pathname, mobileThemeMode, setThemeMode]);
-
-  // 「随系统」要真的跟着系统走：选了它之后，用户在系统里切深浅，页面得当场变。
-  // 只在 mode === 'system' 时订阅，否则系统怎么变都不该覆盖用户的显式选择。
-  useEffect(() => {
-    if (mobileThemeMode !== 'system') return;
-    return watchSystemThemeChange(() => {
-      applyDocumentThemeMode('system', location.pathname);
-    });
-  }, [mobileThemeMode, location.pathname]);
 
   // 壳层卸载(登出回登录页):清掉自己设置的主题,不让移动浅色泄漏到登录页(Codex P2)
   useEffect(
@@ -310,6 +306,13 @@ export default function AppShell() {
   // 展开态的用户名按钮：纯 toggle，不再是 Trigger（一个 Root 只能有一个锚点，锚点归头像）。
   const handleUserMenuTogglePointerDown = useCallback((event: React.PointerEvent<HTMLButtonElement>) => {
     if (event.button !== 0) return;
+    event.preventDefault();
+    handleUserMenuOpenChange(!userMenuOpenRef.current);
+  }, [handleUserMenuOpenChange]);
+  // 不再是 Trigger 就没有它自带的键盘激活；Enter / Space 不发 pointerdown，
+  // 必须自己补，否则这个按钮对键盘用户是死的。
+  const handleUserMenuToggleKeyDown = useCallback((event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (!isMenuKeyboardActivation(event.key)) return;
     event.preventDefault();
     handleUserMenuOpenChange(!userMenuOpenRef.current);
   }, [handleUserMenuOpenChange]);
@@ -1518,6 +1521,7 @@ export default function AppShell() {
                       <button
                         type="button"
                         onPointerDown={handleUserMenuTogglePointerDown}
+                        onKeyDown={handleUserMenuToggleKeyDown}
                         className="min-w-0 flex-1 cursor-pointer rounded-[8px] text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-focus)]"
                         aria-haspopup="menu"
                         aria-expanded={userMenuOpen}

--- a/prd-admin/src/layouts/accountAvatarAction.test.ts
+++ b/prd-admin/src/layouts/accountAvatarAction.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { resolveAccountAvatarAction } from './accountAvatarAction';
+
+const testDirectory = path.dirname(fileURLToPath(import.meta.url));
+const layoutSource = readFileSync(path.resolve(testDirectory, 'AppShell.tsx'), 'utf8');
+
+describe('侧栏底部头像的点击语义', () => {
+  it('菜单关着时，点头像是打开用户菜单', () => {
+    expect(resolveAccountAvatarAction(false)).toBe('open-user-menu');
+  });
+
+  it('菜单开着时，再点一次头像才是修改头像', () => {
+    expect(resolveAccountAvatarAction(true)).toBe('edit-avatar');
+  });
+
+  it('AppShell 的头像事件走的是这个唯一判定源（防止有人把语义又写回事件处理里）', () => {
+    expect(layoutSource).toContain('resolveAccountAvatarAction(userMenuOpenRef.current)');
+  });
+
+  it('头像本身是用户菜单的触发器，且侧栏不再有独立的「···」入口', () => {
+    // 触发器必须包着头像进度环，否则「点头像开菜单」这条诉求就掉了。
+    expect(layoutSource).toMatch(
+      /DropdownMenu\.Trigger asChild>\s*<button[\s\S]{0,1400}?<AvatarProgressRing/
+    );
+    // 「···」按钮（MoreHorizontal）已从侧栏移除，连 import 都不该留。
+    expect(layoutSource).not.toContain('MoreHorizontal');
+  });
+});

--- a/prd-admin/src/layouts/accountAvatarAction.test.ts
+++ b/prd-admin/src/layouts/accountAvatarAction.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
-import { resolveAccountAvatarAction } from './accountAvatarAction';
+import { isMenuKeyboardActivation, resolveAccountAvatarAction } from './accountAvatarAction';
 
 const testDirectory = path.dirname(fileURLToPath(import.meta.url));
 const layoutSource = readFileSync(path.resolve(testDirectory, 'AppShell.tsx'), 'utf8');
@@ -28,5 +28,30 @@ describe('侧栏底部头像的点击语义', () => {
     );
     // 「···」按钮（MoreHorizontal）已从侧栏移除，连 import 都不该留。
     expect(layoutSource).not.toContain('MoreHorizontal');
+  });
+});
+
+describe('展开态用户名按钮的键盘可达性', () => {
+  // 它从 DropdownMenu.Trigger 退回普通 button 时丢了 Trigger 自带的键盘激活。
+  // Enter / Space 不发 pointerdown —— 只挂 onPointerDown 的按钮对键盘用户是死的。
+  it('Enter 与 Space 算激活', () => {
+    expect(isMenuKeyboardActivation('Enter')).toBe(true);
+    expect(isMenuKeyboardActivation(' ')).toBe(true);
+    expect(isMenuKeyboardActivation('Spacebar')).toBe(true);
+  });
+
+  it('普通字符与导航键不算激活', () => {
+    for (const key of ['a', 'Tab', 'Escape', 'ArrowDown', 'Shift']) {
+      expect(isMenuKeyboardActivation(key)).toBe(false);
+    }
+  });
+
+  it('用户名按钮同时挂了 onPointerDown 和 onKeyDown（少一个就有一半用户点不动）', () => {
+    const block = layoutSource.slice(
+      layoutSource.indexOf('handleUserMenuTogglePointerDown}'),
+      layoutSource.indexOf('handleUserMenuTogglePointerDown}') + 400,
+    );
+    expect(block).toContain('onKeyDown={handleUserMenuToggleKeyDown}');
+    expect(block).toContain('aria-haspopup="menu"');
   });
 });

--- a/prd-admin/src/layouts/accountAvatarAction.ts
+++ b/prd-admin/src/layouts/accountAvatarAction.ts
@@ -14,3 +14,15 @@ export type AccountAvatarAction = 'open-user-menu' | 'edit-avatar';
 export function resolveAccountAvatarAction(userMenuOpen: boolean): AccountAvatarAction {
   return userMenuOpen ? 'edit-avatar' : 'open-user-menu';
 }
+
+/**
+ * 键盘是不是在「激活」这个菜单按钮。
+ *
+ * 展开态的用户名按钮不再是 Radix 的 DropdownMenu.Trigger（一个 Root 只能有一个锚点，
+ * 锚点归头像），因此也失去了 Trigger 自带的键盘激活。它只挂 onPointerDown，而键盘
+ * 敲 Enter / Space **不会**触发 pointerdown —— 光靠指针处理，这个 aria-haspopup="menu"
+ * 的按钮对键盘用户就是死的。所以显式补一条键盘判据。
+ */
+export function isMenuKeyboardActivation(key: string): boolean {
+  return key === 'Enter' || key === ' ' || key === 'Spacebar';
+}

--- a/prd-admin/src/layouts/accountAvatarAction.ts
+++ b/prd-admin/src/layouts/accountAvatarAction.ts
@@ -1,0 +1,16 @@
+/**
+ * 侧栏底部头像的点击语义（唯一判定源）。
+ *
+ * 侧栏底部原本有两个控件：头像（直接开「修改我的头像」）+「···」（开用户菜单）。
+ * 现在「···」已移除，头像同时承担两件事，靠「菜单当前开没开」区分：
+ *   - 菜单关着：这一次点击是「打开用户菜单」
+ *   - 菜单开着：这一次点击才是「修改我的头像」
+ *
+ * 抽成函数是为了让这条语义有一个能变红的判据 —— 直接写在 AppShell 的事件处理里，
+ * 删掉也没有任何测试会红。
+ */
+export type AccountAvatarAction = 'open-user-menu' | 'edit-avatar';
+
+export function resolveAccountAvatarAction(userMenuOpen: boolean): AccountAvatarAction {
+  return userMenuOpen ? 'edit-avatar' : 'open-user-menu';
+}

--- a/prd-admin/src/lib/__tests__/mediaQuerySubscribe.test.ts
+++ b/prd-admin/src/lib/__tests__/mediaQuerySubscribe.test.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { subscribeMediaQuery } from '../mediaQuerySubscribe';
+import { stripComments } from '@/test-utils/sourceScan';
 
 const testDirectory = path.dirname(fileURLToPath(import.meta.url));
 const srcDirectory = path.resolve(testDirectory, '../..');
@@ -91,9 +92,12 @@ describe('老旧 Safari 回退不许再抄第五份', () => {
   });
 
   it('「随系统」的订阅走共享实现，不自己 addEventListener', () => {
-    const store = readFileSync(path.resolve(srcDirectory, 'stores/mobileThemeStore.ts'), 'utf8');
+    // 扫之前先去注释：这个文件的注释正好解释「为什么不能直接 addEventListener」，
+    // 判据看得见注释就会误红（本 PR 二轮踩过一次）。
+    const store = stripComments(
+      readFileSync(path.resolve(srcDirectory, 'stores/mobileThemeStore.ts'), 'utf8'),
+    );
     expect(store).toContain('subscribeMediaQuery(SYSTEM_DARK_QUERY');
-    // 只认真正的调用；注释里提到这个名字（解释为什么不能直接用它）不该判红。
-    expect(store).not.toMatch(/\.addEventListener\s*\(/);
+    expect(store).not.toContain('addEventListener');
   });
 });

--- a/prd-admin/src/lib/__tests__/mediaQuerySubscribe.test.ts
+++ b/prd-admin/src/lib/__tests__/mediaQuerySubscribe.test.ts
@@ -1,0 +1,99 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { subscribeMediaQuery } from '../mediaQuerySubscribe';
+
+const testDirectory = path.dirname(fileURLToPath(import.meta.url));
+const srcDirectory = path.resolve(testDirectory, '../..');
+
+function listSourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return listSourceFiles(full);
+    return /\.tsx?$/.test(entry.name) ? [full] : [];
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('subscribeMediaQuery', () => {
+  it('现代浏览器走 addEventListener，并能取消订阅', () => {
+    const add = vi.fn();
+    const remove = vi.fn();
+    vi.stubGlobal('window', {
+      matchMedia: () => ({ matches: false, addEventListener: add, removeEventListener: remove }),
+    });
+
+    const onChange = () => {};
+    const unsubscribe = subscribeMediaQuery('(prefers-color-scheme: dark)', onChange);
+    expect(add).toHaveBeenCalledWith('change', onChange);
+
+    unsubscribe();
+    expect(remove).toHaveBeenCalledWith('change', onChange);
+  });
+
+  it('老旧 Safari（只有 addListener）不抛，改走 addListener/removeListener', () => {
+    const addLegacy = vi.fn();
+    const removeLegacy = vi.fn();
+    // Safari < 14 的 MediaQueryList：没有 addEventListener 这个属性
+    vi.stubGlobal('window', {
+      matchMedia: () => ({ matches: false, addListener: addLegacy, removeListener: removeLegacy }),
+    });
+
+    const onChange = () => {};
+    let unsubscribe: (() => void) | undefined;
+    expect(() => {
+      unsubscribe = subscribeMediaQuery('(prefers-color-scheme: dark)', onChange);
+    }).not.toThrow();
+    expect(addLegacy).toHaveBeenCalledWith(onChange);
+
+    unsubscribe?.();
+    expect(removeLegacy).toHaveBeenCalledWith(onChange);
+  });
+
+  it('两个 API 都没有时不抛（极端老环境），取消订阅也安全', () => {
+    vi.stubGlobal('window', { matchMedia: () => ({ matches: false }) });
+    let unsubscribe: (() => void) | undefined;
+    expect(() => {
+      unsubscribe = subscribeMediaQuery('(prefers-color-scheme: dark)', () => {});
+    }).not.toThrow();
+    expect(() => unsubscribe?.()).not.toThrow();
+  });
+
+  it('拿不到 matchMedia（SSR）时返回空取消函数', () => {
+    vi.stubGlobal('window', {});
+    expect(() => subscribeMediaQuery('(prefers-color-scheme: dark)', () => {})()).not.toThrow();
+  });
+});
+
+describe('老旧 Safari 回退不许再抄第五份', () => {
+  // 本仓库此前已有三处各写一份回退，第四处（外观「随系统」）漏写就直接踩中
+  // 「addEventListener is not a function」。这条是棘轮：只许减不许增。
+  const KNOWN_LEGACY_COPIES = [
+    'lib/mediaQuerySubscribe.ts',        // 唯一实现，新代码都该用它
+    'lib/useReducedMotion.ts',           // 存量，未迁移
+    'stores/themeStore.ts',              // 存量，未迁移
+    'hooks/usePrefersReducedMotion.ts',  // 存量，未迁移
+  ];
+
+  it('自己写 addListener 回退的文件不超出已知清单', () => {
+    const offenders = listSourceFiles(srcDirectory)
+      .filter((file) => !file.includes('__tests__') && !file.endsWith('.test.ts'))
+      .filter((file) => /\.addListener\s*[?(]/.test(readFileSync(file, 'utf8')))
+      .map((file) => path.relative(srcDirectory, file).split(path.sep).join('/'))
+      .filter((rel) => !KNOWN_LEGACY_COPIES.includes(rel));
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('「随系统」的订阅走共享实现，不自己 addEventListener', () => {
+    const store = readFileSync(path.resolve(srcDirectory, 'stores/mobileThemeStore.ts'), 'utf8');
+    expect(store).toContain('subscribeMediaQuery(SYSTEM_DARK_QUERY');
+    // 只认真正的调用；注释里提到这个名字（解释为什么不能直接用它）不该判红。
+    expect(store).not.toMatch(/\.addEventListener\s*\(/);
+  });
+});

--- a/prd-admin/src/lib/__tests__/themeModeRegistry.test.ts
+++ b/prd-admin/src/lib/__tests__/themeModeRegistry.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -9,6 +9,14 @@ import { resolveThemeMode } from '@/stores/mobileThemeStore';
 const testDirectory = path.dirname(fileURLToPath(import.meta.url));
 const srcDirectory = path.resolve(testDirectory, '../..');
 const read = (relative: string) => readFileSync(path.resolve(srcDirectory, relative), 'utf8');
+
+function listSourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return listSourceFiles(full);
+    return /\.tsx?$/.test(entry.name) ? [full] : [];
+  });
+}
 
 // 本套件跑在 node 环境（仓库没配 jsdom），所以要连 window 一起造 ——
 // 只 stub matchMedia 的话 `typeof window === 'undefined'` 那条兜底会先命中，
@@ -91,5 +99,39 @@ describe('拿明暗做分支的地方不许直接比较偏好（否则「随系�
     const source = read(relative);
     expect(source).toContain('useResolvedThemeMode');
     expect(source).not.toMatch(/themeMode === '(dark|light)'/);
+  });
+});
+
+describe('AppShell 之外的独立全屏页必须走共享 hook 落主题', () => {
+  // 这些页面不在 AppShell 里，各自写 effect 时都漏了同一件事：偏好是 'system' 时
+  // store 里的 mode 不变，只把 mode 放进 deps 的 effect 不会重跑，DOM 停在旧主题。
+  // 收敛成 useApplyDocumentTheme 之后，这条守卫防止下一个独立页再抄一份错的。
+  const ALLOWED_CALLERS = [
+    'hooks/useApplyDocumentTheme.ts', // 唯一实现
+    'layouts/AppShell.tsx',           // 壳层自己要管 data-theme 的所有权，单独一份
+    'lib/themeTransition.ts',         // 定义处
+  ];
+
+  it('applyDocumentThemeMode 只允许在唯一实现与壳层里被调用', () => {
+    const offenders = listSourceFiles(srcDirectory)
+      .filter((file) => !file.includes('__tests__') && !file.endsWith('.test.ts'))
+      .filter((file) => readFileSync(file, 'utf8').includes('applyDocumentThemeMode('))
+      .map((file) => path.relative(srcDirectory, file).split(path.sep).join('/'))
+      .filter((rel) => !ALLOWED_CALLERS.includes(rel));
+
+    expect(offenders).toEqual([]);
+  });
+
+  it.each([
+    ['分享阅读页', 'pages/library/LibraryShareViewPage.tsx'],
+    ['数据同步授权页', 'pages/data-sync/DataSyncAuthorizePage.tsx'],
+    ['数据同步回调页', 'pages/data-sync/DataSyncCallbackPage.tsx'],
+  ])('%s 用 useApplyDocumentTheme', (_name, relative) => {
+    expect(read(relative)).toContain('useApplyDocumentTheme(');
+  });
+
+  it('hook 与壳层都把解析后的明暗放进了 effect deps', () => {
+    expect(read('hooks/useApplyDocumentTheme.ts')).toContain('[mode, resolved, pathname]');
+    expect(read('layouts/AppShell.tsx')).toContain('[mobileThemeMode, resolvedThemeMode, location.pathname]');
   });
 });

--- a/prd-admin/src/lib/__tests__/themeModeRegistry.test.ts
+++ b/prd-admin/src/lib/__tests__/themeModeRegistry.test.ts
@@ -1,0 +1,95 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { THEME_MODE_OPTIONS, THEME_MODE_ORDER, THEME_MODE_REGISTRY } from '../themeModeRegistry';
+import { resolveThemeMode } from '@/stores/mobileThemeStore';
+
+const testDirectory = path.dirname(fileURLToPath(import.meta.url));
+const srcDirectory = path.resolve(testDirectory, '../..');
+const read = (relative: string) => readFileSync(path.resolve(srcDirectory, relative), 'utf8');
+
+// 本套件跑在 node 环境（仓库没配 jsdom），所以要连 window 一起造 ——
+// 只 stub matchMedia 的话 `typeof window === 'undefined'` 那条兜底会先命中，
+// 用例会假绿（两个方向都返回 dark，而 dark 恰好是其中一个期望值）。
+function stubMatchMedia(prefersDark: boolean) {
+  vi.stubGlobal('window', {
+    matchMedia: (query: string) => ({
+      matches: query.includes('dark') ? prefersDark : !prefersDark,
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }),
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('外观偏好注册表', () => {
+  it('横排就是白天 / 黑夜 / 随系统三项，顺序固定', () => {
+    expect(THEME_MODE_ORDER).toEqual(['light', 'dark', 'system']);
+    expect(THEME_MODE_OPTIONS.map((o) => o.label)).toEqual(['白天', '黑夜', '随系统']);
+  });
+
+  it('三项各自带图标，且图标互不相同（太阳 / 月亮 / 电脑）', () => {
+    const icons = THEME_MODE_OPTIONS.map((o) => o.icon);
+    expect(icons.every(Boolean)).toBe(true);
+    expect(new Set(icons).size).toBe(3);
+    // 断言的是「装配结果」而不是源码里出现过这几个名字：图标对调、三项都赋同一个，
+    // 光扫 import 是发现不了的。
+    expect(THEME_MODE_REGISTRY.light.icon.displayName ?? THEME_MODE_REGISTRY.light.icon.name).toMatch(/Sun/i);
+    expect(THEME_MODE_REGISTRY.dark.icon.displayName ?? THEME_MODE_REGISTRY.dark.icon.name).toMatch(/Moon/i);
+    expect(THEME_MODE_REGISTRY.system.icon.displayName ?? THEME_MODE_REGISTRY.system.icon.name).toMatch(/Monitor/i);
+  });
+});
+
+describe('随系统的解析', () => {
+  it('系统偏暗时 system 解析成 dark', () => {
+    stubMatchMedia(true);
+    expect(resolveThemeMode('system')).toBe('dark');
+  });
+
+  it('系统偏亮时 system 解析成 light', () => {
+    stubMatchMedia(false);
+    expect(resolveThemeMode('system')).toBe('light');
+  });
+
+  it('用户显式选了白天/黑夜就不看系统', () => {
+    stubMatchMedia(true);
+    expect(resolveThemeMode('light')).toBe('light');
+    stubMatchMedia(false);
+    expect(resolveThemeMode('dark')).toBe('dark');
+  });
+});
+
+describe('三处外观入口都走同一份注册表', () => {
+  // 这三处历史上各写一份 OPTIONS 数组。谁再抄一份，选了「随系统」后那一处会三个都不高亮，
+  // 而且不会有任何测试红 —— 所以这条守卫盯的是「有没有人在用注册表」。
+  it.each([
+    ['侧栏用户菜单', 'layouts/AppShell.tsx'],
+    ['设置-皮肤设置', 'pages/settings/ThemeSkinEditor.tsx'],
+    ['周报 Agent 工具条', 'pages/report-agent/components/ThemeControl.tsx'],
+  ])('%s 消费 THEME_MODE_OPTIONS', (_name, relative) => {
+    expect(read(relative)).toContain('THEME_MODE_OPTIONS');
+  });
+
+  it('落 DOM 的那一步先过 resolveThemeMode，不把 system 直接当值用', () => {
+    expect(read('lib/themeTransition.ts')).toContain("resolveThemeMode(mode) === 'light'");
+  });
+});
+
+describe('拿明暗做分支的地方不许直接比较偏好（否则「随系统」下选错皮肤）', () => {
+  // 加 'system' 这一档的涟漪：这两处原本写 `themeMode === 'dark'` / `themeMode === 'light'`，
+  // 偏好是 'system' 时永远判 false —— DOM 已经暗了，组件却按浅色渲染，且 tsc 全绿。
+  it.each([
+    ['移动端首页皮肤', 'pages/MobileHomePage.tsx'],
+    ['分享阅读页主题钮', 'pages/library/LibraryShareViewPage.tsx'],
+  ])('%s 用 useResolvedThemeMode', (_name, relative) => {
+    const source = read(relative);
+    expect(source).toContain('useResolvedThemeMode');
+    expect(source).not.toMatch(/themeMode === '(dark|light)'/);
+  });
+});

--- a/prd-admin/src/lib/__tests__/themeModeRegistry.test.ts
+++ b/prd-admin/src/lib/__tests__/themeModeRegistry.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { THEME_MODE_OPTIONS, THEME_MODE_ORDER, THEME_MODE_REGISTRY } from '../themeModeRegistry';
 import { resolveThemeMode } from '@/stores/mobileThemeStore';
+import { stripComments } from '@/test-utils/sourceScan';
 
 const testDirectory = path.dirname(fileURLToPath(import.meta.url));
 const srcDirectory = path.resolve(testDirectory, '../..');
@@ -133,5 +134,34 @@ describe('AppShell 之外的独立全屏页必须走共享 hook 落主题', () =
   it('hook 与壳层都把解析后的明暗放进了 effect deps', () => {
     expect(read('hooks/useApplyDocumentTheme.ts')).toContain('[mode, resolved, pathname]');
     expect(read('layouts/AppShell.tsx')).toContain('[mobileThemeMode, resolvedThemeMode, location.pathname]');
+  });
+});
+
+describe('用户菜单里的外观三选项用的是菜单单选角色', () => {
+  // Codex review 四轮 P2：原写法是 DropdownMenu.Item + 自己写 role="radio"，
+  // 子元素的 role 会覆盖掉 Item 给的 role="menuitem"，于是 menu 里挂着几个裸 radio ——
+  // 对屏幕阅读器来说结构是坏的。改回去这三条都会红。
+  // 去掉注释再扫：下面那条 not.toMatch(/role="radio"/) 一开始就被本文件上方
+  // 解释「原来错在哪」的那句注释判红了。判据只该看会执行的代码。
+  const shellSource = stripComments(
+    readFileSync(path.resolve(srcDirectory, 'layouts/AppShell.tsx'), 'utf8'),
+  );
+
+  it('三选项走 Radix 的 RadioGroup / RadioItem', () => {
+    expect(shellSource).toContain('DropdownMenu.RadioGroup');
+    expect(shellSource).toContain('DropdownMenu.RadioItem');
+  });
+
+  it('不自己声明 role / aria-checked，交给 Radix 落 menuitemradio', () => {
+    // 这两个属性一旦自己写，就会覆盖 Radix 给的角色与选中态。
+    expect(shellSource).not.toMatch(/role="radio"/);
+    expect(shellSource).not.toMatch(/role="radiogroup"/);
+    expect(shellSource).not.toMatch(/aria-checked=\{/);
+  });
+
+  it('选中态由 RadioGroup 的 value 驱动（唯一事实源仍是偏好 store）', () => {
+    expect(shellSource).toMatch(
+      /DropdownMenu\.RadioGroup[\s\S]{0,200}?value=\{mobileThemeMode\}/,
+    );
   });
 });

--- a/prd-admin/src/lib/mediaQuerySubscribe.ts
+++ b/prd-admin/src/lib/mediaQuerySubscribe.ts
@@ -1,0 +1,31 @@
+/**
+ * 订阅一个 media query 的变化，带老旧 Safari 回退。
+ *
+ * 为什么需要它：Safari 14（2020-09）之前的 `MediaQueryList` **没有** `addEventListener`，
+ * 只有 `addListener` / `removeListener`。直接 `mql.addEventListener('change', …)` 在那些浏览器上
+ * 是 `undefined is not a function`，会当场抛在 effect 里 —— 不是降级，是整块功能炸掉。
+ *
+ * 本仓库此前已有三处各自写了这段回退（`lib/useReducedMotion.ts`、`stores/themeStore.ts`、
+ * `hooks/usePrefersReducedMotion.ts`），第四处（外观「随系统」）漏写就直接踩中。
+ * 新代码一律用这个函数，不要再抄第四份；守卫见 `lib/__tests__/mediaQuerySubscribe.test.ts`。
+ *
+ * 返回取消订阅函数；拿不到 matchMedia（SSR / 老环境）时返回空函数。
+ */
+type LegacyMediaQueryList = MediaQueryList & {
+  addListener?: (callback: () => void) => void;
+  removeListener?: (callback: () => void) => void;
+};
+
+export function subscribeMediaQuery(query: string, onChange: () => void): () => void {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return () => {};
+
+  const mql = window.matchMedia(query);
+  if (typeof mql.addEventListener === 'function') {
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  }
+
+  const legacy = mql as LegacyMediaQueryList;
+  legacy.addListener?.(onChange);
+  return () => legacy.removeListener?.(onChange);
+}

--- a/prd-admin/src/lib/themeModeRegistry.ts
+++ b/prd-admin/src/lib/themeModeRegistry.ts
@@ -1,0 +1,35 @@
+/**
+ * 外观偏好注册表（唯一数据源）。
+ *
+ * 「有哪几种外观 / 各自叫什么 / 用哪个图标」只在这里定义一次。三处入口消费它：
+ *   - 侧栏用户菜单里的横排三选项（AppShell）
+ *   - 设置 → 皮肤设置「外观」（ThemeSkinEditor）
+ *   - 周报 Agent 工具条的主题控件（report-agent/ThemeControl）
+ *
+ * 之前三处各写一份 OPTIONS 数组，加「随系统」时会漏掉两处 —— 漏掉的那两处不会报错，
+ * 只是选中态谁都不高亮（选了随系统，控件看着像没选）。注册表就是为了让这种漏掉不可能发生。
+ */
+import { Monitor, Moon, Sun, type LucideIcon } from 'lucide-react';
+import type { MobileThemeMode } from '@/stores/mobileThemeStore';
+
+export interface ThemeModeConfig {
+  value: MobileThemeMode;
+  /** 短标签，横排控件用 */
+  label: string;
+  /** 一句话说明，设置页那种带描述的卡片用 */
+  description: string;
+  icon: LucideIcon;
+}
+
+export const THEME_MODE_REGISTRY: Record<MobileThemeMode, ThemeModeConfig> = {
+  light: { value: 'light', label: '白天', description: '明亮环境，纸感浅色', icon: Sun },
+  dark: { value: 'dark', label: '黑夜', description: '夜晚与暗光环境（默认）', icon: Moon },
+  system: { value: 'system', label: '随系统', description: '跟随操作系统的深浅设置', icon: Monitor },
+};
+
+/** 横排顺序：白天 -> 黑夜 -> 随系统。 */
+export const THEME_MODE_ORDER: MobileThemeMode[] = ['light', 'dark', 'system'];
+
+export const THEME_MODE_OPTIONS: ThemeModeConfig[] = THEME_MODE_ORDER.map(
+  (mode) => THEME_MODE_REGISTRY[mode],
+);

--- a/prd-admin/src/lib/themeTransition.ts
+++ b/prd-admin/src/lib/themeTransition.ts
@@ -1,5 +1,5 @@
 import { prefersReducedMotion } from '@/lib/themeApplier';
-import type { MobileThemeMode } from '@/stores/mobileThemeStore';
+import { resolveThemeMode, type MobileThemeMode } from '@/stores/mobileThemeStore';
 
 type ViewTransitionLike = {
   ready: Promise<void>;
@@ -40,7 +40,8 @@ export function isSelfManagedThemePath(pathname: string): boolean {
 export function applyDocumentThemeMode(mode: MobileThemeMode, pathname: string): boolean {
   if (typeof document === 'undefined' || isSelfManagedThemePath(pathname)) return false;
 
-  if (mode === 'light') document.documentElement.setAttribute('data-theme', 'light');
+  // 'system' 是偏好不是结论——这里统一收敛成 light / dark 再落 DOM。
+  if (resolveThemeMode(mode) === 'light') document.documentElement.setAttribute('data-theme', 'light');
   else document.documentElement.removeAttribute('data-theme');
   return true;
 }

--- a/prd-admin/src/pages/MobileHomePage.tsx
+++ b/prd-admin/src/pages/MobileHomePage.tsx
@@ -32,7 +32,7 @@ import {
 import { accentFor, iconFor } from '@/lib/agentAccent';
 import { BUILTIN_TOOLS } from '@/stores/toolboxStore';
 import { resolveMobileCompat } from '@/lib/mobileCompatibility';
-import { useMobileThemeStore } from '@/stores/mobileThemeStore';
+import { useMobileThemeStore, useResolvedThemeMode } from '@/stores/mobileThemeStore';
 import { AgentCardArtwork, AgentCardTask, hasAgentCardArtwork } from '@/components/agent-shell/AgentCardArtwork';
 import {
   formatCompactNumber,
@@ -73,9 +73,10 @@ export default function MobileHomePage() {
   // 打开智能体一律走带记账的出口，否则手机上的启动不计入「你常用的」
   const openRoute = useTrackedNavigate();
   const data = useMobileHomeData();
-  const themeMode = useMobileThemeStore((st) => st.mode);
   const setThemeMode = useMobileThemeStore((st) => st.setMode);
-  const isDark = themeMode === 'dark';
+  // 用解析后的明暗，不用偏好本身：选了「随系统」时 mode === 'dark' 永远为 false，
+  // 皮肤对象会挑成浅色而 DOM 已经是暗色。
+  const isDark = useResolvedThemeMode() === 'dark';
   const C = useAppStoreColors();
 
   const headline = data.recentWork[0] ?? null;

--- a/prd-admin/src/pages/data-sync/DataSyncAuthorizePage.tsx
+++ b/prd-admin/src/pages/data-sync/DataSyncAuthorizePage.tsx
@@ -3,8 +3,7 @@ import { ShieldCheck, ShieldAlert, ChevronDown, ChevronRight } from 'lucide-reac
 
 import { MapSectionLoader, MapSpinner } from '@/components/ui/VideoLoader';
 import { apiRequest } from '@/services/real/apiClient';
-import { applyDocumentThemeMode } from '@/lib/themeTransition';
-import { useMobileThemeStore } from '@/stores/mobileThemeStore';
+import { useApplyDocumentTheme } from '@/hooks/useApplyDocumentTheme';
 import { shouldRequireTrustConfirm } from './trustGate';
 
 /**
@@ -57,11 +56,8 @@ function formatCount(n: number): string {
 export default function DataSyncAuthorizePage() {
   // 同意页在 AppShell 之外（授权链路的中转屏，套导航反而让人以为还在原来那一页），
   // 于是没人替它把用户的明暗偏好落到 html 的 data-theme 上——真机取证时抓到：
-  // 切成浅色之后，这一屏仍然是暗的。这里自己应用一次。
-  const themeMode = useMobileThemeStore((s) => s.mode);
-  useEffect(() => {
-    applyDocumentThemeMode(themeMode, window.location.pathname);
-  }, [themeMode]);
+  // 切成浅色之后，这一屏仍然是暗的。这里自己应用一次（'system' 偏好下也会跟着系统变）。
+  useApplyDocumentTheme(window.location.pathname);
 
   const params = useMemo(readParams, []);
   const [catalog, setCatalog] = useState<ScopeCatalog | null>(null);

--- a/prd-admin/src/pages/data-sync/DataSyncCallbackPage.tsx
+++ b/prd-admin/src/pages/data-sync/DataSyncCallbackPage.tsx
@@ -4,8 +4,7 @@ import { ShieldAlert } from 'lucide-react';
 
 import { MapSpinner } from '@/components/ui/VideoLoader';
 import { apiRequest } from '@/services/real/apiClient';
-import { applyDocumentThemeMode } from '@/lib/themeTransition';
-import { useMobileThemeStore } from '@/stores/mobileThemeStore';
+import { useApplyDocumentTheme } from '@/hooks/useApplyDocumentTheme';
 
 /** 发起跳转时把「这次是去哪台源站」记在这里，回调时凭 state 取回。 */
 const DATA_SYNC_PENDING_PREFIX = 'data-sync:pending:';
@@ -70,10 +69,7 @@ function dropPendingAuthorization(state: string): void {
  */
 export default function DataSyncCallbackPage() {
   // 同上：回跳落地页也在 AppShell 之外，主题要自己应用。
-  const themeMode = useMobileThemeStore((s) => s.mode);
-  useEffect(() => {
-    applyDocumentThemeMode(themeMode, window.location.pathname);
-  }, [themeMode]);
+  useApplyDocumentTheme(window.location.pathname);
 
   const navigate = useNavigate();
   const [error, setError] = useState('');

--- a/prd-admin/src/pages/library/LibraryShareViewPage.tsx
+++ b/prd-admin/src/pages/library/LibraryShareViewPage.tsx
@@ -34,7 +34,8 @@ import type { DocStoreShareView, DocumentEntry } from '@/services/contracts/docu
 import { MapSectionLoader } from '@/components/ui/VideoLoader';
 import { ThemeModeToggle } from '@/components/ui/ThemeModeToggle';
 import { setWikilinkEntries } from '@/lib/wikilinkCache';
-import { applyDocumentThemeMode, transitionThemeMode } from '@/lib/themeTransition';
+import { transitionThemeMode } from '@/lib/themeTransition';
+import { useApplyDocumentTheme } from '@/hooks/useApplyDocumentTheme';
 import { useMobileThemeStore, useResolvedThemeMode } from '@/stores/mobileThemeStore';
 import { useReaderChromeStore } from '@/stores/readerChromeStore';
 import { useIsMobile } from '@/hooks/useBreakpoint';
@@ -62,7 +63,6 @@ export function LibraryShareViewPage() {
   const navigate = useNavigate();
   const location = useLocation();
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
-  const themeMode = useMobileThemeStore((s) => s.mode);
   // 「随系统」下必须按当前真正显示的明暗来翻面，否则点了没反应
   const resolvedThemeMode = useResolvedThemeMode();
   const setThemeMode = useMobileThemeStore((s) => s.setMode);
@@ -80,9 +80,9 @@ export function LibraryShareViewPage() {
   const [galaxyLabelMode, setGalaxyLabelMode] = useState<GalaxyLabelMode>('content');
   const [canOpenStore, setCanOpenStore] = useState(false);
 
-  useEffect(() => {
-    applyDocumentThemeMode(themeMode, location.pathname);
-  }, [location.pathname, themeMode]);
+  // 这一页在 AppShell 之外，壳层的主题接线够不着它 —— 用共享 hook，
+  // 它把解析后的明暗也放进 deps，'system' 偏好下系统一变这里会重新落 DOM。
+  useApplyDocumentTheme(location.pathname);
 
   useEffect(
     () => () => document.documentElement.removeAttribute('data-theme'),

--- a/prd-admin/src/pages/library/LibraryShareViewPage.tsx
+++ b/prd-admin/src/pages/library/LibraryShareViewPage.tsx
@@ -35,7 +35,7 @@ import { MapSectionLoader } from '@/components/ui/VideoLoader';
 import { ThemeModeToggle } from '@/components/ui/ThemeModeToggle';
 import { setWikilinkEntries } from '@/lib/wikilinkCache';
 import { applyDocumentThemeMode, transitionThemeMode } from '@/lib/themeTransition';
-import { useMobileThemeStore } from '@/stores/mobileThemeStore';
+import { useMobileThemeStore, useResolvedThemeMode } from '@/stores/mobileThemeStore';
 import { useReaderChromeStore } from '@/stores/readerChromeStore';
 import { useIsMobile } from '@/hooks/useBreakpoint';
 import {
@@ -63,6 +63,8 @@ export function LibraryShareViewPage() {
   const location = useLocation();
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
   const themeMode = useMobileThemeStore((s) => s.mode);
+  // 「随系统」下必须按当前真正显示的明暗来翻面，否则点了没反应
+  const resolvedThemeMode = useResolvedThemeMode();
   const setThemeMode = useMobileThemeStore((s) => s.setMode);
   const [searchParams, setSearchParams] = useSearchParams();
   // URL ?entry={id} 优先级最高：归档脚本/外部链接可指定一打开就高亮某篇
@@ -89,12 +91,12 @@ export function LibraryShareViewPage() {
 
   const toggleTheme = useCallback<MouseEventHandler<HTMLButtonElement>>((event) => {
     transitionThemeMode({
-      mode: themeMode === 'light' ? 'dark' : 'light',
+      mode: resolvedThemeMode === 'light' ? 'dark' : 'light',
       pathname: location.pathname,
       origin: event,
       commit: setThemeMode,
     });
-  }, [location.pathname, setThemeMode, themeMode]);
+  }, [location.pathname, setThemeMode, resolvedThemeMode]);
 
   const shareSortMode = useMemo(
     () => resolveLibraryShareSortMode(
@@ -333,7 +335,7 @@ export function LibraryShareViewPage() {
           </span>
         </div>
         <div style={{ marginLeft: 'auto', flexShrink: 0, display: 'flex', alignItems: 'center', gap: 8 }}>
-          <ThemeModeToggle mode={themeMode} onToggle={toggleTheme} variant="inline" />
+          <ThemeModeToggle mode={resolvedThemeMode} onToggle={toggleTheme} variant="inline" />
           {/* 只有服务端 GetStore 权限探针通过才进入当前知识库；分享 token 接收者安全回退列表。 */}
           <button
             onClick={() => navigate(knowledgeBaseReturnPath)}

--- a/prd-admin/src/pages/report-agent/components/ThemeControl.tsx
+++ b/prd-admin/src/pages/report-agent/components/ThemeControl.tsx
@@ -1,13 +1,11 @@
 import { useCallback, type MouseEvent } from 'react';
-import { Moon, Sun, type LucideIcon } from 'lucide-react';
 import { useLocation } from 'react-router-dom';
 import { transitionThemeMode } from '@/lib/themeTransition';
+import { THEME_MODE_OPTIONS } from '@/lib/themeModeRegistry';
 import { useMobileThemeStore, type MobileThemeMode } from '@/stores/mobileThemeStore';
 
-const OPTIONS: { value: MobileThemeMode; label: string; icon: LucideIcon }[] = [
-  { value: 'dark', label: '暗色', icon: Moon },
-  { value: 'light', label: '浅色', icon: Sun },
-];
+// 选项来自唯一注册表：漏掉「随系统」会让用户在别处选了它之后，这里三个都不高亮。
+const OPTIONS = THEME_MODE_OPTIONS;
 
 export function ThemeControl() {
   const location = useLocation();

--- a/prd-admin/src/pages/settings/ThemeSkinEditor.tsx
+++ b/prd-admin/src/pages/settings/ThemeSkinEditor.tsx
@@ -7,15 +7,14 @@
 
 import { GlassCard } from '@/components/design/GlassCard';
 import { useThemeStore } from '@/stores/themeStore';
-import { useMobileThemeStore, type MobileThemeMode } from '@/stores/mobileThemeStore';
+import { useMobileThemeStore } from '@/stores/mobileThemeStore';
 import { transitionThemeMode } from '@/lib/themeTransition';
+import { THEME_MODE_OPTIONS } from '@/lib/themeModeRegistry';
 import { MATERIAL_OPTIONS, DEFAULT_THEME_CONFIG, type MaterialMode } from '@/types/theme';
-import { Moon, Sun, Square, Save } from 'lucide-react';
+import { Sun, Square, Save } from 'lucide-react';
 
-const APPEARANCE_OPTIONS: Array<{ value: MobileThemeMode; label: string; description: string; icon: React.ReactNode }> = [
-  { value: 'dark', label: '深色', description: '夜晚与暗光环境（默认）', icon: <Moon size={14} /> },
-  { value: 'light', label: '浅色', description: '白天与明亮环境，纸感浅色', icon: <Sun size={14} /> },
-];
+// 选项来自唯一注册表（含「随系统」），不再在本文件另写一份 —— 少写一处就会和用户菜单漂移。
+const APPEARANCE_OPTIONS = THEME_MODE_OPTIONS;
 
 export function ThemeSkinEditor() {
   const { config, setConfig, saving } = useThemeStore();
@@ -48,11 +47,12 @@ export function ThemeSkinEditor() {
         <SettingSection
           icon={<Sun size={14} />}
           title="外观"
-          description="深色或浅色，全站生效"
+          description="白天、黑夜，或跟随系统，全站生效"
         >
-          <div className="grid grid-cols-2 gap-2">
+          <div className="grid grid-cols-3 gap-2">
             {APPEARANCE_OPTIONS.map((option) => {
               const isActive = appearance === option.value;
+              const OptionIcon = option.icon;
               return (
                 <button
                   type="button"
@@ -75,7 +75,7 @@ export function ThemeSkinEditor() {
                   }}
                 >
                   <div className={`flex items-center gap-1.5 text-xs font-medium ${isActive ? 'text-token-accent' : 'text-token-primary'}`}>
-                    {option.icon}
+                    <OptionIcon size={14} />
                     {option.label}
                   </div>
                   <div className="mt-0.5 text-xs text-token-muted">

--- a/prd-admin/src/stores/mobileThemeStore.ts
+++ b/prd-admin/src/stores/mobileThemeStore.ts
@@ -14,6 +14,8 @@ import { useEffect, useState } from 'react';
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 
+import { subscribeMediaQuery } from '@/lib/mediaQuerySubscribe';
+
 /**
  * 用户选的偏好。'system' 是偏好、不是最终值——落 DOM 前一律先过 resolveThemeMode()。
  * 存量用户存的是 'light' / 'dark'，仍然合法，不需要迁移。
@@ -40,11 +42,9 @@ export function resolveThemeMode(mode: MobileThemeMode): ResolvedThemeMode {
  * 返回取消订阅函数。
  */
 export function watchSystemThemeChange(onChange: () => void): () => void {
-  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return () => {};
-  const query = window.matchMedia(SYSTEM_DARK_QUERY);
-  const handler = () => onChange();
-  query.addEventListener('change', handler);
-  return () => query.removeEventListener('change', handler);
+  // 走共享订阅：Safari 14 之前 MediaQueryList 只有 addListener，直接
+  // addEventListener 会当场抛，「随系统」这一档在那些浏览器上整个用不了。
+  return subscribeMediaQuery(SYSTEM_DARK_QUERY, onChange);
 }
 
 interface MobileThemeState {

--- a/prd-admin/src/stores/mobileThemeStore.ts
+++ b/prd-admin/src/stores/mobileThemeStore.ts
@@ -10,10 +10,42 @@
  * 存储用 localStorage（.claude/rules/no-localstorage.md 例外清单：
  * 纯 UI 偏好、发版后旧值无害、用户期望关浏览器也记住）。
  */
+import { useEffect, useState } from 'react';
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 
-export type MobileThemeMode = 'light' | 'dark';
+/**
+ * 用户选的偏好。'system' 是偏好、不是最终值——落 DOM 前一律先过 resolveThemeMode()。
+ * 存量用户存的是 'light' / 'dark'，仍然合法，不需要迁移。
+ */
+export type MobileThemeMode = 'light' | 'dark' | 'system';
+/** 真正能落到 <html data-theme> 上的值。 */
+export type ResolvedThemeMode = 'light' | 'dark';
+
+const SYSTEM_DARK_QUERY = '(prefers-color-scheme: dark)';
+
+/** 拿不到 matchMedia（SSR / 老环境）时按全站默认当暗色，不猜浅色。 */
+export function systemPrefersDark(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return true;
+  return window.matchMedia(SYSTEM_DARK_QUERY).matches;
+}
+
+export function resolveThemeMode(mode: MobileThemeMode): ResolvedThemeMode {
+  if (mode === 'system') return systemPrefersDark() ? 'dark' : 'light';
+  return mode;
+}
+
+/**
+ * 订阅系统深浅变化。只有偏好是 'system' 时才需要——否则系统怎么变都不该动用户的选择。
+ * 返回取消订阅函数。
+ */
+export function watchSystemThemeChange(onChange: () => void): () => void {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return () => {};
+  const query = window.matchMedia(SYSTEM_DARK_QUERY);
+  const handler = () => onChange();
+  query.addEventListener('change', handler);
+  return () => query.removeEventListener('change', handler);
+}
 
 interface MobileThemeState {
   mode: MobileThemeMode;
@@ -33,3 +65,26 @@ export const useMobileThemeStore = create<MobileThemeState>()(
     },
   ),
 );
+
+/**
+ * 当前**真正生效**的明暗（把 'system' 解开之后的结果），并且跟着系统变化实时更新。
+ *
+ * 凡是要拿明暗做分支的地方（皮肤对象、图标、"点一下切到哪一边"）都必须用它，
+ * 不能直接拿 store 里的 mode 去比 'dark' —— 用户选了「随系统」时那样比永远为 false，
+ * 会出现「DOM 已经是暗色、组件却按浅色渲染」的错位。
+ *
+ * 只读 DOM 的组件（useDataTheme）不受影响，它们本来读的就是解析后的结果。
+ */
+export function useResolvedThemeMode(): ResolvedThemeMode {
+  const mode = useMobileThemeStore((state) => state.mode);
+  const [systemDark, setSystemDark] = useState(systemPrefersDark);
+
+  useEffect(() => {
+    if (mode !== 'system') return;
+    setSystemDark(systemPrefersDark());
+    return watchSystemThemeChange(() => setSystemDark(systemPrefersDark()));
+  }, [mode]);
+
+  if (mode !== 'system') return mode;
+  return systemDark ? 'dark' : 'light';
+}

--- a/prd-admin/src/styles/globals.css
+++ b/prd-admin/src/styles/globals.css
@@ -6,11 +6,10 @@
 @import './doc-diff.css';
 @import './home-launcher.css';
 
-/* CDS preview compatibility: the injected branch badge starts at the lower-left
-   corner. Reserve its compact height so account and avatar controls remain usable
-   before the platform-side collision-safe badge position reaches every CDS host. */
-@media (min-width: 641px) {
-  body:has(> [data-cds-widget-root]) [data-app-sidebar-account] {
-    padding-bottom: 52px;
-  }
-}
+/* CDS preview compatibility: this used to reserve 52px at the bottom of the sidebar
+   account block, back when the injected branch badge sat in the lower-LEFT corner.
+   cds/src/widget-script.ts `defaultWidgetLeft()` now anchors the desktop badge in the
+   right-side safe area (innerWidth-492), so that reserve no longer avoids anything —
+   it just floated the avatar 52px off the bottom of the rail. Removed 2026-08-25.
+   If the widget ever goes back to a left-rail anchor, bring the reserve back; the
+   guard in AppShell.cdsCompatibility.test.ts watches that anchor and will go red. */

--- a/prd-admin/src/test-utils/__tests__/sourceScan.test.ts
+++ b/prd-admin/src/test-utils/__tests__/sourceScan.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { stripComments } from '../sourceScan';
+
+describe('stripComments', () => {
+  it('去掉行注释，保留代码', () => {
+    const out = stripComments('const a = 1; // role="radio" 是反面例子\nconst b = 2;');
+    expect(out).not.toContain('role="radio"');
+    expect(out).toContain('const a = 1;');
+    expect(out).toContain('const b = 2;');
+  });
+
+  it('去掉块注释与 JSDoc', () => {
+    const out = stripComments('/**\n * 不要写 addEventListener\n */\nmql.addListener(fn);');
+    expect(out).not.toContain('addEventListener');
+    expect(out).toContain('mql.addListener(fn);');
+  });
+
+  it('去掉 JSX 注释', () => {
+    const out = stripComments('<div>{/* 别自己写 role="radio" */}<span /></div>');
+    expect(out).not.toContain('role="radio"');
+    expect(out).toContain('<span />');
+  });
+
+  it('注释掉的调用不再被当成调用', () => {
+    // 三轮 review 那条守卫踩的就是这个：`// render();` 被认成「初始化还在调」。
+    const out = stripComments('  // render();\n  fetchBranchInfo();');
+    expect(out).not.toMatch(/^\s*render\(\);/m);
+    expect(out).toContain('fetchBranchInfo();');
+  });
+
+  it('字符串里的 // 不算注释，整段保留', () => {
+    const out = stripComments("const url = 'https://example.com/x'; // 尾注");
+    expect(out).toContain("'https://example.com/x'");
+    expect(out).not.toContain('尾注');
+  });
+
+  it('模板串里的 /* */ 不算注释', () => {
+    const out = stripComments('const css = `a{/* keep */}`;');
+    expect(out).toContain('/* keep */');
+  });
+
+  it('转义引号不会让字符串提前结束', () => {
+    const out = stripComments("const s = 'it\\'s // not a comment'; // 真注释");
+    expect(out).toContain('// not a comment');
+    expect(out).not.toContain('真注释');
+  });
+});

--- a/prd-admin/src/test-utils/sourceScan.ts
+++ b/prd-admin/src/test-utils/sourceScan.ts
@@ -1,0 +1,75 @@
+/**
+ * 源码扫描类守卫的公共前处理：把注释剥掉再断言。
+ *
+ * 为什么需要它：这类守卫的判据是「源码里有没有出现某段文本」，而注释里几乎总会
+ * 出现同一段文本 —— 恰恰是那句解释「为什么不能这么写」的注释。于是判据两个方向
+ * 都会错：
+ *
+ *   - 误红：`expect(src).not.toContain('addEventListener')` 把解释性注释判成违规；
+ *   - 漏判：`/render\(\);/` 把 `// render();` 这种注释掉的调用认成「调用还在」。
+ *
+ * 本 PR 里同一个坑连踩三次（addEventListener / render(); / role="radio"），
+ * 三次都是打补丁收紧正则。正解是扫之前先去注释，让判据只看真正会执行的代码。
+ *
+ * 实现是够用级别的词法扫描：识别行注释、块注释、三种字符串与模板串，
+ * 以及正则字面量的常见形态。它不是完整的 TS parser，但对「读一个源文件、
+ * 断言某段代码在不在」这个用途足够，且不依赖任何解析器。
+ */
+export function stripComments(source: string): string {
+  let out = '';
+  let i = 0;
+  const n = source.length;
+
+  while (i < n) {
+    const c = source[i];
+    const next = source[i + 1];
+
+    // 行注释
+    if (c === '/' && next === '/') {
+      while (i < n && source[i] !== '\n') i += 1;
+      continue;
+    }
+
+    // 块注释（含 JSDoc）
+    if (c === '/' && next === '*') {
+      i += 2;
+      while (i < n && !(source[i] === '*' && source[i + 1] === '/')) i += 1;
+      i += 2;
+      continue;
+    }
+
+    // 字符串 / 模板串：整段原样保留，里面的 // 不算注释
+    if (c === '"' || c === "'" || c === '`') {
+      const quote = c;
+      out += c;
+      i += 1;
+      while (i < n) {
+        if (source[i] === '\\') {
+          out += source[i] + (source[i + 1] ?? '');
+          i += 2;
+          continue;
+        }
+        out += source[i];
+        if (source[i] === quote) {
+          i += 1;
+          break;
+        }
+        i += 1;
+      }
+      continue;
+    }
+
+    out += c;
+    i += 1;
+  }
+
+  return out;
+}
+
+/** 读文件并去掉注释。source-scan 守卫的标准入口。 */
+export function readSourceWithoutComments(
+  read: (relative: string) => string,
+  relative: string,
+): string {
+  return stripComments(read(relative));
+}


### PR DESCRIPTION
## 摘要

侧栏底部两条用户诉求：一是去掉「···」按钮、用户菜单改由点击头像进入、头像下沉到最底部；二是把皮肤切换从侧栏挪进用户菜单，做成横排三选项（白天 / 黑夜 / 随系统，太阳 / 月亮 / 电脑图标）。

「随系统」是新增的一档偏好，牵动的不只是 UI：`MobileThemeMode` 从二值扩成三值，`'system'` 是偏好不是结论，落 DOM 前统一过 `resolveThemeMode()` 收敛；按枚举涟漪逐层扫消费点时抓到两处真缺陷，Codex 三轮 review 又补出三处（见「Review 轮次」）。三处外观入口此前各写一份 OPTIONS 数组，本 PR 收敛成唯一注册表。

## 范围基线（CLAUDE.md §5.5）

- **单一目标**：只做上面两条侧栏诉求，以及为支撑「随系统」所必需的连带修复。
- **不变量**：只读 DOM 的主题消费方（`useDataTheme` 系）行为不变；存量 `'light'` / `'dark'` 偏好不需要迁移；桌面与移动的其它布局不动。
- **明确不做**：不改主题 token 与配色、不动液态玻璃材质开关、不重构 `ThemeModeToggle` 组件本身（仅调用方传入解析后的值）、不碰移动端抽屉的头像语义、**不迁移三处存量的 media query 回退实现**（见「后续事项」）。
- **首轮基线**：15 个文件，+430 / -99，2 个 commit。
- **当前**：19 个文件，+715 / -118，5 个 commit（后 3 个是 review 修复）。

### 范围熔断自查

文件集扩出了首轮清单（新增 4 个文件、带出 data-sync 两页），按 §5.5 属于熔断触发项，已跑 `/scope-check`：

- 19 个文件全部位于 `prd-admin/src` + 1 份 changelog；仓库无 `CODEOWNERS`、无 `.agent-scope.json`。
- **foreign 0 / unknown 0**。新增的 4 个文件是「同一缺陷的唯一实现 + 它的守卫」（`useApplyDocumentTheme` / `mediaQuerySubscribe` 及测试）；被带出的 data-sync 两页与 `MobileHomePage` / `ThemeControl` / `ThemeSkinEditor` 都是**我扩宽的那个联合类型的消费方**，属涟漪必修，不是新语义。
- diff 行数 1.7 倍于首轮基线，未过 2 倍线；三轮 review 修复共 3 个 commit，未达 8 个。
- 三轮 review 只改了一个既有测试文件（`AppShell.cdsCompatibility.test.ts`）+ changelog，文件集未再扩大。
- 结论：**未引入新语义类别，可继续**；三处存量回退实现的迁移已明确划到 PR 外。

## 改动 diff

**前端（prd-admin）— 诉求一：头像与用户菜单**

- `src/layouts/AppShell.tsx`：删除侧栏底部的 `MoreHorizontal`「···」按钮（import 一并清掉），头像成为用户菜单唯一入口；头像点击改为两段语义（菜单关着 = 开菜单，菜单开着 = 进「修改我的头像」）；`DropdownMenu.Root` 改受控 + `modal={false}`，判定落在 `pointerdown` 并 `preventDefault` 绕开 Radix Trigger 自带 toggle；展开态用户名按钮退回普通 toggle 按钮（一个 Root 只保留头像这一个锚点）+ 补 `onKeyDown` 键盘激活；`onCloseAutoFocus` 挡掉菜单向头像的焦点回收；菜单头部加一行提示，让「再点一次」这条隐式交互可见；移除尾部 1px 占位。
- `src/layouts/accountAvatarAction.ts`（新增）：头像点击语义 + 菜单键盘激活的唯一判定源。写在事件处理里删掉不会红，抽出来才有可变红的判据。
- `src/layouts/accountAvatarAction.test.ts`（新增）：7 例，两段语义 / 键盘激活各自的行为用例 + 三条源码守卫。

**前端（prd-admin）— 诉求一：头像贴底**

- `src/styles/globals.css`：删除为「左下角 CDS 预览徽章」保留的 52px 底部留白。`cds/src/widget-script.ts` 的 `defaultWidgetLeft()` 桌面端早已改锚右侧安全区（`innerWidth-492`），这段留白不再避让任何东西，只是把头像顶高了 52px（实测头像到侧栏底边 64px → 16px）。
- `src/layouts/AppShell.cdsCompatibility.test.ts`：守卫从「断言留白存在」改成「断言 widget 仍是右锚 + 留白已移除」，盯的是因不是果；三轮 review 后再补一条接线守卫，断言 widget 的 `render()` 确实把 pos 落成 inline style、且初始化时就调了一次。

**前端（prd-admin）— 诉求二：横排三选项 + 随系统**

- `src/lib/themeModeRegistry.ts`（新增）：外观偏好唯一注册表（value / label / description / icon），横排顺序白天 → 黑夜 → 随系统。
- `src/stores/mobileThemeStore.ts`：`MobileThemeMode` 扩为三值并新增 `ResolvedThemeMode`；新增 `systemPrefersDark()` / `resolveThemeMode()` / `watchSystemThemeChange()` / `useResolvedThemeMode()`（后者响应式，系统深浅一变即重渲染）。
- `src/lib/themeTransition.ts`：`applyDocumentThemeMode` 落 DOM 前先 `resolveThemeMode`，不把 `'system'` 当值用。
- `src/layouts/AppShell.tsx`：侧栏底部的 `ThemeModeToggle` 与分隔线移除；用户菜单内新增横排三选项（`DropdownMenu.Item` 承载，键盘上下键够得到；`onSelect` preventDefault 让点完不关菜单，当场看到整屏换肤）。
- `src/pages/settings/ThemeSkinEditor.tsx`：改消费注册表，外观卡片 2 列改 3 列，新增「随系统」。
- `src/pages/report-agent/components/ThemeControl.tsx`：改消费注册表，同样拿到「随系统」。

**前端（prd-admin）— 涟漪修复（加 'system' 引出的真缺陷）**

- `src/lib/mediaQuerySubscribe.ts`（新增）：带老旧 Safari 回退的 media query 订阅，唯一实现。
- `src/hooks/useApplyDocumentTheme.ts`（新增）：AppShell 之外的独立全屏页落主题的唯一实现，把解析后的明暗一并放进 effect deps。
- `src/pages/library/LibraryShareViewPage.tsx`：主题钮的翻面与图标改按解析后的明暗（原写法在「随系统 + 系统为暗」时点击切到 `'dark'`，等于点了没反应）；落 DOM 改用共享 hook。
- `src/pages/data-sync/DataSyncAuthorizePage.tsx`、`src/pages/data-sync/DataSyncCallbackPage.tsx`：同一形状，改用共享 hook。
- `src/pages/MobileHomePage.tsx`：`isDark` 由 `themeMode === 'dark'` 改为 `useResolvedThemeMode() === 'dark'`。原写法在偏好为 `'system'` 时永远为 false，会挑成浅色皮肤对象而 DOM 已是暗色。
- `src/lib/__tests__/themeModeRegistry.test.ts`（新增，16 例）、`src/lib/__tests__/mediaQuerySubscribe.test.ts`（新增，6 例）。

**文档**

- `changelogs/2026-08-25_sidebar-avatar-user-menu.md`（新增）：本 PR 全部变更的单一 changelog 碎片。

## 测试

- [x] 前端 `pnpm tsc --noEmit` 零错误
- [x] 前端 `pnpm lint` 零 error（327 warning，与改动前同数，本次改动文件零新增）
- [x] 单元测试 `pnpm test` 全绿：193 文件 / 1602 例
- [x] 新增守卫全部跑过红绿闭环：把改动逐条改回原样（重新引入 `MoreHorizontal`、把语义写回事件处理、对调注册表图标、恢复 52px 留白、独立页直接调 `applyDocumentThemeMode`、hook deps 去掉解析值、摘掉 `onKeyDown`、`watchSystemThemeChange` 改回无条件 `addEventListener`、删掉 widget `render()` 里落 inline style 的两行、注释掉 widget 的初始化 `render()` 调用）后，对应用例逐条变红，恢复后转绿
- [x] 真人路径视觉验收 22/22，深浅双主题各一遍，Playwright 直连预览域名：登录 → 点头像开菜单 → 点「白天」→ 关菜单 → 再点头像出「修改我的头像」。断言含：侧栏无「···」、头像是最靠下控件、头像贴到侧栏底边（16px）、侧栏已无皮肤切换按钮、菜单三选项文字为「白天/黑夜/随系统」、三项 top 坐标相同（确为横排）、各带一个 icon、恰好一项选中、第一次点头像不直接弹编辑器、第二次点弹出编辑器
- [x] 三轮 review 追加的运行时几何取证（`67d1d38` 部署，Chromium 1440x900，全新加载不拖不缩）3/3：`#cds-widget` inline `left=948px`＝`innerWidth-492`（非 CSS 默认 `12px`）、徽章矩形 x 948..1351 与账户区 x 15..53 不相交、账户区距侧栏底边 8px
- [x] 验收取证用的是当时最新部署：截图内 CDS 徽章为 `ba02e79`（几何取证那次为 `67d1d38`）

验收地址（走 `cdscli --human preview-url` 取根域，路由按本次改动追加）：

- 侧栏头像与用户菜单三选项：https://user-menu-avatar-interaction-4woqy3-claude-prd-agent.miduo.org/
- 设置「皮肤设置 → 外观」同步为三选项：https://user-menu-avatar-interaction-4woqy3-claude-prd-agent.miduo.org/settings?tab=skin

> 视觉验收跑在 `ba02e79`。之后三轮 review 修复（`0f82c3c` / `67d1d38` / `a5edd02`）分别是键盘可达性、独立全屏页的 DOM 落主题时机、老旧 Safari 的订阅 API、以及一条纯测试的接线守卫，都不改上述已验收的画面；对应路径由单测守卫覆盖（老旧 Safari 那条本地无该环境，走的是注入式行为用例而非真机）。

## Review 轮次

Codex 三轮共五条 P2。前四条判为 A 类（可证明违反本 PR 目标或既有契约），已修复并各配可变红的守卫；第五条前提经运行时取证不成立，未按其建议改动，但补上了它暴露出的守卫漏洞：

| 轮次 | 结论 | 处理 |
|---|---|---|
| 一轮：独立全屏页「随系统」不跟系统走 | A 类，本 PR 引入 | 横扫同类发现共 3 页同形状（Codex 只报了 1 页），收敛成 `useApplyDocumentTheme`；顺带删掉 AppShell 里自己那份 matchMedia 监听 |
| 一轮：用户名按钮丢了键盘激活 | A 类，本 PR 引入 | 补 `isMenuKeyboardActivation` + `onKeyDown`；不改回 Trigger 是因为一个 Root 只能有一个锚点，锚点已给头像 |
| 一轮：一个 PR 两份 changelog 碎片 | A 类，违反 AGENTS.md #4 | 合并为一份 |
| 二轮：老旧 Safari 上「随系统」直接抛 | A 类，本 PR 引入 | Safari 14 之前 `MediaQueryList` 只有 `addListener`；抽 `lib/mediaQuerySubscribe.ts` 唯一实现（仓库此前已有三份各写各的回退，我这处漏写就是第四份的反面教材） |
| 三轮：移除 52px 留白会让徽章盖住贴底头像 | **C 类，前提不成立**（但暴露了守卫漏洞） | 运行时取证否掉：徽章首屏位置由 widget 的 `render()` 落成 inline style（`left:948px`＝`innerWidth-492`），CSS 默认的 `left:12px` 从第一帧起就被覆盖，与账户区完全不相交。**不改回留白**；但原守卫只断言 `defaultWidgetLeft()` 的返回值、没断言它被落到元素上（删掉 `render()` 那两行守卫照样绿）——已补接线守卫 |

## 风险与已知边界

- **无破坏性变更、无数据迁移**。`MobileThemeMode` 是纯前端偏好（localStorage `map-mobile-theme-v2`），存量 `'light'` / `'dark'` 仍然合法，老值直接可用。
- **一次假绿已拦下，值得复述**：首次 CDS 部署报「流水线全绿」，但抓线上 bundle 发现里面没有「随系统」——服务的仍是上一个 commit。按 sha 显式重新触发部署、确认 bundle hash 变化且含新代码之后才跑的验收。后续在这条分支上验收前建议同样先核一次 bundle，别只看部署状态。
- **`modal={false}` 的连带影响**：用户菜单不再锁滚动、不再禁用外部指针事件。这是实现「菜单开着时头像还能收到 pointerdown」的必要条件。菜单的外部点击关闭行为不变。
- **「再点一次改头像」是隐式交互**：已在菜单头部加提示文案兜底，但仍依赖用户读到那一行。
- **老旧 Safari 的回退只有注入式用例覆盖**，没有真机验证（沙箱里没有 Safari 13）。
- **`useResolvedThemeMode` 的订阅只在偏好为 `'system'` 时建立**：显式选了白天/黑夜时系统怎么变都不跟随，这是有意的。
- **非浏览器环境（SSR / 无 `matchMedia`）下 `systemPrefersDark()` 返回 true**，即按全站默认当暗色，不猜浅色。
- **CDS 徽章不会压住贴底头像，有运行时证据**：最新部署（`67d1d38`）预览域名上，Chromium 1440x900 全新加载、不拖不缩，`#cds-widget` 的 inline `left` 为 `948px`（`innerWidth-492`），徽章矩形 x 948..1351 与账户区 x 15..53 完全不相交，账户区距侧栏底边 8px。守卫已同时盯「右锚判据」与「首屏把 pos 落成 inline style 的那两行 + 初始化调用」。
- **守卫判据本身也踩过一次坑，已修**：三轮补的初始化守卫初版会把注释掉的 `// render();` 认成证据（红绿闭环里不变红才暴露），已收紧成只认「整行就是这个调用」。同类教训二轮也有一次（`not.toContain('addEventListener')` 把解释性注释判红）——判据宽窄两个方向都出过错，新守卫一律跑红绿闭环再收。
- **回滚**：本 PR 纯前端，revert 五个 commit 即可，无残留状态。

## 后续事项

- P2：`lib/useReducedMotion.ts` / `stores/themeStore.ts` / `hooks/usePrefersReducedMotion.ts` 三处各自写着一份老旧 Safari 回退，本 PR 只新增了唯一实现 `lib/mediaQuerySubscribe.ts` 并让新代码走它，**存量三处未迁移**（属扩范围，划到 PR 外）。已有棘轮守卫盯着「不许出现第五份」，迁移时把清单一并收敛即可。
- P3：移动端抽屉的头像仍是「点一下直接改头像」（那是另一套 UI，本身带完整菜单列表，本 PR 有意不动）。若日后要与桌面对齐两段语义，复用 `resolveAccountAvatarAction` 即可。
- P3：`ThemeModeToggle` 组件仍是二态展示（由调用方传入解析后的值兜住「随系统」）。若日后有第三处需要三态横排控件，可把 AppShell 里的那段抽成共享组件。