### PR TITLE
每日熵减计划 2026-W35 — D6 changelog→doc 补登 5 条

### DIFF
--- a/changelogs/.entropy-manifest.yml
+++ b/changelogs/.entropy-manifest.yml
@@ -594,3 +594,8 @@ processed:
   - 2026-08-26_cds-report-auto-sync.md
   - 2026-08-26_entropy-cleanup.md
   - 2026-08-26_map-cross-instance-data-sync.md
+  - 2026-08-27_attachment-key-guard-debt.md
+  - 2026-08-27_attachment-key-guard-registry.md
+  - 2026-08-27_attachment-storage-key-guard.md
+  - 2026-08-27_cds-compose-credentials.md
+  - 2026-08-27_data-sync-asset-url-contract.md

--- a/changelogs/2026-08-28_entropy-cleanup.md
+++ b/changelogs/2026-08-28_entropy-cleanup.md
@@ -1,0 +1,1 @@
+| chore | doc | 熵清理：D1-D5/D7 全绿，D6 处理 5 条 changelog（附件对象 key 守卫、CDS compose 凭据、跨实例同步地址契约），内容均已由既有 debt/design 文档覆盖，仅登记 manifest |


### PR DESCRIPTION
## 熵清理摘要

- D1 命名规范：0 违规
- D2 index.yml：0 补缺 / 0 删幽灵
- D3 guide.list：0 补缺 / 0 删幽灵
- D4 技能可发现性：0 补缺
- D6 changelog→doc：本次处理 5 条，manifest 累计 596 条
- D7 可读性：ratchet 全绿（六项欠账均未上升，0 死链）

D6 处理的 5 条 changelog（附件对象 key 守卫 DS35、CDS compose 凭据、跨实例同步地址契约
DS30/31/33/34）内容均已由既有 `doc/debt.platform.cross-instance-data-sync.md` 与
`doc/debt.cds.md` 覆盖，逐条核对后仅登记进 manifest，未追加新章节。

## 改动 diff

- `changelogs/.entropy-manifest.yml`：新增 5 条已处理 changelog 记录
- `changelogs/2026-08-28_entropy-cleanup.md`：本次 changelog 碎片

## 测试

- [x] 双向扫描完成（D1-D4），diff 核验通过（仅追加，无删除行）
- [x] D7 `doc-readability-check.py --ratchet` 全绿
- [x] 运行两次验证：第二次扫描 D6 剩余 3 条未处理（超出本轮 5 条限额，留待下轮），其余维度净变更为 0

---
_Generated by [Claude Code](https://claude.ai/code/session_01DstGYWvWyxyTBWBkXUF9uu)_