### PR TITLE
fix(web-pages): 提高原型 ZIP 文件数上限

### DIFF
--- a/changelogs/2026-09-01_web-pages-zip-file-limit.md
+++ b/changelogs/2026-09-01_web-pages-zip-file-limit.md
@@ -1,0 +1,2 @@
+| fix | prd-api | 提高网页托管 ZIP 文件数上限并补充超限恢复指引 |
+| fix | prd-admin | 同步展示新的 ZIP 文件数上限 |

--- a/prd-admin/src/pages/WebPagesPage.tsx
+++ b/prd-admin/src/pages/WebPagesPage.tsx
@@ -3169,7 +3169,7 @@ function UploadEditDialog({ item, folders, onClose, onSaved, onShareSite, initia
                 ) : (
                   <div className="text-center leading-relaxed">
                     <p className="text-sm text-token-secondary">把文件拖到这里，或点击选择</p>
-                    <p className="mt-1 text-xs text-token-muted">.html / .htm · .zip（≤5000 个文件，自动识别入口）</p>
+                    <p className="mt-1 text-xs text-token-muted">.html / .htm · .zip（≤20000 个文件，自动识别入口）</p>
                     <p className="text-xs text-token-muted">.md · .pdf · .mp4 / .webm / .mov</p>
                     <p className="text-xs text-token-muted">单个文件上限 500 MB</p>
                   </div>

--- a/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
+++ b/prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs
@@ -27,7 +27,10 @@ public class HostedSiteService : IHostedSiteService
     // 后，控制器会把媒体包装成 ZIP 走这条路径，解压上限若仍是 200MB 会让 200-500MB 的上传
     // "过了控制器、却被服务层拒收"。该值同时保留 zip bomb 防御（停止解压超出此总大小的归档）。
     private const long MaxExtractedSize = 500L * 1024 * 1024; // 500MB
-    public const int MaxZipFileCount = 5000;
+    // 现代原型导出会生成大量切片、字体和静态资源；5000 会拒绝体积很小但条目较多的正常包。
+    // 文件数仍保留硬上限以避免用海量空条目消耗解析与对象存储资源；解压总量另由
+    // MaxExtractedSize 独立限制，不能用提高文件数上限绕过 zip bomb 防护。
+    public const int MaxZipFileCount = 20000;
 
     // 网页托管对象的 Cache-Control。配合 SiteUrl 上的 ?v={UpdatedAt.Ticks} 版本指纹形成
     // 「内容指纹缓存」：内容不变 → URL 不变 → 命中浏览器/CDN 缓存（满足"没更新就用缓存"）；
@@ -2569,6 +2572,11 @@ public class HostedSiteService : IHostedSiteService
         public List<(ZipArchiveEntry Entry, string RelativePath, string Mime)> Items = new();
     }
 
+    internal static string? ValidateZipFileCount(int fileCount)
+        => fileCount > MaxZipFileCount
+            ? $"ZIP 包含的文件数超过上限（{MaxZipFileCount}），请删除无用文件或拆分后再上传"
+            : null;
+
     /// <summary>
     /// ZIP 过滤/计数/限额逻辑的唯一来源（路径穿越、__MACOSX、黑名单后缀、文件数、
     /// 解压总大小、空文件处理、≥1 有效文件）。ValidateZip 与 ExtractAndUploadZip 都走它，
@@ -2579,9 +2587,10 @@ public class HostedSiteService : IHostedSiteService
     {
         var plan = new ZipPlan();
 
-        if (archive.Entries.Count > MaxZipFileCount)
+        var fileCountError = ValidateZipFileCount(archive.Entries.Count);
+        if (fileCountError != null)
         {
-            plan.Error = $"ZIP 包含的文件数超过限制 ({MaxZipFileCount})";
+            plan.Error = fileCountError;
             return plan;
         }
 

--- a/prd-api/tests/PrdAgent.Tests/HostedSiteZipLimitTests.cs
+++ b/prd-api/tests/PrdAgent.Tests/HostedSiteZipLimitTests.cs
@@ -5,9 +5,19 @@ namespace PrdAgent.Tests;
 
 public class HostedSiteZipLimitTests
 {
-    [Fact]
-    public void ZipFileCountLimit_allows_static_site_builds_with_many_small_assets()
+    [Theory]
+    [InlineData(5001)]
+    [InlineData(20000)]
+    public void ZipFileCountLimit_allows_large_prototype_archives_within_the_new_boundary(int fileCount)
     {
-        Assert.Equal(5000, HostedSiteService.MaxZipFileCount);
+        Assert.Null(HostedSiteService.ValidateZipFileCount(fileCount));
+    }
+
+    [Fact]
+    public void ZipFileCountLimit_rejects_archives_above_the_boundary_with_recovery_guidance()
+    {
+        var error = HostedSiteService.ValidateZipFileCount(20001);
+
+        Assert.Equal("ZIP 包含的文件数超过上限（20000），请删除无用文件或拆分后再上传", error);
     }
 }


### PR DESCRIPTION
## 摘要
修复 DEF-2026-0192：网页托管 ZIP 的 5000 条目硬上限会拒绝资源较多但总体积较小的正常原型包。将上限提高到 20000，同时保留 500 MB 解压总量、危险扩展名和路径穿越防护，并让超限错误给出可执行的恢复方式。

## 单一目标与范围基线
- 单一目标：让超过 5000、且不超过 20000 个条目的正常原型 ZIP 通过文件数校验。
- 不变量：解压总量上限、安全过滤、上传权限和站点存储结构不变。
- 明确不做：不移除条目硬上限，不改对象存储并发模型，不做数据库迁移或权限调整。
- 首轮范围：4 个文件，新增 27 行、删除 6 行。

## 改动 diff
- `prd-api/src/PrdAgent.Infrastructure/Services/HostedSiteService.cs`：将 ZIP 条目上限提高到 20000，抽出统一边界判据，并补充包含恢复动作的超限文案。
- `prd-api/tests/PrdAgent.Tests/HostedSiteZipLimitTests.cs`：覆盖 5001、20000 可通过与 20001 被拒绝的边界行为。
- `prd-admin/src/pages/WebPagesPage.tsx`：同步上传区显示的新上限。
- `changelogs/2026-09-01_web-pages-zip-file-limit.md`：记录前后端修复。

## 测试
- [x] 后端 `dotnet build --no-restore` 成功，0 个错误；现有警告均不在改动文件。
- [x] 前端 `pnpm tsc --noEmit` 通过；`pnpm lint` 0 错误，本次改动行无新增告警。
- [x] `HostedSiteZipLimitTests` 3/3 通过；临时恢复旧上限时 3/3 失败，确认回归用例能捕获原缺陷。
- [x] CDS 预览部署与页面渲染通过：`/web-pages` 入口随提交 `1fabc9f` 正常发布，L1 页面与 L2 API 冒烟通过；受预览账号凭据传输安全策略限制，未执行真实 ZIP 表单上传，功能行为由红绿边界测试与 CI 证明。

## 风险与已知边界
- 仍保留 20000 条目硬上限，超过时提示删除无用文件或拆分后重试，避免海量空条目消耗解析和对象存储资源。
- 缺陷附件只有截图与请求日志，没有原 ZIP；功能验收通过，但真实附件与表单上传证据缺失，闭环证据状态记为 partial，正式发布后继续自动取证。
- 回滚方式：回退本 PR 提交即可恢复旧上限，无数据迁移。
