### PR TITLE
fix(cds): db-clone-pipeline 测试 afterEach 补 await，解除 await-flush 守卫红灯

### DIFF
--- a/cds/tests/services/db-clone-pipeline.test.ts
+++ b/cds/tests/services/db-clone-pipeline.test.ts
@@ -172,7 +172,7 @@ describe('分支独立库时间点克隆初始化', () => {
     state.addBranch({ id: 'p-feat-x', projectId: 'p', branch: 'feat/x', worktreePath: path.join(tmpDir, 'wt'), status: 'running', createdAt: T, services: {} } as unknown as BranchEntry);
     state.save();
   });
-  afterEach(() => { flushAllJsonStateStores(); fs.rmSync(tmpDir, { recursive: true, force: true }); });
+  afterEach(async () => { await flushAllJsonStateStores(); fs.rmSync(tmpDir, { recursive: true, force: true }); });
 
   it('实例记录里的 ${CDS_MYSQL_ROOT_PASSWORD} 按项目环境变量解析后才进三元组；解不出来的保留模板原样', () => {
     state.updateInfraService('mysql', { env: { MYSQL_ROOT_PASSWORD: '${CDS_MYSQL_ROOT_PASSWORD}', MYSQL_DATABASE: '${NOPE}' } }, 'p');

--- a/changelogs/2026-09-08_cds测试漏await修复.md
+++ b/changelogs/2026-09-08_cds测试漏await修复.md
@@ -1,0 +1,1 @@
+| fix | cds | db-clone-pipeline 测试 afterEach 补 await flushAllJsonStateStores，解除 await-flush 守卫在 main 上的红灯 |


### PR DESCRIPTION
## 摘要
main 当前 CDS 测试是红的：`d0aa311` 新增的 `db-clone-pipeline.test.ts` 在 `afterEach` 里没有 `await flushAllJsonStateStores()`，而 `e6c4b7e`（PR #1484）落地的守卫 `await-flush-state-stores.test.ts` 正是抓这个的。结果所有触碰 `cds/` 的 PR（#1500、#1503）都被拖成「CDS Build & Test」失败。本 PR 补一个 `async` / `await`，无行为变化。

## 改动 diff
### CDS
- `cds/tests/services/db-clone-pipeline.test.ts`：第 175 行 `afterEach(() => { flushAllJsonStateStores(); ... })` 改为 `afterEach(async () => { await flushAllJsonStateStores(); ... })`，与守卫要求一致（写盘完成后再 `rmSync`，避免 ENOTEMPTY 偶发）。

### 文档
- `changelogs/2026-09-08_cds测试漏await修复.md`：新增碎片。

## 测试
- [x] `pnpm vitest run tests/lint/await-flush-state-stores.test.ts tests/services/db-clone-pipeline.test.ts`：25 通过（守卫从红转绿，被改用例 24 个全绿）
- 无运行时代码改动，不涉及预览验收

## 风险与已知边界
- 无。同一修复已移植进 #1503 与 #1500 两个分支，主干合并后它们自动无差异。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0152eoqPpfpg1SFLNL8RdZYq

---
_Generated by [Claude Code](https://claude.ai/code/session_0152eoqPpfpg1SFLNL8RdZYq)_