### PR TITLE
每日熵减计划 2026-W35 — D6 补登 5 条 changelog

### DIFF
--- a/changelogs/.entropy-manifest.yml
+++ b/changelogs/.entropy-manifest.yml
@@ -599,3 +599,8 @@ processed:
   - 2026-08-27_attachment-storage-key-guard.md
   - 2026-08-27_cds-compose-credentials.md
   - 2026-08-27_data-sync-asset-url-contract.md
+  - 2026-08-26_seedance-25-video-generation.md
+  - 2026-08-27_doc-impl-detail-cleanup.md
+  - 2026-08-27_entropy-cleanup.md
+  - 2026-08-28_cds-backup-freshness-vs-coverage.md
+  - 2026-08-28_cds-project-backup-panel.md

--- a/changelogs/2026-08-29_entropy-cleanup.md
+++ b/changelogs/2026-08-29_entropy-cleanup.md
@@ -1,0 +1,1 @@
+| chore | doc | 熵清理：D1-D5/D7 全绿无欠账，D6 处理 5 条 changelog（seedance-2.5 视频路由改动追加进 debt.video-agent.md，其余 4 条均已由既有内容覆盖），登记 manifest |

--- a/doc/debt.video-agent.md
+++ b/doc/debt.video-agent.md
@@ -15,7 +15,7 @@
 1. 直出模式：提示词或首帧图片经 LLM Gateway 路由到视频模型，异步提交、轮询、下载并保存到资产存储。
 2. 分镜模式：文学稿经聊天模型拆分为镜头，用户在制作台逐镜编辑、批量生成、保留历史版本，最后由 ffmpeg 统一画幅和编码并合成为完整 MP4。
 
-火山方舟 Seedance 通过 `volcengine-video` Exchange 转换器适配原生异步任务协议。OpenRouter 兼容协议仍由原视频客户端处理，两者共用 `video-agent.videogen::video-gen` 调用方和模型池治理。
+火山方舟 Seedance 通过 `volcengine-video` Exchange 转换器适配原生异步任务协议。OpenRouter 兼容协议仍由原视频客户端处理，两者共用 `video-agent.videogen::video-gen` 调用方和模型池治理。视频生成调用已统一切换到 LLMGW 权威路由（HTTP 模式）：发送阶段锁定首次解析出的模型，避免二次解析漂移到其他 Provider；下载在该模式下经网关安全注入密钥后取回成片。
 
 ## 已完成
 
@@ -27,6 +27,7 @@
 | full-export | paid | ffmpeg 统一画幅、帧率和编码，合成后上传资产存储 |
 | export-recovery | paid | 导出失败回到编辑态，可修改和重试；导出后继续编辑会使旧成片失效 |
 | seedance-protocol | paid | 火山 Seedance submit、status、download 协议转换已有自动化回归 |
+| seedance-2.5-openrouter | paid | 视频创作高级模型列表新增 OpenRouter Seedance 2.5，时长与分辨率按实时能力约束；appCaller 自助创建已支持 video-gen 等全部网关模型类型 |
 
 ## 未完成边界
 


### PR DESCRIPTION
## 熵清理摘要

- D1 命名规范：0 违规
- D2 index.yml：0 补缺 / 0 删幽灵
- D3 guide.list：0 补缺 / 0 删幽灵
- D4 技能可发现性：0 补缺
- D6 changelog→doc：本次处理 5 条，manifest 累计 601 条
- D7 可读性棘轮：六项欠账均未上升，无死链

## 改动 diff

- `doc/debt.video-agent.md`：追加 seedance-2.5-openrouter 条目 + 一句话说明视频生成已切换到 LLMGW 权威路由（HTTP 模式，锁定首次解析模型 + 网关安全注入密钥下载）——覆盖 `changelogs/2026-08-26_seedance-25-video-generation.md`
- `changelogs/.entropy-manifest.yml`：追加本轮处理的 5 条 changelog 记录
- `changelogs/2026-08-29_entropy-cleanup.md`：本次 changelog 碎片

其余 4 条 changelog（`2026-08-27_doc-impl-detail-cleanup`、`2026-08-27_entropy-cleanup`、`2026-08-28_cds-backup-freshness-vs-coverage`、`2026-08-28_cds-project-backup-panel`）内容已由既有台账覆盖（`doc/debt.cds.md` 的 E62/E83-E89 等条目、以及那两篇文档变更类 changelog 本身就是它所描述的文档编辑），无需追加新章节。

## 测试

- [x] 双向扫描完成，diff 核验通过（无幽灵删除、无代码文件混入）
- [x] `python3 scripts/doc-readability-check.py --ratchet` 通过，六项欠账均未上升
- [x] D2/D3 补缺删幽灵重扫二次确认为 0


---
_Generated by [Claude Code](https://claude.ai/code/session_01BWf3iaZL5zvR5HrMpaojjL)_