### PR TITLE
每日熵减计划 2026-W36 — D6 处理 5 条 changelog

### DIFF
--- a/changelogs/.entropy-manifest.yml
+++ b/changelogs/.entropy-manifest.yml
@@ -629,3 +629,8 @@ processed:
   - 2026-08-29_模型名录数据面门禁.md
   - 2026-08-30_entropy-cleanup.md
   - 2026-08-30_weekly-w35.md
+  - 2026-08-31_cds-manual-web-entry-config.md
+  - 2026-08-31_entropy-cleanup.md
+  - 2026-08-31_visual-business-model-selection.md
+  - 2026-09-01_cds-branch-db-account-collision.md
+  - 2026-09-01_cds-identity-and-multi-project.md

--- a/changelogs/2026-09-04_entropy-cleanup.md
+++ b/changelogs/2026-09-04_entropy-cleanup.md
@@ -1,0 +1,1 @@
+| chore | doc | 熵清理：D1/D2/D3/D4/D7 均干净，D6 处理 5 条 changelog（配置入口、视觉业务模型、分支数据库账号碰撞、身份层与多项目），内容已由 design.cds.web-entry.md、design.visual-agent.md、debt.cds.md、plan.cds.multi-project-identity.md、debt.cds.multi-project-identity.md 覆盖，登记进 manifest 避免重复扫描 |


### PR DESCRIPTION
## 熵清理摘要

- D1 命名规范：0 违规
- D2 index.yml：+0/-0 条
- D3 guide.list：+0/-0 条
- D4 技能可发现性：补缺 0 条
- D7 可读性 ratchet：六项欠账均未上升，无死链
- D6 changelog→doc：本次处理 5 条，manifest 累计 631 条

## 改动 diff

- `changelogs/.entropy-manifest.yml`：新增 5 条已处理 changelog 记录
- `changelogs/2026-09-04_entropy-cleanup.md`：本次 changelog 碎片

本轮 D6 核对的 5 条 changelog（2026-08-31 手动配置入口 / 熵清理自身 / 视觉业务模型选择，2026-09-01 分支数据库账号碰撞 / 身份层与多项目）内容均已由既有设计/债务文档覆盖，无需追加新章节：

- `doc/design.cds.web-entry.md`
- `doc/design.visual-agent.md`
- `doc/debt.cds.md`
- `doc/plan.cds.multi-project-identity.md`
- `doc/debt.cds.multi-project-identity.md`

## 测试

- [x] 双向扫描完成（D1-D4），diff 核验通过
- [x] `python3 scripts/doc-readability-check.py --ratchet` 通过
- [x] `python3 scripts/doc-readability-check.py --skills-audit` 通过（0 输出）
- [x] 运行两次验证：第二次 D6 净变更为 0（本次 5 条已登记）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fy5Ha8W4hE6eZCRcc44B51

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fy5Ha8W4hE6eZCRcc44B51)_